### PR TITLE
feat(web): add repository-style file previews

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15667,6 +15667,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-reconciler": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
@@ -19102,7 +19129,9 @@
         "qrcode": "^1.5.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.17.0",
+        "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.1",
         "unicode-animations": "^1.0.3"

--- a/web/package.json
+++ b/web/package.json
@@ -32,7 +32,9 @@
     "qrcode": "^1.5.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.17.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.1",
     "unicode-animations": "^1.0.3"

--- a/web/src/components/FileMarkdown.tsx
+++ b/web/src/components/FileMarkdown.tsx
@@ -1,0 +1,77 @@
+import type { ComponentProps } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+function ExternalLink({ href, children }: ComponentProps<"a">) {
+  const external = /^(https?:|mailto:)/i.test(href ?? "");
+  return (
+    <a
+      href={href}
+      target={external ? "_blank" : undefined}
+      rel={external ? "noreferrer" : undefined}
+      className="font-medium text-primary underline decoration-primary/35 underline-offset-2 hover:decoration-primary"
+    >
+      {children}
+    </a>
+  );
+}
+
+export function FileMarkdown({ content }: { content: string }) {
+  return (
+    <article className="min-w-0 max-w-none space-y-4 break-words text-sm leading-7 text-foreground">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          a: ExternalLink,
+          blockquote: ({ children }) => (
+            <blockquote className="border-l-4 border-border pl-4 text-text-secondary">
+              {children}
+            </blockquote>
+          ),
+          code: ({ children, className }) => (
+            <code
+              className={`${className ?? ""} rounded-sm bg-secondary/70 px-1.5 py-0.5 font-mono text-xs text-foreground`}
+            >
+              {children}
+            </code>
+          ),
+          h1: ({ children }) => (
+            <h1 className="border-b border-border pb-2 text-3xl font-semibold">{children}</h1>
+          ),
+          h2: ({ children }) => (
+            <h2 className="border-b border-border pb-2 text-2xl font-semibold">{children}</h2>
+          ),
+          h3: ({ children }) => <h3 className="text-xl font-semibold">{children}</h3>,
+          h4: ({ children }) => <h4 className="text-lg font-semibold">{children}</h4>,
+          hr: () => <hr className="border-border" />,
+          img: ({ alt, src }) => (
+            <img
+              src={src}
+              alt={alt ?? ""}
+              className="max-w-full border border-border bg-background object-contain"
+            />
+          ),
+          ol: ({ children }) => <ol className="list-decimal space-y-1 pl-7">{children}</ol>,
+          p: ({ children }) => <p className="whitespace-pre-wrap">{children}</p>,
+          pre: ({ children }) => (
+            <pre className="overflow-x-auto border border-border bg-secondary/50 p-4 font-mono text-xs leading-6 text-foreground [&>code]:bg-transparent [&>code]:p-0">
+              {children}
+            </pre>
+          ),
+          table: ({ children }) => (
+            <table className="w-full border-collapse text-left text-sm">{children}</table>
+          ),
+          td: ({ children }) => <td className="border border-border px-3 py-2">{children}</td>,
+          th: ({ children }) => (
+            <th className="border border-border bg-secondary/60 px-3 py-2 font-semibold">
+              {children}
+            </th>
+          ),
+          ul: ({ children }) => <ul className="list-disc space-y-1 pl-7">{children}</ul>,
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </article>
+  );
+}

--- a/web/src/components/files/FilePreview.tsx
+++ b/web/src/components/files/FilePreview.tsx
@@ -1,0 +1,77 @@
+import { FileIcon } from "lucide-react";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { FileMarkdown } from "@/components/FileMarkdown";
+import type { ManagedFileEntry, ManagedFileReadResponse } from "@/lib/api";
+import type { PreviewKind } from "@/lib/file-browser";
+
+interface FilePreviewProps {
+  entry: ManagedFileEntry;
+  kind: PreviewKind;
+  file: ManagedFileReadResponse | null;
+  text: string;
+  mode: "rendered" | "source";
+  loading: boolean;
+  error: string | null;
+}
+
+export function FilePreview({
+  entry,
+  kind,
+  file,
+  text,
+  mode,
+  loading,
+  error,
+}: FilePreviewProps) {
+  if (loading) {
+    return (
+      <div className="flex min-h-80 items-center justify-center gap-2 text-sm text-text-secondary">
+        <Spinner /> Loading preview...
+      </div>
+    );
+  }
+  if (error) {
+    return <div className="p-4 text-sm text-destructive">{error}</div>;
+  }
+  if (kind === "large") {
+    return (
+      <div className="flex min-h-80 flex-col items-center justify-center gap-2 p-6 text-center">
+        <FileIcon className="h-9 w-9 text-text-tertiary" />
+        <p className="font-medium">File too large to preview</p>
+        <p className="text-sm text-text-secondary">Download file to inspect its contents.</p>
+      </div>
+    );
+  }
+  if (kind === "binary") {
+    return (
+      <div className="flex min-h-80 flex-col items-center justify-center gap-2 p-6 text-center">
+        <FileIcon className="h-9 w-9 text-text-tertiary" />
+        <p className="font-medium">Preview unavailable</p>
+        <p className="text-sm text-text-secondary">{entry.mime_type || "Binary file"}</p>
+      </div>
+    );
+  }
+  if (kind === "image" && file) {
+    return (
+      <div className="flex min-h-80 items-center justify-center bg-background/30 p-6">
+        <img
+          src={file.data_url}
+          alt={entry.name}
+          className="max-h-[65dvh] max-w-full border border-border object-contain"
+        />
+      </div>
+    );
+  }
+  if (kind === "markdown" && mode === "rendered") {
+    return (
+      <div className="overflow-x-auto p-5 sm:p-8">
+        <FileMarkdown content={text} />
+      </div>
+    );
+  }
+  return (
+    <pre className="min-h-80 overflow-auto bg-background/25 p-4 font-mono text-xs leading-6 text-foreground">
+      <code>{text}</code>
+    </pre>
+  );
+}

