### PR TITLE
feat(usage): add machine-readable account snapshots

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -27,6 +27,7 @@ class AccountUsageWindow:
     label: str
     used_percent: Optional[float] = None
     reset_at: Optional[datetime] = None
+    window_minutes: Optional[int] = None
     detail: Optional[str] = None
 
 
@@ -44,6 +45,39 @@ class AccountUsageSnapshot:
     @property
     def available(self) -> bool:
         return bool(self.windows or self.details) and not self.unavailable_reason
+
+
+def account_usage_snapshot_dict(snapshot: AccountUsageSnapshot) -> dict[str, Any]:
+    """Serialize an account-limit observation without exposing credentials.
+
+    This is deliberately a snapshot of provider-reported subscription limits,
+    not Hermes's per-session token counters.  The stable camelCase shape is
+    suitable for local sidecars and other cache-only consumers.
+    """
+    return {
+        "schemaVersion": 1,
+        "provider": snapshot.provider,
+        "source": snapshot.source,
+        "fetchedAt": snapshot.fetched_at.isoformat().replace("+00:00", "Z"),
+        "title": snapshot.title,
+        "plan": snapshot.plan,
+        "windows": [
+            {
+                "label": window.label,
+                "usedPercent": window.used_percent,
+                "resetAt": (
+                    window.reset_at.isoformat().replace("+00:00", "Z")
+                    if window.reset_at is not None
+                    else None
+                ),
+                "windowMinutes": window.window_minutes,
+                "detail": window.detail,
+            }
+            for window in snapshot.windows
+        ],
+        "details": list(snapshot.details),
+        "unavailableReason": snapshot.unavailable_reason,
+    }
 
 
 def _title_case_slug(value: Optional[str]) -> Optional[str]:
@@ -525,16 +559,34 @@ def _fetch_codex_account_usage(
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
-    for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
+    for key, fallback_label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
         window = rate_limit.get(key) or {}
         used = window.get("used_percent")
         if used is None:
             continue
+        limit_seconds = window.get("limit_window_seconds")
+        window_minutes = (
+            int(float(limit_seconds) / 60)
+            if isinstance(limit_seconds, (int, float)) and float(limit_seconds) > 0
+            else None
+        )
+        if window_minutes == 300:
+            label = "Session"
+        elif window_minutes == 10_080:
+            label = "Weekly"
+        elif window_minutes is not None:
+            label = f"{window_minutes} minute window"
+        else:
+            # Older/self-hosted backends may omit duration. Preserve the legacy
+            # display fallback, but consumers can see windowMinutes=null and
+            # must not treat lane position as authoritative semantics.
+            label = fallback_label
         windows.append(
             AccountUsageWindow(
                 label=label,
                 used_percent=float(used),
                 reset_at=_parse_dt(window.get("reset_at")),
+                window_minutes=window_minutes,
             )
         )
     details: list[str] = []
@@ -776,6 +828,7 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
                 label=label,
                 used_percent=used,
                 reset_at=_parse_dt(window.get("resets_at")),
+                window_minutes=300 if key == "five_hour" else 10_080 if key.startswith("seven_day") else None,
             )
         )
     details: list[str] = []

