### PR TITLE
fix(launchd): add ThrottleInterval=30 to gateway plist

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3962,6 +3962,9 @@ def generate_launchd_plist() -> str:
     <key>KeepAlive</key>
     <true/>
     
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
     

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -3569,6 +3569,9 @@ class TestServiceWorkingDirIsStable:
         # The old conditional dict form must NOT appear
         assert "SuccessfulExit" not in plist
         assert "<key>KeepAlive</key>\n    <dict>" not in plist
+        # ThrottleInterval prevents a tight crash/restart loop when Telegram
+        # is unreachable (#64839)
+        assert "<key>ThrottleInterval</key>\n    <integer>30</integer>" in plist
 
 
 class TestLaunchctlBootstrapEioRetry:


### PR DESCRIPTION
## Why

KeepAlive without ThrottleInterval means launchd respawns a crashing gateway instantly — creating a tight crash/restart loop. With a 30s interval, transient network failures or boot-time startup issues get a chance to resolve before launchd tries again, providing independent launchd-supervision backoff hardening regardless of the Telegram adapter's transient error recovery.

## Changes

- `hermes_cli/gateway.py:generate_launchd_plist()` — add `<key>ThrottleInterval</key><integer>30</integer>` after KeepAlive
- `tests/hermes_cli/test_gateway_service.py` — regression assertion that ThrottleInterval is present in the generated plist

## Surface area

- `hermes_cli/gateway.py`: one addition to the plist template
- `tests/hermes_cli/test_gateway_service.py`: one new assertion

## Testing

- All 188 tests in `test_gateway_service.py` pass
- Generated plist verified to contain the ThrottleInterval entry
