### PR TITLE
fix(mcp_catalog): add timeout and stdin=DEVNULL to _run_bootstrap subprocess.run

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -380,7 +380,10 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        proc = subprocess.run(
+            cmd, cwd=str(cwd), shell=True, timeout=600,
+            stdin=subprocess.DEVNULL,
+        )
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"


### PR DESCRIPTION
## Summary

Added a 600s timeout and `stdin=subprocess.DEVNULL` to `subprocess.run` in `_run_bootstrap`.

## Problem

`_run_bootstrap` executes arbitrary shell commands from MCP server `install.bootstrap` lists (e.g. `npm install`, `pip install`). Without a timeout, any hanging command (network stall, broken dependency, interactive prompt) blocks the MCP install process indefinitely.

This is the same bug class fixed in PR #64676 for `_do_git_install`, but `_run_bootstrap` was overlooked.

## Fix

- Added `timeout=600` (10 min — generous enough for large `npm install` runs)
- Added `stdin=subprocess.DEVNULL` to prevent inherited-TTY blocking

## Testing
- Syntax check passed (py_compile)
- Behavior verified