### PR TITLE
fix(mcp): serialize keepalive probes with RPC calls

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1287,6 +1287,47 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    def test_keepalive_ping_waits_for_rpc_lock(self):
+        """Keepalive ping must not race an active MCP tool call."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("srv")
+            server.session = MagicMock()
+            server.session.send_ping = AsyncMock()
+
+            async with server._rpc_lock:
+                probe = asyncio.create_task(server._keepalive_probe())
+                await asyncio.sleep(0)
+                server.session.send_ping.assert_not_awaited()
+
+            await probe
+            server.session.send_ping.assert_awaited_once()
+
+        asyncio.run(_test())
+
+    def test_keepalive_list_tools_fallback_waits_for_rpc_lock(self):
+        """The no-ping fallback must use the same per-server RPC lock."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("srv")
+            server.session = MagicMock()
+            server._ping_unsupported = True
+            server.session.list_tools = AsyncMock(
+                return_value=SimpleNamespace(tools=[])
+            )
+
+            async with server._rpc_lock:
+                probe = asyncio.create_task(server._keepalive_probe())
+                await asyncio.sleep(0)
+                server.session.list_tools.assert_not_awaited()
+
+            await probe
+            server.session.list_tools.assert_awaited_once()
+
+        asyncio.run(_test())
+
 
 # ---------------------------------------------------------------------------
 # discover_mcp_tools toolset injection

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2003,7 +2003,8 @@ class MCPServerTask:
         """
         if not self._ping_unsupported:
             try:
-                await asyncio.wait_for(self.session.send_ping(), timeout=30.0)
+                async with self._rpc_lock:
+                    await asyncio.wait_for(self.session.send_ping(), timeout=30.0)
                 return
             except Exception as exc:
                 # Only a "method not found" means ping is unsupported. Any
@@ -2023,7 +2024,8 @@ class MCPServerTask:
                 )
 
         # Fallback probe for servers without ping support.
-        await asyncio.wait_for(self.session.list_tools(), timeout=30.0)
+        async with self._rpc_lock:
+            await asyncio.wait_for(self.session.list_tools(), timeout=30.0)
 
     async def _wait_for_lifecycle_event(self) -> str:
         """Block until either _shutdown_event or _reconnect_event fires.


### PR DESCRIPTION
## Summary

Serialize MCP keepalive RPCs with the per-server `_rpc_lock` used by normal tool calls.

## Problem

`MCPServerTask._keepalive_probe()` sent `ping` and the `list_tools` fallback without acquiring the lock. On stateful JSON-RPC transports, a keepalive request could therefore race an in-flight `tools/call` response and corrupt the stream, causing false keepalive failures and reconnects.

## Fix

- Guard `session.send_ping()` with `_rpc_lock`.
- Guard the `session.list_tools()` fallback with `_rpc_lock`.
- Add regression tests proving both probes wait while another RPC owns the lock.

## Validation

- `tests/tools/test_mcp_tool.py`: 214 passed
- Related MCP discovery/stability/reconnect tests: 255 passed total
- `py_compile`: passed
- `git diff --check`: passed

## Scope

This is a targeted serialization fix. Existing reconnect, circuit-breaker, and optional-ping fallback behavior is unchanged.
