### PR TITLE
fix(projects): NFC-normalize path identity so accented folders keep their sessions (#65014)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -545,6 +545,24 @@ describe('liveSessionProjectId', () => {
       '/work/notes'
     )
   })
+
+  it('matches NFD and NFC spellings of the same accented folder (#65014)', () => {
+    // The same on-disk folder can reach us as NFC (typed paths, backend cwd)
+    // or NFD (macOS file pickers) — byte-different, visually identical.
+    const nfc = '/projects/sv/bist\u00e5nd'
+    const nfd = nfc.normalize('NFD')
+
+    expect(nfd).not.toBe(nfc) // premise: distinct byte strings
+    expect(liveSessionProjectId(makeSession(nfd), [makeProject('p_bistand', [nfc])])).toBe('p_bistand')
+  })
+
+  it('matches a Windows cwd differing in both case and normalization form (#65014)', () => {
+    const id = liveSessionProjectId(makeSession('d:/projects/sv/bist\u00e5nd'.normalize('NFD')), [
+      makeProject('p_sv', ['D:\\Projects\\SV\\Bist\u00e5nd'.normalize('NFC')])
+    ])
+
+    expect(id).toBe('p_sv')
+  })
 })
 
 describe('sessionProjectColor', () => {

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -557,6 +557,24 @@ describe('liveSessionProjectId', () => {
       '/work/notes'
     )
   })
+
+  it('matches NFD and NFC spellings of the same accented folder (#65014)', () => {
+    // The same on-disk folder can reach us as NFC (typed paths, backend cwd)
+    // or NFD (macOS file pickers) — byte-different, visually identical.
+    const nfc = '/projects/sv/bist\u00e5nd'
+    const nfd = nfc.normalize('NFD')
+
+    expect(nfd).not.toBe(nfc) // premise: distinct byte strings
+    expect(liveSessionProjectId(makeSession(nfd), [makeProject('p_bistand', [nfc])])).toBe('p_bistand')
+  })
+
+  it('matches a Windows cwd differing in both case and normalization form (#65014)', () => {
+    const id = liveSessionProjectId(makeSession('d:/projects/sv/bist\u00e5nd'.normalize('NFD')), [
+      makeProject('p_sv', ['D:\\Projects\\SV\\Bist\u00e5nd'.normalize('NFC')])
+    ])
+
+    expect(id).toBe('p_sv')
+  })
 })
 
 describe('sessionProjectColor', () => {

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -565,11 +565,11 @@ describe('liveSessionProjectId', () => {
     const nfd = nfc.normalize('NFD')
 
     expect(nfd).not.toBe(nfc) // premise: distinct byte strings
-    expect(liveSessionProjectId(makeSession(nfd), [makeProject('p_bistand', [nfc])])).toBe('p_bistand')
+    expect(liveSessionProjectId(makeCwdSession(nfd), [makeProject('p_bistand', [nfc])])).toBe('p_bistand')
   })
 
   it('matches a Windows cwd differing in both case and normalization form (#65014)', () => {
-    const id = liveSessionProjectId(makeSession('d:/projects/sv/bist\u00e5nd'.normalize('NFD')), [
+    const id = liveSessionProjectId(makeCwdSession('d:/projects/sv/bist\u00e5nd'.normalize('NFD')), [
       makeProject('p_sv', ['D:\\Projects\\SV\\Bist\u00e5nd'.normalize('NFC')])
     ])
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -87,9 +87,15 @@ const isWindowsPath = (path: string): boolean =>
  * Segments for identity comparison: Windows paths fold case (and separators, via
  * {@link segments}) so `C:\Work` and `c:/work` are one lane; POSIX stays
  * case-sensitive. Comparison-only — emitted ids/labels keep their spelling.
+ *
+ * Segments are NFC-normalized before comparing: the same on-disk folder can
+ * reach us as NFC (typed paths, backend cwd) or NFD (macOS file pickers,
+ * HFS+/APFS round-trips), and case folding does not unify the two forms — an
+ * accented project folder would otherwise render empty (#65014). Mirrors
+ * `_comparison_segments` in `tui_gateway/project_tree.py`.
  */
 const comparisonSegments = (path: string): string[] => {
-  const segs = segments(path)
+  const segs = segments(path).map(seg => seg.normalize('NFC'))
 
   return isWindowsPath(path) ? segs.map(seg => seg.toLowerCase()) : segs
 }

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -89,9 +89,15 @@ const isWindowsPath = (path: string): boolean =>
  * Segments for identity comparison: Windows paths fold case (and separators, via
  * {@link segments}) so `C:\Work` and `c:/work` are one lane; POSIX stays
  * case-sensitive. Comparison-only — emitted ids/labels keep their spelling.
+ *
+ * Segments are NFC-normalized before comparing: the same on-disk folder can
+ * reach us as NFC (typed paths, backend cwd) or NFD (macOS file pickers,
+ * HFS+/APFS round-trips), and case folding does not unify the two forms — an
+ * accented project folder would otherwise render empty (#65014). Mirrors
+ * `_comparison_segments` in `tui_gateway/project_tree.py`.
  */
 const comparisonSegments = (path: string): string[] => {
-  const segs = segments(path)
+  const segs = segments(path).map(seg => seg.normalize('NFC'))
 
   return isWindowsPath(path) ? segs.map(seg => seg.toLowerCase()) : segs
 }

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -274,6 +274,44 @@ def test_posix_path_identity_remains_case_sensitive():
     ]
 
 
+def test_unicode_normalization_forms_share_one_project_identity():
+    # The same on-disk folder can reach the tree as different byte strings:
+    # macOS file pickers emit NFD ("a" + U+030A) while typed paths and
+    # os.getcwd() are usually NFC (U+00E5). Identity comparison must treat
+    # them as one path or the project renders empty (#65014).
+    import unicodedata
+
+    nfc = unicodedata.normalize("NFC", "/projects/sv/bist\u00e5nd")
+    nfd = unicodedata.normalize("NFD", nfc)
+    assert nfc != nfd  # premise: distinct byte strings for the same folder
+
+    explicit = _project("p_bistand", "Bist\u00e5nd", [nfc])
+    session = _session(nfd)
+
+    tree = pt.build_tree([explicit], [session], [], resolve=lambda _cwd: None, hydrate=True)
+
+    project = next(p for p in tree["projects"] if p["id"] == "p_bistand")
+    assert project["sessionCount"] == 1
+    # No stray auto-project for the NFD spelling of the same folder.
+    assert not any(p.get("isAuto") and "bist" in str(p["id"]) for p in tree["projects"])
+
+
+def test_windows_unicode_normalization_and_case_share_one_identity():
+    import unicodedata
+
+    folder_nfc = unicodedata.normalize("NFC", "D:/Projects/SV/Bist\u00e5nd")
+    cwd_nfd = unicodedata.normalize("NFD", "d:/projects/sv/bist\u00e5nd")
+    assert folder_nfc != cwd_nfd
+
+    explicit = _project("p_sv", "SV", [folder_nfc])
+    session = _session(cwd_nfd)
+
+    tree = pt.build_tree([explicit], [session], [], resolve=lambda _cwd: None, hydrate=True)
+
+    project = next(p for p in tree["projects"] if p["id"] == "p_sv")
+    assert project["sessionCount"] == 1
+
+
 def test_explicit_project_claims_sessions_and_beats_auto():
     project = _project("p_app", "App", ["/www/app"])
     resolve = _resolver(

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -356,6 +356,44 @@ def test_posix_path_identity_remains_case_sensitive():
     ]
 
 
+def test_unicode_normalization_forms_share_one_project_identity():
+    # The same on-disk folder can reach the tree as different byte strings:
+    # macOS file pickers emit NFD ("a" + U+030A) while typed paths and
+    # os.getcwd() are usually NFC (U+00E5). Identity comparison must treat
+    # them as one path or the project renders empty (#65014).
+    import unicodedata
+
+    nfc = unicodedata.normalize("NFC", "/projects/sv/bist\u00e5nd")
+    nfd = unicodedata.normalize("NFD", nfc)
+    assert nfc != nfd  # premise: distinct byte strings for the same folder
+
+    explicit = _project("p_bistand", "Bist\u00e5nd", [nfc])
+    session = _session(nfd)
+
+    tree = pt.build_tree([explicit], [session], [], resolve=lambda _cwd: None, hydrate=True)
+
+    project = next(p for p in tree["projects"] if p["id"] == "p_bistand")
+    assert project["sessionCount"] == 1
+    # No stray auto-project for the NFD spelling of the same folder.
+    assert not any(p.get("isAuto") and "bist" in str(p["id"]) for p in tree["projects"])
+
+
+def test_windows_unicode_normalization_and_case_share_one_identity():
+    import unicodedata
+
+    folder_nfc = unicodedata.normalize("NFC", "D:/Projects/SV/Bist\u00e5nd")
+    cwd_nfd = unicodedata.normalize("NFD", "d:/projects/sv/bist\u00e5nd")
+    assert folder_nfc != cwd_nfd
+
+    explicit = _project("p_sv", "SV", [folder_nfc])
+    session = _session(cwd_nfd)
+
+    tree = pt.build_tree([explicit], [session], [], resolve=lambda _cwd: None, hydrate=True)
+
+    project = next(p for p in tree["projects"] if p["id"] == "p_sv")
+    assert project["sessionCount"] == 1
+
+
 def test_explicit_project_claims_sessions_and_beats_auto():
     project = _project("p_app", "App", ["/www/app"])
     resolve = _resolver(

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -10,6 +10,7 @@ lane = the worktree path. Linked worktrees fold under their MAIN repo (common-di
 from __future__ import annotations
 
 import re
+import unicodedata
 from typing import Any, Callable, Optional
 
 # cwd -> ``{"repo_root", "worktree_root"}`` (COMMON main root / this cwd's checkout root);
@@ -62,10 +63,19 @@ def _is_windows_path(path: str) -> bool:
 
 
 def _comparison_segments(path: str) -> list[str]:
-    """Segments for identity comparison: Windows paths casefold (even on POSIX); display
-    paths and emitted IDs keep their spelling."""
-    segs = _segments(path)
-    return [s.casefold() for s in segs] if _is_windows_path(path) else segs
+    """Path segments suitable for identity comparisons on any host.
+
+    Windows paths remain case-insensitive even when tests or remote backends run
+    on POSIX. Display paths and emitted IDs keep their original spelling.
+
+    Segments are NFC-normalized before comparing: the same on-disk folder can
+    reach us as NFC (typed paths, os.getcwd()) or NFD (macOS file pickers,
+    HFS+/APFS round-trips), and ``casefold()`` does not unify the two forms —
+    an accented project folder would otherwise render empty (#65014). Mirrors
+    ``comparisonSegments`` in the desktop's ``workspace-groups.ts``.
+    """
+    segs = [unicodedata.normalize("NFC", segment) for segment in _segments(path)]
+    return [segment.casefold() for segment in segs] if _is_windows_path(path) else segs
 
 
 def _path_key(path: str) -> str:

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -26,6 +26,7 @@ returns the worktree's own root, which is why the client double-counted them).
 from __future__ import annotations
 
 import re
+import unicodedata
 from typing import Any, Callable, Optional
 
 # A cwd -> git identity resolver. Returns ``{"repo_root", "worktree_root"}`` where
@@ -85,8 +86,14 @@ def _comparison_segments(path: str) -> list[str]:
 
     Windows paths remain case-insensitive even when tests or remote backends run
     on POSIX. Display paths and emitted IDs keep their original spelling.
+
+    Segments are NFC-normalized before comparing: the same on-disk folder can
+    reach us as NFC (typed paths, os.getcwd()) or NFD (macOS file pickers,
+    HFS+/APFS round-trips), and ``casefold()`` does not unify the two forms —
+    an accented project folder would otherwise render empty (#65014). Mirrors
+    ``comparisonSegments`` in the desktop's ``workspace-groups.ts``.
     """
-    segs = _segments(path)
+    segs = [unicodedata.normalize("NFC", segment) for segment in _segments(path)]
     return [segment.casefold() for segment in segs] if _is_windows_path(path) else segs
 
 


### PR DESCRIPTION
## Summary

NFC-normalize the path-identity comparison (backend + desktop mirror) so a project folder containing an accented character keeps its sessions in the Desktop sidebar instead of rendering empty (#65014).

## Changes

- `tui_gateway/project_tree.py`: `_comparison_segments()` NFC-normalizes each segment before the existing Windows `casefold()` — every identity consumer inherits it (`_path_key`, `_lane_key`, `_FolderIndex.match`, `_project_for_session`)
- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts`: same one-line change in `comparisonSegments()`, the documented TS mirror — inherited by `pathKey()` / `isPathUnder()` in the live overlay
- `tests/tui_gateway/test_project_tree.py`: 2 invariant tests — NFD session cwd must match its NFC project folder (POSIX), and a Windows path differing in both case AND normalization form. Both fail on unfixed main
- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts`: the 2 mirror tests via `liveSessionProjectId` — both fail on unfixed code (verified red→green independently per side)

Comparison-only, like the existing case folding: emitted ids, labels, and persisted lane keys keep their original spelling. POSIX case sensitivity unchanged (`test_posix_path_identity_remains_case_sensitive` and its desktop twin pass untouched).

## Root cause

The same on-disk folder reaches the identity comparison as two different byte strings: NFC (`å` = U+00E5 — typed paths, `os.getcwd()`) vs NFD (`a` + U+030A — macOS file pickers, HFS+/APFS round-trips). Neither side of the comparison unifies the forms: `casefold()`/`toLowerCase()` fold case, not normalization form. Paths flow in from four sources that don't agree on form (projects.db folder rows, state.db `cwd`, the Electron git-worktree probe, live `$sessions` rows), so any mismatch silently breaks session→project membership.

`_comparison_segments` was introduced with the authoritative tree builder (4e023f5b) mirroring the client's segment logic, and gained Windows case folding in ceb17916 — normalization form was never handled on either side.

The failure is also worse than "renders empty": the unmatched NFD session mints a phantom duplicate auto-project alongside the explicit one (see E2E below), so the bug presents as both an empty project lane and a stray duplicate.

The issue hypothesized a desktop-only bug (the reporter's backend matched because both their DB strings happened to share a form) — but the backend has the same latent hole, reproduced by the failing test on main. Fixing only the renderer would leave `projects.tree` grouping broken for the NFD-vs-NFC case, which is why both mirrors change together.

Adjacent to #64629 (separator/case identity, already handled) — this is normalization *form*, the remaining axis.

## Validation

| | Before | After |
|---|---|---|
| NFD cwd vs NFC explicit project folder | project `sessionCount=0` (empty lane) + phantom NFD auto-project holding the session | grouped under the explicit project, no phantom |
| Windows path, case + form both differ | no match | one identity |
| POSIX case-distinct paths | distinct (case-sensitive) | distinct (unchanged) |
| Emitted ids/labels/lane keys | original spelling | original spelling (comparison-only) |

E2E on the real `build_tree()` path (`projects.tree` datasource — the desktop renders this 1:1):

```
folder (NFC): '/projects/sv/bistånd'  len=20
cwd    (NFD): '/projects/sv/bistånd'  len=21
byte-equal: False

BEFORE (main af250d8):
  project id='p_bistand'            sessionCount=0  isAuto=False   ← reported symptom
  project id='/projects/sv/bistånd' sessionCount=1  isAuto=True    ← phantom duplicate
AFTER (this PR):
  project id='p_bistand'            sessionCount=1  isAuto=False
```

- `scripts/run_tests.sh tests/tui_gateway/ -q` — 28 files, 347 passed, 0 failed (CI-parity wrapper)
- `apps/desktop`: `npx vitest run …/workspace-groups.test.ts` — 41 passed; `npx tsc --noEmit` clean

Fixes #65014. Refs #64629.
