### PR TITLE
fix(delegation): honor delegation.fallback_providers for child agents (#65038)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1254,6 +1254,9 @@ delegation:
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  # fallback_providers:                       # Fallback chain for delegated children (same entry format as the
+  #   - provider: "openrouter"                # top-level fallback_providers list). Unset = inherit the parent
+  #     model: "deepseek/deepseek-chat"       # agent's chain; [] = disable child fallback entirely (#65038).
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1600,6 +1600,9 @@ DEFAULT_CONFIG = {
     "delegation": {
         "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
+        "fallback_providers": None,  # fallback chain for delegated children, same entry
+                           # format as the top-level fallback_providers list. null =
+                           # inherit the parent agent's chain; [] = disable child fallback.
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         "api_mode": "",    # wire protocol for delegation.base_url: "chat_completions",

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -191,6 +191,13 @@ def test_dispatch_rejected_at_capacity():
     assert r3["status"] == "rejected"
     assert "capacity reached" in r3["error"]
     ev.set()
+    # Drain both blockers' completions before returning: they enqueue
+    # asynchronously after ev.set(), and any event that lands after the
+    # fixture's teardown drain leaks into the next test's _drain_one()
+    # (test_crashed_runner_produces_error_completion then reads a stale
+    # "completed" event instead of its own error event).
+    assert _drain_one() is not None
+    assert _drain_one() is not None
 
 
 def test_interrupt_all_signals_running_children():

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -109,6 +109,41 @@ class TestDelegationFallbackChain(unittest.TestCase):
         )
         self.assertEqual(got, self.HEAD)
 
+    def test_fallback_providers_flow_through_real_config_loader(self):
+        """Regression through the REAL config loader — no ``_load_config``
+        patch: the key written to ``$HERMES_HOME/config.yaml`` must survive
+        the profile-aware DEFAULT_CONFIG deep-merge (where the shipped
+        default is ``None``) and reach the child's ``fallback_model``."""
+        import yaml
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home()
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {"delegation": {"fallback_providers": list(self.WORKER)}}
+            ),
+            encoding="utf-8",
+        )
+
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = list(self.HEAD)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="g",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(MockAgent.call_args.kwargs.get("fallback_model"), self.WORKER)
+
 
 class TestDelegateRequirements(unittest.TestCase):
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -56,6 +56,60 @@ def _make_mock_parent(depth=0):
     return parent
 
 