--- a/web/src/components/files/FileTree.tsx
+++ b/web/src/components/files/FileTree.tsx
@@ -1,0 +1,108 @@
+import { ChevronDown, ChevronRight, FileIcon, FileText, Folder, FolderOpen } from "lucide-react";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import type { ManagedFileEntry } from "@/lib/api";
+import { previewKind } from "@/lib/file-browser";
+
+interface FileTreeProps {
+  path: string;
+  label: string;
+  depth?: number;
+  currentPath: string;
+  selectedPath: string | null;
+  entriesByDirectory: Record<string, ManagedFileEntry[]>;
+  expandedDirectories: Set<string>;
+  loadingDirectories: Set<string>;
+  onToggle: (path: string) => void;
+  onOpenDirectory: (path: string) => void;
+  onOpenFile: (entry: ManagedFileEntry) => void;
+}
+
+export function FileTree(props: FileTreeProps) {
+  const {
+    path,
+    label,
+    depth = 0,
+    currentPath,
+    selectedPath,
+    entriesByDirectory,
+    expandedDirectories,
+    loadingDirectories,
+    onToggle,
+    onOpenDirectory,
+    onOpenFile,
+  } = props;
+  const expanded = expandedDirectories.has(path);
+  const entries = entriesByDirectory[path];
+
+  return (
+    <>
+      <div
+        className={`group flex min-w-0 items-center pr-2 text-sm ${
+          currentPath === path ? "bg-primary/10 text-foreground" : "text-text-secondary"
+        }`}
+        style={{ paddingLeft: `${Math.max(0, depth) * 12 + 4}px` }}
+      >
+        <button
+          type="button"
+          onClick={() => onToggle(path)}
+          className="flex h-7 w-6 shrink-0 items-center justify-center text-text-tertiary"
+          aria-label={`${expanded ? "Collapse" : "Expand"} ${label}`}
+          aria-expanded={expanded}
+        >
+          {loadingDirectories.has(path) ? (
+            <Spinner />
+          ) : expanded ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => onOpenDirectory(path)}
+          className="flex min-w-0 flex-1 items-center gap-2 py-1 text-left hover:text-foreground"
+          title={path}
+        >
+          {expanded ? (
+            <FolderOpen className="h-4 w-4 shrink-0 text-warning" />
+          ) : (
+            <Folder className="h-4 w-4 shrink-0 text-warning" />
+          )}
+          <span className="truncate font-mono text-xs">{label}</span>
+        </button>
+      </div>
+
+      {expanded && entries?.map((entry) =>
+        entry.is_directory ? (
+          <FileTree
+            key={entry.path}
+            {...props}
+            path={entry.path}
+            label={entry.name}
+            depth={depth + 1}
+          />
+        ) : (
+          <button
+            key={entry.path}
+            type="button"
+            onClick={() => onOpenFile(entry)}
+            className={`flex w-full min-w-0 items-center gap-2 py-1.5 pr-2 text-left font-mono text-xs transition hover:bg-background/45 hover:text-foreground ${
+              selectedPath === entry.path
+                ? "bg-primary/10 text-foreground"
+                : "text-text-secondary"
+            }`}
+            style={{ paddingLeft: `${(depth + 1) * 12 + 30}px` }}
+            title={entry.path}
+          >
+            {previewKind(entry.name, entry.mime_type, entry.size ?? 0) === "markdown" ? (
+              <FileText className="h-3.5 w-3.5 shrink-0 text-primary" />
+            ) : (
+              <FileIcon className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
+            )}
+            <span className="truncate">{entry.name}</span>
+          </button>
+        ),
+      )}
+    </>
+  );
+}

