### PR TITLE
feat(cli): clarify token accounting in hermes insights

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -931,7 +931,9 @@ class InsightsEngine:
         lines.append(f"  Sessions:          {o['total_sessions']:<12}  Messages:        {o['total_messages']:,}")
         lines.append(f"  Tool calls:        {o['total_tool_calls']:<12,}  User messages:   {o['user_messages']:,}")
         lines.append(f"  Input tokens:      {o['total_input_tokens']:<12,}  Output tokens:   {o['total_output_tokens']:,}")
-        lines.append(f"  Total tokens:      {o['total_tokens']:,}")
+        lines.append(
+            f"  Processed tokens:  {o['total_tokens']:,} (includes cache reads/writes)"
+        )
         if o["total_hours"] > 0:
             lines.append(f"  Active time:       ~{format_duration_compact(o['total_hours'] * 3600):<11}  Avg session:     ~{format_duration_compact(o['avg_session_duration'])}")
         lines.append(f"  Avg msgs/session:  {o['avg_messages_per_session']:.1f}")
@@ -1046,7 +1048,11 @@ class InsightsEngine:
 
         # Overview
         lines.append(f"**Sessions:** {o['total_sessions']} | **Messages:** {o['total_messages']:,} | **Tool calls:** {o['total_tool_calls']:,}")
-        lines.append(f"**Tokens:** {o['total_tokens']:,} (in: {o['total_input_tokens']:,} / out: {o['total_output_tokens']:,})")
+        lines.append(
+            f"**Processed tokens:** {o['total_tokens']:,} "
+            f"(includes cache reads/writes; in: {o['total_input_tokens']:,} / "
+            f"out: {o['total_output_tokens']:,})"
+        )
         if o["total_hours"] > 0:
             lines.append(f"**Active time:** ~{format_duration_compact(o['total_hours'] * 3600)} | **Avg session:** ~{format_duration_compact(o['avg_session_duration'])}")
         lines.append("")

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -1006,7 +1006,9 @@ class InsightsEngine:
         lines.append(f"  Sessions:          {o['total_sessions']:<12}  Messages:        {o['total_messages']:,}")
         lines.append(f"  Tool calls:        {o['total_tool_calls']:<12,}  User messages:   {o['user_messages']:,}")
         lines.append(f"  Input tokens:      {o['total_input_tokens']:<12,}  Output tokens:   {o['total_output_tokens']:,}")
-        lines.append(f"  Total tokens:      {o['total_tokens']:,}")
+        lines.append(
+            f"  Processed tokens:  {o['total_tokens']:,} (includes cache reads/writes)"
+        )
         if o["total_hours"] > 0:
             lines.append(f"  Active time:       ~{format_duration_compact(o['total_hours'] * 3600):<11}  Avg session:     ~{format_duration_compact(o['avg_session_duration'])}")
         lines.append(f"  Avg msgs/session:  {o['avg_messages_per_session']:.1f}")
@@ -1144,7 +1146,11 @@ class InsightsEngine:
 
         # Overview
         lines.append(f"**Sessions:** {o['total_sessions']} | **Messages:** {o['total_messages']:,} | **Tool calls:** {o['total_tool_calls']:,}")
-        lines.append(f"**Tokens:** {o['total_tokens']:,} (in: {o['total_input_tokens']:,} / out: {o['total_output_tokens']:,})")
+        lines.append(
+            f"**Processed tokens:** {o['total_tokens']:,} "
+            f"(includes cache reads/writes; in: {o['total_input_tokens']:,} / "
+            f"out: {o['total_output_tokens']:,})"
+        )
         if o["total_hours"] > 0:
             lines.append(f"**Active time:** ~{format_duration_compact(o['total_hours'] * 3600)} | **Avg session:** ~{format_duration_compact(o['avg_session_duration'])}")
         lines.append("")

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -388,7 +388,23 @@ class TestTerminalFormatting:
         assert "Notable Sessions" in text
 
 
+    def test_terminal_processed_tokens_explain_cache_accounting(self, db):
+        db.create_session(session_id="s1", source="cli", model="gpt-4o")
+        db.update_token_counts(
+            "s1",
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=200,
+            cache_write_tokens=25,
+        )
+        db._conn.commit()
 
+        report = InsightsEngine(db).generate(days=30)
+        text = InsightsEngine(db).format_terminal(report)
+
+        assert report["overview"]["total_tokens"] == 375
+        assert "Processed tokens:  375 (includes cache reads/writes)" in text
+        assert "Total tokens" not in text
 
     def test_terminal_format_hides_cost_for_custom_models(self, db):
         """Cost display is hidden entirely — custom models no longer show 'N/A' either."""
@@ -416,13 +432,33 @@ class TestGatewayFormatting:
 
 
     def test_gateway_format_hides_cost(self, populated_db):
-        """Gateway format omits dollar figures and internal cache details."""
+        """Gateway format omits dollar figures and exact cache breakdowns."""
         engine = InsightsEngine(populated_db)
         report = engine.generate(days=30)
         text = engine.format_gateway(report)
 
         assert "$" not in text