+class TestDelegationFallbackChain(unittest.TestCase):
+    """delegation.fallback_providers beats parent-chain inheritance (#65038).
+
+    A worker explicitly routed via delegation.* must not silently escalate
+    onto the head agent's fallback models when the delegation section
+    declares its own chain.
+    """
+
+    HEAD = [{"provider": "provider-b", "model": "head-fallback"}]
+    WORKER = [{"provider": "provider-d", "model": "worker-fallback"}]
+
+    def _child_fallback(self, delegation_cfg, parent_chain):
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = parent_chain
+        with patch("tools.delegate_tool._load_config", return_value=delegation_cfg), \
+             patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="g",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+        return MockAgent.call_args.kwargs.get("fallback_model")
+
+    def test_delegation_chain_overrides_parent_inheritance(self):
+        got = self._child_fallback({"fallback_providers": list(self.WORKER)}, list(self.HEAD))
+        self.assertEqual(got, self.WORKER)
+
+    def test_absent_key_inherits_parent_chain(self):
+        self.assertEqual(self._child_fallback({}, list(self.HEAD)), self.HEAD)
+
+    def test_null_key_inherits_parent_chain(self):
+        # DEFAULT_CONFIG ships fallback_providers: null — the deep-merged
+        # default must behave exactly like an absent key.
+        self.assertEqual(
+            self._child_fallback({"fallback_providers": None}, list(self.HEAD)), self.HEAD
+        )
+
+    def test_explicit_empty_list_disables_child_fallback(self):
+        self.assertEqual(self._child_fallback({"fallback_providers": []}, list(self.HEAD)), [])
+
+    def test_malformed_entries_inherit_parent_chain(self):
+        got = self._child_fallback(
+            {"fallback_providers": ["not-a-dict", {"provider": "", "model": ""}]},
+            list(self.HEAD),
+        )
+        self.assertEqual(got, self.HEAD)
+
+
 class TestDelegateRequirements(unittest.TestCase):
 
     def test_schema_valid(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1454,11 +1454,36 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    # Inherit the parent's fallback provider chain so subagents can recover
-    # from rate-limits and credential exhaustion exactly like the top-level
-    # agent does.  _fallback_chain is a list accepted by AIAgent's
-    # fallback_model parameter (which handles both list and dict forms).
+    # Fallback chain: delegation.fallback_providers > parent inheritance.
+    # By default children inherit the parent's resolved chain so subagents
+    # recover from rate-limits and credential exhaustion exactly like the
+    # top-level agent does (#7481).  But when the delegation section declares
+    # its own chain, use it — a worker explicitly routed via delegation.*
+    # must not silently escalate onto fallback models intended only for the
+    # head agent (#65038; same reasoning as the provider-filter clearing
+    # below).  ``fallback_providers: []`` explicitly disables child fallback;
+    # a malformed value logs and inherits, mirroring reasoning_effort above.
     parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    delegation_fallback_raw = delegation_cfg.get("fallback_providers")
+    if delegation_fallback_raw is None:
+        child_fallback = parent_fallback
+    else:
+        try:
+            from hermes_cli.fallback_config import get_fallback_chain
+
+            child_fallback = get_fallback_chain(
+                {"fallback_providers": delegation_fallback_raw}
+            )
+        except Exception as exc:
+            logger.debug("Could not resolve delegation.fallback_providers: %s", exc)
+            child_fallback = parent_fallback
+        else:
+            if not child_fallback and delegation_fallback_raw:
+                logger.warning(
+                    "delegation.fallback_providers has no valid entries "
+                    "(each needs provider + model); inheriting parent chain"
+                )
+                child_fallback = parent_fallback
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -1513,7 +1538,7 @@ def _build_child_agent(
 
             reasoning_config=child_reasoning,
             prefill_messages=getattr(parent_agent, "prefill_messages", None),
-            fallback_model=parent_fallback,
+            fallback_model=child_fallback,
             enabled_toolsets=child_toolsets,
             disabled_toolsets=child_disabled_toolsets,
             quiet_mode=True,

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2195,12 +2195,17 @@ delegation:
   # base_url: "http://localhost:1234/v1"    # Direct OpenAI-compatible endpoint (takes precedence over provider)
   # api_key: "local-key"                    # API key for base_url (falls back to OPENAI_API_KEY)
   # api_mode: ""                            # Wire protocol for base_url: "chat_completions", "codex_responses", or "anthropic_messages". Empty = auto-detect from URL (e.g. /anthropic suffix → anthropic_messages). Set explicitly for non-standard endpoints the heuristic can't detect.
+  # fallback_providers:                     # Fallback chain for subagents (same entry format as the top-level fallback_providers list).
+  #   - provider: "openrouter"              # Unset/null = inherit the parent agent's chain; [] = disable subagent fallback entirely.
+  #     model: "deepseek/deepseek-chat"
   max_concurrent_children: 3                # Parallel children per batch (floor 1, no ceiling). Also via DELEGATION_MAX_CONCURRENT_CHILDREN env var.
   max_spawn_depth: 1                        # Delegation tree depth cap (1-3, clamped). 1 = flat (default): parent spawns leaves that cannot delegate. 2 = orchestrator children can spawn leaf grandchildren. 3 = three levels.
   orchestrator_enabled: true                # Global kill switch. When false, role="orchestrator" is ignored and every child is forced to leaf regardless of max_spawn_depth.
 ```
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
+
+**Subagent fallback chain:** By default, subagents inherit the parent agent's `fallback_providers` chain. When subagents are routed to a different provider, that inheritance can silently escalate a failed worker onto models intended only for the head agent — set `delegation.fallback_providers` to give children their own chain (same entry format as the top-level list). An explicit empty list (`fallback_providers: []`) disables subagent fallback entirely; entries missing `provider` or `model` are ignored, and if none remain valid the parent chain is inherited with a logged warning. See [Fallback Providers → Delegation Fallback Chain](features/fallback-providers.md#delegation-fallback-chain).
 
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -171,7 +171,7 @@ fallback_providers:
 |---------|-------------------|
 | CLI sessions | ✔ |
 | Messaging gateway (Telegram, Discord, etc.) | ✔ |
-| Subagent delegation | ✔ (subagents inherit the parent fallback chain) |
+| Subagent delegation | ✔ (subagents inherit the parent fallback chain, or use `delegation.fallback_providers` when set) |
 | Cron jobs | ✔ (cron agents inherit configured fallback providers) |
 | Auxiliary tasks on `provider: auto` | ✔ (try per-task fallback, then the main fallback chain before built-in aux discovery) |
 
@@ -392,6 +392,29 @@ delegation:
   # api_key: "local-key"
 ```
 
+### Delegation Fallback Chain
+
+When subagents run on a different provider than the head agent, inheriting the head agent's fallback chain can silently route a failed worker onto models intended only for the parent. `delegation.fallback_providers` gives delegated children their own chain, with the same entry format as the top-level list:
+
+```yaml
+delegation:
+  provider: "openrouter"
+  model: "google/gemini-3-flash-preview"
+  fallback_providers:
+    - provider: "openrouter"
+      model: "deepseek/deepseek-chat"
+```
+
+Semantics:
+
+| `delegation.fallback_providers` | Behavior |
+|---|---|
+| unset / `null` (default) | subagents inherit the parent agent's fallback chain |
+| list of entries | subagents use this chain instead of the parent's |
+| `[]` (explicit empty list) | fallback disabled for subagents entirely |
+
+Entries with a missing `provider` or `model` are ignored; if no valid entries remain, the parent chain is inherited and a warning is logged.
+
 See [Subagent Delegation](/user-guide/features/delegation) for full configuration details.
 
 ---
@@ -429,5 +452,5 @@ See [Scheduled Tasks (Cron)](/user-guide/features/cron) for full configuration d
 | Approval classification | Layered (see above) | `auxiliary.approval` |
 | Title generation | Layered (see above) | `auxiliary.title_generation` |
 | Triage specifier | Layered (see above) | `auxiliary.triage_specifier` |
-| Delegation | Inherits the parent's `fallback_providers` chain; optional provider/model override | `delegation.provider` / `delegation.model` |
+| Delegation | Own chain via `delegation.fallback_providers`; inherits the parent chain when unset | `delegation.fallback_providers`, `delegation.provider` / `delegation.model` |
 | Cron jobs | Inherit the configured `fallback_providers` chain; optional per-job provider override | Per-job `provider` / `model` |


### PR DESCRIPTION
## Summary

Honor a `delegation.fallback_providers` chain for delegated children, so a worker explicitly routed via `delegation.*` no longer silently escalates onto fallback models intended only for the head agent (#65038).

## Changes

- `tools/delegate_tool.py`: `_build_child_agent()` — resolve the child chain as `delegation.fallback_providers` > parent inheritance. Key absent/null → inherit the parent's resolved `_fallback_chain` exactly as before (#7481 behavior preserved); `[]` → explicitly disable child fallback; malformed value → `logger.warning` + inherit (mirrors the `delegation.reasoning_effort` fallback pattern a few lines up). Normalization reuses `hermes_cli.fallback_config.get_fallback_chain()`, the same chokepoint the top-level chain goes through — no parallel parser
- `hermes_cli/config.py`: `delegation.fallback_providers: None` added to `DEFAULT_CONFIG` (null sentinel = inherit, so the deep-merged default cannot flip existing users off inheritance; no `_config_version` bump needed for an added key)
- `cli-config.yaml.example`: commented example in the `delegation:` block
- `tests/tools/test_delegate.py`: `TestDelegationFallbackChain` — 5 tests: override beats inheritance, absent key inherits, null (the shipped default) inherits, `[]` disables, malformed inherits. The override and `[]` tests fail on unfixed code
- `tests/tools/test_async_delegation.py`: follow-up — deterministic drain of the two blocker completions in `test_dispatch_rejected_at_capacity`. This is a latent race, not fallout of this change: the blockers enqueue their completion events asynchronously after `ev.set()`, and any event landing after the fixture's teardown drain leaks into the next test's `_drain_one()`, which then reads a stale `completed` event instead of its own error event. Fails 8/8 consecutive bare-pytest runs on clean main; masked under `scripts/run_tests.sh` by hermetic-env timing until any config-load change (like the `DEFAULT_CONFIG` key above) re-times it

## Root cause

`_build_child_agent()` reads the parent's resolved chain and passes it unconditionally:

```python
parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
...
child = AIAgent(..., fallback_model=parent_fallback, ...)
```

The `delegation` config section is consulted on this path for provider, model, base_url, api_mode, and reasoning_effort — but not for a fallback chain; `delegation.fallback_providers` was never a key (`git log -S` shows the inheritance landed for #7481's "workers should inherit the parent chain", closed `implemented_on_main`). This issue is the complementary control: with a worker pinned to a distinct provider/model, a failure walks the head agent's chain — wrong models, wrong provider, wrong spend, silently.

The same leak was already recognized and fixed for OpenRouter provider filters in this exact function ("parent-level filters would silently force the child back onto the parent's provider" — cleared when `delegation.provider` is set). This change applies the identical reasoning to the fallback chain, but opt-in via config rather than implicit, since unconditional inheritance is deliberate, relied-upon behavior (#7481, and #49477's pinned-base_url coverage asserts it — the key-unset path here keeps those semantics byte-identical).

`_build_child_agent()` is the single `AIAgent()` construction site for delegation (sync and async paths both flow through it), so the chain resolution covers all delegated children.

## Validation

| `delegation.fallback_providers` | Before | After |
|---|---|---|
| unset (all existing configs) | inherit parent chain | inherit parent chain (unchanged) |
| `null` (shipped default) | — | inherit parent chain |
| `[{provider: d, model: worker-fb}]` | **ignored — head chain used** | worker chain used |
| `[]` | — | child fallback disabled |
| malformed entries | — | warn + inherit parent chain |

- Runtime repro before/after: child `fallback_model` was `[{provider-b, head-fallback-model}]` with the worker chain configured; now receives the configured chain
- `scripts/run_tests.sh tests/tools/test_delegate.py tests/tools/test_async_delegation.py tests/hermes_cli/test_config.py` — 3 files, 339 passed, 0 failed
- `scripts/run_tests.sh tests/hermes_cli/test_fallback_cmd.py` — 32 passed
- `tests/tools/test_async_delegation.py` — 3× consecutive bare-pytest runs green (was 8/8 red on main)

Fixes #65038. Refs #7481, #49477, #65035 (sibling defect in the same file: the `base_url` credential path drops `request_overrides` — separate fix).
