### PR TITLE
fix(lsp): bound language-server lifecycle safely

### DIFF
--- a/agent/lsp/__init__.py
+++ b/agent/lsp/__init__.py
@@ -42,55 +42,54 @@ _atexit_registered = False
 _service_lock = threading.Lock()
 
 
+def _accepting(svc: LSPService) -> bool:
+    check = getattr(svc, "is_accepting_requests", None)
+    return bool(check()) if callable(check) else True
+
+
 def get_service() -> Optional[LSPService]:
     """Return the process-wide LSP service singleton, or None when disabled.
 
-    The service is created lazily on first call.  ``None`` is returned
-    when LSP is disabled in config, when no workspace can be detected,
-    or when the platform doesn't support subprocess-based LSP servers.
-
-    On first creation, registers an :mod:`atexit` handler that tears
-    down spawned language servers on Python exit so a long-running
-    CLI or gateway session doesn't leak pyright/gopls/etc. processes
-    when it terminates.
+    A closing singleton is never exposed. Callers that race a process-local
+    restart wait on ``_service_lock`` until the previous service has completed
+    shutdown, preventing old and new LSP pools from overlapping.
     """
     global _service, _atexit_registered
-    if _service is not None:
-        return _service if _service.is_active() else None
+    current = _service
+    if current is not None and _accepting(current):
+        return current if current.is_active() else None
     with _service_lock:
-        if _service is not None:
-            return _service if _service.is_active() else None
+        current = _service
+        if current is not None and _accepting(current):
+            return current if current.is_active() else None
         _service = LSPService.create_from_config()
         if not _atexit_registered:
             # ``atexit`` handlers run in LIFO order on normal Python
             # exit and on SystemExit, but NOT on os._exit() or
-            # uncaught signals.  Language servers are stateless
-            # subprocesses — losing them on SIGKILL is fine; they'll
-            # be reaped by the kernel along with their parent.  We
-            # care about clean exits where Python flushes stdio
-            # before terminating; without this hook every
-            # ``hermes chat`` exit would leak pyright processes that
-            # outlive the parent for a few seconds while their
-            # stdout buffers drain.
+            # uncaught signals. Language servers are stateless
+            # subprocesses and are recreated on the next process start.
             atexit.register(_atexit_shutdown)
             _atexit_registered = True
     return _service if (_service is not None and _service.is_active()) else None
 
 
 def shutdown_service() -> None:
-    """Tear down the LSP service if one was started.
-
-    Safe to call multiple times; safe to call when no service was created.
-    """
+    """Synchronously retire the singleton before allowing replacement."""
     global _service
     with _service_lock:
         svc = _service
-        _service = None
-    if svc is not None:
+        if svc is None:
+            return
+        begin = getattr(svc, "begin_shutdown", None)
+        if callable(begin):
+            begin()
         try:
             svc.shutdown()
-        except Exception as e:  # noqa: BLE001
-            logger.debug("LSP shutdown error: %s", e)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("LSP shutdown error: %s", exc)
+        finally:
+            if _service is svc:
+                _service = None
 
 
 def _atexit_shutdown() -> None:

--- a/agent/lsp/__init__.py
+++ b/agent/lsp/__init__.py
@@ -47,6 +47,11 @@ def _accepting(svc: LSPService) -> bool:
     return bool(check()) if callable(check) else True
 
 
+def _closed(svc: LSPService) -> bool:
+    check = getattr(svc, "is_closed", None)
+    return bool(check()) if callable(check) else False
+
+
 def get_service() -> Optional[LSPService]:
     """Return the process-wide LSP service singleton, or None when disabled.
 
@@ -62,6 +67,10 @@ def get_service() -> Optional[LSPService]:
         current = _service
         if current is not None and _accepting(current):
             return current if current.is_active() else None
+        if current is not None and not _closed(current):
+            # Teardown is incomplete or failed. Keep the tombstoned singleton
+            # rather than exposing an overlapping replacement pool.
+            return None
         _service = LSPService.create_from_config()
         if not _atexit_registered:
             # ``atexit`` handlers run in LIFO order on normal Python
@@ -86,10 +95,10 @@ def shutdown_service() -> None:
         try:
             svc.shutdown()
         except Exception as exc:  # noqa: BLE001
-            logger.debug("LSP shutdown error: %s", exc)
-        finally:
-            if _service is svc:
-                _service = None
+            logger.warning("LSP shutdown incomplete; replacement remains blocked: %s", exc)
+            return
+        if _service is svc and _closed(svc):
+            _service = None
 
 
 def _atexit_shutdown() -> None:

--- a/agent/lsp/cli.py
+++ b/agent/lsp/cli.py
@@ -129,6 +129,9 @@ def _cmd_status(emit_json: bool) -> int:
             f"  lifecycle:       "
             f"{'bounded' if lifecycle_info.get('enabled') else 'process-lifetime'}"
         )
+        config_error = lifecycle_info.get("config_error")
+        if config_error:
+            out.append(f"  lifecycle error: {config_error}")
         if lifecycle_info.get("enabled"):
             out.append(
                 "  lifecycle limits:"
@@ -149,7 +152,9 @@ def _cmd_status(emit_json: bool) -> int:
             out.append(f"  active clients:  {len(clients)}")
             for c in clients:
                 out.append(
-                    f"    - {c['server_id']:20s} state={c['state']:10s} root={c['workspace_root']}"
+                    f"    - {c['server_id']:20s} state={c['state']:10s} "
+                    f"lifecycle={c.get('lifecycle_state', c['state']):10s} "
+                    f"root={c['workspace_root']}"
                 )
         else:
             out.append("  active clients:  none")

--- a/agent/lsp/cli.py
+++ b/agent/lsp/cli.py
@@ -122,6 +122,28 @@ def _cmd_status(emit_json: bool) -> int:
         out.append(f"  wait_mode:       {info.get('wait_mode')}")
         out.append(f"  wait_timeout:    {info.get('wait_timeout')}s")
         out.append(f"  install_strategy:{info.get('install_strategy')}")
+        lifecycle_info = info.get("lifecycle")
+        if not isinstance(lifecycle_info, dict):
+            lifecycle_info = {}
+        out.append(
+            f"  lifecycle:       "
+            f"{'bounded' if lifecycle_info.get('enabled') else 'process-lifetime'}"
+        )
+        if lifecycle_info.get("enabled"):
+            out.append(
+                "  lifecycle limits:"
+                f" idle={lifecycle_info.get('idle_timeout_seconds')}s"
+                f" sweep={lifecycle_info.get('sweep_interval_seconds')}s"
+                f" max_clients={lifecycle_info.get('max_clients_per_process')}"
+            )
+            counts = lifecycle_info.get("counts") or {}
+            out.append(
+                "  lifecycle state: "
+                f"{lifecycle_info.get('service_state')} "
+                f"active={counts.get('active', 0)} "
+                f"spawning={counts.get('spawning', 0)} "
+                f"retiring={counts.get('retiring', 0)}"
+            )
         clients = info.get("clients") or []
         if clients:
             out.append(f"  active clients:  {len(clients)}")

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -241,7 +241,7 @@ class LSPClient:
         self._initialize_result: Optional[Dict[str, Any]] = None
         self._sync_kind: int = 1  # 1=Full, 2=Incremental
         self._stopping: bool = False
-        self._shutdown_future: Optional[asyncio.Future] = None
+        self._shutdown_task: Optional[asyncio.Task[None]] = None
 
         # Push event for waiters.
         self._push_event = asyncio.Event()
@@ -256,7 +256,11 @@ class LSPClient:
 
     @property
     def is_running(self) -> bool:
-        return self._state == "running" and self._proc is not None and self._proc.returncode is None
+        return self._state == "running" and self.process_alive
+
+    @property
+    def process_alive(self) -> bool:
+        return self._proc is not None and self._proc.returncode is None
 
     @property
     def state(self) -> str:
@@ -269,6 +273,10 @@ class LSPClient:
         the process is killed and the client is left in state
         ``"error"`` — re-call ``start()`` to retry.
         """
+        if self._shutdown_task is not None:
+            raise LSPProtocolError(
+                "an LSPClient is single-use and cannot restart after shutdown"
+            )
         if self._state in {"running", "starting"}:
             return
         self._state = "starting"
@@ -452,20 +460,22 @@ class LSPClient:
         return 1  # default to Full
 
     async def shutdown(self) -> None:
-        """Best-effort graceful, completion-idempotent shutdown.
+        """Best-effort graceful, cancellation-safe idempotent shutdown.
 
-        Concurrent callers await one cleanup future.  This prevents a later
-        service shutdown from closing the event loop while an earlier caller
-        is still terminating the subprocess tree.
+        Cleanup lives in one retained task. Cancelling any caller does not
+        cancel or falsely complete process-tree teardown; later callers await
+        the same result.
         """
-        existing = self._shutdown_future
-        if existing is not None:
-            await asyncio.shield(existing)
-            return
+        task = self._shutdown_task
+        if task is None:
+            task = asyncio.create_task(
+                self._shutdown_impl(), name=f"hermes-lsp-client-shutdown-{self.server_id}"
+            )
+            self._shutdown_task = task
+        await asyncio.shield(task)
 
-        loop = asyncio.get_running_loop()
-        completion = loop.create_future()
-        self._shutdown_future = completion
+    async def _shutdown_impl(self) -> None:
+        """Own the complete protocol and process-tree shutdown sequence."""
         self._stopping = True
         descendants = self._capture_descendants()
         try:
@@ -487,12 +497,8 @@ class LSPClient:
                     except asyncio.TimeoutError:
                         pass
         finally:
-            try:
-                self._state = "stopped"
-                await self._cleanup_process(descendants)
-            finally:
-                if not completion.done():
-                    completion.set_result(None)
+            self._state = "stopped"
+            await self._cleanup_process(descendants)
 
     def _capture_descendants(self):
         proc = self._proc
@@ -519,10 +525,17 @@ class LSPClient:
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
         proc = self._proc
-        self._proc = None
         captured = list(descendants or [])
         if proc is not None:
             captured.extend(self._capture_descendants_for_pid(proc.pid))
+            if captured:
+                # Terminate descendants leaf-first while the wrapper still
+                # exists, then refresh once to catch helpers created during
+                # the graceful protocol shutdown.
+                await asyncio.to_thread(self._terminate_descendants, captured)
+            refreshed = self._capture_descendants_for_pid(proc.pid)
+            if refreshed:
+                await asyncio.to_thread(self._terminate_descendants, refreshed)
             if proc.returncode is None:
                 try:
                     proc.terminate()
@@ -536,8 +549,7 @@ class LSPClient:
                             pass
                 except ProcessLookupError:
                     pass
-        if captured:
-            await asyncio.to_thread(self._terminate_descendants, captured)
+        self._proc = None
 
     @staticmethod
     def _capture_descendants_for_pid(pid: int):

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import secrets
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -73,6 +74,8 @@ from agent.lsp.protocol import (
 )
 
 logger = logging.getLogger("agent.lsp.client")
+
+_OWNER_TOKEN_ENV = "HERMES_LSP_OWNER_TOKEN"
 
 # Timeouts (seconds) — mirror OpenCode's constants, scaled to seconds.
 INITIALIZE_TIMEOUT = 45.0
@@ -202,6 +205,10 @@ class LSPClient:
         self._cwd = cwd or workspace_root
         self._init_options = initialization_options or {}
         self._seed_first_push = seed_diagnostics_on_first_push
+        # A random marker inherited by the wrapper's entire process tree.
+        # Unlike parent-PID traversal, this still identifies helpers after a
+        # crashed wrapper has exited and the OS has reparented them.
+        self._owner_token = secrets.token_hex(16)
 
         # Process + streams
         self._proc: Optional[asyncio.subprocess.Process] = None
@@ -263,6 +270,24 @@ class LSPClient:
         return self._proc is not None and self._proc.returncode is None
 
     @property
+    def process_tree_alive(self) -> bool:
+        """Whether the wrapper or any token-owned descendant still exists."""
+        if self.process_alive:
+            return True
+        try:
+            import psutil
+
+            for proc in self._capture_owned_processes():
+                try:
+                    if proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE:
+                        return True
+                except (psutil.Error, OSError):
+                    continue
+        except Exception:  # noqa: BLE001
+            pass
+        return False
+
+    @property
     def state(self) -> str:
         return self._state
 
@@ -301,6 +326,10 @@ class LSPClient:
         env = dict(os.environ)
         if self._env:
             env.update(self._env)
+        # Set this after user overrides so ownership cannot be spoofed by a
+        # stale inherited value. The token is not a credential; it is a
+        # process-tree identity used only during cleanup.
+        env[_OWNER_TOKEN_ENV] = self._owner_token
 
         cmd = self._command
         if sys.platform == "win32":
@@ -462,14 +491,28 @@ class LSPClient:
     async def shutdown(self) -> None:
         """Best-effort graceful, cancellation-safe idempotent shutdown.
 
-        Cleanup lives in one retained task. Cancelling any caller does not
-        cancel or falsely complete process-tree teardown; later callers await
-        the same result.
+        Cleanup lives in one shared task. Cancelling any caller does not cancel
+        process-tree teardown; successful complete cleanup remains idempotent.
+        A failed task or a cleanup that leaves an owned process alive is
+        replaced on the next call so tombstones can make progress.
         """
         task = self._shutdown_task
-        if task is None:
+        retry_failed = bool(
+            task is not None
+            and task.done()
+            and (task.cancelled() or task.exception() is not None)
+        )
+        retry_incomplete = bool(
+            task is not None
+            and task.done()
+            and not task.cancelled()
+            and task.exception() is None
+            and self.process_tree_alive
+        )
+        if task is None or retry_failed or retry_incomplete:
             task = asyncio.create_task(
-                self._shutdown_impl(), name=f"hermes-lsp-client-shutdown-{self.server_id}"
+                self._shutdown_impl(),
+                name=f"hermes-lsp-client-shutdown-{self.server_id}",
             )
             self._shutdown_task = task
         await asyncio.shield(task)
@@ -502,14 +545,31 @@ class LSPClient:
 
     def _capture_descendants(self):
         proc = self._proc
-        if proc is None:
-            return []
+        captured = []
+        if proc is not None and proc.returncode is None:
+            captured.extend(self._capture_descendants_for_pid(proc.pid))
+        captured.extend(self._capture_owned_processes())
+        return captured
+
+    def _capture_owned_processes(self):
+        """Find processes carrying this client's inherited ownership token."""
+        proc = self._proc
+        captured = []
         try:
             import psutil
 
-            return psutil.Process(proc.pid).children(recursive=True)
+            wrapper_pid = proc.pid if proc is not None else None
+            for candidate in psutil.process_iter(["pid"]):
+                if candidate.pid in {os.getpid(), wrapper_pid}:
+                    continue
+                try:
+                    if candidate.environ().get(_OWNER_TOKEN_ENV) == self._owner_token:
+                        captured.append(candidate)
+                except (psutil.Error, OSError):
+                    continue
         except Exception:  # noqa: BLE001
-            return []
+            pass
+        return captured
 
     async def _cleanup_process(self, descendants=None) -> None:
         if self._reader_task is not None and not self._reader_task.done():
@@ -526,30 +586,44 @@ class LSPClient:
                 pass
         proc = self._proc
         captured = list(descendants or [])
-        if proc is not None:
-            captured.extend(self._capture_descendants_for_pid(proc.pid))
-            if captured:
-                # Terminate descendants leaf-first while the wrapper still
-                # exists, then refresh once to catch helpers created during
-                # the graceful protocol shutdown.
-                await asyncio.to_thread(self._terminate_descendants, captured)
-            refreshed = self._capture_descendants_for_pid(proc.pid)
-            if refreshed:
-                await asyncio.to_thread(self._terminate_descendants, refreshed)
+        captured.extend(self._capture_descendants())
+
+        # Stop the wrapper before sweeping descendants so it cannot create a
+        # fresh helper between the last scan and its own termination. Poll
+        # returncode instead of awaiting Process.wait(): descendants may hold
+        # inherited stdout/stderr descriptors and keep that await blocked.
+        if proc is not None and proc.returncode is None:
+            try:
+                proc.terminate()
+            except ProcessLookupError:
+                pass
+
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + SHUTDOWN_GRACE
+            while proc.returncode is None and loop.time() < deadline:
+                await asyncio.sleep(0.05)
             if proc.returncode is None:
                 try:
-                    proc.terminate()
-                    try:
-                        await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
-                    except asyncio.TimeoutError:
-                        try:
-                            proc.kill()
-                            await proc.wait()
-                        except ProcessLookupError:
-                            pass
+                    proc.kill()
                 except ProcessLookupError:
                     pass
-        self._proc = None
+                deadline = loop.time() + SHUTDOWN_GRACE
+                while proc.returncode is None and loop.time() < deadline:
+                    await asyncio.sleep(0.05)
+
+        # The wrapper can no longer spawn helpers. Token discovery still finds
+        # processes reparented after its exit; the second sweep catches helpers
+        # that were created while the first captured set was being terminated.
+        captured.extend(self._capture_descendants())
+        if captured:
+            await asyncio.to_thread(self._terminate_descendants, captured)
+        refreshed = self._capture_descendants()
+        if refreshed:
+            await asyncio.to_thread(self._terminate_descendants, refreshed)
+
+        # Preserve a stubborn live wrapper for a later tombstone retry.
+        if proc is None or proc.returncode is not None:
+            self._proc = None
 
     @staticmethod
     def _capture_descendants_for_pid(pid: int):

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -241,6 +241,7 @@ class LSPClient:
         self._initialize_result: Optional[Dict[str, Any]] = None
         self._sync_kind: int = 1  # 1=Full, 2=Incremental
         self._stopping: bool = False
+        self._shutdown_future: Optional[asyncio.Future] = None
 
         # Push event for waiters.
         self._push_event = asyncio.Event()
@@ -451,29 +452,60 @@ class LSPClient:
         return 1  # default to Full
 
     async def shutdown(self) -> None:
-        """Best-effort graceful shutdown.
+        """Best-effort graceful, completion-idempotent shutdown.
 
-        Sends ``shutdown`` + ``exit``, then SIGTERMs/SIGKILLs the
-        process if it doesn't exit cleanly.  Idempotent.
+        Concurrent callers await one cleanup future.  This prevents a later
+        service shutdown from closing the event loop while an earlier caller
+        is still terminating the subprocess tree.
         """
-        if self._stopping:
+        existing = self._shutdown_future
+        if existing is not None:
+            await asyncio.shield(existing)
             return
+
+        loop = asyncio.get_running_loop()
+        completion = loop.create_future()
+        self._shutdown_future = completion
         self._stopping = True
+        descendants = self._capture_descendants()
         try:
             if self.is_running:
                 try:
-                    await asyncio.wait_for(self._send_request("shutdown", None), timeout=2.0)
+                    await asyncio.wait_for(
+                        self._send_request("shutdown", None), timeout=2.0
+                    )
                 except (asyncio.TimeoutError, LSPRequestError, LSPProtocolError):
                     pass
                 try:
                     await self._send_notification("exit", None)
                 except Exception:
                     pass
+                proc = self._proc
+                if proc is not None and proc.returncode is None:
+                    try:
+                        await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
+                    except asyncio.TimeoutError:
+                        pass
         finally:
-            self._state = "stopped"
-            await self._cleanup_process()
+            try:
+                self._state = "stopped"
+                await self._cleanup_process(descendants)
+            finally:
+                if not completion.done():
+                    completion.set_result(None)
 
-    async def _cleanup_process(self) -> None:
+    def _capture_descendants(self):
+        proc = self._proc
+        if proc is None:
+            return []
+        try:
+            import psutil
+
+            return psutil.Process(proc.pid).children(recursive=True)
+        except Exception:  # noqa: BLE001
+            return []
+
+    async def _cleanup_process(self, descendants=None) -> None:
         if self._reader_task is not None and not self._reader_task.done():
             self._reader_task.cancel()
             try:
@@ -488,21 +520,68 @@ class LSPClient:
                 pass
         proc = self._proc
         self._proc = None
-        if proc is None:
+        captured = list(descendants or [])
+        if proc is not None:
+            captured.extend(self._capture_descendants_for_pid(proc.pid))
+            if proc.returncode is None:
+                try:
+                    proc.terminate()
+                    try:
+                        await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
+                    except asyncio.TimeoutError:
+                        try:
+                            proc.kill()
+                            await proc.wait()
+                        except ProcessLookupError:
+                            pass
+                except ProcessLookupError:
+                    pass
+        if captured:
+            await asyncio.to_thread(self._terminate_descendants, captured)
+
+    @staticmethod
+    def _capture_descendants_for_pid(pid: int):
+        try:
+            import psutil
+
+            return psutil.Process(pid).children(recursive=True)
+        except Exception:  # noqa: BLE001
+            return []
+
+    @staticmethod
+    def _terminate_descendants(processes) -> None:
+        """Terminate only descendants captured from this LSP wrapper."""
+        try:
+            import psutil
+        except ImportError:
             return
-        if proc.returncode is None:
+        unique = {}
+        for proc in processes:
+            try:
+                if proc.pid != os.getpid() and proc.is_running():
+                    unique[(proc.pid, proc.create_time())] = proc
+            except (psutil.Error, OSError):
+                continue
+        alive = list(unique.values())
+        for proc in alive:
             try:
                 proc.terminate()
-                try:
-                    await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
-                except asyncio.TimeoutError:
-                    try:
-                        proc.kill()
-                        await proc.wait()
-                    except ProcessLookupError:
-                        pass
-            except ProcessLookupError:
+            except psutil.Error:
                 pass
+        _, alive = psutil.wait_procs(alive, timeout=SHUTDOWN_GRACE)
+        for proc in alive:
+            try:
+                proc.kill()
+            except psutil.Error:
+                pass
+        _, alive = psutil.wait_procs(alive, timeout=SHUTDOWN_GRACE)
+        if alive:
+            logger.warning(
+                "[%s] %d LSP descendant process(es) survived cleanup: %s",
+                "process-tree",
+                len(alive),
+                [proc.pid for proc in alive],
+            )
 
     # ------------------------------------------------------------------
     # request / notification plumbing

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -366,7 +366,9 @@ class LSPClient:
                 creationflags=creationflags,
             )
             if os.name != "nt":
-                self._process_group_id = self._proc.pid
+                process_id = getattr(self._proc, "pid", None)
+                if isinstance(process_id, int) and process_id > 0:
+                    self._process_group_id = process_id
         except FileNotFoundError as e:
             raise LSPProtocolError(
                 f"LSP server binary not found: {cmd[0]} ({e})"

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -45,6 +45,7 @@ Implementation notes:
   backoff up to 3 times.  This matches Claude Code's
   ``LSPServerInstance.sendRequest``.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -110,7 +111,7 @@ def uri_to_path(uri: str) -> str:
     """Inverse of :func:`file_uri`."""
     if not uri.startswith("file://"):
         return uri
-    raw = uri[len("file://"):]
+    raw = uri[len("file://") :]
     if os.name == "nt" and raw.startswith("/") and len(raw) > 2 and raw[2] == ":":
         raw = raw[1:]  # strip leading slash before drive letter
     return os.path.normpath(unquote(raw))
@@ -209,6 +210,10 @@ class LSPClient:
         # Unlike parent-PID traversal, this still identifies helpers after a
         # crashed wrapper has exited and the OS has reparented them.
         self._owner_token = secrets.token_hex(16)
+        # POSIX wrappers already run in a dedicated session/process group.
+        # Retaining the pgid lets cleanup recover descendants that deliberately
+        # or incidentally sanitize their inherited environment.
+        self._process_group_id: Optional[int] = None
 
         # Process + streams
         self._proc: Optional[asyncio.subprocess.Process] = None
@@ -360,6 +365,8 @@ class LSPClient:
                 start_new_session=True,
                 creationflags=creationflags,
             )
+            if os.name != "nt":
+                self._process_group_id = self._proc.pid
         except FileNotFoundError as e:
             raise LSPProtocolError(
                 f"LSP server binary not found: {cmd[0]} ({e})"
@@ -402,7 +409,9 @@ class LSPClient:
                 elif kind == "notification":
                     self._dispatch_notification(key, msg)
                 else:
-                    logger.warning("[%s] dropping invalid message: %r", self.server_id, msg)
+                    logger.warning(
+                        "[%s] dropping invalid message: %r", self.server_id, msg
+                    )
         except LSPProtocolError as e:
             logger.warning("[%s] protocol error in reader loop: %s", self.server_id, e)
         except (asyncio.CancelledError, OSError):
@@ -519,10 +528,12 @@ class LSPClient:
 
     async def _shutdown_impl(self) -> None:
         """Own the complete protocol and process-tree shutdown sequence."""
+        was_running = self.is_running
         self._stopping = True
+        self._state = "stopping"
         descendants = self._capture_descendants()
         try:
-            if self.is_running:
+            if was_running:
                 try:
                     await asyncio.wait_for(
                         self._send_request("shutdown", None), timeout=2.0
@@ -540,8 +551,10 @@ class LSPClient:
                     except asyncio.TimeoutError:
                         pass
         finally:
-            self._state = "stopped"
-            await self._cleanup_process(descendants)
+            try:
+                await self._cleanup_process(descendants)
+            finally:
+                self._state = "error" if self.process_tree_alive else "stopped"
 
     def _capture_descendants(self):
         proc = self._proc
@@ -552,7 +565,7 @@ class LSPClient:
         return captured
 
     def _capture_owned_processes(self):
-        """Find processes carrying this client's inherited ownership token."""
+        """Find token- or POSIX-process-group-owned descendants."""
         proc = self._proc
         captured = []
         try:
@@ -563,7 +576,18 @@ class LSPClient:
                 if candidate.pid in {os.getpid(), wrapper_pid}:
                     continue
                 try:
-                    if candidate.environ().get(_OWNER_TOKEN_ENV) == self._owner_token:
+                    group_owned = bool(
+                        self._process_group_id is not None
+                        and os.name != "nt"
+                        and os.getpgid(candidate.pid) == self._process_group_id
+                    )
+                    token_owned = False
+                    if not group_owned:
+                        token_owned = (
+                            candidate.environ().get(_OWNER_TOKEN_ENV)
+                            == self._owner_token
+                        )
+                    if group_owned or token_owned:
                         captured.append(candidate)
                 except (psutil.Error, OSError):
                     continue
