### PR TITLE
fix(compressor): flatten multimodal list content for the summarizer, keep image URL handles

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1664,7 +1664,21 @@ class ContextCompressor(ContextEngine):
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
-            content = redact_sensitive_text(msg.get("content") or "")
+            content = msg.get("content")
+            if isinstance(content, list):
+                text_parts: list[str] = []
+                for part in content:
+                    if isinstance(part, dict):
+                        if part.get("type") == "text":
+                            text_parts.append(part.get("text", ""))
+                        elif part.get("type") in {
+                            "image", "image_url", "input_image",
+                        }:
+                            text_parts.append("[image]")
+                    elif isinstance(part, str):
+                        text_parts.append(part)
+                content = "\n".join(text_parts)
+            content = redact_sensitive_text(content or "")
             content = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", content)
             # Strip inline reasoning blocks (<think>, <reasoning>, etc.) from
             # assistant content before it reaches the summarizer. Reasoning

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -586,6 +586,27 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
     return result if changed else messages
 
 
+def _image_part_label(part: Dict[str, Any]) -> str:
+    """Render a multimodal image part as a short text label for the summarizer.
+
+    Keeps a real, referenceable URL when the image lives at an http(s)
+    address — the summary can then preserve the handle so the agent (or a
+    later vision_analyze call) can still reach the image after compaction.
+    Base64 ``data:`` URLs carry no reusable reference and would flood the
+    summarizer input, so they collapse to ``[image]``.
+    """
+    url = ""
+    if isinstance(part.get("image_url"), dict):
+        url = str(part["image_url"].get("url") or "")
+    elif isinstance(part.get("image_url"), str):
+        url = part["image_url"]
+    elif isinstance(part.get("url"), str):
+        url = part["url"]
+    if url.startswith(("http://", "https://")):
+        return f"[image: {url}]"
+    return "[image]"
+
+
 def _str_arg(args: dict, key: str, default: str = "") -> str:
     """Safely get a string argument from parsed tool args.
 
@@ -1669,12 +1690,15 @@ class ContextCompressor(ContextEngine):
                 text_parts: list[str] = []
                 for part in content:
                     if isinstance(part, dict):
-                        if part.get("type") == "text":
+                        ptype = part.get("type")
+                        if ptype == "text":
                             text_parts.append(part.get("text", ""))
-                        elif part.get("type") in {
-                            "image", "image_url", "input_image",
-                        }:
-                            text_parts.append("[image]")
+                        elif ptype in {"image", "image_url", "input_image"}:
+                            text_parts.append(_image_part_label(part))
+                        else:
+                            # Unknown part type — keep a marker so the
+                            # summarizer knows content existed here.
+                            text_parts.append(f"[{ptype or 'attachment'}]")
                     elif isinstance(part, str):
                         text_parts.append(part)
                 content = "\n".join(text_parts)

--- a/tests/agent/test_compressor_media_stripping.py
+++ b/tests/agent/test_compressor_media_stripping.py
@@ -56,12 +56,11 @@ class TestMediaDirectiveStripping:
         assert result.count("[media attachment]") == 2
 
     def test_multimodal_list_content_does_not_crash(self, compressor):
-        """content as a list (multimodal) must not crash redact_sensitive_text.
+        """content as a list (multimodal) must be flattened to clean text.
 
-        Regression: msg.get('content') can return a list of parts for
-        multimodal messages (images + text).  The old code passed this
-        list directly to redact_sensitive_text(str), which raised
-        AttributeError on list.replace().
+        Without flattening, str() coercion in redact_sensitive_text dumps
+        the raw part-dict repr — including base64 image data — into the
+        summarizer input, burning summary budget on noise.
         """
         turns = [
             {
@@ -72,10 +71,39 @@ class TestMediaDirectiveStripping:
                 ],
             },
         ]
-        # Must not raise
         result = compressor._serialize_for_summary(turns)
         assert "What is in this image?" in result
         assert "[image]" in result