--- a/hermes_cli/account_usage_command.py
+++ b/hermes_cli/account_usage_command.py
@@ -1,0 +1,68 @@
+"""Non-interactive account usage command used by local status consumers."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from agent.account_usage import (
+    account_usage_snapshot_dict,
+    fetch_account_usage,
+    render_account_usage_lines,
+)
+from hermes_cli.auth import AuthError, resolve_provider
+from hermes_cli.runtime_provider import resolve_requested_provider
+
+
+def _effective_provider(explicit: str | None) -> str:
+    requested = resolve_requested_provider(explicit)
+    try:
+        return resolve_provider(requested)
+    except AuthError:
+        return requested
+
+
+def _write_json_atomic(path: Path, payload: str) -> None:
+    path = path.expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        tmp.write_text(payload + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def account_usage_command(args) -> int:
+    provider = _effective_provider(getattr(args, "provider", None))
+    snapshot = fetch_account_usage(provider)
+    if snapshot is None:
+        message = {
+            "schemaVersion": 1,
+            "provider": provider,
+            "unavailableReason": "Account usage is unavailable for this provider or credential type.",
+        }
+        if getattr(args, "json", False) or getattr(args, "output", None):
+            rendered = json.dumps(message, separators=(",", ":"), sort_keys=True)
+            if getattr(args, "output", None):
+                _write_json_atomic(Path(args.output), rendered)
+            if getattr(args, "json", False):
+                print(rendered)
+        else:
+            print(message["unavailableReason"])
+        return 2
+
+    payload = account_usage_snapshot_dict(snapshot)
+    rendered = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    if getattr(args, "output", None):
+        _write_json_atomic(Path(args.output), rendered)
+    if getattr(args, "json", False):
+        print(rendered)
+    elif not getattr(args, "output", None):
+        for line in render_account_usage_lines(snapshot):
+            print(line)
+    return 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -293,6 +293,7 @@ from hermes_cli.subcommands.login import build_login_parser
 from hermes_cli.subcommands.logout import build_logout_parser
 from hermes_cli.subcommands.auth import build_auth_parser
 from hermes_cli.subcommands.status import build_status_parser
+from hermes_cli.subcommands.usage import build_usage_parser
 from hermes_cli.subcommands.webhook import build_webhook_parser
 from hermes_cli.subcommands.hooks import build_hooks_parser
 from hermes_cli.subcommands.doctor import build_doctor_parser
@@ -4258,6 +4259,13 @@ def cmd_status(args):
     from hermes_cli.status import show_status
 
     show_status(args)
+
+
+def cmd_usage(args):
+    """Show provider-reported account limits outside an interactive session."""
+    from hermes_cli.account_usage_command import account_usage_command
+
+    return account_usage_command(args)
 
 
 def cmd_cron(args):
@@ -12408,7 +12416,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "project", "proxy",
         "prompt-size",
         "send", "sessions", "setup",
-        "skills", "slack", "status", "tools", "uninstall", "update",
+        "skills", "slack", "status", "tools", "uninstall", "update", "usage",
         "version", "webhook", "whatsapp", "whatsapp-cloud", "chat", "secrets", "security",
         # Help-ish invocations — plugin commands not being listed in
         # top-level --help is an acceptable trade-off for skipping an
@@ -13164,6 +13172,7 @@ def main():
     # status command  (parser built in hermes_cli/subcommands/status.py)
     # =========================================================================
     build_status_parser(subparsers, cmd_status=cmd_status)
+    build_usage_parser(subparsers, cmd_usage=cmd_usage)
 
     # =========================================================================
     # cron command  (parser built in hermes_cli/subcommands/cron.py)

--- a/hermes_cli/subcommands/usage.py
+++ b/hermes_cli/subcommands/usage.py
@@ -1,0 +1,27 @@
+"""``hermes usage`` account-limit snapshot command."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_usage_parser(subparsers, *, cmd_usage: Callable) -> None:
+    parser = subparsers.add_parser(
+        "usage",
+        help="Show provider-reported account limits",
+        description="Fetch subscription/account limits for the active or selected provider",
+    )
+    parser.add_argument(
+        "--provider",
+        help="Provider to inspect (defaults to the active runtime provider)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print a stable machine-readable snapshot",
+    )
+    parser.add_argument(
+        "--output",
+        help="Atomically write the JSON snapshot to this local path",
+    )
+    parser.set_defaults(func=cmd_usage)

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -40,10 +40,12 @@ def codex_usage_payload():
             "primary_window": {
                 "used_percent": 21,
                 "reset_at": 1779846359,
+                "limit_window_seconds": 18000,
             },
             "secondary_window": {
                 "used_percent": 4,
                 "reset_at": 1780230796,
+                "limit_window_seconds": 604800,
             },
         },
         "credits": {"has_credits": False},
