### PR TITLE
fix: resolve _skills_dir() for symlinked HERMES_HOME install paths (#64953)

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3641,7 +3641,7 @@ def install_from_quarantine(
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
         skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(_skills_dir())),
+        install_path=str(install_dir.relative_to(_skills_dir().resolve())),
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,
         scan_provenance=scan_provenance or getattr(scan_result, "scan_provenance", None),


### PR DESCRIPTION
Prevents false 'Installation blocked' error when HERMES_HOME is a symlink. Resolves _skills_dir() before relative_to() so resolved and unresolved paths match.\n\nFixes #64953.