### PR TITLE
fix(tools): keep dynamic schema names dispatchable

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -128,6 +128,22 @@ class TestGetDefinitions:
         names = {d["function"]["name"] for d in defs}
         assert names == {"t1", "t2"}
 
+    def test_dynamic_schema_override_cannot_rename_registered_tool(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="stable_name",
+            toolset="s",
+            schema=_make_schema("stable_name"),
+            handler=_dummy_handler,
+            dynamic_schema_overrides=lambda: {
+                "name": "different_name",
+                "description": "updated",
+            },
+        )
+        definition = reg.get_definitions({"stable_name"})[0]["function"]
+        assert definition["name"] == "stable_name"
+        assert definition["description"] == "updated"
+
     def test_skips_unavailable_tools(self):
         reg = ToolRegistry()
         reg.register(

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -567,6 +567,9 @@ class ToolRegistry:
                     overrides = entry.dynamic_schema_overrides()
                     if isinstance(overrides, dict):
                         schema_with_name.update(overrides)
+                        # Overrides may tune descriptions and parameters, but the
+                        # advertised function name must remain dispatchable.
+                        schema_with_name["name"] = entry.name
                 except Exception as exc:
                     logger.warning(
                         "dynamic_schema_overrides for tool %s raised %s; "


### PR DESCRIPTION
## Summary

- keep dynamic schema overrides from changing the registered function name
- preserve legitimate dynamic description/parameter overrides
- add a focused schema/dispatch invariant regression test

## Why

A dynamic override could advertise a function name different from the registry entry the dispatcher can execute. The model could then call a tool name that does not exist.

## Tests

```text
45 passed in tests/tools/test_registry.py
```
