### PR TITLE
fix(gateway): steer busy voice follow-ups after STT

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5359,6 +5359,62 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._enqueue_fifo(session_key, event, adapter)
 
+    async def _prepare_busy_steer_text(self, event: MessageEvent) -> str:
+        """Return steerable text for a busy follow-up, transcribing voice first.
+
+        Fresh and queued voice messages reach the normal inbound STT pipeline,
+        but successful steer messages intentionally bypass that queue. Without
+        preprocessing here, a media-only voice follow-up has an empty text
+        payload and steer mode silently degrades to queue mode.
+
+        Audio file attachments remain files; only voice-message media follows
+        the automatic STT contract used by ``_prepare_inbound_message_text``.
+        If transcription fails, preserve any caption and let the existing
+        steer fallback handle an otherwise empty event without losing it.
+        """
+        text = (event.text or "").strip()
+        media_urls = getattr(event, "media_urls", None) or []
+        media_types = getattr(event, "media_types", None) or []
+        voice_paths: List[str] = []
+
+        for index, path in enumerate(media_urls):
+            media_type = media_types[index] if index < len(media_types) else ""
+            is_voice = event.message_type == MessageType.VOICE or (
+                media_type.startswith("audio/")
+                and event.message_type not in {MessageType.AUDIO, MessageType.DOCUMENT}
+            )
+            if is_voice:
+                voice_paths.append(path)
+
+        if not voice_paths:
+            return text
+
+        enriched_text, successful_transcripts = await self._enrich_message_with_transcription(
+            text,
+            voice_paths,
+        )
+        if not successful_transcripts:
+            return text
+
+        if self._should_echo_stt_transcripts():
+            adapter = self._adapter_for_source(event.source)
+            if adapter:
+                echo_meta = self._thread_metadata_for_source(
+                    event.source,
+                    self._reply_anchor_for_event(event),
+                )
+                for transcript in successful_transcripts:
+                    try:
+                        await adapter.send(
+                            event.source.chat_id,
+                            f'🎙️ "{transcript}"',
+                            metadata=echo_meta,
+                        )
+                    except Exception as exc:
+                        logger.debug("Busy-steer transcript echo failed (non-fatal): %s", exc)
+
+        return (enriched_text or text).strip()
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -5545,7 +5601,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             effective_mode = "queue"
         steered = False
         if effective_mode == "steer":
-            steer_text = (event.text or "").strip()
+            steer_text = await self._prepare_busy_steer_text(event)
             can_steer = (
                 steer_text
                 and running_agent is not None

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -302,6 +302,44 @@ class TestBusySessionAck:
         assert "Interrupting" not in content
 
     @pytest.mark.asyncio
+    async def test_steer_mode_transcribes_voice_before_injection(self, monkeypatch):
+        """A busy voice follow-up is transcribed and steered, never queued."""
+        import gateway.run as _gr
+
+        monkeypatch.delenv("HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED", raising=False)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        runner._should_echo_stt_transcripts = MagicMock(return_value=False)
+        runner._enrich_message_with_transcription = AsyncMock(
+            return_value=('"yönü teknik mimariye çevir"', ["yönü teknik mimariye çevir"])
+        )
+        adapter = _make_adapter()
+
+        event = _make_event(text="")
+        event.message_type = MessageType.VOICE
+        event.media_urls = ["/tmp/follow-up.ogg"]
+        event.media_types = ["audio/ogg"]
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        runner._enrich_message_with_transcription.assert_awaited_once_with(
+            "", ["/tmp/follow-up.ogg"]
+        )
+        agent.steer.assert_called_once_with('"yönü teknik mimariye çevir"')
+        agent.interrupt.assert_not_called()
+        assert sk not in adapter._pending_messages
+        content = adapter._send_with_retry.call_args.kwargs["content"]
+        assert "Steered" in content
+        assert "Queued" not in content
+
+    @pytest.mark.asyncio
     async def test_steer_mode_can_suppress_visible_ack_without_disabling_steer(self, monkeypatch):
         """busy_steer_ack_enabled=false keeps steering but drops the echo bubble."""
         import gateway.run as _gr


### PR DESCRIPTION
## What does this PR do?

Fixes busy-input `steer` behavior for voice messages.

A media-only voice follow-up reaches the gateway busy handler before the normal inbound STT pipeline. Its `event.text` is therefore empty, so `running_agent.steer()` cannot accept it and the gateway silently falls back to queue mode. That makes voice follow-ups behave differently from text follow-ups even when `display.busy_input_mode: steer` is configured.

This change transcribes voice-message media inside the busy steer path before calling `running_agent.steer()`. Successful transcriptions are injected into the active run and are not replayed as a later queued turn. Regular audio-file attachments remain outside automatic STT, matching the existing inbound behavior. If STT fails, any caption is preserved and the existing lossless fallback remains in place.

## Related Issue

No existing issue or PR found after searching open and closed items for busy voice/steer/transcription behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `GatewayRunner._prepare_busy_steer_text()` to transcribe voice-message media before steering.
- Reused the existing STT enrichment and transcript-echo contracts.
- Kept `MessageType.AUDIO` attachments as files rather than automatically transcribing them.
- Added a regression test asserting STT → `agent.steer(transcript)`, no interrupt, and no pending queue replay.

## How to Test

1. Configure `display.busy_input_mode: steer` and enable inbound STT.
2. Start a tool-using agent run from a messaging platform, then send a voice message while it is busy.
3. Verify the voice transcript is injected into the active run and the event is not queued for the next turn.

Targeted automated verification:

```bash
pytest -q tests/gateway/test_busy_session_ack.py tests/gateway/test_stt_transcript_echo_config.py
# 33 passed
```

A full `pytest tests/ -q` run was also attempted, but exceeded the 600-second local execution limit before completion; the targeted gateway/STT suites pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and documented in the new method docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture/workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — change uses existing platform-neutral STT/event abstractions
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool schema changed

## Screenshots / Logs

The regression test covers the original failure mode directly: a voice-only busy event is transcribed, passed to `agent.steer()`, and absent from the adapter pending queue.
