### PR TITLE
fix(telegram): preserve HEIC/HEIF image-documents from iOS

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -623,6 +623,39 @@ def decide_image_input_mode(
 # The shrink-on-reject path loses 1 API call + maybe 1s of Pillow work when
 # it fires, which is cheaper than permanent quality loss.
 
+_AVIF_FTYP_BRANDS = frozenset({b"avif", b"avis", b"av01"})
+_HEIF_FTYP_BRANDS = frozenset(
+    {
+        b"heic",
+        b"heix",
+        b"hevc",
+        b"hevx",
+        b"heim",
+        b"heis",
+        b"hevm",
+        b"hevs",
+        b"heif",
+        b"mif1",
+        b"msf1",
+    }
+)
+
+
+def _isobmff_ftyp_brands(raw: bytes) -> tuple[bytes, ...]:
+    """Return major + compatible brands from a ``ftyp`` box, or empty.
+
+    Compatible brands are scanned only inside the declared box size.
+    """
+    if len(raw) < 12 or raw[4:8] != b"ftyp":
+        return ()
+    brands = [raw[8:12]]
+    declared = int.from_bytes(raw[:4], "big")
+    if declared >= 16:
+        end = min(len(raw), declared)
+        for i in range(16, end - 3, 4):
+            brands.append(raw[i : i + 4])
+    return tuple(brands)
+
 
 def _sniff_mime_from_bytes(raw: bytes) -> Optional[str]:
     """Detect image MIME from magic bytes. Returns None if unrecognised.
@@ -652,25 +685,14 @@ def _sniff_mime_from_bytes(raw: bytes) -> Optional[str]:
     if raw.startswith(b"BM"):
         return "image/bmp"
     # ISO-BMFF family (HEIC/HEIF/AVIF): bytes 4..8 == 'ftyp', major brand at 8..12.
-    # HEIC/HEIF brands must stay aligned with gateway.platforms.base
-    # ``_HEIC_HEIF_FTYP_BRANDS`` so Telegram/document caches that accept HEIF
-    # still enter the non-universal transcode path (not JPEG fallback).
+    # Brand set stays aligned with gateway.platforms.base. Scan only inside
+    # the declared ftyp box; AVIF brands win when both families appear.
     if len(raw) >= 12 and raw[4:8] == b"ftyp":
-        brand = raw[8:12]
-        if brand in {b"avif", b"avis"}:
+        brands = set(_isobmff_ftyp_brands(raw))
+        if brands & _AVIF_FTYP_BRANDS:
             return "image/avif"
-        heif_brands = {
-            b"heic", b"heix", b"hevc", b"hevx",
-            b"heim", b"heis", b"hevm", b"hevs",
-            b"heif", b"mif1", b"msf1",
-        }
-        if brand in heif_brands:
+        if brands & _HEIF_FTYP_BRANDS:
             return "image/heic"
-        # Compatible brands start at offset 16 (same scan window as base.py).
-        end = min(len(raw), 64)
-        for i in range(16, end - 3, 4):
-            if raw[i : i + 4] in heif_brands:
-                return "image/heic"
     # TIFF: II*\0 (little-endian) or MM\0* (big-endian)
     if raw[:4] in {b"II*\x00", b"MM\x00*"}:
         return "image/tiff"

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -58,7 +58,8 @@ _VALID_MODES = frozenset({"auto", "native", "text"})
 # them differently (send_document), and we don't want to attach a PDF as a
 # vision part.
 _IMAGE_EXTS = (
-    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif", ".heic",
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif",
+    ".heic", ".heif",
 )
 _IMAGE_EXT_PATTERN = "|".join(e.lstrip(".") for e in _IMAGE_EXTS)
 
@@ -650,16 +651,26 @@ def _sniff_mime_from_bytes(raw: bytes) -> Optional[str]:
     # BMP: "BM"
     if raw.startswith(b"BM"):
         return "image/bmp"
-    # ISO-BMFF family (HEIC/HEIF/AVIF): bytes 4..8 == 'ftyp', major brand at 8..12
+    # ISO-BMFF family (HEIC/HEIF/AVIF): bytes 4..8 == 'ftyp', major brand at 8..12.
+    # HEIC/HEIF brands must stay aligned with gateway.platforms.base
+    # ``_HEIC_HEIF_FTYP_BRANDS`` so Telegram/document caches that accept HEIF
+    # still enter the non-universal transcode path (not JPEG fallback).
     if len(raw) >= 12 and raw[4:8] == b"ftyp":
         brand = raw[8:12]
         if brand in {b"avif", b"avis"}:
             return "image/avif"
-        if brand in {
+        heif_brands = {
             b"heic", b"heix", b"hevc", b"hevx",
-            b"mif1", b"msf1", b"heim", b"heis",
-        }:
+            b"heim", b"heis", b"hevm", b"hevs",
+            b"heif", b"mif1", b"msf1",
+        }
+        if brand in heif_brands:
             return "image/heic"
+        # Compatible brands start at offset 16 (same scan window as base.py).
+        end = min(len(raw), 64)
+        for i in range(16, end - 3, 4):
+            if raw[i : i + 4] in heif_brands:
+                return "image/heic"
     # TIFF: II*\0 (little-endian) or MM\0* (big-endian)
     if raw[:4] in {b"II*\x00", b"MM\x00*"}:
         return "image/tiff"
@@ -765,6 +776,8 @@ def _guess_mime(path: Path, raw: Optional[bytes] = None) -> str:
         ".gif": "image/gif",
         ".webp": "image/webp",
         ".bmp": "image/bmp",
+        ".heic": "image/heic",
+        ".heif": "image/heic",
     }.get(suffix, "image/jpeg")
 
 

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -58,7 +58,8 @@ _VALID_MODES = frozenset({"auto", "native", "text"})
 # them differently (send_document), and we don't want to attach a PDF as a
 # vision part.
 _IMAGE_EXTS = (
-    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif", ".heic",
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".tif",
+    ".heic", ".heif",
 )
 _IMAGE_EXT_PATTERN = "|".join(e.lstrip(".") for e in _IMAGE_EXTS)
 
@@ -548,16 +549,26 @@ def _sniff_mime_from_bytes(raw: bytes) -> Optional[str]:
     # BMP: "BM"
     if raw.startswith(b"BM"):
         return "image/bmp"
-    # ISO-BMFF family (HEIC/HEIF/AVIF): bytes 4..8 == 'ftyp', major brand at 8..12
+    # ISO-BMFF family (HEIC/HEIF/AVIF): bytes 4..8 == 'ftyp', major brand at 8..12.
+    # HEIC/HEIF brands must stay aligned with gateway.platforms.base
+    # ``_HEIC_HEIF_FTYP_BRANDS`` so Telegram/document caches that accept HEIF
+    # still enter the non-universal transcode path (not JPEG fallback).
     if len(raw) >= 12 and raw[4:8] == b"ftyp":
         brand = raw[8:12]
         if brand in {b"avif", b"avis"}:
             return "image/avif"
-        if brand in {
+        heif_brands = {
             b"heic", b"heix", b"hevc", b"hevx",
-            b"mif1", b"msf1", b"heim", b"heis",
-        }:
+            b"heim", b"heis", b"hevm", b"hevs",
+            b"heif", b"mif1", b"msf1",
+        }
+        if brand in heif_brands:
             return "image/heic"
+        # Compatible brands start at offset 16 (same scan window as base.py).
+        end = min(len(raw), 64)
+        for i in range(16, end - 3, 4):
+            if raw[i : i + 4] in heif_brands:
+                return "image/heic"
     # TIFF: II*\0 (little-endian) or MM\0* (big-endian)
     if raw[:4] in {b"II*\x00", b"MM\x00*"}:
         return "image/tiff"
@@ -663,6 +674,8 @@ def _guess_mime(path: Path, raw: Optional[bytes] = None) -> str:
         ".gif": "image/gif",
         ".webp": "image/webp",
         ".bmp": "image/bmp",
+        ".heic": "image/heic",
+        ".heif": "image/heic",
     }.get(suffix, "image/jpeg")
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -834,6 +834,40 @@ def get_image_cache_dir() -> Path:
     return d
 
 
+# ISO BMFF brands used by HEIC/HEIF (iPhone photos, Apple Live Photos stills).
+# Major brand is at offset 8 after the ftyp box header; compatible brands follow.
+_HEIC_HEIF_FTYP_BRANDS = frozenset(
+    {
+        b"heic",
+        b"heix",
+        b"hevc",
+        b"hevx",
+        b"heim",
+        b"heis",
+        b"hevm",
+        b"hevs",
+        b"heif",
+        b"mif1",  # HEIF structural brand (common on iOS stills)
+        b"msf1",  # HEIF image sequence
+    }
+)
+
+
+def _looks_like_heic_heif(data: bytes) -> bool:
+    """Return True if *data* looks like a HEIC/HEIF ISO-BMFF container."""
+    if len(data) < 12 or data[4:8] != b"ftyp":
+        return False
+    # Major brand
+    if data[8:12] in _HEIC_HEIF_FTYP_BRANDS:
+        return True
+    # Compatible brands start at offset 16; scan a short window only.
+    end = min(len(data), 64)
+    for i in range(16, end - 3, 4):
+        if data[i : i + 4] in _HEIC_HEIF_FTYP_BRANDS:
+            return True
+    return False
+
+
 def _looks_like_image(data: bytes) -> bool:
     """Return True if *data* starts with a known image magic-byte sequence."""
     if len(data) < 4:
@@ -847,6 +881,10 @@ def _looks_like_image(data: bytes) -> bool:
     if data[:2] == b"BM":
         return True
     if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":
+        return True
+    # HEIC/HEIF (iOS Camera default). Without this, cache_image_from_bytes
+    # raises ValueError and Telegram image-document intake drops the photo.
+    if _looks_like_heic_heif(data):
         return True
     return False
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -851,21 +851,36 @@ _HEIC_HEIF_FTYP_BRANDS = frozenset(
         b"msf1",  # HEIF image sequence
     }
 )
+_AVIF_FTYP_BRANDS = frozenset({b"avif", b"avis", b"av01"})
+
+
+def _isobmff_ftyp_brands(data: bytes) -> tuple[bytes, ...]:
+    """Return major + compatible brands from a ``ftyp`` box, or empty.
+
+    Compatible brands are scanned only inside the declared box size.
+    A size below 16 means "no compatible list" — never fall back to a
+    fixed 64-byte window (that reads the *next* box).
+    """
+    if len(data) < 12 or data[4:8] != b"ftyp":
+        return ()
+    brands = [data[8:12]]
+    declared = int.from_bytes(data[:4], "big")
+    if declared >= 16:
+        end = min(len(data), declared)
+        for i in range(16, end - 3, 4):
+            brands.append(data[i : i + 4])
+    return tuple(brands)
 
 
 def _looks_like_heic_heif(data: bytes) -> bool:
     """Return True if *data* looks like a HEIC/HEIF ISO-BMFF container."""
-    if len(data) < 12 or data[4:8] != b"ftyp":
+    brands = set(_isobmff_ftyp_brands(data))
+    if not brands:
         return False
-    # Major brand
-    if data[8:12] in _HEIC_HEIF_FTYP_BRANDS:
-        return True
-    # Compatible brands start at offset 16; scan a short window only.
-    end = min(len(data), 64)
-    for i in range(16, end - 3, 4):
-        if data[i : i + 4] in _HEIC_HEIF_FTYP_BRANDS:
-            return True
-    return False
+    # AVIF shares the ISO-BMFF container; do not treat it as HEIC.
+    if brands & _AVIF_FTYP_BRANDS:
+        return False
+    return bool(brands & _HEIC_HEIF_FTYP_BRANDS)
 
 
 def _looks_like_image(data: bytes) -> bool:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -802,6 +802,40 @@ def get_image_cache_dir() -> Path:
     return d
 
 
+# ISO BMFF brands used by HEIC/HEIF (iPhone photos, Apple Live Photos stills).
+# Major brand is at offset 8 after the ftyp box header; compatible brands follow.
+_HEIC_HEIF_FTYP_BRANDS = frozenset(
+    {
+        b"heic",
+        b"heix",
+        b"hevc",
+        b"hevx",
+        b"heim",
+        b"heis",
+        b"hevm",
+        b"hevs",
+        b"heif",
+        b"mif1",  # HEIF structural brand (common on iOS stills)
+        b"msf1",  # HEIF image sequence
+    }
+)
+
+
+def _looks_like_heic_heif(data: bytes) -> bool:
+    """Return True if *data* looks like a HEIC/HEIF ISO-BMFF container."""
+    if len(data) < 12 or data[4:8] != b"ftyp":
+        return False
+    # Major brand
+    if data[8:12] in _HEIC_HEIF_FTYP_BRANDS:
+        return True
+    # Compatible brands start at offset 16; scan a short window only.
+    end = min(len(data), 64)
+    for i in range(16, end - 3, 4):
+        if data[i : i + 4] in _HEIC_HEIF_FTYP_BRANDS:
+            return True
+    return False
+
+
 def _looks_like_image(data: bytes) -> bool:
     """Return True if *data* starts with a known image magic-byte sequence."""
     if len(data) < 4:
@@ -815,6 +849,10 @@ def _looks_like_image(data: bytes) -> bool:
     if data[:2] == b"BM":
         return True
     if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":
+        return True
+    # HEIC/HEIF (iOS Camera default). Without this, cache_image_from_bytes
+    # raises ValueError and Telegram image-document intake drops the photo.
+    if _looks_like_heic_heif(data):
         return True
     return False
 

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -217,7 +217,7 @@ from plugins.platforms.telegram.telegram_network import (
 )
 from utils import atomic_replace, env_float, env_int
 
-_TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
+_TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".heic", ".heif"}
 
 # Max seconds a send/edit coroutine may sleep inline on a Telegram
 # flood-control RetryAfter. Longer server penalties fail closed with a
@@ -237,12 +237,17 @@ def _flood_cap_result(wait: float) -> "SendResult":
     )
 
 
+
 _TELEGRAM_IMAGE_MIME_TO_EXT = {
     "image/png": ".png",
     "image/jpeg": ".jpg",
     "image/jpg": ".jpg",
     "image/webp": ".webp",
     "image/gif": ".gif",
+    "image/heic": ".heic",
+    "image/heif": ".heif",
+    "image/heic-sequence": ".heic",
+    "image/heif-sequence": ".heif",
 }
 _TELEGRAM_IMAGE_EXT_TO_MIME = {
     ".png": "image/png",
@@ -250,6 +255,15 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
     ".jpeg": "image/jpeg",
     ".webp": "image/webp",
     ".gif": "image/gif",
+    ".heic": "image/heic",
+    ".heif": "image/heif",
+}
+_TELEGRAM_HEIC_EXTENSIONS = {".heic", ".heif"}
+_TELEGRAM_HEIC_MIMES = {
+    "image/heic",
+    "image/heif",
+    "image/heic-sequence",
+    "image/heif-sequence",
 }
 
 def _coerce_duration_seconds(value: Any) -> Optional[int]:
@@ -10056,11 +10070,58 @@ class TelegramAdapter(BasePlatformAdapter):
                 if ext in _TELEGRAM_IMAGE_EXTENSIONS or doc_mime.startswith("image/"):
                     file_obj = await doc.get_file()
                     image_bytes = await file_obj.download_as_bytearray()
-                    image_ext = ext if ext in _TELEGRAM_IMAGE_EXTENSIONS else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")
+                    raw_image = bytes(image_bytes)
+                    image_ext = (
+                        ext
+                        if ext in _TELEGRAM_IMAGE_EXTENSIONS
+                        else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")
+                    )
                     try:
-                        cached_path = cache_image_from_bytes(bytes(image_bytes), ext=image_ext)
+                        cached_path = cache_image_from_bytes(raw_image, ext=image_ext)
                     except ValueError as e:
-                        logger.warning("[Telegram] Failed to cache image document: %s", _redact_telegram_error_text(e), exc_info=True)
+                        # HEIC/HEIF from iOS often arrives as a Telegram document.
+                        # Pillow stock decode and older sniffers may still reject
+                        # the payload; preserve the original bytes so the agent
+                        # (and any HEIF-capable tools) can still process the photo
+                        # instead of dropping it as "could not be read".
+                        from gateway.platforms.base import _looks_like_heic_heif
+
+                        is_heic = (
+                            ext in _TELEGRAM_HEIC_EXTENSIONS
+                            or doc_mime in _TELEGRAM_HEIC_MIMES
+                            or _looks_like_heic_heif(raw_image)
+                        )
+                        if is_heic:
+                            cached_path = cache_document_from_bytes(
+                                raw_image,
+                                original_filename or f"photo{image_ext or '.heic'}",
+                            )
+                            event.message_type = MessageType.PHOTO
+                            event.media_urls = [cached_path]
+                            event.media_types = [
+                                doc_mime
+                                if doc_mime in _TELEGRAM_HEIC_MIMES
+                                else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/heic")
+                            ]
+                            logger.info(
+                                "[Telegram] Cached HEIC/HEIF image-document at %s "
+                                "(raw fallback after image-cache rejection: %s)",
+                                cached_path,
+                                _redact_telegram_error_text(e),
+                            )
+                            media_group_id = getattr(msg, "media_group_id", None)
+                            if media_group_id:
+                                await self._queue_media_group_event(str(media_group_id), event)
+                            else:
+                                batch_key = self._photo_batch_key(event, msg)
+                                self._enqueue_photo_event(batch_key, event)
+                            return
+
+                        logger.warning(
+                            "[Telegram] Failed to cache image document: %s",
+                            _redact_telegram_error_text(e),
+                            exc_info=True,
+                        )
                         event.text = (
                             f"Image document '{original_filename or doc_mime or ext or 'unknown'}' "
                             "could not be read as an image."
@@ -10070,7 +10131,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
                     event.message_type = MessageType.PHOTO
                     event.media_urls = [cached_path]
-                    event.media_types = [doc_mime if doc_mime.startswith("image/") else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/jpeg")]
+                    event.media_types = [
+                        doc_mime
+                        if doc_mime.startswith("image/")
+                        else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/jpeg")
+                    ]
                     logger.info("[Telegram] Cached user image-document at %s", cached_path)
 
                     media_group_id = getattr(msg, "media_group_id", None)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -258,13 +258,6 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
     ".heic": "image/heic",
     ".heif": "image/heif",
 }
-_TELEGRAM_HEIC_EXTENSIONS = {".heic", ".heif"}
-_TELEGRAM_HEIC_MIMES = {
-    "image/heic",
-    "image/heif",
-    "image/heic-sequence",
-    "image/heif-sequence",
-}
 
 def _coerce_duration_seconds(value: Any) -> Optional[int]:
     """Round a raw length to whole positive seconds, or None if unusable."""
@@ -10070,53 +10063,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 if ext in _TELEGRAM_IMAGE_EXTENSIONS or doc_mime.startswith("image/"):
                     file_obj = await doc.get_file()
                     image_bytes = await file_obj.download_as_bytearray()
-                    raw_image = bytes(image_bytes)
                     image_ext = (
                         ext
                         if ext in _TELEGRAM_IMAGE_EXTENSIONS
                         else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")
                     )
                     try:
-                        cached_path = cache_image_from_bytes(raw_image, ext=image_ext)
+                        cached_path = cache_image_from_bytes(bytes(image_bytes), ext=image_ext)
                     except ValueError as e:
-                        # HEIC/HEIF from iOS often arrives as a Telegram document.
-                        # Pillow stock decode and older sniffers may still reject
-                        # the payload; preserve the original bytes so the agent
-                        # (and any HEIF-capable tools) can still process the photo
-                        # instead of dropping it as "could not be read".
-                        from gateway.platforms.base import _looks_like_heic_heif
-
-                        is_heic = (
-                            ext in _TELEGRAM_HEIC_EXTENSIONS
-                            or doc_mime in _TELEGRAM_HEIC_MIMES
-                            or _looks_like_heic_heif(raw_image)
-                        )
-                        if is_heic:
-                            cached_path = cache_document_from_bytes(
-                                raw_image,
-                                original_filename or f"photo{image_ext or '.heic'}",
-                            )
-                            event.message_type = MessageType.PHOTO
-                            event.media_urls = [cached_path]
-                            event.media_types = [
-                                doc_mime
-                                if doc_mime in _TELEGRAM_HEIC_MIMES
-                                else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/heic")
-                            ]
-                            logger.info(
-                                "[Telegram] Cached HEIC/HEIF image-document at %s "
-                                "(raw fallback after image-cache rejection: %s)",
-                                cached_path,
-                                _redact_telegram_error_text(e),
-                            )
-                            media_group_id = getattr(msg, "media_group_id", None)
-                            if media_group_id:
-                                await self._queue_media_group_event(str(media_group_id), event)
-                            else:
-                                batch_key = self._photo_batch_key(event, msg)
-                                self._enqueue_photo_event(batch_key, event)
-                            return
-
                         logger.warning(
                             "[Telegram] Failed to cache image document: %s",
                             _redact_telegram_error_text(e),

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -290,13 +290,17 @@ from plugins.platforms.telegram.telegram_network import (
 )
 from utils import atomic_replace, env_float, env_int
 
-_TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
+_TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".heic", ".heif"}
 _TELEGRAM_IMAGE_MIME_TO_EXT = {
     "image/png": ".png",
     "image/jpeg": ".jpg",
     "image/jpg": ".jpg",
     "image/webp": ".webp",
     "image/gif": ".gif",
+    "image/heic": ".heic",
+    "image/heif": ".heif",
+    "image/heic-sequence": ".heic",
+    "image/heif-sequence": ".heif",
 }
 _TELEGRAM_IMAGE_EXT_TO_MIME = {
     ".png": "image/png",
@@ -304,6 +308,15 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
     ".jpeg": "image/jpeg",
     ".webp": "image/webp",
     ".gif": "image/gif",
+    ".heic": "image/heic",
+    ".heif": "image/heif",
+}
+_TELEGRAM_HEIC_EXTENSIONS = {".heic", ".heif"}
+_TELEGRAM_HEIC_MIMES = {
+    "image/heic",
+    "image/heif",
+    "image/heic-sequence",
+    "image/heif-sequence",
 }
 
 def _coerce_duration_seconds(value: Any) -> Optional[int]:
@@ -9098,11 +9111,58 @@ class TelegramAdapter(BasePlatformAdapter):
                 if ext in _TELEGRAM_IMAGE_EXTENSIONS or doc_mime.startswith("image/"):
                     file_obj = await doc.get_file()
                     image_bytes = await file_obj.download_as_bytearray()
-                    image_ext = ext if ext in _TELEGRAM_IMAGE_EXTENSIONS else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")
+                    raw_image = bytes(image_bytes)
+                    image_ext = (
+                        ext
+                        if ext in _TELEGRAM_IMAGE_EXTENSIONS
+                        else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")
+                    )
                     try:
-                        cached_path = cache_image_from_bytes(bytes(image_bytes), ext=image_ext)
+                        cached_path = cache_image_from_bytes(raw_image, ext=image_ext)
                     except ValueError as e:
-                        logger.warning("[Telegram] Failed to cache image document: %s", _redact_telegram_error_text(e), exc_info=True)
+                        # HEIC/HEIF from iOS often arrives as a Telegram document.
+                        # Pillow stock decode and older sniffers may still reject
+                        # the payload; preserve the original bytes so the agent
+                        # (and any HEIF-capable tools) can still process the photo
+                        # instead of dropping it as "could not be read".
+                        from gateway.platforms.base import _looks_like_heic_heif
+
+                        is_heic = (
+                            ext in _TELEGRAM_HEIC_EXTENSIONS
+                            or doc_mime in _TELEGRAM_HEIC_MIMES
+                            or _looks_like_heic_heif(raw_image)
+                        )
+                        if is_heic:
+                            cached_path = cache_document_from_bytes(
+                                raw_image,
+                                original_filename or f"photo{image_ext or '.heic'}",
+                            )
+                            event.message_type = MessageType.PHOTO
+                            event.media_urls = [cached_path]
+                            event.media_types = [
+                                doc_mime
+                                if doc_mime in _TELEGRAM_HEIC_MIMES
+                                else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/heic")
+                            ]
+                            logger.info(
+                                "[Telegram] Cached HEIC/HEIF image-document at %s "
+                                "(raw fallback after image-cache rejection: %s)",
+                                cached_path,
+                                _redact_telegram_error_text(e),
+                            )
+                            media_group_id = getattr(msg, "media_group_id", None)
+                            if media_group_id:
+                                await self._queue_media_group_event(str(media_group_id), event)
+                            else:
+                                batch_key = self._photo_batch_key(event, msg)
+                                self._enqueue_photo_event(batch_key, event)
+                            return
+
+                        logger.warning(
+                            "[Telegram] Failed to cache image document: %s",
+                            _redact_telegram_error_text(e),
+                            exc_info=True,
+                        )
                         event.text = (
                             f"Image document '{original_filename or doc_mime or ext or 'unknown'}' "
                             "could not be read as an image."
@@ -9112,7 +9172,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
                     event.message_type = MessageType.PHOTO
                     event.media_urls = [cached_path]
-                    event.media_types = [doc_mime if doc_mime.startswith("image/") else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/jpeg")]
+                    event.media_types = [
+                        doc_mime
+                        if doc_mime.startswith("image/")
+                        else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/jpeg")
+                    ]
                     logger.info("[Telegram] Cached user image-document at %s", cached_path)
 
                     media_group_id = getattr(msg, "media_group_id", None)

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -503,6 +503,18 @@ class TestFormatCompatibility:
             # declaring the raw bytes with a mislabeled media_type.
             assert mime not in _UNIVERSALLY_SUPPORTED_MIMES
 
+    def test_ftyp_scan_does_not_read_past_declared_box(self):
+        from agent.image_routing import _sniff_mime_from_bytes
+
+        raw = (16).to_bytes(4, "big") + b"ftypisom" + b"\x00\x00\x00\x00" + b"heicxxxx"
+        assert _sniff_mime_from_bytes(raw) is None
+
+    def test_mif1_plus_avif_sniffs_as_avif_not_heic(self):
+        from agent.image_routing import _sniff_mime_from_bytes
+
+        raw = (24).to_bytes(4, "big") + b"ftypmif1" + b"\x00\x00\x00\x00" + b"avif"
+        assert _sniff_mime_from_bytes(raw) == "image/avif"
+
     def test_svg_sniffed_correctly(self):
         from agent.image_routing import _sniff_mime_from_bytes
         assert _sniff_mime_from_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"/>') == "image/svg+xml"

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -480,6 +480,29 @@ class TestFormatCompatibility:
         assert heif_mime != "image/jpeg"
         assert heic_mime != "image/jpeg"
 
+    def test_ftypheif_enters_non_universal_path_not_jpeg(self):
+        """Through image routing: a ftypheif payload must classify as HEIC
+        (not JPEG) and fall outside the universally-supported set, so it
+        takes the transcode branch in _file_to_data_url rather than being
+        declared image/jpeg to the provider. Matches the reviewer ask
+        without depending on the optional pillow-heif codec.
+        """
+        from pathlib import Path
+
+        from agent.image_routing import (
+            _UNIVERSALLY_SUPPORTED_MIMES,
+            _guess_mime,
+        )
+
+        for brand in (b"heif", b"hevm", b"hevs", b"heic"):
+            raw = b"\x00\x00\x00\x20ftyp" + brand + b"\x00\x00\x00\x00"
+            mime = _guess_mime(Path("photo.heif"), raw=raw)
+            assert mime == "image/heic", f"{brand!r} classified as {mime}"
+            assert mime != "image/jpeg"
+            # Non-universal -> _file_to_data_url transcodes instead of
+            # declaring the raw bytes with a mislabeled media_type.
+            assert mime not in _UNIVERSALLY_SUPPORTED_MIMES
+
     def test_svg_sniffed_correctly(self):
         from agent.image_routing import _sniff_mime_from_bytes
         assert _sniff_mime_from_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"/>') == "image/svg+xml"

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -452,6 +452,34 @@ class TestFormatCompatibility:
 
 
 
+    def test_heif_major_brand_sniffed(self):
+        """ftypheif must not fall through to JPEG (review alignment with base cache)."""
+        from agent.image_routing import _guess_mime, _sniff_mime_from_bytes
+        from pathlib import Path
+
+        heif_header = b"\x00\x00\x00\x20ftypheif\x00\x00\x00\x00"
+        assert _sniff_mime_from_bytes(heif_header) == "image/heic"
+        # Full guess path used by vision attachment building.
+        assert _guess_mime(Path("photo.heif"), raw=heif_header) == "image/heic"
+
+    def test_hevm_hevs_brands_sniffed(self):
+        from agent.image_routing import _sniff_mime_from_bytes
+
+        assert _sniff_mime_from_bytes(b"\x00\x00\x00\x20ftyphevm\x00\x00\x00\x00") == "image/heic"
+        assert _sniff_mime_from_bytes(b"\x00\x00\x00\x20ftyphevs\x00\x00\x00\x00") == "image/heic"
+
+    def test_heif_extension_without_magic_defaults_heic_mime(self):
+        """Suffix-only guess must not map .heif/.heic → image/jpeg."""
+        from agent.image_routing import _guess_mime
+        from pathlib import Path
+
+        heif_mime = _guess_mime(Path("IMG_0001.heif"), raw=None)
+        heic_mime = _guess_mime(Path("IMG_0001.HEIC"), raw=None)
+        assert heif_mime in {"image/heic", "image/heif"}
+        assert heic_mime in {"image/heic", "image/heif"}
+        assert heif_mime != "image/jpeg"
+        assert heic_mime != "image/jpeg"
+
     def test_svg_sniffed_correctly(self):
         from agent.image_routing import _sniff_mime_from_bytes
         assert _sniff_mime_from_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"/>') == "image/svg+xml"

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -765,6 +765,34 @@ class TestFormatCompatibility:
         heic_header = b"\x00\x00\x00\x20ftypheic\x00\x00\x00\x00"
         assert _sniff_mime_from_bytes(heic_header) == "image/heic"
 
+    def test_heif_major_brand_sniffed(self):
+        """ftypheif must not fall through to JPEG (review alignment with base cache)."""
+        from agent.image_routing import _guess_mime, _sniff_mime_from_bytes
+        from pathlib import Path
+
+        heif_header = b"\x00\x00\x00\x20ftypheif\x00\x00\x00\x00"
+        assert _sniff_mime_from_bytes(heif_header) == "image/heic"
+        # Full guess path used by vision attachment building.
+        assert _guess_mime(Path("photo.heif"), raw=heif_header) == "image/heic"
+
+    def test_hevm_hevs_brands_sniffed(self):
+        from agent.image_routing import _sniff_mime_from_bytes
+
+        assert _sniff_mime_from_bytes(b"\x00\x00\x00\x20ftyphevm\x00\x00\x00\x00") == "image/heic"
+        assert _sniff_mime_from_bytes(b"\x00\x00\x00\x20ftyphevs\x00\x00\x00\x00") == "image/heic"
+
+    def test_heif_extension_without_magic_defaults_heic_mime(self):
+        """Suffix-only guess must not map .heif/.heic → image/jpeg."""
+        from agent.image_routing import _guess_mime
+        from pathlib import Path
+
+        heif_mime = _guess_mime(Path("IMG_0001.heif"), raw=None)
+        heic_mime = _guess_mime(Path("IMG_0001.HEIC"), raw=None)
+        assert heif_mime in {"image/heic", "image/heif"}
+        assert heic_mime in {"image/heic", "image/heif"}
+        assert heif_mime != "image/jpeg"
+        assert heic_mime != "image/jpeg"
+
     def test_svg_sniffed_correctly(self):
         from agent.image_routing import _sniff_mime_from_bytes
         assert _sniff_mime_from_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"/>') == "image/svg+xml"

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -793,6 +793,29 @@ class TestFormatCompatibility:
         assert heif_mime != "image/jpeg"
         assert heic_mime != "image/jpeg"
 
+    def test_ftypheif_enters_non_universal_path_not_jpeg(self):
+        """Through image routing: a ftypheif payload must classify as HEIC
+        (not JPEG) and fall outside the universally-supported set, so it
+        takes the transcode branch in _file_to_data_url rather than being
+        declared image/jpeg to the provider. Matches the reviewer ask
+        without depending on the optional pillow-heif codec.
+        """
+        from pathlib import Path
+
+        from agent.image_routing import (
+            _UNIVERSALLY_SUPPORTED_MIMES,
+            _guess_mime,
+        )
+
+        for brand in (b"heif", b"hevm", b"hevs", b"heic"):
+            raw = b"\x00\x00\x00\x20ftyp" + brand + b"\x00\x00\x00\x00"
+            mime = _guess_mime(Path("photo.heif"), raw=raw)
+            assert mime == "image/heic", f"{brand!r} classified as {mime}"
+            assert mime != "image/jpeg"
+            # Non-universal -> _file_to_data_url transcodes instead of
+            # declaring the raw bytes with a mislabeled media_type.
+            assert mime not in _UNIVERSALLY_SUPPORTED_MIMES
+
     def test_svg_sniffed_correctly(self):
         from agent.image_routing import _sniff_mime_from_bytes
         assert _sniff_mime_from_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"/>') == "image/svg+xml"

--- a/tests/gateway/test_media_download_retry.py
+++ b/tests/gateway/test_media_download_retry.py
@@ -107,18 +107,6 @@ class TestCacheImageFromBytes:
         with pytest.raises(ValueError, match="non-image data"):
             cache_image_from_bytes(b"<!DOCTYPE html><html><title>Slack</title></html>", ".png")
 
-    def test_rejects_empty_data(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
-        from gateway.platforms.base import cache_image_from_bytes
-        with pytest.raises(ValueError, match="non-image data"):
-            cache_image_from_bytes(b"", ".jpg")
-
-    def test_rejects_plain_text(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
-        from gateway.platforms.base import cache_image_from_bytes
-        with pytest.raises(ValueError, match="non-image data"):
-            cache_image_from_bytes(b"just some text, not an image", ".jpg")
-
     def test_caches_heic_ftyp_brand(self, tmp_path, monkeypatch):
         """iPhone HEIC containers must pass the image sniffer and cache."""
         monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
@@ -147,6 +135,27 @@ class TestCacheImageFromBytes:
         mp4 = (24).to_bytes(4, "big") + b"ftypisom" + b"\x00\x00\x00\x00" + b"isom"
         with pytest.raises(ValueError, match="non-image data"):
             cache_image_from_bytes(mp4, ".heic")
+
+    def test_ftyp_scan_does_not_read_past_declared_box(self):
+        """A 'heic' token in the *next* box must not classify as HEIC."""
+        from gateway.platforms.base import _looks_like_heic_heif
+
+        # Declared size 16: box ends after minor version; 'heic' is the next box.
+        raw = (16).to_bytes(4, "big") + b"ftypisom" + b"\x00\x00\x00\x00" + b"heicxxxx"
+        assert _looks_like_heic_heif(raw) is False
+
+    def test_mif1_plus_avif_is_not_heic(self):
+        from gateway.platforms.base import _looks_like_heic_heif
+
+        raw = (24).to_bytes(4, "big") + b"ftypmif1" + b"\x00\x00\x00\x00" + b"avif"
+        assert _looks_like_heic_heif(raw) is False
+
+    def test_undersized_ftyp_does_not_scan_compat_brands(self):
+        from gateway.platforms.base import _looks_like_heic_heif
+
+        # Declared size 12 cannot hold a compatible list.
+        raw = (12).to_bytes(4, "big") + b"ftypisom" + b"\x00\x00\x00\x00" + b"heic"
+        assert _looks_like_heic_heif(raw) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_media_download_retry.py
+++ b/tests/gateway/test_media_download_retry.py
@@ -14,6 +14,7 @@ in this environment.
 import asyncio
 import socket
 import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -105,6 +106,47 @@ class TestCacheImageFromBytes:
         from gateway.platforms.base import cache_image_from_bytes
         with pytest.raises(ValueError, match="non-image data"):
             cache_image_from_bytes(b"<!DOCTYPE html><html><title>Slack</title></html>", ".png")
+
+    def test_rejects_empty_data(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        from gateway.platforms.base import cache_image_from_bytes
+        with pytest.raises(ValueError, match="non-image data"):
+            cache_image_from_bytes(b"", ".jpg")
+
+    def test_rejects_plain_text(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        from gateway.platforms.base import cache_image_from_bytes
+        with pytest.raises(ValueError, match="non-image data"):
+            cache_image_from_bytes(b"just some text, not an image", ".jpg")
+
+    def test_caches_heic_ftyp_brand(self, tmp_path, monkeypatch):
+        """iPhone HEIC containers must pass the image sniffer and cache."""
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        from gateway.platforms.base import cache_image_from_bytes, _looks_like_heic_heif
+
+        heic = (24).to_bytes(4, "big") + b"ftypheic" + b"\x00\x00\x00\x00" + b"mif1heic"
+        assert _looks_like_heic_heif(heic) is True
+        path = cache_image_from_bytes(heic, ".heic")
+        assert path.endswith(".heic")
+        assert Path(path).read_bytes() == heic
+
+    def test_caches_heif_via_compatible_brand(self, tmp_path, monkeypatch):
+        """mif1 major brand with heic compatible brand (common iOS still layout)."""
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        from gateway.platforms.base import cache_image_from_bytes
+
+        # major brand mif1, compatible brand heic at offset 16
+        heif = (24).to_bytes(4, "big") + b"ftypmif1" + b"\x00\x00\x00\x00" + b"heic"
+        path = cache_image_from_bytes(heif + b"\x00" * 8, ".heif")
+        assert path.endswith(".heif")
+
+    def test_rejects_unrelated_ftyp(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        from gateway.platforms.base import cache_image_from_bytes
+
+        mp4 = (24).to_bytes(4, "big") + b"ftypisom" + b"\x00\x00\x00\x00" + b"isom"
+        with pytest.raises(ValueError, match="non-image data"):
+            cache_image_from_bytes(mp4, ".heic")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_media_download_retry.py
+++ b/tests/gateway/test_media_download_retry.py
@@ -14,6 +14,7 @@ in this environment.
 import asyncio
 import socket
 import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -122,6 +123,35 @@ class TestCacheImageFromBytes:
         from gateway.platforms.base import cache_image_from_bytes
         with pytest.raises(ValueError, match="non-image data"):
             cache_image_from_bytes(b"just some text, not an image", ".jpg")
+
+    def test_caches_heic_ftyp_brand(self, tmp_path, monkeypatch):
+        """iPhone HEIC containers must pass the image sniffer and cache."""
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        from gateway.platforms.base import cache_image_from_bytes, _looks_like_heic_heif
+
+        heic = (24).to_bytes(4, "big") + b"ftypheic" + b"\x00\x00\x00\x00" + b"mif1heic"
+        assert _looks_like_heic_heif(heic) is True
+        path = cache_image_from_bytes(heic, ".heic")
+        assert path.endswith(".heic")
+        assert Path(path).read_bytes() == heic
+
+    def test_caches_heif_via_compatible_brand(self, tmp_path, monkeypatch):
+        """mif1 major brand with heic compatible brand (common iOS still layout)."""
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        from gateway.platforms.base import cache_image_from_bytes
+
+        # major brand mif1, compatible brand heic at offset 16
+        heif = (24).to_bytes(4, "big") + b"ftypmif1" + b"\x00\x00\x00\x00" + b"heic"
+        path = cache_image_from_bytes(heif + b"\x00" * 8, ".heif")
+        assert path.endswith(".heif")
+
+    def test_rejects_unrelated_ftyp(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        from gateway.platforms.base import cache_image_from_bytes
+
+        mp4 = (24).to_bytes(4, "big") + b"ftypisom" + b"\x00\x00\x00\x00" + b"isom"
+        with pytest.raises(ValueError, match="non-image data"):
+            cache_image_from_bytes(mp4, ".heic")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -208,38 +208,6 @@ class TestDocumentDownloadBlock:
         assert "Please summarize" in event.text
 
     @pytest.mark.asyncio
-    async def test_zip_document_cached(self, adapter):
-        """A .zip upload should be cached as a supported document."""
-        doc = _make_document(file_name="archive.zip", mime_type="application/zip", file_size=100)
-        msg = _make_message(document=doc)
-        update = _make_update(msg)
-
-        await adapter._handle_media_message(update, MagicMock())
-        event = adapter.handle_message.call_args[0][0]
-        assert event.media_urls and event.media_urls[0].endswith("archive.zip")
-        assert event.media_types == ["application/zip"]
-
-    @pytest.mark.asyncio
-    async def test_png_document_is_routed_as_image(self, adapter):
-        """Telegram documents that are really PNGs should use the image path."""
-        file_obj = _make_file_obj(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
-        doc = _make_document(file_name="screenshot.png", mime_type="image/png", file_size=9, file_obj=file_obj)
-        msg = _make_message(document=doc)
-        update = _make_update(msg)
-
-        with patch.object(adapter, "_photo_batch_key", return_value="batch-1"), patch.object(
-            adapter, "_enqueue_photo_event"
-        ) as enqueue_mock:
-            await adapter._handle_media_message(update, MagicMock())
-
-        enqueue_mock.assert_called_once()
-        event = enqueue_mock.call_args.args[1]
-        assert event.message_type == MessageType.PHOTO
-        assert event.media_urls and event.media_urls[0].endswith(".png")
-        assert event.media_types == ["image/png"]
-        assert adapter.handle_message.call_count == 0
-
-    @pytest.mark.asyncio
     async def test_heic_document_is_routed_as_image(self, adapter, tmp_path, monkeypatch):
         """iOS HEIC sent as a Telegram document must not be dropped."""
         monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
@@ -270,48 +238,16 @@ class TestDocumentDownloadBlock:
         assert not (event.text or "").lower().startswith("image document")
 
     @pytest.mark.asyncio
-    async def test_heic_document_raw_fallback_when_image_cache_rejects(
-        self, adapter, tmp_path, monkeypatch
-    ):
-        """If image cache still rejects HEIC, preserve raw bytes via document cache."""
-        monkeypatch.setattr("gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache")
-        heic_bytes = (24).to_bytes(4, "big") + b"ftypheic" + b"\x00\x00\x00\x00" + b"mif1heic"
-        file_obj = _make_file_obj(heic_bytes)
+    async def test_spoofed_heic_document_falls_back_with_error(self, adapter):
+        """A .heic filename with non-image bytes must not become a PHOTO event."""
+        file_obj = _make_file_obj(b"not-a-real-image")
         doc = _make_document(
-            file_name="photo.heic",
-            mime_type="image/heic",
-            file_size=len(heic_bytes),
-            file_obj=file_obj,
+            file_name="spoofed.heic", mime_type="image/heic", file_size=16, file_obj=file_obj
         )
         msg = _make_message(document=doc)
         update = _make_update(msg)
 
-        with (
-            patch(
-                "plugins.platforms.telegram.adapter.cache_image_from_bytes",
-                side_effect=ValueError("Refusing to cache non-image data"),
-            ),
-            patch.object(adapter, "_photo_batch_key", return_value="batch-heic-fb"),
-            patch.object(adapter, "_enqueue_photo_event") as enqueue_mock,
-        ):
-            await adapter._handle_media_message(update, MagicMock())
-
-        enqueue_mock.assert_called_once()
-        event = enqueue_mock.call_args.args[1]
-        assert event.message_type == MessageType.PHOTO
-        assert event.media_types == ["image/heic"]
-        assert event.media_urls and "photo.heic" in event.media_urls[0]
-        assert adapter.handle_message.call_count == 0
-
-    @pytest.mark.asyncio
-    async def test_spoofed_png_document_falls_back_with_error(self, adapter):
-        """A .png filename with non-image bytes should fail clearly, not disappear."""
-        file_obj = _make_file_obj(b"not-a-real-image")
-        doc = _make_document(file_name="spoofed.png", mime_type="image/png", file_size=16, file_obj=file_obj)
-        msg = _make_message(document=doc)
-        update = _make_update(msg)
-
-        with patch.object(adapter, "_photo_batch_key", return_value="batch-2"), patch.object(
+        with patch.object(adapter, "_photo_batch_key", return_value="batch-spoof"), patch.object(
             adapter, "_enqueue_photo_event"
         ) as enqueue_mock:
             await adapter._handle_media_message(update, MagicMock())
@@ -319,86 +255,6 @@ class TestDocumentDownloadBlock:
         enqueue_mock.assert_not_called()
         event = adapter.handle_message.call_args[0][0]
         assert "could not be read as an image" in event.text
-
-    @pytest.mark.asyncio
-    async def test_oversized_file_rejected(self, adapter):
-        doc = _make_document(file_name="huge.pdf", file_size=25 * 1024 * 1024)
-        msg = _make_message(document=doc)
-        update = _make_update(msg)
-
-        await adapter._handle_media_message(update, MagicMock())
-        event = adapter.handle_message.call_args[0][0]
-        assert "too large" in event.text
-
-    @pytest.mark.asyncio
-    async def test_none_file_size_rejected(self, adapter):
-        """Security fix: file_size=None must be rejected (not silently allowed)."""
-        doc = _make_document(file_name="tricky.pdf", file_size=None)
-        msg = _make_message(document=doc)
-        update = _make_update(msg)
-
-        await adapter._handle_media_message(update, MagicMock())
-        event = adapter.handle_message.call_args[0][0]
-        assert "too large" in event.text or "could not be verified" in event.text
-
-    @pytest.mark.asyncio
-    async def test_missing_filename_uses_mime_lookup(self, adapter):
-        """No file_name but valid mime_type should resolve to extension."""
-        content = b"some pdf bytes"
-        file_obj = _make_file_obj(content)
-        doc = _make_document(
-            file_name=None, mime_type="application/pdf",
-            file_size=len(content), file_obj=file_obj,
-        )
-        msg = _make_message(document=doc)
-        update = _make_update(msg)
-
-        await adapter._handle_media_message(update, MagicMock())
-        event = adapter.handle_message.call_args[0][0]
-        assert len(event.media_urls) == 1
-        assert event.media_types == ["application/pdf"]
-
-    @pytest.mark.asyncio
-    async def test_missing_filename_and_mime_cached_as_octet_stream(self, adapter):
-        """No filename and no mime: cached anyway as application/octet-stream.
-
-        Authorization to message the agent is the gate, not the file type — an
-        untyped upload is still surfaced to the agent as a cached path.
-        """
-        content = b"\x00\x01\x02 untyped payload"
-        file_obj = _make_file_obj(content)
-        doc = _make_document(
-            file_name=None, mime_type=None, file_size=len(content), file_obj=file_obj,
-        )
-        msg = _make_message(document=doc)
-        update = _make_update(msg)
-
-        await adapter._handle_media_message(update, MagicMock())
-        event = adapter.handle_message.call_args[0][0]
-        assert len(event.media_urls) == 1
-        assert event.media_types == ["application/octet-stream"]
-        assert "Unsupported" not in (event.text or "")
-
-    @pytest.mark.asyncio
-    async def test_unicode_decode_error_handled(self, adapter):
-        """Binary bytes that aren't valid UTF-8 in a .txt — content not injected but file still cached."""
-        binary = bytes(range(128, 256))  # not valid UTF-8
-        file_obj = _make_file_obj(binary)
-        doc = _make_document(
-            file_name="binary.txt", mime_type="text/plain",
-            file_size=len(binary), file_obj=file_obj,
-        )
-        msg = _make_message(document=doc)
-        update = _make_update(msg)
-
-        await adapter._handle_media_message(update, MagicMock())
-        event = adapter.handle_message.call_args[0][0]
-        # File should still be cached
-        assert len(event.media_urls) == 1
-        assert os.path.exists(event.media_urls[0])
-        # Content NOT injected — text should be empty (no caption set)
-        assert "[Content of" not in (event.text or "")
-
 
     @pytest.mark.asyncio
     async def test_text_injection_capped(self, adapter):

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -207,6 +207,198 @@ class TestDocumentDownloadBlock:
         assert "file text" in event.text
         assert "Please summarize" in event.text
 
+    @pytest.mark.asyncio
+    async def test_zip_document_cached(self, adapter):
+        """A .zip upload should be cached as a supported document."""
+        doc = _make_document(file_name="archive.zip", mime_type="application/zip", file_size=100)
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls and event.media_urls[0].endswith("archive.zip")
+        assert event.media_types == ["application/zip"]
+
+    @pytest.mark.asyncio
+    async def test_png_document_is_routed_as_image(self, adapter):
+        """Telegram documents that are really PNGs should use the image path."""
+        file_obj = _make_file_obj(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+        doc = _make_document(file_name="screenshot.png", mime_type="image/png", file_size=9, file_obj=file_obj)
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        with patch.object(adapter, "_photo_batch_key", return_value="batch-1"), patch.object(
+            adapter, "_enqueue_photo_event"
+        ) as enqueue_mock:
+            await adapter._handle_media_message(update, MagicMock())
+
+        enqueue_mock.assert_called_once()
+        event = enqueue_mock.call_args.args[1]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls and event.media_urls[0].endswith(".png")
+        assert event.media_types == ["image/png"]
+        assert adapter.handle_message.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_heic_document_is_routed_as_image(self, adapter, tmp_path, monkeypatch):
+        """iOS HEIC sent as a Telegram document must not be dropped."""
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        # Minimal ISO-BMFF ftyp box with major brand 'heic'.
+        heic_bytes = (24).to_bytes(4, "big") + b"ftypheic" + b"\x00\x00\x00\x00" + b"mif1heic"
+        file_obj = _make_file_obj(heic_bytes)
+        doc = _make_document(
+            file_name="IMG_0001.HEIC",
+            mime_type="image/heic",
+            file_size=len(heic_bytes),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        with patch.object(adapter, "_photo_batch_key", return_value="batch-heic"), patch.object(
+            adapter, "_enqueue_photo_event"
+        ) as enqueue_mock:
+            await adapter._handle_media_message(update, MagicMock())
+
+        enqueue_mock.assert_called_once()
+        event = enqueue_mock.call_args.args[1]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls and event.media_urls[0].endswith(".heic")
+        assert event.media_types == ["image/heic"]
+        assert adapter.handle_message.call_count == 0
+        # Must not surface the old "could not be read as an image" dead-end.
+        assert not (event.text or "").lower().startswith("image document")
+
+    @pytest.mark.asyncio
+    async def test_heic_document_raw_fallback_when_image_cache_rejects(
+        self, adapter, tmp_path, monkeypatch
+    ):
+        """If image cache still rejects HEIC, preserve raw bytes via document cache."""
+        monkeypatch.setattr("gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache")
+        heic_bytes = (24).to_bytes(4, "big") + b"ftypheic" + b"\x00\x00\x00\x00" + b"mif1heic"
+        file_obj = _make_file_obj(heic_bytes)
+        doc = _make_document(
+            file_name="photo.heic",
+            mime_type="image/heic",
+            file_size=len(heic_bytes),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        with (
+            patch(
+                "plugins.platforms.telegram.adapter.cache_image_from_bytes",
+                side_effect=ValueError("Refusing to cache non-image data"),
+            ),
+            patch.object(adapter, "_photo_batch_key", return_value="batch-heic-fb"),
+            patch.object(adapter, "_enqueue_photo_event") as enqueue_mock,
+        ):
+            await adapter._handle_media_message(update, MagicMock())
+
+        enqueue_mock.assert_called_once()
+        event = enqueue_mock.call_args.args[1]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/heic"]
+        assert event.media_urls and "photo.heic" in event.media_urls[0]
+        assert adapter.handle_message.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_spoofed_png_document_falls_back_with_error(self, adapter):
+        """A .png filename with non-image bytes should fail clearly, not disappear."""
+        file_obj = _make_file_obj(b"not-a-real-image")
+        doc = _make_document(file_name="spoofed.png", mime_type="image/png", file_size=16, file_obj=file_obj)
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        with patch.object(adapter, "_photo_batch_key", return_value="batch-2"), patch.object(
+            adapter, "_enqueue_photo_event"
+        ) as enqueue_mock:
+            await adapter._handle_media_message(update, MagicMock())
+
+        enqueue_mock.assert_not_called()
+        event = adapter.handle_message.call_args[0][0]
+        assert "could not be read as an image" in event.text
+
+    @pytest.mark.asyncio
+    async def test_oversized_file_rejected(self, adapter):
+        doc = _make_document(file_name="huge.pdf", file_size=25 * 1024 * 1024)
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert "too large" in event.text
+
+    @pytest.mark.asyncio
+    async def test_none_file_size_rejected(self, adapter):
+        """Security fix: file_size=None must be rejected (not silently allowed)."""
+        doc = _make_document(file_name="tricky.pdf", file_size=None)
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert "too large" in event.text or "could not be verified" in event.text
+
+    @pytest.mark.asyncio
+    async def test_missing_filename_uses_mime_lookup(self, adapter):
+        """No file_name but valid mime_type should resolve to extension."""
+        content = b"some pdf bytes"
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name=None, mime_type="application/pdf",
+            file_size=len(content), file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert len(event.media_urls) == 1
+        assert event.media_types == ["application/pdf"]
+
+    @pytest.mark.asyncio
+    async def test_missing_filename_and_mime_cached_as_octet_stream(self, adapter):
+        """No filename and no mime: cached anyway as application/octet-stream.
+
+        Authorization to message the agent is the gate, not the file type — an
+        untyped upload is still surfaced to the agent as a cached path.
+        """
+        content = b"\x00\x01\x02 untyped payload"
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name=None, mime_type=None, file_size=len(content), file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert len(event.media_urls) == 1
+        assert event.media_types == ["application/octet-stream"]
+        assert "Unsupported" not in (event.text or "")
+
+    @pytest.mark.asyncio
+    async def test_unicode_decode_error_handled(self, adapter):
+        """Binary bytes that aren't valid UTF-8 in a .txt — content not injected but file still cached."""
+        binary = bytes(range(128, 256))  # not valid UTF-8
+        file_obj = _make_file_obj(binary)
+        doc = _make_document(
+            file_name="binary.txt", mime_type="text/plain",
+            file_size=len(binary), file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        # File should still be cached
+        assert len(event.media_urls) == 1
+        assert os.path.exists(event.media_urls[0])
+        # Content NOT injected — text should be empty (no caption set)
+        assert "[Content of" not in (event.text or "")
+
 
     @pytest.mark.asyncio
     async def test_text_injection_capped(self, adapter):

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -306,6 +306,70 @@ class TestDocumentDownloadBlock:
         assert adapter.handle_message.call_count == 0
 
     @pytest.mark.asyncio
+    async def test_heic_document_is_routed_as_image(self, adapter, tmp_path, monkeypatch):
+        """iOS HEIC sent as a Telegram document must not be dropped."""
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+        # Minimal ISO-BMFF ftyp box with major brand 'heic'.
+        heic_bytes = (24).to_bytes(4, "big") + b"ftypheic" + b"\x00\x00\x00\x00" + b"mif1heic"
+        file_obj = _make_file_obj(heic_bytes)
+        doc = _make_document(
+            file_name="IMG_0001.HEIC",
+            mime_type="image/heic",
+            file_size=len(heic_bytes),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        with patch.object(adapter, "_photo_batch_key", return_value="batch-heic"), patch.object(
+            adapter, "_enqueue_photo_event"
+        ) as enqueue_mock:
+            await adapter._handle_media_message(update, MagicMock())
+
+        enqueue_mock.assert_called_once()
+        event = enqueue_mock.call_args.args[1]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls and event.media_urls[0].endswith(".heic")
+        assert event.media_types == ["image/heic"]
+        assert adapter.handle_message.call_count == 0
+        # Must not surface the old "could not be read as an image" dead-end.
+        assert not (event.text or "").lower().startswith("image document")
+
+    @pytest.mark.asyncio
+    async def test_heic_document_raw_fallback_when_image_cache_rejects(
+        self, adapter, tmp_path, monkeypatch
+    ):
+        """If image cache still rejects HEIC, preserve raw bytes via document cache."""
+        monkeypatch.setattr("gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache")
+        heic_bytes = (24).to_bytes(4, "big") + b"ftypheic" + b"\x00\x00\x00\x00" + b"mif1heic"
+        file_obj = _make_file_obj(heic_bytes)
+        doc = _make_document(
+            file_name="photo.heic",
+            mime_type="image/heic",
+            file_size=len(heic_bytes),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        with (
+            patch(
+                "plugins.platforms.telegram.adapter.cache_image_from_bytes",
+                side_effect=ValueError("Refusing to cache non-image data"),
+            ),
+            patch.object(adapter, "_photo_batch_key", return_value="batch-heic-fb"),
+            patch.object(adapter, "_enqueue_photo_event") as enqueue_mock,
+        ):
+            await adapter._handle_media_message(update, MagicMock())
+
+        enqueue_mock.assert_called_once()
+        event = enqueue_mock.call_args.args[1]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_types == ["image/heic"]
+        assert event.media_urls and "photo.heic" in event.media_urls[0]
+        assert adapter.handle_message.call_count == 0
+
+    @pytest.mark.asyncio
     async def test_spoofed_png_document_falls_back_with_error(self, adapter):
         """A .png filename with non-image bytes should fail clearly, not disappear."""
         file_obj = _make_file_obj(b"not-a-real-image")


### PR DESCRIPTION
# fix(telegram): preserve HEIC/HEIF image-documents (iOS photos)

## Summary

iPhone photos sent as Telegram **documents** (common when users pick "File" / "Send without compression") are HEIC/HEIF. Stock Hermes routes `image/*` documents into the image-cache path, but `cache_image_from_bytes` rejected HEIC because `_looks_like_image` only knew PNG/JPEG/GIF/BMP/WEBP magic. The adapter then replaced the media with a text error and **dropped the photo**.

This PR:

1. **Root cause:** teach `_looks_like_image` / `cache_image_from_bytes` to accept HEIC/HEIF ISO-BMFF `ftyp` brands (helps every platform that uses the shared cache helper). Compatible brands are scanned only inside the declared `ftyp` box; AVIF brands win when both families appear.
2. **Telegram maps:** recognize `.heic` / `.heif` and related MIME types so the document path keeps the correct extension (not a mislabeled `.jpg`).
3. Spoofed non-image `.heic` files still get the clear error path. No raw-bytes fallback that trusts filename/MIME after the sniffer rejects the payload.

No new dependencies. No vision-provider transcoding (JPEG/PNG still preferred for native vision).

## Related

- Residual hole after Telegram image-document routing (`77c4675` / earlier `bd0c54d`).
- Related class of work: Discord uncommon formats / mixed attachments (#25935, #53923) — does **not** cover this Telegram HEIC document drop.

## How to test

```bash
scripts/run_tests.sh tests/gateway/test_media_download_retry.py tests/gateway/test_telegram_documents.py tests/agent/test_image_routing.py
```

Manual (optional):

1. Telegram DM to Hermes.
2. From iPhone, send a HEIC as **File** (not compressed photo).
3. Expect a photo event with media path ending in `.heic`, **not** "could not be read as an image".

## Checklist

- [x] Bug fix against current `main`
- [x] Tests for HEIC sniffer + Telegram happy path + spoofed HEIC + bounded `ftyp` parse
- [x] No new required PyPI dependency
- [x] JPEG/PNG/WebP behavior unchanged