@@ -235,6 +237,61 @@ def test_codex_usage_treats_wham_used_percent_as_used_not_remaining(monkeypatch)
     assert "14% used" in rendered
     assert "15% used" not in rendered
     assert "86% used" not in rendered
+
+
+def test_codex_usage_classifies_weekly_primary_from_provider_duration(monkeypatch):
+    payload = {
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 17,
+                "reset_at": 1780230796,
+                "limit_window_seconds": 604800,
+            },
+        },
+    }
+    monkeypatch.setattr(account_usage.httpx, "Client", lambda timeout: _FakeClient([], payload))
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    assert [(window.label, window.window_minutes) for window in snapshot.windows] == [
+        ("Weekly", 10_080),
+    ]
+
+
+def test_account_usage_snapshot_dict_preserves_provider_observation():
+    snapshot = account_usage.AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=account_usage.datetime(2026, 7, 15, 10, 0, tzinfo=account_usage.timezone.utc),
+        plan="Pro",
+        windows=(
+            account_usage.AccountUsageWindow(
+                label="Weekly",
+                used_percent=17,
+                reset_at=account_usage.datetime(2026, 7, 20, 0, 0, tzinfo=account_usage.timezone.utc),
+            ),
+        ),
+    )
+
+    payload = account_usage.account_usage_snapshot_dict(snapshot)
+
+    assert payload["provider"] == "openai-codex"
+    assert payload["source"] == "usage_api"
+    assert payload["fetchedAt"] == "2026-07-15T10:00:00Z"
+    assert payload["windows"] == [
+        {
+            "label": "Weekly",
+            "usedPercent": 17,
+            "resetAt": "2026-07-20T00:00:00Z",
+            "windowMinutes": None,
+            "detail": None,
+        }
+    ]
 
 
 # ── Banked rate-limit reset credits (`/usage reset`) ─────────────────────────

--- a/tests/hermes_cli/test_account_usage_command.py
+++ b/tests/hermes_cli/test_account_usage_command.py
@@ -1,0 +1,36 @@
+from argparse import Namespace
+from datetime import datetime, timezone
+import json
+
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+from hermes_cli import account_usage_command as command
+
+
+def test_usage_command_writes_machine_readable_snapshot_atomically(tmp_path, monkeypatch):
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime(2026, 7, 15, 10, 0, tzinfo=timezone.utc),
+        windows=(AccountUsageWindow(label="Weekly", used_percent=17),),
+    )
+    monkeypatch.setattr(command, "_effective_provider", lambda _explicit: "openai-codex")
+    monkeypatch.setattr(command, "fetch_account_usage", lambda _provider: snapshot)
+    output = tmp_path / "nested" / "account-usage.json"
+
+    result = command.account_usage_command(
+        Namespace(provider=None, json=False, output=str(output))
+    )
+
+    assert result == 0
+    assert json.loads(output.read_text())["windows"][0]["usedPercent"] == 17
+    assert not list(output.parent.glob("*.tmp"))
+
+
+def test_usage_command_reports_unsupported_provider_as_json(monkeypatch, capsys):
+    monkeypatch.setattr(command, "_effective_provider", lambda _explicit: "zai")
+    monkeypatch.setattr(command, "fetch_account_usage", lambda _provider: None)
+
+    result = command.account_usage_command(Namespace(provider="zai", json=True, output=None))
+
+    assert result == 2
+    assert json.loads(capsys.readouterr().out)["provider"] == "zai"


### PR DESCRIPTION
## Summary

Adds a non-interactive `hermes usage` command for provider-reported subscription limits.

- emits a stable, credential-free JSON snapshot with `--json`
- optionally writes the snapshot atomically with `--output`
- classifies Codex windows from their reported duration instead of primary/secondary lane position
- includes Anthropic window durations
- keeps account quota snapshots separate from per-session token accounting

## Validation

- `scripts/run_tests.sh tests/agent/test_account_usage.py tests/hermes_cli/test_account_usage_command.py`
- targeted Ruff checks
- `hermes usage --help` smoke test