### PR TITLE
fix(desktop): coordinate orphan reaping across profile backends

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -12,9 +12,10 @@ import logging
 import os
 import time
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
 
 from hermes_constants import get_hermes_home
 
@@ -77,16 +78,20 @@ def active_session_limit_message(active_count: int, max_sessions: int) -> str:
     )
 
 
-def _state_dir() -> Path:
-    return Path(get_hermes_home()) / "runtime"
+def _registry_home(registry_home: str | Path | None = None) -> Path:
+    return Path(registry_home) if registry_home is not None else Path(get_hermes_home())
 
 
-def _state_path() -> Path:
-    return _state_dir() / "active_sessions.json"
+def _state_dir(registry_home: str | Path | None = None) -> Path:
+    return _registry_home(registry_home) / "runtime"
 
 
-def _lock_path() -> Path:
-    return _state_dir() / "active_sessions.lock"
+def _state_path(registry_home: str | Path | None = None) -> Path:
+    return _state_dir(registry_home) / "active_sessions.json"
+
+
+def _lock_path(registry_home: str | Path | None = None) -> Path:
+    return _state_dir(registry_home) / "active_sessions.lock"
 
 
 class _FileLock:
@@ -224,6 +229,7 @@ class ActiveSessionLease:
     surface: str
     enabled: bool = True
     released: bool = False
+    registry_home: Optional[str] = None
 
     def release(self) -> None:
         if self.released or not self.enabled:
@@ -237,15 +243,20 @@ def try_acquire_active_session(
     surface: str,
     config: Any,
     metadata: Optional[dict[str, Any]] = None,
+    registry_home: str | Path | None = None,
+    track_liveness: bool = False,
 ) -> tuple[Optional[ActiveSessionLease], Optional[str]]:
     """Acquire an active-session slot.
 
     Returns ``(lease, None)`` on success.  When the cap is disabled, the lease is
-    a no-op object so callers can unconditionally call ``release()``.
+    a no-op object so callers can unconditionally call ``release()`` unless
+    ``track_liveness`` is true.  Liveness tracking keeps a real lease without
+    imposing a concurrency cap; ``registry_home`` lets profile-scoped backends
+    share the owning profile's registry even when launched from another home.
     """
     max_sessions = resolve_max_concurrent_sessions(config)
     lease_id = uuid.uuid4().hex