-        assert "cache" not in text.lower()
+        assert "cache read:" not in text.lower()
+        assert "cache write:" not in text.lower()
+
+    def test_gateway_processed_tokens_explain_cache_accounting(self, db):
+        db.create_session(session_id="s1", source="cli", model="gpt-4o")
+        db.update_token_counts(
+            "s1",
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=200,
+            cache_write_tokens=25,
+        )
+        db._conn.commit()
+
+        report = InsightsEngine(db).generate(days=30)
+        text = InsightsEngine(db).format_gateway(report)
+
+        assert (
+            "**Processed tokens:** 375 "
+            "(includes cache reads/writes; in: 100 / out: 50)"
+        ) in text
 
 
 

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -543,7 +543,23 @@ class TestTerminalFormatting:
         assert "Notable Sessions" in text
 
 
+    def test_terminal_processed_tokens_explain_cache_accounting(self, db):
+        db.create_session(session_id="s1", source="cli", model="gpt-4o")
+        db.update_token_counts(
+            "s1",
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=200,
+            cache_write_tokens=25,
+        )
+        db._conn.commit()
 
+        report = InsightsEngine(db).generate(days=30)
+        text = InsightsEngine(db).format_terminal(report)
+
+        assert report["overview"]["total_tokens"] == 375
+        assert "Processed tokens:  375 (includes cache reads/writes)" in text
+        assert "Total tokens" not in text
 
     def test_terminal_format_unknown_bucket_for_custom_models(self, db):
         """Custom models with no pricing surface as the Unknown bucket (#77223)."""
@@ -575,17 +591,38 @@ class TestGatewayFormatting:
 
 
     def test_gateway_format_hides_cache_details(self, populated_db):
-        """Gateway format omits internal cache details.
+        """Gateway format omits the exact internal cache breakdown.
 
         Dollar figures now appear when there are estimated/included/unknown
         cost buckets (#77223) — the old assertion that '$' is absent is no
-        longer correct because surfacing cost buckets is the fix.
+        longer correct because surfacing cost buckets is the fix. A brief
+        explanation that processed tokens include cache activity is allowed.
         """
         engine = InsightsEngine(populated_db)
         report = engine.generate(days=30)
         text = engine.format_gateway(report)
 
-        assert "cache" not in text.lower()
+        assert "cache read:" not in text.lower()
+        assert "cache write:" not in text.lower()
+
+    def test_gateway_processed_tokens_explain_cache_accounting(self, db):
+        db.create_session(session_id="s1", source="cli", model="gpt-4o")
+        db.update_token_counts(
+            "s1",
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=200,
+            cache_write_tokens=25,
+        )
+        db._conn.commit()
+
+        report = InsightsEngine(db).generate(days=30)
+        text = InsightsEngine(db).format_gateway(report)
+
+        assert (
+            "**Processed tokens:** 375 "
+            "(includes cache reads/writes; in: 100 / out: 50)"
+        ) in text
 
 
 
@@ -772,5 +809,3 @@ class TestEdgeCases:
         # The session has no cost data, so it falls in the "unknown" bucket.
         assert "💰 Cost" in text
         assert "Unknown" in text
-
-


### PR DESCRIPTION
## What does this PR do?

Clarifies what `hermes insights` counts in its aggregate token figure. The terminal and gateway summaries now label the value as **Processed tokens** and state that it includes cache reads and writes.

The accounting is unchanged: `total_tokens` remains input + output + cache read + cache write. This deliberately does not restore the exact cache/cost breakdown that was previously hidden because those metrics were not reliable enough for display.

## Related Issue

Fixes #64978

## Type of Change

- [x] ✨ CLI improvement
- [x] ✅ Tests

## Changes Made

- `agent/insights.py`: rename the ambiguous terminal `Total tokens` and gateway `Tokens` labels to `Processed tokens`, with an explicit cache-inclusion note.
- `tests/agent/test_insights.py`: prove that 100 input + 50 output + 200 cache-read + 25 cache-write tokens render as 375 processed tokens in both output surfaces.
- Preserve current main's pruned formatting tests and the intentional absence of exact cache/cost breakdowns.

## How to Test

1. Record a session containing input, output, cache-read, and cache-write token counts.
2. Run `hermes insights --days 30`.
3. Confirm the overview reports `Processed tokens: ... (includes cache reads/writes)` and that the number contains all four buckets.

## Checklist

- [x] Read the contributing guide.
- [x] Conventional commit.
- [x] Searched open and closed competing PRs.
- [x] Focused output clarification only.
- [ ] Complete repository suite not run; all affected Insights/CLI/gateway tests passed.
- [x] Added behavior-focused terminal and gateway regressions.
- [x] Tested on macOS; change is platform-independent formatting.

## Validation

Validated after rebasing onto current `main` `98105f31f`; head `c1fb25368`:

- `tests/agent/test_insights.py`: **29 passed**.
- Insights, CLI command, and TUI gateway files: **527 passed across 3 files**.
- Ruff: passed.
- Windows footgun check: passed.
- `git diff --check`: clean.
- Current main renders `Total tokens: 375` and `**Tokens:** 375`; the rebased branch renders the explicitly qualified processed-token labels.

## Screenshots / Logs

```text
Input tokens:      100           Output tokens:   50
Processed tokens:  375 (includes cache reads/writes)
```
