### PR TITLE
fix(vision): resolve a relative media path against the task cwd

### DIFF
--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -84,6 +84,25 @@ class TestLocalBackend:
         assert res.data == PNG
         assert res.origin == "file"
 
+    @pytest.mark.asyncio
+    async def test_relative_path_uses_terminal_cwd_not_process_cwd(self, tmp_path, monkeypatch):
+        """Vision sees the same relative path as file and terminal tools."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        workspace = tmp_path / "workspace"
+        image = workspace / "attachments" / "pic.png"
+        image.parent.mkdir(parents=True)
+        image.write_bytes(PNG)
+        process_cwd = tmp_path / "process"
+        process_cwd.mkdir()
+        monkeypatch.chdir(process_cwd)
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+        res = await isrc.resolve_image_source(
+            "attachments/pic.png", isrc.ResolveContext())
+
+        assert res.data == PNG
+        assert res.origin == "file"
 
     @pytest.mark.asyncio
     async def test_svg_passes_through_for_rasterization(self, tmp_path, monkeypatch):

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -102,6 +102,64 @@ class TestLocalBackend:
 
 
     @pytest.mark.asyncio
+    async def test_relative_path_anchors_on_task_cwd_not_process_cwd(self, tmp_path, monkeypatch):
+        """A relative path resolves against the TASK's terminal cwd, like the file
+        tools — not the agent process cwd. A model that wrote 'out.png' into its
+        workspace must be able to vision_analyze('out.png') from a process whose
+        own cwd is somewhere else entirely."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "out.png").write_bytes(PNG)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+        res = await isrc.resolve_image_source("out.png", isrc.ResolveContext())
+        assert res.data == PNG
+        assert res.origin == "file"
+
+
+    @pytest.mark.asyncio
+    async def test_relative_path_anchors_on_task_cwd_for_a_non_default_task(self, tmp_path, monkeypatch):
+        """The anchor is the TASK's cwd, so a real session id (not the "default"
+        fallback) resolves the same way — the task id is threaded through, not dropped."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "out.png").write_bytes(PNG)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+        res = await isrc.resolve_image_source(
+            "out.png", isrc.ResolveContext(task_id="session-42"))
+        assert res.data == PNG
+        assert res.origin == "file"
+
+
+    @pytest.mark.asyncio
+    async def test_tilde_expands_through_the_effective_profile_home(self, tmp_path, monkeypatch):
+        """INTENTIONAL behaviour change: "~" now expands like the file tools do,
+        through get_subprocess_home(). Under TERMINAL_HOME_MODE=profile that is the
+        profile home ({HERMES_HOME}/home), not the process HOME — so vision and
+        write_file agree on what "~/pic.png" means in a gateway/cron run (#48552)."""
+        home = tmp_path / "hermes"
+        profile_home = home / "home"
+        profile_home.mkdir(parents=True)
+        isrc = _reload(monkeypatch, home)
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_HOME_MODE", "profile")
+        process_home = tmp_path / "process_home"
+        process_home.mkdir()
+        monkeypatch.setenv("HOME", str(process_home))
+        (profile_home / "pic.png").write_bytes(PNG)
+        res = await isrc.resolve_image_source("~/pic.png", isrc.ResolveContext())
+        assert res.data == PNG
+        assert res.origin == "file"
+
+
+    @pytest.mark.asyncio
     async def test_svg_passes_through_for_rasterization(self, tmp_path, monkeypatch):
         """SVG has no raster magic bytes but is passed through with mime
         image/svg+xml so the vision call sites can rasterize it to PNG."""
@@ -221,6 +279,56 @@ class TestNonLocalBackendConfinement:
         with patch("tools.image_source._get_active_env", return_value=None):
             with pytest.raises(isrc.SourceNotFound):
                 await isrc.resolve_image_source(str(link), isrc.ResolveContext(task_id="t1"))
+
+
+class TestRemotePathFidelity:
+    """Under a non-local backend the read happens on the OTHER machine, so the path
+    handed to the sandbox must stay lexical: host symlinks and host cwd are not the
+    remote's, and rewriting them silently reads a different file (or none)."""
+
+    @staticmethod
+    def _capture_exec_read(isrc, src, task_id="t1"):
+        captured = {}
+
+        def fake_execute(cmd, **kw):
+            captured["cmd"] = cmd
+            return {"returncode": 0, "output": base64.b64encode(PNG).decode()}
+
+        async def run():
+            with patch("tools.image_source._get_active_env",
+                       return_value=SimpleNamespace(execute=fake_execute)):
+                await isrc.resolve_image_source(src, isrc.ResolveContext(task_id=task_id))
+            return captured["cmd"]
+
+        return run()
+
+    @pytest.mark.asyncio
+    async def test_ssh_absolute_path_is_not_rewritten_by_a_host_symlink(self, tmp_path, monkeypatch):
+        """A host symlink (/var/run -> /run) must not rewrite a path destined for the
+        remote host, whose filesystem layout is its own."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        target = tmp_path / "run"
+        target.mkdir()
+        link = tmp_path / "var-run"
+        try:
+            link.symlink_to(target, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unsupported")
+        cmd = await self._capture_exec_read(isrc, f"{link}/a.png")
+        assert f"{link}/a.png" in cmd
+        assert f"{target}/a.png" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_ssh_relative_path_anchors_on_the_remote_cwd(self, tmp_path, monkeypatch):
+        """A relative path is anchored on the task's terminal cwd — a path on the
+        REMOTE machine, which need not exist on the host."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_CWD", "/srv/remote-workspace")
+        monkeypatch.chdir(tmp_path)
+        cmd = await self._capture_exec_read(isrc, "out.png")
+        assert "/srv/remote-workspace/out.png" in cmd
 
 
 class TestExecReadSafety:

--- a/tools/file_tools_paths.py
+++ b/tools/file_tools_paths.py
@@ -169,10 +169,17 @@ def _resolve_base_dir(
     return _anchor(_host_text(root or os.getcwd(), container_paths), os.getcwd, container_paths)
 
 
-def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | PurePosixPath:
+def _resolve_path_for_task(
+    filepath: str, task_id: str = "default", *, lexical: bool = False) -> Path | PurePosixPath:
     """Resolve *filepath* against the task's absolute base directory
-    (absolute inputs are returned resolved-but-unanchored)."""
-    container_paths = _uses_container_paths(task_id)
+    (absolute inputs are returned resolved-but-unanchored).
+
+    ``lexical=True`` forces pure-posix anchoring with no host symlink
+    dereferencing, for callers whose read happens on another machine (ssh): a
+    host ``/var/run -> /run`` link must not rewrite a path that only means
+    something remotely. Container backends already resolve this way.
+    """
+    container_paths = lexical or _uses_container_paths(task_id)
     return _anchor(_host_text(filepath, container_paths),
                    lambda: _resolve_base_dir(task_id, container_paths=container_paths), container_paths)
 

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -120,7 +120,9 @@ async def resolve_image_source(
     # Everything else is a filesystem path — including bare relative names
     # like "pic.png" (accepted on main; a path-shape gate here regressed them).
     candidate = s[len("file://"):] if s.lower().startswith("file://") else s
-    p = Path(os.path.expanduser(candidate))
+    from tools.file_tools import _resolve_path_for_task
+
+    p = Path(_resolve_path_for_task(candidate, ctx.task_id or "default"))
     # Confinement decision (see module docstring). Under a non-local backend
     # a path is host-readable ONLY if it lands in a media cache (after
     # translating a container-visible cache path back to its host mount);

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -71,7 +71,15 @@ async def resolve_image_source(
     # Everything else is a filesystem path — including bare relative names like "pic.png"
     # (a path-shape gate here regressed them once).
     candidate = s[len("file://"):] if s.lower().startswith("file://") else s
-    p = Path(os.path.expanduser(candidate))
+    # Anchor relative paths exactly like the file tools do: on the task's terminal
+    # cwd, not the agent process cwd. A model that just wrote "out.png" with
+    # write_file could not then vision_analyze("out.png") — the resolver looked in
+    # the process cwd (e.g. the launch dir of a worktree session) and missed it.
+    # Resolve the way we are about to read: only a host read may follow host
+    # symlinks; a sandbox/ssh read gets the path lexically, untouched by host links.
+    from tools.file_tools_paths import _resolve_path_for_task
+    p = Path(_resolve_path_for_task(
+        candidate, ctx.task_id or "default", lexical=not _is_local_terminal_backend()))
     host_target = _permitted_host_read_target(p, ctx)
     if host_target is not None and host_target.is_file():
         _guard_credential_read(host_target, s)


### PR DESCRIPTION
## What does this PR do?

`vision_analyze("out.png")` fails right after `write_file("out.png", ...)`. The file tools resolve relative paths against the task's terminal cwd through `_resolve_path_for_task()`; `resolve_image_source()` still used the process cwd, so the image is looked up in the launch directory and the tool answers `media file not found`. This routes vision through the same resolver.

One detail: under a non-local backend (docker, ssh) the bytes are read remotely, so the path must not go through the host's `.resolve()`. A host `/var/run -> /run` symlink would rewrite a path that only exists on the remote. `_resolve_path_for_task()` grows a `lexical=` flag that selects the pure-posix anchoring container backends already use. File-tool callers keep the default.

Intentional side effect: `~` now expands through the effective profile home like the file tools do, so under `TERMINAL_HOME_MODE=profile` vision and `write_file` agree on what `~/pic.png` means (#48552). Absolute paths keep their spelling on every backend, and confinement is unchanged: the result still goes through `_permitted_host_read_target()`.

Overlaps with open PR #89230 (ssh container paths). If that lands first, the `lexical=` flag is redundant for ssh and the `image_source.py` hunk needs a rebase. Happy to do it.

Update 2026-09-10: rebased on current main (the July version only swapped the resolver and had gone stale); this revision adds the `lexical=` flag for remote backends and the ssh tests. Authored with AI assistance, reviewed by a human.

## Related Issue

No issue filed. Focused follow-up to #57890, which covered relative paths only while the process cwd and the workspace matched. Adjacent: #41541 (skill dir resolving to host paths on remote backends) is the same class of bug.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/image_source.py`: resolve through `_resolve_path_for_task(candidate, task_id, lexical=not _is_local_terminal_backend())`.
- `tools/file_tools_paths.py`: `lexical: bool = False` on `_resolve_path_for_task()`, OR-ed into the existing container-paths decision. No change for existing callers.
- `tests/tools/test_image_source.py`: task-cwd anchoring, a non-default task id, `~` under profile home mode, and two ssh cases (absolute path not rewritten by a host symlink, relative path anchored on the remote cwd).

## How to Test

1. Point `terminal.cwd` at a directory other than the one the agent was launched from.
2. `write_file("out.png", ...)` then `vision_analyze("out.png")`. Before: `media file not found`. After: it resolves.
3. `pytest tests/tools/test_image_source.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass. Ran `tests/tools/test_image_source.py`, `test_resolve_path.py` and `test_vision_native_fast_path.py`; the only failures are pre-existing on `ecfcbb6` (missing Pillow, one cross-file pollution case that passes alone).
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (CachyOS), Python 3.11

### Documentation & Housekeeping

- [x] Documentation: docstrings updated; no docs pages affected
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform: `Path(PurePosixPath(...))` becomes `WindowsPath` exactly as today
- [x] Tool descriptions/schemas: N/A