--- a/web/src/lib/file-browser.test.ts
+++ b/web/src/lib/file-browser.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBreadcrumbs,
+  decodeTextDataUrl,
+  previewKind,
+} from "./file-browser";
+
+describe("previewKind", () => {
+  it("recognizes Markdown independently of MIME type", () => {
+    expect(previewKind("README.md", "application/octet-stream", 42)).toBe("markdown");
+    expect(previewKind("guide.MARKDOWN", "text/plain", 42)).toBe("markdown");
+  });
+
+  it("recognizes source files, images, binary files, and oversized files", () => {
+    expect(previewKind("config.yaml", "application/octet-stream", 42)).toBe("text");
+    expect(previewKind("notes.txt", "text/plain", 42)).toBe("text");
+    expect(previewKind("diagram.png", "image/png", 42)).toBe("image");
+    expect(previewKind("archive.zip", "application/zip", 42)).toBe("binary");
+    expect(previewKind("large.md", "text/markdown", 2 * 1024 * 1024 + 1)).toBe("large");
+  });
+});
+
+describe("decodeTextDataUrl", () => {
+  it("decodes UTF-8 base64 payloads", () => {
+    expect(decodeTextDataUrl("data:text/plain;base64,SGVybWVzIOKckw==")).toBe("Hermes ✓");
+  });
+});
+
+describe("buildBreadcrumbs", () => {
+  it("builds navigable segments below a managed POSIX root", () => {
+    expect(buildBreadcrumbs("/srv/hermes/webdav", "/srv/hermes/webdav/docs/guides")).toEqual([
+      { label: "webdav", path: "/srv/hermes/webdav" },
+      { label: "docs", path: "/srv/hermes/webdav/docs" },
+      { label: "guides", path: "/srv/hermes/webdav/docs/guides" },
+    ]);
+  });
+
+  it("supports Windows paths", () => {
+    expect(buildBreadcrumbs("C:\\Users\\hermes", "C:\\Users\\hermes\\docs")).toEqual([
+      { label: "hermes", path: "C:\\Users\\hermes" },
+      { label: "docs", path: "C:\\Users\\hermes\\docs" },
+    ]);
+  });
+});

--- a/web/src/lib/file-browser.ts
+++ b/web/src/lib/file-browser.ts
@@ -1,0 +1,97 @@
+export const MAX_PREVIEW_BYTES = 2 * 1024 * 1024;
+
+export type PreviewKind = "markdown" | "text" | "image" | "binary" | "large";
+
+const MARKDOWN_EXTENSIONS = new Set([".md", ".markdown", ".mdown", ".mkd"]);
+const TEXT_EXTENSIONS = new Set([
+  ".css",
+  ".csv",
+  ".env",
+  ".ex",
+  ".exs",
+  ".go",
+  ".h",
+  ".html",
+  ".ini",
+  ".java",
+  ".js",
+  ".json",
+  ".jsx",
+  ".log",
+  ".mdx",
+  ".php",
+  ".properties",
+  ".py",
+  ".rb",
+  ".rs",
+  ".sh",
+  ".sql",
+  ".toml",
+  ".ts",
+  ".tsx",
+  ".txt",
+  ".xml",
+  ".yaml",
+  ".yml",
+]);
+
+function extension(name: string): string {
+  const dot = name.lastIndexOf(".");
+  return dot < 0 ? "" : name.slice(dot).toLowerCase();
+}
+
+export function previewKind(name: string, mimeType: string | null, size: number): PreviewKind {
+  if (size > MAX_PREVIEW_BYTES) return "large";
+  if (MARKDOWN_EXTENSIONS.has(extension(name))) return "markdown";
+  if (mimeType?.toLowerCase().startsWith("image/")) return "image";
+  if (mimeType?.toLowerCase().startsWith("text/") || TEXT_EXTENSIONS.has(extension(name))) {
+    return "text";
+  }
+  return "binary";
+}
+
+export function decodeTextDataUrl(dataUrl: string): string {
+  const comma = dataUrl.indexOf(",");
+  if (comma < 0 || !dataUrl.slice(0, comma).includes(";base64")) {
+    throw new Error("Unsupported file payload");
+  }
+
+  const binary = atob(dataUrl.slice(comma + 1));
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+export interface Breadcrumb {
+  label: string;
+  path: string;
+}
+
+export function buildBreadcrumbs(root: string, currentPath: string): Breadcrumb[] {
+  const separator = root.includes("\\") && !root.includes("/") ? "\\" : "/";
+  const trimEnd = (path: string) => {
+    if (path === separator) return path;
+    return path.replace(/[\\/]+$/, "");
+  };
+  const normalizedRoot = trimEnd(root);
+  const normalizedCurrent = trimEnd(currentPath);
+  const rootLabel = normalizedRoot.split(/[\\/]/).filter(Boolean).at(-1) ?? normalizedRoot;
+  const breadcrumbs: Breadcrumb[] = [{ label: rootLabel, path: normalizedRoot }];
+
+  if (normalizedCurrent === normalizedRoot) return breadcrumbs;
+
+  const prefix = `${normalizedRoot}${separator}`;
+  if (!normalizedCurrent.startsWith(prefix)) {
+    return [{ label: normalizedCurrent, path: normalizedCurrent }];
+  }
+
+  let path = normalizedRoot;
+  for (const part of normalizedCurrent.slice(prefix.length).split(separator).filter(Boolean)) {
+    path = `${path}${separator}${part}`;
+    breadcrumbs.push({ label: part, path });
+  }
+  return breadcrumbs;
+}
+
+export function pathName(path: string): string {
+  return path.replace(/[\\/]+$/, "").split(/[\\/]/).filter(Boolean).at(-1) ?? path;
+}

--- a/web/src/pages/FilesPage.tsx
+++ b/web/src/pages/FilesPage.tsx
@@ -1,17 +1,24 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type DragEvent as ReactDragEvent,
 } from "react";
 import {
+  ArrowLeft,
   ArrowUp,
+  ChevronRight,
+  Code2,
   Download,
+  Eye,
   FileIcon,
+  FileText,
   Folder,
   FolderOpen,
   FolderPlus,
+  ImageIcon,
   RefreshCw,
   Trash2,
   Upload,
@@ -32,9 +39,21 @@ import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
+import { FilePreview } from "@/components/files/FilePreview";
+import { FileTree } from "@/components/files/FileTree";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { api } from "@/lib/api";
-import type { ManagedFileEntry, ManagedFilesResponse } from "@/lib/api";
+import type {
+  ManagedFileEntry,
+  ManagedFileReadResponse,
+  ManagedFilesResponse,
+} from "@/lib/api";
+import {
+  buildBreadcrumbs,
+  decodeTextDataUrl,
+  pathName,
+  previewKind,
+} from "@/lib/file-browser";
 import { PluginSlot } from "@/plugins";
 
 const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
@@ -42,12 +61,21 @@ const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
   timeStyle: "short",
 });
 
