### PR TITLE
fix(installer): never hard-reset a diverged custom-branch checkout (#64977)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1221,14 +1221,40 @@ clone_repo() {
             # into a multi-minute download that can stall the installer.
             git remote set-branches origin "$BRANCH" 2>/dev/null || true
             git fetch origin "$BRANCH"
-            git checkout "$BRANCH"
-            # Managed installs should follow origin/$BRANCH exactly. If the
-            # checkout has diverged (or has local-only commits), ff-only pull
-            # cannot succeed — mirror ``hermes update`` and reset to the
-            # fetched remote so bootstrap/install can recover.
-            if ! git pull --ff-only origin "$BRANCH"; then
-                log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
-                git reset --hard "origin/$BRANCH"
+
+            # Decide whether a hard reset to origin/$BRANCH is safe. It is only
+            # safe for a managed checkout that is on $BRANCH with no local
+            # commits ahead of the remote. A user maintaining a custom branch
+            # (e.g. `custom-patches`) or any local commits ahead of origin/$BRANCH
+            # must NOT be hard-reset: that would orphan their work and the
+            # bootstrap/install would silently destroy it (see #64977).
+            local current_branch
+            current_branch=$(git branch --show-current 2>/dev/null || echo "")
+            local has_local_commits=0
+            if git rev-parse --quiet --verify "origin/$BRANCH" >/dev/null 2>&1; then
+                if [ -n "$(git log "origin/$BRANCH..HEAD" --oneline 2>/dev/null)" ]; then
+                    has_local_commits=1
+                fi
+            fi
+
+            if [ "$current_branch" != "$BRANCH" ] || [ "$has_local_commits" -eq 1 ]; then
+                # Diverged user checkout: skip checkout + hard reset so we don't
+                # destroy local work. Stay on the current checkout; the bootstrap
+                # can still proceed with the existing code.
+                log_warn "Checkout diverged from origin/$BRANCH (branch='${current_branch:-<detached>}', local commits present)."
+                log_warn "Skipping 'git reset --hard origin/$BRANCH' to avoid destroying local work."
+                log_warn "To discard local changes and follow origin/$BRANCH exactly, run:"
+                log_warn "    git checkout $BRANCH && git reset --hard origin/$BRANCH"
+            else
+                git checkout "$BRANCH"
+                # Managed installs should follow origin/$BRANCH exactly. If the
+                # checkout has diverged (or has local-only commits), ff-only pull
+                # cannot succeed — mirror ``hermes update`` and reset to the
+                # fetched remote so bootstrap/install can recover.
+                if ! git pull --ff-only origin "$BRANCH"; then
+                    log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
+                    git reset --hard "origin/$BRANCH"
+                fi
             fi
 
             if [ -n "$autostash_ref" ]; then


### PR DESCRIPTION
## Summary

Commit ``a40f22798`` made the ``install.sh`` repository stage run
``git reset --hard origin/$BRANCH`` whenever ``git pull --ff-only`` fails. That
is correct for managed Desktop installs that should track ``origin/main``
exactly, but it is **destructive** for users maintaining a custom branch (e.g.
``custom-patches``) or any local commits ahead of the remote: a Desktop-triggered
bootstrap after venv corruption would switch to ``$BRANCH`` and hard-reset,
orphaning their work (the exact #64977 report — 25 custom commits lost).

## Changes

- ``scripts/install.sh`` (repository stage, ~line 1218)
  - Before the checkout/reset, detect whether the checkout is a **managed**
    one: on ``$BRANCH`` **and** with no local commits ahead of
    ``origin/$BRANCH``.
  - Only when both hold do we run the original ``git checkout $BRANCH`` →
    ``ff-only pull`` → ``git reset --hard origin/$BRANCH`` recovery path.
  - If the user is on a **different branch** or has **local commits ahead of the
    remote**, we **skip the checkout and the hard reset entirely**, log a
    prominent warning (including the exact command to reconcile if they want),
    and leave the existing checkout in place so the bootstrap can still proceed
    with the current code.
  - The local-commit check is guarded by ``git rev-parse --quiet --verify
    origin/$BRANCH`` so a fresh/partial clone without the upstream ref yet is
    still treated as managed (no false skip).

## Why this is the right boundary

The destructive behavior only matters when the checkout has *user* work the
installer shouldn't touch. A clean managed checkout (on ``$BRANCH``, nothing
ahead) behaves exactly as before — bootstrap still recovers via hard reset. The
only behavior change is for diverged/custom checkouts, where skipping the reset
is strictly safer and still lets the install complete.

## How to Test

Visual / manual (shell, not unit-testable easily):
1. On a clone, create a branch ``custom-patches`` with 2 commits ahead of
   ``main``; run the repository stage → it should **skip** reset and warn.
2. On ``main`` with a local commit ahead of ``origin/main`` → also skipped.
3. On a clean ``main`` tracking ``origin/main`` → behaves as before (reset on
   ff-only failure).

Static: ``bash -n scripts/install.sh`` passes (syntax verified locally).

## Checklist

- [x] Scoped to the single repository-stage reset block in install.sh
- [x] ``bash -n`` syntax check passed
- [x] Cross-platform: pure POSIX shell, no platform-specific code
- [x] No hardcoded paths; uses ``$BRANCH`` / ``origin/$BRANCH``

## Risk & Impact

**Low.** The happy path (managed install following origin/main) is unchanged.
The only behavioral change is for diverged/custom checkouts, where the previous
code destroyed user work and the new code preserves it (with a clear warning +
recovery command). No files outside ``scripts/install.sh`` touched.

Type: Bug fix
Closes: #64977