@@ -624,6 +648,8 @@ class LSPClient:
         # Preserve a stubborn live wrapper for a later tombstone retry.
         if proc is None or proc.returncode is not None:
             self._proc = None
+            if not self._capture_owned_processes():
+                self._process_group_id = None
 
     @staticmethod
     def _capture_descendants_for_pid(pid: int):
@@ -674,7 +700,11 @@ class LSPClient:
     # ------------------------------------------------------------------
 
     async def _send_request(self, method: str, params: Any) -> Any:
-        if self._proc is None or self._proc.stdin is None or self._proc.stdin.is_closing():
+        if (
+            self._proc is None
+            or self._proc.stdin is None
+            or self._proc.stdin.is_closing()
+        ):
             raise LSPProtocolError(f"cannot send {method!r}: stdin closed")
         loop = asyncio.get_running_loop()
         req_id = self._next_id
@@ -692,7 +722,9 @@ class LSPClient:
         finally:
             self._pending.pop(req_id, None)
 
-    async def _send_request_with_retry(self, method: str, params: Any, *, timeout: float) -> Any:
+    async def _send_request_with_retry(
+        self, method: str, params: Any, *, timeout: float
+    ) -> Any:
         """Send a request, retrying on ``ContentModified`` (-32801).
 
         Other errors propagate.  The retry policy matches Claude Code's
@@ -701,15 +733,24 @@ class LSPClient:
         """
         for attempt in range(MAX_CONTENT_MODIFIED_RETRIES + 1):
             try:
-                return await asyncio.wait_for(self._send_request(method, params), timeout=timeout)
+                return await asyncio.wait_for(
+                    self._send_request(method, params), timeout=timeout
+                )
             except LSPRequestError as e:
-                if e.code == ERROR_CONTENT_MODIFIED and attempt < MAX_CONTENT_MODIFIED_RETRIES:
-                    await asyncio.sleep(RETRY_BASE_DELAY * (2 ** attempt))
+                if (
+                    e.code == ERROR_CONTENT_MODIFIED
+                    and attempt < MAX_CONTENT_MODIFIED_RETRIES
+                ):
+                    await asyncio.sleep(RETRY_BASE_DELAY * (2**attempt))
                     continue
                 raise
 
     async def _send_notification(self, method: str, params: Any) -> None:
-        if self._proc is None or self._proc.stdin is None or self._proc.stdin.is_closing():
+        if (
+            self._proc is None
+            or self._proc.stdin is None
+            or self._proc.stdin.is_closing()
+        ):
             return
         try:
             self._proc.stdin.write(encode_message(make_notification(method, params)))
@@ -718,7 +759,11 @@ class LSPClient:
             logger.debug("[%s] notify %s failed: %s", self.server_id, method, e)
 
     async def _send_response(self, req_id: Any, result: Any) -> None:
-        if self._proc is None or self._proc.stdin is None or self._proc.stdin.is_closing():
+        if (
+            self._proc is None
+            or self._proc.stdin is None
+            or self._proc.stdin.is_closing()
+        ):
             return
         try:
             self._proc.stdin.write(encode_message(make_response(req_id, result)))
@@ -727,10 +772,16 @@ class LSPClient:
             pass
 
     async def _send_error_response(self, req_id: Any, code: int, message: str) -> None:
-        if self._proc is None or self._proc.stdin is None or self._proc.stdin.is_closing():
+        if (
+            self._proc is None
+            or self._proc.stdin is None
+            or self._proc.stdin.is_closing()
+        ):
             return
         try:
-            self._proc.stdin.write(encode_message(make_error_response(req_id, code, message)))
+            self._proc.stdin.write(
+                encode_message(make_error_response(req_id, code, message))
+            )
             await self._proc.stdin.drain()
         except (BrokenPipeError, ConnectionResetError, OSError):
             pass
@@ -756,12 +807,16 @@ class LSPClient:
         params = msg.get("params")
         handler = self._request_handlers.get(method)
         if handler is None:
-            await self._send_error_response(req_id, ERROR_METHOD_NOT_FOUND, f"method not found: {method}")
+            await self._send_error_response(
+                req_id, ERROR_METHOD_NOT_FOUND, f"method not found: {method}"
+            )
             return
         try:
             result = await handler(params)
         except Exception as e:  # noqa: BLE001 — protocol must not blow up
-            logger.warning("[%s] request handler %s failed: %s", self.server_id, method, e)
+            logger.warning(
+                "[%s] request handler %s failed: %s", self.server_id, method, e
+            )
             await self._send_error_response(req_id, -32000, f"handler failed: {e}")
             return
         await self._send_response(req_id, result)
@@ -773,7 +828,9 @@ class LSPClient:
         try:
             handler(msg.get("params"))
         except Exception as e:  # noqa: BLE001
-            logger.debug("[%s] notification handler %s failed: %s", self.server_id, method, e)
+            logger.debug(
+                "[%s] notification handler %s failed: %s", self.server_id, method, e
+            )
 
     # ------------------------------------------------------------------
     # built-in server-→-client request handlers
@@ -987,9 +1044,7 @@ class LSPClient:
         doc = self._docs.get(abs_path)
         sent_version = doc.version if doc else -1
         try:
