### PR TITLE
fix(weixin): preserve voice transcript origin

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -963,7 +963,10 @@ def _extract_text(item_list: List[Dict[str, Any]]) -> str:
         if item.get("type") == ITEM_VOICE:
             voice_text = str((item.get("voice_item") or {}).get("text") or "")
             if voice_text:
-                return voice_text
+                # Weixin can supply its own speech-to-text result without the
+                # original audio. Preserve the voice origin so the agent can
+                # distinguish this from text typed by the user.
+                return f"[Voice transcription provided by Weixin]\n{voice_text}"
     return ""
 
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -27,6 +27,41 @@ def _make_adapter() -> WeixinAdapter:
     )
 
 
+class TestWeixinInboundVoiceTranscript:
+    def test_voice_transcript_keeps_voice_origin_marker(self):
+        item_list = [
+            {
+                "type": weixin.ITEM_VOICE,
+                "voice_item": {"text": "帮我查一下今天天气"},
+            }
+        ]
+
+        assert weixin._extract_text(item_list) == (
+            "[Voice transcription provided by Weixin]\n"
+            "帮我查一下今天天气"
+        )
+
+    def test_typed_text_remains_unmarked(self):
+        item_list = [
+            {
+                "type": weixin.ITEM_TEXT,
+                "text_item": {"text": "帮我查一下今天天气"},
+            }
+        ]
+
+        assert weixin._extract_text(item_list) == "帮我查一下今天天气"
+
+    def test_empty_voice_transcript_keeps_empty_fallback(self):
+        item_list = [
+            {
+                "type": weixin.ITEM_VOICE,
+                "voice_item": {"text": ""},
+            }
+        ]
+
+        assert weixin._extract_text(item_list) == ""
+
+
 class TestWeixinFormatting:
     def test_format_message_preserves_markdown(self):
         adapter = _make_adapter()


### PR DESCRIPTION
## What does this PR do?

Preserves the voice origin when Weixin supplies a server-side transcript in `voice_item.text`.

Previously, `_extract_text()` returned the transcript as plain text. Because `_download_voice()` intentionally skips downloading audio when Weixin already supplied text, the resulting event had no media and was classified as ordinary text. Downstream agents therefore could not distinguish a voice transcript from text typed by the user.

This change adds a compact platform-origin marker while leaving ordinary text messages unchanged. It is a deliberately narrower alternative to #27235: it preserves the missing semantic information without adding outbound echo state or a new behavior/configuration knob.

## Related Issue

Related to #11686 and #27235.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `gateway/platforms/weixin.py` to retain an explicit voice-transcript marker for `voice_item.text`.
- Add a regression test in `tests/gateway/test_weixin.py` covering the exact inbound payload shape.

## How to Test

1. Send a Weixin voice message for which Weixin provides `voice_item.text`.
2. Confirm the agent receives `[Voice transcription provided by Weixin]` followed by the transcript.
3. Confirm typed text continues to pass through unchanged.

Automated verification:

```text
scripts/run_tests.sh tests/gateway/test_weixin.py -v
72 passed, 0 failed

venv/bin/ruff check gateway/platforms/weixin.py tests/gateway/test_weixin.py
All checks passed!
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs and issues
- [x] My PR contains only related changes
- [ ] I've run the entire `pytest tests/ -q` suite locally (targeted Weixin suite passes)
- [x] I've added tests for my changes
- [x] I've tested on Linux through a live Weixin gateway

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow change
- [x] Cross-platform impact considered; change is platform payload text handling only
- [x] Tool descriptions/schemas update — N/A
