### PR TITLE
fix: avoid process poll reader lock deadlock

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -316,6 +316,70 @@ class TestOrphanedPipeReconciliation:
         except (ProcessLookupError, PermissionError):
             pass
 
+    @pytest.mark.live_system_guard_bypass
+    def test_poll_returns_while_reader_holds_stdout_lock(self, registry):
+        """poll() must not read from stdout while the reader owns its lock."""
+        proc = subprocess.Popen(
+            ["sh", "-c", "( sleep 30 ) & disown; exit 0"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+
+        process_group = os.getpgid(proc.pid)
+        poller = None
+        reader = None
+        result = {}
+        returned_quickly = False
+
+        try:
+            s = _make_session(sid="proc_reader_lock")
+            s.process = proc
+            s.pid = proc.pid
+            registry._running[s.id] = s
+
+            reader = threading.Thread(
+                target=registry._reader_loop,
+                args=(s,),
+                daemon=True,
+                name="proc-reader-lock-test",
+            )
+            s._reader_thread = reader
+            reader.start()
+
+            assert _wait_until(lambda: proc.poll() is not None, timeout=5.0)
+            assert reader.is_alive(), "Descendant should keep the reader blocked"
+
+            poller = threading.Thread(
+                target=lambda: result.setdefault("value", registry.poll(s.id)),
+                daemon=True,
+            )
+            poller.start()
+            poller.join(timeout=1.0)
+            returned_quickly = not poller.is_alive()
+        finally:
+            try:
+                os.killpg(process_group, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+
+            if poller is not None:
+                poller.join(timeout=5.0)
+            if reader is not None:
+                reader.join(timeout=5.0)
+
+        assert poller is not None and not poller.is_alive(), (
+            "poll() did not finish after cleanup"
+        )
+        assert reader is not None and not reader.is_alive(), (
+            "Reader thread did not finish after cleanup"
+        )
+        assert returned_quickly, (
+            "poll() blocked on the BufferedReader lock held by _reader_loop"
+        )
+        assert result["value"]["status"] == "exited"
+
     def test_reconcile_noop_when_child_still_running(self, registry):
         """Reconcile must NOT flip exited when the direct child is alive."""
         proc = _spawn_python_sleep(5.0)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1249,10 +1249,10 @@ class ProcessRegistry:
         7 minutes on Feishu).
 
         This helper closes that window: when `session.exited` is still False
-        but the direct child's `Popen.poll()` reports an exit code, drain any
-        readable bytes non-blocking and flip `session.exited`. The orphaned
-        reader thread remains stuck on its blocking `read()` but is a daemon
-        thread and will be reaped with the process.
+        but the direct child's `Popen.poll()` reports an exit code, flip
+        `session.exited`. If no reader thread is active, also drain any readable
+        bytes non-blocking. An active reader already owns the buffered stdout
+        stream and attempting a second read can block on its internal lock.
 
         Safe no-op on sessions without a local `Popen` (env/PTY), already-
         exited sessions, and detached-recovered sessions.
@@ -1269,13 +1269,14 @@ class ProcessRegistry:
         if rc is None:
             return  # Direct child still running — reader block is legitimate.
 
-        # Direct child exited. Try to drain any bytes the reader hasn't
-        # consumed yet. This is best-effort: if the pipe is held open by a
-        # descendant, the non-blocking read returns what's immediately
-        # available and we stop.
+        # Direct child exited. Drain only when no reader thread is active.
+        # Concurrent reads through the same BufferedReader can block on its
+        # internal lock even after the file descriptor is made non-blocking.
         drained = ""
         stdout = getattr(proc, "stdout", None)
-        if stdout is not None and not _IS_WINDOWS:
+        reader = getattr(session, "_reader_thread", None)
+        reader_is_active = reader is not None and reader.is_alive()
+        if stdout is not None and not _IS_WINDOWS and not reader_is_active:
             try:
                 import fcntl
                 fd = stdout.fileno()


### PR DESCRIPTION
## Summary

Fixes #64533.

`process(action="poll")` could block indefinitely after the direct child had already exited when a descendant process inherited and kept the stdout pipe open.

## Root cause

`_reader_loop()` was blocked in `stdout.buffer.read1()` while holding the Python `BufferedReader` internal lock.

At the same time, `_reconcile_local_exit()` detected that the direct child had exited, made the underlying file descriptor non-blocking, and called `stdout.read()` on the same buffered stream.

Setting `O_NONBLOCK` on the file descriptor does not bypass the `BufferedReader` lock, so the reconciliation path could block behind the active reader thread until the descendant closed the pipe or the gateway idle timeout fired.

## Fix

- Detect whether the session reader thread is still active.
- When it is active, skip the second read from the shared buffered stdout stream.
- Continue marking the direct child as exited and moving the session to the finished registry.
- Preserve the existing best-effort non-blocking drain when no reader thread is active.

## Testing

Added a POSIX regression test that:

1. Starts a direct child which exits immediately.
2. Leaves a descendant holding stdout open.
3. Starts the real `_reader_loop()` so it blocks on the pipe.
4. Calls `registry.poll()` from another thread.
5. Verifies that poll returns promptly with `status == "exited"`.

Before the fix, the regression test blocked on the `BufferedReader` lock.
After the fix, it completes in under one second.

Validation:

- `104 passed` — `tests/tools/test_process_registry.py`
- `ruff check tools/process_registry.py tests/tools/test_process_registry.py`
- `git diff --check`

## Scope

This addresses the single-call blocking path reported in #64533.

#34711 concerns repeated poll-loop escalation and is broader in scope; this change is intentionally limited to preventing concurrent reads from the same buffered stdout stream during exit reconciliation.