### PR TITLE
test(skills): deflake config-cache invalidation on coarse-mtime filesystems

### DIFF
--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -166,8 +166,17 @@ def test_skill_config_raw_cache_invalidates_on_config_edit(tmp_path, monkeypatch
     assert get_disabled_skill_names() == {"old-skill"}
 
     config_path.write_text("skills:\n  disabled: [new-skill]\n", encoding="utf-8")
+    # Force an mtime the cache is guaranteed to read as newer. The cache keys
+    # on (path, st_mtime_ns, st_size); both configs are the same byte length,
+    # so mtime is the only field that can invalidate the entry. `os.utime(...,
+    # None)` stamps the current time, which on filesystems with coarse (1s)
+    # mtime granularity can equal the first write's mtime when both writes land
+    # in the same second — leaving the stale entry cached and flaking the
+    # assertion. Bump a full second past the current value instead, which
+    # survives second-granularity truncation.
     import os
-    os.utime(config_path, None)
+    bumped_ns = config_path.stat().st_mtime_ns + 1_000_000_000
+    os.utime(config_path, ns=(bumped_ns, bumped_ns))
 
     assert get_disabled_skill_names() == {"new-skill"}
 


### PR DESCRIPTION
## What does this PR do?

Deflakes `tests/agent/test_skill_utils.py::test_skill_config_raw_cache_invalidates_on_config_edit`, which fails intermittently on CI runners whose filesystem has coarse (1-second) mtime granularity.

The raw config cache in `agent/skill_utils.py` keys entries on `(path, st_mtime_ns, st_size)` (introduced in #46149). The test writes `config.yaml` with `disabled: [old-skill]`, reads it (populating the cache), rewrites it with `disabled: [new-skill]`, then asserts the next read reflects the edit. Both configs are the **same byte length** (32 bytes), so `st_size` is identical and `st_mtime_ns` is the only field that can invalidate the entry.

The test forces a mtime change with `os.utime(config_path, None)` — added in #46149 alongside the cache precisely to make the edit detectable. But `None` stamps the *current* time: on a filesystem with 1s mtime granularity, when both writes land in the same second the second write shares the first write's mtime, the cache key doesn't change, the stale entry stays cached, and the final assertion flakes. Runners with nanosecond mtime resolution never hit this, which is why it passes almost everywhere and only flakes under coarse-granularity/loaded runners.

The fix keeps that intent but makes it deterministic: stamp an mtime a full second past the file's current value, which survives second-granularity truncation. It's a test-only change — the cache implementation is unchanged and correct for real usage, where config edits are always more than one mtime tick apart.

## Related Issue

No tracked issue — surfaced as an intermittent CI failure. Searched open and merged PRs/issues for `skill_config_raw_cache` / `get_disabled_skill_names cache` and found no existing report or fix. Cache and test both originate in #46149.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/agent/test_skill_utils.py`: replace `os.utime(config_path, None)` with an explicit `+1s` mtime bump (`os.utime(config_path, ns=(bumped_ns, bumped_ns))`) so the cache-invalidation assertion is deterministic under coarse mtime granularity. Comment added explaining why.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_skill_utils.py -q` — 24 passed.
2. The target test passes deterministically across repeated runs.
3. No production code changed; the cache contract (`mtime change ⇒ invalidation`) is exactly what the test still verifies.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`test(skills): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single one-hunk test change)
- [x] I've run the test suite for the touched file and it passes
- [x] I've added/improved tests for my changes (this *is* the test change)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5)

### Documentation & Housekeeping

- [x] Documentation — N/A (test-only)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — the fix specifically hardens the test across filesystems with different mtime granularity
- [x] Tool descriptions/schemas — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)