-    if max_sessions is None:
+    if max_sessions is None and not track_liveness:
         return ActiveSessionLease(
             lease_id=lease_id,
             session_id=session_id,
@@ -254,7 +265,7 @@ def try_acquire_active_session(
         ), None
 
     now = time.time()
-    entry = {
+    entry: dict[str, Any] = {
         "lease_id": lease_id,
         "session_id": str(session_id),
         "surface": str(surface),
@@ -268,15 +279,16 @@ def try_acquire_active_session(
             str(k): v for k, v in metadata.items() if isinstance(k, str)
         }
 
-    state_path = _state_path()
-    with _FileLock(_lock_path()):
+    resolved_home = _registry_home(registry_home)
+    state_path = _state_path(resolved_home)
+    with _FileLock(_lock_path(resolved_home)):
         raw_entries = _read_entries(state_path)
         entries = _prune_dead(raw_entries)
         pruned = len(raw_entries) - len(entries)
         if pruned:
             logger.info("Pruned %d stale active session lease(s)", pruned)
         active_count = len(entries)
-        if active_count >= max_sessions:
+        if max_sessions is not None and active_count >= max_sessions:
             _write_entries(state_path, entries)
             logger.info(
                 "Active session limit reached: active=%d max=%d surface=%s",
@@ -292,13 +304,14 @@ def try_acquire_active_session(
         lease_id=lease_id,
         session_id=str(session_id),
         surface=str(surface),
+        registry_home=str(resolved_home),
     ), None
 
 
 def release_active_session(lease: ActiveSessionLease) -> None:
-    state_path = _state_path()
+    state_path = _state_path(lease.registry_home)
     try:
-        with _FileLock(_lock_path()):
+        with _FileLock(_lock_path(lease.registry_home)):
             entries = _prune_dead(_read_entries(state_path))
             kept = [
                 entry
@@ -327,8 +340,8 @@ def transfer_active_session(
         lease.session_id = new_session_id
         return True
 
-    state_path = _state_path()
-    with _FileLock(_lock_path()):
+    state_path = _state_path(lease.registry_home)
+    with _FileLock(_lock_path(lease.registry_home)):
         entries = _prune_dead(_read_entries(state_path))
         updated = False
         for entry in entries:
@@ -348,10 +361,34 @@ def transfer_active_session(
         return updated
 
 
-def active_session_registry_snapshot() -> list[dict[str, Any]]:
+def active_session_registry_snapshot(
+    registry_home: str | Path | None = None,
+) -> list[dict[str, Any]]:
     """Return the pruned active-session registry for diagnostics/tests."""
-    state_path = _state_path()
-    with _FileLock(_lock_path()):
+    state_path = _state_path(registry_home)
+    with _FileLock(_lock_path(registry_home)):
         entries = _prune_dead(_read_entries(state_path))
         _write_entries(state_path, entries)
         return entries
+
+
+@contextmanager
+def active_session_liveness_guard(
+    session_id: str,
+    *,
+    registry_home: str | Path | None = None,
+) -> Iterator[bool]:
+    """Hold the registry lock while reporting whether ``session_id`` is leased.
+
+    Keeping the lock across the caller's lifecycle mutation prevents a new
+    backend from acquiring a lease and reopening the row between the liveness
+    check and the corresponding ``end_session`` write.
+    """
+    target = str(session_id or "")
+    state_path = _state_path(registry_home)
+    with _FileLock(_lock_path(registry_home)):
+        entries = _prune_dead(_read_entries(state_path))
+        _write_entries(state_path, entries)
+        yield bool(target) and any(
+            str(entry.get("session_id") or "") == target for entry in entries
+        )

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import time
 import uuid
@@ -22,7 +23,13 @@ from hermes_constants import get_hermes_home
 logger = logging.getLogger(__name__)
 
 
-def coerce_max_concurrent_sessions(value: Any, key: str = "max_concurrent_sessions") -> Optional[int]:
+class ActiveSessionRegistryError(RuntimeError):
+    """The liveness registry could not prove a safe ownership decision."""
+
+
+def coerce_max_concurrent_sessions(
+    value: Any, key: str = "max_concurrent_sessions"
+) -> Optional[int]:
     """Return a positive integer cap, or None when disabled/invalid."""
     if value is None:
         return None
@@ -147,34 +154,114 @@ class _FileLock:
             self._fh = None
 
 
-def _read_entries(path: Path) -> list[dict[str, Any]]:
+def _read_entries(path: Path, *, strict: bool = False) -> list[dict[str, Any]]:
     try:
         with open(path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
     except FileNotFoundError:
         return []
-    except Exception:
+    except Exception as exc:
+        if strict:
+            raise ActiveSessionRegistryError(
+                f"active session registry unreadable: {path}"
+            ) from exc
         logger.warning("Ignoring corrupt active session registry at %s", path)
         return []
     entries = data.get("entries") if isinstance(data, dict) else data
     if not isinstance(entries, list):
+        if strict:
+            raise ActiveSessionRegistryError(
+                f"active session registry has invalid shape: {path}"
+            )
         return []
-    return [entry for entry in entries if isinstance(entry, dict)]
+    valid = [entry for entry in entries if isinstance(entry, dict)]
+    if strict and len(valid) != len(entries):
+        raise ActiveSessionRegistryError(
+            f"active session registry contains invalid entries: {path}"
+        )
+    if strict:
+        identities: dict[str, tuple[Any, ...]] = {}
+        for entry in valid:
+            lease_id = entry.get("lease_id")
+            session_id = entry.get("session_id")
+            pid = entry.get("pid")
+            if not isinstance(lease_id, str) or not lease_id.strip():
+                raise ActiveSessionRegistryError(
+                    f"active session registry contains an invalid lease id: {path}"
+                )
+            if not isinstance(session_id, str) or not session_id.strip():
+                raise ActiveSessionRegistryError(
+                    f"active session registry contains an invalid session id: {path}"
+                )
+            if isinstance(pid, bool) or not isinstance(pid, (int, str)):
+                pid_int = 0
+            else:
+                try:
+                    pid_int = int(pid)
+                except (TypeError, ValueError):
+                    pid_int = 0
+            if pid_int <= 0:
+                raise ActiveSessionRegistryError(
+                    f"active session registry contains an invalid pid: {path}"
+                )
+            surface = entry.get("surface")
+            if surface is not None and not isinstance(surface, str):
+                raise ActiveSessionRegistryError(
+                    f"active session registry contains an invalid surface: {path}"
+                )
+            tracked = entry.get("track_liveness")
+            if tracked is not None and not isinstance(tracked, bool):
+                raise ActiveSessionRegistryError(
+                    f"active session registry contains an invalid liveness marker: {path}"
+                )
+            metadata = entry.get("metadata")
+            if metadata is not None and not isinstance(metadata, dict):
+                raise ActiveSessionRegistryError(
+                    f"active session registry contains invalid metadata: {path}"
+                )
+            process_start = entry.get("process_start_time")
+            parsed_process_start = _optional_float(process_start)
+            if process_start not in (None, "") and (
+                parsed_process_start is None or not math.isfinite(parsed_process_start)
+            ):
+                raise ActiveSessionRegistryError(
+                    f"active session registry contains an invalid process start time: {path}"
+                )
+            identity = (
+                session_id,
+                pid_int,
+                parsed_process_start,
+                surface,
+                bool(tracked),
+            )
+            previous = identities.get(lease_id)
+            if previous is not None:
+                raise ActiveSessionRegistryError(
+                    f"active session registry contains a duplicate lease id: {path}"
+                )
+            identities[lease_id] = identity
+    return valid
 
 
 def _write_entries(path: Path, entries: list[dict[str, Any]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
-    with open(tmp, "w", encoding="utf-8") as fh:
-        json.dump({"entries": entries}, fh, sort_keys=True)
-    os.replace(tmp, path)
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump({"entries": entries}, fh, sort_keys=True)
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def _process_start_time(pid: int) -> Optional[float]:
     # Pair pid with process create_time when psutil can read it, so a recycled
     # pid does not keep a stale lease alive indefinitely.
     try:
-        import psutil  # type: ignore
+        import psutil
 
         return float(psutil.Process(pid).create_time())
     except Exception:
@@ -190,19 +277,20 @@ def _optional_float(value: Any) -> Optional[float]:
         return None
 
 
-def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
+def _pid_liveness(pid: Any, process_start_time: Any = None) -> Optional[bool]:
+    """Return True/False for live/dead, or None when liveness is unknowable."""
     try:
         pid_int = int(pid)
     except (TypeError, ValueError):
-        return False
+        return None
     if pid_int <= 0:
-        return False
+        return None
     try:
         from gateway.status import _pid_exists
 
         exists = bool(_pid_exists(pid_int))
     except Exception:
-        return False
+        return None
     if not exists:
         return False
     expected_start = _optional_float(process_start_time)
@@ -210,16 +298,33 @@ def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
         return True
     current_start = _process_start_time(pid_int)
     if current_start is None:
-        return True
+        return None
     return abs(current_start - expected_start) < 0.001
 
 
-def _prune_dead(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return [
-        entry
-        for entry in entries
-        if _pid_alive(entry.get("pid"), entry.get("process_start_time"))
-    ]
+def _pid_alive(pid: Any, process_start_time: Any = None) -> bool:
+    """Conservatively treat an unknown process as alive."""
+    return _pid_liveness(pid, process_start_time) is not False
+
+
+def _prune_dead(
+    entries: list[dict[str, Any]], *, strict: bool = False
+) -> list[dict[str, Any]]:
+    live: list[dict[str, Any]] = []
+    for entry in entries:
+        state = _pid_liveness(entry.get("pid"), entry.get("process_start_time"))
+        if state is None:
+            if strict or bool(entry.get("track_liveness")):
+                raise ActiveSessionRegistryError(
+                    "active session owner liveness is unknown"
+                )
+            # Preserve the legacy concurrency-cap behavior only for legacy
+            # cap entries. A tracked Desktop entry must never be erased by a
+            # cap-only caller that happens to share the same registry.
+            continue
+        if state:
+            live.append(entry)
+    return live
 
 
 @dataclass
@@ -230,11 +335,39 @@ class ActiveSessionLease:
     enabled: bool = True
     released: bool = False
     registry_home: Optional[str] = None
+    track_liveness: bool = False
 
     def release(self) -> None:
         if self.released or not self.enabled:
             return
         release_active_session(self)
+
+
+def _lease_entry(
+    *,
+    lease_id: str,
+    session_id: str,
+    surface: str,
+    metadata: Optional[dict[str, Any]] = None,
+    track_liveness: bool = False,
+) -> dict[str, Any]:
+    now = time.time()
+    entry: dict[str, Any] = {
+        "lease_id": lease_id,
+        "session_id": str(session_id),
+        "surface": str(surface),
+        "pid": os.getpid(),
+        "process_start_time": _process_start_time(os.getpid()),
+        "started_at": now,
+        "updated_at": now,
+    }
+    if track_liveness:
+        entry["track_liveness"] = True
+    if metadata:
+        entry["metadata"] = {
+            str(k): v for k, v in metadata.items() if isinstance(k, str)
+        }
+    return entry
 
 
 def try_acquire_active_session(
@@ -264,26 +397,37 @@ def try_acquire_active_session(
             enabled=False,
         ), None
 
-    now = time.time()
-    entry: dict[str, Any] = {
-        "lease_id": lease_id,
-        "session_id": str(session_id),
-        "surface": str(surface),
-        "pid": os.getpid(),
-        "process_start_time": _process_start_time(os.getpid()),
-        "started_at": now,
-        "updated_at": now,
-    }
-    if metadata:
-        entry["metadata"] = {
-            str(k): v for k, v in metadata.items() if isinstance(k, str)
-        }
+    entry = _lease_entry(
+        lease_id=lease_id,
+        session_id=str(session_id),
+        surface=str(surface),
+        metadata=metadata,
+        track_liveness=track_liveness,
+    )
 
     resolved_home = _registry_home(registry_home)
     state_path = _state_path(resolved_home)
     with _FileLock(_lock_path(resolved_home)):
-        raw_entries = _read_entries(state_path)
-        entries = _prune_dead(raw_entries)
+        try:
+            raw_entries = _read_entries(state_path, strict=True)
+            entries = _prune_dead(raw_entries, strict=track_liveness)
+        except ActiveSessionRegistryError:
+            if track_liveness:
+                raise
+            logger.warning(
+                "Active-session registry is unavailable; allowing an "
+                "untracked session without overwriting it"
+            )
+            return (
+                ActiveSessionLease(
+                    lease_id=lease_id,
+                    session_id=session_id,
+                    surface=surface,
+                    enabled=False,
+                    registry_home=str(resolved_home),
+                ),
+                None,
+            )
         pruned = len(raw_entries) - len(entries)
         if pruned:
             logger.info("Pruned %d stale active session lease(s)", pruned)
@@ -305,22 +449,34 @@ def try_acquire_active_session(
         session_id=str(session_id),
         surface=str(surface),
         registry_home=str(resolved_home),
+        track_liveness=track_liveness,
     ), None
 
 
 def release_active_session(lease: ActiveSessionLease) -> None:
     state_path = _state_path(lease.registry_home)
-    try:
-        with _FileLock(_lock_path(lease.registry_home)):
-            entries = _prune_dead(_read_entries(state_path))
-            kept = [
-                entry
-                for entry in entries
-                if str(entry.get("lease_id") or "") != lease.lease_id
-            ]
-            if len(kept) != len(entries):
-                _write_entries(state_path, kept)
-    finally:
+    with _FileLock(_lock_path(lease.registry_home)):
+        if lease.released:
+            return
+        try:
+            raw_entries = _read_entries(state_path, strict=True)
+            entries = _prune_dead(raw_entries, strict=lease.track_liveness)
+        except ActiveSessionRegistryError:
+            if lease.track_liveness:
+                raise
+            logger.warning(
+                "Active-session registry is unavailable; preserving it while "
+                "releasing an untracked lease"
+            )
+            lease.released = True
+            return
+        kept = [
+            entry
+            for entry in entries
+            if str(entry.get("lease_id") or "") != lease.lease_id
+        ]
+        if kept != raw_entries:
+            _write_entries(state_path, kept)
         lease.released = True
 
 
@@ -342,7 +498,21 @@ def transfer_active_session(
 
     state_path = _state_path(lease.registry_home)
     with _FileLock(_lock_path(lease.registry_home)):
-        entries = _prune_dead(_read_entries(state_path))
+        # release() may have won after the optimistic precheck but before this
+        # thread acquired the file lock. Never resurrect a durably removed lease.
+        if lease.released:
+            return False
+        try:
+            raw_entries = _read_entries(state_path, strict=True)
+            entries = _prune_dead(raw_entries, strict=lease.track_liveness)
+        except ActiveSessionRegistryError:
+            if lease.track_liveness:
+                raise
+            logger.warning(
+                "Active-session registry is unavailable; refusing to overwrite "
+                "it during lease transfer"
+            )
+            return False
         updated = False
         for entry in entries:
             if str(entry.get("lease_id") or "") != lease.lease_id:
@@ -355,6 +525,17 @@ def transfer_active_session(
                 }
             updated = True
             break
+        if not updated and lease.track_liveness:
+            entries.append(
+                _lease_entry(
+                    lease_id=lease.lease_id,
+                    session_id=new_session_id,
+                    surface=lease.surface,
+                    metadata=metadata,
+                    track_liveness=True,
+                )
+            )
+            updated = True
         if updated:
             _write_entries(state_path, entries)
             lease.session_id = new_session_id
@@ -367,8 +548,10 @@ def active_session_registry_snapshot(
     """Return the pruned active-session registry for diagnostics/tests."""
     state_path = _state_path(registry_home)
     with _FileLock(_lock_path(registry_home)):
-        entries = _prune_dead(_read_entries(state_path))
-        _write_entries(state_path, entries)
+        raw_entries = _read_entries(state_path, strict=True)
+        entries = _prune_dead(raw_entries)
+        if entries != raw_entries:
+            _write_entries(state_path, entries)
         return entries
 
 
@@ -387,8 +570,44 @@ def active_session_liveness_guard(
     target = str(session_id or "")
     state_path = _state_path(registry_home)
     with _FileLock(_lock_path(registry_home)):
-        entries = _prune_dead(_read_entries(state_path))
+        entries = _prune_dead(_read_entries(state_path, strict=True), strict=True)
         _write_entries(state_path, entries)
         yield bool(target) and any(
             str(entry.get("session_id") or "") == target for entry in entries
+        )
+
+
+@contextmanager
+def release_active_session_liveness_guard(
+    lease: ActiveSessionLease,
+    session_id: str,
+) -> Iterator[bool]:
+    """Remove ``lease`` and hold its registry lock through a lifecycle write.
+
+    This makes automatic cleanup one atomic ownership decision: the local
+    runtime disappears, sibling liveness is checked, and the caller may end the
+    durable row before any new backend can acquire/reopen it.
+    """
+    if not lease.enabled or lease.released:
+        with active_session_liveness_guard(
+            session_id, registry_home=lease.registry_home
+        ) as active:
+            yield active
+        return
+
+    target = str(session_id or "")
+    state_path = _state_path(lease.registry_home)
+    with _FileLock(_lock_path(lease.registry_home)):
+        raw_entries = _read_entries(state_path, strict=True)
+        entries = _prune_dead(raw_entries, strict=True)
+        kept = [
+            entry
+            for entry in entries
+            if str(entry.get("lease_id") or "") != lease.lease_id
+        ]
+        if kept != raw_entries:
+            _write_entries(state_path, kept)
+        lease.released = True
+        yield bool(target) and any(
+            str(entry.get("session_id") or "") == target for entry in kept
         )

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -2,34 +2,59 @@ import logging
 import os
 import subprocess
 import sys
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+
+import pytest
 
 from hermes_cli import active_sessions
 
 
 def test_resolve_max_concurrent_sessions_values(caplog):
     assert active_sessions.resolve_max_concurrent_sessions({}) is None
-    assert active_sessions.resolve_max_concurrent_sessions({"max_concurrent_sessions": None}) is None
-    assert active_sessions.resolve_max_concurrent_sessions({"max_concurrent_sessions": 0}) is None
-    assert active_sessions.resolve_max_concurrent_sessions({"max_concurrent_sessions": -1}) is None
-    assert active_sessions.resolve_max_concurrent_sessions({"max_concurrent_sessions": "3"}) == 3
     assert (
-        active_sessions.resolve_max_concurrent_sessions(
-            {"gateway": {"max_concurrent_sessions": 4}}
-        )
+        active_sessions.resolve_max_concurrent_sessions({
+            "max_concurrent_sessions": None
+        })
+        is None
+    )
+    assert (
+        active_sessions.resolve_max_concurrent_sessions({"max_concurrent_sessions": 0})
+        is None
+    )
+    assert (
+        active_sessions.resolve_max_concurrent_sessions({"max_concurrent_sessions": -1})
+        is None
+    )
+    assert (
+        active_sessions.resolve_max_concurrent_sessions({
+            "max_concurrent_sessions": "3"
+        })
+        == 3
+    )
+    assert (
+        active_sessions.resolve_max_concurrent_sessions({
+            "gateway": {"max_concurrent_sessions": 4}
+        })
         == 4
     )
     assert (
-        active_sessions.resolve_max_concurrent_sessions(
-            {"max_concurrent_sessions": 2, "gateway": {"max_concurrent_sessions": 4}}
-        )
+        active_sessions.resolve_max_concurrent_sessions({
+            "max_concurrent_sessions": 2,
+            "gateway": {"max_concurrent_sessions": 4},
+        })
         == 2
     )
 
     caplog.set_level(logging.WARNING)
-    assert active_sessions.resolve_max_concurrent_sessions({"max_concurrent_sessions": "many"}) is None
+    assert (
+        active_sessions.resolve_max_concurrent_sessions({
+            "max_concurrent_sessions": "many"
+        })
+        is None
+    )
     assert any(
         "Ignoring invalid max_concurrent_sessions='many'" in record.message
         for record in caplog.records
@@ -107,9 +132,10 @@ def test_active_session_registry_prunes_dead_pids(tmp_path, monkeypatch):
 
     assert message is None
     assert lease is not None
-    assert [entry["session_id"] for entry in active_sessions.active_session_registry_snapshot()] == [
-        "session-1"
-    ]
+    assert [
+        entry["session_id"]
+        for entry in active_sessions.active_session_registry_snapshot()
+    ] == ["session-1"]
     lease.release()
 
 
@@ -138,6 +164,322 @@ def test_transfer_active_session_reanchors_existing_lease(tmp_path, monkeypatch)
     assert snapshot[0]["session_id"] == "session-new"
     assert snapshot[0]["metadata"] == {"live_session_id": "ui-1"}
     lease.release()
+
+
+def test_liveness_registry_corruption_fails_closed_without_overwrite(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    state_path = home / "runtime" / "active_sessions.json"
+    state_path.parent.mkdir(parents=True)
+    corrupt = "{not-json"
+    state_path.write_text(corrupt, encoding="utf-8")
+
+    with pytest.raises(active_sessions.ActiveSessionRegistryError):
+        with active_sessions.active_session_liveness_guard("session-1"):
+            pass
+
+    with pytest.raises(active_sessions.ActiveSessionRegistryError):
+        active_sessions.active_session_registry_snapshot()
+
+    assert state_path.read_text(encoding="utf-8") == corrupt
+
+    with pytest.raises(active_sessions.ActiveSessionRegistryError):
+        active_sessions.try_acquire_active_session(
+            session_id="desktop-1",
+            surface="desktop",
+            config={},
+            track_liveness=True,
+        )
+    assert state_path.read_text(encoding="utf-8") == corrupt
+
+    # The pre-existing concurrency-cap path remains available/fail-open, but
+    # must not erase evidence that strict liveness ownership is unknown.
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="cli-1",
+        surface="cli",
+        config={"max_concurrent_sessions": 1},
+    )
+    assert lease is not None and message is None
+    assert lease.enabled is False
+    assert state_path.read_text(encoding="utf-8") == corrupt
+    lease.release()
+    assert state_path.read_text(encoding="utf-8") == corrupt
+
+
+def test_strict_registry_rejects_structurally_invalid_entries(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    state_path = home / "runtime" / "active_sessions.json"
+    base = {
+        "lease_id": "lease-1",
+        "session_id": "session-1",
+        "surface": "desktop",
+        "pid": os.getpid(),
+        "track_liveness": True,
+    }
+    invalid_entries = (
+        {key: value for key, value in base.items() if key != "lease_id"},
+        {**base, "lease_id": ""},
+        {key: value for key, value in base.items() if key != "session_id"},
+        {**base, "session_id": "  "},
+        {**base, "pid": 0},
+        {**base, "pid": 1.5},
+        {**base, "surface": 1},
+        {**base, "track_liveness": "yes"},
+        {**base, "metadata": []},
+        {**base, "process_start_time": "not-a-number"},
+        {**base, "process_start_time": "nan"},
+    )
+
+    for entry in invalid_entries:
+        active_sessions._write_entries(state_path, [entry])
+        original = state_path.read_text(encoding="utf-8")
+        with pytest.raises(active_sessions.ActiveSessionRegistryError):
+            with active_sessions.active_session_liveness_guard("session-1"):
+                pass
+        assert state_path.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.parametrize(
+    "second_session_id",
+    ("session-a", "session-b"),
+    ids=("exact-duplicate", "conflicting-duplicate"),
+)
+def test_strict_registry_rejects_duplicate_lease_ids(
+    tmp_path, monkeypatch, second_session_id
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    state_path = home / "runtime" / "active_sessions.json"
+    active_sessions._write_entries(
+        state_path,
+        [
+            {
+                "lease_id": "duplicate-lease",
+                "session_id": "session-a",
+                "surface": "desktop",
+                "pid": os.getpid(),
+                "track_liveness": True,
+            },
+            {
+                "lease_id": "duplicate-lease",
+                "session_id": second_session_id,
+                "surface": "desktop",
+                "pid": os.getpid(),
+                "track_liveness": True,
+            },
+        ],
+    )
+    original = state_path.read_text(encoding="utf-8")
+
+    with pytest.raises(active_sessions.ActiveSessionRegistryError):
+        active_sessions.active_session_registry_snapshot()
+
+    assert state_path.read_text(encoding="utf-8") == original
+
+
+def test_cap_transfer_does_not_overwrite_registry_corruption(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    state_path = home / "runtime" / "active_sessions.json"
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="cli-old",
+        surface="cli",
+        config={"max_concurrent_sessions": 1},
+    )
+    assert lease is not None and message is None
+
+    corrupt = "{not-json"
+    state_path.write_text(corrupt, encoding="utf-8")
+    assert not active_sessions.transfer_active_session(
+        lease,
+        session_id="cli-new",
+    )
+    assert lease.session_id == "cli-old"
+    assert state_path.read_text(encoding="utf-8") == corrupt
+
+    lease.release()
+    assert lease.released is True
+    assert state_path.read_text(encoding="utf-8") == corrupt
+
+
+def test_liveness_guard_rejects_unknown_pid_state(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    state_path = home / "runtime" / "active_sessions.json"
+    active_sessions._write_entries(
+        state_path,
+        [
+            {
+                "lease_id": "unknown-owner",
+                "session_id": "session-1",
+                "surface": "desktop",
+                "pid": 12345,
+                "track_liveness": True,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "gateway.status._pid_exists",
+        lambda _pid: (_ for _ in ()).throw(OSError("pid lookup unavailable")),
+    )
+
+    with pytest.raises(active_sessions.ActiveSessionRegistryError):
+        with active_sessions.active_session_liveness_guard("session-1"):
+            pass
+
+    original = state_path.read_text(encoding="utf-8")
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="cli-cap-session",
+        surface="cli",
+        config={"max_concurrent_sessions": 1},
+    )
+    assert lease is not None and message is None
+    assert lease.enabled is False
+    assert state_path.read_text(encoding="utf-8") == original
+
+
+def test_liveness_release_failure_is_retryable(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="session-1",
+        surface="desktop",
+        config={},
+        track_liveness=True,
+    )
+    assert lease is not None and message is None
+
+    original_write = active_sessions._write_entries
+    monkeypatch.setattr(
+        active_sessions,
+        "_write_entries",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("replace failed")),
+    )
+    with pytest.raises(OSError, match="replace failed"):
+        lease.release()
+    assert lease.released is False
+
+    monkeypatch.setattr(active_sessions, "_write_entries", original_write)
+    lease.release()
+    assert lease.released is True
+    assert active_sessions.active_session_registry_snapshot() == []
+
+
+def test_liveness_transfer_upserts_missing_entry_without_consuming_a_new_slot(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="session-old",
+        surface="desktop",
+        config={"max_concurrent_sessions": 1},
+        track_liveness=True,
+    )
+    assert lease is not None and message is None
+    (home / "runtime" / "active_sessions.json").unlink()
+
+    assert active_sessions.transfer_active_session(lease, session_id="session-new")
+    snapshot = active_sessions.active_session_registry_snapshot()
+    assert [(entry["lease_id"], entry["session_id"]) for entry in snapshot] == [
+        (lease.lease_id, "session-new")
+    ]
+
+    blocked, limit_message = active_sessions.try_acquire_active_session(
+        session_id="session-other",
+        surface="desktop",
+        config={"max_concurrent_sessions": 1},
+        track_liveness=True,
+    )
+    assert blocked is None
+    assert limit_message is not None
+    lease.release()
+
+
+def test_liveness_transfer_write_failure_keeps_old_id_for_retry(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="session-old",
+        surface="desktop",
+        config={},
+        track_liveness=True,
+    )
+    assert lease is not None and message is None
+
+    original_write = active_sessions._write_entries
+    monkeypatch.setattr(
+        active_sessions,
+        "_write_entries",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("replace failed")),
+    )
+    with pytest.raises(OSError, match="replace failed"):
+        active_sessions.transfer_active_session(lease, session_id="session-new")
+    assert lease.session_id == "session-old"
+
+    monkeypatch.setattr(active_sessions, "_write_entries", original_write)
+    assert active_sessions.transfer_active_session(lease, session_id="session-new")
+    assert lease.session_id == "session-new"
+    lease.release()
+
+
+def test_release_wins_against_transfer_waiting_on_same_lease_lock(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="session-old",
+        surface="desktop",
+        config={},
+        track_liveness=True,
+    )
+    assert lease is not None and message is None
+
+    release_wrote = threading.Event()
+    allow_release = threading.Event()
+    transfer_at_lock = threading.Event()
+    original_write = active_sessions._write_entries
+    original_enter = active_sessions._FileLock.__enter__
+
+    def _blocking_write(path, entries):
+        original_write(path, entries)
+        if threading.current_thread().name == "lease-release":
+            release_wrote.set()
+            assert allow_release.wait(timeout=5)
+
+    def _instrumented_enter(lock):
+        if threading.current_thread().name == "lease-transfer":
+            transfer_at_lock.set()
+        return original_enter(lock)
+
+    monkeypatch.setattr(active_sessions, "_write_entries", _blocking_write)
+    monkeypatch.setattr(active_sessions._FileLock, "__enter__", _instrumented_enter)
+    transfer_result: list[bool] = []
+    release_thread = threading.Thread(target=lease.release, name="lease-release")
+    transfer_thread = threading.Thread(
+        target=lambda: transfer_result.append(
+            active_sessions.transfer_active_session(lease, session_id="session-new")
+        ),
+        name="lease-transfer",
+    )
+
+    release_thread.start()
+    assert release_wrote.wait(timeout=5)
+    transfer_thread.start()
+    assert transfer_at_lock.wait(timeout=5)
+    allow_release.set()
+    release_thread.join(timeout=5)
+    transfer_thread.join(timeout=5)
+
+    assert not release_thread.is_alive()
+    assert not transfer_thread.is_alive()
+    assert transfer_result == [False]
+    assert lease.released is True
+    assert active_sessions.active_session_registry_snapshot() == []
 
 
 def test_pid_alive_uses_safe_pid_exists_without_signalling(monkeypatch):
@@ -182,7 +524,7 @@ def test_active_session_hard_exit_is_reclaimed(tmp_path, monkeypatch):
         env=env,
         text=True,
         capture_output=True,
-        timeout=10,
+        timeout=60,
         check=True,
     )
     child_pid = int(child.stdout.strip())
@@ -196,9 +538,10 @@ def test_active_session_hard_exit_is_reclaimed(tmp_path, monkeypatch):
     assert child_pid > 0
     assert message is None
     assert lease is not None
-    assert [entry["session_id"] for entry in active_sessions.active_session_registry_snapshot()] == [
-        "next-session"
-    ]
+    assert [
+        entry["session_id"]
+        for entry in active_sessions.active_session_registry_snapshot()
+    ] == ["next-session"]
     lease.release()
 
 
@@ -217,13 +560,17 @@ def test_concurrent_acquire_claims_only_one_last_slot(tmp_path, monkeypatch):
     with ThreadPoolExecutor(max_workers=8) as pool:
         results = list(pool.map(_claim, range(8)))
 
-    leases = [lease for lease, message in results if lease is not None and message is None]
+    leases = [
+        lease for lease, message in results if lease is not None and message is None
+    ]
     blocked = [message for lease, message in results if lease is None and message]
 
     try:
         assert len(leases) == 1
         assert len(blocked) == 7
-        assert active_sessions.active_session_registry_snapshot()[0]["session_id"].startswith("session-")
+        assert active_sessions.active_session_registry_snapshot()[0][
+            "session_id"
+        ].startswith("session-")
     finally:
         for lease in leases:
             lease.release()
@@ -244,6 +591,7 @@ def test_cross_process_acquire_claims_only_one_last_slot(tmp_path, monkeypatch):
     script = (
         "import os, time\n"
         "from pathlib import Path\n"
+        "from gateway.status import _pid_exists as _preload_pid_exists\n"
         "from hermes_cli.active_sessions import try_acquire_active_session\n"
         "idx = os.environ['WORKER_INDEX']\n"
         "worker_count = int(os.environ['WORKER_COUNT'])\n"
@@ -252,7 +600,7 @@ def test_cross_process_acquire_claims_only_one_last_slot(tmp_path, monkeypatch):
         "results_dir = Path(os.environ['RESULTS_DIR'])\n"
         "go_file = Path(os.environ['GO_FILE'])\n"
         "(ready_dir / idx).write_text('ready', encoding='utf-8')\n"
-        "deadline = time.time() + 10\n"
+        "deadline = time.time() + 60\n"
         "while not go_file.exists():\n"
         "    if time.time() > deadline:\n"
         "        raise RuntimeError('timed out waiting for go file')\n"
@@ -270,7 +618,7 @@ def test_cross_process_acquire_claims_only_one_last_slot(tmp_path, monkeypatch):
         "else:\n"
         "    (results_dir / idx).write_text('OK', encoding='utf-8')\n"
         "    print('OK', flush=True)\n"
-        "    deadline = time.time() + 10\n"
+        "    deadline = time.time() + 120\n"
         "    while len(list(results_dir.iterdir())) < worker_count:\n"
         "        if time.time() > deadline:\n"
         "            raise RuntimeError('timed out waiting for all workers to attempt acquire')\n"
@@ -279,11 +627,15 @@ def test_cross_process_acquire_claims_only_one_last_slot(tmp_path, monkeypatch):
     )
     workers: list[subprocess.Popen[str]] = []
     try:
-        for index in range(6):
+        # Three contenders are sufficient to prove the one-slot invariant:
+        # two race immediately and one arrives late while the winner still
+        # holds its lease. Keeping this small avoids Windows process-start and
+        # antivirus jitter turning the ownership assertion into a stress test.
+        for index in range(3):
             worker_env = env.copy()
             worker_env["WORKER_INDEX"] = str(index)
-            worker_env["WORKER_COUNT"] = "6"
-            worker_env["DELAYED_WORKER_INDEX"] = "5"
+            worker_env["WORKER_COUNT"] = "3"
+            worker_env["DELAYED_WORKER_INDEX"] = "2"
             worker_env["READY_DIR"] = str(ready_dir)
             worker_env["RESULTS_DIR"] = str(results_dir)
             worker_env["GO_FILE"] = str(go_file)
@@ -297,7 +649,7 @@ def test_cross_process_acquire_claims_only_one_last_slot(tmp_path, monkeypatch):
                 )
             )
 
-        deadline = time.time() + 10
+        deadline = time.time() + 60
         while len(list(ready_dir.iterdir())) < len(workers):
             if time.time() > deadline:
                 raise AssertionError("workers did not become ready")
@@ -306,7 +658,7 @@ def test_cross_process_acquire_claims_only_one_last_slot(tmp_path, monkeypatch):
 
         outputs = []
         for worker in workers:
-            stdout, stderr = worker.communicate(timeout=10)
+            stdout, stderr = worker.communicate(timeout=120)
             assert worker.returncode == 0, stderr
             outputs.append(stdout.strip())
     finally:
@@ -350,7 +702,8 @@ def test_pid_start_time_mismatch_prunes_reused_pid(tmp_path, monkeypatch):
 
     assert message is None
     assert lease is not None
-    assert [entry["session_id"] for entry in active_sessions.active_session_registry_snapshot()] == [
-        "new-session"
-    ]
+    assert [
+        entry["session_id"]
+        for entry in active_sessions.active_session_registry_snapshot()
+    ] == ["new-session"]
     lease.release()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6339,7 +6339,11 @@ def test_prompt_submit_auto_titles_session_on_complete(monkeypatch):
                 ],
             }
 
-    server._sessions["sid"] = _session(agent=_Agent())
+    owned_db = object()
+    agent = _Agent()
+    agent._session_db = owned_db
+    server._sessions["sid"] = _session(agent=agent)
+    server._sessions["sid"]["profile_home"] = "/profile-home"
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
@@ -6357,6 +6361,7 @@ def test_prompt_submit_auto_titles_session_on_complete(monkeypatch):
 
     mock_title.assert_called_once()
     args = mock_title.call_args.args
+    assert args[0] is owned_db
     assert args[1] == "session-key"
     assert args[2] == "Tell me about Rome"
     assert args[3] == "Rome was founded in 753 BC."
@@ -7884,6 +7889,110 @@ def test_notification_poller_delivers_completion(monkeypatch):
         server._sessions.pop("sid_poll", None)
         while not process_registry.completion_queue.empty():
             process_registry.completion_queue.get_nowait()
+
+
+def test_notification_poller_requeues_until_ownership_transfer_succeeds(monkeypatch):
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    sid = "sid-ownership-barrier"
+    agent = types.SimpleNamespace(session_id="new-key")
+    session = _session(
+        agent=agent,
+        session_key="old-key",
+        _ownership_sync_pending="new-key",
+    )
+    server._sessions[sid] = session
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    event = {
+        "type": "watch_match",
+        "session_id": "proc-ownership-barrier",
+        "session_key": "new-key",
+        "command": "worker",
+        "pattern": "READY",
+        "output": "READY",
+    }
+    isolated_queue.put(event)
+    transfer_results = iter((False, True))
+    turns: list[str] = []
+    emitted: list[tuple] = []
+
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(
+        server,
+        "_transfer_active_session_slot",
+        lambda *_args, **_kwargs: next(transfer_results),
+    )
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *_args: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+
+    def _run(_rid, _sid, current, text):
+        turns.append(text)
+        current["running"] = False
+
+    monkeypatch.setattr(server, "_run_prompt_submit", _run)
+    stop = threading.Event()
+    stop.set()
+
+    try:
+        server._notification_poller_loop(stop, sid, session)
+        assert isolated_queue.qsize() == 1
+        assert turns == []
+        assert emitted == []
+        assert session["session_key"] == "old-key"
+        assert session["_ownership_sync_pending"] == "new-key"
+        assert session["running"] is False
+
+        server._notification_poller_loop(stop, sid, session)
+        assert isolated_queue.empty()
+        assert len(turns) == 1
+        assert session["session_key"] == "new-key"
+        assert "_ownership_sync_pending" not in session
+        assert session["running"] is False
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_notification_poller_claim_denied_rolls_back_running(monkeypatch):
+    import queue as _queue_mod
+
+    from tools import async_delegation
+    from tools.process_registry import process_registry
+
+    sid = "sid-claim-denied"
+    session = _session(session_key="claim-key")
+    server._sessions[sid] = session
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    isolated_queue.put({
+        "type": "watch_match",
+        "session_id": "proc-claim-denied",
+        "session_key": "claim-key",
+        "command": "worker",
+        "pattern": "READY",
+        "output": "READY",
+    })
+    turns: list[str] = []
+
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    monkeypatch.setattr(async_delegation, "claim_event_delivery", lambda *_args: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args: None)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, _session, text: turns.append(text),
+    )
+    stop = threading.Event()
+    stop.set()
+
+    try:
+        server._notification_poller_loop(stop, sid, session)
+        assert turns == []
+        assert session["running"] is False
+    finally:
+        server._sessions.pop(sid, None)
 
 
 def test_notification_poller_skips_consumed(monkeypatch):

--- a/tests/tui_gateway/test_cross_process_orphan_ownership.py
+++ b/tests/tui_gateway/test_cross_process_orphan_ownership.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import threading
 import time
+import types
 from pathlib import Path
 
 import pytest
@@ -23,11 +24,25 @@ import os
 import time
 from pathlib import Path
 
+from hermes_cli import active_sessions
 from hermes_cli.active_sessions import try_acquire_active_session
 
-attempted_file = os.environ.get("ATTEMPTED_FILE")
-if attempted_file:
-    Path(attempted_file).write_text("attempted", encoding="utf-8")
+boundary_file = os.environ.get("BOUNDARY_FILE")
+if boundary_file:
+    original_enter = active_sessions._FileLock.__enter__
+    def instrumented_enter(self):
+        Path(boundary_file).write_text("boundary", encoding="utf-8")
+        return original_enter(self)
+    active_sessions._FileLock.__enter__ = instrumented_enter
+
+go_file = os.environ.get("GO_FILE")
+if go_file:
+    Path(os.environ["WAITING_FILE"]).write_text("waiting", encoding="utf-8")
+    deadline = time.monotonic() + 120
+    while not Path(go_file).exists():
+        if time.monotonic() >= deadline:
+            raise RuntimeError("timed out waiting for acquisition signal")
+        time.sleep(0.02)
 lease, message = try_acquire_active_session(
     session_id=os.environ["SESSION_ID"],
     surface="desktop",
@@ -37,7 +52,7 @@ lease, message = try_acquire_active_session(
 assert lease is not None and message is None, message
 Path(os.environ["READY_FILE"]).write_text("ready", encoding="utf-8")
 try:
-    deadline = time.monotonic() + 30
+    deadline = time.monotonic() + 120
     release_file = Path(os.environ["RELEASE_FILE"])
     while not release_file.exists():
         if time.monotonic() >= deadline:
@@ -54,7 +69,9 @@ def _spawn_lease_holder(
     session_id: str,
     ready_file: Path,
     release_file: Path,
-    attempted_file: Path | None = None,
+    boundary_file: Path | None = None,
+    go_file: Path | None = None,
+    waiting_file: Path | None = None,
 ) -> subprocess.Popen[str]:
     repo_root = Path(__file__).resolve().parents[2]
     env = os.environ.copy()
@@ -70,8 +87,11 @@ def _spawn_lease_holder(
         "RELEASE_FILE": str(release_file),
         "SESSION_ID": session_id,
     })
-    if attempted_file is not None:
-        env["ATTEMPTED_FILE"] = str(attempted_file)
+    if boundary_file is not None:
+        env["BOUNDARY_FILE"] = str(boundary_file)
+    if go_file is not None and waiting_file is not None:
+        env["GO_FILE"] = str(go_file)
+        env["WAITING_FILE"] = str(waiting_file)
     return subprocess.Popen(
         [sys.executable, "-c", _LEASE_HOLDER_SCRIPT],
         env=env,
@@ -86,7 +106,7 @@ def _wait_for_child_file(
     path: Path,
     *,
     label: str,
-    timeout: float = 10.0,
+    timeout: float = 60.0,
 ) -> None:
     deadline = time.monotonic() + timeout
     while not path.exists():
@@ -146,34 +166,172 @@ def test_orphan_guard_fails_closed_when_registry_is_unavailable(
         assert sibling_active is True
 
 
+def test_desktop_claim_fails_closed_when_registry_setup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: (_ for _ in ()).throw(OSError("config unavailable")),
+    )
+
+    desktop_lease, desktop_message = server._claim_active_session_slot(
+        "desktop-session",
+        live_session_id="desktop-runtime",
+        surface="desktop",
+    )
+    tui_lease, tui_message = server._claim_active_session_slot(
+        "tui-session",
+        live_session_id="tui-runtime",
+        surface="tui",
+    )
+
+    assert desktop_lease is None
+    assert desktop_message == server._SESSION_OWNERSHIP_UNAVAILABLE
+    assert (tui_lease, tui_message) == (None, None)
+
+
+def test_server_release_retries_liveness_lease_before_dropping_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Lease:
+        enabled = True
+        released = False
+        track_liveness = True
+        calls = 0
+
+        def release(self):
+            self.calls += 1
+            if self.calls == 1:
+                raise OSError("replace failed once")
+            self.released = True
+
+    lease = _Lease()
+    session = {"active_session_lease": lease}
+    monkeypatch.setattr(server.time, "sleep", lambda *_args: None)
+
+    assert server._release_active_session_slot(session) is True
+    assert lease.calls == 2
+    assert "active_session_lease" not in session
+
+
+def test_automatic_cleanup_preserves_corrupt_registry_without_overwrite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profile_home = tmp_path / "profile-home"
+    state_path = profile_home / "runtime" / "active_sessions.json"
+    state_path.parent.mkdir(parents=True)
+    corrupt = "{not-json"
+    state_path.write_text(corrupt, encoding="utf-8")
+    ended: list[tuple[str, str]] = []
+
+    class _FakeDB:
+        def get_session(self, target: str) -> dict[str, str]:
+            return {"id": target, "source": "desktop"}
+
+        def end_session(self, target: str, reason: str) -> None:
+            ended.append((target, reason))
+
+    @contextlib.contextmanager
+    def _profile_db(_session: dict):
+        yield _FakeDB()
+
+    monkeypatch.setattr(server, "_session_db", _profile_db)
+    monkeypatch.setattr(
+        server, "_notify_session_boundary", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda *args, **kwargs: None
+    )
+    session = {
+        "agent": None,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "profile_home": str(profile_home),
+        "session_key": "preserved-session",
+        "slash_worker": None,
+        "source": "desktop",
+    }
+
+    server._finalize_session(session, end_reason="idle_timeout")
+
+    assert ended == []
+    assert state_path.read_text(encoding="utf-8") == corrupt
+
+
+def test_compression_ownership_failure_quiesces_until_next_rpc_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools import approval
+
+    outcomes = iter((False, True))
+    monkeypatch.setattr(
+        server,
+        "_transfer_active_session_slot",
+        lambda *_args, **_kwargs: next(outcomes),
+    )
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda *_args: None)
+    monkeypatch.setattr(approval, "unregister_gateway_notify", lambda *_args: None)
+    monkeypatch.setattr(approval, "register_gateway_notify", lambda *_args: None)
+    monkeypatch.setattr(approval, "is_session_yolo_enabled", lambda *_args: False)
+    session = {
+        "agent": types.SimpleNamespace(session_id="session-new"),
+        "session_key": "session-old",
+    }
+    server._sessions["runtime-1"] = session
+
+    try:
+        with pytest.raises(RuntimeError, match="ownership transfer failed"):
+            server._sync_session_key_after_compress("runtime-1", session)
+        assert session["session_key"] == "session-old"
+        assert session["_ownership_sync_pending"] == "session-new"
+
+        resumed, err = server._sess_nowait({"session_id": "runtime-1"}, "retry-request")
+        assert err is None
+        assert resumed is session
+        assert session["session_key"] == "session-new"
+        assert "_ownership_sync_pending" not in session
+    finally:
+        server._sessions.pop("runtime-1", None)
+
+
 def test_liveness_guard_serializes_cross_process_acquire(tmp_path: Path) -> None:
     home = tmp_path / "guard-home"
-    attempted_file = tmp_path / "child-attempted"
+    waiting_file = tmp_path / "child-waiting"
+    boundary_file = tmp_path / "child-lock-boundary"
+    go_file = tmp_path / "child-go"
     acquired_file = tmp_path / "child-acquired"
     release_file = tmp_path / "child-release"
     session_id = "guarded-session"
     child: subprocess.Popen[str] | None = None
 
     try:
+        child = _spawn_lease_holder(
+            home=home,
+            session_id=session_id,
+            ready_file=acquired_file,
+            release_file=release_file,
+            boundary_file=boundary_file,
+            go_file=go_file,
+            waiting_file=waiting_file,
+        )
+        _wait_for_child_file(child, waiting_file, label="lease contender bootstrap")
+
         with active_session_liveness_guard(
             session_id,
             registry_home=home,
         ) as active:
             assert active is False
-            child = _spawn_lease_holder(
-                home=home,
-                session_id=session_id,
-                ready_file=acquired_file,
-                release_file=release_file,
-                attempted_file=attempted_file,
-            )
-            _wait_for_child_file(child, attempted_file, label="lease contender")
+            go_file.write_text("go", encoding="utf-8")
+            _wait_for_child_file(child, boundary_file, label="lease lock boundary")
+            time.sleep(0.25)
             assert not acquired_file.exists()
+            assert child.poll() is None
 
         assert child is not None
         _wait_for_child_file(child, acquired_file, label="lease contender")
         release_file.write_text("release", encoding="utf-8")
-        stdout, stderr = child.communicate(timeout=10)
+        stdout, stderr = child.communicate(timeout=30)
         assert child.returncode == 0, f"stdout: {stdout}\nstderr: {stderr}"
         assert active_session_registry_snapshot(registry_home=home) == []
     finally:
@@ -181,10 +339,10 @@ def test_liveness_guard_serializes_cross_process_acquire(tmp_path: Path) -> None
             _stop_child(child, release_file)
 
 
-def test_ws_orphan_reap_preserves_session_owned_by_other_backend(
+def test_automatic_desktop_cleanup_preserves_sibling_and_ends_sole_owner(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A profile sidecar must not end another backend's live durable session."""
+    """Every automatic cleanup reason must preserve another Desktop backend."""
     profile_home = tmp_path / "profile-home"
     ready_file = tmp_path / "child-ready"
     release_file = tmp_path / "child-release"
@@ -233,38 +391,63 @@ def test_ws_orphan_reap_preserves_session_owned_by_other_backend(
     try:
         _wait_for_child_file(child, ready_file, label="lease holder")
 
-        local_lease, message = server._claim_active_session_slot(
+        reasons = (
+            "ws_orphan_reap",
+            "ws_disconnect",
+            "idle_timeout",
+            "lru_evict",
+            "tui_shutdown",
+        )
+        assert set(reasons) == server._AUTOMATIC_SESSION_END_REASONS
+
+        for index, reason in enumerate(reasons):
+            local_lease, message = server._claim_active_session_slot(
+                session_id,
+                live_session_id=f"local-runtime-{index}",
+                surface="desktop",
+                profile_home=profile_home,
+            )
+            assert local_lease is not None and message is None
+            assert (
+                len(active_session_registry_snapshot(registry_home=profile_home)) == 2
+            )
+
+            server._finalize_session(_session(local_lease), end_reason=reason)
+
+            assert ended == []
+            remaining = active_session_registry_snapshot(registry_home=profile_home)
+            assert len(remaining) == 1
+            assert remaining[0]["session_id"] == session_id
+
+        # Explicit user close retains force/end semantics even with a sibling.
+        explicit_lease, message = server._claim_active_session_slot(
             session_id,
-            live_session_id="local-runtime",
+            live_session_id="explicit-runtime",
             surface="desktop",
             profile_home=profile_home,
         )
-        assert local_lease is not None and message is None
-        assert len(active_session_registry_snapshot(registry_home=profile_home)) == 2
-
-        server._finalize_session(_session(local_lease), end_reason="ws_orphan_reap")
-
-        assert ended == []
-        remaining = active_session_registry_snapshot(registry_home=profile_home)
-        assert len(remaining) == 1
-        assert remaining[0]["session_id"] == session_id
+        assert explicit_lease is not None and message is None
+        server._finalize_session(_session(explicit_lease), end_reason="tui_close")
+        assert ended == [(session_id, "tui_close")]
+        ended.clear()
 
         release_file.write_text("release", encoding="utf-8")
-        stdout, stderr = child.communicate(timeout=10)
+        stdout, stderr = child.communicate(timeout=30)
         assert child.returncode == 0, f"stdout: {stdout}\nstderr: {stderr}"
         assert active_session_registry_snapshot(registry_home=profile_home) == []
 
-        sole_lease, message = server._claim_active_session_slot(
-            session_id,
-            live_session_id="sole-runtime",
-            surface="desktop",
-            profile_home=profile_home,
-        )
-        assert sole_lease is not None and message is None
+        for index, reason in enumerate(reasons):
+            sole_lease, message = server._claim_active_session_slot(
+                session_id,
+                live_session_id=f"sole-runtime-{index}",
+                surface="desktop",
+                profile_home=profile_home,
+            )
+            assert sole_lease is not None and message is None
 
-        server._finalize_session(_session(sole_lease), end_reason="ws_orphan_reap")
+            server._finalize_session(_session(sole_lease), end_reason=reason)
+            assert active_session_registry_snapshot(registry_home=profile_home) == []
 
-        assert ended == [(session_id, "ws_orphan_reap")]
-        assert active_session_registry_snapshot(registry_home=profile_home) == []
+        assert ended == [(session_id, reason) for reason in reasons]
     finally:
         _stop_child(child, release_file)

--- a/tests/tui_gateway/test_cross_process_orphan_ownership.py
+++ b/tests/tui_gateway/test_cross_process_orphan_ownership.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.active_sessions import (
+    active_session_liveness_guard,
+    active_session_registry_snapshot,
+    try_acquire_active_session,
+)
+from tui_gateway import server
+
+
+_LEASE_HOLDER_SCRIPT = """
+import os
+import time
+from pathlib import Path
+
+from hermes_cli.active_sessions import try_acquire_active_session
+
+attempted_file = os.environ.get("ATTEMPTED_FILE")
+if attempted_file:
+    Path(attempted_file).write_text("attempted", encoding="utf-8")
+lease, message = try_acquire_active_session(
+    session_id=os.environ["SESSION_ID"],
+    surface="desktop",
+    config={},
+    track_liveness=True,
+)
+assert lease is not None and message is None, message
+Path(os.environ["READY_FILE"]).write_text("ready", encoding="utf-8")
+try:
+    deadline = time.monotonic() + 30
+    release_file = Path(os.environ["RELEASE_FILE"])
+    while not release_file.exists():
+        if time.monotonic() >= deadline:
+            raise RuntimeError("timed out waiting for release signal")
+        time.sleep(0.02)
+finally:
+    lease.release()
+"""
+
+
+def _spawn_lease_holder(
+    *,
+    home: Path,
+    session_id: str,
+    ready_file: Path,
+    release_file: Path,
+    attempted_file: Path | None = None,
+) -> subprocess.Popen[str]:
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    for key in list(env):
+        if key.endswith("_API_KEY") or key.endswith("_TOKEN"):
+            env.pop(key)
+    env.update({
+        "HERMES_HOME": str(home),
+        "PYTHONPATH": os.pathsep.join(
+            part for part in (str(repo_root), env.get("PYTHONPATH", "")) if part
+        ),
+        "READY_FILE": str(ready_file),
+        "RELEASE_FILE": str(release_file),
+        "SESSION_ID": session_id,
+    })
+    if attempted_file is not None:
+        env["ATTEMPTED_FILE"] = str(attempted_file)
+    return subprocess.Popen(
+        [sys.executable, "-c", _LEASE_HOLDER_SCRIPT],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _wait_for_child_file(
+    child: subprocess.Popen[str],
+    path: Path,
+    *,
+    label: str,
+    timeout: float = 10.0,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while not path.exists():
+        if child.poll() is not None:
+            stdout, stderr = child.communicate()
+            pytest.fail(
+                f"{label} process exited before signalling readiness\n"
+                f"stdout: {stdout}\nstderr: {stderr}"
+            )
+        if time.monotonic() >= deadline:
+            pytest.fail(f"timed out waiting for {label} process")
+        time.sleep(0.02)
+
+
+def _stop_child(child: subprocess.Popen[str], release_file: Path) -> None:
+    release_file.touch()
+    if child.poll() is None:
+        child.kill()
+    child.communicate()
+
+
+def test_unlimited_session_lease_remains_noop_without_liveness_tracking(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "untracked-home"
+
+    lease, message = try_acquire_active_session(
+        session_id="untracked-session",
+        surface="tui",
+        config={},
+        registry_home=home,
+    )
+
+    assert lease is not None and message is None
+    assert lease.enabled is False
+    assert active_session_registry_snapshot(registry_home=home) == []
+
+
+def test_orphan_guard_fails_closed_when_registry_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hermes_cli import active_sessions
+
+    def _unavailable(*_args, **_kwargs):
+        raise OSError("registry unavailable")
+
+    monkeypatch.setattr(
+        active_sessions,
+        "active_session_liveness_guard",
+        _unavailable,
+    )
+
+    with server._other_runtime_lease_guard(
+        "preserved-session",
+        {"profile_home": None},
+    ) as sibling_active:
+        assert sibling_active is True
+
+
+def test_liveness_guard_serializes_cross_process_acquire(tmp_path: Path) -> None:
+    home = tmp_path / "guard-home"
+    attempted_file = tmp_path / "child-attempted"
+    acquired_file = tmp_path / "child-acquired"
+    release_file = tmp_path / "child-release"
+    session_id = "guarded-session"
+    child: subprocess.Popen[str] | None = None
+
+    try:
+        with active_session_liveness_guard(
+            session_id,
+            registry_home=home,
+        ) as active:
+            assert active is False
+            child = _spawn_lease_holder(
+                home=home,
+                session_id=session_id,
+                ready_file=acquired_file,
+                release_file=release_file,
+                attempted_file=attempted_file,
+            )
+            _wait_for_child_file(child, attempted_file, label="lease contender")
+            assert not acquired_file.exists()
+
+        assert child is not None
+        _wait_for_child_file(child, acquired_file, label="lease contender")
+        release_file.write_text("release", encoding="utf-8")
+        stdout, stderr = child.communicate(timeout=10)
+        assert child.returncode == 0, f"stdout: {stdout}\nstderr: {stderr}"
+        assert active_session_registry_snapshot(registry_home=home) == []
+    finally:
+        if child is not None:
+            _stop_child(child, release_file)
+
+
+def test_ws_orphan_reap_preserves_session_owned_by_other_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A profile sidecar must not end another backend's live durable session."""
+    profile_home = tmp_path / "profile-home"
+    ready_file = tmp_path / "child-ready"
+    release_file = tmp_path / "child-release"
+    session_id = "shared-profile-session"
+    child = _spawn_lease_holder(
+        home=profile_home,
+        session_id=session_id,
+        ready_file=ready_file,
+        release_file=release_file,
+    )
+    ended: list[tuple[str, str]] = []
+
+    class _FakeDB:
+        def get_session(self, target: str) -> dict[str, str] | None:
+            return {"id": target, "source": "desktop"}
+
+        def end_session(self, target: str, reason: str) -> None:
+            ended.append((target, reason))
+
+    @contextlib.contextmanager
+    def _profile_db(_session: dict):
+        yield _FakeDB()
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_session_db", _profile_db)
+    monkeypatch.setattr(
+        server, "_notify_session_boundary", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.interrupt_for_session", lambda *args, **kwargs: None
+    )
+
+    def _session(lease) -> dict:
+        return {
+            "active_session_lease": lease,
+            "agent": None,
+            "history": [],
+            "history_lock": threading.Lock(),
+            "profile_home": str(profile_home),
+            "session_key": session_id,
+            "slash_worker": None,
+            "source": "desktop",
+        }
+
+    try:
+        _wait_for_child_file(child, ready_file, label="lease holder")
+
+        local_lease, message = server._claim_active_session_slot(
+            session_id,
+            live_session_id="local-runtime",
+            surface="desktop",
+            profile_home=profile_home,
+        )
+        assert local_lease is not None and message is None
+        assert len(active_session_registry_snapshot(registry_home=profile_home)) == 2
+
+        server._finalize_session(_session(local_lease), end_reason="ws_orphan_reap")
+
+        assert ended == []
+        remaining = active_session_registry_snapshot(registry_home=profile_home)
+        assert len(remaining) == 1
+        assert remaining[0]["session_id"] == session_id
+
+        release_file.write_text("release", encoding="utf-8")
+        stdout, stderr = child.communicate(timeout=10)
+        assert child.returncode == 0, f"stdout: {stdout}\nstderr: {stderr}"
+        assert active_session_registry_snapshot(registry_home=profile_home) == []
+
+        sole_lease, message = server._claim_active_session_slot(
+            session_id,
+            live_session_id="sole-runtime",
+            surface="desktop",
+            profile_home=profile_home,
+        )
+        assert sole_lease is not None and message is None
+
+        server._finalize_session(_session(sole_lease), end_reason="ws_orphan_reap")
+
+        assert ended == [(session_id, "ws_orphan_reap")]
+        assert active_session_registry_snapshot(registry_home=profile_home) == []
+    finally:
+        _stop_child(child, release_file)

--- a/tests/tui_gateway/test_profile_session_ownership.py
+++ b/tests/tui_gateway/test_profile_session_ownership.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import threading
+import types
+from pathlib import Path
+from typing import Any
+
+import hermes_state
+from hermes_constants import get_hermes_home
+from hermes_state import SessionDB
+from tui_gateway import server
+
+
+def test_init_session_publishes_profile_and_lease_before_worker(
+    tmp_path: Path, monkeypatch
+) -> None:
+    sid = "profile-runtime"
+    profile_home = tmp_path / "profile-home"
+    lease = object()
+    observed: dict[str, object] = {}
+    agent = types.SimpleNamespace(model="test/model")
+
+    def _worker(_key, _model, profile_home=None):
+        observed.update(server._sessions[sid])
+        observed["worker_profile_home"] = profile_home
+        return types.SimpleNamespace(close=lambda: None)
+
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_SlashWorker", _worker)
+    monkeypatch.setattr(server, "_attach_worker", lambda *_args: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *_args: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda *_args: None)
+    monkeypatch.setattr(
+        server, "_start_notification_poller", lambda *_args: threading.Event()
+    )
+    monkeypatch.setattr(
+        server, "_notify_session_boundary", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *_args: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+
+    try:
+        server._init_session(
+            sid,
+            "profile-session",
+            agent,
+            [],
+            cwd=str(tmp_path),
+            source="desktop",
+            profile_home=profile_home,
+            active_session_lease=lease,
+        )
+
+        assert observed["profile_home"] == str(profile_home)
+        assert observed["active_session_lease"] is lease
+        assert observed["worker_profile_home"] == str(profile_home)
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_same_durable_key_resumes_independently_per_profile(
+    tmp_path: Path, monkeypatch
+) -> None:
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    db_a = SessionDB(db_path=profile_a / "state.db")
+    db_b = SessionDB(db_path=profile_b / "state.db")
+    key = "shared-durable-key"
+    db_a.create_session(key, source="desktop", model="test/a")
+    db_b.create_session(key, source="desktop", model="test/b")
+    homes = {"a": profile_a, "b": profile_b}
+    transports = {"current": object()}
+    created_leases: list[object] = []
+
+    def _db_factory(*, db_path: str | Path | None = None, **_kwargs: Any):
+        assert db_path is not None
+        path = Path(db_path).resolve()
+        if path == (profile_a / "state.db").resolve():
+            return db_a
+        if path == (profile_b / "state.db").resolve():
+            return db_b
+        raise AssertionError(f"unexpected profile db: {path}")
+
+    def _claim(*_args, **_kwargs):
+        lease = types.SimpleNamespace(enabled=False, released=False)
+        created_leases.append(lease)
+        return lease, None
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _db_factory)
+    monkeypatch.setattr(server, "_profile_home", lambda name: homes.get(name))
+    monkeypatch.setattr(server, "_claim_active_session_slot", _claim)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "current_transport", lambda: transports["current"])
+
+    created_sids: list[str] = []
+    try:
+        result_a = server._methods["session.resume"](
+            "resume-a",
+            {"session_id": key, "profile": "a", "source": "desktop"},
+        )["result"]
+        sid_a = result_a["session_id"]
+        created_sids.append(sid_a)
+        transport_a = server._sessions[sid_a]["transport"]
+
+        transports["current"] = object()
+        result_b = server._methods["session.resume"](
+            "resume-b",
+            {"session_id": key, "profile": "b", "source": "desktop"},
+        )["result"]
+        sid_b = result_b["session_id"]
+        created_sids.append(sid_b)
+
+        assert sid_b != sid_a
+        assert server._sessions[sid_a]["profile_home"] == str(profile_a)
+        assert server._sessions[sid_b]["profile_home"] == str(profile_b)
+        assert server._sessions[sid_b]["transport"] is transports["current"]
+        assert server._sessions[sid_b]["transport"] is not transport_a
+        assert server._find_live_session_by_key(key, profile_home=profile_a) == (
+            sid_a,
+            server._sessions[sid_a],
+        )
+        assert server._find_live_session_by_key(key, profile_home=profile_b) == (
+            sid_b,
+            server._sessions[sid_b],
+        )
+
+        transports["current"] = object()
+        reused_a = server._methods["session.resume"](
+            "resume-a-again",
+            {"session_id": key, "profile": "a", "source": "desktop"},
+        )["result"]
+        assert reused_a["session_id"] == sid_a
+        assert len(created_leases) == 2
+    finally:
+        for sid in created_sids:
+            server._sessions.pop(sid, None)
+        db_a.close()
+        db_b.close()
+
+
+def test_child_mirror_routes_same_key_by_profile(tmp_path, monkeypatch):
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    key = "shared-child-key"
+    sid_a = "child-live-a"
+    sid_b = "child-live-b"
+    server._sessions[sid_a] = {
+        "session_key": key,
+        "profile_home": str(profile_a),
+        "agent": None,
+        "_finalized": False,
+    }
+    server._sessions[sid_b] = {
+        "session_key": key,
+        "profile_home": str(profile_b),
+        "agent": None,
+        "_finalized": False,
+    }
+    emitted: list[tuple[str, str, dict | None]] = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
+    server._child_mirrors.clear()
+    server._active_child_runs.clear()
+
+    try:
+        server._mirror_subagent_to_child(
+            "subagent.text",
+            {"child_session_id": key, "text": "profile-a-token"},
+            profile_home=profile_a,
+        )
+        server._mirror_subagent_to_child(
+            "subagent.text",
+            {"child_session_id": key, "text": "profile-b-token"},
+            profile_home=profile_b,
+        )
+
+        deltas = [item for item in emitted if item[0] == "message.delta"]
+        assert deltas == [
+            ("message.delta", sid_a, {"text": "profile-a-token"}),
+            ("message.delta", sid_b, {"text": "profile-b-token"}),
+        ]
+        assert server._child_run_active(key, profile_a)
+        assert server._child_run_active(key, profile_b)
+        assert len(server._child_mirrors) == 2
+
+        server._mirror_subagent_to_child(
+            "subagent.complete",
+            {"child_session_id": key, "summary": "done-a"},
+            profile_home=profile_a,
+        )
+        assert not server._child_run_active(key, profile_a)
+        assert server._child_run_active(key, profile_b)
+        server._mirror_subagent_to_child(
+            "subagent.complete",
+            {"child_session_id": key, "summary": "done-b"},
+            profile_home=profile_b,
+        )
+        assert not server._child_run_active(key, profile_b)
+        assert server._child_mirrors == {}
+    finally:
+        server._sessions.pop(sid_a, None)
+        server._sessions.pop(sid_b, None)
+        server._child_mirrors.clear()
+        server._active_child_runs.clear()
+
+
+def test_profile_live_metadata_uses_profile_db(tmp_path: Path, monkeypatch) -> None:
+    launch_home = tmp_path / "launch-home"
+    profile_home = tmp_path / "profile-home"
+    launch_db = SessionDB(db_path=launch_home / "state.db")
+    profile_db = SessionDB(db_path=profile_home / "state.db")
+    sid = "profile-live-metadata"
+    key = "shared-metadata-key"
+    launch_db.create_session(key, source="desktop", model="test/launch")
+    profile_db.create_session(key, source="desktop", model="test/profile")
+    launch_db.set_session_title(key, "Launch title")
+    profile_db.set_session_title(key, "Profile title")
+    launch_db.append_message(key, "user", "launch message")
+    profile_db.append_message(key, "user", "profile message")
+    session = {
+        "agent": types.SimpleNamespace(model="test/profile", provider="test"),
+        "created_at": 1.0,
+        "history": [{"role": "user", "content": "memory fallback"}],
+        "history_lock": threading.Lock(),
+        "pending_title": None,
+        "profile_home": str(profile_home),
+        "running": False,
+        "session_key": key,
+    }
+    server._sessions[sid] = session
+    monkeypatch.setattr(server, "_get_db", lambda: launch_db)
+    monkeypatch.setattr(server, "_get_usage", lambda _agent: {"total": 0})
+    monkeypatch.setattr(
+        server, "_emit_session_info_for_session", lambda *_args, **_kwargs: None
+    )
+
+    try:
+        assert server._session_live_title(session, key) == "Profile title"
+
+        title = server._methods["session.title"]("title-get", {"session_id": sid})[
+            "result"
+        ]
+        assert title["title"] == "Profile title"
+
+        history = server._methods["session.history"]("history", {"session_id": sid})[
+            "result"
+        ]
+        assert history["messages"] == [{"role": "user", "text": "profile message"}]
+
+        status = server._methods["session.status"]("status", {"session_id": sid})[
+            "result"
+        ]["output"]
+        assert "Title: Profile title" in status
+        assert "profile-home" in status
+        assert "launch-home" not in status
+
+        renamed = server._methods["session.title"](
+            "title-set", {"session_id": sid, "title": "Profile renamed"}
+        )["result"]
+        assert renamed == {"pending": False, "title": "Profile renamed"}
+        assert profile_db.get_session_title(key) == "Profile renamed"
+        assert launch_db.get_session_title(key) == "Launch title"
+    finally:
+        server._sessions.pop(sid, None)
+        profile_db.close()
+        launch_db.close()
+
+
+def test_profile_retry_truncate_and_undo_use_profile_db(
+    tmp_path: Path, monkeypatch
+) -> None:
+    launch_home = tmp_path / "launch-home"
+    profile_home = tmp_path / "profile-home"
+    launch_db = SessionDB(db_path=launch_home / "state.db")
+    profile_db = SessionDB(db_path=profile_home / "state.db")
+    sid = "profile-history-mutation"
+    key = "shared-history-key"
+    for db, prefix in ((launch_db, "launch"), (profile_db, "profile")):
+        db.create_session(key, source="desktop", model="test/model")
+        for turn in range(1, 4):
+            db.append_message(key, "user", f"{prefix} question {turn}")
+            db.append_message(key, "assistant", f"{prefix} answer {turn}")
+    profile_history = profile_db.get_messages_as_conversation(key)
+    session = {
+        "agent": types.SimpleNamespace(model="test/model", provider="test"),
+        "attached_images": [],
+        "cols": 100,
+        "cwd": str(tmp_path),
+        "history": list(profile_history),
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "profile_home": str(profile_home),
+        "running": False,
+        "session_key": key,
+        "source": "desktop",
+    }
+    server._sessions[sid] = session
+
+    class _NoopThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(server, "_get_db", lambda: launch_db)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server.threading, "Thread", _NoopThread)
+    monkeypatch.setattr(server, "current_transport", lambda: None)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+
+    try:
+        submit = server._methods["prompt.submit"](
+            "retry",
+            {
+                "session_id": sid,
+                "text": "replacement",
+                "truncate_before_user_ordinal": 1,
+            },
+        )
+        assert "error" not in submit, submit
+        assert len(profile_db.get_messages_as_conversation(key)) == 2
+        assert len(launch_db.get_messages_as_conversation(key)) == 6
+
+        session["running"] = False
+        undo = server._methods["command.dispatch"](
+            "undo", {"session_id": sid, "name": "undo", "arg": ""}
+        )
+        assert "error" not in undo, undo
+        assert undo["result"]["message"] == "profile question 1"
+        assert profile_db.get_messages_as_conversation(key) == []
+        launch_history = launch_db.get_messages_as_conversation(key)
+        assert len(launch_history) == 6
+        assert launch_history[0]["content"] == "launch question 1"
+    finally:
+        server._sessions.pop(sid, None)
+        profile_db.close()
+        launch_db.close()
+
+
+def test_profile_branch_uses_profile_db_home_and_atomic_session_fields(
+    tmp_path: Path, monkeypatch
+) -> None:
+    launch_home = tmp_path / "launch-home"
+    profile_home = tmp_path / "profile-home"
+    launch_db = SessionDB(db_path=launch_home / "state.db")
+    profile_db = SessionDB(db_path=profile_home / "state.db")
+    parent_sid = "profile-parent-runtime"
+    parent_key = "profile-parent"
+    child_key = "profile-child"
+    fake_lease = object()
+    captured: dict[str, Any] = {}
+
+    profile_db.create_session(
+        parent_key,
+        source="desktop",
+        model="test/model",
+        cwd=str(tmp_path),
+    )
+    profile_db.set_session_title(parent_key, "Parent")
+    server._sessions[parent_sid] = {
+        "agent": types.SimpleNamespace(model="test/model", session_id=parent_key),
+        "cols": 100,
+        "cwd": str(tmp_path),
+        "history": [{"role": "user", "content": "hello"}],
+        "history_lock": threading.Lock(),
+        "profile_home": str(profile_home),
+        "session_key": parent_key,
+        "source": "desktop",
+    }
+
+    def _claim(_key, **kwargs):
+        captured["claim_profile_home"] = kwargs.get("profile_home")
+        return fake_lease, None
+
+    def _make_agent(_sid, _key, **kwargs):
+        captured["agent_db"] = kwargs.get("session_db")
+        captured["agent_home"] = Path(get_hermes_home())
+        return types.SimpleNamespace(model="test/model", session_id=child_key)
+
+    def _init(_sid, _key, _agent, _history, **kwargs):
+        captured["init"] = kwargs
+
+    monkeypatch.setattr(server, "_get_db", lambda: launch_db)
+    monkeypatch.setattr(server, "_new_session_key", lambda: child_key)
+    monkeypatch.setattr(server, "_claim_active_session_slot", _claim)
+    monkeypatch.setattr(server, "_make_agent", _make_agent)
+    monkeypatch.setattr(server, "_init_session", _init)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_set_session_context", lambda *_args: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda *_args: None)
+
+    owned_db = None
+    try:
+        response = server.handle_request({
+            "id": "branch-profile",
+            "method": "session.branch",
+            "params": {"session_id": parent_sid},
+        })
+
+        assert response is not None
+        assert "error" not in response, response
+        assert profile_db.get_session(child_key) is not None
+        assert launch_db.get_session(child_key) is None
+        assert captured["claim_profile_home"] == str(profile_home)
+        assert captured["agent_home"] == profile_home
+        owned_db = captured["agent_db"]
+        assert owned_db is not launch_db
+        assert owned_db.get_session(child_key) is not None
+        init_kwargs = captured["init"]
+        assert init_kwargs["session_db"] is owned_db
+        assert init_kwargs["profile_home"] == str(profile_home)
+        assert init_kwargs["active_session_lease"] is fake_lease
+    finally:
+        server._sessions.pop(parent_sid, None)
+        if owned_db is not None:
+            owned_db.close()
+        profile_db.close()
+        launch_db.close()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -420,6 +420,11 @@ def _notify_session_boundary(
         pass
 
 
+_SESSION_OWNERSHIP_UNAVAILABLE = (
+    "Hermes could not safely reserve this session. Try again."
+)
+
+
 def _claim_active_session_slot(
     session_key: str,
     *,
@@ -427,6 +432,7 @@ def _claim_active_session_slot(
     surface: str = "tui",
     profile_home: str | Path | None = None,
 ) -> tuple[Any, str | None]:
+    track_liveness = str(surface or "").strip().lower() == "desktop"
     try:
         home_token = (
             set_hermes_home_override(str(profile_home))
@@ -446,46 +452,86 @@ def _claim_active_session_slot(
             config=config,
             metadata={"live_session_id": live_session_id},
             registry_home=profile_home,
-            track_liveness=str(surface or "").strip().lower() == "desktop",
+            track_liveness=track_liveness,
         )
     except Exception as exc:
         logger.warning("Failed to claim active session slot: %s", exc)
-        return None, None
+        return (
+            (None, _SESSION_OWNERSHIP_UNAVAILABLE)
+            if track_liveness
+            else (None, None)
+        )
 
 
-def _release_active_session_slot(session: dict | None) -> None:
-    if not session:
-        return
-    lease = session.pop("active_session_lease", None)
+def _release_active_session_lease(lease) -> bool:
     if lease is None:
-        return
-    try:
-        lease.release()
-    except Exception:
-        logger.debug("Failed to release active session slot", exc_info=True)
+        return True
+    attempts = 3 if getattr(lease, "track_liveness", False) else 1
+    for attempt in range(attempts):
+        try:
+            lease.release()
+            break
+        except Exception:
+            if attempt + 1 >= attempts:
+                logger.warning("Failed to release active session slot", exc_info=True)
+                return False
+            time.sleep(0.05 * (attempt + 1))
+    return bool(lease.released or not lease.enabled)
+
+
+def _release_active_session_slot(session: dict | None) -> bool:
+    if not session:
+        return True
+    lease = session.get("active_session_lease")
+    if _release_active_session_lease(lease):
+        if session.get("active_session_lease") is lease:
+            session.pop("active_session_lease", None)
+        return True
+    return False
 
 
 @contextlib.contextmanager
 def _other_runtime_lease_guard(session_id: str, session: dict):
-    """Hold the owning profile's lease lock while checking sibling runtimes."""
-    stack = contextlib.ExitStack()
+    """Release this runtime and lock sibling ownership through the DB write."""
+    lease = session.get("active_session_lease")
     try:
-        from hermes_cli.active_sessions import active_session_liveness_guard
-
-        active = stack.enter_context(
-            active_session_liveness_guard(
-                session_id,
-                registry_home=session.get("profile_home"),
-            )
+        from hermes_cli.active_sessions import (
+            active_session_liveness_guard,
+            release_active_session_liveness_guard,
         )
-    except Exception:
-        stack.close()
+    except Exception as exc:
         logger.warning(
-            "Failed to inspect active session leases; preserving session %s",
+            "Failed to load active session ownership guard; preserving session %s: %s",
             session_id,
-            exc_info=True,
+            exc,
         )
-        # An automatic disconnect reap must prefer a ghost row over ending a
+        yield True
+        return
+
+    last_error: Exception | None = None
+    for attempt in range(3):
+        stack = contextlib.ExitStack()
+        try:
+            if lease is not None and getattr(lease, "enabled", False):
+                guard = release_active_session_liveness_guard(lease, session_id)
+            else:
+                guard = active_session_liveness_guard(
+                    session_id, registry_home=session.get("profile_home")
+                )
+            active = stack.enter_context(guard)
+            break
+        except Exception as exc:
+            stack.close()
+            last_error = exc
+            if attempt < 2:
+                time.sleep(0.05 * (attempt + 1))
+    else:
+        logger.warning(
+            "Failed to inspect active session leases; preserving session %s: %s",
+            session_id,
+            last_error,
+        )
+        # Automatic cleanup must prefer a ghost row over ending a
         # session that may still be owned by another backend.
         yield True
         return
@@ -493,6 +539,12 @@ def _other_runtime_lease_guard(session_id: str, session: dict):
         yield active
     finally:
         stack.close()
+        if (
+            lease is not None
+            and getattr(lease, "released", False)
+            and session.get("active_session_lease") is lease
+        ):
+            session.pop("active_session_lease", None)
 
 
 def _transfer_active_session_slot(
@@ -518,6 +570,9 @@ def _transfer_active_session_slot(
     except Exception:
         logger.debug("Failed to transfer active session slot", exc_info=True)
 
+    if getattr(lease, "track_liveness", False):
+        return False
+
     # Fallback: the in-place transfer could not move the lease (entry pruned /
     # pid-check transiently failed). Reserve the new slot BEFORE releasing the
     # old one, so a concurrent gateway at the session cap cannot grab the freed
@@ -532,10 +587,7 @@ def _transfer_active_session_slot(
     if new_lease is not None:
         old_lease = session.pop("active_session_lease", None)
         if old_lease is not None:
-            try:
-                old_lease.release()
-            except Exception:
-                logger.debug("Failed to release stale active session slot", exc_info=True)
+            _release_active_session_lease(old_lease)
         session["active_session_lease"] = new_lease
         return True
     # Reserve failed — retain the existing lease rather than dropping it.
@@ -559,6 +611,14 @@ def _transfer_active_session_slot(
 _NON_GATEWAY_SOURCES = frozenset({
     "", "tui", "cli", "webui", "desktop", "cron", "subagent", "test",
     "local", "acp", "webhook", "api_server", "msgraph_webhook",
+})
+
+_AUTOMATIC_SESSION_END_REASONS = frozenset({
+    "ws_orphan_reap",
+    "ws_disconnect",
+    "idle_timeout",
+    "lru_evict",
+    "tui_shutdown",
 })
 
 
@@ -598,7 +658,14 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     if not session or session.get("_finalized"):
         return
     session["_finalized"] = True
-    _release_active_session_slot(session)
+    _desktop_automatic_cleanup = bool(
+        end_reason in _AUTOMATIC_SESSION_END_REASONS
+        and _session_source(session).strip().lower() == "desktop"
+    )
+    # Automatic Desktop cleanup removes its lease inside the lock-held lifecycle
+    # guard below. Explicit close and non-Desktop paths keep force/end semantics.
+    if not _desktop_automatic_cleanup:
+        _release_active_session_slot(session)
     stop_event = session.get("_notif_stop")
     if stop_event is not None:
         stop_event.set()
@@ -666,22 +733,20 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     # Use session_id (from agent.session_id) not session_key — after compression,
     # session_key may be stale (the ended parent) while session_id is the live
     # continuation. Fix for #20001.
-    _desktop_orphan_reap = bool(
-        session_id
-        and end_reason == "ws_orphan_reap"
-        and _session_source(session).strip().lower() == "desktop"
-    )
+    if _desktop_automatic_cleanup and not session_id:
+        _release_active_session_slot(session)
     _lifecycle_guard = (
         _other_runtime_lease_guard(session_id, session)
-        if _desktop_orphan_reap and session_id
+        if _desktop_automatic_cleanup and session_id
         else contextlib.nullcontext(False)
     )
     with _lifecycle_guard as _other_runtime_owns_lifecycle:
         _tui_owns_lifecycle = not _other_runtime_owns_lifecycle
         if _other_runtime_owns_lifecycle:
             logger.info(
-                "Preserving session %s during ws_orphan_reap: another backend owns an active lease",
+                "Preserving session %s during %s: another backend owns an active lease",
                 session_id,
+                end_reason,
             )
         if session_id:
             try:
@@ -1061,6 +1126,29 @@ def _db_unavailable_error(rid, *, code: int):
 # (a ContextVar override) for the duration of the call so config/skills/model and
 # message persistence all resolve to the right profile. Omitted/own profile → the
 # launch profile (unchanged for single-profile and per-profile-remote setups).
+def _canonical_profile_home(profile_home: str | Path | None = None) -> str:
+    """Return the stable filesystem identity for a launch or explicit profile."""
+    raw = profile_home if profile_home is not None else _hermes_home
+    try:
+        resolved = Path(raw).expanduser().resolve()
+    except (OSError, RuntimeError):
+        resolved = Path(os.path.abspath(os.path.expanduser(str(raw))))
+    return os.path.normcase(os.path.normpath(str(resolved)))
+
+
+def _profile_session_identity(
+    session_key: str, profile_home: str | Path | None = None
+) -> tuple[str, str]:
+    return _canonical_profile_home(profile_home), str(session_key or "")
+
+
+def _profile_session_registry_key(
+    session_key: str, profile_home: str | Path | None = None
+) -> str | tuple[str, str]:
+    identity = _profile_session_identity(session_key, profile_home)
+    return identity[1] if identity[0] == _canonical_profile_home() else identity
+
+
 def _profile_home(profile: str | None) -> Path | None:
     """Resolve a named profile's home on THIS host, or None for the launch profile."""
     name = (profile or "").strip()
@@ -1073,7 +1161,7 @@ def _profile_home(profile: str | None) -> Path | None:
     except Exception:
         return None
     # Already the launch profile? No override needed.
-    if home.resolve() == Path(_hermes_home).resolve():
+    if _canonical_profile_home(home) == _canonical_profile_home():
         return None
     return home if (home / "state.db").exists() or home.exists() else None
 
@@ -1384,7 +1472,10 @@ def _start_agent_build(sid: str, session: dict) -> None:
     # to a full agent mid-stream and silently kill the mirror (the mirror bails
     # once agent is set). Once the child completes, the guard lifts and the next
     # prompt/RPC builds the agent normally so the user can talk to the session.
-    if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
+    if session.get("lazy") and _child_run_active(
+        str(session.get("session_key") or ""),
+        session.get("profile_home"),
+    ):
         return
     lock = session.setdefault("agent_build_lock", threading.Lock())
     with lock:
@@ -1544,9 +1635,28 @@ def _start_agent_build(sid: str, session: dict) -> None:
     threading.Thread(target=_build, daemon=True).start()
 
 
+def _session_ownership_ready(sid: str, session: dict) -> bool:
+    if not session.get("_ownership_sync_pending"):
+        return True
+    try:
+        _sync_session_key_after_compress(sid, session)
+    except Exception:
+        return False
+    return not session.get("_ownership_sync_pending")
+
+
 def _sess_nowait(params, rid):
-    s = _sessions.get(params.get("session_id") or "")
-    return (s, None) if s else (None, _err(rid, 4001, "session not found"))
+    sid = params.get("session_id") or ""
+    s = _sessions.get(sid)
+    if not s:
+        return None, _err(rid, 4001, "session not found")
+    if not _session_ownership_ready(sid, s):
+        return None, _err(
+            rid,
+            4091,
+            "Session ownership is temporarily unavailable. Try again.",
+        )
+    return s, None
 
 
 def _sess(params, rid):
@@ -3232,6 +3342,7 @@ def _sync_session_key_after_compress(
     new_session_id = getattr(agent, "session_id", None) or ""
     old_key = session.get("session_key", "") or ""
     if not new_session_id or new_session_id == old_key:
+        session.pop("_ownership_sync_pending", None)
         return
 
     lease_reanchored = _transfer_active_session_slot(
@@ -3240,12 +3351,21 @@ def _sync_session_key_after_compress(
         new_session_id=new_session_id,
     )
     if not lease_reanchored:
+        session["_ownership_sync_pending"] = new_session_id
         logger.warning(
             "Compression session lease did not re-anchor: sid=%s old_session_id=%s new_session_id=%s",
             sid,
             old_key,
             new_session_id,
         )
+        raise RuntimeError(
+            "session ownership transfer failed; retry after the registry is available"
+        )
+    # Publish the routed key before clearing the retry barrier. Another RPC may
+    # enter as soon as the barrier disappears, so it must never observe the old
+    # key paired with the new durable lease.
+    session["session_key"] = new_session_id
+    session.pop("_ownership_sync_pending", None)
 
     try:
         from tools.approval import (
@@ -3260,7 +3380,6 @@ def _sync_session_key_after_compress(
             unregister_gateway_notify(old_key)
         except Exception:
             pass
-        session["session_key"] = new_session_id
         try:
             yolo_was_on = is_session_yolo_enabled(old_key)
         except Exception:
@@ -3279,10 +3398,9 @@ def _sync_session_key_after_compress(
         except Exception:
             pass
     except Exception:
-        # Even if the approval module fails to import, still anchor the
-        # session_key on the new continuation id so downstream lookups
-        # don't keep targeting the ended row.
-        session["session_key"] = new_session_id
+        # Approval routing is best-effort; the durable lease/key transfer above
+        # remains authoritative even if this optional module is unavailable.
+        pass
 
     if clear_pending_title:
         session["pending_title"] = None
@@ -3870,7 +3988,11 @@ def _on_tool_progress(
         # catch-all. The mirror keys off the child sid and is unaffected.
         if event_type != "subagent.text":
             _emit(event_type, sid, payload)
-        _mirror_subagent_to_child(event_type, payload)
+        _mirror_subagent_to_child(
+            event_type,
+            payload,
+            profile_home=(_sessions.get(sid) or {}).get("profile_home"),
+        )
 
 
 # ── Child-session live mirror ────────────────────────────────────────
@@ -3882,47 +4004,58 @@ def _on_tool_progress(
 # persists. Translate the relayed events into the native stream events the
 # window already renders — emitted on the CHILD sid, routed to its transport
 # by write_json — so the window shows a real midstream turn.
-_child_mirrors: dict[str, dict] = {}
+_child_mirrors: dict[str | tuple[str, str], dict] = {}
 _child_mirrors_lock = threading.Lock()
 # Stored child session ids with a delegation run currently in flight (refreshed
 # on every relayed subagent.* event, popped on subagent.complete). Lets a lazy
 # watch resume report running=true so the window shows a busy indicator even
 # while the child is silent inside a long tool call (no events for 25s+).
-_active_child_runs: dict[str, float] = {}
+_active_child_runs: dict[str | tuple[str, str], float] = {}
 # Staleness bound for the registry: entries refresh on every relayed event, so
 # anything this quiet means the completion event was lost (callback raised,
 # parent crashed) — don't let a leaked entry pin "running" forever.
 _CHILD_RUN_STALE_S = 3600.0
 
 
-def _child_run_active(child_key: str) -> bool:
-    ts = _active_child_runs.get(child_key)
+def _child_run_active(
+    child_key: str, profile_home: str | Path | None = None
+) -> bool:
+    ts = _active_child_runs.get(_profile_session_registry_key(child_key, profile_home))
     return ts is not None and (time.time() - ts) < _CHILD_RUN_STALE_S
 
 
-def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
+def _mirror_subagent_to_child(
+    event_type: str,
+    payload: dict,
+    *,
+    profile_home: str | Path | None = None,
+) -> None:
     child_key = str(payload.get("child_session_id") or "")
     if not child_key:
         return
+    child_identity = _profile_session_registry_key(child_key, profile_home)
     # Liveness registry first — it must be accurate even when no window is
     # open, so a window opened mid-run can immediately know the child is busy.
     if event_type == "subagent.complete":
-        _active_child_runs.pop(child_key, None)
+        _active_child_runs.pop(child_identity, None)
     else:
-        _active_child_runs[child_key] = time.time()
+        _active_child_runs[child_identity] = time.time()
     # Mirror only into a live watch session (keyed by session_key; its live sid
     # differs from the stored id) that has NOT been upgraded to a full agent.
     # No window / closed → nothing to mirror; an upgraded session owns a real
     # native stream and mirroring on top would interleave two turns on one sid.
     # Either way drop state so a reopened window starts a fresh synthetic turn.
-    live = _find_live_session_by_key(child_key)
+    live = _find_live_session_by_key(child_key, profile_home=profile_home)
     if live is None or live[1].get("agent") is not None:
         with _child_mirrors_lock:
-            _child_mirrors.pop(child_key, None)
+            _child_mirrors.pop(child_identity, None)
         return
     csid = live[0]
     with _child_mirrors_lock:
-        st = _child_mirrors.setdefault(child_key, {"seq": 0, "open_tool": None, "started": False})
+        st = _child_mirrors.setdefault(
+            child_identity,
+            {"seq": 0, "open_tool": None, "started": False},
+        )
         if not st["started"]:
             st["started"] = True
             _emit("message.start", csid)
@@ -3958,7 +4091,7 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
                 _emit("tool.complete", csid, st["open_tool"])
             summary = str(payload.get("summary") or payload.get("text") or "")
             _emit("message.complete", csid, {"text": summary})
-            _child_mirrors.pop(child_key, None)
+            _child_mirrors.pop(child_identity, None)
 
 
 def _agent_cbs(sid: str) -> dict:
@@ -4750,6 +4883,8 @@ def _init_session(
     cwd: str | None = None,
     session_db=None,
     source: str | None = None,
+    profile_home: str | Path | None = None,
+    active_session_lease=None,
 ):
     now = time.time()
     with _sessions_lock:
@@ -4763,6 +4898,7 @@ def _init_session(
             "created_at": now,
             "last_active": now,
             "running": False,
+            "active_session_lease": active_session_lease,
             "attached_images": [],
             "image_counter": 0,
             "cwd": cwd or _completion_cwd(),
@@ -4770,6 +4906,9 @@ def _init_session(
             "slash_worker": None,
             "show_reasoning": _load_show_reasoning(),
             "source": _resolve_session_source(source),
+            "profile_home": (
+                str(profile_home) if profile_home is not None else None
+            ),
             "tool_progress_mode": _load_tool_progress_mode(),
             "edit_snapshots": {},
             "tool_started_at": {},
@@ -5623,10 +5762,13 @@ def _claim_or_reuse_live(
     resume lock, or — if a concurrent resume already won — release ``lease`` and
     return the winner for the caller to reuse."""
     with _session_resume_lock:
-        live = _find_live_session_by_key(session_key)
+        live = _find_live_session_by_key(
+            session_key,
+            profile_home=record.get("profile_home"),
+        )
         if live is not None:
             if lease is not None:
-                lease.release()
+                _release_active_session_lease(lease)
             return live
         with _sessions_lock:
             _sessions[sid] = record
@@ -5678,7 +5820,9 @@ def _(rid, params: dict) -> dict:
         found = db.get_session_by_title(target)
         if found:
             target = found["id"]
-        elif is_truthy_value(params.get("lazy", False)) and _child_run_active(target):
+        elif is_truthy_value(params.get("lazy", False)) and _child_run_active(
+            target, profile_home
+        ):
             # Race: a watch window opened on a freshly-spawned subagent. The
             # child relays `subagent.start` (which carries child_session_id and
             # triggers the window) BEFORE its first run_conversation() flushes
@@ -5730,14 +5874,14 @@ def _(rid, params: dict) -> dict:
         # A lazy watch session never owns a run loop, so its payload's running
         # flag is always False — overlay the child-run registry so a reconnecting
         # watch window keeps its busy indicator while the child is still mid-run.
-        if session.get("agent") is None and _child_run_active(target):
+        if session.get("agent") is None and _child_run_active(target, profile_home):
             payload["running"] = True
             payload["status"] = "streaming"
         return payload
 
     # Fast path: if the session is already live, reuse it under the lock.
     with _session_resume_lock:
-        live = _find_live_session_by_key(target)
+        live = _find_live_session_by_key(target, profile_home=profile_home)
         if live is not None:
             return _ok(rid, _reuse_live_payload(*live))
 
@@ -5766,7 +5910,7 @@ def _(rid, params: dict) -> dict:
             history = db.get_messages_as_conversation(target)
         except Exception as e:
             if lease is not None:
-                lease.release()
+                _release_active_session_lease(lease)
             return _err(rid, 5000, f"resume failed: {e}")
         cwd = profile_resume_cwd or _default_session_cwd()
         record = _deferred_session_record(
@@ -5784,7 +5928,7 @@ def _(rid, params: dict) -> dict:
             return _ok(rid, _reuse_live_payload(*live))
         # A delegated child mid-run emits no session events of its own — report
         # its liveness from the relay registry so the window shows a busy turn.
-        child_running = _child_run_active(target)
+        child_running = _child_run_active(target, profile_home)
         messages = _history_to_messages(history)
         return _ok(
             rid,
@@ -5835,7 +5979,7 @@ def _(rid, params: dict) -> dict:
             display_history = db.get_messages_as_conversation(target, include_ancestors=True)
         except Exception as e:
             if lease is not None:
-                lease.release()
+                _release_active_session_lease(lease)
             return _err(rid, 5000, f"resume failed: {e}")
         # Display keeps the full transcript; the model-fed history drops a
         # dangling/interrupted tool-call tail so a session killed mid-loop does
@@ -5944,7 +6088,7 @@ def _(rid, params: dict) -> dict:
             _clear_session_context(tokens)
     except Exception as e:
         if lease is not None:
-            lease.release()
+            _release_active_session_lease(lease)
         return _err(rid, 5000, f"resume failed: {e}")
     finally:
         if home_token is not None:
@@ -5954,7 +6098,7 @@ def _(rid, params: dict) -> dict:
     # live session while we were building. Re-check under the lock; if it won,
     # discard our just-built agent and reuse theirs (no worker/poller wired yet).
     with _session_resume_lock:
-        live = _find_live_session_by_key(target)
+        live = _find_live_session_by_key(target, profile_home=profile_home)
         if live is not None:
             try:
                 if hasattr(agent, "close"):
@@ -5962,7 +6106,7 @@ def _(rid, params: dict) -> dict:
             except Exception:
                 pass
             if lease is not None:
-                lease.release()
+                _release_active_session_lease(lease)
             other_sid, other_session = live
             payload = _live_session_payload(
                 other_sid,
@@ -5989,6 +6133,8 @@ def _(rid, params: dict) -> dict:
                     cwd=profile_resume_cwd,
                     session_db=db,
                     source=source,
+                    profile_home=profile_home,
+                    active_session_lease=lease,
                 )
             finally:
                 if init_home_token is not None:
@@ -5999,15 +6145,9 @@ def _(rid, params: dict) -> dict:
                         "model_override"
                     ]
                 _sessions[sid]["display_history_prefix"] = display_history_prefix
-                # Remember the profile home so each turn re-binds HERMES_HOME (the
-                # agent persists to its own db, but mid-turn home reads — memory,
-                # skills — must resolve to the resumed profile too).
-                if profile_home is not None:
-                    _sessions[sid]["profile_home"] = str(profile_home)
-                _sessions[sid]["active_session_lease"] = lease
         except Exception as e:
             if lease is not None:
-                lease.release()
+                _release_active_session_lease(lease)
             return _err(rid, 5000, f"resume failed: {e}")
         session = _sessions.get(sid) or {}
     return _ok(
@@ -6083,12 +6223,12 @@ def _message_preview(history: list) -> str:
 
 def _session_live_title(session: dict, key: str) -> str:
     title = str(session.get("pending_title") or "").strip()
-    db = _get_db()
-    if db is not None:
-        try:
-            title = str(db.get_session_title(key) or title or "").strip()
-        except Exception:
-            pass
+    with _session_db(session) as db:
+        if db is not None:
+            try:
+                title = str(db.get_session_title(key) or title or "").strip()
+            except Exception:
+                pass
     return title
 
 
@@ -6127,11 +6267,20 @@ def _session_lookup_key(session: dict, *, fallback: str = "") -> str:
     )
 
 
-def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
+def _find_live_session_by_key(
+    session_key: str,
+    *,
+    profile_home: str | Path | None = None,
+) -> tuple[str, dict] | None:
+    expected = _profile_session_identity(session_key, profile_home)
     for sid, session in list(_sessions.items()):
         if session.get("_finalized"):
             continue
-        if _session_lookup_key(session, fallback=sid) == session_key:
+        current = _profile_session_identity(
+            _session_lookup_key(session, fallback=sid),
+            session.get("profile_home"),
+        )
+        if current == expected:
             return sid, session
     return None
 
@@ -6293,83 +6442,77 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
-    db = _get_db()
-    if db is None:
-        return _db_unavailable_error(rid, code=5007)
     key = session["session_key"]
-    if "title" not in params:
-        fallback = session.get("pending_title") or ""
-        try:
-            resolved_title = db.get_session_title(key) or ""
-            if fallback:
-                if db.set_session_title(key, fallback):
-                    session["pending_title"] = None
-                    resolved_title = fallback
-                else:
-                    existing_row = db.get_session(key)
-                    existing_title = ((existing_row or {}).get("title") or "").strip()
-                    if existing_title == fallback:
+    title = None
+    if "title" in params:
+        title = (params.get("title", "") or "").strip()
+        if not title:
+            return _err(rid, 4021, "title required")
+
+    with _session_db(session) as db:
+        if db is None:
+            return _db_unavailable_error(rid, code=5007)
+        if title is None:
+            fallback = session.get("pending_title") or ""
+            try:
+                resolved_title = db.get_session_title(key) or ""
+                if fallback:
+                    if db.set_session_title(key, fallback):
                         session["pending_title"] = None
                         resolved_title = fallback
-                    elif not resolved_title:
-                        resolved_title = fallback
-            elif resolved_title:
-                session["pending_title"] = None
-        except Exception:
-            resolved_title = fallback
-        _emit_session_info_for_session(params.get("session_id", ""), session)
-        return _ok(
-            rid,
-            {
-                "title": resolved_title,
-                "session_key": key,
-            },
-        )
-    title = (params.get("title", "") or "").strip()
-    if not title:
-        return _err(rid, 4021, "title required")
-    try:
-        if db.set_session_title(key, title):
-            session["pending_title"] = None
-            _emit_session_info_for_session(params.get("session_id", ""), session)
-            return _ok(rid, {"pending": False, "title": title})
-        # rowcount == 0 can mean "same value" as well as "missing row".
-        existing_row = db.get_session(key)
-        if existing_row:
-            session["pending_title"] = None
+                    else:
+                        existing_row = db.get_session(key)
+                        existing_title = ((existing_row or {}).get("title") or "").strip()
+                        if existing_title == fallback:
+                            session["pending_title"] = None
+                            resolved_title = fallback
+                        elif not resolved_title:
+                            resolved_title = fallback
+                elif resolved_title:
+                    session["pending_title"] = None
+            except Exception:
+                resolved_title = fallback
             _emit_session_info_for_session(params.get("session_id", ""), session)
             return _ok(
                 rid,
                 {
-                    "pending": False,
-                    "title": (existing_row.get("title") or title),
+                    "title": resolved_title,
+                    "session_key": key,
                 },
             )
-        # No row yet (the DB write is deferred to the first prompt so empty
-        # drafts don't litter the sidebar). An explicit /title is clear user
-        # intent, not an abandoned draft — so persist the row NOW and set the
-        # title, mirroring the messaging gateway's _handle_title_command. The
-        # old behavior only queued pending_title and relied on the post-turn
-        # apply block; if that turn never landed under this session_key the
-        # title was silently lost and the sidebar fell back to the message
-        # preview. Creating the row up front removes that race entirely. The
-        # min-messages sidebar filter keeps a titled 0-message row hidden, so
-        # a /title'd-but-never-used draft still doesn't clutter the list.
-        _ensure_session_db_row(session)
-        with _session_db(session) as scoped_db:
-            if scoped_db is not None and scoped_db.set_session_title(key, title):
+
+        try:
+            if db.set_session_title(key, title):
                 session["pending_title"] = None
                 _emit_session_info_for_session(params.get("session_id", ""), session)
                 return _ok(rid, {"pending": False, "title": title})
-        # Row creation didn't take (DB unavailable, or a concurrent writer) —
-        # fall back to queuing so the post-turn apply block can still recover.
-        session["pending_title"] = title
-        _emit_session_info_for_session(params.get("session_id", ""), session)
-        return _ok(rid, {"pending": True, "title": title})
-    except ValueError as e:
-        return _err(rid, 4022, str(e))
-    except Exception as e:
-        return _err(rid, 5007, str(e))
+            # rowcount == 0 can mean "same value" as well as "missing row".
+            existing_row = db.get_session(key)
+            if existing_row:
+                session["pending_title"] = None
+                _emit_session_info_for_session(params.get("session_id", ""), session)
+                return _ok(
+                    rid,
+                    {
+                        "pending": False,
+                        "title": (existing_row.get("title") or title),
+                    },
+                )
+            # Persist an explicitly titled draft now; the sidebar's min-message
+            # filter still keeps an unused zero-message row hidden.
+            _ensure_session_db_row(session)
+            if db.set_session_title(key, title):
+                session["pending_title"] = None
+                _emit_session_info_for_session(params.get("session_id", ""), session)
+                return _ok(rid, {"pending": False, "title": title})
+            # Row creation did not take (DB unavailable or concurrent writer).
+            session["pending_title"] = title
+            _emit_session_info_for_session(params.get("session_id", ""), session)
+            return _ok(rid, {"pending": True, "title": title})
+        except ValueError as e:
+            return _err(rid, 4022, str(e))
+        except Exception as e:
+            return _err(rid, 5007, str(e))
 
 
 def _main_runtime_from_agent(agent) -> dict | None:
@@ -7881,15 +8024,23 @@ def _(rid, params: dict) -> dict:
 
     from hermes_constants import display_hermes_home
 
+    status_home = display_hermes_home()
+    if profile_home := session.get("profile_home"):
+        home_token = set_hermes_home_override(profile_home)
+        try:
+            status_home = display_hermes_home()
+        finally:
+            reset_hermes_home_override(home_token)
+
     key = session.get("session_key") or params.get("session_id") or ""
     agent = session.get("agent")
     meta = {}
-    db = _get_db()
-    if db and key:
-        try:
-            meta = db.get_session(key) or {}
-        except Exception:
-            meta = {}
+    with _session_db(session) as db:
+        if db and key:
+            try:
+                meta = db.get_session(key) or {}
+            except Exception:
+                meta = {}
 
     def _dt(value, fallback: datetime | None = None) -> datetime:
         if value:
@@ -7913,7 +8064,7 @@ def _(rid, params: dict) -> dict:
         "Hermes TUI Status",
         "",
         f"Session ID: {key}",
-        f"Path: {display_hermes_home()}",
+        f"Path: {status_home}",
     ]
     title = (meta.get("title") or "").strip()
     if title:
@@ -7936,14 +8087,14 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     history = list(session.get("history", []))
-    db = _get_db()
-    if db is not None and session.get("session_key"):
-        try:
-            history = db.get_messages_as_conversation(
-                session["session_key"], include_ancestors=True
-            )
-        except Exception:
-            pass
+    with _session_db(session) as db:
+        if db is not None and session.get("session_key"):
+            try:
+                history = db.get_messages_as_conversation(
+                    session["session_key"], include_ancestors=True
+                )
+            except Exception:
+                pass
     return _ok(
         rid,
         {
@@ -8149,24 +8300,49 @@ def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
-    db = _get_db()
-    if db is None:
-        return _db_unavailable_error(rid, code=5008)
     old_key = session["session_key"]
     with session["history_lock"]:
         history = [dict(msg) for msg in session.get("history", [])]
     if not history:
         return _err(rid, 4008, "nothing to branch — send a message first")
+
+    profile_home = session.get("profile_home")
+    owns_db = bool(profile_home)
+    try:
+        if owns_db:
+            from hermes_state import SessionDB
+
+            db = SessionDB(db_path=Path(profile_home) / "state.db")
+        else:
+            db = _get_db()
+    except Exception as exc:
+        return _err(rid, 5008, f"branch database unavailable: {exc}")
+    if db is None:
+        return _db_unavailable_error(rid, code=5008)
+
     new_key = _new_session_key()
     new_sid = uuid.uuid4().hex[:8]
     source = _session_source(session)
-    lease, limit_message = _claim_active_session_slot(
-        new_key, live_session_id=new_sid, surface=source
+    lease = None
+    agent = None
+    phase = "persist"
+    home_token = (
+        set_hermes_home_override(str(profile_home)) if profile_home else None
     )
-    if limit_message is not None:
-        return _err(rid, 4090, limit_message)
-    branch_name = params.get("name", "")
     try:
+        lease, limit_message = _claim_active_session_slot(
+            new_key,
+            live_session_id=new_sid,
+            surface=source,
+            profile_home=profile_home,
+        )
+        if limit_message is not None:
+            if owns_db:
+                with contextlib.suppress(Exception):
+                    db.close()
+            return _err(rid, 4090, limit_message)
+
+        branch_name = params.get("name", "")
         if branch_name:
             title = branch_name
         else:
@@ -8196,17 +8372,15 @@ def _(rid, params: dict) -> dict:
                 content=msg.get("content"),
             )
         db.set_session_title(new_key, title)
-    except Exception as e:
-        if lease is not None:
-            lease.release()
-        return _err(rid, 5008, f"branch failed: {e}")
-    try:
+
+        phase = "agent"
         tokens = _set_session_context(new_key)
         try:
             agent = _make_agent(
                 new_sid,
                 new_key,
                 session_id=new_key,
+                session_db=db,
                 platform_override=source,
             )
         finally:
@@ -8217,14 +8391,27 @@ def _(rid, params: dict) -> dict:
             agent,
             list(history),
             cols=session.get("cols", 80),
+            session_db=db,
             source=source,
+            profile_home=profile_home,
+            active_session_lease=lease,
         )
-        if new_sid in _sessions:
-            _sessions[new_sid]["active_session_lease"] = lease
-    except Exception as e:
+    except Exception as exc:
         if lease is not None:
-            lease.release()
-        return _err(rid, 5000, f"agent init failed on branch: {e}")
+            _release_active_session_lease(lease)
+        if agent is not None:
+            with contextlib.suppress(Exception):
+                agent.close()
+        if owns_db:
+            with contextlib.suppress(Exception):
+                db.close()
+        code = 5008 if phase == "persist" else 5000
+        label = "branch failed" if phase == "persist" else "agent init failed on branch"
+        return _err(rid, code, f"{label}: {exc}")
+    finally:
+        if home_token is not None:
+            reset_hermes_home_override(home_token)
+
     return _ok(rid, {"session_id": new_sid, "title": title, "parent": old_key})
 
 
@@ -8562,7 +8749,10 @@ def _(rid, params: dict) -> dict:
         # racing the in-flight child on the same stored session (interleaved
         # transcript, stale fork). After the run completes, submitting is fine:
         # the upgrade resumes the child's transcript as a normal conversation.
-        if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
+        if session.get("lazy") and _child_run_active(
+            str(session.get("session_key") or ""),
+            session.get("profile_home"),
+        ):
             return _err(rid, 4009, "subagent still running — wait for it to finish")
         if truncate_user_ordinal is not None:
             try:
@@ -8581,11 +8771,15 @@ def _(rid, params: dict) -> dict:
             truncated = history[: user_indices[ordinal]]
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
-            if (db := _get_db()) is not None:
-                try:
-                    db.replace_messages(session["session_key"], truncated)
-                except Exception as exc:
-                    print(f"[tui_gateway] prompt.submit: replace_messages failed: {exc}", file=sys.stderr)
+            with _session_db(session) as db:
+                if db is not None:
+                    try:
+                        db.replace_messages(session["session_key"], truncated)
+                    except Exception as exc:
+                        print(
+                            f"[tui_gateway] prompt.submit: replace_messages failed: {exc}",
+                            file=sys.stderr,
+                        )
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
@@ -8669,9 +8863,9 @@ def _notification_event_belongs_elsewhere(sid: str, session: dict, evt: dict) ->
     # desktop session instead of becoming an orphan that any poller may consume.
     resolved_key = evt_key
     try:
-        db = _get_db()
-        if db is not None:
-            resolved_key = db.resolve_resume_session_id(evt_key) or evt_key
+        with _session_db(session) as db:
+            if db is not None:
+                resolved_key = db.resolve_resume_session_id(evt_key) or evt_key
     except Exception:
         resolved_key = evt_key
 
@@ -8743,10 +8937,10 @@ def _session_owns_notification_event(sid: str, session: dict, evt: dict) -> bool
     if evt_key in current_keys:
         return True
     try:
-        db = _get_db()
-        resolved_key = (
-            db.resolve_resume_session_id(evt_key) if db is not None else evt_key
-        ) or evt_key
+        with _session_db(session) as db:
+            resolved_key = (
+                db.resolve_resume_session_id(evt_key) if db is not None else evt_key
+            ) or evt_key
     except Exception:
         resolved_key = evt_key
     return resolved_key in current_keys
@@ -8810,6 +9004,15 @@ def _notification_poller_loop(
         try:
             evt = process_registry.completion_queue.get(timeout=0.5)
         except Exception:
+            continue
+
+        # Compression rotated the durable key but the cross-process lease has
+        # not moved yet. Requeue before routing, emitting, or marking the
+        # session running; notification turns share the same admission barrier
+        # as foreground RPCs.
+        if not _session_ownership_ready(sid, session):
+            process_registry.completion_queue.put(evt)
+            time.sleep(0.25)
             continue
 
         # Multiple desktop sessions share this one process-wide queue. Only
@@ -8885,6 +9088,8 @@ def _notification_poller_loop(
         )
         _claim = claim_event_delivery(evt, "tui-poller")
         if _claim is None:
+            with session["history_lock"]:
+                session["running"] = False
             continue
         try:
             _emit("message.start", sid)
@@ -8909,6 +9114,9 @@ def _notification_poller_loop(
             evt = process_registry.completion_queue.get_nowait()
         except Exception:
             break
+        if not _session_ownership_ready(sid, session):
+            deferred.append(evt)
+            continue
         if _notification_event_belongs_elsewhere(sid, session, evt):
             deferred.append(evt)
             continue
@@ -8945,6 +9153,8 @@ def _notification_poller_loop(
         )
         _claim = claim_event_delivery(evt, "tui-poller")
         if _claim is None:
+            with session["history_lock"]:
+                session["running"] = False
             continue
         try:
             _emit("message.start", sid)
@@ -9351,23 +9561,23 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             # Apply pending_title now that the DB row exists.
             _pending = session.get("pending_title")
             if _pending and status == "complete":
-                _pdb = _get_db()
-                if _pdb:
-                    _session_key = session.get("session_key") or sid
-                    try:
-                        if _pdb.set_session_title(_session_key, _pending):
+                with _session_db(session) as _pdb:
+                    if _pdb:
+                        _session_key = session.get("session_key") or sid
+                        try:
+                            if _pdb.set_session_title(_session_key, _pending):
+                                session["pending_title"] = None
+                        except ValueError as exc:
+                            # Invalid/duplicate title — non-retryable, drop it.
+                            # Auto-title will take over. Fix for #19029.
                             session["pending_title"] = None
-                    except ValueError as exc:
-                        # Invalid/duplicate title — non-retryable, drop it.
-                        # Auto-title will take over. Fix for #19029.
-                        session["pending_title"] = None
-                        logger.info(
-                            "Dropping pending title for session %s: %s",
-                            _session_key, exc,
-                        )
-                    except Exception:
-                        # Transient DB failure — keep pending_title for retry.
-                        pass
+                            logger.info(
+                                "Dropping pending title for session %s: %s",
+                                _session_key, exc,
+                            )
+                        except Exception:
+                            # Transient DB failure — keep pending_title for retry.
+                            pass
 
             if (
                 status == "complete"
@@ -9380,8 +9590,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     from agent.title_generator import maybe_auto_title
 
                     _title_key = session.get("session_key") or sid
+                    _title_db = getattr(agent, "_session_db", None)
+                    if _title_db is None and not session.get("profile_home"):
+                        _title_db = _get_db()
                     maybe_auto_title(
-                        _get_db(),
+                        _title_db,
                         _title_key,
                         text,
                         raw,
@@ -9449,6 +9662,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 session["last_active"] = time.time()
                 _clear_inflight_turn(session)
             _emit("session.info", sid, _session_info(agent, session))
+
+        # Compression rotated the durable id but its lease could not be moved.
+        # Stay quiescent until the next RPC retries the ownership transfer.
+        if session.get("_ownership_sync_pending"):
+            return
 
         # A user prompt that arrived mid-turn (interrupt + queue) wins over
         # every auto follow-up below — drain it first and skip them this cycle;
@@ -12341,9 +12559,6 @@ def _(rid, params: dict) -> dict:
             return _err(
                 rid, 4009, "session busy — /interrupt the current turn before /undo"
             )
-        db = _get_db()
-        if db is None:
-            return _db_unavailable_error(rid, code=5008)
         session_key = session.get("session_key", "")
         if not session_key:
             return _err(rid, 4001, "no session key for undo")
@@ -12357,28 +12572,31 @@ def _(rid, params: dict) -> dict:
                 return _err(rid, 4004, f"undo: invalid count {arg_str!r} — use /undo or /undo N")
         if n < 1:
             n = 1
-        try:
-            recents = db.list_recent_user_messages(session_key, limit=max(n, 10))
-        except Exception as e:
-            return _err(rid, 5008, f"undo: failed to load history: {e}")
-        if not recents:
-            return _err(rid, 4018, "no user messages to undo")
-        # recents[0] is the most-recent user turn; pick the Nth-from-last.
-        # If N exceeds the number of user turns, back up to the oldest.
-        target_idx = min(n - 1, len(recents) - 1)
-        target_id = recents[target_idx]["id"]
-        try:
-            result = db.rewind_to_message(session_key, target_id)
-        except ValueError as e:
-            return _err(rid, 4004, f"undo: {e}")
-        except Exception as e:
-            return _err(rid, 5008, f"undo: {e}")
-        # Reload the active-only transcript into the in-memory session
-        # history so subsequent turns see the truncated view.
-        try:
-            active = db.get_messages_as_conversation(session_key)
-        except Exception:
-            active = []
+        with _session_db(session) as db:
+            if db is None:
+                return _db_unavailable_error(rid, code=5008)
+            try:
+                recents = db.list_recent_user_messages(session_key, limit=max(n, 10))
+            except Exception as e:
+                return _err(rid, 5008, f"undo: failed to load history: {e}")
+            if not recents:
+                return _err(rid, 4018, "no user messages to undo")
+            # recents[0] is the most-recent user turn; pick the Nth-from-last.
+            # If N exceeds the number of user turns, back up to the oldest.
+            target_idx = min(n - 1, len(recents) - 1)
+            target_id = recents[target_idx]["id"]
+            try:
+                result = db.rewind_to_message(session_key, target_id)
+            except ValueError as e:
+                return _err(rid, 4004, f"undo: {e}")
+            except Exception as e:
+                return _err(rid, 5008, f"undo: {e}")
+            # Reload the active-only transcript into the in-memory session
+            # history so subsequent turns see the truncated view.
+            try:
+                active = db.get_messages_as_conversation(session_key)
+            except Exception:
+                active = []
         with session["history_lock"]:
             session["history"] = list(active)
             session["history_version"] = int(session.get("history_version", 0)) + 1

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -425,15 +425,28 @@ def _claim_active_session_slot(
     *,
     live_session_id: str,
     surface: str = "tui",
+    profile_home: str | Path | None = None,
 ) -> tuple[Any, str | None]:
     try:
+        home_token = (
+            set_hermes_home_override(str(profile_home))
+            if profile_home is not None
+            else None
+        )
+        try:
+            config = _load_cfg()
+        finally:
+            if home_token is not None:
+                reset_hermes_home_override(home_token)
         from hermes_cli.active_sessions import try_acquire_active_session
 
         return try_acquire_active_session(
             session_id=session_key,
             surface=surface,
-            config=_load_cfg(),
+            config=config,
             metadata={"live_session_id": live_session_id},
+            registry_home=profile_home,
+            track_liveness=str(surface or "").strip().lower() == "desktop",
         )
     except Exception as exc:
         logger.warning("Failed to claim active session slot: %s", exc)
@@ -450,6 +463,36 @@ def _release_active_session_slot(session: dict | None) -> None:
         lease.release()
     except Exception:
         logger.debug("Failed to release active session slot", exc_info=True)
+
+
+@contextlib.contextmanager
+def _other_runtime_lease_guard(session_id: str, session: dict):
+    """Hold the owning profile's lease lock while checking sibling runtimes."""
+    stack = contextlib.ExitStack()
+    try:
+        from hermes_cli.active_sessions import active_session_liveness_guard
+
+        active = stack.enter_context(
+            active_session_liveness_guard(
+                session_id,
+                registry_home=session.get("profile_home"),
+            )
+        )
+    except Exception:
+        stack.close()
+        logger.warning(
+            "Failed to inspect active session leases; preserving session %s",
+            session_id,
+            exc_info=True,
+        )
+        # An automatic disconnect reap must prefer a ghost row over ending a
+        # session that may still be owned by another backend.
+        yield True
+        return
+    try:
+        yield active
+    finally:
+        stack.close()
 
 
 def _transfer_active_session_slot(
@@ -484,6 +527,7 @@ def _transfer_active_session_slot(
         new_session_id,
         live_session_id=sid,
         surface=_session_source(session),
+        profile_home=session.get("profile_home"),
     )
     if new_lease is not None:
         old_lease = session.pop("active_session_lease", None)
@@ -622,25 +666,42 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
     # Use session_id (from agent.session_id) not session_key — after compression,
     # session_key may be stale (the ended parent) while session_id is the live
     # continuation. Fix for #20001.
-    _tui_owns_lifecycle = True
-    if session_id:
-        try:
-            db = _get_db()
-            if db is not None:
-                # Don't end gateway-originated sessions — the gateway owns
-                # their lifecycle.  The TUI is a viewer, not the owner.
-                # Ending a gateway session in state.db triggers a Groundhog
-                # Day routing loop: the gateway's #54878 self-heal detects
-                # the stale entry, recovers to the parent session, context
-                # compression splits back to the reaped child, and the cycle
-                # repeats on every inbound message.  (#60609)
-                row = db.get_session(session_id)
-                source = (row or {}).get("source", "")
-                _tui_owns_lifecycle = not _is_gateway_owned_source(source)
-                if _tui_owns_lifecycle:
-                    db.end_session(session_id, end_reason)
-        except Exception:
-            pass
+    _desktop_orphan_reap = bool(
+        session_id
+        and end_reason == "ws_orphan_reap"
+        and _session_source(session).strip().lower() == "desktop"
+    )
+    _lifecycle_guard = (
+        _other_runtime_lease_guard(session_id, session)
+        if _desktop_orphan_reap and session_id
+        else contextlib.nullcontext(False)
+    )
+    with _lifecycle_guard as _other_runtime_owns_lifecycle:
+        _tui_owns_lifecycle = not _other_runtime_owns_lifecycle
+        if _other_runtime_owns_lifecycle:
+            logger.info(
+                "Preserving session %s during ws_orphan_reap: another backend owns an active lease",
+                session_id,
+            )
+        if session_id:
+            try:
+                with _session_db(session) as db:
+                    if db is not None:
+                        # Don't end gateway-originated sessions — the gateway owns
+                        # their lifecycle.  The TUI is a viewer, not the owner.
+                        # Ending a gateway session in state.db triggers a Groundhog
+                        # Day routing loop: the gateway's #54878 self-heal detects
+                        # the stale entry, recovers to the parent session, context
+                        # compression splits back to the reaped child, and the cycle
+                        # repeats on every inbound message.  (#60609)
+                        row = db.get_session(session_id)
+                        source = (row or {}).get("source", "")
+                        if _is_gateway_owned_source(source):
+                            _tui_owns_lifecycle = False
+                        elif _tui_owns_lifecycle:
+                            db.end_session(session_id, end_reason)
+            except Exception:
+                pass
 
     # A session's in-flight async delegations end WITH the session (#55578):
     # once nobody owns the return address, a still-running background subagent
@@ -5259,7 +5320,10 @@ def _(rid, params: dict) -> dict:
     ready = threading.Event()
     now = time.time()
     lease, limit_message = _claim_active_session_slot(
-        key, live_session_id=sid, surface=source
+        key,
+        live_session_id=sid,
+        surface=source,
+        profile_home=profile_home,
     )
     if limit_message is not None:
         return _err(rid, 4090, limit_message)
@@ -5688,7 +5752,10 @@ def _(rid, params: dict) -> dict:
         sid = uuid.uuid4().hex[:8]
         source = _resolve_session_source(str(params.get("source") or "").strip() or None)
         lease, limit_message = _claim_active_session_slot(
-            target, live_session_id=sid, surface=source
+            target,
+            live_session_id=sid,
+            surface=source,
+            profile_home=profile_home,
         )
         if limit_message is not None:
             return _err(rid, 4090, limit_message)
@@ -5752,7 +5819,10 @@ def _(rid, params: dict) -> dict:
         sid = uuid.uuid4().hex[:8]
         source = _resolve_session_source(str(params.get("source") or "").strip() or None)
         lease, limit_message = _claim_active_session_slot(
-            target, live_session_id=sid, surface=source
+            target,
+            live_session_id=sid,
+            surface=source,
+            profile_home=profile_home,
         )
         if limit_message is not None:
             return _err(rid, 4090, limit_message)
@@ -5825,7 +5895,10 @@ def _(rid, params: dict) -> dict:
     sid = uuid.uuid4().hex[:8]
     source = _resolve_session_source(str(params.get("source") or "").strip() or None)
     lease, limit_message = _claim_active_session_slot(
-        target, live_session_id=sid, surface=source
+        target,
+        live_session_id=sid,
+        surface=source,
+        profile_home=profile_home,
     )
     if limit_message is not None:
         return _err(rid, 4090, limit_message)


### PR DESCRIPTION
## What does this PR do?

Prevents one Desktop profile backend from ending a durable session while another live Desktop backend process still owns and runs that same session.

The Desktop can temporarily serve one profile from two Python backends:

- the primary backend, using a per-session `profile_home`; and
- the profile sidecar, using that profile as its process-level `HERMES_HOME`.

Both can hold a runtime for the same durable session. Process-local orphan checks cannot see the sibling backend, so a WebSocket disconnect could previously mark the shared profile `state.db` row ended and interrupt durable-key delegations even while the primary worker was still producing messages.

This PR uses the profile-local active-session registry as a cross-process ownership signal. Desktop sessions retain liveness leases even when `max_concurrent_sessions` is disabled; other surfaces keep the existing unlimited/no-op behavior. Automatic Desktop finalization atomically releases the local lease and checks sibling ownership while holding the registry lock across the durable DB decision.

The protected automatic reasons are:

- `ws_orphan_reap`
- `ws_disconnect`
- `idle_timeout`
- `lru_evict`
- `tui_shutdown`

If another live lease exists—or registry/PID ownership cannot be inspected safely—the local runtime is cleaned up but the durable row and sibling delegation work are preserved. A sole owner still ends normally, and explicit user-close semantics are unchanged.

This is complementary to #44102 and #49900, which guard same-process `running`/agent-build/pending-work state. It also differs from #60609 and #63207: those protect gateway-owned messaging sessions, while this bug involves separate `source=desktop` backend processes.

## Related Issue

Related to #60609 and #63207, but this is a distinct cross-process Desktop profile-backend ownership case.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### `hermes_cli/active_sessions.py`

- Route registry reads/writes through an explicit profile home.
- Track Desktop liveness independently from concurrency-limit enforcement.
- Preserve malformed/unreadable registries instead of treating them as empty, including valid JSON with invalid entry identity/types or conflicting lease IDs.
- Distinguish dead, live, and unknown PID ownership; PID reuse is checked with process start time when available.
- Make strict liveness acquire/inspect/transfer/release errors visible to callers.
- Keep failed releases retryable and prevent a release-vs-transfer race from resurrecting an entry.
- Add a lock-held local-release + sibling-liveness guard for automatic finalization.

### `tui_gateway/server.py`

- Fail Desktop create/resume/branch closed when liveness ownership cannot be registered; preserve existing TUI behavior.
- Carry `profile_home`, profile DB, and lease ownership through initial session publication.
- Route profile branch persistence and agent construction through the owning profile DB.
- Guard all five automatic Desktop end reasons against live sibling leases.
- Preserve durable rows and durable-key delegations when sibling ownership exists or inspection is unknown.
- Retry transient liveness-release failures without dropping the lease reference.
- Keep compression key rotation quiescent until lease transfer succeeds, preventing old/new durable-key mismatch from leaking into the next RPC or queued prompt.
- Key live-session reuse and delegated-child mirrors by `(profile_home, durable_key)` so equal keys in different profiles remain isolated.
- Route live title/status/history, retry truncation, `/undo`, pending titles, and auto-title through the owning profile DB.
- Hold notification-driven turns behind the same ownership-transfer barrier as foreground RPCs, and roll back `running` when another consumer already owns delivery.

### Tests

- Real Windows subprocess/file-lock coverage for profile-local sibling ownership.
- Lock-boundary handshakes for acquire/finalize serialization.
- Automatic-reason matrix for sibling preservation and sole-owner completion.
- Corrupt/structurally invalid registry, conflicting lease ID, read/write/replace failure, PID unknown/reuse, acquire fail-closed, transfer failure, release retry, and release-vs-transfer race coverage.
- Same-key cross-profile live identity plus profile DB create/resume/branch/title/status/history/retry/undo/auto-title routing coverage.
- Notification ownership-transfer failure/retry and delivery-claim rollback coverage.
- Existing gateway-owned, delegation lifecycle, protocol, and session-limit regressions.

## How to Test

1. Run the ownership and related gateway regressions in a clean non-Desktop environment:

   ```bash
   env -u PYTHONPATH -u HERMES_DESKTOP -u HERMES_DESKTOP_TERMINAL \
     uv run pytest \
       tests/hermes_cli/test_active_sessions.py \
       tests/hermes_cli/test_cli_active_session_limit.py \
       tests/tui_gateway/test_cross_process_orphan_ownership.py \
       tests/tui_gateway/test_profile_session_ownership.py \
       tests/tui_gateway/test_gateway_owned_session_reap.py \
       tests/tui_gateway/test_delegation_session_lifecycle.py \
       tests/tui_gateway/test_protocol.py \
       -q -o addopts=
   ```

   Result on Windows 10 / CPython 3.11: `137 passed`.

2. Run the full TUI gateway server regression file:

   ```bash
   env -u PYTHONPATH -u HERMES_DESKTOP -u HERMES_DESKTOP_TERMINAL \
     uv run pytest tests/test_tui_gateway_server.py -q -o addopts=
   ```

   Result: `325 passed`.

3. Run the separate compaction status regressions:

   ```bash
   env -u PYTHONPATH -u HERMES_DESKTOP -u HERMES_DESKTOP_TERMINAL \
     uv run pytest tests/tui_gateway/test_compaction_status.py -q -o addopts=
   ```

   Result: `4 passed`.

4. Run static checks:

   ```bash
   uv run ruff check \
     hermes_cli/active_sessions.py \
     tui_gateway/server.py \
     tests/hermes_cli/test_active_sessions.py \
     tests/tui_gateway/test_cross_process_orphan_ownership.py \
     tests/tui_gateway/test_profile_session_ownership.py

   env -u PYTHONPATH uv run ty check \
     hermes_cli/active_sessions.py \
     tests/hermes_cli/test_active_sessions.py \
     tests/tui_gateway/test_cross_process_orphan_ownership.py \
     tests/tui_gateway/test_profile_session_ownership.py

   env -u PYTHONPATH uv run python -m py_compile \
     hermes_cli/active_sessions.py tui_gateway/server.py

   git diff --check origin/main...HEAD
   ```

   Results: Ruff, py_compile, diff check, and the focused ty check passed. `tui_gateway/server.py` retains existing repository ty diagnostics; none fall on this PR's changed lines.

A total of **466 related tests passed locally**. The repository-wide suite is deferred to CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched open/closed PRs and issues for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass locally (466 related tests passed; full suite deferred to CI)
- [x] I've added tests for my changes
- [x] I've tested on Windows 10 / CPython 3.11

### Documentation & Housekeeping

- [x] Relevant API docstrings were updated; no user-facing docs or config keys changed
- [x] Cross-platform impact was considered: Windows exercises `msvcrt` locally; CI will exercise POSIX `flock`
- [x] Tool descriptions/schemas are not affected

## Screenshots / Logs

No UI changes. The spawned-process regression tests are the executable reproduction and verification evidence.
