### PR TITLE
fix(discord): declare online presence on connect

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1368,6 +1368,10 @@ class DiscordAdapter(BasePlatformAdapter):
             self._client = commands.Bot(
                 command_prefix="!",  # Not really used, we handle raw messages
                 intents=intents,
+                # Include an explicit presence in Discord's IDENTIFY payload.
+                # Without this, discord.py omits the presence object entirely,
+                # which can leave a connected, responsive bot shown as offline.
+                status=discord.Status.online,
                 allowed_mentions=_build_allowed_mentions(),
                 **proxy_kwargs_for_bot(proxy_url),
             )

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1222,6 +1222,10 @@ class DiscordAdapter(BasePlatformAdapter):
             self._client = commands.Bot(
                 command_prefix="!",  # Not really used, we handle raw messages
                 intents=intents,
+                # Include an explicit presence in Discord's IDENTIFY payload.
+                # Without this, discord.py omits the presence object entirely,
+                # which can leave a connected, responsive bot shown as offline.
+                status=discord.Status.online,
                 allowed_mentions=_build_allowed_mentions(),
                 **proxy_kwargs_for_bot(proxy_url),
             )

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -141,6 +141,44 @@ class SlowSyncBot(FakeBot):
 
 
 @pytest.mark.asyncio
+async def test_connect_declares_online_presence(monkeypatch):
+    """Discord IDENTIFY must explicitly declare Hermes as online (#64932)."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(
+        message_content=False,
+        dm_messages=False,
+        guild_messages=False,
+        members=False,
+        voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    created = {}
+
+    def fake_bot_factory(
+        *, command_prefix, intents, status, proxy=None, allowed_mentions=None, **_
+    ):
+        created["status"] = status
+        created["bot"] = FakeBot(intents=intents, allowed_mentions=allowed_mentions)
+        return created["bot"]
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    assert await adapter.connect() is True
+    assert created["status"] is discord_platform.discord.Status.online
+
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "initial_allowed",
     [


### PR DESCRIPTION
## What does this PR do?

Makes the Discord bot declare an explicit online presence when its gateway client is created.

Hermes currently omits the `status` option from `commands.Bot(...)`. With the pinned discord.py 2.7.1, that leaves the initial Gateway IDENTIFY payload without an explicit presence. Passing `discord.Status.online` at construction time lets discord.py include the presence on every fresh Identify without adding a fallible network call to Hermes' `on_ready()` handler.

## Related Issue

Fixes #64932

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/discord/adapter.py`: pass `status=discord.Status.online` when constructing the Discord bot.
- `tests/gateway/test_discord_connect.py`: capture the constructor argument and prove each connection explicitly declares online status.
- Preserve current `main`'s reconnect cleanup, ready handling, post-connect initialization, liveness, and missed-message backfill behavior.

## How to Test

1. Start Hermes with the Discord platform enabled.
2. Wait for the gateway to report Discord as connected.
3. Confirm the bot appears online in the Discord client and still responds normally.

Automated validation after rebasing onto `main` `9460cc11d` (head `bbea7cc24`):

- RED proof: on the rebased tree with the production `status` argument removed, `test_connect_declares_online_presence` failed because the Bot constructor received no `status`.
- GREEN regression: **1 passed**.
- `tests/gateway/test_discord_connect.py`: **14 passed** as part of the affected suite.
- Complete Discord-related surface: **333 passed across 49 files**.
- Ruff: passed.
- Windows footgun check: passed.
- `git diff --check`: clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Python 3.11.15. No live Discord account or Docker deployment was tested locally.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — SDK enum only; Windows footgun scan passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshot is applicable because this changes the Discord Gateway IDENTIFY payload rather than a Hermes UI.

```text
Focused regression: 1 passed
Discord connect file: 14 passed
Complete Discord-related surface: 333 passed across 49 files
Ruff: All checks passed
Windows footgun scan: No issues found
git diff --check: passed
```

The issue reporter confirmed the connected-but-grey behavior on a Docker deployment and remains available to validate the resulting image after merge.