### PR TITLE
fix(constants): stop is_container() false positives on hosts that run containers (#65051)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1139,13 +1139,40 @@ def is_container() -> bool:
         pass
     # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
     # runtime still shows up in the mount table (overlay rootfs, runtime mount
-    # paths), so scan mountinfo as a last resort.
+    # paths), so inspect mountinfo as a last resort — but only the mounts that
+    # prove we are INSIDE a container. Substring-scanning the whole table
+    # false-positives on any HOST that merely runs containers: containerd
+    # shim mounts (/run/containerd/io.containerd.runtime.v2.task/...) and
+    # docker overlay mounts are visible in the host namespace (#65051), and
+    # Docker Desktop mounts containerd snapshot overlays into the WSL2 host
+    # (#51930). Two mount shapes are container-conclusive:
+    #   * the ROOT mount ("/") is provided by a container runtime — its
+    #     fs-root path, source, or super options reference runtime paths;
+    #   * /etc/resolv.conf|hostname|hosts are bind-mounted from kubelet/
+    #     runtime-managed dirs (how runtimes inject network identity; a host
+    #     never bind-mounts its own /etc identity files from those paths).
+    _RUNTIME_MARKERS = (
+        "docker", "containerd", "crio", "podman", "kubepods", "kubelet", "buildkit",
+    )
+    _IDENTITY_MOUNTS = {"/", "/etc/resolv.conf", "/etc/hostname", "/etc/hosts"}
     try:
         with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
-            mountinfo = f.read()
-            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
-                _container_detected = True
-                return True
+            for line in f:
+                fields = line.split()
+                if len(fields) < 5 or fields[4] not in _IDENTITY_MOUNTS:
+                    continue
+                # fields[3] is the mount's root within its filesystem; after
+                # the "-" separator come fstype, source, and super options
+                # (e.g. overlay upperdir=/var/lib/docker/overlay2/...).
+                try:
+                    sep = fields.index("-")
+                    probe_fields = [fields[3]] + fields[sep + 1:]
+                except ValueError:
+                    probe_fields = [fields[3]]
+                probe = " ".join(probe_fields)
+                if any(marker in probe for marker in _RUNTIME_MARKERS):
+                    _container_detected = True
+                    return True
     except OSError:
         pass
     _container_detected = False

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1153,6 +1153,11 @@ def is_container() -> bool:
     #     never bind-mounts its own /etc identity files from those paths).
     _RUNTIME_MARKERS = (
         "docker", "containerd", "crio", "podman", "kubepods", "kubelet", "buildkit",
+        # Podman and CRI-O keep container roots under the shared
+        # containers/storage tree (rootful /var/lib/containers/storage/...,
+        # rootless ~/.local/share/containers/storage/...) — those paths spell
+        # neither "podman" nor "crio".
+        "containers/storage",
     )
     _IDENTITY_MOUNTS = {"/", "/etc/resolv.conf", "/etc/hostname", "/etc/hosts"}
     try:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1167,11 +1167,15 @@ def is_container() -> bool:
                 if len(fields) < 5 or fields[4] not in _IDENTITY_MOUNTS:
                     continue
                 # fields[3] is the mount's root within its filesystem; after
-                # the "-" separator come fstype, source, and super options
-                # (e.g. overlay upperdir=/var/lib/docker/overlay2/...).
+                # the "-" separator come fstype, source, and super options.
+                # Probe ONLY the fs-root path and the super options (e.g.
+                # overlay upperdir=/var/lib/docker/overlay2/...): the fstype
+                # and SOURCE fields prove device provenance, not containment —
+                # a host root on an LVM volume group named "docker"
+                # (/dev/mapper/docker--vg-root) must not match.
                 try:
                     sep = fields.index("-")
-                    probe_fields = [fields[3]] + fields[sep + 1:]
+                    probe_fields = [fields[3]] + fields[sep + 3:]
                 except ValueError:
                     probe_fields = [fields[3]]
                 probe = " ".join(probe_fields)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1630,13 +1630,40 @@ def is_container() -> bool:
         pass
     # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
     # runtime still shows up in the mount table (overlay rootfs, runtime mount
-    # paths), so scan mountinfo as a last resort.
+    # paths), so inspect mountinfo as a last resort — but only the mounts that
+    # prove we are INSIDE a container. Substring-scanning the whole table
+    # false-positives on any HOST that merely runs containers: containerd
+    # shim mounts (/run/containerd/io.containerd.runtime.v2.task/...) and
+    # docker overlay mounts are visible in the host namespace (#65051), and
+    # Docker Desktop mounts containerd snapshot overlays into the WSL2 host
+    # (#51930). Two mount shapes are container-conclusive:
+    #   * the ROOT mount ("/") is provided by a container runtime — its
+    #     fs-root path, source, or super options reference runtime paths;
+    #   * /etc/resolv.conf|hostname|hosts are bind-mounted from kubelet/
+    #     runtime-managed dirs (how runtimes inject network identity; a host
+    #     never bind-mounts its own /etc identity files from those paths).
+    _RUNTIME_MARKERS = (
+        "docker", "containerd", "crio", "podman", "kubepods", "kubelet", "buildkit",
+    )
+    _IDENTITY_MOUNTS = {"/", "/etc/resolv.conf", "/etc/hostname", "/etc/hosts"}
     try:
         with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
-            mountinfo = f.read()
-            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
-                _container_detected = True
-                return True
+            for line in f:
+                fields = line.split()
+                if len(fields) < 5 or fields[4] not in _IDENTITY_MOUNTS:
+                    continue
+                # fields[3] is the mount's root within its filesystem; after
+                # the "-" separator come fstype, source, and super options
+                # (e.g. overlay upperdir=/var/lib/docker/overlay2/...).
+                try:
+                    sep = fields.index("-")
+                    probe_fields = [fields[3]] + fields[sep + 1:]
+                except ValueError:
+                    probe_fields = [fields[3]]
+                probe = " ".join(probe_fields)
+                if any(marker in probe for marker in _RUNTIME_MARKERS):
+                    _container_detected = True
+                    return True
     except OSError:
         pass
     _container_detected = False

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1658,11 +1658,15 @@ def is_container() -> bool:
                 if len(fields) < 5 or fields[4] not in _IDENTITY_MOUNTS:
                     continue
                 # fields[3] is the mount's root within its filesystem; after
-                # the "-" separator come fstype, source, and super options
-                # (e.g. overlay upperdir=/var/lib/docker/overlay2/...).
+                # the "-" separator come fstype, source, and super options.
+                # Probe ONLY the fs-root path and the super options (e.g.
+                # overlay upperdir=/var/lib/docker/overlay2/...): the fstype
+                # and SOURCE fields prove device provenance, not containment —
+                # a host root on an LVM volume group named "docker"
+                # (/dev/mapper/docker--vg-root) must not match.
                 try:
                     sep = fields.index("-")
-                    probe_fields = [fields[3]] + fields[sep + 1:]
+                    probe_fields = [fields[3]] + fields[sep + 3:]
                 except ValueError:
                     probe_fields = [fields[3]]
                 probe = " ".join(probe_fields)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1644,6 +1644,11 @@ def is_container() -> bool:
     #     never bind-mounts its own /etc identity files from those paths).
     _RUNTIME_MARKERS = (
         "docker", "containerd", "crio", "podman", "kubepods", "kubelet", "buildkit",
+        # Podman and CRI-O keep container roots under the shared
+        # containers/storage tree (rootful /var/lib/containers/storage/...,
+        # rootless ~/.local/share/containers/storage/...) — those paths spell
+        # neither "podman" nor "crio".
+        "containers/storage",
     )
     _IDENTITY_MOUNTS = {"/", "/etc/resolv.conf", "/etc/hostname", "/etc/hosts"}
     try:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -534,6 +534,32 @@ class TestIsContainer:
         monkeypatch.setattr("builtins.open", _fake_open)
         assert is_container() is True
 
+    def test_lvm_docker_volume_group_root_is_not_container(self, monkeypatch, tmp_path):
+        """Review catch on #65060: the mount SOURCE proves device provenance,
+        not containment — a host whose root lives on an LVM volume group named
+        'docker' (/dev/mapper/docker--vg-root) must not be flagged."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/init.scope\n")
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "35 1 253:0 / / rw,relatime shared:1 - ext4 /dev/mapper/docker--vg-root rw\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is False
+
     def test_detects_rootless_podman_via_storage_root(self, monkeypatch, tmp_path):
         """Podman/CRI-O roots live under containers/storage (no 'podman'/'crio'
         in the path) — the root-mount check must still detect them even when

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -534,6 +534,34 @@ class TestIsContainer:
         monkeypatch.setattr("builtins.open", _fake_open)
         assert is_container() is True
 
+    def test_detects_rootless_podman_via_storage_root(self, monkeypatch, tmp_path):
+        """Podman/CRI-O roots live under containers/storage (no 'podman'/'crio'
+        in the path) — the root-mount check must still detect them even when
+        /run/.containerenv is unavailable."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/\n")
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "600 599 0:58 / / rw,relatime - overlay overlay "
+            "rw,lowerdir=/home/user/.local/share/containers/storage/overlay/l/A,"
+            "upperdir=/home/user/.local/share/containers/storage/overlay/abc/diff\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is True
+
     def test_caches_result(self, monkeypatch):
         """Second call uses cached value without re-probing."""
         monkeypatch.setattr(hermes_constants, "_container_detected", True)

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -450,6 +450,90 @@ class TestIsContainer:
         monkeypatch.setattr("builtins.open", _fake_open)
         assert is_container() is True
 
+    def test_host_running_containers_is_not_container(self, monkeypatch, tmp_path):
+        """#65051: a HOST that runs containers has containerd shim mounts and
+        docker overlay mounts in its own mount table — they must not flag the
+        host itself as containerised (the root mount is a real device)."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/init.scope\n")  # bare host, cgroup v2
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "35 1 253:0 / / rw,relatime shared:1 - ext4 /dev/vda1 rw\n"
+            "812 35 0:60 / /var/lib/docker/overlay2/abc123/merged rw,relatime shared:401 - "
+            "overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/X,upperdir=/var/lib/docker/overlay2/abc123/diff\n"
+            "890 35 0:75 / /run/containerd/io.containerd.runtime.v2.task/moby/deadbeef/rootfs "
+            "rw,relatime shared:410 - overlay overlay rw\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is False
+
+    def test_wsl_docker_desktop_snapshots_not_container(self, monkeypatch, tmp_path):
+        """#51930 variant: Docker Desktop mounts containerd snapshot overlays
+        into the WSL2 host — non-root mounts must not flag the WSL host."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/\n")
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "60 1 8:32 / / rw,relatime - ext4 /dev/sdc rw,discard\n"
+            "310 60 0:55 / /mnt/docker-desktop/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/12/fs "
+            "rw,relatime - overlay overlay rw\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is False
+
+    def test_detects_pod_via_resolvconf_bind_mount(self, monkeypatch, tmp_path):
+        """A kubelet-managed /etc/resolv.conf bind mount proves we are INSIDE
+        a pod even when the root mount carries no runtime marker."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/\n")
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "1000 999 0:50 / / rw,relatime - overlay overlay rw\n"
+            "1010 1000 8:1 /var/lib/kubelet/pods/uid-123/etc-hosts /etc/hosts "
+            "rw,relatime - ext4 /dev/sda1 rw\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is True
+
     def test_caches_result(self, monkeypatch):
         """Second call uses cached value without re-probing."""
         monkeypatch.setattr(hermes_constants, "_container_detected", True)

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -447,6 +447,32 @@ class TestIsContainer:
         monkeypatch.setattr("builtins.open", _fake_open)
         assert is_container() is True
 