-            params: Dict[str, Any] = {
-                "textDocument": {"uri": file_uri(abs_path)}
-            }
+            params: Dict[str, Any] = {"textDocument": {"uri": file_uri(abs_path)}}
             result = await self._send_request_with_retry(
                 "textDocument/diagnostic",
                 params,
@@ -1046,7 +1101,9 @@ class LSPClient:
         if timeout is not None and timeout > 0:
             budget = timeout
         else:
-            budget = DIAGNOSTICS_FULL_WAIT if mode == "full" else DIAGNOSTICS_DOCUMENT_WAIT
+            budget = (
+                DIAGNOSTICS_FULL_WAIT if mode == "full" else DIAGNOSTICS_DOCUMENT_WAIT
+            )
         deadline = asyncio.get_event_loop().time() + budget
         abs_path = os.path.abspath(path)
 
@@ -1057,7 +1114,9 @@ class LSPClient:
 
             # Concurrent: document pull + push wait.
             pull_task = asyncio.create_task(self._pull_document_diagnostics(abs_path))
-            push_task = asyncio.create_task(self._wait_for_fresh_push(abs_path, version, remaining))
+            push_task = asyncio.create_task(
+                self._wait_for_fresh_push(abs_path, version, remaining)
+            )
             done, pending = await asyncio.wait(
                 {pull_task, push_task},
                 timeout=remaining,
@@ -1083,7 +1142,9 @@ class LSPClient:
 
             # Loop until budget runs out.
 
-    async def _wait_for_fresh_push(self, path: str, version: int, timeout: float) -> None:
+    async def _wait_for_fresh_push(
+        self, path: str, version: int, timeout: float
+    ) -> None:
         """Wait until a fresh publishDiagnostics arrives for ``path`` at ``version``+."""
         deadline = asyncio.get_event_loop().time() + timeout
         baseline = self._push_counter
@@ -1102,7 +1163,9 @@ class LSPClient:
                         break
                     self._push_event.clear()
                     try:
-                        await asyncio.wait_for(self._push_event.wait(), timeout=remaining)
+                        await asyncio.wait_for(
+                            self._push_event.wait(), timeout=remaining
+                        )
                     except asyncio.TimeoutError:
                         break
                 return
@@ -1116,11 +1179,15 @@ class LSPClient:
                 continue
             self._push_event.clear()
             try:
-                await asyncio.wait_for(self._push_event.wait(), timeout=min(remaining, 0.5))
+                await asyncio.wait_for(
+                    self._push_event.wait(), timeout=min(remaining, 0.5)
+                )
             except asyncio.TimeoutError:
                 continue
 
-    def diagnostics_for(self, path: str, *, fresh_only: bool = False) -> List[Dict[str, Any]]:
+    def diagnostics_for(
+        self, path: str, *, fresh_only: bool = False
+    ) -> List[Dict[str, Any]]:
         """Return current merged + deduped diagnostics for one file.
 
         Diagnostics from push and pull stores are concatenated and
@@ -1173,15 +1240,13 @@ def _diagnostic_key(d: Dict[str, Any]) -> str:
     code = d.get("code")
     if code is not None and not isinstance(code, str):
         code = str(code)
-    return "\x00".join(
-        [
-            str(d.get("severity") or 1),
-            str(code or ""),
-            str(d.get("source") or ""),
-            str(d.get("message") or "").strip(),
-            f"{start.get('line', 0)}:{start.get('character', 0)}-{end.get('line', 0)}:{end.get('character', 0)}",
-        ]
-    )
+    return "\x00".join([
+        str(d.get("severity") or 1),
+        str(code or ""),
+        str(d.get("source") or ""),
+        str(d.get("message") or "").strip(),
+        f"{start.get('line', 0)}:{start.get('character', 0)}-{end.get('line', 0)}:{end.get('character', 0)}",
+    ])
 
 
 __all__ = [

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -183,6 +183,14 @@ class LSPService:
         # introduced by the current edit.
         self._delta_baseline: Dict[str, List[Dict[str, Any]]] = {}
 
+        # Idle reaper — periodically shuts down clients that haven't
+        # been used for longer than ``_idle_timeout`` seconds.  Without
+        # this, language-server processes accumulate indefinitely in
+        # long-running gateways (one per unique workspace_root).
+        self._reaper_task: Optional[asyncio.Task] = None
+        if self._enabled and self._idle_timeout > 0:
+            self._start_reaper()
+
     @classmethod
     def create_from_config(cls) -> Optional["LSPService"]:
         """Build a service from ``hermes_cli.config`` settings.
@@ -236,6 +244,59 @@ class LSPService:
             init_overrides=init_overrides,
             disabled_servers=disabled,
         )
+
+    # ------------------------------------------------------------------
+    # idle reaper
+    # ------------------------------------------------------------------
+
+    def _start_reaper(self) -> None:
+        """Schedule the idle-reaper coroutine on the background loop."""
+        if self._loop._loop is None:
+            return
+        self._reaper_task = asyncio.run_coroutine_threadsafe(
+            self._reaper_loop(), self._loop._loop
+        )
+
+    async def _reaper_loop(self) -> None:
+        """Periodically reap language-server clients that have been
+        idle for longer than ``_idle_timeout`` seconds.
+
+        Runs every ``min(_idle_timeout / 2, 60)`` seconds — frequent
+        enough to clean up promptly, infrequent enough to be cheap.
+        """
+        interval = max(30.0, min(self._idle_timeout / 2, 60.0))
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                await self._reap_idle_clients()
+        except asyncio.CancelledError:
+            return
+
+    async def _reap_idle_clients(self) -> None:
+        """Shut down clients that have been idle past the timeout."""
+        now = time.time()
+        to_reap: List[Tuple[Tuple[str, str], LSPClient]] = []
+        with self._state_lock:
+            for key, client in list(self._clients.items()):
+                last = self._last_used.get(key, 0.0)
+                if now - last > self._idle_timeout:
+                    to_reap.append((key, client))
+                    self._clients.pop(key, None)
+                    self._last_used.pop(key, None)
+        if not to_reap:
+            return
+        logger.info(
+            "LSP idle reaper: shutting down %d client(s) idle >%ss",
+            len(to_reap), self._idle_timeout,
+        )
+        for key, client in to_reap:
+            logger.debug(
+                "  reaping %s (workspace=%s)", key[0], key[1],
+            )
+            try:
+                await client.shutdown()
+            except Exception:  # noqa: BLE001
+                pass
 
     # ------------------------------------------------------------------
     # public API
@@ -449,6 +510,10 @@ class LSPService:
         """Tear down all clients and stop the background loop."""
         if not self._enabled:
             return
+        # Cancel the idle reaper before shutting down clients.
+        if self._reaper_task is not None:
+            self._reaper_task.cancel()
+            self._reaper_task = None
         try:
             self._loop.run(self._shutdown_async(), timeout=10.0)
         except Exception as e:  # noqa: BLE001

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -15,7 +15,7 @@ Design choices:
   re-use it.
 
 - A **broken-set** records deterministic ``(server_id, workspace_root)``
-  failures such as an unavailable spawn command. In opt-in lifecycle mode,
+  failures such as an unavailable spawn command. In bounded lifecycle mode,
   transient startup/request failures use a short monotonic cooldown so the
   service can recover; process-lifetime mode preserves permanent marking.
 
@@ -110,21 +110,22 @@ def _lifecycle_config(
 ) -> Tuple[bool, float, float, int, Optional[str]]:
     """Parse bounded-lifecycle settings and surface invalid policy explicitly.
 
-    If an explicitly enabled policy is malformed, safe bounded defaults remain
-    enabled rather than silently reverting to unbounded process-lifetime
-    retention. The validation error is exposed through status.
+    Bounded lifecycle is the default. An explicit ``enabled: false`` preserves
+    process-lifetime retention. Malformed enabled policies remain bounded
+    rather than silently reverting to unbounded retention, and expose the
+    validation error through status.
     """
 
     raw = lsp_cfg.get("lifecycle")
-    defaults = (False, DEFAULT_IDLE_TIMEOUT, DEFAULT_SWEEP_INTERVAL, 0, None)
+    defaults = (True, DEFAULT_IDLE_TIMEOUT, DEFAULT_SWEEP_INTERVAL, 0, None)
     if raw is None:
         return defaults
     if not isinstance(raw, dict):
         error = "lsp.lifecycle must be a mapping"
         logger.warning(error)
-        return False, DEFAULT_IDLE_TIMEOUT, DEFAULT_SWEEP_INTERVAL, 0, error
+        return True, DEFAULT_IDLE_TIMEOUT, DEFAULT_SWEEP_INTERVAL, 0, error
 
-    enabled = raw.get("enabled", False)
+    enabled = raw.get("enabled", True)
     enabled_valid = isinstance(enabled, bool)
     try:
         if not enabled_valid:
@@ -180,11 +181,11 @@ def _lifecycle_config(
                 "max_clients_per_process must be an integer between "
                 f"0 and {MAX_CLIENTS_PER_PROCESS}"
             )
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, OverflowError) as exc:
         error = str(exc)
         logger.warning("invalid lsp.lifecycle configuration: %s", error)
         return (
-            bool(enabled) if enabled_valid else False,
+            bool(enabled) if enabled_valid else True,
             DEFAULT_IDLE_TIMEOUT,
             DEFAULT_SWEEP_INTERVAL,
             0,
@@ -499,12 +500,20 @@ class LSPService:
             if client is not None:
                 await client.shutdown()
                 terminated = not bool(
-                    getattr(client, "process_alive", client.is_running)
+                    getattr(
+                        client,
+                        "process_tree_alive",
+                        getattr(client, "process_alive", client.is_running),
+                    )
                 )
         except BaseException as exc:  # noqa: BLE001
             error = exc
             terminated = client is None or not bool(
-                getattr(client, "process_alive", client.is_running)
+                getattr(
+                    client,
+                    "process_tree_alive",
+                    getattr(client, "process_alive", client.is_running),
+                )
             )
             if isinstance(exc, asyncio.CancelledError):
                 raise
@@ -819,7 +828,7 @@ class LSPService:
         """Retire a failed generation and preserve the configured retry policy.
 
         Legacy process-lifetime mode keeps the historical permanent broken
-        mark. Opt-in lifecycle mode uses a short retry cooldown so an
+        mark. Bounded lifecycle mode uses a short retry cooldown so an
         intentionally bounded gateway can recover from transient cold starts.
         """
         target = self._resolve_target(file_path)
@@ -1156,7 +1165,23 @@ class LSPService:
             return client
         except asyncio.CancelledError:
             if client is not None:
-                await asyncio.shield(client.shutdown())
+                try:
+                    await asyncio.shield(client.shutdown())
+                except (
+                    asyncio.CancelledError,
+                    Exception,
+                ) as cleanup_exc:  # includes cancellation
+                    with self._state_lock:
+                        current = self._entries.get(entry.key)
+                        if current is entry:
+                            entry.client = client
+                            entry.state = "retiring"
+                            entry.pending_eviction = "spawn-cleanup-failed"
+                    logger.warning(
+                        "LSP cancelled spawn cleanup failed for %s: %s",
+                        entry.key,
+                        cleanup_exc,
+                    )
             raise
         except Exception as exc:  # noqa: BLE001
             eventlog.log_spawn_failed(srv.server_id, entry.workspace_root, exc)
@@ -1166,7 +1191,20 @@ class LSPService:
                 else:
                     self._broken.add(entry.key)
             if client is not None:
-                await client.shutdown()
+                try:
+                    await client.shutdown()
+                except (asyncio.CancelledError, Exception) as cleanup_exc:
+                    with self._state_lock:
+                        current = self._entries.get(entry.key)
+                        if current is entry:
+                            entry.client = client
+                            entry.state = "retiring"
+                            entry.pending_eviction = "spawn-cleanup-failed"
+                    logger.warning(
+                        "LSP failed-spawn cleanup failed for %s: %s",
+                        entry.key,
+                        cleanup_exc,
+                    )
             return None
         finally:
             with self._state_lock:

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -33,6 +33,7 @@ servers are missing binaries and auto-install is off, ``is_active``
 returns False and the file_operations layer falls through to the
 in-process syntax check.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -83,6 +84,7 @@ class _ClientEntry:
     leases: int = 0
     lease_tasks: set[asyncio.Task[Any]] = field(default_factory=set)
     spawn_task: Optional[asyncio.Task] = None
+    build_task: Optional[asyncio.Task[Any]] = None
     retire_task: Optional[asyncio.Task] = None
     pending_eviction: Optional[str] = None
 
@@ -154,9 +156,7 @@ def _lifecycle_config(
                 or result > maximum
             ):
                 comparator = "greater than zero" if positive else "non-negative"
-                raise ValueError(
-                    f"{name} must be {comparator} and at most {maximum:g}"
-                )
+                raise ValueError(f"{name} must be {comparator} and at most {maximum:g}")
             return result
 
         idle_timeout = finite_number(
@@ -231,9 +231,18 @@ class _BackgroundLoop:
             for task in pending:
                 task.cancel()
             if pending:
-                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
             try:
                 loop.run_until_complete(loop.shutdown_asyncgens())
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                # Cancelling an ``asyncio.to_thread`` awaiter does not stop its
+                # worker. Do not declare the owner loop dead while binary
+                # discovery/install work is still running in its executor.
+                loop.run_until_complete(loop.shutdown_default_executor())
             except Exception:  # noqa: BLE001
                 pass
             self._thread_id = None
@@ -248,6 +257,7 @@ class _BackgroundLoop:
         Returns the coroutine's result, or raises its exception.
         """
         from agent.async_utils import safe_schedule_threadsafe
+
         if self.is_owner_thread():
             if asyncio.iscoroutine(coro):
                 coro.close()
@@ -366,6 +376,7 @@ class LSPService:
         """
         try:
             from hermes_cli.config import load_config
+
             cfg = load_config()
         except Exception as e:  # noqa: BLE001
             logger.debug("LSP config load failed: %s", e)
@@ -430,7 +441,9 @@ class LSPService:
 
     async def _initialize_async_state(self) -> None:
         self._admission_lock = asyncio.Lock()
-        if self._lifecycle_enabled and (self._idle_timeout > 0 or self._max_clients > 0):
+        if self._lifecycle_enabled and (
+            self._idle_timeout > 0 or self._max_clients > 0
+        ):
             self._reaper_task = asyncio.create_task(
                 self._reaper_loop(), name="hermes-lsp-reaper"
             )
@@ -532,7 +545,9 @@ class LSPService:
                     self._reap_count += 1
                 elif terminated and reason == "capacity":
                     self._capacity_eviction_count += 1
-            level = logging.WARNING if error is not None or not terminated else logging.INFO
+            level = (
+                logging.WARNING if error is not None or not terminated else logging.INFO
+            )
             logger.log(
                 level,
                 "LSP lifecycle retired server=%s root=%s generation=%s "
@@ -805,6 +820,7 @@ class LSPService:
                     # that mapped into a deleted region drop out
                     # silently — they no longer apply.
                     from agent.lsp.range_shift import shift_baseline
+
                     baseline = shift_baseline(baseline, line_shift)
                 seen = {_diag_key(d) for d in baseline}
                 diags = [d for d in diags if _diag_key(d) not in seen]
@@ -812,7 +828,10 @@ class LSPService:
             # to the just-emitted state, mirroring claude-code's
             # diagnosticTracking.
             try:
-                fresh = self._loop.run(self._current_diags_async(file_path), timeout=2.0) or []
+                fresh = (
+                    self._loop.run(self._current_diags_async(file_path), timeout=2.0)
+                    or []
+                )
             except Exception:  # noqa: BLE001
                 fresh = []
             if fresh:
@@ -843,9 +862,7 @@ class LSPService:
                 first_failure = key not in self._broken
                 self._broken.add(key)
         try:
-            self._loop.run(
-                self._retire_key_async(key, "request-failure"), timeout=3.0
-            )
+            self._loop.run(self._retire_key_async(key, "request-failure"), timeout=3.0)
         except Exception as cleanup_exc:  # noqa: BLE001
             logger.debug("LSP failed-generation cleanup for %s: %s", key, cleanup_exc)
         if first_failure:
@@ -994,9 +1011,7 @@ class LSPService:
                         return None
 
             if wait_task is not None:
-                await asyncio.gather(
-                    asyncio.shield(wait_task), return_exceptions=True
-                )
+                await asyncio.gather(asyncio.shield(wait_task), return_exceptions=True)
                 continue
             if not spawn:
                 return None
@@ -1045,9 +1060,7 @@ class LSPService:
                                 existing.client,
                                 owner,
                             )
-                        wait_task = self._begin_retirement_locked(
-                            existing, "crashed"
-                        )
+                        wait_task = self._begin_retirement_locked(existing, "crashed")
                         if wait_task is None:
                             return None
                     elif existing is not None and existing.state == "spawning":
@@ -1131,9 +1144,7 @@ class LSPService:
                     entry.client = target
                     entry.state = "retiring"
                     entry.pending_eviction = "spawn-cleanup-failed"
-            logger.warning(
-                "LSP spawn cleanup incomplete for %s: %s", entry.key, detail
-            )
+            logger.warning("LSP spawn cleanup incomplete for %s: %s", entry.key, detail)
 
         try:
             ctx = ServerContext(
@@ -1143,7 +1154,19 @@ class LSPService:
                 env_overrides=self._env_overrides,
                 init_overrides=self._init_overrides,
             )
-            spec = await asyncio.to_thread(srv.build_spawn, entry.workspace_root, ctx)
+            build_task = asyncio.create_task(
+                asyncio.to_thread(srv.build_spawn, entry.workspace_root, ctx),
+                name=f"hermes-lsp-build-{entry.generation}",
+            )
+            with self._state_lock:
+                current = self._entries.get(entry.key)
+                if current is entry:
+                    entry.build_task = build_task
+            spec = await asyncio.shield(build_task)
+            with self._state_lock:
+                current = self._entries.get(entry.key)
+                if current is entry:
+                    entry.build_task = None
             if spec is None:
                 eventlog.log_server_unavailable(srv.server_id, srv.server_id)
                 with self._state_lock:
@@ -1239,6 +1262,11 @@ class LSPService:
                 for entry in self._entries.values()
                 if entry.spawn_task is not None and not entry.spawn_task.done()
             ]
+            build_tasks = [
+                entry.build_task
+                for entry in self._entries.values()
+                if entry.build_task is not None and not entry.build_task.done()
+            ]
             maintenance = [
                 task
                 for task in self._maintenance_tasks
@@ -1247,13 +1275,18 @@ class LSPService:
         for task in spawn_tasks + maintenance:
             task.cancel()
         if spawn_tasks or maintenance:
+            await asyncio.gather(*(spawn_tasks + maintenance), return_exceptions=True)
+        if build_tasks:
+            # ``build_spawn`` runs in the default executor. Cancelling its
+            # spawn awaiter cannot stop discovery or an auto-install already
+            # running in the worker thread. Await that separately tracked work
+            # before closing so a replacement singleton cannot overlap it.
             await asyncio.gather(
-                *(spawn_tasks + maintenance), return_exceptions=True
+                *(asyncio.shield(task) for task in build_tasks),
+                return_exceptions=True,
             )
 
-        deadline = (
-            asyncio.get_running_loop().time() + SHUTDOWN_LEASE_DRAIN_TIMEOUT
-        )
+        deadline = asyncio.get_running_loop().time() + SHUTDOWN_LEASE_DRAIN_TIMEOUT
         while True:
             with self._state_lock:
                 leased = sum(entry.leases for entry in self._entries.values())
@@ -1399,15 +1432,13 @@ def _diag_key(d: Dict[str, Any]) -> str:
     code = d.get("code")
     if code is not None and not isinstance(code, str):
         code = str(code)
-    return "\x00".join(
-        [
-            str(d.get("severity") or 1),
-            str(code or ""),
-            str(d.get("source") or ""),
-            str(d.get("message") or "").strip(),
-            f"{start.get('line', 0)}:{start.get('character', 0)}-{end.get('line', 0)}:{end.get('character', 0)}",
-        ]
-    )
+    return "\x00".join([
+        str(d.get("severity") or 1),
+        str(code or ""),
+        str(d.get("source") or ""),
+        str(d.get("message") or "").strip(),
+        f"{start.get('line', 0)}:{start.get('character', 0)}-{end.get('line', 0)}:{end.get('character', 0)}",
+    ])
 
 
 __all__ = ["LSPService"]

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -14,9 +14,9 @@ Design choices:
   the first request for a key spawns the client; subsequent requests
   re-use it.
 
-- A **broken-set** records ``(server_id, workspace_root)`` pairs that
-  failed to spawn or initialize.  These are never retried for the
-  life of the service.  Mirrors OpenCode's design.
+- A **broken-set** records deterministic ``(server_id, workspace_root)``
+  failures such as an unavailable spawn command. Transient startup/request
+  failures use a short monotonic cooldown so the service can recover.
 
 - A **delta baseline** map keeps "diagnostics-as-of-the-last-snapshot"
   per file.  ``snapshot_baseline()`` is called BEFORE a write; the
@@ -35,11 +35,14 @@ in-process syntax check.
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 import logging
+import math
 import os
 import threading
 import time
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Tuple
 
 from agent.lsp import eventlog
 from agent.lsp.client import (
@@ -58,7 +61,104 @@ from agent.lsp.workspace import (
 
 logger = logging.getLogger("agent.lsp.manager")
 
-DEFAULT_IDLE_TIMEOUT = 600  # seconds; servers idle for >10min get reaped
+DEFAULT_IDLE_TIMEOUT = 7200.0
+DEFAULT_SWEEP_INTERVAL = 60.0
+MAX_IDLE_TIMEOUT = 365 * 24 * 60 * 60
+MAX_SWEEP_INTERVAL = 24 * 60 * 60
+MAX_CLIENTS_PER_PROCESS = 64
+
+
+@dataclass
+class _ClientEntry:
+    """One generation of one canonical ``(server, workspace)`` client."""
+
+    key: Tuple[str, str]
+    generation: int
+    workspace_root: str
+    state: str
+    last_used: float
+    client: Optional[LSPClient] = None
+    leases: int = 0
+    spawn_task: Optional[asyncio.Task] = None
+    retire_task: Optional[asyncio.Task] = None
+    pending_eviction: Optional[str] = None
+
+
+@dataclass
+class _ClientLease:
+    """Generation-bound token that protects a client from retirement."""
+
+    service: "LSPService"
+    key: Tuple[str, str]
+    generation: int
+    client: LSPClient
+    released: bool = False
+
+    def release(self) -> None:
+        if self.released:
+            return
+        self.released = True
+        self.service._release_lease(self)
+
+
+def _lifecycle_config(lsp_cfg: Dict[str, Any]) -> Tuple[bool, float, float, int]:
+    """Parse opt-in bounded lifecycle settings without truthy coercion.
+
+    Invalid lifecycle configuration falls back to legacy process-lifetime
+    retention.  A malformed resource policy must never disable LSP itself.
+    """
+
+    raw = lsp_cfg.get("lifecycle")
+    defaults = (False, DEFAULT_IDLE_TIMEOUT, DEFAULT_SWEEP_INTERVAL, 0)
+    if raw is None:
+        return defaults
+    if not isinstance(raw, dict):
+        logger.warning("lsp.lifecycle must be a mapping; lifecycle remains disabled")
+        return defaults
+
+    enabled = raw.get("enabled", False)
+    if not isinstance(enabled, bool):
+        logger.warning("lsp.lifecycle.enabled must be true or false; lifecycle remains disabled")
+        return defaults
+
+    def finite_number(name: str, default: float, *, positive: bool, maximum: float) -> float:
+        value = raw.get(name, default)
+        valid_type = isinstance(value, (int, float)) and not isinstance(value, bool)
+        if not valid_type or not math.isfinite(float(value)):
+            raise ValueError(f"{name} must be a finite number")
+        result = float(value)
+        if (positive and result <= 0) or (not positive and result < 0) or result > maximum:
+            comparator = "greater than zero" if positive else "non-negative"
+            raise ValueError(f"{name} must be {comparator} and at most {maximum:g}")
+        return result
+
+    try:
+        idle_timeout = finite_number(
+            "idle_timeout_seconds",
+            DEFAULT_IDLE_TIMEOUT,
+            positive=False,
+            maximum=MAX_IDLE_TIMEOUT,
+        )
+        sweep_interval = finite_number(
+            "sweep_interval_seconds",
+            DEFAULT_SWEEP_INTERVAL,
+            positive=True,
+            maximum=MAX_SWEEP_INTERVAL,
+        )
+        max_clients = raw.get("max_clients_per_process", 0)
+        if (
+            not isinstance(max_clients, int)
+            or isinstance(max_clients, bool)
+            or not 0 <= max_clients <= MAX_CLIENTS_PER_PROCESS
+        ):
+            raise ValueError(
+                "max_clients_per_process must be an integer between "
+                f"0 and {MAX_CLIENTS_PER_PROCESS}"
+            )
+    except (TypeError, ValueError) as exc:
+        logger.warning("invalid lsp.lifecycle configuration (%s); lifecycle remains disabled", exc)
+        return defaults
+    return enabled, idle_timeout, sweep_interval, max_clients
 
 
 class _BackgroundLoop:
@@ -154,7 +254,11 @@ class LSPService:
         env_overrides: Optional[Dict[str, Dict[str, str]]] = None,
         init_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
         disabled_servers: Optional[List[str]] = None,
+        lifecycle_enabled: bool = False,
         idle_timeout: float = DEFAULT_IDLE_TIMEOUT,
+        sweep_interval: float = DEFAULT_SWEEP_INTERVAL,
+        max_clients: int = 0,
+        clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self._enabled = enabled
         self._wait_mode = wait_mode if wait_mode in {"document", "full"} else "document"
@@ -164,32 +268,37 @@ class LSPService:
         self._env_overrides = env_overrides or {}
         self._init_overrides = init_overrides or {}
         self._disabled_servers = set(disabled_servers or [])
+        self._lifecycle_enabled = lifecycle_enabled
         self._idle_timeout = idle_timeout
+        self._sweep_interval = sweep_interval
+        self._max_clients = max_clients
+        self._clock = clock
 
-        self._loop = _BackgroundLoop()
-        if self._enabled:
-            self._loop.start()
-
-        # Per-(server_id, workspace_root) state
-        self._clients: Dict[Tuple[str, str], LSPClient] = {}
+        # All registry transitions are guarded by this lock. Async spawn and
+        # retirement work always happens after releasing it.
+        self._state_lock = threading.RLock()
+        self._service_state = "open"
+        self._entries: Dict[Tuple[str, str], _ClientEntry] = {}
         self._broken: set = set()
-        self._spawning: Dict[Tuple[str, str], asyncio.Future] = {}
-        self._last_used: Dict[Tuple[str, str], float] = {}
-        self._state_lock = threading.Lock()
+        self._cooldowns: Dict[Tuple[str, str], float] = {}
+        self._next_generation = 0
+        self._admission_lock: Optional[asyncio.Lock] = None
+        self._reaper_task: Optional[asyncio.Task] = None
+        self._maintenance_tasks: set[asyncio.Task] = set()
+        self._reap_count = 0
+        self._capacity_eviction_count = 0
+        self._overflow_count = 0
 
         # Delta baseline: file path → snapshot of diagnostics taken
-        # immediately before a write.  ``get_diagnostics_sync`` filters
+        # immediately before a write. ``get_diagnostics_sync`` filters
         # out anything in the baseline so the agent only sees errors
         # introduced by the current edit.
         self._delta_baseline: Dict[str, List[Dict[str, Any]]] = {}
 
-        # Idle reaper — periodically shuts down clients that haven't
-        # been used for longer than ``_idle_timeout`` seconds.  Without
-        # this, language-server processes accumulate indefinitely in
-        # long-running gateways (one per unique workspace_root).
-        self._reaper_task: Optional[asyncio.Task] = None
-        if self._enabled and self._idle_timeout > 0:
-            self._start_reaper()
+        self._loop = _BackgroundLoop()
+        if self._enabled:
+            self._loop.start()
+            self._loop.run(self._initialize_async_state(), timeout=2.0)
 
     @classmethod
     def create_from_config(cls) -> Optional["LSPService"]:
@@ -234,6 +343,8 @@ class LSPService:
                 if isinstance(init, dict):
                     init_overrides[name] = init
 
+        lifecycle_enabled, idle_timeout, sweep_interval, max_clients = _lifecycle_config(lsp_cfg)
+
         return cls(
             enabled=enabled,
             wait_mode=wait_mode,
@@ -243,60 +354,227 @@ class LSPService:
             env_overrides=env_overrides,
             init_overrides=init_overrides,
             disabled_servers=disabled,
+            lifecycle_enabled=lifecycle_enabled,
+            idle_timeout=idle_timeout,
+            sweep_interval=sweep_interval,
+            max_clients=max_clients,
         )
 
     # ------------------------------------------------------------------
-    # idle reaper
+    # bounded client lifecycle
     # ------------------------------------------------------------------
 
-    def _start_reaper(self) -> None:
-        """Schedule the idle-reaper coroutine on the background loop."""
-        if self._loop._loop is None:
-            return
-        self._reaper_task = asyncio.run_coroutine_threadsafe(
-            self._reaper_loop(), self._loop._loop
-        )
+    async def _initialize_async_state(self) -> None:
+        self._admission_lock = asyncio.Lock()
+        if self._lifecycle_enabled and (self._idle_timeout > 0 or self._max_clients > 0):
+            self._reaper_task = asyncio.create_task(
+                self._reaper_loop(), name="hermes-lsp-reaper"
+            )
 
     async def _reaper_loop(self) -> None:
-        """Periodically reap language-server clients that have been
-        idle for longer than ``_idle_timeout`` seconds.
-
-        Runs every ``min(_idle_timeout / 2, 60)`` seconds — frequent
-        enough to clean up promptly, infrequent enough to be cheap.
-        """
-        interval = max(30.0, min(self._idle_timeout / 2, 60.0))
-        try:
-            while True:
-                await asyncio.sleep(interval)
+        """Sweep forever, but survive an individual sweep failure."""
+        while True:
+            await asyncio.sleep(self._sweep_interval)
+            try:
                 await self._reap_idle_clients()
-        except asyncio.CancelledError:
-            return
+                await self._converge_capacity()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("LSP lifecycle sweep failed; continuing: %s", exc)
 
     async def _reap_idle_clients(self) -> None:
-        """Shut down clients that have been idle past the timeout."""
-        now = time.time()
-        to_reap: List[Tuple[Tuple[str, str], LSPClient]] = []
-        with self._state_lock:
-            for key, client in list(self._clients.items()):
-                last = self._last_used.get(key, 0.0)
-                if now - last > self._idle_timeout:
-                    to_reap.append((key, client))
-                    self._clients.pop(key, None)
-                    self._last_used.pop(key, None)
-        if not to_reap:
+        """Retire idle, unleased generations using monotonic age."""
+        if not self._lifecycle_enabled or self._idle_timeout <= 0:
             return
-        logger.info(
-            "LSP idle reaper: shutting down %d client(s) idle >%ss",
-            len(to_reap), self._idle_timeout,
-        )
-        for key, client in to_reap:
-            logger.debug(
-                "  reaping %s (workspace=%s)", key[0], key[1],
+        now = self._clock()
+        retire_tasks: List[asyncio.Task] = []
+        with self._state_lock:
+            if self._service_state != "open":
+                return
+            for entry in list(self._entries.values()):
+                if (
+                    entry.state == "active"
+                    and entry.leases == 0
+                    and now - entry.last_used >= self._idle_timeout
+                ):
+                    task = self._begin_retirement_locked(entry, "idle")
+                    if task is not None:
+                        retire_tasks.append(task)
+        if retire_tasks:
+            await asyncio.gather(
+                *(asyncio.shield(task) for task in retire_tasks),
+                return_exceptions=True,
             )
-            try:
+
+    def _begin_retirement_locked(
+        self, entry: _ClientEntry, reason: str
+    ) -> Optional[asyncio.Task]:
+        """Publish RETIRING atomically; perform shutdown outside the lock."""
+        if entry.state == "retiring":
+            return entry.retire_task
+        if entry.state != "active" or entry.client is None:
+            return None
+        if entry.leases:
+            entry.pending_eviction = reason
+            return None
+        entry.state = "retiring"
+        entry.pending_eviction = reason
+        task = asyncio.create_task(
+            self._retire_entry(entry, reason),
+            name=f"hermes-lsp-retire-{entry.generation}",
+        )
+        entry.retire_task = task
+        return task
+
+    async def _retire_entry(self, entry: _ClientEntry, reason: str) -> None:
+        """Completion-idempotent retirement for one concrete generation."""
+        client = entry.client
+        error: Optional[BaseException] = None
+        try:
+            if client is not None:
                 await client.shutdown()
-            except Exception:  # noqa: BLE001
-                pass
+        except BaseException as exc:  # noqa: BLE001
+            error = exc
+            if isinstance(exc, asyncio.CancelledError):
+                raise
+        finally:
+            with self._state_lock:
+                current = self._entries.get(entry.key)
+                if current is entry:
+                    self._entries.pop(entry.key, None)
+                if reason == "idle":
+                    self._reap_count += 1
+                elif reason == "capacity":
+                    self._capacity_eviction_count += 1
+            level = logging.WARNING if error is not None else logging.INFO
+            logger.log(
+                level,
+                "LSP lifecycle retired server=%s root=%s generation=%s "
+                "reason=%s outcome=%s",
+                entry.key[0],
+                entry.workspace_root,
+                entry.generation,
+                reason,
+                "error" if error is not None else "clean",
+            )
+
+    async def _retire_key_async(self, key: Tuple[str, str], reason: str) -> bool:
+        """Request retirement without interrupting an active lease."""
+        wait_task: Optional[asyncio.Task] = None
+        with self._state_lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return True
+            if entry.state == "spawning":
+                wait_task = entry.spawn_task
+                if wait_task is not None:
+                    wait_task.cancel()
+            elif entry.state == "retiring":
+                wait_task = entry.retire_task
+            else:
+                wait_task = self._begin_retirement_locked(entry, reason)
+                if wait_task is None:
+                    return False
+        if wait_task is not None:
+            await asyncio.gather(asyncio.shield(wait_task), return_exceptions=True)
+        return True
+
+    def _release_lease(self, lease: _ClientLease) -> None:
+        retire_task: Optional[asyncio.Task] = None
+        should_converge = False
+        with self._state_lock:
+            entry = self._entries.get(lease.key)
+            if entry is None or entry.generation != lease.generation:
+                return
+            if entry.leases <= 0:
+                logger.warning(
+                    "LSP lifecycle lease underflow prevented for generation=%s",
+                    lease.generation,
+                )
+                return
+            entry.leases -= 1
+            entry.last_used = self._clock()
+            if entry.leases == 0 and entry.pending_eviction:
+                retire_task = self._begin_retirement_locked(
+                    entry, entry.pending_eviction
+                )
+            should_converge = (
+                self._lifecycle_enabled
+                and self._max_clients > 0
+                and len(self._entries) > self._max_clients
+            )
+        if retire_task is not None:
+            self._track_maintenance(retire_task)
+        if should_converge:
+            self._track_maintenance(
+                asyncio.create_task(
+                    self._converge_capacity(), name="hermes-lsp-capacity-converge"
+                )
+            )
+
+    def _track_maintenance(self, task: asyncio.Task) -> None:
+        self._maintenance_tasks.add(task)
+        task.add_done_callback(self._maintenance_tasks.discard)
+
+    def _select_lru_victim_locked(self) -> Optional[_ClientEntry]:
+        candidates = [
+            entry
+            for entry in self._entries.values()
+            if entry.state == "active" and entry.leases == 0
+        ]
+        return min(candidates, key=lambda entry: entry.last_used, default=None)
+
+    async def _converge_capacity(self) -> None:
+        if not self._lifecycle_enabled or self._max_clients <= 0:
+            return
+        admission_lock = self._admission_lock
+        if admission_lock is None:
+            return
+        async with admission_lock:
+            while True:
+                with self._state_lock:
+                    if (
+                        self._service_state != "open"
+                        or len(self._entries) <= self._max_clients
+                    ):
+                        return
+                    victim = self._select_lru_victim_locked()
+                    if victim is None:
+                        return
+                    retire_task = self._begin_retirement_locked(victim, "capacity")
+                if retire_task is None:
+                    return
+                await asyncio.gather(
+                    asyncio.shield(retire_task), return_exceptions=True
+                )
+
+    def _resolve_target(
+        self, file_path: str, *, log_miss: bool = False
+    ) -> Optional[Tuple[Any, Tuple[str, str], str]]:
+        """Resolve one canonical registry key while preserving the LSP root."""
+        srv = find_server_for_file(file_path)
+        if srv is None or srv.server_id in self._disabled_servers:
+            return None
+        ws_root, gated = resolve_workspace_for_file(file_path)
+        if not (ws_root and gated):
+            if log_miss:
+                eventlog.log_no_project_root(srv.server_id, file_path)
+            return None
+        try:
+            per_server_root = srv.resolve_root(file_path, ws_root)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("LSP root resolution failed for %s: %s", file_path, exc)
+            return None
+        if per_server_root is None:
+            if log_miss:
+                eventlog.log_disabled(
+                    srv.server_id, file_path, "exclude marker hit (server gated off)"
+                )
+            return None
+        workspace_root = os.path.abspath(per_server_root)
+        canonical_root = os.path.normcase(os.path.realpath(workspace_root))
+        return srv, (srv.server_id, canonical_root), workspace_root
 
     # ------------------------------------------------------------------
     # public API
@@ -304,39 +582,36 @@ class LSPService:
 
     def is_active(self) -> bool:
         """Return True iff this service should be consulted at all."""
-        return self._enabled
+        return self._enabled and self.is_accepting_requests()
+
+    def is_accepting_requests(self) -> bool:
+        with self._state_lock:
+            return self._service_state == "open"
+
+    def begin_shutdown(self) -> bool:
+        """Publish CLOSING synchronously before shutdown enters the loop."""
+        with self._state_lock:
+            if self._service_state != "open":
+                return False
+            self._service_state = "closing"
+            return True
 
     def enabled_for(self, file_path: str) -> bool:
-        """Return True iff LSP should run for this specific file.
-
-        Gates on workspace detection (file or cwd inside a git worktree),
-        on whether any registered server matches the extension, and
-        on whether the (server_id, workspace_root) pair is in the
-        broken-set from a previous spawn failure.
-
-        Files in already-broken pairs return False so the file_operations
-        layer skips the LSP path entirely — no spawn attempts, no
-        timeout cost — until the service is restarted (``hermes lsp
-        restart``) or the process exits.
-        """
-        if not self._enabled:
+        """Return True when this file has an admissible LSP target."""
+        if not self._enabled or not self.is_accepting_requests():
             return False
-        srv = find_server_for_file(file_path)
-        if srv is None or srv.server_id in self._disabled_servers:
+        target = self._resolve_target(file_path)
+        if target is None:
             return False
-        ws_root, gated_in = resolve_workspace_for_file(file_path)
-        if not (ws_root and gated_in):
-            return False
-        # Broken-set short-circuit.  Use the per-server root if we can
-        # compute one cheaply; otherwise fall back to the workspace
-        # root as the broken key (which is what _get_or_spawn would
-        # have used anyway when it failed).
-        try:
-            per_server_root = srv.resolve_root(file_path, ws_root) or ws_root
-        except Exception:  # noqa: BLE001
-            per_server_root = ws_root
-        if (srv.server_id, per_server_root) in self._broken:
-            return False
+        _, key, _ = target
+        with self._state_lock:
+            if key in self._broken:
+                return False
+            retry_after = self._cooldowns.get(key)
+            if retry_after is not None:
+                if self._clock() < retry_after:
+                    return False
+                self._cooldowns.pop(key, None)
         return True
 
     def snapshot_baseline(self, file_path: str) -> None:
@@ -346,9 +621,9 @@ class LSPService:
         can filter out pre-existing errors.  Best-effort — failures
         are silently swallowed so a flaky server can't break a write.
 
-        Outer timeouts (e.g. server hangs during initialize) mark the
-        (server_id, workspace_root) pair as broken so subsequent edits
-        skip it instantly instead of re-paying the timeout cost.
+        Outer failures retire the affected generation and apply a short
+        monotonic cooldown so subsequent edits skip it briefly instead of
+        re-paying the timeout or permanently disabling the workspace.
         """
         if not self.enabled_for(file_path):
             return
@@ -459,182 +734,274 @@ class LSPService:
         return diags
 
     def _mark_broken_for_file(self, file_path: str, exc: BaseException) -> None:
-        """Mark the (server_id, workspace_root) pair as broken so subsequent
-        edits skip it instantly instead of re-paying timeout cost.
+        """Retire a timed-out generation and apply a short retry cooldown.
 
-        Called when the outer ``_loop.run`` timeout cancels an in-flight
-        spawn/initialize that the inner ``_get_or_spawn`` task was still
-        holding open.  Without this, every subsequent write would re-enter
-        the spawn path and re-pay the full ``snapshot_baseline``
-        timeout (8s) until the binary is fixed.
-
-        Also kills any orphan client process that survived the cancelled
-        future, and emits a single eventlog WARNING so the user knows
-        which server gave up.
-
-        ``exc`` is whatever exception the outer wrapper caught — used
-        only for logging, never re-raised.
+        Request and cold-index timeouts are transient. They must not poison a
+        healthy server/workspace pair for the remainder of the process.
         """
-        srv = find_server_for_file(file_path)
-        if srv is None:
+        target = self._resolve_target(file_path)
+        if target is None:
             return
-        ws_root, gated = resolve_workspace_for_file(file_path)
-        if not (ws_root and gated):
-            return
-        try:
-            per_server_root = srv.resolve_root(file_path, ws_root) or ws_root
-        except Exception:  # noqa: BLE001
-            per_server_root = ws_root
-        key = (srv.server_id, per_server_root)
-        already_broken = key in self._broken
-        self._broken.add(key)
-
-        # Kill any client we managed to spawn before the timeout.  The
-        # cancelled future never reached the broken-set add inside
-        # ``_get_or_spawn`` so the client may still be hanging in
-        # ``_clients`` with a half-initialized state.
+        srv, key, workspace_root = target
         with self._state_lock:
-            client = self._clients.pop(key, None)
-        if client is not None:
-            try:
-                # Fire-and-forget shutdown — give it a second to cleanup,
-                # but don't block.  We're already on a slow path.
-                self._loop.run(client.shutdown(), timeout=1.0)
-            except Exception:  # noqa: BLE001
-                pass
-
-        if not already_broken:
-            eventlog.log_spawn_failed(srv.server_id, per_server_root, exc)
+            first_failure = key not in self._cooldowns
+            self._cooldowns[key] = self._clock() + 5.0
+        try:
+            self._loop.run(
+                self._retire_key_async(key, "request-failure"), timeout=3.0
+            )
+        except Exception as cleanup_exc:  # noqa: BLE001
+            logger.debug("LSP failed-generation cleanup for %s: %s", key, cleanup_exc)
+        if first_failure:
+            eventlog.log_spawn_failed(srv.server_id, workspace_root, exc)
 
     def shutdown(self) -> None:
-        """Tear down all clients and stop the background loop."""
+        """Close admission, drain lifecycle work, and stop the loop."""
         if not self._enabled:
+            with self._state_lock:
+                self._service_state = "closed"
             return
-        # Cancel the idle reaper before shutting down clients.
-        if self._reaper_task is not None:
-            self._reaper_task.cancel()
-            self._reaper_task = None
+        self.begin_shutdown()
         try:
-            self._loop.run(self._shutdown_async(), timeout=10.0)
-        except Exception as e:  # noqa: BLE001
-            logger.debug("LSP shutdown error: %s", e)
-        self._loop.stop()
-        clear_cache()
+            self._loop.run(self._shutdown_async(), timeout=15.0)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("LSP shutdown did not complete cleanly: %s", exc)
+        finally:
+            self._loop.stop()
+            with self._state_lock:
+                self._service_state = "closed"
+            clear_cache()
 
     # ------------------------------------------------------------------
     # async internals
     # ------------------------------------------------------------------
 
+    @asynccontextmanager
+    async def _leased_client(
+        self, file_path: str, *, spawn: bool = True
+    ) -> AsyncIterator[Optional[LSPClient]]:
+        lease = await self._acquire_lease(file_path, spawn=spawn)
+        try:
+            yield lease.client if lease is not None else None
+        finally:
+            if lease is not None:
+                lease.release()
+
     async def _snapshot_async(self, file_path: str) -> List[Dict[str, Any]]:
-        client = await self._get_or_spawn(file_path)
-        if client is None:
-            return []
-        try:
-            version = await client.open_file(file_path, language_id=language_id_for(file_path))
-            fresh = await client.wait_for_diagnostics(file_path, version, mode=self._wait_mode)
-        except Exception as e:  # noqa: BLE001
-            logger.debug("snapshot open/wait failed: %s", e)
-            return []
-        self._last_used[(client.server_id, client.workspace_root)] = time.time()
-        if not fresh:
-            # No fresh data for the pre-edit content — an empty baseline
-            # is safe: worst case the delta filter removes less, never
-            # more.  Never seed the baseline from stale stores.
-            return []
-        return list(client.diagnostics_for(file_path, fresh_only=True))
+        async with self._leased_client(file_path) as client:
+            if client is None:
+                return []
+            try:
+                version = await client.open_file(
+                    file_path, language_id=language_id_for(file_path)
+                )
+                fresh = await client.wait_for_diagnostics(
+                    file_path, version, mode=self._wait_mode
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("snapshot open/wait failed: %s", exc)
+                return []
+            if not fresh:
+                # Never seed the delta baseline from stale diagnostics.
+                return []
+            return list(client.diagnostics_for(file_path, fresh_only=True))
 
-    async def _open_and_wait_async(self, file_path: str) -> Optional[List[Dict[str, Any]]]:
-        """Open + wait for FRESH diagnostics.
+    async def _open_and_wait_async(
+        self, file_path: str
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Open + wait for fresh diagnostics while holding a lifecycle lease.
 
-        Returns the fresh diagnostic list, or ``None`` when the server
-        never produced post-change data within the wait budget.  The
-        distinction matters: ``[]`` means "server checked the new
-        content, it's clean", ``None`` means "no verdict" — the caller
-        must not substitute stale data for either.
+        ``[]`` means the server checked the current content and found it clean;
+        ``None`` means no fresh verdict arrived within the wait budget.
         """
-        client = await self._get_or_spawn(file_path)
-        if client is None:
-            return None
-        try:
-            version = await client.open_file(file_path, language_id=language_id_for(file_path))
-            await client.save_file(file_path)
-            fresh = await client.wait_for_diagnostics(
-                file_path, version, mode=self._wait_mode, timeout=self._wait_timeout
-            )
-        except Exception as e:  # noqa: BLE001
-            logger.debug("open/wait failed for %s: %s", file_path, e)
-            return None
-        self._last_used[(client.server_id, client.workspace_root)] = time.time()
-        if not fresh:
-            return None
-        return list(client.diagnostics_for(file_path, fresh_only=True))
+        async with self._leased_client(file_path) as client:
+            if client is None:
+                return None
+            try:
+                version = await client.open_file(
+                    file_path, language_id=language_id_for(file_path)
+                )
+                await client.save_file(file_path)
+                fresh = await client.wait_for_diagnostics(
+                    file_path,
+                    version,
+                    mode=self._wait_mode,
+                    timeout=self._wait_timeout,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("open/wait failed for %s: %s", file_path, exc)
+                return None
+            if not fresh:
+                return None
+            return list(client.diagnostics_for(file_path, fresh_only=True))
 
     async def _current_diags_async(self, file_path: str) -> List[Dict[str, Any]]:
-        ws, gated = resolve_workspace_for_file(file_path)
-        srv = find_server_for_file(file_path)
-        if not (ws and gated and srv):
-            return []
-        with self._state_lock:
-            client = self._clients.get((srv.server_id, ws))
-        if client is None:
-            return []
-        return list(client.diagnostics_for(file_path, fresh_only=True))
+        async with self._leased_client(file_path, spawn=False) as client:
+            if client is None:
+                return []
+            return list(client.diagnostics_for(file_path, fresh_only=True))
 
-    async def _get_or_spawn(self, file_path: str) -> Optional[LSPClient]:
-        srv = find_server_for_file(file_path)
-        if srv is None:
+    async def _acquire_lease(
+        self, file_path: str, *, spawn: bool
+    ) -> Optional[_ClientLease]:
+        target = self._resolve_target(file_path, log_miss=True)
+        if target is None:
             return None
-        if srv.server_id in self._disabled_servers:
-            eventlog.log_disabled(srv.server_id, file_path, "disabled in config")
-            return None
-        ws_root, gated = resolve_workspace_for_file(file_path)
-        if not (ws_root and gated):
-            eventlog.log_no_project_root(srv.server_id, file_path)
-            return None
-        per_server_root = srv.resolve_root(file_path, ws_root)
-        if per_server_root is None:
-            eventlog.log_disabled(
-                srv.server_id, file_path, "exclude marker hit (server gated off)"
-            )
-            return None  # exclude marker hit, server gated off
+        srv, key, workspace_root = target
 
-        key = (srv.server_id, per_server_root)
-        if key in self._broken:
-            return None
-        with self._state_lock:
-            client = self._clients.get(key)
-            if client is not None and client.is_running:
-                eventlog.log_active(srv.server_id, per_server_root)
-                return client
-            spawning = self._spawning.get(key)
-        if spawning is not None:
-            try:
-                return await spawning
-            except Exception:  # noqa: BLE001
+        while True:
+            wait_task: Optional[asyncio.Task] = None
+            with self._state_lock:
+                if self._service_state != "open" or key in self._broken:
+                    return None
+                retry_after = self._cooldowns.get(key)
+                if retry_after is not None:
+                    if self._clock() < retry_after:
+                        return None
+                    self._cooldowns.pop(key, None)
+                entry = self._entries.get(key)
+                if entry is not None and entry.state == "active":
+                    if entry.client is not None and entry.client.is_running:
+                        entry.leases += 1
+                        entry.last_used = self._clock()
+                        eventlog.log_active(srv.server_id, workspace_root)
+                        return _ClientLease(
+                            self, key, entry.generation, entry.client
+                        )
+                    wait_task = self._begin_retirement_locked(entry, "crashed")
+                    if wait_task is None:
+                        # Another operation still owns this dead generation.
+                        # Its final release will retire it; fall back rather
+                        # than spinning the event loop.
+                        return None
+                elif entry is not None and entry.state == "spawning":
+                    wait_task = entry.spawn_task
+                elif entry is not None and entry.state == "retiring":
+                    wait_task = entry.retire_task
+
+            if wait_task is not None:
+                await asyncio.gather(
+                    asyncio.shield(wait_task), return_exceptions=True
+                )
+                continue
+            if not spawn:
                 return None
+            lease = await self._reserve_spawn(srv, key, workspace_root)
+            if lease is not None:
+                return lease
+            # A concurrent retirement may have completed while admission was
+            # serialized. Re-evaluate canonical state before falling back.
+            with self._state_lock:
+                if self._service_state != "open" or key in self._broken:
+                    return None
+                retry_after = self._cooldowns.get(key)
+                if retry_after is not None and self._clock() < retry_after:
+                    return None
 
-        # Begin spawn
-        loop = asyncio.get_running_loop()
-        spawn_future: asyncio.Future = loop.create_future()
-        with self._state_lock:
-            self._spawning[key] = spawn_future
+    async def _reserve_spawn(
+        self, srv: Any, key: Tuple[str, str], workspace_root: str
+    ) -> Optional[_ClientLease]:
+        """Serialize capacity, retirement, spawn, and the first lease."""
+        admission_lock = self._admission_lock
+        if admission_lock is None:
+            return None
+        async with admission_lock:
+            while True:
+                wait_task: Optional[asyncio.Task] = None
+                with self._state_lock:
+                    if self._service_state != "open" or key in self._broken:
+                        return None
+                    retry_after = self._cooldowns.get(key)
+                    if retry_after is not None:
+                        if self._clock() < retry_after:
+                            return None
+                        self._cooldowns.pop(key, None)
+                    existing = self._entries.get(key)
+                    if existing is not None and existing.state == "active":
+                        if existing.client is not None and existing.client.is_running:
+                            existing.leases += 1
+                            existing.last_used = self._clock()
+                            return _ClientLease(
+                                self, key, existing.generation, existing.client
+                            )
+                        wait_task = self._begin_retirement_locked(
+                            existing, "crashed"
+                        )
+                        if wait_task is None:
+                            return None
+                    elif existing is not None and existing.state == "spawning":
+                        wait_task = existing.spawn_task
+                    elif existing is not None and existing.state == "retiring":
+                        wait_task = existing.retire_task
+                    else:
+                        if (
+                            self._lifecycle_enabled
+                            and self._max_clients > 0
+                            and len(self._entries) >= self._max_clients
+                        ):
+                            victim = self._select_lru_victim_locked()
+                            if victim is not None:
+                                wait_task = self._begin_retirement_locked(
+                                    victim, "capacity"
+                                )
+                            else:
+                                # A cancelled caller may leave its shielded
+                                # spawn running. Count that reservation and
+                                # wait for it (or a retirement) before
+                                # admitting another distinct key. Only fully
+                                # active, fully leased pools may overflow.
+                                wait_task = next(
+                                    (
+                                        item.spawn_task or item.retire_task
+                                        for item in self._entries.values()
+                                        if item.state in {"spawning", "retiring"}
+                                        and (item.spawn_task or item.retire_task)
+                                    ),
+                                    None,
+                                )
+                            if victim is None and wait_task is None:
+                                self._overflow_count += 1
+                                logger.info(
+                                    "LSP lifecycle temporarily over capacity: "
+                                    "all %s client slots are leased",
+                                    self._max_clients,
+                                )
+                        if wait_task is None:
+                            self._next_generation += 1
+                            entry = _ClientEntry(
+                                key=key,
+                                generation=self._next_generation,
+                                workspace_root=workspace_root,
+                                state="spawning",
+                                last_used=self._clock(),
+                            )
+                            wait_task = asyncio.create_task(
+                                self._spawn_entry(entry, srv),
+                                name=f"hermes-lsp-spawn-{entry.generation}",
+                            )
+                            entry.spawn_task = wait_task
+                            self._entries[key] = entry
+                if wait_task is None:
+                    return None
+                await asyncio.gather(
+                    asyncio.shield(wait_task), return_exceptions=True
+                )
+
+    async def _spawn_entry(self, entry: _ClientEntry, srv: Any) -> Optional[LSPClient]:
+        client: Optional[LSPClient] = None
         try:
             ctx = ServerContext(
-                workspace_root=per_server_root,
+                workspace_root=entry.workspace_root,
                 install_strategy=self._install_strategy,
                 binary_overrides=self._binary_overrides,
                 env_overrides=self._env_overrides,
                 init_overrides=self._init_overrides,
             )
-            spec = srv.build_spawn(per_server_root, ctx)
+            spec = srv.build_spawn(entry.workspace_root, ctx)
             if spec is None:
-                # ``build_spawn`` returns None when the binary can't be
-                # located (auto-install disabled, manual-only server,
-                # or install attempt failed).  Surface this once via
-                # the structured logger so the user can act on it.
                 eventlog.log_server_unavailable(srv.server_id, srv.server_id)
-                self._broken.add(key)
-                spawn_future.set_result(None)
+                with self._state_lock:
+                    self._broken.add(entry.key)
                 return None
             client = LSPClient(
                 server_id=srv.server_id,
@@ -643,53 +1010,147 @@ class LSPService:
                 env=spec.env,
                 cwd=spec.cwd,
                 initialization_options=spec.initialization_options,
-                seed_diagnostics_on_first_push=spec.seed_diagnostics_on_first_push or srv.seed_first_push,
+                seed_diagnostics_on_first_push=(
+                    spec.seed_diagnostics_on_first_push or srv.seed_first_push
+                ),
             )
-            try:
-                await client.start()
-            except Exception as e:  # noqa: BLE001
-                eventlog.log_spawn_failed(srv.server_id, per_server_root, e)
-                self._broken.add(key)
-                spawn_future.set_result(None)
-                return None
+            await client.start()
+            publish = False
             with self._state_lock:
-                self._clients[key] = client
-            self._last_used[key] = time.time()
-            eventlog.log_active(srv.server_id, per_server_root)
-            spawn_future.set_result(client)
+                current = self._entries.get(entry.key)
+                if (
+                    current is entry
+                    and entry.state == "spawning"
+                    and self._service_state == "open"
+                ):
+                    entry.client = client
+                    entry.state = "active"
+                    entry.last_used = self._clock()
+                    publish = True
+            if not publish:
+                await client.shutdown()
+                return None
+            eventlog.log_active(srv.server_id, entry.workspace_root)
+            logger.info(
+                "LSP lifecycle spawned server=%s root=%s generation=%s",
+                srv.server_id,
+                entry.workspace_root,
+                entry.generation,
+            )
             return client
+        except asyncio.CancelledError:
+            if client is not None:
+                await asyncio.shield(client.shutdown())
+            raise
+        except BaseException as exc:  # noqa: BLE001
+            eventlog.log_spawn_failed(srv.server_id, entry.workspace_root, exc)
+            with self._state_lock:
+                self._cooldowns[entry.key] = self._clock() + 5.0
+            if client is not None:
+                await client.shutdown()
+            return None
         finally:
             with self._state_lock:
-                self._spawning.pop(key, None)
+                current = self._entries.get(entry.key)
+                if current is entry and entry.state == "spawning":
+                    self._entries.pop(entry.key, None)
 
     async def _shutdown_async(self) -> None:
+        reaper = self._reaper_task
+        self._reaper_task = None
+        if reaper is not None:
+            reaper.cancel()
+            await asyncio.gather(reaper, return_exceptions=True)
+
         with self._state_lock:
-            clients = list(self._clients.values())
-            self._clients.clear()
+            retirement_tasks = {
+                entry.retire_task
+                for entry in self._entries.values()
+                if entry.retire_task is not None
+            }
+            spawn_tasks = [
+                entry.spawn_task
+                for entry in self._entries.values()
+                if entry.spawn_task is not None and not entry.spawn_task.done()
+            ]
+            maintenance = [
+                task
+                for task in self._maintenance_tasks
+                if task not in retirement_tasks and not task.done()
+            ]
+        for task in spawn_tasks + maintenance:
+            task.cancel()
+        if spawn_tasks or maintenance:
+            await asyncio.gather(
+                *(spawn_tasks + maintenance), return_exceptions=True
+            )
+
+        deadline = asyncio.get_running_loop().time() + 5.0
+        while True:
+            with self._state_lock:
+                leased = sum(entry.leases for entry in self._entries.values())
+            if leased == 0 or asyncio.get_running_loop().time() >= deadline:
+                break
+            await asyncio.sleep(0.05)
+        if leased:
+            logger.warning(
+                "LSP shutdown lease drain timed out with %s active lease(s); "
+                "forcing bounded cleanup",
+                leased,
+            )
+
+        retire_tasks: List[asyncio.Task] = []
+        with self._state_lock:
+            for entry in list(self._entries.values()):
+                if entry.state == "retiring" and entry.retire_task is not None:
+                    retire_tasks.append(entry.retire_task)
+                    continue
+                if entry.state == "active":
+                    if entry.leases:
+                        entry.leases = 0
+                    task = self._begin_retirement_locked(entry, "shutdown")
+                    if task is not None:
+                        retire_tasks.append(task)
+        if retire_tasks:
+            await asyncio.gather(
+                *(asyncio.shield(task) for task in retire_tasks),
+                return_exceptions=True,
+            )
+
+        with self._state_lock:
+            self._entries.clear()
             self._broken.clear()
-            self._last_used.clear()
-        await asyncio.gather(
-            *(c.shutdown() for c in clients),
-            return_exceptions=True,
-        )
+            self._cooldowns.clear()
+            self._maintenance_tasks.clear()
+            self._service_state = "closed"
 
     # ------------------------------------------------------------------
     # status / introspection (used by ``hermes lsp status``)
     # ------------------------------------------------------------------
 
     def get_status(self) -> Dict[str, Any]:
-        """Return a snapshot of the service for the CLI status command."""
+        """Return a lifecycle-aware service snapshot for CLI/status JSON."""
+        now = self._clock()
         with self._state_lock:
             clients = [
                 {
-                    "server_id": k[0],
-                    "workspace_root": k[1],
-                    "state": c.state,
-                    "running": c.is_running,
+                    "server_id": entry.key[0],
+                    "workspace_root": entry.workspace_root,
+                    "state": entry.state,
+                    "running": bool(entry.client and entry.client.is_running),
+                    "generation": entry.generation,
+                    "leases": entry.leases,
+                    "idle_seconds": max(0.0, now - entry.last_used),
+                    "eviction_reason": entry.pending_eviction,
                 }
-                for k, c in self._clients.items()
+                for entry in self._entries.values()
             ]
             broken = list(self._broken)
+            counts = {
+                state: sum(entry.state == state for entry in self._entries.values())
+                for state in ("spawning", "active", "retiring")
+            }
+            service_state = self._service_state
         return {
             "enabled": self._enabled,
             "wait_mode": self._wait_mode,
@@ -698,6 +1159,20 @@ class LSPService:
             "clients": clients,
             "broken": broken,
             "disabled_servers": sorted(self._disabled_servers),
+            "lifecycle": {
+                "enabled": self._lifecycle_enabled,
+                "service_state": service_state,
+                "idle_timeout_seconds": self._idle_timeout,
+                "sweep_interval_seconds": self._sweep_interval,
+                "max_clients_per_process": self._max_clients,
+                "reaper_running": bool(
+                    self._reaper_task is not None and not self._reaper_task.done()
+                ),
+                "counts": counts,
+                "reaped": self._reap_count,
+                "capacity_evictions": self._capacity_eviction_count,
+                "temporary_overflows": self._overflow_count,
+            },
         }
 
 

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -978,6 +978,11 @@ class LSPService:
                     wait_task = entry.spawn_task
                 elif entry is not None and entry.state == "retiring":
                     wait_task = entry.retire_task
+                    if wait_task is None:
+                        # A failed retirement is a tombstone. Fall back
+                        # immediately instead of repeatedly asking admission
+                        # to create an unsafe overlapping generation.
+                        return None
 
             if wait_task is not None:
                 await asyncio.gather(

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -15,8 +15,9 @@ Design choices:
   re-use it.
 
 - A **broken-set** records deterministic ``(server_id, workspace_root)``
-  failures such as an unavailable spawn command. Transient startup/request
-  failures use a short monotonic cooldown so the service can recover.
+  failures such as an unavailable spawn command. In opt-in lifecycle mode,
+  transient startup/request failures use a short monotonic cooldown so the
+  service can recover; process-lifetime mode preserves permanent marking.
 
 - A **delta baseline** map keeps "diagnostics-as-of-the-last-snapshot"
   per file.  ``snapshot_baseline()`` is called BEFORE a write; the
@@ -36,7 +37,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 import math
 import os
@@ -66,6 +67,7 @@ DEFAULT_SWEEP_INTERVAL = 60.0
 MAX_IDLE_TIMEOUT = 365 * 24 * 60 * 60
 MAX_SWEEP_INTERVAL = 24 * 60 * 60
 MAX_CLIENTS_PER_PROCESS = 64
+SHUTDOWN_LEASE_DRAIN_TIMEOUT = 5.0
 
 
 @dataclass
@@ -79,6 +81,7 @@ class _ClientEntry:
     last_used: float
     client: Optional[LSPClient] = None
     leases: int = 0
+    lease_tasks: set[asyncio.Task[Any]] = field(default_factory=set)
     spawn_task: Optional[asyncio.Task] = None
     retire_task: Optional[asyncio.Task] = None
     pending_eviction: Optional[str] = None
@@ -92,6 +95,7 @@ class _ClientLease:
     key: Tuple[str, str]
     generation: int
     client: LSPClient
+    owner: Optional[asyncio.Task[Any]] = None
     released: bool = False
 
     def release(self) -> None:
@@ -101,38 +105,59 @@ class _ClientLease:
         self.service._release_lease(self)
 
 
-def _lifecycle_config(lsp_cfg: Dict[str, Any]) -> Tuple[bool, float, float, int]:
-    """Parse opt-in bounded lifecycle settings without truthy coercion.
+def _lifecycle_config(
+    lsp_cfg: Dict[str, Any],
+) -> Tuple[bool, float, float, int, Optional[str]]:
+    """Parse bounded-lifecycle settings and surface invalid policy explicitly.
 
-    Invalid lifecycle configuration falls back to legacy process-lifetime
-    retention.  A malformed resource policy must never disable LSP itself.
+    If an explicitly enabled policy is malformed, safe bounded defaults remain
+    enabled rather than silently reverting to unbounded process-lifetime
+    retention. The validation error is exposed through status.
     """
 
     raw = lsp_cfg.get("lifecycle")
-    defaults = (False, DEFAULT_IDLE_TIMEOUT, DEFAULT_SWEEP_INTERVAL, 0)
+    defaults = (False, DEFAULT_IDLE_TIMEOUT, DEFAULT_SWEEP_INTERVAL, 0, None)
     if raw is None:
         return defaults
     if not isinstance(raw, dict):
-        logger.warning("lsp.lifecycle must be a mapping; lifecycle remains disabled")
-        return defaults
+        error = "lsp.lifecycle must be a mapping"
+        logger.warning(error)
+        return False, DEFAULT_IDLE_TIMEOUT, DEFAULT_SWEEP_INTERVAL, 0, error
 
     enabled = raw.get("enabled", False)
-    if not isinstance(enabled, bool):
-        logger.warning("lsp.lifecycle.enabled must be true or false; lifecycle remains disabled")
-        return defaults
-
-    def finite_number(name: str, default: float, *, positive: bool, maximum: float) -> float:
-        value = raw.get(name, default)
-        valid_type = isinstance(value, (int, float)) and not isinstance(value, bool)
-        if not valid_type or not math.isfinite(float(value)):
-            raise ValueError(f"{name} must be a finite number")
-        result = float(value)
-        if (positive and result <= 0) or (not positive and result < 0) or result > maximum:
-            comparator = "greater than zero" if positive else "non-negative"
-            raise ValueError(f"{name} must be {comparator} and at most {maximum:g}")
-        return result
-
+    enabled_valid = isinstance(enabled, bool)
     try:
+        if not enabled_valid:
+            raise ValueError("enabled must be true or false")
+        allowed = {
+            "enabled",
+            "idle_timeout_seconds",
+            "sweep_interval_seconds",
+            "max_clients_per_process",
+        }
+        unknown = sorted(set(raw) - allowed)
+        if unknown:
+            raise ValueError("unknown key(s): " + ", ".join(unknown))
+
+        def finite_number(
+            name: str, default: float, *, positive: bool, maximum: float
+        ) -> float:
+            value = raw.get(name, default)
+            valid_type = isinstance(value, (int, float)) and not isinstance(value, bool)
+            if not valid_type or not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be a finite number")
+            result = float(value)
+            if (
+                (positive and result <= 0)
+                or (not positive and result < 0)
+                or result > maximum
+            ):
+                comparator = "greater than zero" if positive else "non-negative"
+                raise ValueError(
+                    f"{name} must be {comparator} and at most {maximum:g}"
+                )
+            return result
+
         idle_timeout = finite_number(
             "idle_timeout_seconds",
             DEFAULT_IDLE_TIMEOUT,
@@ -156,9 +181,16 @@ def _lifecycle_config(lsp_cfg: Dict[str, Any]) -> Tuple[bool, float, float, int]
                 f"0 and {MAX_CLIENTS_PER_PROCESS}"
             )
     except (TypeError, ValueError) as exc:
-        logger.warning("invalid lsp.lifecycle configuration (%s); lifecycle remains disabled", exc)
-        return defaults
-    return enabled, idle_timeout, sweep_interval, max_clients
+        error = str(exc)
+        logger.warning("invalid lsp.lifecycle configuration: %s", error)
+        return (
+            bool(enabled) if enabled_valid else False,
+            DEFAULT_IDLE_TIMEOUT,
+            DEFAULT_SWEEP_INTERVAL,
+            0,
+            error,
+        )
+    return enabled, idle_timeout, sweep_interval, max_clients, None
 
 
 class _BackgroundLoop:
@@ -171,6 +203,7 @@ class _BackgroundLoop:
     def __init__(self) -> None:
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._thread: Optional[threading.Thread] = None
+        self._thread_id: Optional[int] = None
         self._ready = threading.Event()
 
     def start(self) -> None:
@@ -187,15 +220,26 @@ class _BackgroundLoop:
     def _run_forever(self) -> None:
         loop = asyncio.new_event_loop()
         self._loop = loop
+        self._thread_id = threading.get_ident()
         asyncio.set_event_loop(loop)
         self._ready.set()
         try:
             loop.run_forever()
         finally:
+            pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
             try:
-                loop.close()
+                loop.run_until_complete(loop.shutdown_asyncgens())
             except Exception:  # noqa: BLE001
                 pass
+            self._thread_id = None
+            loop.close()
+
+    def is_owner_thread(self) -> bool:
+        return self._thread_id == threading.get_ident()
 
     def run(self, coro, *, timeout: Optional[float] = None) -> Any:
         """Submit a coroutine to the loop and block until done.
@@ -203,6 +247,10 @@ class _BackgroundLoop:
         Returns the coroutine's result, or raises its exception.
         """
         from agent.async_utils import safe_schedule_threadsafe
+        if self.is_owner_thread():
+            if asyncio.iscoroutine(coro):
+                coro.close()
+            raise RuntimeError("cannot synchronously wait on the LSP owner loop")
         if self._loop is None:
             if asyncio.iscoroutine(coro):
                 coro.close()
@@ -216,18 +264,24 @@ class _BackgroundLoop:
             fut.cancel()
             raise
 
-    def stop(self) -> None:
+    def stop(self, *, timeout: float = 5.0) -> bool:
         loop = self._loop
         if loop is None:
-            return
+            return True
+        if self.is_owner_thread():
+            raise RuntimeError("the LSP owner loop cannot join itself")
         try:
             loop.call_soon_threadsafe(loop.stop)
         except RuntimeError:
             pass
-        if self._thread is not None:
-            self._thread.join(timeout=2.0)
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=timeout)
+            if thread.is_alive():
+                return False
         self._loop = None
         self._thread = None
+        return True
 
 
 class LSPService:
@@ -258,6 +312,7 @@ class LSPService:
         idle_timeout: float = DEFAULT_IDLE_TIMEOUT,
         sweep_interval: float = DEFAULT_SWEEP_INTERVAL,
         max_clients: int = 0,
+        lifecycle_error: Optional[str] = None,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self._enabled = enabled
@@ -272,6 +327,7 @@ class LSPService:
         self._idle_timeout = idle_timeout
         self._sweep_interval = sweep_interval
         self._max_clients = max_clients
+        self._lifecycle_error = lifecycle_error
         self._clock = clock
 
         # All registry transitions are guarded by this lock. Async spawn and
@@ -343,7 +399,13 @@ class LSPService:
                 if isinstance(init, dict):
                     init_overrides[name] = init
 
-        lifecycle_enabled, idle_timeout, sweep_interval, max_clients = _lifecycle_config(lsp_cfg)
+        (
+            lifecycle_enabled,
+            idle_timeout,
+            sweep_interval,
+            max_clients,
+            lifecycle_error,
+        ) = _lifecycle_config(lsp_cfg)
 
         return cls(
             enabled=enabled,
@@ -358,6 +420,7 @@ class LSPService:
             idle_timeout=idle_timeout,
             sweep_interval=sweep_interval,
             max_clients=max_clients,
+            lifecycle_error=lifecycle_error,
         )
 
     # ------------------------------------------------------------------
@@ -431,23 +494,36 @@ class LSPService:
         """Completion-idempotent retirement for one concrete generation."""
         client = entry.client
         error: Optional[BaseException] = None
+        terminated = client is None
         try:
             if client is not None:
                 await client.shutdown()
+                terminated = not bool(
+                    getattr(client, "process_alive", client.is_running)
+                )
         except BaseException as exc:  # noqa: BLE001
             error = exc
+            terminated = client is None or not bool(
+                getattr(client, "process_alive", client.is_running)
+            )
             if isinstance(exc, asyncio.CancelledError):
                 raise
         finally:
             with self._state_lock:
                 current = self._entries.get(entry.key)
                 if current is entry:
-                    self._entries.pop(entry.key, None)
-                if reason == "idle":
+                    if terminated:
+                        self._entries.pop(entry.key, None)
+                    else:
+                        # Keep a tombstone that blocks replacement until a
+                        # later shutdown retry can confirm process exit.
+                        entry.retire_task = None
+                        entry.pending_eviction = f"{reason}-failed"
+                if terminated and reason == "idle":
                     self._reap_count += 1
-                elif reason == "capacity":
+                elif terminated and reason == "capacity":
                     self._capacity_eviction_count += 1
-            level = logging.WARNING if error is not None else logging.INFO
+            level = logging.WARNING if error is not None or not terminated else logging.INFO
             logger.log(
                 level,
                 "LSP lifecycle retired server=%s root=%s generation=%s "
@@ -456,7 +532,7 @@ class LSPService:
                 entry.workspace_root,
                 entry.generation,
                 reason,
-                "error" if error is not None else "clean",
+                "clean" if terminated and error is None else "incomplete",
             )
 
     async def _retire_key_async(self, key: Tuple[str, str], reason: str) -> bool:
@@ -494,6 +570,8 @@ class LSPService:
                 )
                 return
             entry.leases -= 1
+            if lease.owner is not None:
+                entry.lease_tasks.discard(lease.owner)
             entry.last_used = self._clock()
             if entry.leases == 0 and entry.pending_eviction:
                 retire_task = self._begin_retirement_locked(
@@ -587,6 +665,10 @@ class LSPService:
     def is_accepting_requests(self) -> bool:
         with self._state_lock:
             return self._service_state == "open"
+
+    def is_closed(self) -> bool:
+        with self._state_lock:
+            return self._service_state == "closed"
 
     def begin_shutdown(self) -> bool:
         """Publish CLOSING synchronously before shutdown enters the loop."""
@@ -734,18 +816,23 @@ class LSPService:
         return diags
 
     def _mark_broken_for_file(self, file_path: str, exc: BaseException) -> None:
-        """Retire a timed-out generation and apply a short retry cooldown.
+        """Retire a failed generation and preserve the configured retry policy.
 
-        Request and cold-index timeouts are transient. They must not poison a
-        healthy server/workspace pair for the remainder of the process.
+        Legacy process-lifetime mode keeps the historical permanent broken
+        mark. Opt-in lifecycle mode uses a short retry cooldown so an
+        intentionally bounded gateway can recover from transient cold starts.
         """
         target = self._resolve_target(file_path)
         if target is None:
             return
         srv, key, workspace_root = target
         with self._state_lock:
-            first_failure = key not in self._cooldowns
-            self._cooldowns[key] = self._clock() + 5.0
+            if self._lifecycle_enabled:
+                first_failure = key not in self._cooldowns
+                self._cooldowns[key] = self._clock() + 5.0
+            else:
+                first_failure = key not in self._broken
+                self._broken.add(key)
         try:
             self._loop.run(
                 self._retire_key_async(key, "request-failure"), timeout=3.0
@@ -756,21 +843,31 @@ class LSPService:
             eventlog.log_spawn_failed(srv.server_id, workspace_root, exc)
 
     def shutdown(self) -> None:
-        """Close admission, drain lifecycle work, and stop the loop."""
+        """Close admission, drain lifecycle work, and stop the owner loop."""
+        with self._state_lock:
+            if self._service_state == "closed":
+                return
+        if self._loop.is_owner_thread():
+            raise RuntimeError("use asynchronous teardown from the LSP owner loop")
         if not self._enabled:
             with self._state_lock:
                 self._service_state = "closed"
             return
         self.begin_shutdown()
         try:
-            self._loop.run(self._shutdown_async(), timeout=15.0)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("LSP shutdown did not complete cleanly: %s", exc)
-        finally:
-            self._loop.stop()
+            self._loop.run(self._shutdown_async(), timeout=30.0)
+        except Exception:
+            # Keep the singleton in CLOSING. Publishing a replacement while
+            # this loop or one of its process trees may still be alive would
+            # recreate the overlap this lifecycle manager exists to prevent.
             with self._state_lock:
-                self._service_state = "closed"
-            clear_cache()
+                self._service_state = "closing"
+            raise
+        if not self._loop.stop(timeout=5.0):
+            with self._state_lock:
+                self._service_state = "closing"
+            raise RuntimeError("LSP owner loop did not terminate")
+        clear_cache()
 
     # ------------------------------------------------------------------
     # async internals
@@ -862,11 +959,14 @@ class LSPService:
                 entry = self._entries.get(key)
                 if entry is not None and entry.state == "active":
                     if entry.client is not None and entry.client.is_running:
+                        owner = asyncio.current_task()
                         entry.leases += 1
+                        if owner is not None:
+                            entry.lease_tasks.add(owner)
                         entry.last_used = self._clock()
                         eventlog.log_active(srv.server_id, workspace_root)
                         return _ClientLease(
-                            self, key, entry.generation, entry.client
+                            self, key, entry.generation, entry.client, owner
                         )
                     wait_task = self._begin_retirement_locked(entry, "crashed")
                     if wait_task is None:
@@ -901,13 +1001,13 @@ class LSPService:
     async def _reserve_spawn(
         self, srv: Any, key: Tuple[str, str], workspace_root: str
     ) -> Optional[_ClientLease]:
-        """Serialize capacity, retirement, spawn, and the first lease."""
+        """Atomically reserve a generation without serializing its cold start."""
         admission_lock = self._admission_lock
         if admission_lock is None:
             return None
-        async with admission_lock:
-            while True:
-                wait_task: Optional[asyncio.Task] = None
+        while True:
+            wait_task: Optional[asyncio.Task] = None
+            async with admission_lock:
                 with self._state_lock:
                     if self._service_state != "open" or key in self._broken:
                         return None
@@ -919,10 +1019,17 @@ class LSPService:
                     existing = self._entries.get(key)
                     if existing is not None and existing.state == "active":
                         if existing.client is not None and existing.client.is_running:
+                            owner = asyncio.current_task()
                             existing.leases += 1
+                            if owner is not None:
+                                existing.lease_tasks.add(owner)
                             existing.last_used = self._clock()
                             return _ClientLease(
-                                self, key, existing.generation, existing.client
+                                self,
+                                key,
+                                existing.generation,
+                                existing.client,
+                                owner,
                             )
                         wait_task = self._begin_retirement_locked(
                             existing, "crashed"
@@ -932,6 +1039,10 @@ class LSPService:
                     elif existing is not None and existing.state == "spawning":
                         wait_task = existing.spawn_task
                     elif existing is not None and existing.state == "retiring":
+                        if existing.retire_task is None:
+                            # A failed retirement is a tombstone. Never overlap
+                            # it with a replacement whose predecessor may live.
+                            return None
                         wait_task = existing.retire_task
                     else:
                         if (
@@ -945,11 +1056,10 @@ class LSPService:
                                     victim, "capacity"
                                 )
                             else:
-                                # A cancelled caller may leave its shielded
-                                # spawn running. Count that reservation and
-                                # wait for it (or a retirement) before
-                                # admitting another distinct key. Only fully
-                                # active, fully leased pools may overflow.
+                                # Count in-flight reservations and await their
+                                # terminal transition before admitting another
+                                # key. Only a fully active, fully leased pool
+                                # may overflow temporarily.
                                 wait_task = next(
                                     (
                                         item.spawn_task or item.retire_task
@@ -981,11 +1091,12 @@ class LSPService:
                             )
                             entry.spawn_task = wait_task
                             self._entries[key] = entry
-                if wait_task is None:
-                    return None
-                await asyncio.gather(
-                    asyncio.shield(wait_task), return_exceptions=True
-                )
+            if wait_task is None:
+                return None
+            # Never hold global admission while binary discovery, install, or
+            # initialize runs. The published per-key entry remains the
+            # single-flight reservation for concurrent callers.
+            await asyncio.gather(asyncio.shield(wait_task), return_exceptions=True)
 
     async def _spawn_entry(self, entry: _ClientEntry, srv: Any) -> Optional[LSPClient]:
         client: Optional[LSPClient] = None
@@ -997,7 +1108,7 @@ class LSPService:
                 env_overrides=self._env_overrides,
                 init_overrides=self._init_overrides,
             )
-            spec = srv.build_spawn(entry.workspace_root, ctx)
+            spec = await asyncio.to_thread(srv.build_spawn, entry.workspace_root, ctx)
             if spec is None:
                 eventlog.log_server_unavailable(srv.server_id, srv.server_id)
                 with self._state_lock:
@@ -1042,10 +1153,13 @@ class LSPService:
             if client is not None:
                 await asyncio.shield(client.shutdown())
             raise
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             eventlog.log_spawn_failed(srv.server_id, entry.workspace_root, exc)
             with self._state_lock:
-                self._cooldowns[entry.key] = self._clock() + 5.0
+                if self._lifecycle_enabled:
+                    self._cooldowns[entry.key] = self._clock() + 5.0
+                else:
+                    self._broken.add(entry.key)
             if client is not None:
                 await client.shutdown()
             return None
@@ -1085,7 +1199,9 @@ class LSPService:
                 *(spawn_tasks + maintenance), return_exceptions=True
             )
 
-        deadline = asyncio.get_running_loop().time() + 5.0
+        deadline = (
+            asyncio.get_running_loop().time() + SHUTDOWN_LEASE_DRAIN_TIMEOUT
+        )
         while True:
             with self._state_lock:
                 leased = sum(entry.leases for entry in self._entries.values())
@@ -1093,21 +1209,45 @@ class LSPService:
                 break
             await asyncio.sleep(0.05)
         if leased:
+            with self._state_lock:
+                lease_tasks = {
+                    task
+                    for entry in self._entries.values()
+                    for task in entry.lease_tasks
+                    if not task.done()
+                }
+            current_task = asyncio.current_task()
+            lease_tasks.discard(current_task)
             logger.warning(
                 "LSP shutdown lease drain timed out with %s active lease(s); "
-                "forcing bounded cleanup",
+                "cancelling %s owning request task(s)",
                 leased,
+                len(lease_tasks),
             )
+            for task in lease_tasks:
+                task.cancel()
+            if lease_tasks:
+                await asyncio.gather(*lease_tasks, return_exceptions=True)
+            with self._state_lock:
+                leased = sum(entry.leases for entry in self._entries.values())
+            if leased:
+                raise RuntimeError(
+                    f"LSP shutdown could not drain {leased} active lease(s)"
+                )
 
         retire_tasks: List[asyncio.Task] = []
         with self._state_lock:
             for entry in list(self._entries.values()):
-                if entry.state == "retiring" and entry.retire_task is not None:
-                    retire_tasks.append(entry.retire_task)
-                    continue
+                if entry.state == "retiring":
+                    if entry.retire_task is not None:
+                        retire_tasks.append(entry.retire_task)
+                        continue
+                    # Retry an incomplete tombstone during whole-service
+                    # shutdown. The client's shared shutdown task guarantees
+                    # this joins any cleanup still in progress.
+                    entry.state = "active"
+                    entry.pending_eviction = None
                 if entry.state == "active":
-                    if entry.leases:
-                        entry.leases = 0
                     task = self._begin_retirement_locked(entry, "shutdown")
                     if task is not None:
                         retire_tasks.append(task)
@@ -1118,7 +1258,14 @@ class LSPService:
             )
 
         with self._state_lock:
-            self._entries.clear()
+            if self._entries:
+                raise RuntimeError(
+                    "LSP shutdown left non-terminated generations: "
+                    + ", ".join(
+                        f"{entry.key[0]}:{entry.generation}:{entry.state}"
+                        for entry in self._entries.values()
+                    )
+                )
             self._broken.clear()
             self._cooldowns.clear()
             self._maintenance_tasks.clear()
@@ -1136,7 +1283,10 @@ class LSPService:
                 {
                     "server_id": entry.key[0],
                     "workspace_root": entry.workspace_root,
-                    "state": entry.state,
+                    "state": (
+                        entry.client.state if entry.client is not None else entry.state
+                    ),
+                    "lifecycle_state": entry.state,
                     "running": bool(entry.client and entry.client.is_running),
                     "generation": entry.generation,
                     "leases": entry.leases,
@@ -1165,6 +1315,7 @@ class LSPService:
                 "idle_timeout_seconds": self._idle_timeout,
                 "sweep_interval_seconds": self._sweep_interval,
                 "max_clients_per_process": self._max_clients,
+                "config_error": self._lifecycle_error,
                 "reaper_running": bool(
                     self._reaper_task is not None and not self._reaper_task.done()
                 ),

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -1114,6 +1114,27 @@ class LSPService:
 
     async def _spawn_entry(self, entry: _ClientEntry, srv: Any) -> Optional[LSPClient]:
         client: Optional[LSPClient] = None
+
+        def cleanup_incomplete(target: LSPClient) -> bool:
+            return bool(
+                getattr(
+                    target,
+                    "process_tree_alive",
+                    getattr(target, "process_alive", target.is_running),
+                )
+            )
+
+        def retain_cleanup_tombstone(target: LSPClient, detail: Any) -> None:
+            with self._state_lock:
+                current = self._entries.get(entry.key)
+                if current is entry:
+                    entry.client = target
+                    entry.state = "retiring"
+                    entry.pending_eviction = "spawn-cleanup-failed"
+            logger.warning(
+                "LSP spawn cleanup incomplete for %s: %s", entry.key, detail
+            )
+
         try:
             ctx = ServerContext(
                 workspace_root=entry.workspace_root,
@@ -1154,6 +1175,8 @@ class LSPService:
                     publish = True
             if not publish:
                 await client.shutdown()
+                if cleanup_incomplete(client):
+                    retain_cleanup_tombstone(client, "live process tree")
                 return None
             eventlog.log_active(srv.server_id, entry.workspace_root)
             logger.info(
@@ -1171,17 +1194,10 @@ class LSPService:
                     asyncio.CancelledError,
                     Exception,
                 ) as cleanup_exc:  # includes cancellation
-                    with self._state_lock:
-                        current = self._entries.get(entry.key)
-                        if current is entry:
-                            entry.client = client
-                            entry.state = "retiring"
-                            entry.pending_eviction = "spawn-cleanup-failed"
-                    logger.warning(
-                        "LSP cancelled spawn cleanup failed for %s: %s",
-                        entry.key,
-                        cleanup_exc,
-                    )
+                    retain_cleanup_tombstone(client, cleanup_exc)
+                else:
+                    if cleanup_incomplete(client):
+                        retain_cleanup_tombstone(client, "live process tree")
             raise
         except Exception as exc:  # noqa: BLE001
             eventlog.log_spawn_failed(srv.server_id, entry.workspace_root, exc)
@@ -1194,17 +1210,10 @@ class LSPService:
                 try:
                     await client.shutdown()
                 except (asyncio.CancelledError, Exception) as cleanup_exc:
-                    with self._state_lock:
-                        current = self._entries.get(entry.key)
-                        if current is entry:
-                            entry.client = client
-                            entry.state = "retiring"
-                            entry.pending_eviction = "spawn-cleanup-failed"
-                    logger.warning(
-                        "LSP failed-spawn cleanup failed for %s: %s",
-                        entry.key,
-                        cleanup_exc,
-                    )
+                    retain_cleanup_tombstone(client, cleanup_exc)
+                else:
+                    if cleanup_incomplete(client):
+                        retain_cleanup_tombstone(client, "live process tree")
             return None
         finally:
             with self._state_lock:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3510,6 +3510,18 @@ DEFAULT_CONFIG = {
         # ``"off"`` — alias for ``manual``.
         "install_strategy": "auto",
 
+        # Optional bounded lifecycle for long-running local gateways that touch
+        # many workspaces. Disabled by default to preserve process-lifetime
+        # server retention and warm indexes. When enabled, idle servers are
+        # retired after the configured timeout and client capacity is enforced
+        # per Hermes process. A cap of 0 means unlimited.
+        "lifecycle": {
+            "enabled": False,
+            "idle_timeout_seconds": 7200,
+            "sweep_interval_seconds": 60,
+            "max_clients_per_process": 0,
+        },
+
         # Per-server overrides.  Each key is a server_id from the
         # registry (``pyright``, ``typescript``, ``gopls``,
         # ``rust-analyzer``, etc.) and accepts:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3510,13 +3510,12 @@ DEFAULT_CONFIG = {
         # ``"off"`` — alias for ``manual``.
         "install_strategy": "auto",
 
-        # Optional bounded lifecycle for long-running local gateways that touch
-        # many workspaces. Disabled by default to preserve process-lifetime
-        # server retention and warm indexes. When enabled, idle servers are
-        # retired after the configured timeout and client capacity is enforced
-        # per Hermes process. A cap of 0 means unlimited.
+        # Bounded lifecycle for long-running local gateways that touch many
+        # workspaces. Enabled by default with a conservative two-hour idle
+        # timeout; set enabled=false to preserve process-lifetime retention and
+        # warm indexes. Client capacity is per Hermes process; 0 is unlimited.
         "lifecycle": {
-            "enabled": False,
+            "enabled": True,
             "idle_timeout_seconds": 7200,
             "sweep_interval_seconds": 60,
             "max_clients_per_process": 0,

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -30,6 +30,7 @@ The script writes JSON-RPC framed messages to stdout and reads from
 stdin.  No third-party dependencies — uses only stdlib so it runs
 under whatever Python the test process picks up.
 """
+
 from __future__ import annotations
 
 import json
@@ -77,13 +78,18 @@ def main():
             with open(pid_file, "w", encoding="utf-8") as handle:
                 handle.write(str(child.pid))
         script = "clean"
-    elif script == "spawn_loop":
+    elif script in {"spawn_loop", "spawn_loop_sanitized"}:
         spawn_forever = True
+        sanitize_children = script == "spawn_loop_sanitized"
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
         pid_file = os.environ["MOCK_LSP_CHILD_PID_FILE"]
 
         def spawn_children():
             while True:
+                child_env = None
+                if sanitize_children:
+                    child_env = dict(os.environ)
+                    child_env.pop("HERMES_LSP_OWNER_TOKEN", None)
                 child = subprocess.Popen(
                     [
                         sys.executable,
@@ -92,6 +98,7 @@ def main():
                         "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
                         "time.sleep(300)",
                     ],
+                    env=child_env,
                 )
                 with open(pid_file, "a", encoding="utf-8") as handle:
                     handle.write(f"{child.pid}\n")
@@ -108,19 +115,20 @@ def main():
         if "id" in msg and msg.get("method") == "initialize":
             if script == "slow":
                 time.sleep(1.0)
-            write_message(
-                {
-                    "jsonrpc": "2.0",
-                    "id": msg["id"],
-                    "result": {
-                        "capabilities": {
-                            "textDocumentSync": 1,  # Full
-                            "diagnosticProvider": {"interFileDependencies": False, "workspaceDiagnostics": False},
+            write_message({
+                "jsonrpc": "2.0",
+                "id": msg["id"],
+                "result": {
+                    "capabilities": {
+                        "textDocumentSync": 1,  # Full
+                        "diagnosticProvider": {
+                            "interFileDependencies": False,
+                            "workspaceDiagnostics": False,
                         },
-                        "serverInfo": {"name": "mock-lsp", "version": "0.1"},
                     },
-                }
-            )
+                    "serverInfo": {"name": "mock-lsp", "version": "0.1"},
+                },
+            })
             if script == "crash":
                 return 0
             continue
@@ -156,32 +164,22 @@ def main():
                 # Ghost scenario: publish an error for the ORIGINAL
                 # content, then never publish again after edits.
                 if not is_change:
-                    write_message(
-                        {
-                            "jsonrpc": "2.0",
-                            "method": "textDocument/publishDiagnostics",
-                            "params": {"uri": uri, "version": version, "diagnostics": error_diag},
-                        }
-                    )
+                    write_message({
+                        "jsonrpc": "2.0",
+                        "method": "textDocument/publishDiagnostics",
+                        "params": {
+                            "uri": uri,
+                            "version": version,
+                            "diagnostics": error_diag,
+                        },
+                    })
                 continue
             if script == "slow_push":
                 diagnostics = error_diag
                 if is_change:
                     time.sleep(float(os.environ.get("MOCK_LSP_PUSH_DELAY", "1.0")))
                     diagnostics = []
-                write_message(
-                    {
-                        "jsonrpc": "2.0",
-                        "method": "textDocument/publishDiagnostics",
-                        "params": {"uri": uri, "version": version, "diagnostics": diagnostics},
-                    }
-                )
-                continue
-            diagnostics = []
-            if script == "errors":
-                diagnostics = error_diag
-            write_message(
-                {
+                write_message({
                     "jsonrpc": "2.0",
                     "method": "textDocument/publishDiagnostics",
                     "params": {
@@ -189,30 +187,38 @@ def main():
                         "version": version,
                         "diagnostics": diagnostics,
                     },
-                }
-            )
+                })
+                continue
+            diagnostics = []
+            if script == "errors":
+                diagnostics = error_diag
+            write_message({
+                "jsonrpc": "2.0",
+                "method": "textDocument/publishDiagnostics",
+                "params": {
+                    "uri": uri,
+                    "version": version,
+                    "diagnostics": diagnostics,
+                },
+            })
             continue
 
         if msg.get("method") == "textDocument/diagnostic":
             if script in {"stale", "slow_push"}:
                 # These scripts model push-only servers so the ghost
                 # can't be papered over by the pull channel.
-                write_message(
-                    {
-                        "jsonrpc": "2.0",
-                        "id": msg["id"],
-                        "error": {"code": -32601, "message": "method not found"},
-                    }
-                )
-                continue
-            # Pull endpoint — return empty.
-            write_message(
-                {
+                write_message({
                     "jsonrpc": "2.0",
                     "id": msg["id"],
-                    "result": {"kind": "full", "items": []},
-                }
-            )
+                    "error": {"code": -32601, "message": "method not found"},
+                })
+                continue
+            # Pull endpoint — return empty.
+            write_message({
+                "jsonrpc": "2.0",
+                "id": msg["id"],
+                "result": {"kind": "full", "items": []},
+            })
             continue
 
         if msg.get("method") == "textDocument/didSave":
@@ -229,13 +235,14 @@ def main():
 
         # Unknown request: respond with method-not-found.
         if "id" in msg:
-            write_message(
-                {
-                    "jsonrpc": "2.0",
-                    "id": msg["id"],
-                    "error": {"code": -32601, "message": f"method not found: {msg.get('method')}"},
-                }
-            )
+            write_message({
+                "jsonrpc": "2.0",
+                "id": msg["id"],
+                "error": {
+                    "code": -32601,
+                    "message": f"method not found: {msg.get('method')}",
+                },
+            })
 
 
 if __name__ == "__main__":

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import time
 
@@ -64,6 +65,15 @@ def write_message(obj):
 
 def main():
     script = os.environ.get("MOCK_LSP_SCRIPT", "clean")
+    if script == "child":
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(300)"],
+        )
+        pid_file = os.environ.get("MOCK_LSP_CHILD_PID_FILE")
+        if pid_file:
+            with open(pid_file, "w", encoding="utf-8") as handle:
+                handle.write(str(child.pid))
+        script = "clean"
 
     while True:
         msg = read_message()

--- a/tests/agent/lsp/_mock_lsp_server.py
+++ b/tests/agent/lsp/_mock_lsp_server.py
@@ -34,8 +34,10 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import subprocess
 import sys
+import threading
 import time
 
 
@@ -65,6 +67,7 @@ def write_message(obj):
 
 def main():
     script = os.environ.get("MOCK_LSP_SCRIPT", "clean")
+    spawn_forever = False
     if script == "child":
         child = subprocess.Popen(
             [sys.executable, "-c", "import time; time.sleep(300)"],
@@ -73,6 +76,28 @@ def main():
         if pid_file:
             with open(pid_file, "w", encoding="utf-8") as handle:
                 handle.write(str(child.pid))
+        script = "clean"
+    elif script == "spawn_loop":
+        spawn_forever = True
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        pid_file = os.environ["MOCK_LSP_CHILD_PID_FILE"]
+
+        def spawn_children():
+            while True:
+                child = subprocess.Popen(
+                    [
+                        sys.executable,
+                        "-c",
+                        "import signal,time; "
+                        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+                        "time.sleep(300)",
+                    ],
+                )
+                with open(pid_file, "a", encoding="utf-8") as handle:
+                    handle.write(f"{child.pid}\n")
+                time.sleep(0.05)
+
+        threading.Thread(target=spawn_children, daemon=True).start()
         script = "clean"
 
     while True:
@@ -198,6 +223,8 @@ def main():
             continue
 
         if msg.get("method") == "exit":
+            if spawn_forever:
+                continue
             return 0
 
         # Unknown request: respond with method-not-found.

--- a/tests/agent/lsp/test_bounded_lifecycle.py
+++ b/tests/agent/lsp/test_bounded_lifecycle.py
@@ -8,6 +8,7 @@ from typing import cast
 
 import pytest
 
+import agent.lsp.manager as manager_module
 from agent.lsp.client import LSPClient
 from agent.lsp.manager import (
     LSPService,
@@ -77,7 +78,7 @@ def install_entry(
 
 
 def test_lifecycle_config_is_opt_in_and_strict(caplog):
-    assert _lifecycle_config({}) == (False, 7200.0, 60.0, 0)
+    assert _lifecycle_config({}) == (False, 7200.0, 60.0, 0, None)
     assert _lifecycle_config(
         {
             "lifecycle": {
@@ -87,24 +88,25 @@ def test_lifecycle_config_is_opt_in_and_strict(caplog):
                 "max_clients_per_process": 3,
             }
         }
-    ) == (True, 120.0, 5.0, 3)
+    ) == (True, 120.0, 5.0, 3, None)
 
-    invalid_values = [
-        {"enabled": "false"},
+    invalid_enabled = _lifecycle_config({"lifecycle": {"enabled": "false"}})
+    assert invalid_enabled[:4] == (False, 7200.0, 60.0, 0)
+    assert invalid_enabled[4]
+
+    invalid_enabled_policies = [
         {"enabled": True, "idle_timeout_seconds": True},
         {"enabled": True, "idle_timeout_seconds": float("nan")},
         {"enabled": True, "sweep_interval_seconds": 0},
         {"enabled": True, "max_clients_per_process": 1.5},
         {"enabled": True, "max_clients_per_process": 65},
+        {"enabled": True, "max_client_per_process": 3},
     ]
-    for lifecycle in invalid_values:
-        assert _lifecycle_config({"lifecycle": lifecycle}) == (
-            False,
-            7200.0,
-            60.0,
-            0,
-        )
-    assert "lifecycle remains disabled" in caplog.text
+    for lifecycle in invalid_enabled_policies:
+        parsed = _lifecycle_config({"lifecycle": lifecycle})
+        assert parsed[:4] == (True, 7200.0, 60.0, 0)
+        assert parsed[4]
+    assert "invalid lsp.lifecycle configuration" in caplog.text
 
 
 def test_create_from_config_wires_lifecycle_settings(monkeypatch):
@@ -133,6 +135,37 @@ def test_create_from_config_wires_lifecycle_settings(monkeypatch):
         assert lifecycle["idle_timeout_seconds"] == 1800.0
         assert lifecycle["sweep_interval_seconds"] == 30.0
         assert lifecycle["max_clients_per_process"] == 4
+        assert lifecycle["config_error"] is None
+        assert lifecycle["reaper_running"] is True
+    finally:
+        service.shutdown()
+
+
+def test_invalid_enabled_policy_stays_bounded_and_surfaces_error(monkeypatch):
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {
+            "lsp": {
+                "enabled": True,
+                "lifecycle": {
+                    "enabled": True,
+                    "max_clients_per_process": 65,
+                },
+            }
+        },
+    )
+    service = LSPService.create_from_config()
+    assert service is not None
+    try:
+        lifecycle = service.get_status()["lifecycle"]
+        assert lifecycle["enabled"] is True
+        assert lifecycle["idle_timeout_seconds"] == 7200.0
+        assert lifecycle["sweep_interval_seconds"] == 60.0
+        assert lifecycle["max_clients_per_process"] == 0
+        assert "between 0 and 64" in lifecycle["config_error"]
         assert lifecycle["reaper_running"] is True
     finally:
         service.shutdown()
@@ -147,7 +180,32 @@ def test_feature_disabled_preserves_process_lifetime_retention():
     try:
         service._loop.run(service._reap_idle_clients(), timeout=2.0)
         assert client.shutdown_calls == 0
-        assert service.get_status()["lifecycle"]["reaper_running"] is False
+        status = service.get_status()
+        assert status["lifecycle"]["reaper_running"] is False
+        assert status["clients"][0]["state"] == "running"
+        assert status["clients"][0]["lifecycle_state"] == "active"
+    finally:
+        service.shutdown()
+
+
+def test_service_shutdown_is_idempotent_and_stops_owner_thread():
+    service = make_service(clock=lambda: 0.0)
+    service.shutdown()
+    service.shutdown()
+    assert service.is_closed() is True
+    assert service._loop._thread is None
+
+
+def test_synchronous_shutdown_is_rejected_on_owner_loop():
+    service = make_service(clock=lambda: 0.0)
+
+    async def scenario():
+        with pytest.raises(RuntimeError, match="asynchronous teardown"):
+            service.shutdown()
+
+    try:
+        service._loop.run(scenario(), timeout=2.0)
+        assert service.is_accepting_requests() is True
     finally:
         service.shutdown()
 
@@ -193,6 +251,81 @@ def test_active_lease_blocks_reaping_until_a_later_idle_sweep(monkeypatch):
         service.shutdown()
 
 
+def test_shutdown_cancels_lease_owner_and_waits_for_final_release(monkeypatch):
+    now = [100.0]
+    service = make_service(clock=lambda: now[0])
+    key = ("fake", "/repo")
+    entry, client = install_entry(service, key, last_used=0.0)
+    started = asyncio.Event()
+    blocker = asyncio.Event()
+    monkeypatch.setattr(manager_module, "SHUTDOWN_LEASE_DRAIN_TIMEOUT", 0.01)
+
+    async def owner():
+        task = asyncio.current_task()
+        assert task is not None
+        with service._state_lock:
+            entry.leases = 1
+            entry.lease_tasks.add(task)
+        lease = _ClientLease(
+            service,
+            key,
+            entry.generation,
+            cast(LSPClient, client),
+            task,
+        )
+        started.set()
+        try:
+            await blocker.wait()
+        finally:
+            lease.release()
+
+    async def scenario():
+        owner_task = asyncio.create_task(owner())
+        await started.wait()
+        service.begin_shutdown()
+        await service._shutdown_async()
+        assert owner_task.cancelled()
+
+    try:
+        service._loop.run(scenario(), timeout=2.0)
+        assert client.shutdown_calls == 1
+        assert service.get_status()["clients"] == []
+    finally:
+        blocker.set()
+        assert service._loop.stop() is True
+
+
+def test_failed_retirement_tombstone_blocks_overlapping_replacement():
+    service = make_service(clock=lambda: 0.0)
+    key = ("fake", "/repo")
+    entry, _ = install_entry(service, key, last_used=0.0)
+
+    class FailingClient(FakeClient):
+        async def shutdown(self) -> None:
+            self.shutdown_calls += 1
+            raise RuntimeError("process still alive")
+
+    client = FailingClient()
+    with service._state_lock:
+        entry.client = cast(LSPClient, client)
+
+    async def scenario():
+        assert await service._retire_key_async(key, "idle") is True
+        with service._state_lock:
+            assert service._entries[key] is entry
+            assert entry.state == "retiring"
+            assert entry.retire_task is None
+        srv = SimpleNamespace(server_id="fake")
+        assert await service._reserve_spawn(srv, key, "/repo") is None
+
+    try:
+        service._loop.run(scenario(), timeout=2.0)
+    finally:
+        client.running = False
+        client.state = "stopped"
+        service.shutdown()
+
+
 def test_generation_bound_release_is_idempotent_and_cannot_touch_replacement():
     now = [10.0]
     service = make_service(clock=lambda: now[0])
@@ -211,6 +344,85 @@ def test_generation_bound_release_is_idempotent_and_cannot_touch_replacement():
     finally:
         with service._state_lock:
             replacement.leases = 0
+        service.shutdown()
+
+
+def test_distinct_cold_starts_are_not_globally_serialized(monkeypatch):
+    service = make_service(clock=lambda: 0.0, lifecycle_enabled=False)
+    both_started = asyncio.Event()
+    started = []
+
+    async def fake_spawn(entry, _srv):
+        started.append(entry.key)
+        if len(started) == 2:
+            both_started.set()
+        await both_started.wait()
+        client = FakeClient(entry.key[0], entry.workspace_root)
+        with service._state_lock:
+            entry.client = cast(LSPClient, client)
+            entry.state = "active"
+        return cast(LSPClient, client)
+
+    monkeypatch.setattr(service, "_spawn_entry", fake_spawn)
+
+    async def scenario():
+        srv = SimpleNamespace(server_id="fake")
+        first = asyncio.create_task(service._reserve_spawn(srv, ("fake", "/a"), "/a"))
+        second = asyncio.create_task(service._reserve_spawn(srv, ("fake", "/b"), "/b"))
+        leases = await asyncio.wait_for(asyncio.gather(first, second), timeout=1.0)
+        assert all(lease is not None for lease in leases)
+        for lease in leases:
+            assert lease is not None
+            lease.release()
+
+    try:
+        service._loop.run(scenario(), timeout=2.0)
+        assert set(started) == {("fake", "/a"), ("fake", "/b")}
+    finally:
+        service.shutdown()
+
+
+def test_capacity_admission_waits_for_inflight_retirement(monkeypatch):
+    service = make_service(clock=lambda: 0.0, max_clients=1)
+    old_entry, _ = install_entry(service, ("fake", "/old"), last_used=0.0)
+    release_retirement = asyncio.Event()
+    spawn_started = asyncio.Event()
+
+    async def fake_spawn(entry, _srv):
+        spawn_started.set()
+        client = FakeClient(entry.key[0], entry.workspace_root)
+        with service._state_lock:
+            entry.client = cast(LSPClient, client)
+            entry.state = "active"
+        return cast(LSPClient, client)
+
+    monkeypatch.setattr(service, "_spawn_entry", fake_spawn)
+
+    async def scenario():
+        async def retire_old():
+            await release_retirement.wait()
+            with service._state_lock:
+                service._entries.pop(old_entry.key, None)
+
+        with service._state_lock:
+            old_entry.state = "retiring"
+            old_entry.retire_task = asyncio.create_task(retire_old())
+        srv = SimpleNamespace(server_id="fake")
+        reservation = asyncio.create_task(
+            service._reserve_spawn(srv, ("fake", "/new"), "/new")
+        )
+        await asyncio.sleep(0)
+        assert not spawn_started.is_set()
+        release_retirement.set()
+        lease = await asyncio.wait_for(reservation, timeout=1.0)
+        assert lease is not None
+        lease.release()
+
+    try:
+        service._loop.run(scenario(), timeout=2.0)
+        assert spawn_started.is_set()
+    finally:
+        release_retirement.set()
         service.shutdown()
 
 

--- a/tests/agent/lsp/test_bounded_lifecycle.py
+++ b/tests/agent/lsp/test_bounded_lifecycle.py
@@ -1,0 +1,293 @@
+"""Race-focused tests for the opt-in bounded LSP client lifecycle."""
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from agent.lsp.client import LSPClient
+from agent.lsp.manager import (
+    LSPService,
+    _ClientEntry,
+    _ClientLease,
+    _lifecycle_config,
+)
+
+
+class FakeClient:
+    def __init__(self, server_id: str = "fake", workspace_root: str = "/repo"):
+        self.server_id = server_id
+        self.workspace_root = workspace_root
+        self.state = "running"
+        self.running = True
+        self.shutdown_calls = 0
+
+    @property
+    def is_running(self) -> bool:
+        return self.running
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+        await asyncio.sleep(0)
+        self.running = False
+        self.state = "stopped"
+
+    def diagnostics_for(self, _file_path: str):
+        return []
+
+
+def make_service(*, clock, lifecycle_enabled=True, idle_timeout=100.0, max_clients=0, sweep=3600.0):
+    return LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=1.0,
+        install_strategy="manual",
+        lifecycle_enabled=lifecycle_enabled,
+        idle_timeout=idle_timeout,
+        sweep_interval=sweep,
+        max_clients=max_clients,
+        clock=clock,
+    )
+
+
+def install_entry(
+    service: LSPService,
+    key: tuple[str, str],
+    *,
+    last_used: float,
+    leases: int = 0,
+) -> tuple[_ClientEntry, FakeClient]:
+    client = FakeClient(key[0], key[1])
+    with service._state_lock:
+        service._next_generation += 1
+        entry = _ClientEntry(
+            key=key,
+            generation=service._next_generation,
+            workspace_root=key[1],
+            state="active",
+            last_used=last_used,
+            client=cast(LSPClient, client),
+            leases=leases,
+        )
+        service._entries[key] = entry
+    return entry, client
+
+
+def test_lifecycle_config_is_opt_in_and_strict(caplog):
+    assert _lifecycle_config({}) == (False, 7200.0, 60.0, 0)
+    assert _lifecycle_config(
+        {
+            "lifecycle": {
+                "enabled": True,
+                "idle_timeout_seconds": 120,
+                "sweep_interval_seconds": 5,
+                "max_clients_per_process": 3,
+            }
+        }
+    ) == (True, 120.0, 5.0, 3)
+
+    invalid_values = [
+        {"enabled": "false"},
+        {"enabled": True, "idle_timeout_seconds": True},
+        {"enabled": True, "idle_timeout_seconds": float("nan")},
+        {"enabled": True, "sweep_interval_seconds": 0},
+        {"enabled": True, "max_clients_per_process": 1.5},
+        {"enabled": True, "max_clients_per_process": 65},
+    ]
+    for lifecycle in invalid_values:
+        assert _lifecycle_config({"lifecycle": lifecycle}) == (
+            False,
+            7200.0,
+            60.0,
+            0,
+        )
+    assert "lifecycle remains disabled" in caplog.text
+
+
+def test_create_from_config_wires_lifecycle_settings(monkeypatch):
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {
+            "lsp": {
+                "enabled": True,
+                "lifecycle": {
+                    "enabled": True,
+                    "idle_timeout_seconds": 1800,
+                    "sweep_interval_seconds": 30,
+                    "max_clients_per_process": 4,
+                },
+            }
+        },
+    )
+    service = LSPService.create_from_config()
+    assert service is not None
+    try:
+        lifecycle = service.get_status()["lifecycle"]
+        assert lifecycle["enabled"] is True
+        assert lifecycle["idle_timeout_seconds"] == 1800.0
+        assert lifecycle["sweep_interval_seconds"] == 30.0
+        assert lifecycle["max_clients_per_process"] == 4
+        assert lifecycle["reaper_running"] is True
+    finally:
+        service.shutdown()
+
+
+def test_feature_disabled_preserves_process_lifetime_retention():
+    now = [1000.0]
+    service = make_service(
+        clock=lambda: now[0], lifecycle_enabled=False, idle_timeout=1.0
+    )
+    _, client = install_entry(service, ("fake", "/repo"), last_used=0.0)
+    try:
+        service._loop.run(service._reap_idle_clients(), timeout=2.0)
+        assert client.shutdown_calls == 0
+        assert service.get_status()["lifecycle"]["reaper_running"] is False
+    finally:
+        service.shutdown()
+
+
+def test_idle_boundary_and_monotonic_clock():
+    now = [99.9]
+    service = make_service(clock=lambda: now[0], idle_timeout=100.0)
+    _, client = install_entry(service, ("fake", "/repo"), last_used=0.0)
+    try:
+        service._loop.run(service._reap_idle_clients(), timeout=2.0)
+        assert client.shutdown_calls == 0
+        now[0] = 100.0
+        service._loop.run(service._reap_idle_clients(), timeout=2.0)
+        assert client.shutdown_calls == 1
+        assert service.get_status()["clients"] == []
+    finally:
+        service.shutdown()
+
+
+def test_active_lease_blocks_reaping_until_a_later_idle_sweep(monkeypatch):
+    now = [100.0]
+    service = make_service(clock=lambda: now[0], idle_timeout=50.0)
+    key = ("fake", "/repo")
+    entry, client = install_entry(service, key, last_used=0.0)
+    target = (SimpleNamespace(server_id="fake"), key, "/repo")
+    monkeypatch.setattr(service, "_resolve_target", lambda *args, **kwargs: target)
+
+    async def scenario():
+        lease = await service._acquire_lease("/repo/x.py", spawn=False)
+        assert lease is not None
+        assert entry.leases == 1
+        await service._reap_idle_clients()
+        assert client.shutdown_calls == 0
+        lease.release()
+        assert entry.leases == 0
+        now[0] = 151.0
+        await service._reap_idle_clients()
+
+    try:
+        service._loop.run(scenario(), timeout=2.0)
+        assert client.shutdown_calls == 1
+    finally:
+        service.shutdown()
+
+
+def test_generation_bound_release_is_idempotent_and_cannot_touch_replacement():
+    now = [10.0]
+    service = make_service(clock=lambda: now[0])
+    key = ("fake", "/repo")
+    old_entry, old_client = install_entry(service, key, last_used=0.0, leases=1)
+    old_lease = _ClientLease(
+        service, key, old_entry.generation, cast(LSPClient, old_client)
+    )
+    with service._state_lock:
+        service._entries.pop(key)
+    replacement, _ = install_entry(service, key, last_used=5.0, leases=1)
+    try:
+        old_lease.release()
+        old_lease.release()
+        assert replacement.leases == 1
+    finally:
+        with service._state_lock:
+            replacement.leases = 0
+        service.shutdown()
+
+
+def test_capacity_evicts_exactly_the_unleased_lru_generation():
+    now = [100.0]
+    service = make_service(clock=lambda: now[0], max_clients=3)
+    clients = {}
+    for index in range(4):
+        key = ("fake", f"/repo-{index}")
+        _, clients[key] = install_entry(service, key, last_used=float(index))
+    try:
+        service._loop.run(service._converge_capacity(), timeout=2.0)
+        status = service.get_status()
+        assert len(status["clients"]) == 3
+        assert clients[("fake", "/repo-0")].shutdown_calls == 1
+        assert status["lifecycle"]["capacity_evictions"] == 1
+    finally:
+        service.shutdown()
+
+
+def test_all_leased_overflow_converges_on_release():
+    now = [100.0]
+    service = make_service(clock=lambda: now[0], max_clients=3)
+    entries = []
+    clients = []
+    for index in range(4):
+        entry, client = install_entry(
+            service,
+            ("fake", f"/repo-{index}"),
+            last_used=float(index),
+            leases=1,
+        )
+        entries.append(entry)
+        clients.append(client)
+
+    async def scenario():
+        await service._converge_capacity()
+        assert len(service._entries) == 4
+        lease = _ClientLease(
+            service,
+            entries[0].key,
+            entries[0].generation,
+            cast(LSPClient, clients[0]),
+        )
+        lease.release()
+        await asyncio.sleep(0)
+        pending = list(service._maintenance_tasks)
+        if pending:
+            await asyncio.gather(*pending)
+
+    try:
+        service._loop.run(scenario(), timeout=2.0)
+        assert len(service.get_status()["clients"]) == 3
+        assert clients[0].shutdown_calls == 1
+    finally:
+        with service._state_lock:
+            for entry in service._entries.values():
+                entry.leases = 0
+        service.shutdown()
+
+
+def test_reaper_scheduler_survives_one_failed_sweep(monkeypatch):
+    now = [0.0]
+    service = make_service(clock=lambda: now[0], sweep=0.01)
+    completed = threading.Event()
+    calls = []
+
+    async def flaky_sweep():
+        calls.append(len(calls) + 1)
+        if len(calls) == 1:
+            raise RuntimeError("synthetic sweep failure")
+        completed.set()
+
+    monkeypatch.setattr(service, "_reap_idle_clients", flaky_sweep)
+    try:
+        assert completed.wait(timeout=1.0)
+        assert len(calls) >= 2
+        assert service.get_status()["lifecycle"]["reaper_running"] is True
+    finally:
+        service.shutdown()

--- a/tests/agent/lsp/test_bounded_lifecycle.py
+++ b/tests/agent/lsp/test_bounded_lifecycle.py
@@ -295,10 +295,14 @@ def test_shutdown_cancels_lease_owner_and_waits_for_final_release(monkeypatch):
         assert service._loop.stop() is True
 
 
-def test_failed_retirement_tombstone_blocks_overlapping_replacement():
+def test_failed_retirement_tombstone_blocks_overlapping_replacement(monkeypatch):
     service = make_service(clock=lambda: 0.0)
     key = ("fake", "/repo")
     entry, _ = install_entry(service, key, last_used=0.0)
+    srv = SimpleNamespace(server_id="fake")
+    monkeypatch.setattr(
+        service, "_resolve_target", lambda *args, **kwargs: (srv, key, "/repo")
+    )
 
     class FailingClient(FakeClient):
         async def shutdown(self) -> None:
@@ -315,8 +319,13 @@ def test_failed_retirement_tombstone_blocks_overlapping_replacement():
             assert service._entries[key] is entry
             assert entry.state == "retiring"
             assert entry.retire_task is None
-        srv = SimpleNamespace(server_id="fake")
         assert await service._reserve_spawn(srv, key, "/repo") is None
+        assert (
+            await asyncio.wait_for(
+                service._acquire_lease("/repo/x.py", spawn=True), timeout=0.1
+            )
+            is None
+        )
 
     try:
         service._loop.run(scenario(), timeout=2.0)

--- a/tests/agent/lsp/test_bounded_lifecycle.py
+++ b/tests/agent/lsp/test_bounded_lifecycle.py
@@ -109,6 +109,35 @@ def test_lifecycle_config_is_opt_in_and_strict(caplog):
     assert "invalid lsp.lifecycle configuration" in caplog.text
 
 
+def test_default_config_declares_default_off_lifecycle_policy():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["lsp"]["lifecycle"] == {
+        "enabled": False,
+        "idle_timeout_seconds": 7200,
+        "sweep_interval_seconds": 60,
+        "max_clients_per_process": 0,
+    }
+
+
+def test_create_from_default_config_wires_process_lifetime_policy(monkeypatch):
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(config_module, "load_config", lambda: config_module.DEFAULT_CONFIG)
+    service = LSPService.create_from_config()
+    assert service is not None
+    try:
+        lifecycle = service.get_status()["lifecycle"]
+        assert lifecycle["enabled"] is False
+        assert lifecycle["idle_timeout_seconds"] == 7200.0
+        assert lifecycle["sweep_interval_seconds"] == 60.0
+        assert lifecycle["max_clients_per_process"] == 0
+        assert lifecycle["config_error"] is None
+        assert lifecycle["reaper_running"] is False
+    finally:
+        service.shutdown()
+
+
 def test_create_from_config_wires_lifecycle_settings(monkeypatch):
     from hermes_cli import config as config_module
 

--- a/tests/agent/lsp/test_bounded_lifecycle.py
+++ b/tests/agent/lsp/test_bounded_lifecycle.py
@@ -1,4 +1,4 @@
-"""Race-focused tests for the opt-in bounded LSP client lifecycle."""
+"""Race-focused tests for the bounded LSP client lifecycle."""
 from __future__ import annotations
 
 import asyncio
@@ -77,8 +77,8 @@ def install_entry(
     return entry, client
 
 
-def test_lifecycle_config_is_opt_in_and_strict(caplog):
-    assert _lifecycle_config({}) == (False, 7200.0, 60.0, 0, None)
+def test_lifecycle_config_is_default_on_and_strict(caplog):
+    assert _lifecycle_config({}) == (True, 7200.0, 60.0, 0, None)
     assert _lifecycle_config(
         {
             "lifecycle": {
@@ -89,15 +89,24 @@ def test_lifecycle_config_is_opt_in_and_strict(caplog):
             }
         }
     ) == (True, 120.0, 5.0, 3, None)
+    assert _lifecycle_config({"lifecycle": {"enabled": False}}) == (
+        False,
+        7200.0,
+        60.0,
+        0,
+        None,
+    )
 
     invalid_enabled = _lifecycle_config({"lifecycle": {"enabled": "false"}})
-    assert invalid_enabled[:4] == (False, 7200.0, 60.0, 0)
+    assert invalid_enabled[:4] == (True, 7200.0, 60.0, 0)
     assert invalid_enabled[4]
 
     invalid_enabled_policies = [
         {"enabled": True, "idle_timeout_seconds": True},
         {"enabled": True, "idle_timeout_seconds": float("nan")},
         {"enabled": True, "sweep_interval_seconds": 0},
+        {"enabled": True, "idle_timeout_seconds": 10**400},
+        {"enabled": True, "sweep_interval_seconds": 10**400},
         {"enabled": True, "max_clients_per_process": 1.5},
         {"enabled": True, "max_clients_per_process": 65},
         {"enabled": True, "max_client_per_process": 3},
@@ -109,18 +118,18 @@ def test_lifecycle_config_is_opt_in_and_strict(caplog):
     assert "invalid lsp.lifecycle configuration" in caplog.text
 
 
-def test_default_config_declares_default_off_lifecycle_policy():
+def test_default_config_declares_default_on_lifecycle_policy():
     from hermes_cli.config import DEFAULT_CONFIG
 
     assert DEFAULT_CONFIG["lsp"]["lifecycle"] == {
-        "enabled": False,
+        "enabled": True,
         "idle_timeout_seconds": 7200,
         "sweep_interval_seconds": 60,
         "max_clients_per_process": 0,
     }
 
 
-def test_create_from_default_config_wires_process_lifetime_policy(monkeypatch):
+def test_create_from_default_config_wires_bounded_policy(monkeypatch):
     from hermes_cli import config as config_module
 
     monkeypatch.setattr(config_module, "load_config", lambda: config_module.DEFAULT_CONFIG)
@@ -128,12 +137,12 @@ def test_create_from_default_config_wires_process_lifetime_policy(monkeypatch):
     assert service is not None
     try:
         lifecycle = service.get_status()["lifecycle"]
-        assert lifecycle["enabled"] is False
+        assert lifecycle["enabled"] is True
         assert lifecycle["idle_timeout_seconds"] == 7200.0
         assert lifecycle["sweep_interval_seconds"] == 60.0
         assert lifecycle["max_clients_per_process"] == 0
         assert lifecycle["config_error"] is None
-        assert lifecycle["reaper_running"] is False
+        assert lifecycle["reaper_running"] is True
     finally:
         service.shutdown()
 
@@ -362,6 +371,107 @@ def test_failed_retirement_tombstone_blocks_overlapping_replacement(monkeypatch)
         client.running = False
         client.state = "stopped"
         service.shutdown()
+
+
+def test_service_shutdown_stays_closing_while_tombstone_is_live():
+    service = make_service(clock=lambda: 0.0)
+    key = ("fake", "/repo")
+    entry, _ = install_entry(service, key, last_used=0.0)
+
+    class FailingClient(FakeClient):
+        @property
+        def process_alive(self) -> bool:
+            return False
+
+        @property
+        def process_tree_alive(self) -> bool:
+            return self.running
+
+        async def shutdown(self) -> None:
+            self.shutdown_calls += 1
+            if self.shutdown_calls >= 2:
+                self.running = False
+                self.state = "stopped"
+
+    client = FailingClient()
+    with service._state_lock:
+        entry.client = cast(LSPClient, client)
+
+    service.begin_shutdown()
+    with pytest.raises(RuntimeError, match="non-terminated generations"):
+        service._loop.run(service._shutdown_async(), timeout=2.0)
+
+    assert service.is_closed() is False
+    status = service.get_status()
+    assert status["lifecycle"]["service_state"] == "closing"
+    assert status["lifecycle"]["counts"]["retiring"] == 1
+    assert status["clients"][0]["running"] is True
+    assert client.shutdown_calls == 1
+
+    service.shutdown()
+    assert client.shutdown_calls == 2
+    assert service.is_closed() is True
+
+
+def test_cancelled_spawn_cleanup_failure_is_retained_and_retried(monkeypatch):
+    service = make_service(clock=lambda: 0.0)
+    started = asyncio.Event()
+    release_start = asyncio.Event()
+    created = []
+
+    class SpawnClient(FakeClient):
+        async def start(self) -> None:
+            started.set()
+            await release_start.wait()
+
+        @property
+        def process_alive(self) -> bool:
+            return self.running
+
+        async def shutdown(self) -> None:
+            self.shutdown_calls += 1
+            if self.shutdown_calls == 1:
+                raise RuntimeError("synthetic first cleanup failure")
+            self.running = False
+            self.state = "stopped"
+
+    def make_client(**_kwargs):
+        client = SpawnClient()
+        created.append(client)
+        return client
+
+    srv = SimpleNamespace(
+        server_id="fake",
+        seed_first_push=False,
+        build_spawn=lambda root, _ctx: SimpleNamespace(
+            workspace_root=root,
+            command=["fake"],
+            env=None,
+            cwd=root,
+            initialization_options=None,
+            seed_diagnostics_on_first_push=False,
+        ),
+    )
+    monkeypatch.setattr(manager_module, "LSPClient", make_client)
+
+    async def scenario():
+        reservation = asyncio.create_task(
+            service._reserve_spawn(srv, ("fake", "/repo"), "/repo")
+        )
+        await started.wait()
+        service.begin_shutdown()
+        await service._shutdown_async()
+        assert await reservation is None
+
+    try:
+        service._loop.run(scenario(), timeout=2.0)
+        assert created[0].shutdown_calls == 2
+        assert created[0].process_alive is False
+        assert service.is_closed() is True
+        assert service.get_status()["clients"] == []
+    finally:
+        release_start.set()
+        assert service._loop.stop() is True
 
 
 def test_generation_bound_release_is_idempotent_and_cannot_touch_replacement():

--- a/tests/agent/lsp/test_bounded_lifecycle.py
+++ b/tests/agent/lsp/test_bounded_lifecycle.py
@@ -1,4 +1,5 @@
 """Race-focused tests for the bounded LSP client lifecycle."""
+
 from __future__ import annotations
 
 import asyncio
@@ -40,7 +41,9 @@ class FakeClient:
         return []
 
 
-def make_service(*, clock, lifecycle_enabled=True, idle_timeout=100.0, max_clients=0, sweep=3600.0):
+def make_service(
+    *, clock, lifecycle_enabled=True, idle_timeout=100.0, max_clients=0, sweep=3600.0
+):
     return LSPService(
         enabled=True,
         wait_mode="document",
@@ -79,16 +82,14 @@ def install_entry(
 
 def test_lifecycle_config_is_default_on_and_strict(caplog):
     assert _lifecycle_config({}) == (True, 7200.0, 60.0, 0, None)
-    assert _lifecycle_config(
-        {
-            "lifecycle": {
-                "enabled": True,
-                "idle_timeout_seconds": 120,
-                "sweep_interval_seconds": 5,
-                "max_clients_per_process": 3,
-            }
+    assert _lifecycle_config({
+        "lifecycle": {
+            "enabled": True,
+            "idle_timeout_seconds": 120,
+            "sweep_interval_seconds": 5,
+            "max_clients_per_process": 3,
         }
-    ) == (True, 120.0, 5.0, 3, None)
+    }) == (True, 120.0, 5.0, 3, None)
     assert _lifecycle_config({"lifecycle": {"enabled": False}}) == (
         False,
         7200.0,
@@ -132,7 +133,9 @@ def test_default_config_declares_default_on_lifecycle_policy():
 def test_create_from_default_config_wires_bounded_policy(monkeypatch):
     from hermes_cli import config as config_module
 
-    monkeypatch.setattr(config_module, "load_config", lambda: config_module.DEFAULT_CONFIG)
+    monkeypatch.setattr(
+        config_module, "load_config", lambda: config_module.DEFAULT_CONFIG
+    )
     service = LSPService.create_from_config()
     assert service is not None
     try:
@@ -143,6 +146,30 @@ def test_create_from_default_config_wires_bounded_policy(monkeypatch):
         assert lifecycle["max_clients_per_process"] == 0
         assert lifecycle["config_error"] is None
         assert lifecycle["reaper_running"] is True
+    finally:
+        service.shutdown()
+
+
+def test_create_from_config_wires_explicit_lifecycle_opt_out(monkeypatch):
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {
+            "lsp": {
+                "enabled": True,
+                "lifecycle": {"enabled": False},
+            }
+        },
+    )
+    service = LSPService.create_from_config()
+    assert service is not None
+    try:
+        lifecycle = service.get_status()["lifecycle"]
+        assert lifecycle["enabled"] is False
+        assert lifecycle["config_error"] is None
+        assert lifecycle["reaper_running"] is False
     finally:
         service.shutdown()
 
@@ -232,6 +259,61 @@ def test_service_shutdown_is_idempotent_and_stops_owner_thread():
     service.shutdown()
     assert service.is_closed() is True
     assert service._loop._thread is None
+
+
+def test_service_shutdown_waits_for_inflight_build_spawn():
+    service = make_service(clock=lambda: 0.0)
+    build_started = threading.Event()
+    release_build = threading.Event()
+    build_completed = threading.Event()
+    shutdown_completed = threading.Event()
+    shutdown_errors = []
+
+    def blocking_build(_root, _ctx):
+        build_started.set()
+        if not release_build.wait(timeout=2.0):
+            raise RuntimeError("test did not release build_spawn")
+        build_completed.set()
+        return None
+
+    srv = SimpleNamespace(
+        server_id="fake",
+        seed_first_push=False,
+        build_spawn=blocking_build,
+    )
+    loop = service._loop._loop
+    assert loop is not None
+    reservation = asyncio.run_coroutine_threadsafe(
+        service._reserve_spawn(srv, ("fake", "/repo"), "/repo"), loop
+    )
+    assert build_started.wait(timeout=1.0)
+
+    def shutdown_service():
+        try:
+            service.shutdown()
+        except Exception as exc:  # noqa: BLE001
+            shutdown_errors.append(exc)
+        finally:
+            shutdown_completed.set()
+
+    shutdown_thread = threading.Thread(target=shutdown_service)
+    shutdown_thread.start()
+    try:
+        assert not shutdown_completed.wait(timeout=0.1)
+        assert service.is_accepting_requests() is False
+        assert service.is_closed() is False
+        release_build.set()
+        shutdown_thread.join(timeout=2.0)
+        assert shutdown_completed.is_set()
+        assert shutdown_errors == []
+        assert build_completed.is_set()
+        assert reservation.result(timeout=1.0) is None
+        assert service.is_closed() is True
+    finally:
+        release_build.set()
+        shutdown_thread.join(timeout=2.0)
+        if not service.is_closed():
+            service.shutdown()
 
 
 def test_synchronous_shutdown_is_rejected_on_owner_loop():

--- a/tests/agent/lsp/test_bounded_lifecycle.py
+++ b/tests/agent/lsp/test_bounded_lifecycle.py
@@ -474,6 +474,64 @@ def test_cancelled_spawn_cleanup_failure_is_retained_and_retried(monkeypatch):
         assert service._loop.stop() is True
 
 
+def test_failed_spawn_with_live_tree_retains_tombstone(monkeypatch):
+    service = make_service(clock=lambda: 0.0)
+    created = []
+
+    class SpawnClient(FakeClient):
+        async def start(self) -> None:
+            raise RuntimeError("startup failed after child spawned")
+
+        @property
+        def process_alive(self) -> bool:
+            return False
+
+        @property
+        def process_tree_alive(self) -> bool:
+            return self.running
+
+        async def shutdown(self) -> None:
+            self.shutdown_calls += 1
+            if self.shutdown_calls >= 2:
+                self.running = False
+                self.state = "stopped"
+
+    def make_client(**_kwargs):
+        client = SpawnClient()
+        created.append(client)
+        return client
+
+    srv = SimpleNamespace(
+        server_id="fake",
+        seed_first_push=False,
+        build_spawn=lambda root, _ctx: SimpleNamespace(
+            workspace_root=root,
+            command=["fake"],
+            env=None,
+            cwd=root,
+            initialization_options=None,
+            seed_diagnostics_on_first_push=False,
+        ),
+    )
+    monkeypatch.setattr(manager_module, "LSPClient", make_client)
+
+    async def scenario():
+        assert await service._reserve_spawn(srv, ("fake", "/repo"), "/repo") is None
+        with service._state_lock:
+            entry = service._entries[("fake", "/repo")]
+            assert entry.state == "retiring"
+            assert entry.client is created[0]
+        service.begin_shutdown()
+        await service._shutdown_async()
+
+    service._loop.run(scenario(), timeout=2.0)
+    assert created[0].shutdown_calls == 2
+    assert created[0].process_tree_alive is False
+    assert service.is_closed() is True
+    assert service.get_status()["clients"] == []
+    assert service._loop.stop() is True
+
+
 def test_generation_bound_release_is_idempotent_and_cannot_touch_replacement():
     now = [10.0]
     service = make_service(clock=lambda: now[0])

--- a/tests/agent/lsp/test_broken_set.py
+++ b/tests/agent/lsp/test_broken_set.py
@@ -45,6 +45,7 @@ def test_mark_failed_file_adds_retryable_cooldown_key(tmp_path, monkeypatch):
         wait_mode="document",
         wait_timeout=2.0,
         install_strategy="manual",
+        lifecycle_enabled=True,
         clock=lambda: now[0],
     )
     try:
@@ -56,6 +57,27 @@ def test_mark_failed_file_adds_retryable_cooldown_key(tmp_path, monkeypatch):
         now[0] = 106.0
         assert svc.enabled_for(str(src)) is True
         assert key not in svc._cooldowns
+    finally:
+        svc.shutdown()
+
+
+def test_process_lifetime_mode_preserves_permanent_broken_pair(tmp_path, monkeypatch):
+    repo = _make_git_workspace(tmp_path)
+    monkeypatch.chdir(str(repo))
+    src = repo / "x.py"
+    src.write_text("")
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=2.0,
+        install_strategy="manual",
+    )
+    try:
+        svc._mark_broken_for_file(str(src), RuntimeError("simulated"))
+        key = ("pyright", str(repo.resolve()))
+        assert key in svc._broken
+        assert key not in svc._cooldowns
+        assert svc.enabled_for(str(src)) is False
     finally:
         svc.shutdown()
 
@@ -74,6 +96,7 @@ def test_enabled_for_returns_false_during_cooldown(tmp_path, monkeypatch):
         wait_mode="document",
         wait_timeout=2.0,
         install_strategy="manual",
+        lifecycle_enabled=True,
     )
     try:
         # Initially enabled.
@@ -102,6 +125,7 @@ def test_enabled_for_other_file_in_same_project_also_skipped(tmp_path, monkeypat
         wait_mode="document",
         wait_timeout=2.0,
         install_strategy="manual",
+        lifecycle_enabled=True,
     )
     try:
         svc._mark_broken_for_file(str(a), RuntimeError("simulated"))
@@ -130,6 +154,7 @@ def test_unrelated_project_not_affected_by_cooldown(tmp_path, monkeypatch):
         wait_mode="document",
         wait_timeout=2.0,
         install_strategy="manual",
+        lifecycle_enabled=True,
     )
     try:
         svc._mark_broken_for_file(str(a_src), RuntimeError("simulated"))
@@ -150,6 +175,7 @@ def test_mark_broken_handles_missing_server_silently(tmp_path):
         wait_mode="document",
         wait_timeout=2.0,
         install_strategy="manual",
+        lifecycle_enabled=True,
     )
     try:
         # No registered server for .xyz; must not raise.
@@ -169,6 +195,7 @@ def test_mark_broken_handles_no_workspace_silently(tmp_path):
         wait_mode="document",
         wait_timeout=2.0,
         install_strategy="manual",
+        lifecycle_enabled=True,
     )
     try:
         svc._mark_broken_for_file(str(src), RuntimeError("x"))
@@ -191,6 +218,7 @@ def test_snapshot_failure_enters_retryable_cooldown(tmp_path, monkeypatch):
         wait_mode="document",
         wait_timeout=2.0,
         install_strategy="manual",
+        lifecycle_enabled=True,
         clock=lambda: now[0],
     )
     try:

--- a/tests/agent/lsp/test_broken_set.py
+++ b/tests/agent/lsp/test_broken_set.py
@@ -1,16 +1,10 @@
-"""Tests for the broken-set short-circuit added to handle outer-timeout failures.
+"""Tests for transient LSP failure cooldowns.
 
-When ``snapshot_baseline`` or ``get_diagnostics_sync`` time out from the
-service layer (because a language server hangs during initialize, or
-the binary is wedged), the inner spawn task is cancelled — but the
-inner exception handler that adds to ``_broken`` never runs.  Without
-the service-layer fallback added in this module, every subsequent
-edit re-pays the full timeout cost until the process exits.
-
-This module verifies:
-- ``_mark_broken_for_file`` adds the right key
-- ``enabled_for`` short-circuits on broken keys
-- a missing binary is broken-set'd after one snapshot attempt
+Request-level and cold-index timeouts must stop repeated edits from paying the
+same timeout immediately, without permanently disabling the workspace. A
+short monotonic cooldown replaces the old process-lifetime broken mark.
+Deterministic configuration failures (for example, no spawn command) still
+use ``_broken``.
 """
 from __future__ import annotations
 
@@ -39,31 +33,35 @@ def _make_git_workspace(tmp_path: Path) -> Path:
     return repo
 
 
-def test_mark_broken_for_file_adds_correct_key(tmp_path, monkeypatch):
-    """``_mark_broken_for_file`` keys the broken-set on
-    (server_id, per_server_root) so subsequent ``enabled_for`` calls
-    for files in the same project skip immediately."""
+def test_mark_failed_file_adds_retryable_cooldown_key(tmp_path, monkeypatch):
     repo = _make_git_workspace(tmp_path)
     monkeypatch.chdir(str(repo))
     src = repo / "x.py"
     src.write_text("")
+    now = [100.0]
 
     svc = LSPService(
         enabled=True,
         wait_mode="document",
         wait_timeout=2.0,
         install_strategy="manual",
+        clock=lambda: now[0],
     )
     try:
         svc._mark_broken_for_file(str(src), RuntimeError("simulated"))
-        # The pyright server resolves to the repo root via pyproject.toml.
-        assert ("pyright", str(repo)) in svc._broken
+        key = ("pyright", str(repo.resolve()))
+        assert key in svc._cooldowns
+        assert key not in svc._broken
+        assert svc.enabled_for(str(src)) is False
+        now[0] = 106.0
+        assert svc.enabled_for(str(src)) is True
+        assert key not in svc._cooldowns
     finally:
         svc.shutdown()
 
 
-def test_enabled_for_returns_false_after_broken(tmp_path, monkeypatch):
-    """Once a (server_id, root) pair is in the broken-set,
+def test_enabled_for_returns_false_during_cooldown(tmp_path, monkeypatch):
+    """Once a (server_id, root) pair is cooling down,
     ``enabled_for`` returns False so the file_operations layer skips
     the LSP path entirely."""
     repo = _make_git_workspace(tmp_path)
@@ -80,16 +78,16 @@ def test_enabled_for_returns_false_after_broken(tmp_path, monkeypatch):
     try:
         # Initially enabled.
         assert svc.enabled_for(str(src)) is True
-        # Mark broken.
+        # Start the retry cooldown.
         svc._mark_broken_for_file(str(src), RuntimeError("simulated"))
-        # Now disabled — the broken-set short-circuits.
+        # Now disabled — the cooldown short-circuits.
         assert svc.enabled_for(str(src)) is False
     finally:
         svc.shutdown()
 
 
 def test_enabled_for_other_file_in_same_project_also_skipped(tmp_path, monkeypatch):
-    """The broken key is (server_id, root), so ALL files routed through
+    """The cooldown key is (server_id, root), so ALL files routed through
     the same server in the same project are skipped — not just the one
     that triggered the failure."""
     repo = _make_git_workspace(tmp_path)
@@ -114,8 +112,8 @@ def test_enabled_for_other_file_in_same_project_also_skipped(tmp_path, monkeypat
         svc.shutdown()
 
 
-def test_unrelated_project_not_affected_by_broken(tmp_path, monkeypatch):
-    """Marking pyright broken for project A must NOT affect project B."""
+def test_unrelated_project_not_affected_by_cooldown(tmp_path, monkeypatch):
+    """Cooling down pyright for project A must NOT affect project B."""
     repo_a = _make_git_workspace(tmp_path)
     repo_b = tmp_path / "repo-b"
     repo_b.mkdir()
@@ -137,7 +135,7 @@ def test_unrelated_project_not_affected_by_broken(tmp_path, monkeypatch):
         svc._mark_broken_for_file(str(a_src), RuntimeError("simulated"))
         # Project A skipped.
         assert svc.enabled_for(str(a_src)) is False
-        # Project B still enabled — the broken key is per-project.
+        # Project B still enabled — the cooldown key is per-project.
         monkeypatch.chdir(str(repo_b))
         assert svc.enabled_for(str(b_src)) is True
     finally:
@@ -157,6 +155,7 @@ def test_mark_broken_handles_missing_server_silently(tmp_path):
         # No registered server for .xyz; must not raise.
         svc._mark_broken_for_file(str(tmp_path / "weird.xyz"), RuntimeError("x"))
         assert len(svc._broken) == 0
+        assert len(svc._cooldowns) == 0
     finally:
         svc.shutdown()
 
@@ -174,27 +173,27 @@ def test_mark_broken_handles_no_workspace_silently(tmp_path):
     try:
         svc._mark_broken_for_file(str(src), RuntimeError("x"))
         assert len(svc._broken) == 0
+        assert len(svc._cooldowns) == 0
     finally:
         svc.shutdown()
 
 
-def test_snapshot_failure_marks_broken_via_outer_timeout(tmp_path, monkeypatch):
-    """End-to-end: ``snapshot_baseline``'s outer ``_loop.run`` timeout
-    triggers ``_mark_broken_for_file``, so a second call to
-    ``enabled_for`` returns False."""
+def test_snapshot_failure_enters_retryable_cooldown(tmp_path, monkeypatch):
+    """A snapshot failure skips immediate retries without permanent disablement."""
     repo = _make_git_workspace(tmp_path)
     monkeypatch.chdir(str(repo))
     src = repo / "x.py"
     src.write_text("")
+    now = [100.0]
 
     svc = LSPService(
         enabled=True,
         wait_mode="document",
         wait_timeout=2.0,
         install_strategy="manual",
+        clock=lambda: now[0],
     )
     try:
-        # Force the inner snapshot coroutine to raise.
         async def boom(_path):
             raise RuntimeError("outer-timeout simulated")
 
@@ -202,9 +201,11 @@ def test_snapshot_failure_marks_broken_via_outer_timeout(tmp_path, monkeypatch):
             assert svc.enabled_for(str(src)) is True
             svc.snapshot_baseline(str(src))
 
-        # After the failure, the file's pair is in the broken-set and
-        # ``enabled_for`` skips it.
-        assert ("pyright", str(repo)) in svc._broken
+        key = ("pyright", str(repo.resolve()))
+        assert key in svc._cooldowns
+        assert key not in svc._broken
         assert svc.enabled_for(str(src)) is False
+        now[0] = 106.0
+        assert svc.enabled_for(str(src)) is True
     finally:
         svc.shutdown()

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -126,6 +126,69 @@ async def test_client_shutdown_idempotent(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_concurrent_shutdown_callers_wait_for_same_cleanup(tmp_path: Path, monkeypatch):
+    client = _client(tmp_path, "clean")
+    await client.start()
+    cleanup_entered = asyncio.Event()
+    allow_cleanup = asyncio.Event()
+    original_cleanup = client._cleanup_process
+
+    async def blocked_cleanup(descendants=None):
+        cleanup_entered.set()
+        await allow_cleanup.wait()
+        await original_cleanup(descendants)
+
+    monkeypatch.setattr(client, "_cleanup_process", blocked_cleanup)
+    first = asyncio.create_task(client.shutdown())
+    await cleanup_entered.wait()
+    second = asyncio.create_task(client.shutdown())
+    await asyncio.sleep(0)
+    assert not second.done()
+    allow_cleanup.set()
+    await asyncio.gather(first, second)
+
+
+@pytest.mark.asyncio
+@pytest.mark.live_system_guard_bypass
+async def test_shutdown_removes_wrapper_descendant_tree(tmp_path: Path):
+    import psutil
+
+    pid_file = tmp_path / "child.pid"
+    env = {
+        "MOCK_LSP_SCRIPT": "child",
+        "MOCK_LSP_CHILD_PID_FILE": str(pid_file),
+        "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+    }
+    client = LSPClient(
+        server_id="mock-child",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, MOCK_SERVER],
+        env=env,
+        cwd=str(tmp_path),
+    )
+    await client.start()
+    for _ in range(100):
+        if pid_file.exists():
+            break
+        await asyncio.sleep(0.01)
+    child_pid = int(pid_file.read_text())
+    assert psutil.pid_exists(child_pid)
+
+    await client.shutdown()
+
+    for _ in range(100):
+        if not psutil.pid_exists(child_pid):
+            break
+        try:
+            if psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE:
+                break
+        except psutil.NoSuchProcess:
+            break
+        await asyncio.sleep(0.01)
+    assert not psutil.pid_exists(child_pid) or psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE
+
+
+@pytest.mark.asyncio
 async def test_client_diagnostics_are_deduped(tmp_path: Path):
     """Repeated identical pushes must not produce duplicate diagnostics."""
     f = tmp_path / "x.py"

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from agent.lsp.client import LSPClient
+from agent.lsp.protocol import LSPProtocolError
 
 
 MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
@@ -140,12 +141,97 @@ async def test_concurrent_shutdown_callers_wait_for_same_cleanup(tmp_path: Path,
 
     monkeypatch.setattr(client, "_cleanup_process", blocked_cleanup)
     first = asyncio.create_task(client.shutdown())
-    await cleanup_entered.wait()
-    second = asyncio.create_task(client.shutdown())
-    await asyncio.sleep(0)
-    assert not second.done()
-    allow_cleanup.set()
-    await asyncio.gather(first, second)
+    second = None
+    try:
+        await cleanup_entered.wait()
+        second = asyncio.create_task(client.shutdown())
+        await asyncio.sleep(0)
+        assert not second.done()
+        allow_cleanup.set()
+        await asyncio.gather(first, second)
+    finally:
+        allow_cleanup.set()
+        pending = [first]
+        if second is not None:
+            pending.append(second)
+        await asyncio.gather(*pending, return_exceptions=True)
+        await client.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.live_system_guard_bypass
+async def test_cancelling_shutdown_caller_does_not_cancel_shared_cleanup(
+    tmp_path: Path, monkeypatch
+):
+    import psutil
+
+    pid_file = tmp_path / "cancel-child.pid"
+    client = LSPClient(
+        server_id="mock-cancel-child",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, MOCK_SERVER],
+        env={
+            "MOCK_LSP_SCRIPT": "child",
+            "MOCK_LSP_CHILD_PID_FILE": str(pid_file),
+            "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+        },
+        cwd=str(tmp_path),
+    )
+    child_pid = None
+    allow_cleanup = asyncio.Event()
+    first = None
+    try:
+        await client.start()
+        for _ in range(100):
+            if pid_file.exists():
+                break
+            await asyncio.sleep(0.01)
+        child_pid = int(pid_file.read_text())
+        cleanup_entered = asyncio.Event()
+        original_cleanup = client._cleanup_process
+
+        async def blocked_cleanup(descendants=None):
+            cleanup_entered.set()
+            await allow_cleanup.wait()
+            await original_cleanup(descendants)
+
+        monkeypatch.setattr(client, "_cleanup_process", blocked_cleanup)
+        first = asyncio.create_task(client.shutdown())
+        await cleanup_entered.wait()
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        second = asyncio.create_task(client.shutdown())
+        await asyncio.sleep(0)
+        assert not second.done()
+        allow_cleanup.set()
+        await second
+        assert client.process_alive is False
+        assert (
+            not psutil.pid_exists(child_pid)
+            or psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE
+        )
+    finally:
+        allow_cleanup.set()
+        if first is not None:
+            await asyncio.gather(first, return_exceptions=True)
+        await asyncio.shield(client.shutdown())
+        if child_pid is not None and psutil.pid_exists(child_pid):
+            try:
+                child = psutil.Process(child_pid)
+                child.kill()
+                child.wait(timeout=2.0)
+            except psutil.Error:
+                pass
+
+
+@pytest.mark.asyncio
+async def test_client_rejects_restart_after_shutdown(tmp_path: Path):
+    client = _client(tmp_path, "clean")
+    await client.start()
+    await client.shutdown()
+    with pytest.raises(LSPProtocolError, match="single-use"):
+        await client.start()
 
 
 @pytest.mark.asyncio
@@ -166,26 +252,40 @@ async def test_shutdown_removes_wrapper_descendant_tree(tmp_path: Path):
         env=env,
         cwd=str(tmp_path),
     )
-    await client.start()
-    for _ in range(100):
-        if pid_file.exists():
-            break
-        await asyncio.sleep(0.01)
-    child_pid = int(pid_file.read_text())
-    assert psutil.pid_exists(child_pid)
-
-    await client.shutdown()
-
-    for _ in range(100):
-        if not psutil.pid_exists(child_pid):
-            break
-        try:
-            if psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE:
+    child_pid = None
+    try:
+        await client.start()
+        for _ in range(100):
+            if pid_file.exists():
                 break
-        except psutil.NoSuchProcess:
-            break
-        await asyncio.sleep(0.01)
-    assert not psutil.pid_exists(child_pid) or psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE
+            await asyncio.sleep(0.01)
+        child_pid = int(pid_file.read_text())
+        assert psutil.pid_exists(child_pid)
+
+        await client.shutdown()
+
+        for _ in range(100):
+            if not psutil.pid_exists(child_pid):
+                break
+            try:
+                if psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE:
+                    break
+            except psutil.NoSuchProcess:
+                break
+            await asyncio.sleep(0.01)
+        assert (
+            not psutil.pid_exists(child_pid)
+            or psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE
+        )
+    finally:
+        await asyncio.shield(client.shutdown())
+        if child_pid is not None and psutil.pid_exists(child_pid):
+            try:
+                child = psutil.Process(child_pid)
+                child.kill()
+                child.wait(timeout=2.0)
+            except psutil.Error:
+                pass
 
 
 @pytest.mark.asyncio

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -159,6 +159,57 @@ async def test_concurrent_shutdown_callers_wait_for_same_cleanup(tmp_path: Path,
 
 
 @pytest.mark.asyncio
+async def test_failed_shared_shutdown_can_be_retried(tmp_path: Path, monkeypatch):
+    client = _client(tmp_path, "clean")
+    await client.start()
+    original_cleanup = client._cleanup_process
+    attempts = 0
+
+    async def fail_once(descendants=None):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("synthetic cleanup failure")
+        await original_cleanup(descendants)
+
+    monkeypatch.setattr(client, "_cleanup_process", fail_once)
+    with pytest.raises(RuntimeError, match="synthetic cleanup failure"):
+        await client.shutdown()
+
+    await client.shutdown()
+    assert attempts == 2
+    assert client.process_alive is False
+
+
+@pytest.mark.asyncio
+async def test_successful_incomplete_shared_shutdown_is_retried(
+    tmp_path: Path, monkeypatch
+):
+    client = _client(tmp_path, "clean")
+    await client.start()
+    original_shutdown = client._shutdown_impl
+    attempts = 0
+
+    async def leave_tree_once():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return
+        await original_shutdown()
+
+    monkeypatch.setattr(client, "_shutdown_impl", leave_tree_once)
+    try:
+        await client.shutdown()
+        assert client.process_tree_alive is True
+
+        await client.shutdown()
+        assert attempts == 2
+        assert client.process_tree_alive is False
+    finally:
+        await asyncio.shield(client.shutdown())
+
+
+@pytest.mark.asyncio
 @pytest.mark.live_system_guard_bypass
 async def test_cancelling_shutdown_caller_does_not_cancel_shared_cleanup(
     tmp_path: Path, monkeypatch
@@ -282,6 +333,125 @@ async def test_shutdown_removes_wrapper_descendant_tree(tmp_path: Path):
         if child_pid is not None and psutil.pid_exists(child_pid):
             try:
                 child = psutil.Process(child_pid)
+                child.kill()
+                child.wait(timeout=2.0)
+            except psutil.Error:
+                pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.live_system_guard_bypass
+async def test_shutdown_finds_owned_descendant_after_wrapper_exit(tmp_path: Path):
+    import psutil
+
+    pid_file = tmp_path / "orphan-child.pid"
+    client = LSPClient(
+        server_id="mock-orphan-child",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, MOCK_SERVER],
+        env={
+            "MOCK_LSP_SCRIPT": "child",
+            "MOCK_LSP_CHILD_PID_FILE": str(pid_file),
+            "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+        },
+        cwd=str(tmp_path),
+    )
+    child_pid = None
+    try:
+        await client.start()
+        for _ in range(100):
+            if pid_file.exists():
+                break
+            await asyncio.sleep(0.01)
+        child_pid = int(pid_file.read_text())
+        assert psutil.pid_exists(child_pid)
+
+        assert client._proc is not None
+        client._proc.kill()
+        # The helper inherited the wrapper's pipe descriptors, so awaiting
+        # Process.wait() here can block until that helper is cleaned up. Poll
+        # only for the wrapper exit notification, then let shutdown recover
+        # the token-owned orphan and close the pipes.
+        for _ in range(100):
+            if client._proc.returncode is not None:
+                break
+            await asyncio.sleep(0.01)
+        assert client._proc.returncode is not None
+        assert client.process_alive is False
+        assert client.process_tree_alive is True
+        await client.shutdown()
+        assert client.process_tree_alive is False
+
+        for _ in range(100):
+            if not psutil.pid_exists(child_pid):
+                break
+            try:
+                if psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE:
+                    break
+            except psutil.NoSuchProcess:
+                break
+            await asyncio.sleep(0.01)
+        assert (
+            not psutil.pid_exists(child_pid)
+            or psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE
+        )
+    finally:
+        await asyncio.shield(client.shutdown())
+        if child_pid is not None and psutil.pid_exists(child_pid):
+            try:
+                child = psutil.Process(child_pid)
+                child.kill()
+                child.wait(timeout=2.0)
+            except psutil.Error:
+                pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.live_system_guard_bypass
+async def test_shutdown_sweeps_children_spawned_until_wrapper_kill(tmp_path: Path):
+    import psutil
+
+    pid_file = tmp_path / "spawn-loop-children.pid"
+    client = LSPClient(
+        server_id="mock-spawn-loop",
+        workspace_root=str(tmp_path),
+        command=[sys.executable, MOCK_SERVER],
+        env={
+            "MOCK_LSP_SCRIPT": "spawn_loop",
+            "MOCK_LSP_CHILD_PID_FILE": str(pid_file),
+            "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+        },
+        cwd=str(tmp_path),
+    )
+    pids = set()
+    try:
+        await client.start()
+        for _ in range(100):
+            if pid_file.exists():
+                pids = {int(pid) for pid in pid_file.read_text().splitlines()}
+                if len(pids) >= 3:
+                    break
+            await asyncio.sleep(0.02)
+        assert len(pids) >= 3
+
+        await client.shutdown()
+        if pid_file.exists():
+            pids.update(int(pid) for pid in pid_file.read_text().splitlines())
+        assert client.process_tree_alive is False
+        assert all(
+            not psutil.pid_exists(pid)
+            or psutil.Process(pid).status() == psutil.STATUS_ZOMBIE
+            for pid in pids
+        )
+    finally:
+        await asyncio.shield(client.shutdown())
+        if pid_file.exists():
+            pids.update(int(pid) for pid in pid_file.read_text().splitlines())
+        for pid in pids:
+            if not psutil.pid_exists(pid):
+                continue
+            try:
+                child = psutil.Process(pid)
                 child.kill()
                 child.wait(timeout=2.0)
             except psutil.Error:

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -5,6 +5,7 @@ it through real LSP traffic, and asserts diagnostic flow.  This is
 the closest thing we have to integration coverage without requiring
 pyright/gopls/etc. to be installed in CI.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -83,7 +84,9 @@ async def test_client_didchange_bumps_version(tmp_path: Path):
     try:
         v0 = await client.open_file(str(f), language_id="python")
         f.write_text("print('hi 2')\n")
-        v1 = await client.open_file(str(f), language_id="python")  # re-open path = didChange
+        v1 = await client.open_file(
+            str(f), language_id="python"
+        )  # re-open path = didChange
         assert v1 == v0 + 1
         await client.wait_for_diagnostics(str(f), v1, mode="document")
         # Mock pushed a diagnostic for both events; merged view has one
@@ -127,7 +130,9 @@ async def test_client_shutdown_idempotent(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_shutdown_callers_wait_for_same_cleanup(tmp_path: Path, monkeypatch):
+async def test_concurrent_shutdown_callers_wait_for_same_cleanup(
+    tmp_path: Path, monkeypatch
+):
     client = _client(tmp_path, "clean")
     await client.start()
     cleanup_entered = asyncio.Event()
@@ -144,11 +149,13 @@ async def test_concurrent_shutdown_callers_wait_for_same_cleanup(tmp_path: Path,
     second = None
     try:
         await cleanup_entered.wait()
+        assert client.state == "stopping"
         second = asyncio.create_task(client.shutdown())
         await asyncio.sleep(0)
         assert not second.done()
         allow_cleanup.set()
         await asyncio.gather(first, second)
+        assert client.state == "stopped"
     finally:
         allow_cleanup.set()
         pending = [first]
@@ -408,16 +415,31 @@ async def test_shutdown_finds_owned_descendant_after_wrapper_exit(tmp_path: Path
 
 @pytest.mark.asyncio
 @pytest.mark.live_system_guard_bypass
-async def test_shutdown_sweeps_children_spawned_until_wrapper_kill(tmp_path: Path):
+@pytest.mark.parametrize(
+    "script",
+    [
+        "spawn_loop",
+        pytest.param(
+            "spawn_loop_sanitized",
+            marks=pytest.mark.skipif(
+                os.name == "nt",
+                reason="sanitized fallback uses the POSIX process group",
+            ),
+        ),
+    ],
+)
+async def test_shutdown_sweeps_children_spawned_until_wrapper_kill(
+    tmp_path: Path, script: str
+):
     import psutil
 
     pid_file = tmp_path / "spawn-loop-children.pid"
     client = LSPClient(
-        server_id="mock-spawn-loop",
+        server_id=f"mock-{script}",
         workspace_root=str(tmp_path),
         command=[sys.executable, MOCK_SERVER],
         env={
-            "MOCK_LSP_SCRIPT": "spawn_loop",
+            "MOCK_LSP_SCRIPT": script,
             "MOCK_LSP_CHILD_PID_FILE": str(pid_file),
             "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
         },

--- a/tests/agent/lsp/test_lifecycle.py
+++ b/tests/agent/lsp/test_lifecycle.py
@@ -7,6 +7,7 @@ pyright/gopls/etc. are still alive on the host.
 from __future__ import annotations
 
 import atexit
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -142,3 +143,56 @@ def test_get_service_returns_none_when_create_fails(monkeypatch):
     monkeypatch.setattr(atexit, "register", lambda fn: None)
 
     assert lsp_module.get_service() is None
+
+
+def test_restart_barrier_never_exposes_overlapping_singletons(monkeypatch):
+    closing = threading.Event()
+    release_shutdown = threading.Event()
+    replacement_created = threading.Event()
+
+    class OldService:
+        def __init__(self):
+            self.accepting = True
+
+        def is_active(self):
+            return self.accepting
+
+        def is_accepting_requests(self):
+            return self.accepting
+
+        def begin_shutdown(self):
+            self.accepting = False
+            return True
+
+        def shutdown(self):
+            closing.set()
+            assert release_shutdown.wait(timeout=2.0)
+
+    replacement = MagicMock()
+    replacement.is_active.return_value = True
+    replacement.is_accepting_requests.return_value = True
+    lsp_module._service = OldService()
+    monkeypatch.setattr(atexit, "register", lambda fn: None)
+
+    def create_replacement():
+        replacement_created.set()
+        return replacement
+
+    monkeypatch.setattr(
+        lsp_module.LSPService,
+        "create_from_config",
+        classmethod(lambda cls: create_replacement()),
+    )
+
+    shutdown_thread = threading.Thread(target=lsp_module.shutdown_service)
+    result = []
+    get_thread = threading.Thread(target=lambda: result.append(lsp_module.get_service()))
+    shutdown_thread.start()
+    assert closing.wait(timeout=1.0)
+    get_thread.start()
+    assert not replacement_created.wait(timeout=0.05)
+    release_shutdown.set()
+    shutdown_thread.join(timeout=2.0)
+    get_thread.join(timeout=2.0)
+
+    assert result == [replacement]

--- a/tests/agent/lsp/test_lifecycle.py
+++ b/tests/agent/lsp/test_lifecycle.py
@@ -153,12 +153,16 @@ def test_restart_barrier_never_exposes_overlapping_singletons(monkeypatch):
     class OldService:
         def __init__(self):
             self.accepting = True
+            self.closed = False
 
         def is_active(self):
             return self.accepting
 
         def is_accepting_requests(self):
             return self.accepting
+
+        def is_closed(self):
+            return self.closed
 
         def begin_shutdown(self):
             self.accepting = False
@@ -167,6 +171,7 @@ def test_restart_barrier_never_exposes_overlapping_singletons(monkeypatch):
         def shutdown(self):
             closing.set()
             assert release_shutdown.wait(timeout=2.0)
+            self.closed = True
 
     replacement = MagicMock()
     replacement.is_active.return_value = True
@@ -196,3 +201,40 @@ def test_restart_barrier_never_exposes_overlapping_singletons(monkeypatch):
     get_thread.join(timeout=2.0)
 
     assert result == [replacement]
+
+
+def test_failed_shutdown_keeps_singleton_tombstone_and_blocks_replacement(monkeypatch):
+    class FailedService:
+        def __init__(self):
+            self.accepting = True
+
+        def is_active(self):
+            return self.accepting
+
+        def is_accepting_requests(self):
+            return self.accepting
+
+        def is_closed(self):
+            return False
+
+        def begin_shutdown(self):
+            self.accepting = False
+            return True
+
+        def shutdown(self):
+            raise RuntimeError("owner loop still alive")
+
+    failed = FailedService()
+    lsp_module._service = failed
+    created = []
+    monkeypatch.setattr(
+        lsp_module.LSPService,
+        "create_from_config",
+        classmethod(lambda cls: created.append(True)),
+    )
+
+    lsp_module.shutdown_service()
+
+    assert lsp_module._service is failed
+    assert lsp_module.get_service() is None
+    assert created == []

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -174,3 +174,67 @@ def test_service_status_includes_clients(mock_pyright):
         assert any(c["server_id"] == "pyright" for c in info["clients"])
     finally:
         svc.shutdown()
+
+
+def test_idle_reaper_shuts_down_idle_clients(mock_pyright):
+    """Clients idle past ``idle_timeout`` must be reaped automatically."""
+    import time as _time
+
+    repo = mock_pyright
+    f = repo / "x.py"
+    f.write_text("print('hi')\n")
+
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=3.0,
+        install_strategy="manual",
+        idle_timeout=0.5,  # 0.5 second — triggers quickly for test
+    )
+    try:
+        assert svc.enabled_for(str(f))
+        svc.get_diagnostics_sync(str(f))
+        # Client should be alive now.
+        info = svc.get_status()
+        assert len(info["clients"]) == 1
+        assert info["clients"][0]["running"] is True
+
+        # Wait for idle timeout to expire.
+        _time.sleep(1.0)
+
+        # Directly invoke reap — should remove the idle client.
+        svc._loop.run(svc._reap_idle_clients(), timeout=5.0)
+
+        # Client should be gone.
+        info = svc.get_status()
+        assert len(info["clients"]) == 0
+    finally:
+        svc.shutdown()
+
+
+def test_idle_reaper_keeps_active_clients(mock_pyright):
+    """Clients that were recently used must NOT be reaped."""
+    repo = mock_pyright
+    f = repo / "x.py"
+    f.write_text("print('hi')\n")
+
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=3.0,
+        install_strategy="manual",
+        idle_timeout=300.0,  # 5 minutes — won't expire
+    )
+    try:
+        svc.get_diagnostics_sync(str(f))
+        info = svc.get_status()
+        assert len(info["clients"]) == 1
+
+        # Directly invoke reap — should NOT remove the active client.
+        svc._loop.run(svc._reap_idle_clients(), timeout=5.0)
+
+        info = svc.get_status()
+        assert len(info["clients"]) == 1
+        assert info["clients"][0]["running"] is True
+    finally:
+        svc.shutdown()

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -7,6 +7,7 @@ on.
 """
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 import sys
 from pathlib import Path
 
@@ -189,7 +190,9 @@ def test_idle_reaper_shuts_down_idle_clients(mock_pyright):
         wait_mode="document",
         wait_timeout=3.0,
         install_strategy="manual",
+        lifecycle_enabled=True,
         idle_timeout=0.5,  # 0.5 second — triggers quickly for test
+        sweep_interval=0.05,
     )
     try:
         assert svc.enabled_for(str(f))
@@ -208,6 +211,15 @@ def test_idle_reaper_shuts_down_idle_clients(mock_pyright):
         # Client should be gone.
         info = svc.get_status()
         assert len(info["clients"]) == 0
+
+        # Intentional retirement is not a permanent broken mark. The next
+        # edit cold-starts a fresh generation.
+        svc.get_diagnostics_sync(str(f))
+        info = svc.get_status()
+        assert svc.enabled_for(str(f))
+        assert len(info["clients"]) == 1
+        assert info["clients"][0]["generation"] == 2
+        assert info["clients"][0]["running"] is True
     finally:
         svc.shutdown()
 
@@ -223,7 +235,9 @@ def test_idle_reaper_keeps_active_clients(mock_pyright):
         wait_mode="document",
         wait_timeout=3.0,
         install_strategy="manual",
+        lifecycle_enabled=True,
         idle_timeout=300.0,  # 5 minutes — won't expire
+        sweep_interval=60.0,
     )
     try:
         svc.get_diagnostics_sync(str(f))
@@ -236,5 +250,67 @@ def test_idle_reaper_keeps_active_clients(mock_pyright):
         info = svc.get_status()
         assert len(info["clients"]) == 1
         assert info["clients"][0]["running"] is True
+    finally:
+        svc.shutdown()
+
+
+def test_concurrent_same_workspace_requests_share_one_spawn(mock_pyright):
+    repo = mock_pyright
+    f = repo / "x.py"
+    f.write_text("print('hi')\n")
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=3.0,
+        install_strategy="manual",
+        lifecycle_enabled=True,
+        idle_timeout=300.0,
+        sweep_interval=60.0,
+    )
+    try:
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(
+                pool.map(lambda _: svc.get_diagnostics_sync(str(f)), range(8))
+            )
+        assert all(isinstance(result, list) for result in results)
+        status = svc.get_status()
+        assert len(status["clients"]) == 1
+        assert status["clients"][0]["generation"] == 1
+    finally:
+        svc.shutdown()
+
+
+def test_capacity_retires_lru_before_spawning_replacement(
+    tmp_path, mock_pyright
+):
+    files = []
+    for index in range(3):
+        repo = tmp_path / f"repo-{index}"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        file_path = repo / "x.py"
+        file_path.write_text("print('hi')\n")
+        files.append(file_path)
+
+    svc = LSPService(
+        enabled=True,
+        wait_mode="document",
+        wait_timeout=3.0,
+        install_strategy="manual",
+        lifecycle_enabled=True,
+        idle_timeout=0.0,
+        sweep_interval=60.0,
+        max_clients=2,
+    )
+    try:
+        for file_path in files:
+            assert len(svc.get_diagnostics_sync(str(file_path))) == 1
+        status = svc.get_status()
+        assert len(status["clients"]) == 2
+        assert status["lifecycle"]["capacity_evictions"] == 1
+        roots = {client["workspace_root"] for client in status["clients"]}
+        assert str(files[0].parent.resolve()) not in roots
+        assert str(files[1].parent.resolve()) in roots
+        assert str(files[2].parent.resolve()) in roots
     finally:
         svc.shutdown()

--- a/tests/agent/lsp/test_service.py
+++ b/tests/agent/lsp/test_service.py
@@ -270,9 +270,11 @@ def test_concurrent_same_workspace_requests_share_one_spawn(mock_pyright):
     try:
         with ThreadPoolExecutor(max_workers=8) as pool:
             results = list(
-                pool.map(lambda _: svc.get_diagnostics_sync(str(f)), range(8))
+                pool.map(
+                    lambda _: svc.get_diagnostics_sync(str(f), delta=False), range(8)
+                )
             )
-        assert all(isinstance(result, list) for result in results)
+        assert all(len(result) == 1 for result in results)
         status = svc.get_status()
         assert len(status["clients"]) == 1
         assert status["clients"][0]["generation"] == 1

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -164,6 +164,14 @@ lsp:
   #   manual  — only use binaries already on PATH
   install_strategy: auto
 
+  # Optional bounded lifecycle for long-running, multi-workspace processes.
+  # Disabled by default: absent/false preserves process-lifetime retention.
+  lifecycle:
+    enabled: false
+    idle_timeout_seconds: 7200
+    sweep_interval_seconds: 60
+    max_clients_per_process: 0  # 0 = unlimited
+
   # Per-server overrides (all optional).
   servers:
     pyright:
@@ -222,9 +230,21 @@ answered after it). Slow servers that haven't re-checked yet result
 in "no data" for that edit — never in yesterday's errors being
 re-reported as current.
 
-Servers are kept alive for the life of the Hermes process. There's
-no idle-timeout reaper — the cost of restarting the server's index
-on every write would be far higher than holding the daemon.
+By default, servers are kept alive for the life of the Hermes process,
+preserving warm indexes and existing behavior. Long-running gateways that
+touch many workspaces can opt into `lsp.lifecycle`. The bounded lifecycle:
+
+- retires only clients that have no active diagnostics operation;
+- waits for a retired process tree to exit before replacing that slot;
+- can enforce a process-local least-recently-used client cap;
+- temporarily exceeds the cap rather than interrupting active work; and
+- respawns an intentionally retired server on the next edit.
+
+The next edit after retirement pays the server's cold-start/indexing cost.
+`idle_timeout_seconds: 0` disables idle retirement, while
+`max_clients_per_process: 0` keeps the client count unlimited. Lifecycle
+limits are per Hermes process, not shared across gateways, CLI sessions, or
+workers that happen to use the same profile.
 
 ## Disabling
 

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -244,7 +244,11 @@ process when preserving warm indexes matters more than bounding resources. The
 bounded lifecycle:
 
 - retires only clients that have no active diagnostics operation;
-- waits for a retired process tree to exit before replacing that slot;
+- waits for a retired process tree to exit before replacing that slot, using an
+  inherited ownership token and POSIX process-group identity to recover helpers
+  after their direct wrapper exits;
+- waits for in-flight binary discovery or installation before allowing a
+  replacement service;
 - can enforce a process-local least-recently-used client cap;
 - temporarily exceeds the cap rather than interrupting active work; and
 - respawns an intentionally retired server on the next edit.

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -164,10 +164,10 @@ lsp:
   #   manual  — only use binaries already on PATH
   install_strategy: auto
 
-  # Optional bounded lifecycle for long-running, multi-workspace processes.
-  # Disabled by default: absent/false preserves process-lifetime retention.
+  # Bounded lifecycle for long-running, multi-workspace processes.
+  # Enabled by default; set false to preserve process-lifetime retention.
   lifecycle:
-    enabled: false
+    enabled: true
     idle_timeout_seconds: 7200
     sweep_interval_seconds: 60
     max_clients_per_process: 0  # 0 = unlimited
@@ -189,10 +189,10 @@ lsp:
 Lifecycle validation is strict: `idle_timeout_seconds` must be between `0`
 and `31536000`, `sweep_interval_seconds` must be greater than `0` and at most
 `86400`, and `max_clients_per_process` must be an integer from `0` through
-`64`. Unknown keys and invalid values are reported by `hermes lsp status`. If
-an explicitly enabled policy is malformed, Hermes keeps lifecycle management
-enabled with the safe `7200s / 60s / unlimited-count` defaults rather than
-silently falling back to unbounded process-lifetime retention.
+`64`. Unknown keys and invalid values are reported by `hermes lsp status`.
+If an enabled policy is malformed, Hermes keeps lifecycle management enabled
+with the safe `7200s / 60s / unlimited-count` defaults rather than silently
+falling back to unbounded process-lifetime retention.
 
 ### Per-server keys
 
@@ -238,9 +238,10 @@ answered after it). Slow servers that haven't re-checked yet result
 in "no data" for that edit — never in yesterday's errors being
 re-reported as current.
 
-By default, servers are kept alive for the life of the Hermes process,
-preserving warm indexes and existing behavior. Long-running gateways that
-touch many workspaces can opt into `lsp.lifecycle`. The bounded lifecycle:
+By default, servers idle for two hours are retired. Set
+`lsp.lifecycle.enabled: false` to keep servers alive for the life of the Hermes
+process when preserving warm indexes matters more than bounding resources. The
+bounded lifecycle:
 
 - retires only clients that have no active diagnostics operation;
 - waits for a retired process tree to exit before replacing that slot;

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -186,6 +186,14 @@ lsp:
       disabled: true       # skip TS even when its extensions match
 ```
 
+Lifecycle validation is strict: `idle_timeout_seconds` must be between `0`
+and `31536000`, `sweep_interval_seconds` must be greater than `0` and at most
+`86400`, and `max_clients_per_process` must be an integer from `0` through
+`64`. Unknown keys and invalid values are reported by `hermes lsp status`. If
+an explicitly enabled policy is malformed, Hermes keeps lifecycle management
+enabled with the safe `7200s / 60s / unlimited-count` defaults rather than
+silently falling back to unbounded process-lifetime retention.
+
 ### Per-server keys
 
 * `disabled: true` — skip this server entirely even when its


### PR DESCRIPTION
## Summary

Long-running Hermes gateways keep one language-server process per `(server_id, workspace_root)` for the life of the Python process. This PR adds a **bounded lifecycle** without allowing an idle sweep, cancellation, or concurrent cold start to kill work that is still using a client.

- retires truly idle LSP clients after a configurable timeout
- optionally caps clients per Hermes process with least-recently-used admission
- prevents duplicate same-key cold starts
- protects active operations with generation-bound leases
- preserves failed-retirement tombstones so a replacement cannot overlap a still-live predecessor
- makes service and client shutdown idempotent, cancellation-resilient, and process-tree aware
- recovers token- or POSIX-process-group-owned descendants even after wrapper exit
- drains in-flight binary discovery/install work before allowing singleton replacement
- preserves current-main fresh-diagnostics semantics while clients are leased
- exposes lifecycle state and counters through `hermes lsp status`

The lifecycle policy is **enabled by default** with a conservative two-hour idle timeout. Users who prefer process-lifetime clients and permanently warm indexes can explicitly set `lsp.lifecycle.enabled: false`.

Closes #25016
Closes #36681

Related narrower fixes: #36684 and #52751.

## Why the lifecycle machinery is deliberate

A simple timer that pops `_clients[key]` and calls `shutdown()` is unsafe under concurrency:

1. diagnostics or edits may still be awaiting that client;
2. two first-use callers can race and spawn duplicate servers;
3. a stale release can mutate a replacement generation;
4. failed cleanup can leave the old process alive while a replacement starts;
5. cancelling one shutdown waiter must not cancel shared cleanup;
6. language servers may leave descendant processes after the direct child exits.

This implementation makes those states explicit rather than hiding them behind timing assumptions.

## Configuration

```yaml
lsp:
  lifecycle:
    enabled: true
    idle_timeout_seconds: 7200
    sweep_interval_seconds: 60
    max_clients_per_process: 8
```

Canonical defaults are declared in `hermes_cli.config.DEFAULT_CONFIG`:

- `enabled: true`
- `idle_timeout_seconds: 7200`
- `sweep_interval_seconds: 60`
- `max_clients_per_process: 0` (`0` means unlimited)

Invalid enabled policies fall back to safe lifecycle values and surface `config_error` in status output.

## Review map

| Concern | Primary files | What to verify |
|---|---|---|
| Admission, leases, retirement, capacity | `agent/lsp/manager.py` | single-flight spawn; lease/generation invariants; idle/LRU retirement; failed-retirement tombstones |
| Diagnostic compatibility | `agent/lsp/manager.py` | current-main `fresh_only` behavior is preserved across leased clients |
| Subprocess cleanup | `agent/lsp/client.py` | stop-first token/process-group sweep; wrapper-vs-tree liveness; shared, retryable shutdown |
| Singleton replacement | `agent/lsp/__init__.py` | a closing or incompletely retired pool cannot overlap a replacement |
| User-facing status | `agent/lsp/cli.py` | lifecycle mode, limits, counters, and errors are visible |
| Defaults and propagation | `hermes_cli/config.py`, `tests/agent/lsp/test_bounded_lifecycle.py` | default-on policy and explicit opt-out reach `LSPService.create_from_config()` |
| Operational guidance | `website/docs/user-guide/features/lsp.md` | default behavior, opt-out, limits, and observability |

## Current-main refresh

Refreshed onto `b259668ca` on 2026-07-28. The refresh adapts the lifecycle work to upstream diagnostic-freshness changes added after the original PR branch while preserving its contributor authorship/history. Review-hardening commits cover failed spawn cleanup, retryable shared teardown, post-wrapper descendant recovery, process-group ownership, executor-drain safety, overflowing numeric policy input, and default-on policy consistency.

The branch contains only the LSP series; no downstream Brave-routing or Kanban changes are included.

## Verification

```text
204 passed  tests/agent/lsp
158 passed  adjacent agent/file-mutation regressions
325 passed  hermes_cli config/default/drift validation
----------
687 passed, 0 failed
```

Additional checks:

- Ruff check and format validation on all changed Python and LSP tests: passed
- `python -m compileall` on `agent/lsp` and `hermes_cli/config.py`: passed
- Windows subprocess creation-flag regression suite: 40 passed
- `git diff --check`: passed
- `hermes lsp status` under a temporary blank `HERMES_HOME`: passed and reported default `bounded` lifecycle with no active clients
- refreshed diff scanned for local paths, profile names, credentials, conflict markers, and unrelated carry code: clean

## Credit

The first commit preserves @liuhao1024's original idle-reaper work and authorship from #36684. The later commits add the concurrency, cleanup, configuration, compatibility, and regression hardening needed for a long-running multi-workspace process.
