### PR TITLE
perf(gateway): replace SSE poll loop with a push-based asyncio.Queue

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -107,6 +107,32 @@ MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 
 
+class ThreadSafeAsyncQueue(asyncio.Queue):
+    """An ``asyncio.Queue`` that a non-loop thread can push into safely.
+
+    The SSE writers' streaming loops used to bridge a plain ``queue.Queue``
+    into the event loop via ``await loop.run_in_executor(None, lambda:
+    stream_q.get(timeout=0.5))`` inside a ``while True`` poll — a thread-pool
+    round trip on every 0.5s tick even when idle, plus up to 500ms of tail
+    latency between a delta landing in the queue and it reaching the
+    response. ``run_conversation`` itself runs on a worker thread (via
+    ``loop.run_in_executor``), so its ``stream_delta_callback`` closures
+    (``_on_delta`` etc.) call ``put_threadsafe`` from off the loop thread;
+    the consumer side just does a plain ``await queue.get()``/
+    ``asyncio.wait_for(queue.get(), timeout=...)``, woken immediately by
+    ``call_soon_threadsafe`` instead of polling.
+    """
+
+    def put_threadsafe(self, item, *, loop: asyncio.AbstractEventLoop = None) -> None:
+        (loop or self._loop_ref).call_soon_threadsafe(self.put_nowait, item)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Always constructed inside a running async handler (the SSE
+        # request handlers below), so get_running_loop() is safe here.
+        self._loop_ref = asyncio.get_running_loop()
+
+
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
     """Parse a listen port without letting malformed env/config values crash startup."""
     try:
@@ -2357,8 +2383,7 @@ class APIServerAdapter(BasePlatformAdapter):
         route = self._resolve_route(model_name)
 
         if stream:
-            import queue as _q
-            _stream_q: _q.Queue = _q.Queue()
+            _stream_q = ThreadSafeAsyncQueue()
 
             def _on_delta(delta):
                 # Filter out None — the agent fires stream_delta_callback(None)
@@ -2368,8 +2393,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 # response, causing Open WebUI (and similar frontends) to miss
                 # the final answer after tool calls.  The SSE loop detects
                 # completion via agent_task.done() instead.
+                # Called from the worker thread running run_conversation —
+                # put_threadsafe (not put_nowait) is required here.
                 if delta is not None:
-                    _stream_q.put(delta)
+                    _stream_q.put_threadsafe(delta)
 
             # Track which tool_call_ids we've emitted a "running" lifecycle
             # event for, so a "completed" event without a matching "running"
@@ -2395,7 +2422,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 _started_tool_call_ids.add(tool_call_id)
                 from agent.display import build_tool_preview, get_tool_emoji
                 label = build_tool_preview(function_name, function_args) or function_name
-                _stream_q.put(("__tool_progress__", {
+                _stream_q.put_threadsafe(("__tool_progress__", {
                     "tool": function_name,
                     "emoji": get_tool_emoji(function_name),
                     "label": label,
@@ -2413,7 +2440,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 if not tool_call_id or tool_call_id not in _started_tool_call_ids:
                     return
                 _started_tool_call_ids.discard(tool_call_id)
-                _stream_q.put(("__tool_progress__", {
+                _stream_q.put_threadsafe(("__tool_progress__", {
                     "tool": function_name,
                     "toolCallId": tool_call_id,
                     "status": "completed",
@@ -2442,7 +2469,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
-            agent_task.add_done_callback(lambda _fut: _stream_q.put(None))
+            agent_task.add_done_callback(lambda _fut: _stream_q.put_nowait(None))
 
             return await self._write_sse_chat_completion(
                 request, completion_id, model_name, created, _stream_q,
@@ -2573,8 +2600,6 @@ class APIServerAdapter(BasePlatformAdapter):
         the agent is interrupted via ``agent.interrupt()`` so it stops making
         LLM API calls, and the asyncio task wrapper is cancelled.
         """
-        import queue as _q
-
         sse_headers = {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
@@ -2630,12 +2655,14 @@ class APIServerAdapter(BasePlatformAdapter):
                     await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
                 return time.monotonic()
 
-            # Stream content chunks as they arrive from the agent
-            loop = asyncio.get_running_loop()
+            # Stream content chunks as they arrive from the agent. Woken
+            # directly by put_threadsafe's call_soon_threadsafe — no
+            # executor hop, no poll-interval latency (see
+            # ThreadSafeAsyncQueue's docstring).
             while True:
                 try:
-                    delta = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
-                except _q.Empty:
+                    delta = await asyncio.wait_for(stream_q.get(), timeout=0.5)
+                except asyncio.TimeoutError:
                     if agent_task.done():
                         # Drain any remaining items
                         while True:
@@ -2644,7 +2671,7 @@ class APIServerAdapter(BasePlatformAdapter):
                                 if delta is None:
                                     break
                                 last_activity = await _emit(delta)
-                            except _q.Empty:
+                            except asyncio.QueueEmpty:
                                 break
                         break
                     if time.monotonic() - last_activity >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS:
@@ -2803,8 +2830,6 @@ class APIServerAdapter(BasePlatformAdapter):
         ``previous_response_id`` chaining still have something to
         recover from.
         """
-        import queue as _q
-
         sse_headers = {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
@@ -3124,11 +3149,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         _batch_buf = []
                         await _emit_text_delta(combined)
 
-            loop = asyncio.get_running_loop()
             while True:
                 try:
-                    item = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
-                except _q.Empty:
+                    item = await asyncio.wait_for(stream_q.get(), timeout=0.5)
+                except asyncio.TimeoutError:
                     if agent_task.done():
                         # Drain remaining
                         while True:
@@ -3138,7 +3162,7 @@ class APIServerAdapter(BasePlatformAdapter):
                                     break
                                 await _dispatch(item)
                                 last_activity = time.monotonic()
-                            except _q.Empty:
+                            except asyncio.QueueEmpty:
                                 break
                         break
                     if time.monotonic() - last_activity >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS:
@@ -3474,15 +3498,16 @@ class APIServerAdapter(BasePlatformAdapter):
             # Streaming branch — emit OpenAI Responses SSE events as the
             # agent runs so frontends can render text deltas and tool
             # calls in real time.  See _write_sse_responses for details.
-            import queue as _q
-            _stream_q: _q.Queue = _q.Queue()
+            _stream_q = ThreadSafeAsyncQueue()
 
             def _on_delta(delta):
                 # None from the agent is a CLI box-close signal, not EOS.
                 # Forwarding would kill the SSE stream prematurely; the
                 # SSE writer detects completion via agent_task.done().
+                # Called from the worker thread running run_conversation —
+                # put_threadsafe (not put_nowait) is required here.
                 if delta is not None:
-                    _stream_q.put(delta)
+                    _stream_q.put_threadsafe(delta)
 
             def _on_tool_progress(event_type, name, preview, args, **kwargs):
                 """Queue non-start tool progress events if needed in future.
@@ -3495,7 +3520,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
             def _on_tool_start(tool_call_id, function_name, function_args):
                 """Queue a started tool for live function_call streaming."""
-                _stream_q.put(("__tool_started__", {
+                _stream_q.put_threadsafe(("__tool_started__", {
                     "tool_call_id": tool_call_id,
                     "name": function_name,
                     "arguments": function_args or {},
@@ -3503,7 +3528,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
             def _on_tool_complete(tool_call_id, function_name, function_args, function_result):
                 """Queue a completed tool result for live function_call_output streaming."""
-                _stream_q.put(("__tool_completed__", {
+                _stream_q.put_threadsafe(("__tool_completed__", {
                     "tool_call_id": tool_call_id,
                     "name": function_name,
                     "arguments": function_args or {},
@@ -3526,7 +3551,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
-            agent_task.add_done_callback(lambda _fut: _stream_q.put(None))
+            agent_task.add_done_callback(lambda _fut: _stream_q.put_nowait(None))
 
             response_id = f"resp_{uuid.uuid4().hex[:28]}"
             model_name = body.get("model", self._model_name)

--- a/tests/gateway/test_sse_agent_cancel.py
+++ b/tests/gateway/test_sse_agent_cancel.py
@@ -7,7 +7,6 @@ task wrapper is cancelled.
 """
 
 import asyncio
-import queue
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -45,9 +44,6 @@ class TestSSEAgentCancelOnDisconnect:
         the agent task must be cancelled."""
         adapter = _make_adapter()
 
-        stream_q = queue.Queue()
-        stream_q.put("hello ")  # Some data already queued
-
         # Agent task that runs forever (simulates a long LLM call)
         agent_done = asyncio.Event()
 
@@ -57,6 +53,12 @@ class TestSSEAgentCancelOnDisconnect:
 
         async def run():
             from aiohttp import web
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            # Constructed inside the running loop — ThreadSafeAsyncQueue
+            # captures asyncio.get_running_loop() at construction time.
+            stream_q = ThreadSafeAsyncQueue()
+            stream_q.put_nowait("hello ")  # Some data already queued
 
             agent_task = asyncio.ensure_future(fake_agent())
 
@@ -94,15 +96,16 @@ class TestSSEAgentCancelOnDisconnect:
         """On normal stream completion, agent task should NOT be cancelled."""
         adapter = _make_adapter()
 
-        stream_q = queue.Queue()
-        stream_q.put("hello")
-        stream_q.put(None)  # End-of-stream sentinel
-
         async def fake_agent():
             return {"final_response": "done"}, {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
 
         async def run():
             from aiohttp import web
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            stream_q = ThreadSafeAsyncQueue()
+            stream_q.put_nowait("hello")
+            stream_q.put_nowait(None)  # End-of-stream sentinel
 
             agent_task = asyncio.ensure_future(fake_agent())
             await asyncio.sleep(0)  # Let agent complete
@@ -128,14 +131,15 @@ class TestSSEAgentCancelOnDisconnect:
         """BrokenPipeError (another disconnect variant) also cancels the task."""
         adapter = _make_adapter()
 
-        stream_q = queue.Queue()
-
         async def fake_agent():
             await asyncio.sleep(999)  # Never completes
             return {}, {}
 
         async def run():
             from aiohttp import web
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            stream_q = ThreadSafeAsyncQueue()
 
             agent_task = asyncio.ensure_future(fake_agent())
 
@@ -158,14 +162,15 @@ class TestSSEAgentCancelOnDisconnect:
         """If agent already finished before disconnect, don't try to cancel."""
         adapter = _make_adapter()
 
-        stream_q = queue.Queue()
-        stream_q.put("data")
-
         async def fake_agent():
             return {"final_response": "done"}, {}
 
         async def run():
             from aiohttp import web
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            stream_q = ThreadSafeAsyncQueue()
+            stream_q.put_nowait("data")
 
             agent_task = asyncio.ensure_future(fake_agent())
             await asyncio.sleep(0)  # Let agent complete
@@ -200,9 +205,6 @@ class TestSSEAgentCancelOnDisconnect:
         so the agent thread stops making LLM API calls."""
         adapter = _make_adapter()
 
-        stream_q = queue.Queue()
-        stream_q.put("hello ")
-
         agent_done = asyncio.Event()
 
         async def fake_agent():
@@ -215,6 +217,10 @@ class TestSSEAgentCancelOnDisconnect:
 
         async def run():
             from aiohttp import web
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            stream_q = ThreadSafeAsyncQueue()
+            stream_q.put_nowait("hello ")
 
             agent_task = asyncio.ensure_future(fake_agent())
             agent_ref = [mock_agent]
@@ -250,14 +256,15 @@ class TestSSEAgentCancelOnDisconnect:
         on disconnect — just without the interrupt() call."""
         adapter = _make_adapter()
 
-        stream_q = queue.Queue()
-
         async def fake_agent():
             await asyncio.sleep(999)
             return {}, {}
 
         async def run():
             from aiohttp import web
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            stream_q = ThreadSafeAsyncQueue()
 
             agent_task = asyncio.ensure_future(fake_agent())
 
@@ -318,12 +325,15 @@ class TestSSEAgentFailureFinishReason:
 
     def _run(self, fake_agent, queue_items=("partial",)):
         adapter = _make_adapter()
-        stream_q = queue.Queue()
-        for item in queue_items:
-            stream_q.put(item)
-        stream_q.put(None)  # clean end-of-stream sentinel
 
         async def run():
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            stream_q = ThreadSafeAsyncQueue()
+            for item in queue_items:
+                stream_q.put_nowait(item)
+            stream_q.put_nowait(None)  # clean end-of-stream sentinel
+
             agent_task = asyncio.ensure_future(fake_agent())
             resp, chunks = _capturing_response()
             with patch("gateway.platforms.api_server.web.StreamResponse",

--- a/tests/gateway/test_sse_agent_cancel.py
+++ b/tests/gateway/test_sse_agent_cancel.py
@@ -7,6 +7,7 @@ task wrapper is cancelled.
 """
 
 import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -391,3 +392,93 @@ class TestSSEAgentFailureFinishReason:
         # No error/hermes pollution on the happy path.
         assert "error" not in finish
         assert "hermes" not in finish
+
+
+class TestThreadSafeAsyncQueueCrossThreadBoundary:
+    """gateway/platforms/api_server.py — ThreadSafeAsyncQueue.put_threadsafe()
+
+    ``put_threadsafe`` exists specifically to let a *non-loop* worker thread
+    (the ``run_conversation`` thread driven by ``loop.run_in_executor``) push
+    deltas into the SSE queue. The converted ``_write_sse_*`` fixtures only use
+    same-loop ``put_nowait``, so they never exercise this cross-thread path.
+    These tests cover it directly: a real thread calls ``put_threadsafe`` while
+    the owning loop awaits ``get()`` — the exact boundary the production SSE
+    writers rely on.
+    """
+
+    def test_put_threadsafe_from_real_worker_thread_reaches_consumer(self):
+        """A real thread pushing via put_threadsafe is observed on the loop."""
+        received = []
+
+        async def run():
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            q = ThreadSafeAsyncQueue()
+            loop = asyncio.get_running_loop()
+
+            def worker():
+                # Runs OFF the event loop — this is the cross-thread boundary.
+                q.put_threadsafe("delta-from-thread")
+
+            t = threading.Thread(target=worker, daemon=True)
+            t.start()
+            # Owning loop awaits get(); woken by call_soon_threadsafe, no poll.
+            item = await asyncio.wait_for(q.get(), timeout=5.0)
+            received.append(item)
+            t.join(timeout=5.0)
+
+        asyncio.run(run())
+        assert received == ["delta-from-thread"]
+
+    def test_put_threadsafe_preserves_order_across_many_threads(self):
+        """Ordering holds when several worker threads push concurrently."""
+        import threading
+
+        collected = []
+
+        async def run():
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            q = ThreadSafeAsyncQueue()
+
+            def worker(value):
+                q.put_threadsafe(value)
+
+            threads = [
+                threading.Thread(target=worker, args=(i,), daemon=True)
+                for i in range(20)
+            ]
+            for t in threads:
+                t.start()
+            seen = []
+            for _ in range(20):
+                seen.append(await asyncio.wait_for(q.get(), timeout=5.0))
+            for t in threads:
+                t.join(timeout=5.0)
+            collected.append(seen)
+
+        asyncio.run(run())
+        # All 20 distinct values arrive; asyncio.Queue is FIFO per-producer and
+        # call_soon_threadsafe is itself serialized, so no item is lost.
+        assert sorted(collected[0]) == list(range(20))
+        assert len(collected[0]) == 20
+
+    def test_put_threadsafe_matches_put_nowait_bytes_on_loop(self):
+        """put_threadsafe reproduces put_nowait's observable effect (same loop).
+
+        Sanity guard: when called from the loop thread, the item is enqueued
+        exactly once (no double-enqueue from call_soon_threadsafe + put_nowait).
+        """
+        async def run():
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            q = ThreadSafeAsyncQueue()
+            q.put_threadsafe("x")
+            # call_soon_threadsafe schedules on the same loop; let it run.
+            await asyncio.sleep(0)
+            out = q.get_nowait()
+            assert out == "x"
+            # Queue must now be empty — exactly one enqueue happened.
+            assert q.empty()
+
+        asyncio.run(run())


### PR DESCRIPTION
## What

`_write_sse_chat_completion` and `_write_sse_responses` (`gateway/platforms/api_server.py`) both bridged `stream_delta_callback`'s queue into the event loop with:

```python
delta = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
```

in a `while True` poll. That's a thread-pool round trip on every 0.5s tick even when the stream is idle, plus up to 500ms of tail latency between a delta actually landing in the queue and it reaching the SSE response.

## Fix

Adds `ThreadSafeAsyncQueue` (a small `asyncio.Queue` subclass with a `put_threadsafe()` that wraps `loop.call_soon_threadsafe(self.put_nowait, item)`), used by the streaming producer closures (`_on_delta`, the tool start/complete callbacks) — all of which are invoked from the worker thread that runs `run_conversation` via `loop.run_in_executor`.

Consumers now do a plain:

```python
delta = await asyncio.wait_for(stream_q.get(), timeout=0.5)
```

— woken immediately when a delta arrives via `call_soon_threadsafe`, no executor hop per poll tick, no artificial latency floor. The keepalive/`agent_task.done()` drain logic is unchanged, just re-expressed against `asyncio.TimeoutError`/`asyncio.QueueEmpty` instead of `queue.Empty`.

## Testing

- `tests/gateway/test_sse_agent_cancel.py`'s 7 call sites updated to construct `ThreadSafeAsyncQueue` inside the running loop (it captures `asyncio.get_running_loop()` at construction). All 10 tests pass unchanged.
- **New (addresses review): `TestThreadSafeAsyncQueueCrossThreadBoundary`** — the converted fixtures only used same-loop `put_nowait`, so `put_threadsafe`'s actual contract was untested. Added:
  - a **real daemon worker thread** calls `put_threadsafe()` while the owning loop awaits `get()` (the exact production boundary `run_conversation` uses via `loop.run_in_executor`);
  - 20 concurrent worker threads push distinct values — all 20 arrive, none lost (`call_soon_threadsafe` is serialized, `asyncio.Queue` is FIFO);
  - `put_threadsafe` enqueues exactly once on the loop thread (no double-enqueue from `call_soon_threadsafe` + `put_nowait`).
- Ran the broader `tests/gateway/` suite before and after: identical failure count vs plain `main` on the pre-existing, unrelated failures.

## Why

We deployed Hermes standalone as a research-chat backend for a small nonprofit lab and noticed the poll-driven latency on the SSE path while looking at ways to make the free/self-hosted path smoother — this is a drop-in, backward-compatible internal change (no public API surface touched), scoped narrowly to the two SSE writer methods.