### PR TITLE
fix(dashboard-auth): BasicAuthProvider 500 on /auth/login and auto-SSO redirect

### DIFF
--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -179,12 +179,16 @@ def _auto_sso_response(request: Request) -> Response | None:
     # token-only credentials (drain/service providers) are never candidates.
     providers = list_session_providers()
     if len(providers) != 1:
-        # Zero → nothing to redirect to. Two+ → user must choose at /login.
+        # Zero -> nothing to redirect to. Two+ -> user must choose at /login.
         return None
 
-    from hermes_cli.dashboard_auth.prefix import prefix_from_request
-
     provider = providers[0]
+    # Password-only providers (supports_password=True) don't have an OAuth
+    # redirect flow - their start_login raises NotImplementedError. Skip
+    # auto-SSO and fall through to /login which renders the password form.
+    if getattr(provider, "supports_password", False):
+        return None
+    from hermes_cli.dashboard_auth.prefix import prefix_from_request
     prefix = prefix_from_request(request)
     next_param = _safe_next_target(request)
     from urllib.parse import quote

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -193,6 +193,15 @@ async def auth_login(request: Request, provider: str, next: str = ""):
             detail=f"Provider does not support interactive login: {provider!r}",
         )
 
+    # Password-only providers don't have an OAuth redirect flow; redirect
+    # to /login which renders the username/password form.
+    if getattr(p, "supports_password", False):
+        from urllib.parse import quote
+        login_url = "/login"
+        if next:
+            login_url += f"?next={quote(next, safe='')}"
+        return RedirectResponse(url=login_url, status_code=302)
+
     try:
         ls = p.start_login(redirect_uri=_redirect_uri(request))
     except ProviderError as e:


### PR DESCRIPTION
## Problem

Two bugs prevent BasicAuthProvider (username/password dashboard auth) from working on a non-loopback bind (`0.0.0.0`):

### Bug 1: Auto-SSO redirect crashes on password providers
`_auto_sso_response` in `middleware.py` checks if there's exactly one session provider, and if so, auto-redirects to `/auth/login?provider=N`. But `BasicAuthProvider.start_login()` raises `NotImplementedError` because it's a password-only provider with no OAuth redirect flow. Result: **HTTP 500 on first page load**.

### Bug 2: /auth/login endpoint crashes on password providers
The `/auth/login?provider=basic` route calls `p.start_login()` unconditionally. For password-only providers this also raises `NotImplementedError` → 500.

## Fix

Both fixes add a `supports_password` check before the OAuth-specific code path:

1. **middleware.py**: Skip auto-SSO redirect for password providers, fall through to `/login` which renders the password form.
2. **routes.py**: Redirect password providers to `/login` instead of calling `start_login()`.

OAuth providers are completely unaffected — the checks only gate on `supports_password=True`.

## Verification

- All 85 existing dashboard-auth tests pass
- Manual testing with BasicAuthProvider on `0.0.0.0` bind confirms:
  - `/` → redirect to `/login` → 200 (was 500)
  - `/auth/login?provider=basic` → redirect to `/login` → 200 (was 500)
  - `POST /auth/password-login` → 200 with session cookies set