### PR TITLE
fix(desktop): preserve runtime session timer across warm switches

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -47,6 +47,7 @@ import {
   $resumeFailedSessionId,
   $selectedStoredSessionId,
   $sessions,
+  $sessionStartedAt,
   $turnStartedAt,
   getSessionOwnerHint,
   knownSessionOwner,
@@ -68,6 +69,7 @@ import {
   setResumeFailedSessionId,
   setSelectedStoredSessionId,
   setSessions,
+  setSessionStartedAt,
   setTurnStartedAt
 } from '@/store/session'
 import { requestForSessionProfile, type SessionProfileRoute } from '@/store/session-request-router'
@@ -837,6 +839,7 @@ describe('resumeSession failure recovery', () => {
     cleanup()
     setActiveSessionId(null)
     setResumeFailedSessionId(null)
+    setSessionStartedAt(null)
     setMessages([])
     setSessions([])
     clearClarifyRequest()
@@ -1379,6 +1382,7 @@ describe('resumeSession failure recovery', () => {
             personality: '',
             provider: '',
             reasoningEffort: '',
+            runtimeStartedAt: 0,
             sawAssistantPayload: false,
             serviceTier: '',
             storedSessionId: 'stored-1',
@@ -1505,6 +1509,7 @@ function BranchHarness({
   navigate = vi.fn(),
   onCurrentReady,
   onReady,
+  onStateUpdate,
   onRefs,
   requestGateway,
   selectedStoredSessionId = null
@@ -1513,6 +1518,7 @@ function BranchHarness({
   navigate?: ReturnType<typeof vi.fn>
   onCurrentReady?: (branchCurrentSession: (messageId?: string) => Promise<boolean>) => void
   onReady: (branchStoredSession: (storedSessionId: string, sessionProfile?: string | null) => Promise<boolean>) => void
+  onStateUpdate?: (sessionId: string, state: ClientSessionState) => void
   onRefs?: (refs: {
     activeSessionIdRef: MutableRefObject<string | null>
     selectedStoredSessionIdRef: MutableRefObject<string | null>
@@ -1542,7 +1548,12 @@ function BranchHarness({
     selectedStoredSessionIdRef,
     sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
     syncSessionStateToView: vi.fn(),
-    updateSessionState: () => ({}) as ClientSessionState
+    updateSessionState: (sessionId, updater) => {
+      const next = updater(createClientSessionState(null))
+      onStateUpdate?.(sessionId, next)
+
+      return next
+    }
   })
 
   useEffect(() => {
@@ -1660,6 +1671,46 @@ describe('branchStoredSession desktop source tagging', () => {
     expect($selectedStoredSessionId.get()).toBe('stored-other')
     // The branch instead opens as its own tile.
     expect($sessionTiles.get().some(tile => tile.storedSessionId === 'branch-stored')).toBe(true)
+  })
+
+  it('keeps the branch runtime elapsed anchor in its tile state without stealing the primary session', async () => {
+    const runtimeStartedAt = 1_700_000_000_000
+    vi.spyOn(Date, 'now').mockReturnValue(runtimeStartedAt)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    })
+
+    const stateUpdates: Array<{ sessionId: string; state: ClientSessionState }> = []
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+    setSessions([storedSession({ id: 'stored-parent', message_count: 1 })])
+    setSelectedStoredSessionId('stored-parent')
+    vi.mocked(getAllSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    render(
+      <BranchHarness
+        onReady={branch => (branchStoredSession = branch)}
+        onStateUpdate={(sessionId, state) => stateUpdates.push({ sessionId, state })}
+        requestGateway={requestGateway}
+      />
+    )
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(true)
+
+    expect(stateUpdates).toContainEqual(
+      expect.objectContaining({
+        sessionId: 'branch-runtime',
+        state: expect.objectContaining({ runtimeStartedAt })
+      })
+    )
+    expect($selectedStoredSessionId.get()).toBe('stored-parent')
   })
 
   it('tags desktop branch sessions as desktop sessions', async () => {
@@ -2019,6 +2070,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
     cleanup()
     setActiveSessionId(null)
     setResumeFailedSessionId(null)
+    setSessionStartedAt(null)
     setMessages([])
     setSessions([])
     vi.mocked(getSession).mockReset()
@@ -3586,6 +3638,42 @@ describe('resumeSession warm-cache mapping integrity', () => {
       publications.filter(snapshot => snapshot.latest && !snapshot.older),
       `Tail-only warm-cache publication escaped: ${JSON.stringify(publications)}`
     ).toEqual([])
+  })
+
+  it('keeps the runtime elapsed anchor when a warm-cached session is reselected', async () => {
+    const runtimeStartedAt = 1_700_000_000_000
+
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', { ...clientState('stored-A'), runtimeStartedAt }]])
+    }
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.usage') {
+        return { input: 0, output: 0, total: 0 } as never
+      }
+
+      return {} as never
+    })
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={r => (resume = r)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    vi.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000)
+    await resume!('stored-A', true)
+
+    expect($sessionStartedAt.get()).toBe(runtimeStartedAt)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1337,6 +1337,57 @@ describe('resumeSession failure recovery', () => {
     expect(resumeParams).toMatchObject({ source: 'desktop', omit_messages: true })
   })
 
+  it('captures a cold runtime anchor before session.resume settles and stores it in the runtime cache', async () => {
+    const resumeStartedAt = 1_700_000_000_000
+    const afterResumeSettles = 1_800_000_000_000
+    const now = vi.spyOn(Date, 'now').mockReturnValue(resumeStartedAt)
+    const resumeDeferred = deferred<never>()
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = { current: new Map() }
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-1' } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return await resumeDeferred.promise
+      }
+
+      return {} as never
+    })
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        requestGateway={requestGateway}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    let resumePromise!: Promise<unknown>
+    act(() => {
+      resumePromise = resume!('stored-1', true)
+    })
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('session.resume', expect.any(Object)))
+
+    // The visible timer is anchored before the delayed RPC resolves.
+    expect($sessionStartedAt.get()).toBe(resumeStartedAt)
+    now.mockReturnValue(afterResumeSettles)
+    resumeDeferred.resolve({
+      session_id: 'runtime-1',
+      resumed: 'stored-1',
+      messages: [],
+      info: {}
+    } as never)
+
+    await act(async () => {
+      await resumePromise
+    })
+
+    // The cache must retain the pre-await anchor, not a completion-time value.
+    expect(sessionStateByRuntimeIdRef.current.get('runtime-1')?.runtimeStartedAt).toBe(resumeStartedAt)
+  })
+
   it('arms the failure latch when resume succeeds with an empty transcript for a non-empty stored session', async () => {
     setSessions([storedSession({ message_count: 4 })])
 
@@ -3651,7 +3702,21 @@ describe('resumeSession warm-cache mapping integrity', () => {
       current: new Map([['rt-A', { ...clientState('stored-A'), runtimeStartedAt }]])
     }
 
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'stored-A' } as never)
+
     const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          session_id: 'rt-A',
+          session_key: 'stored-A',
+          resumed: 'stored-A',
+          message_count: 0,
+          messages: [],
+          running: false,
+          info: {}
+        } as never
+      }
+
       if (method === 'session.usage') {
         return { input: 0, output: 0, total: 0 } as never
       }

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -619,13 +619,16 @@ export function useSessionActions({
         setNewChatWorkspaceTarget(undefined)
         setActiveSessionId(created.session_id)
         setSelectedStoredSessionId(stored)
-        setSessionStartedAt(Date.now())
+        const runtimeStartedAt = Date.now()
+        setSessionStartedAt(runtimeStartedAt)
         const yoloArmed = $yoloActive.get()
         const runtimeInfo = applyRuntimeInfo(created.info)
 
-        if (runtimeInfo) {
-          updateSessionState(created.session_id, state => ({ ...state, ...runtimeInfo }), stored)
-        }
+        updateSessionState(
+          created.session_id,
+          state => ({ ...state, ...(runtimeInfo ?? {}), runtimeStartedAt }),
+          stored
+        )
 
         // User may have armed YOLO on the new-chat draft before the runtime
         // session existed — apply it to the freshly created session.
@@ -1076,7 +1079,7 @@ export function useSessionActions({
           // un-owned for the life of the session (#71254).
           setWorkspaceCwdOwner(storedSessionId)
           setCurrentBranch(cachedViewState.branch)
-          setSessionStartedAt(Date.now())
+          setSessionStartedAt(cachedViewState.runtimeStartedAt)
 
           try {
             let activated: SessionResumeResponse | null = null
@@ -1434,7 +1437,8 @@ export function useSessionActions({
       clearNotifications()
       setSelectedStoredSessionId(storedSessionId)
       selectedStoredSessionIdRef.current = storedSessionId
-      setSessionStartedAt(Date.now())
+      const runtimeStartedAt = Date.now()
+      setSessionStartedAt(runtimeStartedAt)
 
       const stored =
         $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ?? storedForProfile
@@ -1704,6 +1708,7 @@ export function useSessionActions({
           state => ({
             ...state,
             ...(runtimeInfo ?? {}),
+            runtimeStartedAt,
             messages: visibleMessagesForView,
             busy: resumedRunning,
             awaitingResponse: resumedRunning && !recoveredInFlightTail,
@@ -1980,6 +1985,7 @@ export function useSessionActions({
 
         const effectiveBranchMessages = responseBranchMessages.length ? responseBranchMessages : branchMessages
         const routedSessionId = branched.stored_session_id ?? branched.session_id
+        const runtimeStartedAt = Date.now()
         const preview = effectiveBranchMessages.map(({ content }) => content).find(Boolean) ?? null
         // Draft until submit: nest under the parent at the parent's recency so it
         // doesn't bubble to the top until a real message lands (backend persists
@@ -2005,6 +2011,7 @@ export function useSessionActions({
           branched.session_id,
           state => ({
             ...state,
+            runtimeStartedAt,
             messages: effectiveBranchMessages.map(({ source }) => source),
             busy: false,
             awaitingResponse: false

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -147,20 +147,12 @@ describe('useSessionStateCache — per-session timers', () => {
     render(<Harness activeSessionId="fg-runtime" onReady={c => (cache = c)} selectedStoredSessionId="fg-stored" />)
 
     act(() => {
-      cache.updateSessionState(
-        'bg-runtime',
-        state => ({ ...state, runtimeStartedAt: 1_700_000_000_000 }),
-        'bg-stored'
-      )
+      cache.updateSessionState('bg-runtime', state => ({ ...state, runtimeStartedAt: 1_700_000_000_000 }), 'bg-stored')
     })
     expect($sessionStartedAt.get()).toBeNull()
 
     act(() => {
-      cache.updateSessionState(
-        'fg-runtime',
-        state => ({ ...state, runtimeStartedAt: 1_700_000_111_000 }),
-        'fg-stored'
-      )
+      cache.updateSessionState('fg-runtime', state => ({ ...state, runtimeStartedAt: 1_700_000_111_000 }), 'fg-stored')
     })
     expect($sessionStartedAt.get()).toBe(1_700_000_111_000)
   })

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -11,6 +11,7 @@ import {
   $currentReasoningEffort,
   $currentServiceTier,
   $messages,
+  $sessionStartedAt,
   $turnStartedAt,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
@@ -19,6 +20,7 @@ import {
   setCurrentProvider,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
+  setSessionStartedAt,
   setTurnStartedAt
 } from '@/store/session'
 import {
@@ -104,7 +106,7 @@ function Harness({ activeSessionId, onReady, selectedStoredSessionId }: HarnessP
   return null
 }
 
-describe('useSessionStateCache — per-session turn timer', () => {
+describe('useSessionStateCache — per-session timers', () => {
   beforeEach(() => {
     // The view-sync flush runs on a real rAF in the browser path; in jsdom we
     // want it synchronous so the global mirror is observable immediately. The
@@ -125,6 +127,7 @@ describe('useSessionStateCache — per-session turn timer', () => {
     setCurrentReasoningEffort('')
     setCurrentServiceTier('')
     setCurrentFastMode(false)
+    setSessionStartedAt(null)
   })
 
   afterEach(() => {
@@ -136,6 +139,30 @@ describe('useSessionStateCache — per-session turn timer', () => {
     setCurrentReasoningEffort('')
     setCurrentServiceTier('')
     setCurrentFastMode(false)
+    setSessionStartedAt(null)
+  })
+
+  it('mirrors only the focused runtime session anchor into the global timer', () => {
+    let cache!: Cache
+    render(<Harness activeSessionId="fg-runtime" onReady={c => (cache = c)} selectedStoredSessionId="fg-stored" />)
+
+    act(() => {
+      cache.updateSessionState(
+        'bg-runtime',
+        state => ({ ...state, runtimeStartedAt: 1_700_000_000_000 }),
+        'bg-stored'
+      )
+    })
+    expect($sessionStartedAt.get()).toBeNull()
+
+    act(() => {
+      cache.updateSessionState(
+        'fg-runtime',
+        state => ({ ...state, runtimeStartedAt: 1_700_000_111_000 }),
+        'fg-stored'
+      )
+    })
+    expect($sessionStartedAt.get()).toBe(1_700_000_111_000)
   })
 
   it("keeps a background session's running turn clock and never mirrors it to the view", () => {

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -17,6 +17,7 @@ import {
   setCurrentProvider,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
+  setSessionStartedAt,
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
@@ -260,6 +261,9 @@ export function useSessionStateCache({
     setBusy(pending.state.busy)
     setMutableRef(busyRef, pending.state.busy)
     setAwaitingResponse(pending.state.awaitingResponse)
+    // Keep the foreground duration anchored to the runtime's first renderer
+    // attachment. Background state remains cached without stealing this view.
+    setSessionStartedAt(pending.state.runtimeStartedAt)
     // Mirror the focused session's per-session turn clock into the global
     // atom the statusbar timer reads. Keeps a backgrounded turn's elapsed
     // time intact on focus instead of zeroing it (the "timer restarts" bug).

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { type ReactElement } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { group } from '@/components/pane-shell/tree/model'
+import { $activeTreeGroup, $layoutTree } from '@/components/pane-shell/tree/store'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import {
+  $activeSessionId,
+  $selectedStoredSessionId,
+  $sessions,
+  $sessionStartedAt
+} from '@/store/session'
+import { $sessionStates, $sessionTiles } from '@/store/session-states'
+import type { SessionInfo } from '@/types/hermes'
+
+import { useStatusbarItems } from './use-statusbar-items'
+
+vi.mock('@/app/shell/approval-mode-menu', () => ({
+  useApprovalModeStatusbarItem: () => ({ id: 'approval-mode', label: 'Approvals', variant: 'menu' })
+}))
+
+async function requestGateway<T = unknown>(_method: string, _params?: Record<string, unknown>): Promise<T> {
+  return {} as T
+}
+
+const options = () => ({
+  agentsOpen: false,
+  chatOpen: true,
+  commandCenterOpen: false,
+  extraLeftItems: [],
+  extraRightItems: [],
+  freshDraftReady: false,
+  gatewayState: 'open',
+  inferenceStatus: null,
+  openAgents: vi.fn(),
+  openCommandCenterSection: vi.fn(),
+  requestGateway,
+  statusSnapshot: null,
+  toggleCommandCenter: vi.fn()
+})
+
+const sessionRow = (id: string, startedAt: number, parentSessionId: string | null = null) =>
+  ({
+    id,
+    parent_session_id: parentSessionId,
+    started_at: startedAt
+  }) as SessionInfo
+
+afterEach(() => {
+  cleanup()
+  $activeTreeGroup.set(null)
+  $layoutTree.set(null)
+  $activeSessionId.set(null)
+  $selectedStoredSessionId.set(null)
+  $sessions.set([])
+  $sessionStartedAt.set(null)
+  $sessionStates.set({})
+  $sessionTiles.set([])
+})
+
+describe('useStatusbarItems session timer', () => {
+  it("anchors a focused branch tile to its runtime cache instead of the parent's stored age", () => {
+    const parentRowStartedAt = 1_600_000_000
+    const branchRuntimeStartedAt = 1_800_000_000_000
+
+    $activeSessionId.set('parent-runtime')
+    $selectedStoredSessionId.set('parent-stored')
+    $sessionStartedAt.set(1_700_000_000_000)
+    $sessions.set([
+      sessionRow('parent-stored', parentRowStartedAt),
+      sessionRow('branch-stored', parentRowStartedAt, 'parent-stored')
+    ])
+    $sessionTiles.set([{ runtimeId: 'branch-runtime', storedSessionId: 'branch-stored' }])
+    $sessionStates.set({
+      'branch-runtime': {
+        ...createClientSessionState('branch-stored'),
+        runtimeStartedAt: branchRuntimeStartedAt
+      }
+    })
+    $layoutTree.set(
+      group(['workspace', 'session-tile:branch-stored'], {
+        active: 'session-tile:branch-stored',
+        id: 'main'
+      })
+    )
+    $activeTreeGroup.set('main')
+
+    const { result } = renderHook(() => useStatusbarItems(options()))
+    const sessionTimer = result.current.statusbarItems.find(item => item.id === 'session-timer')
+    const duration = sessionTimer?.detail as ReactElement<{ since: number | null }> | undefined
+
+    expect(duration?.props.since).toBe(branchRuntimeStartedAt)
+    expect(duration?.props.since).not.toBe(parentRowStartedAt * 1000)
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.test.tsx
@@ -5,12 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { group } from '@/components/pane-shell/tree/model'
 import { $activeTreeGroup, $layoutTree } from '@/components/pane-shell/tree/store'
 import { createClientSessionState } from '@/lib/chat-runtime'
-import {
-  $activeSessionId,
-  $selectedStoredSessionId,
-  $sessions,
-  $sessionStartedAt
-} from '@/store/session'
+import { $activeSessionId, $selectedStoredSessionId, $sessions, $sessionStartedAt } from '@/store/session'
 import { $sessionStates, $sessionTiles } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -137,6 +137,12 @@ export function useStatusbarItems({
   // Only the fields read here are selected, so an unchanged readout bails out
   // instead of rebuilding all ~9 statusbar items per token.
   const focusedBusy = useStoreSelector($focusedSessionState, state => Boolean(state?.busy))
+
+  const focusedRuntimeStartedAt = useStoreSelector(
+    $focusedSessionState,
+    state => state?.runtimeStartedAt ?? null
+  )
+
   const focusedTurnStartedAt = useStoreSelector($focusedSessionState, state => state?.turnStartedAt ?? null)
   // `usage` is an object, so it can't be compared as a scalar. It IS however
   // replaced wholesale rather than mutated, and only changes when the backend
@@ -222,11 +228,11 @@ export function useStatusbarItems({
   const projectTree = useStore($projectTree)
   const projectName = useMemo(() => projectNameForCwd(currentCwd), [currentCwd, projectTree])
 
+  const focusedRowSessionStartedAt = focusedRowStartedAt === null ? null : focusedRowStartedAt * 1000
+
   const sessionStartedAt = primaryFocused
     ? primarySessionStartedAt
-    : focusedRowStartedAt
-      ? focusedRowStartedAt * 1000
-      : null
+    : (focusedRuntimeStartedAt ?? focusedRowSessionStartedAt)
 
   // The backend only knows a session's MEASURED occupancy once a turn has run
   // in this process, so a resumed conversation reports none and the gauge had

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -138,10 +138,7 @@ export function useStatusbarItems({
   // instead of rebuilding all ~9 statusbar items per token.
   const focusedBusy = useStoreSelector($focusedSessionState, state => Boolean(state?.busy))
 
-  const focusedRuntimeStartedAt = useStoreSelector(
-    $focusedSessionState,
-    state => state?.runtimeStartedAt ?? null
-  )
+  const focusedRuntimeStartedAt = useStoreSelector($focusedSessionState, state => state?.runtimeStartedAt ?? null)
 
   const focusedTurnStartedAt = useStoreSelector($focusedSessionState, state => state?.turnStartedAt ?? null)
   // `usage` is an object, so it can't be compared as a scalar. It IS however

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -166,8 +166,8 @@ export function useStatusbarItems({
 
   const turnStartedAt = primaryFocused ? primaryTurnStartedAt : focusedTurnStartedAt
 
-  // A tile's session-start + cold cwd come from its stored row (the cache only
-  // knows runtime state). Only these scalars are read off `$sessions`, so
+  // A tile's stored row supplies the cold/fallback session-start and cwd when
+  // no focused runtime value is available. Only these scalars are read off `$sessions`, so
   // select them — a whole-list `useStore` re-ran the hook on every session-list
   // write (title updates, poll refreshes, archives).
   const focusedRowStartedAt = useStoreSelector($sessions, sessions =>

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -211,6 +211,9 @@ export interface ClientSessionState {
   /** A blocking clarify prompt is waiting on the user for this session. Drives
    *  the sidebar "needs input" indicator; cleared when the turn resumes/ends. */
   needsInput: boolean
+  /** Epoch ms this renderer attached to the live runtime. Per-runtime so a
+   *  cached session keeps its elapsed anchor when it becomes foreground again. */
+  runtimeStartedAt: number
   /** Epoch ms the current turn started, or null when idle. Per-session so a
    *  background turn's elapsed timer keeps counting while another session is
    *  focused, and switching sessions doesn't zero a still-running turn's clock.

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage, ChatMessagePart } from '@/lib/chat-messages'
 import type { ComposerAttachment } from '@/store/composer'
@@ -8,6 +8,7 @@ import {
   attachmentId,
   coalesceToolOnlyAssistants,
   coerceThinkingText,
+  createClientSessionState,
   createToolMergeCache,
   messageCreatedAt,
   optimisticAttachmentRef,
@@ -18,6 +19,19 @@ import {
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
 const THUMB_URL = 'data:image/png;base64,dGh1bWI='
+
+describe('createClientSessionState', () => {
+  it('anchors a fresh runtime to its creation time', () => {
+    const createdAt = 1_700_000_000_000
+    const now = vi.spyOn(Date, 'now').mockReturnValue(createdAt)
+
+    try {
+      expect(createClientSessionState('stored-1').runtimeStartedAt).toBe(createdAt)
+    } finally {
+      now.mockRestore()
+    }
+  })
+})
 
 function attachment(overrides: Partial<ComposerAttachment> & Pick<ComposerAttachment, 'kind'>): ComposerAttachment {
   return { id: 'a', label: 'file.png', ...overrides }

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -42,6 +42,7 @@ export function createClientSessionState(
     interrupted: false,
     interimBoundaryPending: false,
     needsInput: false,
+    runtimeStartedAt: Date.now(),
     turnStartedAt: null,
     turnLive: false,
     usage: null


### PR DESCRIPTION
## What does this PR do?

Preserves the Desktop session-duration timer across warm session switches by storing the renderer's runtime attachment timestamp in each `ClientSessionState` instead of resetting the timer whenever a cached session becomes foreground again.

The runtime anchor is initialized for newly created state, retained through create, cold-resume, warm-resume, branch, tile, and live-status rehydration flows, and mirrored to the global status-bar timer only when that runtime owns the foreground view. For a focused non-primary tile, the status bar reads `runtimeStartedAt` directly from `$focusedSessionState`; the primary session continues to use `$sessionStartedAt`. This prevents a new branch tile from inheriting the older parent/stored-row age.

### 2026-08-11 refresh

The four implementation commits are rebased directly onto `origin/main` at `936dd7346fd7fd8107af1ce7fc019c07c001c1bd`, followed by one comment-only Standards clarification. The refreshed exact candidate is `09a7a093a1e21fe57b4c8f3743250ce219df0546` (tree `ec40fcf95b9fb94a228ac4eefadcb2e0acc5d21a`). All commits preserve Jakub Wolniewicz as author and committer. `git range-diff` shows only the semantic adaptation of renamed upstream message-fetch helpers in the existing tests; the feature remains unchanged.

The refreshed exact SHA received independent **Spec PASS**. Focused Vitest, changed-file ESLint and Prettier, Desktop typecheck, production build, `git diff --check`, ancestry, and conflict-free `git merge-tree` all pass. Older SHA/base references later in this body are retained only as historical evidence from the previous review cycle; this refresh section is authoritative.

## Related Issue

No linked issue was identified during this local-only remediation of PR #64992.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `runtimeStartedAt` to `ClientSessionState` and initialized it from `Date.now()` in `createClientSessionState`.
- Preserved the same runtime anchor through fresh create, cold resume, warm-cache reuse, branch runtime creation, tile creation, and live-status rehydration.
- Centralized foreground mirroring in `useSessionStateCache`, matching the existing foreground-only turn-timer behavior.
- Updated `use-statusbar-items.tsx` to select the focused runtime's `runtimeStartedAt` for non-primary tiles while preserving `$sessionStartedAt` for the primary view.
- Added mutation-sensitive coverage that:
  - explicitly resolves the persisted transcript mock in the warm-cache test, eliminating test-order leakage and allowing an isolated `-t` run;
  - controls `Date.now()` and proves a fresh state uses its creation timestamp;
  - delays `session.resume`, advances time while it is pending, and proves the pre-await anchor is stored in the runtime cache.
- Made the resume test harness persist updates in its supplied runtime-state map so the cold-resume test exercises the cache contract rather than only observing a callback value.

## How to Test

From `apps/desktop`:

1. Run the warm-cache regression by itself:
   ```bash
   NODE_ENV=test NODE_OPTIONS="--max-old-space-size=8192 --localstorage-file=/tmp/hermes-pr-64992-warm-baseline.json" \
     npm exec -- vitest run --project ui \
       src/app/session/hooks/use-session-actions.test.tsx \
       -t 'keeps the runtime elapsed anchor when a warm-cached session is reselected'
   ```
   Result: **1 passed, 43 skipped**.
2. Run the three Standards hardening regressions together:
   ```bash
   NODE_ENV=test NODE_OPTIONS="--max-old-space-size=8192 --localstorage-file=/tmp/hermes-pr-64992-new-tests-final.json" \
     npm exec -- vitest run --project ui \
       src/app/session/hooks/use-session-actions.test.tsx \
       src/lib/chat-runtime.test.ts \
       -t 'keeps the runtime elapsed anchor when a warm-cached session is reselected|anchors a fresh runtime to its creation time|captures a cold runtime anchor before session.resume settles and stores it in the runtime cache'
   ```
   Result: **2 files passed, 3 tests passed, 71 skipped**.
3. Run the complete focused timer/status-bar lane on the exact candidate:
   ```bash
   NODE_ENV=test NODE_OPTIONS="--max-old-space-size=8192 --localstorage-file=/tmp/hermes-pr-64992-focused-formatted.json" \
     npm exec -- vitest run --project ui \
       src/app/shell/hooks/use-statusbar-items.test.tsx \
       src/app/session/hooks/use-session-actions.test.tsx \
       src/app/session/hooks/use-session-state-cache.test.tsx \
       src/lib/chat-runtime.test.ts
   ```
   Result: **4 files passed, 88 tests passed** (`1 + 44 + 13 + 30`).
4. Check the three repaired formatting paths:
   ```bash
   npm exec -- prettier --check \
     src/app/session/hooks/use-session-state-cache.test.tsx \
     src/app/shell/hooks/use-statusbar-items.test.tsx \
     src/app/shell/hooks/use-statusbar-items.tsx
   ```
   Result: **passed**; all three files use Prettier code style. Prettier `--debug-check` on the exact parent blobs passed, and TypeScript transpilation of each exact parent/HEAD pair produced identical JavaScript, confirming no semantic AST change.
5. Run Desktop type checking:
   ```bash
   NODE_ENV=test npm run typecheck
   ```
   Result: **passed** (`tsc` renderer, Electron, and E2E configs).
6. Lint every changed TypeScript/TSX file:
   ```bash
   NODE_ENV=test npm exec -- eslint \
     src/app/session/hooks/use-session-actions.test.tsx \
     src/app/session/hooks/use-session-actions/index.ts \
     src/app/session/hooks/use-session-state-cache.test.tsx \
     src/app/session/hooks/use-session-state-cache.ts \
     src/app/shell/hooks/use-statusbar-items.test.tsx \
     src/app/shell/hooks/use-statusbar-items.tsx \
     src/app/types.ts \
     src/lib/chat-runtime.test.ts \
     src/lib/chat-runtime.ts
   ```
   Result: **passed with 0 errors**; ESLint reports one existing non-blocking `react-hooks/exhaustive-deps` warning for the intentional `projectTree` invalidation dependency in `use-statusbar-items.tsx`.
7. Build the production Desktop bundle from the committed candidate:
   ```bash
   NODE_ENV=production npm run build
   ```
   Result: **passed** on refreshed SHA `09a7a093a1e21fe57b4c8f3743250ce219df0546`; Vite built the renderer, Electron main/preload bundles were produced, `node-pty` was staged for `linux-x64`, and `assert-dist-built` passed.
8. From the repository root:
   ```bash
   git diff --check 936dd7346fd7fd8107af1ce7fc019c07c001c1bd...HEAD
   git status --porcelain=v1
   git merge-base --is-ancestor 936dd7346fd7fd8107af1ce7fc019c07c001c1bd HEAD
   ```
   Result: **passed**; the worktree/index are clean and the exact base is an ancestor of the candidate.

### Mutation probes

All three probes were applied to production source, run against only the named regression, required a non-zero Vitest exit, and were then reversed:

- Warm cache: changed `setSessionStartedAt(cachedViewState.runtimeStartedAt)` to `setSessionStartedAt(Date.now())` → **failed as expected**, receiving `1800000000000` instead of `1700000000000`.
- Fresh-state factory: changed `runtimeStartedAt: Date.now()` to `runtimeStartedAt: 0` → **failed as expected**, receiving `0` instead of `1700000000000`.
- Cold resume: removed the `runtimeStartedAt` assignment from the post-resume cache update → **failed as expected**, receiving completion time `1800000000000` instead of pre-await time `1700000000000`.

These mutation probes were performed during the earlier review cycle and restored before the current-main rebase. The refreshed exact candidate is instead bound by its committed SHA and the rerun focused/typecheck/lint/build gates above; historical pre-rebase file hashes are intentionally omitted.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A: Desktop TypeScript-only change; focused Vitest, typecheck, lint, mutation probes, and production build were run instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.1.5-1-cachyos x86_64; Node.js v25.4.0; npm 11.7.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A: internal state behavior with inline type/intent documentation)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — behavior is renderer-only and platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A)

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

No visual styling change. The final formatted candidate passed Prettier check on the three repaired paths, Prettier AST/idempotence debug-check, exact-parent/HEAD semantic transpile comparison, **88/88 focused tests**, Desktop typecheck, changed-file ESLint (**0 errors / 1 existing warning**), three earlier mutation probes, production build, ancestry check, and `git diff --check`.

Non-blocking build warnings remain from frozen rebase base `936dd7346fd7fd8107af1ce7fc019c07c001c1bd` and tooling: deprecated `advancedChunks`, one generated-CSS parser warning, the large `@tabler/icons-react` barrel warning, and an ineffective dynamic-import warning.