+        assert "base64" not in result
+
+    def test_multimodal_remote_image_keeps_url(self, compressor):
+        """http(s) image parts keep their URL as a referenceable handle."""
+        turns = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look at this"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/a.png"}},
+                ],
+            },
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "[image: https://example.com/a.png]" in result
+
+    def test_multimodal_unknown_part_type_keeps_marker(self, compressor):
+        """Unknown part types are not silently dropped."""
+        turns = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "see attachment"},
+                    {"type": "document", "title": "spec.pdf"},
+                ],
+            },
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "see attachment" in result
+        assert "[document]" in result
 
     def test_multimodal_list_text_parts_extracted(self, compressor):
         """Text parts from multimodal list content are preserved in output."""

--- a/tests/agent/test_compressor_media_stripping.py
+++ b/tests/agent/test_compressor_media_stripping.py
@@ -54,3 +54,49 @@ class TestMediaDirectiveStripping:
         result = compressor._serialize_for_summary(turns)
         assert "MEDIA:" not in result
         assert result.count("[media attachment]") == 2
+
+    def test_multimodal_list_content_does_not_crash(self, compressor):
+        """content as a list (multimodal) must not crash redact_sensitive_text.
+
+        Regression: msg.get('content') can return a list of parts for
+        multimodal messages (images + text).  The old code passed this
+        list directly to redact_sensitive_text(str), which raised
+        AttributeError on list.replace().
+        """
+        turns = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is in this image?"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
+                ],
+            },
+        ]
+        # Must not raise
+        result = compressor._serialize_for_summary(turns)
+        assert "What is in this image?" in result
+        assert "[image]" in result
+
+    def test_multimodal_list_text_parts_extracted(self, compressor):
+        """Text parts from multimodal list content are preserved in output."""
+        turns = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "first part"},
+                    {"type": "text", "text": "second part"},
+                ],
+            },
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "first part" in result
+        assert "second part" in result
+
+    def test_multimodal_list_bare_strings_handled(self, compressor):
+        """Bare strings inside a content list are joined."""
+        turns = [
+            {"role": "user", "content": ["hello", "world"]},
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "hello" in result
+        assert "world" in result


### PR DESCRIPTION
## Summary

Compression summarizer input for multimodal turns is now clean text — remote image URLs survive as referenceable handles, base64 never leaks. Salvage of @AlexFucuson9's #59994 with follow-ups.

The live bug (probed on main): `_serialize_for_summary` passed list-shaped multimodal `content` into `redact_sensitive_text`, whose `str()` coercion dumps the raw part-dict repr — including base64 image data — into the summarizer input. An 11KB data-URL image produced 5,527 chars of repr noise burning summary budget; the same turn now serializes to 114 chars of signal. (The PR's original crash premise is stale — `redact_sensitive_text` grew `str()` coercion in #52147 — but the coercion is exactly what causes the leak.)

## Changes

- `agent/context_compressor.py` (@AlexFucuson9, cherry-picked): flatten list content — text parts kept verbatim, image parts become markers, bare strings joined.
- Follow-up: remote `http(s)` image parts render as `[image: <url>]` so the summary keeps a handle the agent can still use after compaction (vision tools take the URL); base64 `data:` URLs collapse to `[image]` (no reusable reference — leaking them is the bug). Unknown part types render as `[<type>]` instead of being silently dropped.
- Tests (@AlexFucuson9's 3 + 2 follow-up): flattening, text extraction, bare strings, remote-URL handle, unknown-part marker; docstrings corrected to the live premise.

## Validation

| Input | Serialized |
|---|---|
| text + 11KB data-URL image (before) | 5,527 chars of repr/base64 noise |
| same (after) | `What is in this image?` + `[image]` — 114 chars |
| remote image part | `[image: https://example.com/a.png]` |
| unknown `document` part | `[document]` |

Targeted suites (media stripping + context compressor + type-safety): 200/200. This aligns `_serialize_for_summary` with the sibling `_trajectory_normalize_msg` path, which already flattens image parts for trajectory saving.

## Infographic

![multimodal-summarizer-input](https://v3b.fal.media/files/b/0aa25c72/Ck401WVHpsZokaMHUMKkS_j9H5Zsnx.png)
