### PR TITLE
fix(skills): add skills.read_only hard deny for runtime skill writes

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2390,6 +2390,13 @@ DEFAULT_CONFIG = {
         #                     never crammed into a chat bubble), apply with
         #                     /skills approve <id> or drop with /skills reject <id>.
         "write_approval": False,
+        # Hard read-only mode for platform / shared skill mounts. When true,
+        # every runtime skill mutation is refused (skill_manage, background
+        # self-improvement review, curator archive/prune, dashboard skill
+        # editor, hub install/uninstall via API). Listing, viewing, using,
+        # and executing existing skill scripts still work. Independent of
+        # write_approval (which stages writes) — read_only is a hard deny.
+        "read_only": False,
     },
 
     # Curator — background skill maintenance.

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -519,6 +519,13 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     from tools.skills_guard import scan_skill_cached, should_allow_install, format_scan_report
 
     c = console or _console
+    try:
+        from tools.skill_manager_tool import skills_read_only_enabled, _READ_ONLY_MESSAGE
+        if skills_read_only_enabled():
+            c.print(f"[bold red]Installation blocked:[/] {_READ_ONLY_MESSAGE}\n")
+            return
+    except Exception:
+        pass
     ensure_hub_dirs()
 
     # Resolve which source adapter handles this identifier
@@ -630,7 +637,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     # Quarantine the bundle
     try:
         q_path = quarantine_bundle(bundle)