+    def test_lvm_docker_volume_group_root_is_not_container(self, monkeypatch, tmp_path):
+        """Review catch on #65060: the mount SOURCE proves device provenance,
+        not containment — a host whose root lives on an LVM volume group named
+        'docker' (/dev/mapper/docker--vg-root) must not be flagged."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/init.scope\n")
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "35 1 253:0 / / rw,relatime shared:1 - ext4 /dev/mapper/docker--vg-root rw\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is False
+
     def test_detects_rootless_podman_via_storage_root(self, monkeypatch, tmp_path):
         """Podman/CRI-O roots live under containers/storage (no 'podman'/'crio'
         in the path) — the root-mount check must still detect them even when

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -363,6 +363,90 @@ class TestIsContainer:
 
 
 
+    def test_host_running_containers_is_not_container(self, monkeypatch, tmp_path):
+        """#65051: a HOST that runs containers has containerd shim mounts and
+        docker overlay mounts in its own mount table — they must not flag the
+        host itself as containerised (the root mount is a real device)."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/init.scope\n")  # bare host, cgroup v2
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "35 1 253:0 / / rw,relatime shared:1 - ext4 /dev/vda1 rw\n"
+            "812 35 0:60 / /var/lib/docker/overlay2/abc123/merged rw,relatime shared:401 - "
+            "overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/X,upperdir=/var/lib/docker/overlay2/abc123/diff\n"
+            "890 35 0:75 / /run/containerd/io.containerd.runtime.v2.task/moby/deadbeef/rootfs "
+            "rw,relatime shared:410 - overlay overlay rw\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is False
+
+    def test_wsl_docker_desktop_snapshots_not_container(self, monkeypatch, tmp_path):
+        """#51930 variant: Docker Desktop mounts containerd snapshot overlays
+        into the WSL2 host — non-root mounts must not flag the WSL host."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/\n")
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "60 1 8:32 / / rw,relatime - ext4 /dev/sdc rw,discard\n"
+            "310 60 0:55 / /mnt/docker-desktop/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/12/fs "
+            "rw,relatime - overlay overlay rw\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is False
+
+    def test_detects_pod_via_resolvconf_bind_mount(self, monkeypatch, tmp_path):
+        """A kubelet-managed /etc/resolv.conf bind mount proves we are INSIDE
+        a pod even when the root mount carries no runtime marker."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/\n")
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "1000 999 0:50 / / rw,relatime - overlay overlay rw\n"
+            "1010 1000 8:1 /var/lib/kubelet/pods/uid-123/etc-hosts /etc/hosts "
+            "rw,relatime - ext4 /dev/sda1 rw\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is True
+
     def test_caches_result(self, monkeypatch):
         """Second call uses cached value without re-probing."""
         monkeypatch.setattr(hermes_constants, "_container_detected", True)

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -447,6 +447,34 @@ class TestIsContainer:
         monkeypatch.setattr("builtins.open", _fake_open)
         assert is_container() is True
 
+    def test_detects_rootless_podman_via_storage_root(self, monkeypatch, tmp_path):
+        """Podman/CRI-O roots live under containers/storage (no 'podman'/'crio'
+        in the path) — the root-mount check must still detect them even when
+        /run/.containerenv is unavailable."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/\n")
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "600 599 0:58 / / rw,relatime - overlay overlay "
+            "rw,lowerdir=/home/user/.local/share/containers/storage/overlay/l/A,"
+            "upperdir=/home/user/.local/share/containers/storage/overlay/abc/diff\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is True
+
     def test_caches_result(self, monkeypatch):
         """Second call uses cached value without re-probing."""
         monkeypatch.setattr(hermes_constants, "_container_detected", True)


