### PR TITLE
fix(gemini): accept validated inline video data parts

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -219,15 +219,28 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             text = item.get("text")
             if isinstance(text, str) and text:
                 parts.append({"text": text})
-        elif ptype == "image_url":
-            url = ((item.get("image_url") or {}).get("url") or "")
+        elif ptype in {"image_url", "video_url"}:
+            field = "video_url" if ptype == "video_url" else "image_url"
+            ref = item.get(field) or {}
+            url = ref.get("url", "") if isinstance(ref, dict) else ref
             if not isinstance(url, str) or not url.startswith("data:"):
                 continue
             try:
                 header, encoded = url.split(",", 1)
-                mime = header.split(":", 1)[1].split(";", 1)[0]
-                raw = base64.b64decode(encoded)
-            except Exception:
+                media_spec = header.split(":", 1)[1]
+                mime, *params = media_spec.split(";")
+                if "base64" not in {param.strip().lower() for param in params}:
+                    continue
+                if ptype == "video_url" and mime not in {
+                    "video/mp4",
+                    "video/mpeg",
+                    "video/webm",
+                    "video/quicktime",
+                    "video/avi",
+                }:
+                    continue
+                raw = base64.b64decode(encoded, validate=True)
+            except (ValueError, TypeError, base64.binascii.Error):
                 continue
             parts.append(
                 {

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -19,6 +19,48 @@ class DummyResponse:
         return self._payload
 
 
+def test_build_native_request_accepts_base64_video_parts():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this clip"},
+                {
+                    "type": "video_url",
+                    "video_url": {"url": "data:video/mp4;base64,AAEC"},
+                },
+            ],
+        }],
+        tools=[],
+        tool_choice=None,
+    )
+    assert request["contents"][0]["parts"] == [
+        {"text": "Describe this clip"},
+        {"inlineData": {"mimeType": "video/mp4", "data": "AAEC"}},
+    ]
+
+
+def test_build_native_request_rejects_malformed_video_data_parts():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    for url in (
+        "data:video/mp4,AAEC",
+        "data:video/mp4;base64,!!!!",
+        "data:text/plain;base64,AAEC",
+        "data:video/x-matroska;base64,AAEC",
+    ):
+        request = build_gemini_request(
+            messages=[{"role": "user", "content": [{
+                "type": "video_url", "video_url": {"url": url}
+            }]}],
+            tools=[],
+            tool_choice=None,
+        )
+        assert request["contents"] == []
+
+
 def test_build_native_request_preserves_thought_signature_on_tool_replay():
     from agent.gemini_native_adapter import build_gemini_request
 

--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -36,17 +36,17 @@ class TestDetectVideoMimeType:
     def test_mov(self, tmp_path):
         p = tmp_path / "clip.mov"
         p.write_bytes(b"\x00" * 10)
-        assert _detect_video_mime_type(p) == "video/mov"
+        assert _detect_video_mime_type(p) == "video/quicktime"
 
-    def test_avi_fallback_mp4(self, tmp_path):
+    def test_avi(self, tmp_path):
         p = tmp_path / "clip.avi"
         p.write_bytes(b"\x00" * 10)
-        assert _detect_video_mime_type(p) == "video/mp4"
+        assert _detect_video_mime_type(p) == "video/avi"
 
-    def test_mkv_fallback_mp4(self, tmp_path):
+    def test_mkv_is_unsupported(self, tmp_path):
         p = tmp_path / "clip.mkv"
         p.write_bytes(b"\x00" * 10)
-        assert _detect_video_mime_type(p) == "video/mp4"
+        assert _detect_video_mime_type(p) is None
 
     def test_mpeg(self, tmp_path):
         p = tmp_path / "clip.mpeg"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1525,13 +1525,13 @@ registry.register(
 # Video Analysis Tool
 # ---------------------------------------------------------------------------
 
-# Extension → MIME. avi/mkv fall back to mp4.
+# Extension → Gemini-supported video MIME. Unsupported containers such as
+# Matroska must be transcoded before this path rather than mislabeled as MP4.
 _VIDEO_MIME_TYPES = {
     ".mp4": "video/mp4",
     ".webm": "video/webm",
-    ".mov": "video/mov",
-    ".avi": "video/mp4",
-    ".mkv": "video/mp4",
+    ".mov": "video/quicktime",
+    ".avi": "video/avi",
     ".mpeg": "video/mpeg",
     ".mpg": "video/mpeg",
 }


### PR DESCRIPTION
## Summary

- let the native Gemini adapter translate valid inline `video_url` data URIs to `inlineData`
- require strict base64 and Gemini-supported video MIME types
- correct MOV/AVI MIME mapping and stop mislabeling unsupported MKV as MP4
- add adapter and video MIME regression coverage

## Why

The video tool already emits inline video content, but the native Gemini adapter only translated image parts. Invalid/mislabeled video payloads also produced opaque provider errors.

## Tests

```text
58 passed in tests/agent/test_gemini_native_adapter.py and tests/tools/test_video_analyze.py
```
