### PR TITLE
fix(kanban): gate worker guidance on task scope

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1213,15 +1213,15 @@ def init_agent(
     elif not agent.quiet_mode:
         print("🛠️  No tools loaded (all tools filtered out or unavailable)")
 
-    # Kanban worker/orchestrator lifecycle guidance is session-static:
-    # the dispatcher decides at spawn time whether this process is a kanban
-    # worker (kanban_show tool is present iff HERMES_KANBAN_TASK is set).
+    # Kanban worker lifecycle guidance is session-static. Tool availability is
+    # not worker identity: orchestrator profiles also expose kanban_show. The
+    # dispatcher-owned task env var is the authoritative worker signal.
     # Resolving the ~835-token block once here avoids re-running the
     # membership test + reference on every system-prompt rebuild
     # (init + each context compression).
     from agent.prompt_builder import KANBAN_GUIDANCE
     agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+        KANBAN_GUIDANCE if os.environ.get("HERMES_KANBAN_TASK") else ""
     )
 
     # Check tool requirements

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -225,14 +225,14 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
-    # Kanban worker/orchestrator lifecycle — only present when the
-    # dispatcher spawned this process (kanban_show check_fn gates on
-    # HERMES_KANBAN_TASK env var). Normal chat sessions never see
-    # this block. Resolved once at __init__ (see _kanban_worker_guidance).
+    # Kanban worker lifecycle — only present when the dispatcher spawned this
+    # process. Orchestrator profiles may expose kanban_show too, so tool
+    # availability is not sufficient proof of worker identity. Resolved once
+    # at __init__ (see _kanban_worker_guidance).
     _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)
     if _kanban_guidance:
         tool_guidance.append(_kanban_guidance)
-    elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
+    elif _kanban_guidance is None and os.environ.get("HERMES_KANBAN_TASK"):
         # Fallback for code paths that bypass agent_init (rare).
         tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1424,6 +1424,65 @@ def test_kanban_guidance_not_in_normal_prompt(monkeypatch, tmp_path):
     assert "kanban_show()" not in prompt
 
 
+def test_kanban_guidance_not_in_orchestrator_prompt(monkeypatch, tmp_path):
+    """Kanban tool availability does not make a normal chat a task worker."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("toolsets:\n  - kanban\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path as _P
+    monkeypatch.setattr(_P, "home", lambda: tmp_path)
+
+    from tools.registry import invalidate_check_fn_cache
+    from model_tools import _clear_tool_defs_cache
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+
+    from run_agent import AIAgent
+    a = AIAgent(
+        api_key="test",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert "kanban_show" in a.valid_tool_names
+    prompt = a._build_system_prompt()
+    assert "Kanban task execution protocol" not in prompt
+    assert "kanban_show()" not in prompt
+
+
+def test_kanban_guidance_fallback_requires_worker_env(monkeypatch):
+    """Prompt construction paths that bypass agent_init use the same signal."""
+    from types import SimpleNamespace
+    from agent.system_prompt import build_system_prompt
+
+    agent = SimpleNamespace(
+        load_soul_identity=False,
+        skip_context_files=True,
+        valid_tool_names={"kanban_show"},
+        _task_completion_guidance=False,
+        _parallel_tool_call_guidance=False,
+        _tool_use_enforcement=False,
+        _environment_probe=False,
+        _kanban_worker_guidance=None,
+        _memory_store=None,
+        _memory_manager=None,
+        model="",
+        provider="",
+        platform="",
+        pass_session_id=False,
+        session_id="",
+    )
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    assert "Kanban task execution protocol" not in build_system_prompt(agent)
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake")
+    assert "Kanban task execution protocol" in build_system_prompt(agent)
+
+
 def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
     """A worker session (HERMES_KANBAN_TASK set) MUST have the full
     lifecycle guidance in its system prompt."""


### PR DESCRIPTION
## Summary
- treat `HERMES_KANBAN_TASK` as the authoritative worker identity signal
- keep Kanban tools available to orchestrator chats without injecting false worker lifecycle instructions
- cover initialized and fallback system-prompt paths

## Verification
- `pytest -q tests/tools/test_kanban_tools.py tests/agent/test_system_prompt.py` — 108 passed
- focused live probe: `kanban_show_loaded=True`, no task env, false worker guidance absent
- isolated Kanban DB/decompose/lifecycle suites — 245 passed
- `py_compile` and `git diff --check` passed

The combined 848-test Kanban run exposed 16 existing order-dependent failures; each affected module passes in isolation and none touches the changed prompt-gating paths.