### PR DESCRIPTION
## Summary

Stop `is_container()` reporting "inside a container" on hosts that merely *run* containers, by replacing the whole-file mountinfo substring scan with a structural check of the mounts that actually prove containment (#65051).

## Changes

- `hermes_constants.py`: `is_container()` — the cgroup-v2 last-resort now parses `/proc/self/mountinfo` per-line and only inspects container-conclusive mounts: the ROOT mount (`/`) whose fs-root path / source / super options reference a runtime (docker, containerd, crio, podman, kubepods, kubelet, buildkit), or `/etc/resolv.conf|hostname|hosts` bind-mounted from kubelet/runtime-managed dirs (how runtimes inject network identity — a host never bind-mounts its own /etc identity files from those paths). `/.dockerenv`, `/run/.containerenv`, `KUBERNETES_SERVICE_HOST`, and the `/proc/1/cgroup` markers are untouched
- `tests/test_hermes_constants.py`: 3 tests — bare-VPS host running docker containers (containerd shim mounts + overlay mounts in the host table → False; the #65051 shape), WSL2 + Docker Desktop snapshot mounts (→ False; the #51930 shape), and kubelet `/etc/hosts` bind mount (→ True; new detection coverage). The two False cases fail on unfixed code; all 8 existing detection tests pass unchanged, including the #47111 cgroup-v2 containerd-pod case

## Root cause

The mountinfo fallback added in #47144 (for #47111: cgroup-v2 pods where `/proc/1/cgroup` is a markerless `0::/`) scans the entire file:

```python
if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
```

But container runtime mounts are visible in the **host's** mount namespace too: running any Docker container puts `/run/containerd/io.containerd.runtime.v2.task/moby/<id>/rootfs` shim mounts in the host's table, so `"containerd" in mountinfo` is true on exactly the machines most likely to configure `terminal.backend: docker` for isolation. #51930 hit the same class from the WSL side (Docker Desktop snapshot mounts); #51935 proposed skipping the mountinfo check on WSL — this change fixes the class structurally instead, covering bare hosts and WSL with one rule, and keeps mountinfo-based detection working where it is needed.

Distinguishing signal: what matters is not *whether* runtime paths appear in the table, but *which mount* they provide. Inside a container the root mount itself comes from the runtime (the existing cgroup-v2 test's fixture — `... /containerd/.../rootfs / ... overlay` — is exactly this shape and passes unchanged); on a host the root is a real device and the runtime paths hang off non-identity mount points.

The false positive is user-visible beyond `hermes doctor`'s misleading "Running inside a container — using local terminal backend" line: `is_container()` also gates voice-mode audio, config-file permission hardening (`_is_container` chmod behavior), gateway service-manager detection, and the startup security audit.

Note on the issue's second claim ("backend silently forced to local at dispatch time"): I could not find such a code path — `terminal_tool._get_env_config()` reads `TERMINAL_ENV` with no `is_container()` gate, and the doctor message is display-only. Posted the dispatch-chain trace on the issue; the observed host execution is most likely the systemd service user resolving a different `HERMES_HOME` than the config file being edited. This PR fixes the verified detection bug.

## Validation

| Environment | Before | After |
|---|---|---|
| Bare KVM host, Docker containers running (#65051) | container=True (shim mounts match "containerd") | container=False |
| WSL2 + Docker Desktop (#51930) | container=True (snapshot mounts) | container=False |
| containerd/CRI-O pod, cgroup v2 (#47111) | container=True | container=True (unchanged) |
| kubelet /etc/hosts bind mount, unmarked root | container=False (missed) | container=True |
| /.dockerenv, podman, k8s env, cgroup-v1 markers | detected | detected (untouched) |

- `scripts/run_tests.sh tests/test_hermes_constants.py` — 95 passed, 0 failed
- Consumers: `scripts/run_tests.sh tests/tools/test_voice_mode.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_container_aware_cli.py` — 140 passed, 0 failed

Fixes #65051. Refs #47111/#47144 (origin of the fallback), #51930/#51935 (WSL variant of the same class — the WSL skip becomes unnecessary with this), #34397, #25402.
