### PR TITLE
fix(mcp): ignore refreshes from closed or superseded sessions

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1127,6 +1127,70 @@ class TestMCPServerTask:
                 "mcp__srv__get_prompt",
             }
 
+    def test_refresh_tools_ignores_closed_session(self):
+        """A queued dynamic refresh can race with shutdown/reconnect."""
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("srv")
+        server.session = None
+        server._registered_tool_names = ["mcp__srv__old"]
+
+        asyncio.run(server._refresh_tools())
+
+        assert server._registered_tool_names == ["mcp__srv__old"]
+
+    def test_refresh_resolves_session_after_waiting_for_rpc_lock(self):
+        """A reconnect while queued must query the replacement session."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("srv")
+            old_session = MagicMock()
+            old_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+            new_session = MagicMock()
+            new_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+            server.session = old_session
+
+            await server._rpc_lock.acquire()
+            task = asyncio.create_task(server._refresh_tools())
+            await asyncio.sleep(0)
+            server.session = new_session
+            server._rpc_lock.release()
+            await task
+
+            old_session.list_tools.assert_not_awaited()
+            new_session.list_tools.assert_awaited_once()
+
+        asyncio.run(_test())
+
+    def test_refresh_discards_response_from_superseded_session(self):
+        """An old in-flight response must not mutate the current registry."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            started = asyncio.Event()
+            finish = asyncio.Event()
+            server = MCPServerTask("srv")
+            old_session = MagicMock()
+
+            async def list_tools():
+                started.set()
+                await finish.wait()
+                return SimpleNamespace(tools=[])
+
+            old_session.list_tools = AsyncMock(side_effect=list_tools)
+            server.session = old_session
+            server._registered_tool_names = ["mcp__srv__old"]
+            task = asyncio.create_task(server._refresh_tools())
+            await started.wait()
+            server.session = MagicMock()
+            finish.set()
+            await task
+
+            assert server._registered_tool_names == ["mcp__srv__old"]
+
+        asyncio.run(_test())
+
     def test_schedule_tools_refresh_keeps_task_until_done(self):
         """Background refresh tasks are strongly referenced and then discarded."""
         from tools.mcp_tool import MCPServerTask

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1938,9 +1938,27 @@ class MCPServerTask:
             # Capture old tool names for change diff
             old_tool_names = set(self._registered_tool_names)
 
-            # 1. Fetch current tool list from server
+            # 1. Resolve the current session only after entering the RPC lock.
+            # A refresh can queue behind shutdown/reconnect; capturing before
+            # the lock would query a superseded session.
             async with self._rpc_lock:
-                tools_result = await self.session.list_tools()
+                session = self.session
+                if session is None:
+                    logger.debug(
+                        "MCP server '%s': skipping dynamic tool refresh; session is closed",
+                        self.name,
+                    )
+                    return
+                tools_result = await session.list_tools()
+
+            # Reconnect may replace the session while list_tools is in flight.
+            # Never let an old response overwrite the current registry.
+            if self.session is not session:
+                logger.debug(
+                    "MCP server '%s': discarding tool refresh from superseded session",
+                    self.name,
+                )
+                return
             new_mcp_tools = tools_result.tools if hasattr(tools_result, "tools") else []
 
             # 2. Re-register with fresh tool list. Avoid nuke-and-repave for


### PR DESCRIPTION
## Summary

- resolve the active MCP session only after acquiring the RPC lock
- skip refresh cleanly when shutdown has cleared the session
- discard tool-list responses from sessions superseded during reconnect
- cover closed, queued-replacement, and in-flight-replacement races

## Why

A queued `notifications/tools/list_changed` refresh can overlap shutdown or reconnect. Capturing the session before the RPC lock can query a stale session and let an old response overwrite the current tool registry.

## Tests

```text
215 passed in tests/tools/test_mcp_tool.py
```