-    except ValueError as exc:
+    except (ValueError, PermissionError) as exc:
         c.print(f"[bold red]Installation blocked:[/] {exc}\n")
         from tools.skills_hub import append_audit_log
         append_audit_log("BLOCKED", bundle.name, bundle.source,
@@ -720,7 +727,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     # Install
     try:
         install_dir = install_from_quarantine(q_path, bundle.name, category, bundle, result)
-    except ValueError as exc:
+    except (ValueError, PermissionError) as exc:
         c.print(f"[bold red]Installation blocked:[/] {exc}\n")
         shutil.rmtree(q_path, ignore_errors=True)
         from tools.skills_hub import append_audit_log

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1447,3 +1447,29 @@ class TestSkillsReadOnly:
             assert ok is False
             assert "read_only" in msg
             assert (skills / "to-archive" / "SKILL.md").exists()
+
+    def test_read_only_blocks_restore_skill(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        skills = hermes_home / "skills"
+        skills.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        _set_skills_read_only(False)
+
+        # skill_usage resolves by frontmatter name:, so keep dir name in sync.
+        content = VALID_SKILL_CONTENT.replace("name: test-skill", "name: to-restore")
+        with _skill_dir(skills):
+            assert _create_skill("to-restore", content)["success"] is True
+            from tools.skill_usage import mark_agent_created, archive_skill, restore_skill
+            mark_agent_created("to-restore")
+            ok, msg = archive_skill("to-restore")
+            assert ok is True, msg
+            assert not (skills / "to-restore").exists()
+            assert (skills / ".archive" / "to-restore" / "SKILL.md").exists()
+
+            _set_skills_read_only(True)
+            ok, msg = restore_skill("to-restore")
+            assert ok is False
+            assert "read_only" in msg
+            assert not (skills / "to-restore").exists()
+            assert (skills / ".archive" / "to-restore" / "SKILL.md").exists()

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1348,3 +1348,102 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+
+# ---------------------------------------------------------------------------
+# skills.read_only hard deny (#64926)
+# ---------------------------------------------------------------------------
+
+
+def _set_skills_read_only(enabled: bool) -> None:
+    import hermes_cli.config as cfg
+    c = cfg.load_config()
+    c.setdefault("skills", {})["read_only"] = enabled
+    cfg.save_config(c)
+
+
+class TestSkillsReadOnly:
+    def test_read_only_blocks_skill_manage_patch(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        skills = hermes_home / "skills"
+        skills.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        _set_skills_read_only(True)
+
+        with _skill_dir(skills):
+            _set_skills_read_only(True)
+            created = _create_skill("locked-skill", VALID_SKILL_CONTENT)
+            # create itself should be refused under read_only
+            assert created["success"] is False
+            assert "read_only" in created["error"]
+
+            _set_skills_read_only(False)
+            assert _create_skill("locked-skill", VALID_SKILL_CONTENT)["success"] is True
+
+            _set_skills_read_only(True)
+            result = json.loads(skill_manage(
+                action="patch",
+                name="locked-skill",
+                old_string="Step 1: Do the thing.",
+                new_string="Step 1: Changed.",
+            ))
+            assert result["success"] is False
+            assert "read_only" in result["error"]
+            skill_md = (skills / "locked-skill" / "SKILL.md").read_text(encoding="utf-8")
+            assert "Step 1: Do the thing." in skill_md
+            assert "Step 1: Changed." not in skill_md
+
+    def test_read_only_blocks_direct_helpers(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        skills = hermes_home / "skills"
+        skills.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        _set_skills_read_only(False)
+
+        with _skill_dir(skills):
+            assert _create_skill("helper-skill", VALID_SKILL_CONTENT)["success"] is True
+            _set_skills_read_only(True)
+            assert _edit_skill("helper-skill", VALID_SKILL_CONTENT_2)["success"] is False
+            assert _patch_skill(
+                "helper-skill", "Step 1: Do the thing.", "patched"
+            )["success"] is False
+            assert _write_file(
+                "helper-skill", "references/a.md", "x"
+            )["success"] is False
+            assert _delete_skill("helper-skill")["success"] is False
+            assert (skills / "helper-skill" / "SKILL.md").exists()
+
+    def test_read_only_off_allows_writes(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        skills = hermes_home / "skills"
+        skills.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        _set_skills_read_only(False)
+
+        with _skill_dir(skills):
+            assert _create_skill("open-skill", VALID_SKILL_CONTENT)["success"] is True
+            patched = _patch_skill(
+                "open-skill", "Step 1: Do the thing.", "Step 1: Allowed."
+            )
+            assert patched["success"] is True
+
+    def test_read_only_blocks_archive_skill(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        skills = hermes_home / "skills"
+        skills.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        _set_skills_read_only(False)
+
+        with _skill_dir(skills):
+            assert _create_skill("to-archive", VALID_SKILL_CONTENT)["success"] is True
+            from tools.skill_usage import mark_agent_created, archive_skill
+            mark_agent_created("to-archive")
+            _set_skills_read_only(True)
+            ok, msg = archive_skill("to-archive")
+            assert ok is False
+            assert "read_only" in msg
+            assert (skills / "to-archive" / "SKILL.md").exists()

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1967,6 +1967,38 @@ class TestQuarantineBundleBinaryAssets:
 
         assert not absolute_target.exists()
 
+    def test_quarantine_bundle_refuses_read_only(self, tmp_path, monkeypatch):
+        """skills.read_only must refuse before writing skills/.hub/quarantine."""
+        import tools.skills_hub as hub
+
+        monkeypatch.setattr(
+            "tools.skill_manager_tool.skills_read_only_enabled",
+            lambda: True,
+        )
+        skills_dir = tmp_path / "skills"
+        hub_dir = skills_dir / ".hub"
+        quarantine_dir = hub_dir / "quarantine"
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "HUB_DIR", hub_dir), \
+             patch.object(hub, "LOCK_FILE", hub_dir / "lock.json"), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_dir), \
+             patch.object(hub, "AUDIT_LOG", hub_dir / "audit.log"), \
+             patch.object(hub, "TAPS_FILE", hub_dir / "taps.json"), \
+             patch.object(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache"):
+            bundle = SkillBundle(
+                name="locked-skill",
+                files={"SKILL.md": "---\nname: locked-skill\n---\n"},
+                source="official",
+                identifier="official/locked-skill",
+                trust_level="builtin",
+            )
+
+            with pytest.raises(PermissionError, match="read_only"):
+                quarantine_bundle(bundle)
+
+        assert not quarantine_dir.exists()
+        assert not (skills_dir / ".hub").exists()
+
 
 # ---------------------------------------------------------------------------
 # GitHubSource._download_directory — tree API + fallback (#2940)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -118,6 +118,37 @@ def _guard_agent_created_enabled() -> bool:
         return False
 
 
+def skills_read_only_enabled() -> bool:
+    """Read skills.read_only from config (default False).
+
+    When true, refuse all runtime skill mutations while still allowing
+    list/view/use/execute. Used by platform deployments that mount a
+    shared skills tree and do not want Hermes to rewrite it (#64926).
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return is_truthy_value(
+            cfg_get(cfg, "skills", "read_only"),
+            default=False,
+        )
+    except Exception:
+        return False
+
+
+_READ_ONLY_MESSAGE = (
+    "Skill writes are disabled (skills.read_only: true). "
+    "Skills are read-only — listing, viewing, and using them still works."
+)
+
+
+def _refuse_if_read_only() -> Optional[Dict[str, Any]]:
+    """Return an error dict when skills.read_only is on, else None."""
+    if not skills_read_only_enabled():
+        return None
+    return {"success": False, "error": _READ_ONLY_MESSAGE}
+
+
 def _security_scan_skill(skill_dir: Path) -> Optional[str]:
     """Scan a skill directory after write. Returns error string if blocked, else None.
 
@@ -792,6 +823,9 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
 
 def _create_skill(name: str, content: str, category: str = None) -> Dict[str, Any]:
     """Create a new user skill with SKILL.md content."""
+    refused = _refuse_if_read_only()
+    if refused:
+        return refused
     # Validate name
     err = _validate_name(name)
     if err:
@@ -860,6 +894,9 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
 
 def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     """Replace the SKILL.md of any existing skill (full rewrite)."""
+    refused = _refuse_if_read_only()
+    if refused:
+        return refused
     err = _validate_frontmatter(content)
     if err:
         return {"success": False, "error": err}
@@ -923,6 +960,9 @@ def _patch_skill(
     Defaults to SKILL.md. Use file_path to patch a supporting file instead.
     Requires a unique match unless replace_all is True.
     """
+    refused = _refuse_if_read_only()
+    if refused:
+        return refused
     if not old_string:
         return {"success": False, "error": "old_string is required for 'patch'."}
     if new_string is None:
@@ -1036,6 +1076,9 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
         target must exist on disk. Validated here so the model can't claim an
         umbrella that doesn't exist.
     """
+    refused = _refuse_if_read_only()
+    if refused:
+        return refused
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
@@ -1131,6 +1174,9 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
 
 def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     """Add or overwrite a supporting file within any skill directory."""
+    refused = _refuse_if_read_only()
+    if refused:
+        return refused
     err = _validate_file_path(file_path)
     if err:
         return {"success": False, "error": err}
@@ -1193,6 +1239,9 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
 
 def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     """Remove a supporting file from any skill directory."""
+    refused = _refuse_if_read_only()
+    if refused:
+        return refused
     err = _validate_file_path(file_path)
     if err:
         return {"success": False, "error": err}
@@ -1334,6 +1383,11 @@ def skill_manage(
 
     Returns JSON string with results.
     """
+    if action in {"create", "edit", "patch", "delete", "write_file", "remove_file"}:
+        refused = _refuse_if_read_only()
+        if refused:
+            return tool_error(refused["error"], success=False)
+
     preflight = _background_review_preflight(action, name)
     if preflight is not None:
         return json.dumps(preflight, ensure_ascii=False)

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -701,6 +701,13 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
     when one is archived, its name is added to the suppression list so the
     update-time re-seeder leaves it archived instead of restoring it.
     """
+    try:
+        from tools.skill_manager_tool import skills_read_only_enabled, _READ_ONLY_MESSAGE
+        if skills_read_only_enabled():
+            return False, _READ_ONLY_MESSAGE
+    except Exception:
+        pass
+
     local_skill_dir = _find_skill_dir(skill_name)
     if local_skill_dir is None and _find_external_skill_dir(skill_name) is not None:
         return False, _external_read_only_message(skill_name)

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -772,6 +772,13 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     way to lift a prune). Restoring clears any suppression entry so future
     updates may re-seed the built-in again.
     """
+    try:
+        from tools.skill_manager_tool import skills_read_only_enabled, _READ_ONLY_MESSAGE
+        if skills_read_only_enabled():
+            return False, _READ_ONLY_MESSAGE
+    except Exception:
+        pass
+
     # Hub skills always have an external upstream owner — never shadow them.
     if is_hub_installed(skill_name):
         return False, (

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3578,6 +3578,15 @@ def install_from_quarantine(
     scan_provenance: Optional[Dict[str, Any]] = None,
 ) -> Path:
     """Move a scanned skill from quarantine into the skills directory."""
+    try:
+        from tools.skill_manager_tool import skills_read_only_enabled, _READ_ONLY_MESSAGE
+        if skills_read_only_enabled():
+            raise PermissionError(_READ_ONLY_MESSAGE)
+    except PermissionError:
+        raise
+    except Exception:
+        pass
+
     safe_skill_name = _validate_skill_name(skill_name)
     safe_category = _validate_install_parent_path(category) if category else ""
     quarantine_resolved = quarantine_path.resolve()
@@ -3658,6 +3667,13 @@ def install_from_quarantine(
 
 def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
     """Remove a hub-installed skill. Refuses to remove builtins."""
+    try:
+        from tools.skill_manager_tool import skills_read_only_enabled, _READ_ONLY_MESSAGE
+        if skills_read_only_enabled():
+            return False, _READ_ONLY_MESSAGE
+    except Exception:
+        pass
+
     lock = HubLockFile()
     entry = lock.get_installed(skill_name)
     if not entry:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3546,6 +3546,15 @@ def ensure_hub_dirs() -> None:
 
 def quarantine_bundle(bundle: SkillBundle) -> Path:
     """Write a skill bundle to the quarantine directory for scanning."""
+    try:
+        from tools.skill_manager_tool import skills_read_only_enabled, _READ_ONLY_MESSAGE
+        if skills_read_only_enabled():
+            raise PermissionError(_READ_ONLY_MESSAGE)
+    except PermissionError:
+        raise
+    except Exception:
+        pass
+
     ensure_hub_dirs()
     skill_name = _validate_skill_name(bundle.name)
     validated_files: List[Tuple[str, Union[str, bytes]]] = []

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -508,6 +508,29 @@ in the pending JSON file). Memory writes have the same gate under
 > (dangerous-pattern heuristics), not an approval gate — the two are
 > independent. See [Guard on agent-created skill writes](/user-guide/configuration#guard-on-agent-created-skill-writes).
 
+### Read-only skills (`skills.read_only`)
+
+For platform / shared deployments where skills are managed outside Hermes
+(for example a Kubernetes volume mount) and must never be rewritten at
+runtime, turn on hard read-only mode:
+
+```yaml
+skills:
+  read_only: true
+```
+
+When enabled, Hermes still lists, views, uses, and executes skills, but
+**refuses every runtime skill mutation**, including:
+
+- `skill_manage` create / edit / patch / delete / write_file / remove_file
+- background self-improvement skill patches
+- curator archive / prune of skill directories
+- dashboard / web UI skill create / edit
+- hub install / uninstall through the agent surface
+
+This is independent of `skills.write_approval` (which stages writes for
+review). `read_only` is a hard deny — nothing is staged.
+
 ## Skills Hub
 
 Browse, search, install, and manage skills from online registries, `skills.sh`, direct well-known skill endpoints, and official optional skills.


### PR DESCRIPTION
## What does this PR do?

Adds `skills.read_only` (default `false`) so platform/shared deployments can freeze the skills tree at runtime.

Existing knobs are not a hard deny: `write_approval: false` writes freely, `write_approval: true` only stages, and `creation_nudge_interval: 0` only drops the skill-review prompt. Operators mounting centrally managed skills (e.g. K8s volumes) still saw runtime mutations such as `Self-improvement review: Patched SKILL.md…`.

When `skills.read_only: true`, Hermes still lists/views/uses/executes skills, but refuses runtime mutations across:

- `skill_manage` (foreground agent + background self-improvement)
- write helpers (`_create/_edit/_patch/_delete/_write_file/_remove_file`) used by the dashboard editor
- curator `archive_skill`
- hub `install_from_quarantine` / `uninstall_skill`

Independent of `write_approval` — this is a hard deny, not staging.

A dispatcher-only gate is not enough: dashboard `POST /api/skills` and `PUT /api/skills/content` call `_create_skill` / `_edit_skill` directly and bypass `skill_manage`.

## Related Issue

Fixes #64926

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py` — `skills.read_only: false` in `DEFAULT_CONFIG`
- `tools/skill_manager_tool.py` — `skills_read_only_enabled()` / `_refuse_if_read_only()`; gate in `skill_manage` and write helpers
- `tools/skill_usage.py` — refuse `archive_skill` under read_only
- `tools/skills_hub.py` — refuse hub install/uninstall under read_only
- `website/docs/user-guide/features/skills.md` — document the flag
- `tests/tools/test_skill_manager_tool.py` — `TestSkillsReadOnly`

## How to Test

1. `pytest tests/tools/test_skill_manager_tool.py::TestSkillsReadOnly -v`
2. Live with `skills.read_only: true` and `creation_nudge_interval: 1`: chat that loads a local skill + preference correction; wait for BG review — FG/BG `skill_manage` refuse; notify must not include `Patched SKILL.md`; skill file hash unchanged
3. Control with `read_only: false`: same chat — expect `Self-improvement review: … Patched SKILL.md…` and on-disk change
4. Dashboard: `GET /api/skills` 200; `POST /api/skills` and `PUT /api/skills/content` 400 with read_only message
5. Hub: `install_from_quarantine` / `uninstall_skill` refuse under read_only

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`read_only: true` (no patch):

Tool skill_manage returned error: Skill writes are disabled (skills.read_only: true)...
Self-improvement review: User profile updated

`read_only: false` control:

Self-improvement review: User profile updated · Patched SKILL.md in skill 'ontology-infer-sql' (1 replacement).