+type DirectoryEntries = Record<string, ManagedFileEntry[]>;
+type PreviewMode = "rendered" | "source";
+
 function joinPath(base: string, name: string): string {
   const cleanName = name.trim().replace(/^[\\/]+/, "");
   if (!cleanName) return base;
   const separator = base.includes("\\") && !base.includes("/") ? "\\" : "/";
   if (!base || base.endsWith("/") || base.endsWith("\\")) return `${base}${cleanName}`;
   return `${base}${separator}${cleanName}`;
+}
+
+function isPathWithin(root: string, path: string): boolean {
+  const separator = root.includes("\\") && !root.includes("/") ? "\\" : "/";
+  const cleanRoot = root.replace(/[\\/]+$/, "");
+  return path === cleanRoot || path.startsWith(`${cleanRoot}${separator}`);
 }
 
 function formatBytes(size: number | null): string {
@@ -67,10 +95,6 @@ function downloadDataUrl(dataUrl: string, name: string) {
   link.remove();
 }
 
-function displayPath(path: string | null | undefined): string {
-  return path?.trim() || "Files";
-}
-
 function transferHasFiles(event: ReactDragEvent<HTMLElement>): boolean {
   return Array.from(event.dataTransfer.types).includes("Files");
 }
@@ -80,9 +104,21 @@ export default function FilesPage() {
   const { setAfterTitle, setEnd } = usePageHeader();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const dragDepthRef = useRef(0);
+  const currentRequestRef = useRef(0);
+  const previewRequestRef = useRef(0);
   const [currentPath, setCurrentPath] = useState<string | undefined>(undefined);
   const [pathInput, setPathInput] = useState("");
   const [listing, setListing] = useState<ManagedFilesResponse | null>(null);
+  const [treeRoot, setTreeRoot] = useState<string | null>(null);
+  const [entriesByDirectory, setEntriesByDirectory] = useState<DirectoryEntries>({});
+  const [expandedDirectories, setExpandedDirectories] = useState<Set<string>>(new Set());
+  const [loadingDirectories, setLoadingDirectories] = useState<Set<string>>(new Set());
+  const [selectedEntry, setSelectedEntry] = useState<ManagedFileEntry | null>(null);
+  const [selectedFile, setSelectedFile] = useState<ManagedFileReadResponse | null>(null);
+  const [previewText, setPreviewText] = useState("");
+  const [previewMode, setPreviewMode] = useState<PreviewMode>("rendered");
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [draggingFiles, setDraggingFiles] = useState(false);
@@ -96,62 +132,141 @@ export default function FilesPage() {
   const activePath = listing?.path ?? currentPath ?? "";
   const canChangePath = listing?.can_change_path ?? false;
   const canUpload = Boolean(activePath) && !uploading;
-  const headerPath = displayPath(listing?.locked_root ?? listing?.path ?? currentPath);
-
-  const load = useCallback(
-    async (path = currentPath) => {
-      setLoading(true);
-      setError(null);
-      try {
-        const result = await api.listFiles(path);
-        setListing(result);
-        setCurrentPath(result.path);
-        setPathInput(result.path);
-      } catch (e) {
-        setError(String(e));
-      } finally {
-        setLoading(false);
-      }
-    },
-    [currentPath],
+  const selectedKind = selectedEntry
+    ? previewKind(selectedEntry.name, selectedEntry.mime_type, selectedEntry.size ?? 0)
+    : null;
+  const breadcrumbRoot = listing?.locked_root ?? treeRoot ?? activePath;
+  const breadcrumbs = useMemo(
+    () => (breadcrumbRoot && activePath ? buildBreadcrumbs(breadcrumbRoot, activePath) : []),
+    [activePath, breadcrumbRoot],
   );
 
-  useEffect(() => {
-    // Existing dashboard data pages fetch from effects; keep this local and explicit
-    // until the shared lint profile is updated for async page loaders.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    void load(currentPath);
-  }, [currentPath]); // eslint-disable-line react-hooks/exhaustive-deps
+  const loadCurrentDirectory = useCallback(async (path?: string) => {
+    const requestId = ++currentRequestRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await api.listFiles(path);
+      if (requestId !== currentRequestRef.current) return;
+      setListing(result);
+      setCurrentPath(result.path);
+      setPathInput(result.path);
+      setEntriesByDirectory((current) => ({ ...current, [result.path]: result.entries }));
+      setExpandedDirectories((current) => new Set(current).add(result.path));
+      setTreeRoot((root) => {
+        if (result.locked_root) return result.locked_root;
+        return root && isPathWithin(root, result.path) ? root : result.path;
+      });
+    } catch (e) {
+      if (requestId === currentRequestRef.current) setError(String(e));
+    } finally {
+      if (requestId === currentRequestRef.current) setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void loadCurrentDirectory(currentPath);
+  }, [currentPath, loadCurrentDirectory]);
+
+  useEffect(() => {
+    const headerPath = listing?.locked_root ?? listing?.path ?? currentPath ?? "Files";
     setAfterTitle(
       <Badge tone="outline" className="max-w-[22rem] truncate text-xs" title={headerPath}>
         {headerPath}
       </Badge>,
     );
     setEnd(
-      <div className="flex items-center gap-2">
-        <Button
-          ghost
-          size="icon"
-          type="button"
-          onClick={() => void load()}
-          disabled={loading}
-          aria-label="Refresh files"
-        >
-          {loading ? <Spinner /> : <RefreshCw />}
-        </Button>
-      </div>,
+      <Button
+        ghost
+        size="icon"
+        type="button"
+        onClick={() => void loadCurrentDirectory(currentPath)}
+        disabled={loading}
+        aria-label="Refresh files"
+      >
+        {loading ? <Spinner /> : <RefreshCw />}
+      </Button>,
     );
     return () => {
       setAfterTitle(null);
       setEnd(null);
     };
-  }, [headerPath, load, loading, setAfterTitle, setEnd]);
+  }, [currentPath, listing, loadCurrentDirectory, loading, setAfterTitle, setEnd]);
 
-  const openDirectory = (entry: ManagedFileEntry) => {
-    if (entry.is_directory) {
-      setCurrentPath(entry.path);
+  const ensureDirectoryLoaded = async (path: string) => {
+    if (entriesByDirectory[path] || loadingDirectories.has(path)) return;
+    setLoadingDirectories((current) => new Set(current).add(path));
+    try {
+      const result = await api.listFiles(path);
+      setEntriesByDirectory((current) => ({ ...current, [result.path]: result.entries }));
+    } catch (e) {
+      showToast(`Could not open folder: ${e}`, "error");
+    } finally {
+      setLoadingDirectories((current) => {
+        const next = new Set(current);
+        next.delete(path);
+        return next;
+      });
+    }
+  };
+
+  const clearSelection = () => {
+    previewRequestRef.current += 1;
+    setSelectedEntry(null);
+    setSelectedFile(null);
+    setPreviewText("");
+    setPreviewError(null);
+    setPreviewLoading(false);
+  };
+
+  const openDirectory = (path: string) => {
+    clearSelection();
+    setExpandedDirectories((current) => new Set(current).add(path));
+    if (path === currentPath) void loadCurrentDirectory(path);
+    else setCurrentPath(path);
+  };
+
+  const toggleDirectory = (path: string) => {
+    if (expandedDirectories.has(path)) {
+      setExpandedDirectories((current) => {
+        const next = new Set(current);
+        next.delete(path);
+        return next;
+      });
+      return;
+    }
+    setExpandedDirectories((current) => new Set(current).add(path));
+    void ensureDirectoryLoaded(path);
+  };
+
+  const openFile = async (entry: ManagedFileEntry) => {
+    if (entry.is_directory) return;
+    const kind = previewKind(entry.name, entry.mime_type, entry.size ?? 0);
+    const requestId = ++previewRequestRef.current;
+    setSelectedEntry(entry);
+    setSelectedFile(null);
+    setPreviewText("");
+    setPreviewMode(kind === "markdown" ? "rendered" : "source");
+    setPreviewError(null);
+
+    if (kind === "large" || kind === "binary") {
+      setPreviewLoading(false);
+      return;
+    }
+
+    setPreviewLoading(true);
+    try {
+      const file = await api.readFile(entry.path);
+      if (requestId !== previewRequestRef.current) return;
+      setSelectedFile(file);
+      if (kind === "markdown" || kind === "text") {
+        setPreviewText(decodeTextDataUrl(file.data_url));
+      }
+    } catch (e) {
+      if (requestId === previewRequestRef.current) setPreviewError(`Preview failed: ${e}`);
+    } finally {
+      if (requestId === previewRequestRef.current) setPreviewLoading(false);
     }
   };
 
@@ -161,7 +276,12 @@ export default function FilesPage() {
       showToast("Path required", "error");
       return;
     }
-    await load(nextPath);
+    clearSelection();
+    setTreeRoot(null);
+    setEntriesByDirectory({});
+    setExpandedDirectories(new Set());
+    if (nextPath === currentPath) await loadCurrentDirectory(nextPath);
+    else setCurrentPath(nextPath);
   };
 
   const createDirectory = async () => {
@@ -180,7 +300,7 @@ export default function FilesPage() {
       setFolderName("");
       setCreateDialogOpen(false);
       showToast("Folder created", "success");
-      await load();
+      await loadCurrentDirectory(currentPath);
     } catch (e) {
       showToast(`Create failed: ${e}`, "error");
     } finally {
@@ -196,7 +316,7 @@ export default function FilesPage() {
         await api.uploadFile(joinPath(activePath, file.name), file, true);
       }
       showToast(`${files.length} file${files.length === 1 ? "" : "s"} uploaded`, "success");
-      await load();
+      await loadCurrentDirectory(currentPath);
     } catch (e) {
       showToast(`Upload failed: ${e}`, "error");
     } finally {
@@ -222,9 +342,7 @@ export default function FilesPage() {
     if (!canUpload || !transferHasFiles(event)) return;
     event.preventDefault();
     dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
-    if (dragDepthRef.current === 0) {
-      setDraggingFiles(false);
-    }
+    if (dragDepthRef.current === 0) setDraggingFiles(false);
   };
 
   const handleDrop = (event: ReactDragEvent<HTMLElement>) => {
@@ -238,7 +356,7 @@ export default function FilesPage() {
   const downloadFile = async (entry: ManagedFileEntry) => {
     if (entry.is_directory) return;
     try {
-      const file = await api.readFile(entry.path);
+      const file = selectedFile?.path === entry.path ? selectedFile : await api.readFile(entry.path);
       downloadDataUrl(file.data_url, file.name);
     } catch (e) {
       showToast(`Download failed: ${e}`, "error");
@@ -250,9 +368,16 @@ export default function FilesPage() {
     setDeleting(true);
     try {
       await api.deleteFile(pendingDelete.path, pendingDelete.is_directory);
+      if (
+        selectedEntry &&
+        (selectedEntry.path === pendingDelete.path ||
+          (pendingDelete.is_directory && isPathWithin(pendingDelete.path, selectedEntry.path)))
+      ) {
+        clearSelection();
+      }
       showToast("Deleted", "success");
       setPendingDelete(null);
-      await load();
+      await loadCurrentDirectory(currentPath);
     } catch (e) {
       showToast(`Delete failed: ${e}`, "error");
     } finally {
@@ -293,9 +418,20 @@ export default function FilesPage() {
             </Button>
           </form>
         ) : (
-          <div className="min-w-0 truncate font-mono text-sm text-text-secondary" title={activePath}>
-            {activePath}
-          </div>
+          <nav className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto font-mono text-xs" aria-label="File path">
+            {breadcrumbs.map((breadcrumb, index) => (
+              <span key={breadcrumb.path} className="flex shrink-0 items-center gap-1">
+                {index > 0 && <ChevronRight className="h-3.5 w-3.5 text-text-tertiary" />}
+                <button
+                  type="button"
+                  onClick={() => openDirectory(breadcrumb.path)}
+                  className="px-1 py-1 text-text-secondary hover:bg-background/40 hover:text-foreground"
+                >
+                  {breadcrumb.label}
+                </button>
+              </span>
+            ))}
+          </nav>
         )}
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <Button
@@ -332,14 +468,14 @@ export default function FilesPage() {
         onDrop={handleDrop}
         disabled={!canUpload}
         aria-label="Upload files"
-        className={`flex min-h-20 w-full min-w-0 items-center justify-between gap-4 border border-dashed px-4 py-3 text-left transition ${
+        className={`flex min-h-16 w-full min-w-0 items-center justify-between gap-4 border border-dashed px-4 py-3 text-left transition ${
           draggingFiles
             ? "border-primary bg-primary/10 text-foreground"
             : "border-border bg-background/20 text-text-secondary hover:border-text-tertiary hover:bg-background/35"
         } disabled:cursor-not-allowed disabled:opacity-60`}
       >
         <span className="flex min-w-0 items-center gap-3">
-          <span className="flex h-9 w-9 shrink-0 items-center justify-center border border-border bg-background/45 text-text-tertiary">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center border border-border bg-background/45 text-text-tertiary">
             {uploading ? <Spinner /> : <Upload className="h-4 w-4" />}
           </span>
           <span className="min-w-0">
@@ -356,104 +492,213 @@ export default function FilesPage() {
         </span>
       </button>
 
-      <Card className="min-w-0 max-w-full overflow-hidden">
-        <CardContent className="overflow-x-auto p-0">
-          {error && (
-            <div className="border-b border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
-              {error}
+      {error && (
+        <div className="border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="grid min-h-[34rem] min-w-0 gap-4 lg:grid-cols-[17rem_minmax(0,1fr)]">
+        <Card className="min-w-0 overflow-hidden">
+          <CardContent className="flex h-full min-h-64 flex-col p-0">
+            <div className="border-b border-border px-3 py-2 text-xs font-semibold uppercase tracking-[0.08em] text-text-tertiary">
+              File tree
             </div>
-          )}
-
-          <div className="grid min-w-[42rem] grid-cols-[minmax(12rem,1fr)_7rem_10rem_5.5rem] items-center gap-3 border-b border-border px-4 py-2 text-xs font-semibold uppercase tracking-[0.08em] text-text-tertiary">
-            <span>Name</span>
-            <span>Size</span>
-            <span>Modified</span>
-            <span className="text-right">Actions</span>
-          </div>
-
-          {listing?.parent && (
-            <button
-              type="button"
-              onClick={() => setCurrentPath(listing.parent ?? undefined)}
-              className="grid w-full min-w-[42rem] grid-cols-[minmax(12rem,1fr)_7rem_10rem_5.5rem] items-center gap-3 border-b border-border/60 px-4 py-2 text-left text-sm transition hover:bg-background/40"
-            >
-              <span className="flex min-w-0 items-center gap-2 font-mono text-text-secondary">
-                <ArrowUp className="h-4 w-4 shrink-0 text-text-tertiary" />
-                ..
-              </span>
-              <span />
-              <span />
-              <span />
-            </button>
-          )}
-
-          {loading && !listing ? (
-            <div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
-              <Spinner />
-              Loading files...
+            <div className="min-h-0 flex-1 overflow-auto py-1">
+              {treeRoot ? (
+                <FileTree
+                  path={treeRoot}
+                  label={pathName(treeRoot)}
+                  depth={0}
+                  currentPath={activePath}
+                  selectedPath={selectedEntry?.path ?? null}
+                  entriesByDirectory={entriesByDirectory}
+                  expandedDirectories={expandedDirectories}
+                  loadingDirectories={loadingDirectories}
+                  onToggle={toggleDirectory}
+                  onOpenDirectory={openDirectory}
+                  onOpenFile={(entry) => void openFile(entry)}
+                />
+              ) : (
+                <div className="flex items-center justify-center gap-2 py-10 text-sm text-text-secondary">
+                  <Spinner /> Loading tree...
+                </div>
+              )}
             </div>
-          ) : listing && listing.entries.length === 0 ? (
-            <div className="py-12 text-center text-sm text-muted-foreground">No files</div>
-          ) : (
-            listing?.entries.map((entry) => (
-              <div
-                key={entry.path}
-                className="grid min-w-[42rem] grid-cols-[minmax(12rem,1fr)_7rem_10rem_5.5rem] items-center gap-3 border-b border-border/60 px-4 py-2 text-sm last:border-b-0 hover:bg-background/35"
-              >
-                <button
-                  type="button"
-                  onClick={() => (entry.is_directory ? openDirectory(entry) : void downloadFile(entry))}
-                  className="flex min-w-0 items-center gap-2 text-left font-mono text-foreground"
-                >
-                  {entry.is_directory ? (
-                    <Folder className="h-4 w-4 shrink-0 text-warning" />
-                  ) : (
-                    <FileIcon className="h-4 w-4 shrink-0 text-text-tertiary" />
-                  )}
-                  <span className="truncate">{entry.name}</span>
-                </button>
-                <span className="text-xs tabular-nums text-text-secondary">{formatBytes(entry.size)}</span>
-                <span className="truncate text-xs text-text-secondary">
-                  {Number.isFinite(entry.mtime) ? DATE_FORMAT.format(entry.mtime * 1000) : "-"}
-                </span>
-                <span className="flex justify-end gap-1">
-                  {entry.is_directory ? (
-                    <Button
-                      ghost
-                      size="icon"
-                      type="button"
-                      onClick={() => openDirectory(entry)}
-                      aria-label={`Open ${entry.name}`}
-                    >
-                      <FolderOpen />
+          </CardContent>
+        </Card>
+
+        <Card className="min-w-0 overflow-hidden">
+          <CardContent className="min-w-0 p-0">
+            {selectedEntry && selectedKind ? (
+              <>
+                <div className="flex min-w-0 flex-wrap items-center justify-between gap-2 border-b border-border px-3 py-2">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <Button ghost size="icon" type="button" onClick={clearSelection} aria-label="Back to directory">
+                      <ArrowLeft />
                     </Button>
-                  ) : (
+                    {selectedKind === "markdown" ? (
+                      <FileText className="h-4 w-4 shrink-0 text-primary" />
+                    ) : selectedKind === "image" ? (
+                      <ImageIcon className="h-4 w-4 shrink-0 text-text-tertiary" />
+                    ) : (
+                      <FileIcon className="h-4 w-4 shrink-0 text-text-tertiary" />
+                    )}
+                    <div className="min-w-0">
+                      <div className="truncate font-mono text-sm font-medium" title={selectedEntry.path}>
+                        {selectedEntry.name}
+                      </div>
+                      <div className="text-xs text-text-tertiary">{formatBytes(selectedEntry.size)}</div>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    {selectedKind === "markdown" && (
+                      <div className="mr-1 flex border border-border">
+                        <button
+                          type="button"
+                          onClick={() => setPreviewMode("rendered")}
+                          className={`flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-semibold uppercase ${
+                            previewMode === "rendered" ? "bg-secondary text-foreground" : "text-text-secondary"
+                          }`}
+                        >
+                          <Eye className="h-3.5 w-3.5" /> Preview
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setPreviewMode("source")}
+                          className={`flex items-center gap-1.5 border-l border-border px-2.5 py-1.5 text-xs font-semibold uppercase ${
+                            previewMode === "source" ? "bg-secondary text-foreground" : "text-text-secondary"
+                          }`}
+                        >
+                          <Code2 className="h-3.5 w-3.5" /> Source
+                        </button>
+                      </div>
+                    )}
                     <Button
                       ghost
                       size="icon"
                       type="button"
-                      onClick={() => void downloadFile(entry)}
-                      aria-label={`Download ${entry.name}`}
+                      onClick={() => void downloadFile(selectedEntry)}
+                      aria-label={`Download ${selectedEntry.name}`}
                     >
                       <Download />
                     </Button>
+                    <Button
+                      ghost
+                      size="icon"
+                      type="button"
+                      onClick={() => setPendingDelete(selectedEntry)}
+                      aria-label={`Delete ${selectedEntry.name}`}
+                      className="text-destructive hover:text-destructive"
+                    >
+                      <Trash2 />
+                    </Button>
+                  </div>
+                </div>
+                <FilePreview
+                  entry={selectedEntry}
+                  kind={selectedKind}
+                  file={selectedFile}
+                  text={previewText}
+                  mode={previewMode}
+                  loading={previewLoading}
+                  error={previewError}
+                />
+              </>
+            ) : (
+              <>
+                <div className="flex items-center justify-between border-b border-border px-4 py-3">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <FolderOpen className="h-4 w-4 shrink-0 text-warning" />
+                    <span className="truncate font-mono text-sm" title={activePath}>{pathName(activePath)}</span>
+                  </div>
+                  <Badge tone="outline" className="text-xs">
+                    {listing?.entries.length ?? 0} items
+                  </Badge>
+                </div>
+                <div className="overflow-x-auto">
+                  <div className="grid min-w-[42rem] grid-cols-[minmax(12rem,1fr)_7rem_10rem_5.5rem] items-center gap-3 border-b border-border px-4 py-2 text-xs font-semibold uppercase tracking-[0.08em] text-text-tertiary">
+                    <span>Name</span>
+                    <span>Size</span>
+                    <span>Modified</span>
+                    <span className="text-right">Actions</span>
+                  </div>
+
+                  {listing?.parent && (
+                    <button
+                      type="button"
+                      onClick={() => openDirectory(listing.parent ?? activePath)}
+                      className="grid w-full min-w-[42rem] grid-cols-[minmax(12rem,1fr)_7rem_10rem_5.5rem] items-center gap-3 border-b border-border/60 px-4 py-2 text-left text-sm transition hover:bg-background/40"
+                    >
+                      <span className="flex min-w-0 items-center gap-2 font-mono text-text-secondary">
+                        <ArrowUp className="h-4 w-4 shrink-0 text-text-tertiary" /> ..
+                      </span>
+                      <span />
+                      <span />
+                      <span />
+                    </button>
                   )}
-                  <Button
-                    ghost
-                    size="icon"
-                    type="button"
-                    onClick={() => setPendingDelete(entry)}
-                    aria-label={`Delete ${entry.name}`}
-                    className="text-destructive hover:text-destructive"
-                  >
-                    <Trash2 />
-                  </Button>
-                </span>
-              </div>
-            ))
-          )}
-        </CardContent>
-      </Card>
+
+                  {loading && !listing ? (
+                    <div className="flex items-center justify-center gap-2 py-12 text-sm text-text-secondary">
+                      <Spinner /> Loading files...
+                    </div>
+                  ) : listing && listing.entries.length === 0 ? (
+                    <div className="py-12 text-center text-sm text-text-secondary">No files</div>
+                  ) : (
+                    listing?.entries.map((entry) => (
+                      <div
+                        key={entry.path}
+                        className="grid min-w-[42rem] grid-cols-[minmax(12rem,1fr)_7rem_10rem_5.5rem] items-center gap-3 border-b border-border/60 px-4 py-2 text-sm last:border-b-0 hover:bg-background/35"
+                      >
+                        <button
+                          type="button"
+                          onClick={() => entry.is_directory ? openDirectory(entry.path) : void openFile(entry)}
+                          className="flex min-w-0 items-center gap-2 text-left font-mono text-foreground"
+                        >
+                          {entry.is_directory ? (
+                            <Folder className="h-4 w-4 shrink-0 text-warning" />
+                          ) : previewKind(entry.name, entry.mime_type, entry.size ?? 0) === "markdown" ? (
+                            <FileText className="h-4 w-4 shrink-0 text-primary" />
+                          ) : (
+                            <FileIcon className="h-4 w-4 shrink-0 text-text-tertiary" />
+                          )}
+                          <span className="truncate">{entry.name}</span>
+                        </button>
+                        <span className="text-xs tabular-nums text-text-secondary">{formatBytes(entry.size)}</span>
+                        <span className="truncate text-xs text-text-secondary">
+                          {Number.isFinite(entry.mtime) ? DATE_FORMAT.format(entry.mtime * 1000) : "-"}
+                        </span>
+                        <span className="flex justify-end gap-1">
+                          {entry.is_directory ? (
+                            <Button ghost size="icon" type="button" onClick={() => openDirectory(entry.path)} aria-label={`Open ${entry.name}`}>
+                              <FolderOpen />
+                            </Button>
+                          ) : (
+                            <Button ghost size="icon" type="button" onClick={() => void downloadFile(entry)} aria-label={`Download ${entry.name}`}>
+                              <Download />
+                            </Button>
+                          )}
+                          <Button
+                            ghost
+                            size="icon"
+                            type="button"
+                            onClick={() => setPendingDelete(entry)}
+                            aria-label={`Delete ${entry.name}`}
+                            className="text-destructive hover:text-destructive"
+                          >
+                            <Trash2 />
+                          </Button>
+                        </span>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
 
       <PluginSlot name="files:bottom" />
 
@@ -468,9 +713,7 @@ export default function FilesPage() {
         <DialogContent className="max-w-sm">
           <DialogHeader>
             <DialogTitle>Create folder</DialogTitle>
-            <DialogDescription>
-              Target: {activePath || "Loading"}
-            </DialogDescription>
+            <DialogDescription>Target: {activePath || "Loading"}</DialogDescription>
           </DialogHeader>
           <div className="p-4">
             <Input


### PR DESCRIPTION
## Summary

- add a lazy, expandable file tree to the Files dashboard
- render Markdown files with GFM tables, task lists, code blocks, and Preview/Source modes
- preview text and image files while preserving upload, create, download, and delete operations
- cap inline previews at 2 MiB and fall back cleanly for binary or oversized files

## Verification

- `npm test --workspace web` (77 tests)
- `npm run build --workspace web`
- changed-file ESLint
- Chromium smoke: nested tree navigation, Markdown rendering/source switching, upload, folder creation, and deletion
