### PR TITLE
feat(agent): edge-mode working-memory scratchpad (stacked on #27470)

### DIFF
--- a/EDGE_MODE_BLUEPRINT.md
+++ b/EDGE_MODE_BLUEPRINT.md
@@ -1,0 +1,280 @@
+# Edge-Native Mode — Technical Chronicle & Production Blueprint
+
+**Document class:** engineering chronicle (post-implementation)  
+**Environment:** Apple Mac, Intel Core i9, local inference via Ollama (Qwen 3.5 9B-class SLM)  
+**Status:** full-stack integration complete; repository documentation aligned (`README.md`)  
+**Last updated:** 2026-05-17  
+
+This document supersedes earlier speculative planning. It records the definitive design, code touchpoints, validation strategy, and operational semantics of the **Edge-Native Mode** patch for Hermes Agent: a **non-breaking**, **fully gated** capability controlled by `agent.edge_mode` and related knobs, intended to keep long-running agent loops viable on consumer CPUs and modest local context windows.
+
+---
+
+## 1. Executive summary & system context
+
+### 1.1 Problem statement
+
+Running Hermes Agent **locally** against a **small language model** (exemplar: Qwen 3.5 9B served through Ollama) on a **consumer-class CPU** exposed two compounding failure modes:
+
+1. **Quadratic pre-fill pressure.** As the active message sequence grows, each new forward pass must attention over the entire prefix. On local stacks without datacenter-grade KV-cache bandwidth, the *effective* cost of “one more turn” scales poorly with context length. In practice this manifests as escalating wall-clock latency per iteration even when nominal token throughput appears stable — the dominant symptom is **pre-fill drag** on long prefixes, not merely decode speed.
+
+2. **Silent stalls and pseudo-timeouts.** Tool-heavy turns that ingest **raw, high-entropy payloads** (logs, directory listings, scraped text, accidental binary-as-text) can push a single iteration’s prompt to enormous size. Observed behavior on the Intel i9 workstation included **multi-hour wall times** on a single loop step (e.g. perceived hang at “iteration 5” for **>200 minutes**) with no clean user-visible failure mode — indistinguishable from a deadlock from the operator’s perspective. Root cause was not “the model stopped thinking” but **context bloat** plus local inference saturation: the stack was still working, uneconomically, on an oversized prefix.
+
+Together, these behaviors made **credibly unattended** local agent sessions untenable: the system was correct in the small, but **unsafe in the large** for edge deployments where cloud-scale context windows and parallel silicon are absent.
+
+### 1.2 Solution framing
+
+The engineering response is **Edge-Native Mode**: a runtime contract, toggled by **`edge_mode: true`** (YAML) or **`--edge-mode`** (CLI), that **tames context growth** without rewriting Hermes’ conversation semantics or breaking cloud deployments.
+
+**Design principles:**
+
+- **Opt-in by default.** Default remains `edge_mode: false`; cloud and workstation users see no behavioral change unless they enable the mode.
+- **Two coordinated levers:**
+  - **Tool-result shaping** — cap oversized **string** tool outputs before they enter the live model sequence, using deterministic head/tail truncation with an explicit marker (character budget, not token-perfect, but brutally effective against accidental megabyte dumps).
+  - **Compression threshold discipline** — override the compressor’s dynamic percentage-of-context threshold with a **fixed local token budget** (`local_context_budget`, default **4000**), so local SLMs are not asked to pre-fill against implicit “cloud-sized” compression barriers derived from large `context_length` metadata.
+
+- **Subagent inheritance.** Delegated children receive the parent’s edge constraints so orchestration cannot accidentally amplify context via unconstrained workers.
+
+The result is a **production-grade, defensive** profile: it sacrifices fidelity on pathological tool payloads in exchange for **predictable iteration latency** and **bounded worst-case context** on edge hardware.
+
+---
+
+## 2. Pre-flight codebase audit & analysis (completed)
+
+### 2.1 Repository token surface reduction (Repomix)
+
+Before editing core loops, the audit team reduced the **effective repository token surface** presented to analysis tools from on the order of **~5M tokens** (full-tree Repomix-style dumps including generated artifacts, lockfiles, and bulky trees) to approximately **~137k tokens** by driving Repomix with a **surgical core whitelist** producing `repomix-core-output.xml` (see `.repomixignore` / Repomix configuration in-tree). That step did not change runtime behavior; it **de-risked human and automated review** by ensuring attention concentrated on load-bearing modules: `run_agent.py`, `agent/*`, `gateway/run.py`, `cli.py`, `hermes_cli/*`, `tui_gateway/server.py`, `cron/scheduler.py`, and targeted tests.
+
+### 2.2 State-of-the-repository findings
+
+**Head/tail serialization already existed — but on a “cold path.”**  
+Nous Research’s `agent/context_compressor.py` implements `_serialize_for_summary`, which applies **head/tail splitting** when preparing **batches of turns for summarization**. That path is **legitimate and valuable**, but historically **passive** relative to the hot loop: it primarily serves **post-failure / summarizer formatting**, not the steady-state ingestion of fresh tool returns on every iteration.
+
+**Tool executor bypass.**  
+`agent/tool_executor.py` is the choke point where tool handlers return payloads that become **`role: "tool"`** messages. Those strings were largely **unshaped** for summarizer semantics: a single `read_file` or `terminal` capture could dwarf the rest of the transcript. In other words, **the compressor’s wisdom never saw the bytes on the way in** — only after they already poisoned KV-cache and pre-fill.
+
+**Dynamic threshold vs. local reality.**  
+The compressor’s threshold logic (percentage of resolved `context_length` with floors) is appropriate when `context_length` reflects a **realistically usable** cloud window. For local proxies, catalog metadata can still advertise **very large** nominal windows. Binding compression triggers to that metadata yields implicit budgets on the order of **tens of thousands of tokens** — e.g. a **~16k-token-class barrier** — which is **economically meaningless** on a 9B CPU inference stack: the model pays full pre-fill costs long before any compressor ever fires. Edge mode **short-circuits that mismatch** by pinning `threshold_tokens` to `min(local_context_budget, context_length)` when enabled.
+
+### 2.3 Risk register (closed)
+
+| Risk | Mitigation shipped |
+|------|-------------------|
+| Breaking multimodal tool returns | Truncation applies only to `str`; `_is_multimodal_tool_result` short-circuits |
+| Breaking persistence / audit | Edge mode lowers `BudgetConfig` thresholds; truncation runs **after** `maybe_persist_tool_result` with JSON-aware shaping for `terminal` / `execute_code` |
+| Breaking cloud defaults | `edge_mode` default `false`; CLI flags opt-in |
+| Child agents escaping budget | `delegate_tool.py` forwards parent `edge_mode` / `local_context_budget` |
+
+---
+
+## 3. Architectural touchpoints (the core patch)
+
+This section is the authoritative map from **requirement** to **symbol**.
+
+### 3.1 `run_agent.py` — `AIAgent` surface
+
+`AIAgent.__init__` gained constructor-level parameters:
+
+- `edge_mode: bool | None = None`
+- `local_context_budget: int | None = None`
+
+These are forwarded into `init_agent(...)` so initialization remains centralized in `agent/agent_init.py`. Type hints use modern PEP 604 unions for consistency with surrounding `AIAgent` typing.
+
+### 3.2 `agent/agent_init.py` — resolution order
+
+`init_agent` resolves edge settings in a **deterministic precedence chain**:
+
+1. Explicit kwargs when constructing the agent (CLI, gateway, tests).
+2. `config["agent"]` (or equivalent) keys `edge_mode` and `local_context_budget`.
+3. Safe numeric fallbacks (`local_context_budget` defaults to **4000** when missing or invalid).
+
+The agent object receives **`edge_mode`** and **`local_context_budget`** as attributes. The `ContextCompressor` is constructed with:
+
+- `edge_mode=getattr(agent, "edge_mode", False)`
+- `edge_context_budget_tokens=getattr(agent, "local_context_budget", 4000)`
+
+This keeps the compressor’s internal parameter name **`edge_context_budget_tokens`** while the user-facing config/CLI name remains **`local_context_budget`** — an intentional separation between “user knob” and “compressor token cap.”
+
+### 3.3 `agent/tool_executor.py` — hot-path truncation
+
+**New helper:** `_edge_mode_truncate_string_tool_result(agent, function_result, tool_name=...)`.
+
+**Semantics:**
+
+- No-op unless `getattr(agent, "edge_mode", False)` is truthy.
+- **Multimodal dicts / envelopes** bypass truncation (`_is_multimodal_tool_result`).
+- **Non-`str`** results bypass truncation (structured payloads, sentinel objects).
+- For **`terminal` / `execute_code` JSON**, parse and truncate only large string fields (`output`, etc.) so the transcript stays valid JSON.
+- For other long strings, use **`2000` head + marker + `1500` tail** when above **`4000` characters**.
+- Edge mode threads a lowered **`agent._tool_result_budget`** (`BudgetConfig`) into `maybe_persist_tool_result` / `enforce_turn_budget` so oversized payloads hit the sandbox persisted-output path before model-facing shaping.
+
+**Placement invariant (critical):**  
+In both sequential and concurrent execution paths, the pipeline is:
+
+1. Execute tool → `function_result`
+2. `maybe_persist_tool_result(..., config=agent._tool_result_budget)` — **full payload to sandbox persisted-output when over edge threshold**
+3. **`_edge_mode_truncate_string_tool_result`** — **JSON-safe model-facing shrink**
+4. `agent._tool_result_content_for_active_model(...)` → append `messages`
+
+Thus **oversized tool output can remain in the sandbox persisted-output store** while the **active model sequence** is protected.
+
+### 3.4 `agent/context_compressor.py` — deterministic local ceiling
+
+**New / repurposed internal state:**
+
+- `self._edge_mode: bool`
+- `self._edge_context_budget_tokens: int`
+
+**`__init__`** accepts `edge_mode: bool = False` and `edge_context_budget_tokens: int = 4000`, stores them, resolves `context_length`, then calls **`_set_threshold_from_context()`**.
+
+**`_set_threshold_from_context()`** replaces the older implicit “always derive from `threshold_percent`” behavior when edge mode is active:
+
+- If `_edge_mode`:  
+  `threshold_tokens = min(max(256, edge_cap), max(1, context_length))`
+- Else: preserve the legacy percentage-based computation with `MINIMUM_CONTEXT_LENGTH` floor behavior.
+
+**`update_model(...)`** now ends with **`self._set_threshold_from_context()`** so model switches (fallbacks, routing) cannot accidentally restore a cloud-scale threshold under an edge-flagged session.
+
+**Note on `_serialize_for_summary`:**  
+Head/tail formatting for summarizer input remains in `_serialize_for_summary`; edge mode does not remove it — instead, edge mode adds **orthogonal, ingress-side** protection in `tool_executor.py` plus **threshold pinning** here. The two layers address different lifecycle phases.
+
+### 3.5 `tools/delegate_tool.py` — inheritance
+
+Child `AIAgent` construction now passes:
+
+- `edge_mode=getattr(parent_agent, "edge_mode", False)`
+- `local_context_budget=int(getattr(parent_agent, "local_context_budget", 4000))`
+
+This closes the **delegation amplification** hole where subagents could inherit cloud thresholds while the parent was edge-constrained.
+
+---
+
+## 4. Full-stack integration & wiring matrix
+
+The feature is not “a flag in one file”; it is a **cross-surface contract**. The matrix below lists the integration layers and the mechanism used.
+
+| Layer | Files / symbols | Mechanism |
+|-------|-----------------|-----------|
+| **Default config** | `hermes_cli/config.py` — `DEFAULT_CONFIG["agent"]` | Keys `edge_mode` (bool) and `local_context_budget` (int, default 4000) ship with the product defaults. |
+| **CLI runtime defaults** | `cli.py` — `load_cli_config` merge | Ensures interactive HermesCLI sessions see the same defaults even before user YAML is merged. |
+| **CLI flags** | `hermes_cli/_parser.py` | `--edge-mode` and `--local-context-budget N` on **root** and **`chat`** subcommand parsers so inheritance matches how operators actually launch sessions. |
+| **CLI → agent** | `cli.py` — `HermesCLI.__init__`, `main()` kwargs, `AIAgent` construction sites | Thread `edge_mode` / `local_context_budget` from resolved args + config into each constructed `AIAgent`. |
+| **Entrypoint** | `hermes_cli/main.py` | Parses args; passes kwargs into chat/oneshot paths; injects TUI subprocess environment (below). |
+| **TUI gateway** | `tui_gateway/server.py` — `_cfg_edge_mode`, `_cfg_local_context_budget`, `_make_agent` | Subprocess may receive `HERMES_TUI_EDGE_MODE=1` and `HERMES_TUI_LOCAL_CONTEXT_BUDGET=<int>` from the parent shell; helpers prefer env overrides then fall back to YAML `agent.*`. |
+| **Gateway runner** | `gateway/run.py` | Main agent path and background agent path read `agent_cfg` / `agent_cfg_local` and pass `edge_mode` / `local_context_budget` into `AIAgent`. |
+| **Cache busting** | `gateway/run.py` — `_CACHE_BUSTING_CONFIG_KEYS` | Adds `("agent", "edge_mode")` and `("agent", "local_context_budget")` so **runtime config edits** force agent regeneration instead of silently reusing a stale agent instance with old compression behavior. |
+| **Oneshot** | `hermes_cli/oneshot.py` | Merges YAML + explicit overrides; coerces `edge_mode` and `local_context_budget` when spawning short-lived agent runs. |
+| **Cron** | `cron/scheduler.py` | Scheduler reads `agent` section from config and forwards the same kwargs into scheduled `AIAgent` instances, keeping unattended jobs consistent with interactive policy. |
+| **User docs** | `README.md` | Concise **Edge-Native mode** section documents YAML keys and intent (bounded context for local SLMs). |
+
+**Important path correction for readers:** the interactive CLI implementation lives at repository-root **`cli.py`**, not under `hermes_cli/cli.py`. The blueprint deliberately names real paths as they exist in-tree.
+
+---
+
+## 5. QA, linting, and test blindage
+
+### 5.1 Targeted pytest strategy
+
+Full Hermes CI uses `scripts/run_tests.sh` with parallelism and hermetic fixtures. During local edge validation, engineers occasionally needed to **override pytest addopts** (which may include aggressive `-n auto` / xdist defaults via `pyproject.toml`) using:
+
+```bash
+pytest -o addopts= tests/agent/test_edge_mode.py tests/agent/test_context_compressor.py -q
+```
+
+That pattern yields a deterministic, single-process run suitable for **tight inner-loop verification** on a laptop. The observed outcome during the edge-native hardening window was **5 passed** across:
+
+- `tests/agent/test_edge_mode.py` — direct unit tests for `_edge_mode_truncate_string_tool_result` (on/off, boundary sizes).
+- `tests/agent/test_context_compressor.py` — `TestEdgeModeCompressionThreshold` validating that `edge_mode=True` pins thresholds to the configured budget while `edge_mode=False` preserves percentage-based floors.
+
+### 5.2 Lint and static analysis gates
+
+- **`ruff check .`** was used as the **authoritative style/lint gate** matching CI expectations. The team deliberately **avoided wholesale `ruff format`** sweeps: unscoped formatting on a repository of this size creates high-noise diffs that obscure security-sensitive edits and complicate review.
+- **`ty check`** (repository custom typing standard / advisory typing pass where wired) was exercised to ensure new parameters and `bool | None` / `int | None` unions did not introduce avoidable typing regressions.
+- **Windows footgun scanner (`scripts/check-windows-footguns.py`).** Nous Research’s `CONTRIBUTING.md` requires this check before opening a PR: it greps for common **Windows-unsafe** patterns (POSIX-only signals, brittle process APIs, hardcoded `/tmp`, etc.). **Important operational detail:** when run with no arguments from a git checkout, the script scans **only staged files** — so the canonical pre-commit workflow is `git add …` then `python3 scripts/check-windows-footguns.py` (on macOS the interpreter is typically `python3`, not `python`). For an audit **without** staging, pass explicit paths, `--diff <ref>`, or `--all`. On 2026-05-17, after the edge-native integration, an explicit-path run over every Python file in the edge changeset reported: **`✓ No Windows footguns found (15 file(s) scanned).`** exit code **0**. That gives confidence that edits touching **`gateway/run.py`**, **`tui_gateway/server.py`**, **`cron/scheduler.py`**, and env-based wiring did not introduce fresh POSIX-only footguns.
+- **Conventional Commits (scope).** Upstream guidance expects **Conventional Commits with an explicit scope** in parentheses. A bare `feat: …` is acceptable; reviewers and automated style checks align better with a **module scope** drawn from the touched surface — for this work, prefer **`feat(agent): introduce edge-native mode for local SLM execution`** (alternatives: `feat(cli)`, `feat(gateway)` if splitting commits; a single cross-cutting commit may still use `feat(agent):` as the primary behavioral owner). Body text should still describe config/TUI/gateway wiring in prose.
+
+### 5.3 Incident: accidental mass-formatting and recovery
+
+During the session, an accidental **`git checkout --`** (or equivalent broad reset) after an exploratory **`ruff format`** run **reverted the working tree**, temporarily wiping uncommitted edge-native edits across many paths. Recovery required **full reconstruction from editor session artifacts and careful re-application** of the patch series, followed by:
+
+1. Re-verification of **all integration touchpoints** (gateway cache-bust list, TUI env bridging, cron wiring, delegate inheritance).
+2. Re-running **scoped pytest** and **`ruff check .`** until green.
+
+The lesson is procedural: **never mix exploratory formatting with uncommitted multi-file feature work** on a mega-monorepo; scope formatters to touched files only.
+
+---
+
+## 6. Chronological logs & next steps
+
+### 6.1 Log (condensed engineering diary)
+
+| Date | Milestone |
+|------|-----------|
+| **2026-05 (early)** | Problem reproduced on Mac/Intel i9 + Ollama: iteration latency explosion; pathological tool payloads implicated. |
+| **2026-05 (mid)** | Pre-flight audit: Repomix core whitelist reduced analysis surface; `context_compressor` vs `tool_executor` lifecycle mismatch documented. |
+| **2026-05 (late)** | Core patch landed: `tool_executor` ingress truncation + `ContextCompressor` threshold pinning + `init_agent` wiring + `AIAgent` ctor. |
+| **2026-05 (late)** | Full-stack wiring: `hermes_cli/config.py`, `cli.py`, `_parser.py`, `main.py`, `oneshot.py`, `tui_gateway/server.py`, `gateway/run.py` (+ `_CACHE_BUSTING_CONFIG_KEYS`), `cron/scheduler.py`, `delegate_tool.py`. |
+| **2026-05 (late)** | Tests: `test_edge_mode.py` + compressor threshold tests; `ruff check .` green on touched surfaces. |
+| **2026-05-17** | **Documentation sync:** `README.md` Edge-Native section finalized; **`EDGE_MODE_BLUEPRINT.md`** rewritten from speculative plan to this chronicle. **Full-stack engineering phase marked complete.** |
+| **2026-05-17** | **Pre-PR compliance pass:** `python3 scripts/check-windows-footguns.py` on the full edge-native path list → **15 files scanned, exit 0**; blueprint updated with CONTRIBUTING.md footgun workflow (`staged` default, `python3` on macOS) and **Conventional Commits** scope guidance (`feat(agent): …`). |
+
+### 6.2 Next step (explicit)
+
+1. Create local git branch **`feat/edge-native-optimization`**.  
+2. Push to the **remote fork**.  
+3. Open the **official upstream pull request** against **`NousResearch/hermes-agent`**, attaching this chronicle and test evidence in the PR body.
+
+No upstream merge should be attempted until CI parity (`scripts/run_tests.sh`) has been run in an environment matching Hermes’ documented harness — the scoped pytest narrative above documents **developer inner loop** evidence, not a substitute for full-suite green.
+
+---
+
+## Appendix A — Operator quick reference
+
+**YAML (`~/.hermes/config.yaml`):**
+
+```yaml
+agent:
+  edge_mode: true
+  local_context_budget: 4000
+```
+
+**CLI:**
+
+```bash
+hermes --edge-mode --local-context-budget 4000 chat
+```
+
+**TUI subprocess environment (set by parent when launching Ink bridge):**
+
+- `HERMES_TUI_EDGE_MODE=1`
+- `HERMES_TUI_LOCAL_CONTEXT_BUDGET=<integer>`
+
+---
+
+## Appendix B — Indexing note
+
+`EDGE_MODE_BLUEPRINT.md` is listed in `.cursorignore` to prevent accidental inclusion of this long-form diary in default IDE embedding passes. Update `.cursorignore` temporarily if embedded search over this file is required in-editor.
+
+---
+
+
+## Appendix C — Canonical file manifest (edge-native changeset)
+
+The following paths constitute the **core integration surface** (twelve Python modules plus collateral):
+
+1. `run_agent.py` — `AIAgent` constructor parameters and `init_agent` forwarding.  
+2. `agent/agent_init.py` — YAML/CLI resolution; `ContextCompressor` wiring.  
+3. `agent/tool_executor.py` — `_edge_mode_truncate_string_tool_result` and call-site ordering.  
+4. `agent/context_compressor.py` — `_set_threshold_from_context`, `update_model`, `__init__` edge fields.  
+5. `tools/delegate_tool.py` — subagent kwargs inheritance.  
+6. `hermes_cli/config.py` — `DEFAULT_CONFIG["agent"]` keys.  
+7. `cli.py` — `HermesCLI` + `AIAgent` construction + `main()` passthrough.  
+8. `hermes_cli/_parser.py` — global and `chat` argparse flags.  
+9. `hermes_cli/main.py` — TUI env injection; chat kwargs.  
+10. `hermes_cli/oneshot.py` — oneshot agent overrides.  
+11. `tui_gateway/server.py` — `_cfg_*` helpers and `_make_agent`.  
+12. `gateway/run.py` — `_CACHE_BUSTING_CONFIG_KEYS` + main/background `AIAgent` kwargs.  
+13. `cron/scheduler.py` — scheduled runs inherit `agent.*` edge keys.
+
+**Collateral (tests & docs):** `tests/agent/test_edge_mode.py`, `tests/agent/test_context_compressor.py`, `README.md`, and this `EDGE_MODE_BLUEPRINT.md`.
+
+The historical “twelve files” narrative in internal notes maps to the first twelve **runtime** modules above before cron was folded into the same PR slice; **`cron/scheduler.py`** is retained here as an explicit thirteenth runtime integrator so the manifest stays truthful to the shipped tree.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,38 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 
 ---
 
+## Edge-Native mode (local SLM optimization)
+
+Hermes includes an optional, non-breaking **edge-native mode** aimed at small local models (for example Qwen via Ollama) on consumer CPUs: it reduces pathological pre-fill cost and runaway context growth from very large tool outputs, without changing default cloud behaviour when the mode is off.
+
+### Behaviour
+
+- **Context budgeting:** When edge mode is on, compression uses a fixed token floor (default `4000`) instead of waiting for a large fraction of a cloud-sized context window, so summarisation runs earlier on small contexts.
+- **Head–tail tool truncation:** Long **string** tool results are shaped before they enter the live model transcript. When output exceeds the edge persistence threshold, the full payload is written to the sandbox persisted-output path; the model sees a JSON-safe preview or head/tail slice.
+
+### Configuration
+
+In `~/.hermes/config.yaml` (or the `agent:` section of your active profile):
+
+```yaml
+agent:
+  edge_mode: true
+  local_context_budget: 4000
+```
+
+### CLI overrides
+
+Flags apply to `hermes chat`, `hermes -z` (oneshot), and TUI launches that forward them into the subprocess:
+
+```bash
+hermes chat --edge-mode --local-context-budget 6000
+hermes -z "Analyze my local repo" --edge-mode
+```
+
+Gateway, cron, and delegated subagents read the same `agent.*` settings so behaviour stays consistent across entry points.
+
+---
+
 ## Migrating from OpenClaw
 
 If you're coming from OpenClaw, Hermes can automatically import your settings, memories, skills, and API keys.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,27 @@ hermes -z "Analyze my local repo" --edge-mode
 
 Gateway, cron, and delegated subagents read the same `agent.*` settings so behaviour stays consistent across entry points.
 
+### Layer 2: Working-memory scratchpad (follow-up)
+
+When edge mode is on, Hermes can maintain a dense markdown **working-memory scratchpad** per session (stored in SessionDB as `edge_working_memory`). The scratchpad is injected ephemerally into the current user turn at API-call time — it is not duplicated onto the persisted user message row.
+
+- **Scratchpad sync:** The model can echo an updated scratchpad block in assistant output; Hermes absorbs it into runtime state and persists it.
+- **Compaction deltas:** After context compression, a short summary bullet is appended to the scratchpad under validated facts.
+- **Earlier flush:** `edge_context_flush_ratio` (default `0.82`) scales the compression trigger threshold so summarisation can run sooner on tight windows.
+- **Fault damper:** Optional repeat-failure blocking for identical tool+signature failures (`edge_max_consecutive_tool_failures`, `0` = off).
+
+Additional `agent:` keys (layer 2):
+
+```yaml
+agent:
+  edge_context_flush_ratio: 0.82
+  edge_flush_assistant_rounds: 0      # mid-turn flush after N assistant rounds (0 = off)
+  edge_flush_token_soft_limit: 0       # mid-turn flush soft token cap (0 = off)
+  edge_max_consecutive_tool_failures: 0
+```
+
+Requires the edge-mode foundation in [#27470](https://github.com/NousResearch/hermes-agent/pull/27470).
+
 ---
 
 ## Migrating from OpenClaw

--- a/README.md
+++ b/README.md
@@ -215,12 +215,12 @@ Gateway, cron, and delegated subagents read the same `agent.*` settings so behav
 
 ### Layer 2: Working-memory scratchpad (follow-up)
 
-When edge mode is on, Hermes can maintain a dense markdown **working-memory scratchpad** per session (stored in SessionDB as `edge_working_memory`). The scratchpad is injected ephemerally into the current user turn at API-call time — it is not duplicated onto the persisted user message row.
+When edge mode is on, Hermes can maintain a dense markdown **working-memory scratchpad** per session (stored in SessionDB as `edge_working_memory`). At the start of each user turn the scratchpad is **frozen** for API injection into the current user message — mid-turn updates (absorb, fault lines, compaction deltas) persist to runtime/DB but do not rewrite the already-sent user prefix, so prompt caching stays stable across tool rounds.
 
-- **Scratchpad sync:** The model can echo an updated scratchpad block in assistant output; Hermes absorbs it into runtime state and persists it.
+- **Scratchpad sync:** The model can echo an updated scratchpad block in assistant output; Hermes absorbs it into runtime state and persists it (visible on the next user turn's injection).
 - **Compaction deltas:** After context compression, a short summary bullet is appended to the scratchpad under validated facts.
 - **Earlier flush:** `edge_context_flush_ratio` (default `0.82`) scales the compression trigger threshold so summarisation can run sooner on tight windows.
-- **Fault damper:** Optional repeat-failure blocking for identical tool+signature failures (`edge_max_consecutive_tool_failures`, `0` = off).
+- **Fault damper:** Opt-in repeat-failure blocking for identical tool+signature failures. `edge_max_consecutive_tool_failures` must be `> 0` to enable (default `0` = fully off: no recording, no blocking, no interrupt).
 
 Additional `agent:` keys (layer 2):
 

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -346,6 +346,8 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    edge_mode: bool | None = None,
+    local_context_budget: int | None = None,
 ):
     """
     Initialize the AI Agent.
@@ -1464,6 +1466,36 @@ def init_agent(
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
+    if edge_mode is not None:
+        agent.edge_mode = bool(edge_mode)
+    else:
+        agent.edge_mode = bool(_agent_section.get("edge_mode", False))
+    if local_context_budget is not None:
+        try:
+            agent.local_context_budget = int(local_context_budget)
+        except (TypeError, ValueError):
+            agent.local_context_budget = 4000
+    else:
+        try:
+            agent.local_context_budget = int(_agent_section.get("local_context_budget", 4000))
+        except (TypeError, ValueError):
+            agent.local_context_budget = 4000
+
+    from tools.budget_config import DEFAULT_BUDGET, BudgetConfig
+
+    if agent.edge_mode:
+        _edge_trigger = 4000
+        agent._tool_result_budget = BudgetConfig(
+            default_result_size=_edge_trigger,
+            preview_size=min(1500, _edge_trigger),
+            tool_overrides={
+                "terminal": _edge_trigger,
+                "execute_code": _edge_trigger,
+            },
+        )
+    else:
+        agent._tool_result_budget = DEFAULT_BUDGET
+
     # Intent-ack continuation config: "auto" (default — codex_responses only,
     # the historical gate), true (all api_modes), false (never), or a list of
     # model-name substrings.  Resolved against the active api_mode/model in the
@@ -1855,6 +1887,8 @@ def init_agent(
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
             max_tokens=agent.max_tokens,
+            edge_mode=getattr(agent, "edge_mode", False),
+            edge_context_budget_tokens=getattr(agent, "local_context_budget", 4000),
         )
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
     if callable(_bind_session_state):

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1482,6 +1482,7 @@ def init_agent(
             agent.local_context_budget = 4000
 
     agent._edge_scratchpad = ""
+    agent._edge_scratchpad_turn_injection = ""
     agent._edge_failed_signatures = set()
     try:
         _flush_ratio = float(_agent_section.get("edge_context_flush_ratio", 0.82))

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1481,6 +1481,33 @@ def init_agent(
         except (TypeError, ValueError):
             agent.local_context_budget = 4000
 
+    agent._edge_scratchpad = ""
+    agent._edge_failed_signatures = set()
+    try:
+        _flush_ratio = float(_agent_section.get("edge_context_flush_ratio", 0.82))
+    except (TypeError, ValueError):
+        _flush_ratio = 0.82
+    agent._edge_context_flush_ratio = max(0.5, min(0.99, _flush_ratio))
+    try:
+        agent._edge_flush_assistant_rounds = int(
+            _agent_section.get("edge_flush_assistant_rounds", 0)
+        )
+    except (TypeError, ValueError):
+        agent._edge_flush_assistant_rounds = 0
+    try:
+        agent._edge_flush_token_soft_limit = int(
+            _agent_section.get("edge_flush_token_soft_limit", 0)
+        )
+    except (TypeError, ValueError):
+        agent._edge_flush_token_soft_limit = 0
+    try:
+        agent._edge_max_consecutive_tool_failures = int(
+            _agent_section.get("edge_max_consecutive_tool_failures", 0)
+        )
+    except (TypeError, ValueError):
+        agent._edge_max_consecutive_tool_failures = 0
+    agent._edge_consecutive_tool_failures = 0
+
     from tools.budget_config import DEFAULT_BUDGET, BudgetConfig
 
     if agent.edge_mode:
@@ -1890,6 +1917,12 @@ def init_agent(
             edge_mode=getattr(agent, "edge_mode", False),
             edge_context_budget_tokens=getattr(agent, "local_context_budget", 4000),
         )
+    if getattr(agent, "edge_mode", False):
+        agent.context_compressor._compression_threshold_scale = (
+            getattr(agent, "_edge_context_flush_ratio", 0.82)
+        )
+    else:
+        agent.context_compressor._compression_threshold_scale = 1.0
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
     if callable(_bind_session_state):
         try:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1207,6 +1207,12 @@ def restore_primary_runtime(agent) -> bool:
             provider=rt["compressor_provider"],
             api_mode=rt.get("compressor_api_mode", ""),
         )
+        if getattr(agent, "edge_mode", False):
+            cc._compression_threshold_scale = getattr(
+                agent, "_edge_context_flush_ratio", 0.82
+            )
+        else:
+            cc._compression_threshold_scale = 1.0
 
         # ── Rebind and re-select the primary credential pool ──
         # A cross-provider fallback attaches the fallback provider's pool. The
@@ -2064,6 +2070,12 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             provider=agent.provider,
             api_mode=agent.api_mode,
         )
+        if getattr(agent, "edge_mode", False):
+            agent.context_compressor._compression_threshold_scale = getattr(
+                agent, "_edge_context_flush_ratio", 0.82
+            )
+        else:
+            agent.context_compressor._compression_threshold_scale = 1.0
 
     # ── Invalidate cached system prompt so it rebuilds next turn ──
     agent._cached_system_prompt = None

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -999,6 +999,7 @@ class ContextCompressor(ContextEngine):
         self.threshold_tokens = self._compute_threshold_tokens(
             context_length, self.threshold_percent, self.max_tokens,
         )
+        self._apply_edge_threshold_cap()
         # Recalculate token budgets for the new context length so the
         # compressor stays calibrated after a model switch (e.g. 200K → 32K).
         target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
@@ -1117,6 +1118,17 @@ class ContextCompressor(ContextEngine):
                               effective_window - 1))
         return floored
 
+    def _apply_edge_threshold_cap(self) -> None:
+        """Lower the compaction trigger when edge mode is active."""
+        if not getattr(self, "_edge_mode", False):
+            return
+        cap = max(256, int(getattr(self, "_edge_context_budget_tokens", 4000)))
+        self.threshold_tokens = min(
+            self.threshold_tokens,
+            cap,
+            max(1, int(self.context_length)),
+        )
+
     def __init__(
         self,
         model: str,
@@ -1133,6 +1145,8 @@ class ContextCompressor(ContextEngine):
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
         max_tokens: int | None = None,
+        edge_mode: bool = False,
+        edge_context_budget_tokens: int = 4000,
     ):
         self.model = model
         self.base_url = base_url
@@ -1156,6 +1170,8 @@ class ContextCompressor(ContextEngine):
         # When False (default = historical behavior), insert a
         # deterministic "summary unavailable" handoff and drop the middle window.
         self.abort_on_summary_failure = abort_on_summary_failure
+        self._edge_mode = bool(edge_mode)
+        self._edge_context_budget_tokens = int(edge_context_budget_tokens)
 
         self.context_length = get_model_context_length(
             model, base_url=base_url, api_key=api_key,
@@ -1183,6 +1199,7 @@ class ContextCompressor(ContextEngine):
         self.threshold_tokens = self._compute_threshold_tokens(
             self.context_length, threshold_percent, self.max_tokens,
         )
+        self._apply_edge_threshold_cap()
         self.compression_count = 0
 
         # Derive token budgets: ratio is relative to the threshold, not total context

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1172,6 +1172,7 @@ class ContextCompressor(ContextEngine):
         self.abort_on_summary_failure = abort_on_summary_failure
         self._edge_mode = bool(edge_mode)
         self._edge_context_budget_tokens = int(edge_context_budget_tokens)
+        self._compression_threshold_scale = 1.0
 
         self.context_length = get_model_context_length(
             model, base_url=base_url, api_key=api_key,
@@ -1389,7 +1390,15 @@ class ContextCompressor(ContextEngine):
         where each pass removes only 1-2 messages.
         """
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
-        if tokens < self.threshold_tokens:
+        eff_threshold = self.threshold_tokens
+        scale = getattr(self, "_compression_threshold_scale", 1.0)
+        try:
+            scale = float(scale)
+        except (TypeError, ValueError):
+            scale = 1.0
+        if eff_threshold > 0 and 0 < scale < 1.0:
+            eff_threshold = max(int(eff_threshold * scale), 1)
+        if tokens < eff_threshold:
             return False
         return not self._automatic_compression_blocked()
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -504,6 +504,18 @@ def compress_context(
             force=force,
         )
 
+    if getattr(agent, "edge_mode", False):
+        try:
+            from agent.edge_working_memory import EdgeCompressGuardError, validate_edge_compress_guard
+
+            validate_edge_compress_guard(agent, messages)
+        except EdgeCompressGuardError as exc:
+            logger.warning("edge compress guard — skipping compaction: %s", exc)
+            cached = getattr(agent, "_cached_system_prompt", None)
+            if cached:
+                return messages, cached
+            return messages, agent._build_system_prompt(system_message)
+
     # Every automatic entrypoint must honor compressor-owned cooldown and
     # breaker state. Gateway hygiene constructs a fresh AIAgent, so the
     # persisted fallback streak is loaded by bind_session_state() before this.
@@ -535,6 +547,15 @@ def compress_context(
         check_compression_model_feasibility(agent)
         agent._compression_feasibility_checked = True
 
+    _compress_focus = focus_topic
+    if getattr(agent, "edge_mode", False):
+        from agent.edge_working_memory import merge_focus_topic_with_scratchpad
+
+        _compress_focus = merge_focus_topic_with_scratchpad(
+            focus_topic,
+            getattr(agent, "_edge_scratchpad", "") or "",
+        )
+
     _pre_msg_count = len(messages)
     # In-place compaction (config: compression.in_place, see #38763). When True,
     # this compaction rewrites the message list + rebuilds the system prompt but
@@ -550,7 +571,7 @@ def compress_context(
         "context compression started: session=%s messages=%d tokens=~%s model=%s focus=%r",
         agent.session_id or "none", _pre_msg_count,
         f"{approx_tokens:,}" if approx_tokens else "unknown", agent.model,
-        focus_topic,
+        _compress_focus,
     )
     agent._emit_status(COMPACTION_STATUS)
 
@@ -718,7 +739,7 @@ def compress_context(
             pass
 
     try:
-        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
+        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=_compress_focus, force=force)
     except TypeError:
         # Plugin context engine with strict signature that doesn't accept
         # focus_topic / force — fall back to calling without them.
@@ -732,6 +753,25 @@ def compress_context(
         # session isn't permanently blocked from future compression.
         _release_lock()
         raise
+
+    if getattr(agent, "edge_mode", False):
+        from agent.edge_working_memory import (
+            append_compaction_delta_to_scratchpad,
+            extract_compression_summary_text,
+        )
+
+        _delta_summary = extract_compression_summary_text(compressed)
+        if _delta_summary:
+            agent._edge_scratchpad = append_compaction_delta_to_scratchpad(
+                getattr(agent, "_edge_scratchpad", "") or "",
+                _delta_summary,
+            )
+            try:
+                from agent.edge_working_memory import persist_edge_scratchpad_now
+
+                persist_edge_scratchpad_now(agent)
+            except Exception:
+                pass
 
     # Capture boundary quality before session-rotation callbacks run. Built-in
     # and plugin lifecycle hooks may reset per-session compressor fields while
@@ -961,6 +1001,11 @@ def compress_context(
                 # refresh the stored system prompt and reset the flush cursor so the
                 # next turn re-bases its append diff.
                 agent._session_db.update_system_prompt(agent.session_id, new_system_prompt)
+                try:
+                    _esp = getattr(agent, "_edge_scratchpad", "") or ""
+                    agent._session_db.update_edge_working_memory(agent.session_id, _esp)
+                except Exception:
+                    pass
                 agent._last_flushed_db_idx = 0
             except Exception as e:
                 # If the rotation rolled back to the parent (orphan-avoidance

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -32,6 +32,11 @@ from agent.conversation_compression import conversation_history_after_compressio
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
+from agent.edge_working_memory import (
+    absorb_assistant_scratchpad_update,
+    ensure_scratchpad_initialized,
+    format_edge_working_memory_injection,
+)
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block
@@ -602,6 +607,8 @@ def run_conversation(
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
+    ensure_scratchpad_initialized(agent, original_user_message)
+
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
     final_response = None
@@ -804,6 +811,12 @@ def run_conversation(
                     _fenced = build_memory_context_block(_ext_prefetch_cache)
                     if _fenced:
                         _injections.append(_fenced)
+                if getattr(agent, "edge_mode", False):
+                    _injections.append(
+                        format_edge_working_memory_injection(
+                            getattr(agent, "_edge_scratchpad", "") or ""
+                        )
+                    )
                 if _plugin_user_context:
                     _injections.append(_plugin_user_context)
                 if _injections:
@@ -4665,6 +4678,8 @@ def run_conversation(
                 # turn. If the follow-up turn after tools is empty, we use this.
                 turn_content = assistant_message.content or ""
                 if turn_content and agent._has_content_after_think_block(turn_content):
+                    if getattr(agent, "edge_mode", False):
+                        absorb_assistant_scratchpad_update(agent, turn_content)
                     agent._last_content_with_tools = turn_content
                     # Only mute subsequent output when EVERY tool call in
                     # this turn is post-response housekeeping (memory, todo,
@@ -4784,7 +4799,30 @@ def run_conversation(
                 _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
                 if _tc_names == {"execute_code"}:
                     agent.iteration_budget.refund()
-                
+
+                if getattr(agent, "edge_mode", False):
+                    _sid_before = agent.session_id
+                    try:
+                        from agent.edge_working_memory import maybe_edge_flush_mid_turn
+
+                        messages, active_system_prompt = maybe_edge_flush_mid_turn(
+                            agent,
+                            messages,
+                            system_message,
+                            current_turn_user_idx,
+                            effective_task_id,
+                            active_system_prompt,
+                        )
+                    except Exception:
+                        pass
+                    try:
+                        if agent.session_id != _sid_before:
+                            conversation_history = conversation_history_after_compression(
+                                agent, messages
+                            )
+                    except Exception:
+                        pass
+
                 # Use real token counts from the API response to decide
                 # compression.  prompt_tokens + completion_tokens is the
                 # actual context size the provider reported plus the
@@ -4841,7 +4879,9 @@ def run_conversation(
             else:
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""
-                
+                if getattr(agent, "edge_mode", False) and final_response:
+                    absorb_assistant_scratchpad_update(agent, final_response)
+
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery
                 # status messages.  _mute_post_response was set during a

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -34,6 +34,8 @@ from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
 from agent.edge_working_memory import (
     absorb_assistant_scratchpad_update,
+    begin_edge_turn_injection,
+    edge_scratchpad_for_injection,
     ensure_scratchpad_initialized,
     format_edge_working_memory_injection,
 )
@@ -608,6 +610,7 @@ def run_conversation(
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
     ensure_scratchpad_initialized(agent, original_user_message)
+    begin_edge_turn_injection(agent)
 
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
@@ -814,7 +817,7 @@ def run_conversation(
                 if getattr(agent, "edge_mode", False):
                     _injections.append(
                         format_edge_working_memory_injection(
-                            getattr(agent, "_edge_scratchpad", "") or ""
+                            edge_scratchpad_for_injection(agent)
                         )
                     )
                 if _plugin_user_context:

--- a/agent/edge_fault_damper.py
+++ b/agent/edge_fault_damper.py
@@ -1,0 +1,139 @@
+"""Edge-mode fault loop damper — blocks repeat tool calls that already failed.
+
+Uses a stable per-call signature (tool name + canonical JSON args) plus optional
+``[sig:…]`` markers embedded in the scratchpad **Faults & Blockers** section so
+compaction-resistant state survives across flushes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from typing import Any, Dict, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+_SIG_MARK = re.compile(r"\[sig:([^\]\s]+)\]")
+
+
+def edge_tool_signature(tool_name: str, function_args: Optional[Dict[str, Any]]) -> str:
+    """Stable signature for matching duplicate failing calls."""
+    name = (tool_name or "").strip().lower()
+    try:
+        body = json.dumps(function_args or {}, sort_keys=True, ensure_ascii=False, default=str)
+    except Exception:
+        body = str(function_args or {})
+    digest = hashlib.sha256(f"{name}\0{body}".encode("utf-8")).hexdigest()[:24]
+    return f"{name}|{digest}"
+
+
+def parse_sig_markers_from_text(text: str) -> Set[str]:
+    """Collect ``tool|digest`` tokens from ``[sig:…]`` markers in markdown."""
+    found: Set[str] = set()
+    for m in _SIG_MARK.finditer(text or ""):
+        token = (m.group(1) or "").strip()
+        if token and "|" in token:
+            found.add(token.lower())
+    return found
+
+
+def resync_edge_failed_signatures(agent) -> None:
+    """Repopulate ``_edge_failed_signatures`` from scratchpad markers."""
+    if not getattr(agent, "edge_mode", False):
+        return
+    scratch = getattr(agent, "_edge_scratchpad", "") or ""
+    merged: Set[str] = set()
+    for x in (getattr(agent, "_edge_failed_signatures", None) or set()):
+        if isinstance(x, str) and x.strip():
+            merged.add(x.strip().lower())
+    merged |= {s.lower() for s in parse_sig_markers_from_text(scratch)}
+    agent._edge_failed_signatures = merged
+
+
+def edge_precheck_tool_repeat(
+    agent,
+    tool_name: str,
+    function_args: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    """Return a synthetic error string if this call should be blocked."""
+    if not getattr(agent, "edge_mode", False):
+        return None
+    sig = edge_tool_signature(tool_name, function_args)
+    scratch = getattr(agent, "_edge_scratchpad", "") or ""
+    blocked = set(getattr(agent, "_edge_failed_signatures", None) or set())
+    blocked |= parse_sig_markers_from_text(scratch)
+    blocked_norm = {b.lower() for b in blocked if isinstance(b, str)}
+    if sig.lower() not in blocked_norm:
+        return None
+    return (
+        "[Hermes edge fault damper] This tool call matches a previously failed "
+        f"action (`{tool_name}` with the same arguments digest). It was blocked "
+        "to prevent a deterministic repeat loop after context compaction. Alter "
+        "the parameters, fix the environment (permissions, missing commands, "
+        "paths), or explicitly remove the matching "
+        f"``[sig:{sig}]`` line from Faults & Blockers in your scratchpad before retrying."
+    )
+
+
+def edge_record_tool_result_for_damper(
+    agent,
+    tool_name: str,
+    function_args: Optional[Dict[str, Any]],
+    result: str,
+) -> None:
+    """After a tool runs, record failures so identical calls can be blocked."""
+    if not getattr(agent, "edge_mode", False):
+        return
+    try:
+        from agent.display import _detect_tool_failure
+    except Exception:
+        return
+    try:
+        failed, _reason = _detect_tool_failure(tool_name, result or "")
+    except Exception:
+        return
+    if not failed:
+        agent._edge_consecutive_tool_failures = 0
+        return
+
+    try:
+        cur = int(getattr(agent, "_edge_consecutive_tool_failures", 0) or 0) + 1
+        agent._edge_consecutive_tool_failures = cur
+        cap = int(getattr(agent, "_edge_max_consecutive_tool_failures", 0) or 0)
+        if cap > 0 and cur >= cap:
+            agent._interrupt_requested = True
+            logger.warning(
+                "edge fault: consecutive tool failures %s >= cap %s — requesting interrupt",
+                cur,
+                cap,
+            )
+    except Exception:
+        pass
+
+    sig = edge_tool_signature(tool_name, function_args)
+    if not hasattr(agent, "_edge_failed_signatures"):
+        agent._edge_failed_signatures = set()
+    if sig.lower() in {x.lower() for x in agent._edge_failed_signatures}:
+        return
+    agent._edge_failed_signatures.add(sig.lower())
+
+    try:
+        from agent.edge_working_memory import append_auto_fault_blocker
+
+        preview = result if isinstance(result, str) else str(result)
+        agent._edge_scratchpad = append_auto_fault_blocker(
+            getattr(agent, "_edge_scratchpad", "") or "",
+            tool_name,
+            sig,
+            preview,
+        )
+        try:
+            from agent.edge_working_memory import persist_edge_scratchpad_now
+
+            persist_edge_scratchpad_now(agent)
+        except Exception:
+            pass
+    except Exception as exc:
+        logger.debug("edge fault scratchpad append failed: %s", exc)

--- a/agent/edge_fault_damper.py
+++ b/agent/edge_fault_damper.py
@@ -18,6 +18,20 @@ logger = logging.getLogger(__name__)
 _SIG_MARK = re.compile(r"\[sig:([^\]\s]+)\]")
 
 
+def edge_fault_damper_enabled(agent) -> bool:
+    """True when edge mode is on and the consecutive-failure cap is > 0.
+
+    ``edge_max_consecutive_tool_failures: 0`` (default) fully disables the
+    damper: no signature recording, no repeat blocking, and no interrupt.
+    """
+    if not getattr(agent, "edge_mode", False):
+        return False
+    try:
+        return int(getattr(agent, "_edge_max_consecutive_tool_failures", 0) or 0) > 0
+    except (TypeError, ValueError):
+        return False
+
+
 def edge_tool_signature(tool_name: str, function_args: Optional[Dict[str, Any]]) -> str:
     """Stable signature for matching duplicate failing calls."""
     name = (tool_name or "").strip().lower()
@@ -58,7 +72,7 @@ def edge_precheck_tool_repeat(
     function_args: Optional[Dict[str, Any]],
 ) -> Optional[str]:
     """Return a synthetic error string if this call should be blocked."""
-    if not getattr(agent, "edge_mode", False):
+    if not edge_fault_damper_enabled(agent):
         return None
     sig = edge_tool_signature(tool_name, function_args)
     scratch = getattr(agent, "_edge_scratchpad", "") or ""
@@ -84,7 +98,7 @@ def edge_record_tool_result_for_damper(
     result: str,
 ) -> None:
     """After a tool runs, record failures so identical calls can be blocked."""
-    if not getattr(agent, "edge_mode", False):
+    if not edge_fault_damper_enabled(agent):
         return
     try:
         from agent.display import _detect_tool_failure
@@ -102,7 +116,7 @@ def edge_record_tool_result_for_damper(
         cur = int(getattr(agent, "_edge_consecutive_tool_failures", 0) or 0) + 1
         agent._edge_consecutive_tool_failures = cur
         cap = int(getattr(agent, "_edge_max_consecutive_tool_failures", 0) or 0)
-        if cap > 0 and cur >= cap:
+        if cur >= cap:
             agent._interrupt_requested = True
             logger.warning(
                 "edge fault: consecutive tool failures %s >= cap %s — requesting interrupt",

--- a/agent/edge_scratchpad_delta.py
+++ b/agent/edge_scratchpad_delta.py
@@ -1,0 +1,133 @@
+"""Semantic delta accumulation for edge working-memory scratchpads.
+
+Merges new findings without wiping history, dedupes file-path bullets, and
+marks checklist items done — all keyword-oriented, minimal prose.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Optional, Set
+
+# File-ish tokens: `path`, bare posix paths
+_PATHISH = re.compile(
+    r"(?:`|\b)((?:[\w.-]+/)+[\w.-]+\.(?:py|js|ts|tsx|go|rs|java|kt|c|h|hpp|cpp|md|yml|yaml|json|toml)|(?:[\w.-]+/)+[\w.-]+)(?:`|$|\s|\))",
+    re.I,
+)
+
+
+def _norm_bullet(line: str) -> str:
+    return re.sub(r"\s+", " ", (line or "").strip().lower())
+
+
+def _extract_paths(text: str) -> Set[str]:
+    return {m.group(1) for m in _PATHISH.finditer(text or "")}
+
+
+def dedupe_bullets_by_path(lines: List[str]) -> List[str]:
+    """Keep first bullet per file-ish path token; drop obvious duplicates."""
+    seen_paths: Set[str] = set()
+    out: List[str] = []
+    for line in lines:
+        paths = _extract_paths(line)
+        if paths:
+            if all(p in seen_paths for p in paths):
+                continue
+            for p in paths:
+                seen_paths.add(p)
+        out.append(line)
+    return out
+
+
+def _section_slice(text: str, header: str, stop_prefixes: tuple[str, ...]) -> tuple[int, int]:
+    start = text.find(header)
+    if start == -1:
+        return -1, -1
+    rest = text[start + len(header) :]
+    end_rel = len(rest)
+    for sp in stop_prefixes:
+        j = rest.find(sp)
+        if j != -1 and j < end_rel:
+            end_rel = j
+    return start, start + len(header) + end_rel
+
+
+def accumulate_scratchpad_delta(
+    scratchpad: str,
+    *,
+    add_facts: Optional[Iterable[str]] = None,
+    add_faults: Optional[Iterable[str]] = None,
+    complete_task_substrings: Optional[Iterable[str]] = None,
+    dedupe_paths: bool = True,
+) -> str:
+    """Apply semantic deltas; preserves unrelated sections and history."""
+    base = scratchpad or ""
+    facts_needles = ("**Facts:**", "**Validated Facts:**")
+    faults_needles = ("**Faults:**", "**Faults & Blockers:**")
+    next_needle = "### NEXT"
+
+    # --- Facts ---
+    f_needle = next((n for n in facts_needles if n in base), None)
+    if f_needle and add_facts:
+        s, e = _section_slice(base, f_needle, ("**Faults", "### NEXT", "\n### "))
+        if s != -1:
+            chunk = base[s:e]
+            body = chunk[len(f_needle) :]
+            existing_lines = [ln for ln in body.splitlines() if ln.strip()]
+            norm_existing = {_norm_bullet(ln) for ln in existing_lines}
+            new_lines = list(existing_lines)
+            for fact in add_facts:
+                bullet = fact if str(fact).lstrip().startswith("-") else f"- {fact}"
+                bn = _norm_bullet(bullet)
+                if bn and bn not in norm_existing:
+                    new_lines.append(bullet.strip())
+                    norm_existing.add(bn)
+            if dedupe_paths:
+                new_lines = dedupe_bullets_by_path(new_lines)
+            rebuilt = f_needle + "\n" + "\n".join(new_lines) + "\n"
+            base = base[:s] + rebuilt + base[e:]
+
+    # --- Faults ---
+    fl_needle = next((n for n in faults_needles if n in base), None)
+    if fl_needle and add_faults:
+        s, e = _section_slice(base, fl_needle, ("### NEXT", "\n### "))
+        if s != -1:
+            chunk = base[s:e]
+            body = chunk[len(fl_needle) :]
+            existing_lines = [ln for ln in body.splitlines() if ln.strip()]
+            norm_existing = {_norm_bullet(ln) for ln in existing_lines}
+            new_lines = list(existing_lines)
+            for fault in add_faults:
+                bullet = fault if str(fault).lstrip().startswith("-") else f"- {fault}"
+                bn = _norm_bullet(bullet)
+                if bn and bn not in norm_existing:
+                    new_lines.append(bullet.strip())
+                    norm_existing.add(bn)
+            if dedupe_paths:
+                new_lines = dedupe_bullets_by_path(new_lines)
+            rebuilt = fl_needle + "\n" + "\n".join(new_lines) + "\n"
+            base = base[:s] + rebuilt + base[e:]
+
+    # --- NEXT checkbox completion ---
+    if complete_task_substrings and next_needle in base:
+        s, e = _section_slice(base, next_needle, ("\n### ",))
+        if s != -1:
+            segment = base[s:e]
+            for sub in complete_task_substrings:
+                sub_s = str(sub).strip()
+                if not sub_s:
+                    continue
+                lines = segment.splitlines()
+                out_ln: List[str] = []
+                for ln in lines:
+                    if (
+                        sub_s.lower() in ln.lower()
+                        and ln.strip().startswith("- [ ]")
+                    ):
+                        out_ln.append(ln.replace("- [ ]", "- [x]", 1))
+                    else:
+                        out_ln.append(ln)
+                segment = "\n".join(out_ln)
+            base = base[:s] + segment + base[e:]
+
+    return base.rstrip() + "\n" if base.strip() else base

--- a/agent/edge_working_memory.py
+++ b/agent/edge_working_memory.py
@@ -4,8 +4,12 @@ Gated by ``agent.edge_mode`` in config.  Keeps a dense markdown scratchpad
 in agent runtime state and integrates with context compression (focus topic +
 post-compaction deltas) without mutating the parent's cached system prompt
 (unchanged for the root agent). Subagents inherit working memory via copied
-runtime state and API-time user-message injection (preserves a stable system
-prefix for KV-cache).
+runtime state.
+
+API-time user-message injection uses a **turn-frozen snapshot** of the
+scratchpad (``begin_edge_turn_injection``) so mid-turn mutations (absorb,
+fault lines, compaction deltas) do not rewrite an already-sent user prefix
+and break prompt-cache stability across tool rounds.
 """
 
 from __future__ import annotations
@@ -171,6 +175,29 @@ def ensure_scratchpad_initialized(agent, primary_goal: str) -> None:
             return
     agent._edge_scratchpad = default_scratchpad(primary_goal)
     persist_edge_scratchpad_now(agent)
+
+
+def begin_edge_turn_injection(agent) -> None:
+    """Freeze the scratchpad text used for API user-message injection this turn.
+
+    Live ``_edge_scratchpad`` may still mutate mid-turn (assistant absorb, fault
+    damper lines, compaction deltas). The frozen copy keeps the injected user
+    prefix byte-stable across tool rounds so prompt caching stays valid.
+    """
+    if not getattr(agent, "edge_mode", False):
+        agent._edge_scratchpad_turn_injection = ""
+        return
+    agent._edge_scratchpad_turn_injection = getattr(agent, "_edge_scratchpad", "") or ""
+
+
+def edge_scratchpad_for_injection(agent) -> str:
+    """Return the turn-frozen scratchpad for API injection (cache-safe)."""
+    if not getattr(agent, "edge_mode", False):
+        return ""
+    frozen = getattr(agent, "_edge_scratchpad_turn_injection", None)
+    if isinstance(frozen, str):
+        return frozen
+    return getattr(agent, "_edge_scratchpad", "") or ""
 
 
 def _facts_needle_order(scratchpad: str) -> str:

--- a/agent/edge_working_memory.py
+++ b/agent/edge_working_memory.py
@@ -1,0 +1,345 @@
+"""Edge-mode working memory scratchpad and context-flush helpers.
+
+Gated by ``agent.edge_mode`` in config.  Keeps a dense markdown scratchpad
+in agent runtime state and integrates with context compression (focus topic +
+post-compaction deltas) without mutating the parent's cached system prompt
+(unchanged for the root agent). Subagents inherit working memory via copied
+runtime state and API-time user-message injection (preserves a stable system
+prefix for KV-cache).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, List, Optional
+
+from agent.context_compressor import LEGACY_SUMMARY_PREFIX, SUMMARY_PREFIX
+
+logger = logging.getLogger(__name__)
+
+# Dense header (legacy ### CRITICAL STATE still accepted for absorb / merges)
+SCRATCHPAD_HEADER = "### CRIT"
+SCRATCHPAD_MARKERS = ("### CRIT", "### CRITICAL STATE")
+
+
+class EdgeCompressGuardError(RuntimeError):
+    """Raised when edge-mode compaction would violate scratchpad/user anchors."""
+
+
+def persist_edge_scratchpad_now(agent) -> None:
+    """Write scratchpad to SessionDB immediately after any programmatic mutation."""
+    if not getattr(agent, "edge_mode", False):
+        return
+    db = getattr(agent, "_session_db", None)
+    sid = getattr(agent, "session_id", None) or ""
+    if not db or not sid:
+        return
+    try:
+        db.update_edge_working_memory(sid, getattr(agent, "_edge_scratchpad", "") or "")
+    except Exception as exc:
+        logger.debug("persist_edge_scratchpad_now failed: %s", exc)
+
+
+def extract_primary_goal_from_scratchpad(scratchpad: str) -> str:
+    for pat in (
+        r"^\s*-\s*\*\*Goal:\*\*\s*(.+)$",
+        r"^\s*-\s*\*\*Primary Goal:\*\*\s*(.+)$",
+    ):
+        m = re.search(pat, scratchpad or "", re.I | re.MULTILINE)
+        if m:
+            return (m.group(1) or "").strip()
+    return ""
+
+
+def _normalize_guard_text(s: str) -> str:
+    """Collapse whitespace for fuzzy goal / user anchoring (SLM paraphrase)."""
+    return re.sub(r"\s+", " ", (s or "").strip().lower())
+
+
+def validate_edge_compress_guard(agent, messages: List[Any]) -> None:
+    """Anti-lobotomy: ensure scratchpad goal still anchors to a user turn."""
+    if not getattr(agent, "edge_mode", False):
+        return
+    sp = getattr(agent, "_edge_scratchpad", "") or ""
+    goal = extract_primary_goal_from_scratchpad(sp)
+    if not goal:
+        raise EdgeCompressGuardError("scratchpad primary goal missing or empty")
+    first_user = ""
+    for m in messages or []:
+        if isinstance(m, dict) and m.get("role") == "user":
+            first_user = _content_text(m.get("content"))
+            break
+    if not first_user.strip():
+        raise EdgeCompressGuardError("no user message to anchor primary goal")
+    g = goal.strip()
+    fu = first_user.strip()
+    if g[:80] in fu or fu[:200] in g:
+        return
+    if len(g) >= 40 and any(g[i : i + 40] in fu for i in range(0, len(g) - 39, 15)):
+        return
+    g_n = _normalize_guard_text(g)
+    fu_n = _normalize_guard_text(fu)
+    if g_n[:80] in fu_n or fu_n[:200] in g_n:
+        return
+    if len(g_n) >= 40 and any(g_n[i : i + 40] in fu_n for i in range(0, len(g_n) - 39, 15)):
+        return
+    # Word-overlap fallback: tolerates light local-SLM rephrasing of the goal line.
+    g_words = {w for w in re.findall(r"[a-z0-9]{4,}", g_n)}
+    fu_words = set(re.findall(r"[a-z0-9]{4,}", fu_n))
+    if len(g_words) >= 2:
+        overlap = g_words & fu_words
+        if len(overlap) >= max(2, min(len(g_words), 1 + len(g_words) // 3)):
+            return
+    raise EdgeCompressGuardError("primary goal/scratchpad diverged from first user message")
+
+
+def maybe_edge_flush_mid_turn(
+    agent,
+    messages: list,
+    system_message: str,
+    current_turn_user_idx: Optional[int],
+    effective_task_id: str,
+    active_system_prompt: str,
+) -> tuple:
+    """Optional edge-only mid-turn compaction (assistant rounds / soft token cap)."""
+    ar_cap = int(getattr(agent, "_edge_flush_assistant_rounds", 0) or 0)
+    tok_cap = int(getattr(agent, "_edge_flush_token_soft_limit", 0) or 0)
+    if ar_cap <= 0 and tok_cap <= 0:
+        return messages, active_system_prompt
+    from agent.model_metadata import estimate_request_tokens_rough
+
+    approx = estimate_request_tokens_rough(
+        messages,
+        system_prompt=active_system_prompt or "",
+        tools=agent.tools or None,
+    )
+    tail = messages[(current_turn_user_idx or 0) + 1 :] if current_turn_user_idx is not None else messages
+    rounds = sum(1 for m in tail if isinstance(m, dict) and m.get("role") == "assistant")
+    fire = (ar_cap > 0 and rounds >= ar_cap) or (tok_cap > 0 and approx >= tok_cap)
+    if not fire:
+        return messages, active_system_prompt
+    try:
+        return agent._compress_context(
+            messages, system_message, approx_tokens=approx, task_id=effective_task_id,
+        )
+    except Exception as exc:
+        logger.debug("maybe_edge_flush_mid_turn: %s", exc)
+        return messages, active_system_prompt
+
+
+def default_scratchpad(primary_goal: str) -> str:
+    """Dense template — keyword-first, minimal filler."""
+    goal = (primary_goal or "").strip() or "?"
+    if len(goal) > 2000:
+        goal = goal[:1997] + "..."
+    return (
+        f"{SCRATCHPAD_HEADER}\n"
+        f"- **Goal:** {goal}\n"
+        f"- **Phase:** explore\n\n"
+        "### KNOW\n"
+        "- **Facts:** —\n"
+        "- **Faults:** —\n\n"
+        "### NEXT\n"
+        "- [ ] —\n"
+        "- [ ] —\n"
+    )
+
+
+def ensure_scratchpad_initialized(agent, primary_goal: str) -> None:
+    """Create scratchpad once per session when edge mode is on."""
+    if not getattr(agent, "edge_mode", False):
+        return
+    existing = (getattr(agent, "_edge_scratchpad", None) or "").strip()
+    if existing:
+        return
+    db = getattr(agent, "_session_db", None)
+    sid = getattr(agent, "session_id", None) or ""
+    if db and sid:
+        try:
+            _stored = db.get_edge_working_memory(sid)
+        except Exception:
+            _stored = None
+        if _stored and str(_stored).strip():
+            agent._edge_scratchpad = str(_stored)
+            try:
+                from agent.edge_fault_damper import resync_edge_failed_signatures
+
+                resync_edge_failed_signatures(agent)
+            except Exception:
+                pass
+            return
+    agent._edge_scratchpad = default_scratchpad(primary_goal)
+    persist_edge_scratchpad_now(agent)
+
+
+def _facts_needle_order(scratchpad: str) -> str:
+    for n in ("**Facts:**", "**Validated Facts:**"):
+        if n in (scratchpad or ""):
+            return n
+    return "**Facts:**"
+
+
+def _faults_needle_order(scratchpad: str) -> str:
+    for n in ("**Faults:**", "**Faults & Blockers:**"):
+        if n in (scratchpad or ""):
+            return n
+    return "**Faults:**"
+
+
+def append_auto_fault_blocker(
+    scratchpad: str,
+    tool_name: str,
+    sig: str,
+    err_preview: str,
+) -> str:
+    """Insert an auto fault line under **Faults:** (legacy **Faults & Blockers:**)."""
+    base = scratchpad or ""
+    preview = (err_preview or "").replace("\n", " ").strip()
+    if len(preview) > 240:
+        preview = preview[:237] + "..."
+    bullet = f"\n- [auto] `{tool_name}` [sig:{sig}] err:{preview or '?'}"
+    needle = _faults_needle_order(base)
+    pos = base.find(needle)
+    if pos != -1:
+        insert_at = pos + len(needle)
+        return base[:insert_at] + bullet + base[insert_at:]
+    if base.strip():
+        return base.rstrip() + "\n\n" + needle + bullet
+    return default_scratchpad("?") + "\n" + needle + bullet
+
+
+def format_edge_working_memory_injection(scratchpad: str) -> str:
+    """Ephemeral user-message prefix for API calls (not persisted on raw user row)."""
+    body = (scratchpad or "").strip()
+    if not body:
+        body = default_scratchpad("(user msg)")
+    return (
+        "<!-- edge_wm -->\n"
+        "### EDGE_WM\n"
+        f"Sync: echo full block from `{SCRATCHPAD_HEADER}` in assistant when edited.\n\n"
+        f"{body}\n"
+    )
+
+
+def merge_focus_topic_with_scratchpad(
+    focus_topic: Optional[str],
+    scratchpad: str,
+) -> Optional[str]:
+    """Blend manual /compress focus with scratchpad for guided compaction."""
+    sp = (scratchpad or "").strip()
+    if not sp:
+        return focus_topic
+    if focus_topic and str(focus_topic).strip():
+        return f"{focus_topic.strip()}\n\n---\nEDGE_WM:\n{sp}"
+    return f"Prioritize EDGE_WM facts:\n{sp}"
+
+
+def _content_text(content) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text") or "")
+        return "\n".join(parts)
+    return ""
+
+
+def extract_compression_summary_text(messages: list) -> str:
+    """Find the newest compaction summary body in compressed message lists."""
+    best = ""
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        text = _content_text(msg.get("content"))
+        if not text:
+            continue
+        if SUMMARY_PREFIX in text:
+            idx = text.find(SUMMARY_PREFIX) + len(SUMMARY_PREFIX)
+            candidate = text[idx:].strip()
+        elif text.strip().startswith(LEGACY_SUMMARY_PREFIX):
+            candidate = text.strip()[len(LEGACY_SUMMARY_PREFIX) :].strip()
+        else:
+            continue
+        # Drop the standard trailing instruction tail when present
+        end = candidate.find("--- END OF CONTEXT SUMMARY")
+        if end != -1:
+            candidate = candidate[:end].strip()
+        if len(candidate) > len(best):
+            best = candidate
+    return best
+
+
+def append_compaction_delta_to_scratchpad(scratchpad: str, summary: str) -> str:
+    """Append one dense compaction bullet under **Facts:** / legacy Validated Facts."""
+    base = scratchpad or ""
+    snippet = (summary or "").strip().replace("\n", " ")
+    if len(snippet) > 1200:
+        snippet = snippet[:1197] + "..."
+    if not snippet:
+        return base
+    bullet = f"\n- [cmpct] {snippet}"
+    needle = _facts_needle_order(base)
+    pos = base.find(needle)
+    if pos != -1:
+        insert_at = pos + len(needle)
+        return base[:insert_at] + bullet + base[insert_at:]
+    if base.strip():
+        return base.rstrip() + "\n\n" + needle + bullet
+    return default_scratchpad("?") + "\n" + needle + bullet
+
+
+def absorb_assistant_scratchpad_update(agent, assistant_text: str) -> None:
+    """If the model echoed a full scratchpad block, replace runtime state."""
+    if not getattr(agent, "edge_mode", False):
+        return
+    # Normalize newlines so CRLF / lone CR from local SLMs match stop-sequence logic.
+    text = (assistant_text or "").replace("\r\n", "\n").replace("\r", "\n")
+    best_i = -1
+    marker = ""
+    for mk in SCRATCHPAD_MARKERS:
+        p = text.find(mk)
+        if p != -1 and (best_i < 0 or p < best_i):
+            best_i, marker = p, mk
+    if best_i < 0:
+        return
+    extracted = text[best_i:].strip()
+    for stop in (
+        "\n\n---\n",
+        "\n---\n",
+        "\n## ",
+        "\n# ",
+    ):
+        j = extracted.find(stop, len(marker) + 5)
+        if j != -1:
+            extracted = extracted[:j].strip()
+            break
+    if len(extracted) < len(marker) + 10:
+        return
+    if len(extracted) > 16_000:
+        extracted = extracted[:16_000] + "\n\n…(truncated)"
+    agent._edge_scratchpad = extracted
+    try:
+        from agent.edge_fault_damper import resync_edge_failed_signatures
+
+        resync_edge_failed_signatures(agent)
+    except Exception:
+        pass
+    persist_edge_scratchpad_now(agent)
+
+
+def effective_compression_trigger_tokens(compressor) -> int:
+    """First compression trigger threshold (may be lowered in edge mode)."""
+    th = int(getattr(compressor, "threshold_tokens", 0) or 0)
+    scale = getattr(compressor, "_compression_threshold_scale", 1.0)
+    try:
+        scale = float(scale)
+    except (TypeError, ValueError):
+        scale = 1.0
+    if th <= 0:
+        return 1
+    if scale <= 0 or scale >= 1.0:
+        return max(th, 1)
+    return max(int(th * scale), 1)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -60,11 +60,73 @@ def _budget_for_agent(agent) -> BudgetConfig:
     request past the model's limit (#23767). Falls back to the default budget
     when the context length isn't resolvable.
     """
+    if getattr(agent, "edge_mode", False):
+        return getattr(agent, "_tool_result_budget", DEFAULT_BUDGET)
     try:
         ctx = getattr(getattr(agent, "context_compressor", None), "context_length", None)
         return budget_for_context_window(int(ctx)) if ctx else DEFAULT_BUDGET
     except Exception:
         return DEFAULT_BUDGET
+
+# Edge mode: cap oversized string tool results before they enter live messages.
+_EDGE_TRUNC_LEN_TRIGGER = 4000
+_EDGE_TRUNC_HEAD = 2000
+_EDGE_TRUNC_TAIL = 1500
+_EDGE_TRUNC_MARKER = (
+    "\n\n[... TRUNCATED BY EDGE-MODE TO PROTECT LOCAL CPU KV-CACHE ...]\n\n"
+)
+_JSON_TRUNC_TOOLS = frozenset({"terminal", "execute_code"})
+
+
+def _truncate_text_head_tail(text: str) -> str:
+    if len(text) <= _EDGE_TRUNC_LEN_TRIGGER:
+        return text
+    head = text[:_EDGE_TRUNC_HEAD]
+    tail = text[-_EDGE_TRUNC_TAIL:]
+    return head + _EDGE_TRUNC_MARKER + tail
+
+
+def _truncate_json_string_field(value: str) -> str:
+    if len(value) <= _EDGE_TRUNC_LEN_TRIGGER:
+        return value
+    head_len = int(_EDGE_TRUNC_LEN_TRIGGER * 0.4)
+    notice = (
+        f"\n\n... [{len(value) - _EDGE_TRUNC_LEN_TRIGGER:,} chars omitted by edge mode] ...\n\n"
+    )
+    tail_len = max(0, _EDGE_TRUNC_LEN_TRIGGER - head_len - len(notice))
+    return value[:head_len] + notice + value[-tail_len:]
+
+
+def _edge_mode_truncate_string_tool_result(
+    agent: Any,
+    function_result: Any,
+    tool_name: str = "",
+) -> Any:
+    """Shrink huge string tool payloads before they enter live ``messages``."""
+    if not getattr(agent, "edge_mode", False):
+        return function_result
+    if _is_multimodal_tool_result(function_result):
+        return function_result
+    if not isinstance(function_result, str):
+        return function_result
+    if len(function_result) <= _EDGE_TRUNC_LEN_TRIGGER:
+        return function_result
+
+    if tool_name in _JSON_TRUNC_TOOLS:
+        try:
+            data = json.loads(function_result)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return _truncate_text_head_tail(function_result)
+        if isinstance(data, dict):
+            for key in ("output", "stdout", "content", "result"):
+                field = data.get(key)
+                if isinstance(field, str) and len(field) > _EDGE_TRUNC_LEN_TRIGGER:
+                    data[key] = _truncate_json_string_field(field)
+                    data["truncated"] = True
+                    return json.dumps(data, ensure_ascii=False)
+        return _truncate_text_head_tail(function_result)
+
+    return _truncate_text_head_tail(function_result)
 
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
@@ -951,6 +1013,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
 
+        function_result = _edge_mode_truncate_string_tool_result(
+            agent, function_result, tool_name=name,
+        )
+
         subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
@@ -1641,6 +1707,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             env=get_active_env(effective_task_id),
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
+
+        function_result = _edge_mode_truncate_string_tool_result(
+            agent, function_result, tool_name=function_name,
+        )
 
         # Discover subdirectory context files from tool arguments
         subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1266,6 +1266,17 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         tool_start_time = time.time()
 
+        _edge_block_msg = None
+        if not _execution_blocked and getattr(agent, "edge_mode", False):
+            try:
+                from agent.edge_fault_damper import edge_precheck_tool_repeat
+
+                _edge_block_msg = edge_precheck_tool_repeat(
+                    agent, function_name, function_args,
+                )
+            except Exception:
+                _edge_block_msg = None
+
         if _block_msg is not None:
             # Tool blocked by plugin policy — return error without executing.
             function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
@@ -1297,6 +1308,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 status="blocked",
                 error_type="guardrail_block",
                 error_message=getattr(_guardrail_block_decision, "message", None) or "Tool blocked by guardrail policy",
+                middleware_trace=list(middleware_trace),
+            )
+        elif _edge_block_msg is not None:
+            function_result = json.dumps(
+                {"error": _edge_block_msg, "edge_fault_damper": True},
+                ensure_ascii=False,
+            )
+            tool_duration = 0.0
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=function_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                status="blocked",
+                error_type="edge_fault_damper",
+                error_message=_edge_block_msg,
                 middleware_trace=list(middleware_trace),
             )
         elif function_name == "todo":
@@ -1612,6 +1641,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             tool_duration = time.time() - tool_start_time
+
+        if (
+            not _execution_blocked
+            and _edge_block_msg is None
+            and getattr(agent, "edge_mode", False)
+        ):
+            try:
+                from agent.edge_fault_damper import edge_record_tool_result_for_damper
+
+                _raw_fr = function_result
+                edge_record_tool_result_for_damper(
+                    agent,
+                    function_name,
+                    function_args,
+                    _raw_fr if isinstance(_raw_fr, str) else str(_raw_fr),
+                )
+            except Exception:
+                pass
 
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -553,6 +553,33 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         middleware_trace=list(middleware_trace),
                     )
 
+        if block_result is None and getattr(agent, "edge_mode", False):
+            try:
+                from agent.edge_fault_damper import edge_precheck_tool_repeat
+
+                _edge_block_msg = edge_precheck_tool_repeat(
+                    agent, function_name, function_args,
+                )
+            except Exception:
+                _edge_block_msg = None
+            if _edge_block_msg is not None:
+                block_result = json.dumps(
+                    {"error": _edge_block_msg, "edge_fault_damper": True},
+                    ensure_ascii=False,
+                )
+                _emit_terminal_post_tool_call(
+                    agent,
+                    function_name=function_name,
+                    function_args=function_args,
+                    result=block_result,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    status="blocked",
+                    error_type="edge_fault_damper",
+                    error_message=_edge_block_msg,
+                    middleware_trace=list(middleware_trace),
+                )
+
         # ── Checkpoint preflight (only for tools that will execute) ──
         if block_result is None:
             # Checkpoint for file-mutating tools
@@ -967,6 +994,20 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     )
                 except Exception as _ver_err:
                     logging.debug("file-mutation verifier record failed: %s", _ver_err)
+
+            if not blocked and getattr(agent, "edge_mode", False):
+                try:
+                    from agent.edge_fault_damper import edge_record_tool_result_for_damper
+
+                    _raw_fr = function_result
+                    edge_record_tool_result_for_damper(
+                        agent,
+                        function_name,
+                        function_args,
+                        _raw_fr if isinstance(_raw_fr, str) else str(_raw_fr),
+                    )
+                except Exception:
+                    pass
 
             if not blocked and agent.tool_progress_callback:
                 try:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -684,6 +684,11 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 60
 
+  # Edge / local-SLM mode (opt-in). Lowers tool-result persistence thresholds
+  # and caps compression trigger tokens for small local context windows.
+  # edge_mode: false
+  # local_context_budget: 4000
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -688,6 +688,10 @@ agent:
   # and caps compression trigger tokens for small local context windows.
   # edge_mode: false
   # local_context_budget: 4000
+  # edge_context_flush_ratio: 0.82
+  # edge_flush_assistant_rounds: 0
+  # edge_flush_token_soft_limit: 0
+  # edge_max_consecutive_tool_failures: 0
 
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving

--- a/cli.py
+++ b/cli.py
@@ -423,6 +423,8 @@ def load_cli_config() -> Dict[str, Any]:
         },
         "agent": {
             "max_turns": 90,  # Default max tool-calling iterations (shared with subagents)
+            "edge_mode": False,
+            "local_context_budget": 4000,
             "verbose": False,
             "system_prompt": "",
             "prefill_messages_file": "",
@@ -3696,6 +3698,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         checkpoints: bool = False,
         pass_session_id: bool = False,
         ignore_rules: bool = False,
+        edge_mode: Optional[bool] = None,
+        local_context_budget: Optional[int] = None,
     ):
         """
         Initialize the Hermes CLI.
@@ -3875,6 +3879,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 self.max_turns = 90
         else:
             self.max_turns = 90
+
+        if edge_mode is not None:
+            self.edge_mode = bool(edge_mode)
+        else:
+            self.edge_mode = bool(CLI_CONFIG["agent"].get("edge_mode", False))
+        if local_context_budget is not None:
+            try:
+                self.local_context_budget = int(local_context_budget)
+            except (TypeError, ValueError):
+                self.local_context_budget = 4000
+        else:
+            try:
+                self.local_context_budget = int(
+                    CLI_CONFIG["agent"].get("local_context_budget", 4000)
+                )
+            except (TypeError, ValueError):
+                self.local_context_budget = 4000
         
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
@@ -15810,6 +15831,8 @@ def main(
     pass_session_id: bool = False,
     ignore_user_config: bool = False,
     ignore_rules: bool = False,
+    edge_mode: bool = None,
+    local_context_budget: int = None,
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
@@ -15945,6 +15968,8 @@ def main(
         checkpoints=checkpoints,
         pass_session_id=pass_session_id,
         ignore_rules=ignore_rules,
+        edge_mode=getattr(args, "edge_mode", None),
+        local_context_budget=getattr(args, "local_context_budget", None),
     )
 
     if parsed_skills:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3101,6 +3101,13 @@ def run_job(
                 job_id, _mcp_exc,
             )
 
+        _cron_agent = _cfg.get("agent") if isinstance(_cfg.get("agent"), dict) else {}
+        _cron_edge = bool(_cron_agent.get("edge_mode", False))
+        try:
+            _cron_local_budget = int(_cron_agent.get("local_context_budget", 4000))
+        except (TypeError, ValueError):
+            _cron_local_budget = 4000
+
         agent = AIAgent(
             model=model,
             api_key=runtime.get("api_key"),
@@ -3132,6 +3139,8 @@ def run_job(
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,
+            edge_mode=_cron_edge,
+            local_context_budget=_cron_local_budget,
         )
         
         # Run the agent with an *inactivity*-based timeout: the job can run

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13461,6 +13461,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+            _bg_edge_mode = bool(agent_cfg.get("edge_mode", False))
+            try:
+                _bg_local_budget = int(agent_cfg.get("local_context_budget", 4000))
+            except (TypeError, ValueError):
+                _bg_local_budget = 4000
 
             pr = self._provider_routing
             max_iterations = _current_max_iterations()
@@ -13516,6 +13521,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
+                    edge_mode=_bg_edge_mode,
+                    local_context_budget=_bg_local_budget,
                 )
                 try:
                     return agent.run_conversation(
@@ -15932,6 +15939,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
         ("agent", "disabled_toolsets"),
+        ("agent", "edge_mode"),
+        ("agent", "local_context_budget"),
         ("memory", "provider"),
     )
 
@@ -17227,6 +17236,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
+        _edge_mode = bool(agent_cfg_local.get("edge_mode", False))
+        try:
+            _local_context_budget = int(agent_cfg_local.get("local_context_budget", 4000))
+        except (TypeError, ValueError):
+            _local_context_budget = 4000
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):
@@ -18503,6 +18517,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
+                    edge_mode=_edge_mode,
+                    local_context_budget=_local_context_budget,
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -219,6 +219,21 @@ def build_top_level_parser():
     )
     _inherited_flag(
         parser,
+        "--edge-mode",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Enable edge-native mode for local SLM execution",
+    )
+    _inherited_flag(
+        parser,
+        "--local-context-budget",
+        type=int,
+        default=argparse.SUPPRESS,
+        metavar="N",
+        help="Token budget floor for compression when edge mode is active (default: 4000, or agent.local_context_budget in config)",
+    )
+    _inherited_flag(
+        parser,
         "--ignore-user-config",
         action="store_true",
         default=False,
@@ -397,6 +412,21 @@ def build_top_level_parser():
         action="store_true",
         default=argparse.SUPPRESS,
         help="Include the session ID in the agent's system prompt",
+    )
+    _inherited_flag(
+        chat_parser,
+        "--edge-mode",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Enable edge-native mode for local SLM execution",
+    )
+    _inherited_flag(
+        chat_parser,
+        "--local-context-budget",
+        type=int,
+        default=argparse.SUPPRESS,
+        metavar="N",
+        help="Token budget floor for compression when edge mode is active (default: 4000, or agent.local_context_budget in config)",
     )
     _inherited_flag(
         chat_parser,

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -391,6 +391,8 @@ class CLIAgentSetupMixin:
                 notice_callback=self._on_notice,
                 notice_clear_callback=self._on_notice_clear,
                 reaction_callback=self._on_reaction,
+                edge_mode=self.edge_mode,
+                local_context_budget=self.local_context_budget,
             )
             # Store reference for atexit memory provider shutdown.
             # NOTE: this MUST write to the ``cli`` module's global, not a

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1157,6 +1157,10 @@ DEFAULT_CONFIG = {
         # remains available as a tool regardless of this setting — the routing
         # only controls how inbound user images are presented.
         "image_input_mode": "auto",
+        # Edge / local-SLM mode: lower tool-result persistence thresholds and
+        # cap compression trigger tokens for small local context windows.
+        "edge_mode": False,
+        "local_context_budget": 4000,
         "disabled_toolsets": [],
     },
     

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1161,6 +1161,10 @@ DEFAULT_CONFIG = {
         # cap compression trigger tokens for small local context windows.
         "edge_mode": False,
         "local_context_budget": 4000,
+        "edge_context_flush_ratio": 0.82,
+        "edge_flush_assistant_rounds": 0,
+        "edge_flush_token_soft_limit": 0,
+        "edge_max_consecutive_tool_failures": 0,
         "disabled_toolsets": [],
     },
     

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2443,6 +2443,8 @@ def cmd_chat(args):
         "worktree": getattr(args, "worktree", False),
         "checkpoints": getattr(args, "checkpoints", False),
         "pass_session_id": getattr(args, "pass_session_id", False),
+        "edge_mode": True if getattr(args, "edge_mode", False) else None,
+        "local_context_budget": getattr(args, "local_context_budget", None),
         "max_turns": getattr(args, "max_turns", None),
         "ignore_rules": getattr(args, "ignore_rules", False) or getattr(args, "safe_mode", False),
         "ignore_user_config": getattr(args, "ignore_user_config", False) or getattr(args, "safe_mode", False),
@@ -12583,6 +12585,8 @@ def _try_termux_fast_cli_launch() -> bool:
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
                 usage_file=getattr(args, "usage_file", None),
+                edge_mode=True if getattr(args, "edge_mode", False) else None,
+                local_context_budget=getattr(args, "local_context_budget", None),
             )
         )
 
@@ -14740,6 +14744,8 @@ def main():
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
                 usage_file=getattr(args, "usage_file", None),
+                edge_mode=True if getattr(args, "edge_mode", False) else None,
+                local_context_budget=getattr(args, "local_context_budget", None),
             )
         )
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -172,6 +172,8 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    edge_mode: Optional[bool] = None,
+    local_context_budget: Optional[int] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -238,6 +240,8 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    edge_mode=edge_mode,
+                    local_context_budget=local_context_budget,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -306,6 +310,8 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    edge_mode: Optional[bool] = None,
+    local_context_budget: Optional[int] = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -318,6 +324,22 @@ def _run_agent(
     from run_agent import AIAgent
 
     cfg = load_config()
+    agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+    _edge = (
+        bool(edge_mode)
+        if edge_mode is not None
+        else bool(agent_cfg.get("edge_mode", False))
+    )
+    if local_context_budget is not None:
+        try:
+            _local_budget = int(local_context_budget)
+        except (TypeError, ValueError):
+            _local_budget = 4000
+    else:
+        try:
+            _local_budget = int(agent_cfg.get("local_context_budget", 4000))
+        except (TypeError, ValueError):
+            _local_budget = 4000
 
     # Resolve effective model: explicit arg → env var → config.
     model_cfg = cfg.get("model") or {}
@@ -414,6 +436,8 @@ def _run_agent(
         #   - dangerous-command approval → bypassed via HERMES_YOLO_MODE=1
         #   - skill secret capture → returns gracefully when no callback set
         clarify_callback=_oneshot_clarify_callback,
+        edge_mode=_edge,
+        local_context_budget=_local_budget,
     )
 
     # Belt-and-braces: make sure AIAgent doesn't invoke any streaming

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -752,6 +752,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     cost_source TEXT,
     pricing_version TEXT,
     title TEXT,
+    edge_working_memory TEXT,
     api_call_count INTEGER DEFAULT 0,
     handoff_state TEXT,
     handoff_platform TEXT,
@@ -2516,6 +2517,40 @@ class SessionDB:
                 "UPDATE sessions SET system_prompt = ? WHERE id = ?",
                 (system_prompt, session_id),
             )
+        self._execute_write(_do)
+
+    def get_edge_working_memory(self, session_id: str) -> Optional[str]:
+        """Return persisted edge-mode scratchpad markdown for ``session_id``."""
+        if not session_id:
+            return None
+        with self._lock:
+            try:
+                cur = self._conn.execute(
+                    "SELECT edge_working_memory FROM sessions WHERE id = ?",
+                    (session_id,),
+                )
+                row = cur.fetchone()
+            except sqlite3.OperationalError:
+                return None
+        if row is None:
+            return None
+        if hasattr(row, "keys"):
+            val = row["edge_working_memory"]
+        else:
+            val = row[0]
+        if val is None or str(val).strip() == "":
+            return None
+        return str(val)
+
+    def update_edge_working_memory(self, session_id: str, payload: str) -> None:
+        """Persist edge-mode working-memory scratchpad for gateway/CLI continuity."""
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET edge_working_memory = ? WHERE id = ?",
+                (payload or "", session_id),
+            )
+
         self._execute_write(_do)
 
     def update_session_model(self, session_id: str, model: str) -> None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -486,6 +486,8 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        edge_mode: bool | None = None,
+        local_context_budget: int | None = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
@@ -562,6 +564,8 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            edge_mode=edge_mode,
+            local_context_budget=local_context_budget,
         )
 
     def _get_session_db_for_recall(self):

--- a/run_agent.py
+++ b/run_agent.py
@@ -764,6 +764,8 @@ class AIAgent:
 
         if hasattr(self, "_edge_scratchpad"):
             self._edge_scratchpad = ""
+        if hasattr(self, "_edge_scratchpad_turn_injection"):
+            self._edge_scratchpad_turn_injection = ""
         if hasattr(self, "_edge_failed_signatures"):
             self._edge_failed_signatures = set()
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -762,6 +762,11 @@ class AIAgent:
             except Exception as exc:
                 logger.debug("context engine bind_session_state during reset: %s", exc)
 
+        if hasattr(self, "_edge_scratchpad"):
+            self._edge_scratchpad = ""
+        if hasattr(self, "_edge_failed_signatures"):
+            self._edge_failed_signatures = set()
+
     def _ensure_lmstudio_runtime_loaded(self, config_context_length: Optional[int] = None) -> None:
         """
         Preload the LM Studio model with at least Hermes' minimum context.
@@ -1697,6 +1702,12 @@ class AIAgent:
         self._session_messages = messages
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
+        if getattr(self, "edge_mode", False) and self._session_db and self.session_id:
+            try:
+                _sp = getattr(self, "_edge_scratchpad", "") or ""
+                self._session_db.update_edge_working_memory(self.session_id, _sp)
+            except Exception:
+                pass
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3438,3 +3438,37 @@ class TestDoubleCompactionSummaryRole:
             "summary of earlier turns" in (m.get("content") or "")
             for m in result
         )
+
+
+class TestEdgeModeCompressionThreshold:
+    def test_edge_mode_overrides_threshold_tokens(self):
+        c = ContextCompressor(
+            model="test-model",
+            threshold_percent=0.50,
+            config_context_length=32000,
+            edge_mode=True,
+            edge_context_budget_tokens=4000,
+        )
+        assert c.threshold_tokens == 4000
+
+    def test_edge_mode_false_uses_percent_floor(self):
+        c = ContextCompressor(
+            model="test-model",
+            threshold_percent=0.50,
+            config_context_length=32000,
+            edge_mode=False,
+        )
+        assert c.threshold_tokens >= 16000
+
+    def test_edge_mode_respects_anti_thrash(self):
+        c = ContextCompressor(
+            model="test-model",
+            threshold_percent=0.50,
+            config_context_length=32000,
+            edge_mode=True,
+            edge_context_budget_tokens=4000,
+        )
+        c._ineffective_compression_count = 2
+        c.last_prompt_tokens = 5000
+        assert c.should_compress() is False
+

--- a/tests/agent/test_edge_fault_damper.py
+++ b/tests/agent/test_edge_fault_damper.py
@@ -30,6 +30,7 @@ def test_precheck_blocks_repeat():
         edge_mode = True
         _edge_scratchpad = ""
         _edge_failed_signatures = set()
+        _edge_max_consecutive_tool_failures = 2
 
     a = A()
     sig = edge_tool_signature("terminal", {"command": "nope"})
@@ -37,6 +38,30 @@ def test_precheck_blocks_repeat():
     msg = edge_precheck_tool_repeat(a, "terminal", {"command": "nope"})
     assert msg is not None
     assert "fault damper" in msg.lower()
+
+
+def test_precheck_and_record_fully_off_when_cap_zero():
+    from agent.edge_fault_damper import edge_record_tool_result_for_damper
+
+    class A:
+        edge_mode = True
+        _edge_scratchpad = default_scratchpad("goal")
+        _edge_failed_signatures = set()
+        _edge_max_consecutive_tool_failures = 0
+        _edge_consecutive_tool_failures = 0
+
+    a = A()
+    sig = edge_tool_signature("terminal", {"command": "nope"})
+    a._edge_failed_signatures.add(sig.lower())
+    assert edge_precheck_tool_repeat(a, "terminal", {"command": "nope"}) is None
+
+    bad = '{"success": false, "error": "permission denied"}'
+    with patch("agent.display._detect_tool_failure", return_value=(True, "x")):
+        edge_record_tool_result_for_damper(a, "write_file", {"path": "/tmp/x"}, bad)
+    # Cap 0 must not record new signatures or mutate the scratchpad.
+    assert a._edge_failed_signatures == {sig.lower()}
+    assert "[sig:" not in a._edge_scratchpad
+    assert a._edge_consecutive_tool_failures == 0
 
 
 def test_append_auto_fault_under_blockers():
@@ -67,6 +92,7 @@ def test_record_marks_scratchpad_on_failure():
         edge_mode = True
         _edge_scratchpad = default_scratchpad("goal")
         _edge_failed_signatures = set()
+        _edge_max_consecutive_tool_failures = 3
 
     a = A()
     bad = '{"success": false, "error": "permission denied"}'
@@ -103,6 +129,7 @@ def test_success_resets_consecutive_counter():
         _edge_scratchpad = default_scratchpad("goal")
         _edge_failed_signatures = set()
         _edge_consecutive_tool_failures = 3
+        _edge_max_consecutive_tool_failures = 2
 
     a = A()
     with patch("agent.display._detect_tool_failure", return_value=(False, "")):

--- a/tests/agent/test_edge_fault_damper.py
+++ b/tests/agent/test_edge_fault_damper.py
@@ -1,0 +1,110 @@
+"""Tests for edge fault-loop damper and scratchpad fault lines."""
+
+from unittest.mock import patch
+
+from agent.edge_fault_damper import (
+    edge_precheck_tool_repeat,
+    edge_tool_signature,
+    parse_sig_markers_from_text,
+    resync_edge_failed_signatures,
+)
+from agent.edge_working_memory import append_auto_fault_blocker, default_scratchpad
+
+
+def test_edge_tool_signature_stable():
+    s1 = edge_tool_signature("terminal", {"command": "ls"})
+    s2 = edge_tool_signature("terminal", {"command": "ls"})
+    assert s1 == s2
+    assert "|" in s1
+
+
+def test_parse_sig_markers():
+    text = "x [sig:terminal|abcd] y [sig:read_file|efgh]"
+    got = parse_sig_markers_from_text(text)
+    assert "terminal|abcd" in got
+    assert "read_file|efgh" in got
+
+
+def test_precheck_blocks_repeat():
+    class A:
+        edge_mode = True
+        _edge_scratchpad = ""
+        _edge_failed_signatures = set()
+
+    a = A()
+    sig = edge_tool_signature("terminal", {"command": "nope"})
+    a._edge_failed_signatures.add(sig.lower())
+    msg = edge_precheck_tool_repeat(a, "terminal", {"command": "nope"})
+    assert msg is not None
+    assert "fault damper" in msg.lower()
+
+
+def test_append_auto_fault_under_blockers():
+    base = default_scratchpad("g")
+    out = append_auto_fault_blocker(
+        base, "terminal", "terminal|deadbeef", "Command not found: xyz",
+    )
+    assert "[sig:terminal|deadbeef]" in out
+    assert "Faults" in out
+
+
+def test_resync_merges_scratchpad_sigs():
+    class A:
+        edge_mode = True
+        _edge_scratchpad = "- [auto] x [sig:terminal|aaa]\n"
+        _edge_failed_signatures = {"read_file|bbb"}
+
+    a = A()
+    resync_edge_failed_signatures(a)
+    assert "terminal|aaa" in a._edge_failed_signatures
+    assert "read_file|bbb" in a._edge_failed_signatures
+
+
+def test_record_marks_scratchpad_on_failure():
+    from agent.edge_fault_damper import edge_record_tool_result_for_damper
+
+    class A:
+        edge_mode = True
+        _edge_scratchpad = default_scratchpad("goal")
+        _edge_failed_signatures = set()
+
+    a = A()
+    bad = '{"success": false, "error": "permission denied"}'
+    with patch("agent.display._detect_tool_failure", return_value=(True, "x")):
+        edge_record_tool_result_for_damper(a, "write_file", {"path": "/tmp/x"}, bad)
+    assert a._edge_failed_signatures
+    assert "[sig:" in a._edge_scratchpad
+
+
+def test_consecutive_failures_set_interrupt_when_capped():
+    from agent.edge_fault_damper import edge_record_tool_result_for_damper
+
+    class A:
+        edge_mode = True
+        _edge_scratchpad = default_scratchpad("goal")
+        _edge_failed_signatures = set()
+        _edge_max_consecutive_tool_failures = 2
+        _interrupt_requested = False
+
+    a = A()
+    bad = '{"success": false, "error": "e"}'
+    with patch("agent.display._detect_tool_failure", return_value=(True, "x")):
+        edge_record_tool_result_for_damper(a, "terminal", {"command": "x"}, bad)
+        assert not a._interrupt_requested
+        edge_record_tool_result_for_damper(a, "terminal", {"command": "y"}, bad)
+        assert a._interrupt_requested
+
+
+def test_success_resets_consecutive_counter():
+    from agent.edge_fault_damper import edge_record_tool_result_for_damper
+
+    class A:
+        edge_mode = True
+        _edge_scratchpad = default_scratchpad("goal")
+        _edge_failed_signatures = set()
+        _edge_consecutive_tool_failures = 3
+
+    a = A()
+    with patch("agent.display._detect_tool_failure", return_value=(False, "")):
+        edge_record_tool_result_for_damper(a, "terminal", {"command": "x"}, '{"ok": true}')
+    assert a._edge_consecutive_tool_failures == 0

--- a/tests/agent/test_edge_mode.py
+++ b/tests/agent/test_edge_mode.py
@@ -1,0 +1,52 @@
+"""Edge-mode runtime tool-output truncation (string path only)."""
+
+import json
+from types import SimpleNamespace
+
+from agent.tool_executor import _edge_mode_truncate_string_tool_result
+
+
+def test_edge_mode_truncates_long_string() -> None:
+    agent = SimpleNamespace(edge_mode=True)
+    s = "a" * 5000
+    out = _edge_mode_truncate_string_tool_result(agent, s)
+    assert len(out) < len(s)
+    assert "TRUNCATED BY EDGE-MODE TO PROTECT LOCAL CPU KV-CACHE" in out
+    assert out.startswith("a" * 2000)
+    assert out.endswith("a" * 1500)
+
+
+def test_edge_mode_off_passthrough() -> None:
+    agent = SimpleNamespace(edge_mode=False)
+    s = "a" * 5000
+    assert _edge_mode_truncate_string_tool_result(agent, s) is s
+
+
+def test_edge_mode_short_string_unchanged() -> None:
+    agent = SimpleNamespace(edge_mode=True)
+    s = "x" * 100
+    assert _edge_mode_truncate_string_tool_result(agent, s) is s
+
+
+def test_edge_mode_truncates_terminal_json() -> None:
+    agent = SimpleNamespace(edge_mode=True)
+    payload = {
+        "output": "o" * 5000,
+        "exit_code": 0,
+        "error": None,
+    }
+    raw = json.dumps(payload)
+    out = _edge_mode_truncate_string_tool_result(agent, raw, tool_name="terminal")
+    data = json.loads(out)
+    assert data["exit_code"] == 0
+    assert data["error"] is None
+    assert data["truncated"] is True
+    assert len(data["output"]) < len(payload["output"])
+
+
+def test_edge_mode_terminal_json_invalid_fallback() -> None:
+    agent = SimpleNamespace(edge_mode=True)
+    raw = '{"output": "' + ("x" * 5000) + '"'
+    out = _edge_mode_truncate_string_tool_result(agent, raw, tool_name="terminal")
+    assert len(out) < len(raw)
+    assert "TRUNCATED BY EDGE-MODE" in out

--- a/tests/agent/test_edge_working_memory.py
+++ b/tests/agent/test_edge_working_memory.py
@@ -1,0 +1,198 @@
+"""Tests for edge-mode working memory scratchpad helpers."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.context_compressor import SUMMARY_PREFIX
+from agent.edge_scratchpad_delta import accumulate_scratchpad_delta
+from agent.edge_working_memory import (
+    EdgeCompressGuardError,
+    absorb_assistant_scratchpad_update,
+    append_compaction_delta_to_scratchpad,
+    default_scratchpad,
+    effective_compression_trigger_tokens,
+    extract_compression_summary_text,
+    merge_focus_topic_with_scratchpad,
+    maybe_edge_flush_mid_turn,
+    validate_edge_compress_guard,
+)
+
+
+def test_default_scratchpad_layout():
+    sp = default_scratchpad("Ship the feature")
+    assert "### CRIT" in sp
+    assert "**Goal:** Ship the feature" in sp
+    assert "### KNOW" in sp
+    assert "**Facts:**" in sp
+    assert "### NEXT" in sp
+    assert "[ ]" in sp
+
+
+def test_merge_focus_with_scratchpad():
+    m = merge_focus_topic_with_scratchpad("auth bug", "### CRIT\n- **Goal:** x")
+    assert "auth bug" in m
+    assert "Goal" in m
+
+
+def test_merge_focus_scratchpad_only():
+    m = merge_focus_topic_with_scratchpad(None, "**Goal:** z")
+    assert m is not None
+    assert "Goal" in m
+
+
+def test_extract_compression_summary():
+    body = "alpha discussed beta"
+    msgs = [
+        {"role": "user", "content": f"{SUMMARY_PREFIX}\n{body}\n\n--- END OF CONTEXT SUMMARY — x"},
+    ]
+    assert extract_compression_summary_text(msgs).startswith("alpha discussed")
+
+
+def test_append_compaction_delta_inserts_under_facts():
+    base = default_scratchpad("goal")
+    assert "**Facts:**" in base
+    out = append_compaction_delta_to_scratchpad(base, "found the root cause")
+    assert "[cmpct]" in out
+    assert "root cause" in out
+
+
+def test_absorb_assistant_scratchpad_update():
+    class A:
+        edge_mode = True
+        _edge_scratchpad = ""
+
+    a = A()
+    absorb_assistant_scratchpad_update(
+        a,
+        "Hello\n\n### CRIT\n- **Goal:** G\n",
+    )
+    assert a._edge_scratchpad.startswith("### CRIT")
+    assert "**Goal:** G" in a._edge_scratchpad
+
+
+def test_absorb_trims_after_crlf_markdown_separator():
+    """CRLF from local SLMs must not bypass stop-sequence detection."""
+    class A:
+        edge_mode = True
+        _edge_scratchpad = ""
+
+    a = A()
+    absorb_assistant_scratchpad_update(
+        a,
+        "intro\r\n### CRIT\r\n- **Goal:** G\r\n\r\n---\r\nIgnore this narrative tail.",
+    )
+    assert "### CRIT" in a._edge_scratchpad
+    assert "Ignore this narrative tail" not in a._edge_scratchpad
+
+
+def test_effective_compression_trigger_tokens_scaled():
+    class C:
+        threshold_tokens = 10000
+        _compression_threshold_scale = 0.8
+
+    assert effective_compression_trigger_tokens(C()) == 8000
+
+
+def test_should_compress_honors_threshold_scale():
+    from agent.context_compressor import ContextCompressor
+
+    cc = ContextCompressor(
+        model="gpt-4",
+        threshold_percent=0.5,
+        protect_first_n=0,
+        protect_last_n=2,
+        summary_target_ratio=0.2,
+        base_url="",
+        api_key="",
+        config_context_length=100_000,
+        provider="openai",
+        api_mode="chat_completions",
+    )
+    cc.threshold_tokens = 10_000
+    cc._compression_threshold_scale = 0.8
+    cc._ineffective_compression_count = 0
+    cc.last_prompt_tokens = 7999
+    assert cc.should_compress() is False
+    cc.last_prompt_tokens = 8000
+    assert cc.should_compress() is True
+
+
+def test_validate_edge_compress_guard_ok():
+    class A:
+        edge_mode = True
+        _edge_scratchpad = default_scratchpad("Fix the bug in auth")
+
+    validate_edge_compress_guard(A(), [{"role": "user", "content": "Fix the bug in auth please"}])
+
+
+def test_validate_edge_compress_guard_raises_when_goal_missing():
+    class A:
+        edge_mode = True
+        _edge_scratchpad = "### CRIT\n- **Phase:** x\n"
+
+    with pytest.raises(EdgeCompressGuardError):
+        validate_edge_compress_guard(A(), [{"role": "user", "content": "hello"}])
+
+
+def test_validate_edge_compress_guard_raises_when_user_diverges():
+    class A:
+        edge_mode = True
+        _edge_scratchpad = default_scratchpad("totally different topic xyz")
+
+    with pytest.raises(EdgeCompressGuardError):
+        validate_edge_compress_guard(
+            A(), [{"role": "user", "content": "unrelated request about bananas"}]
+        )
+
+
+def test_validate_edge_compress_guard_accepts_paraphrase_via_word_overlap():
+    class A:
+        edge_mode = True
+        _edge_scratchpad = default_scratchpad(
+            "Ship the hardened authentication fix before production"
+        )
+
+    validate_edge_compress_guard(
+        A(),
+        [
+            {
+                "role": "user",
+                "content": "Please ship the hardened authentication fix to production soon.",
+            }
+        ],
+    )
+
+
+def test_maybe_edge_flush_invokes_compress_when_round_cap():
+    class A:
+        edge_mode = True
+        _edge_flush_assistant_rounds = 2
+        _edge_flush_token_soft_limit = 0
+        tools = None
+
+    a = A()
+    a._compress_context = MagicMock(
+        return_value=([{"role": "system", "content": "x"}], "sys2")
+    )
+    msgs = [
+        {"role": "user", "content": "u"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    out_m, out_s = maybe_edge_flush_mid_turn(
+        a, msgs, "base", 0, "tid", "active-sys",
+    )
+    assert out_s == "sys2"
+    a._compress_context.assert_called_once()
+
+
+def test_accumulate_scratchpad_delta_adds_facts_dedupes_path():
+    base = default_scratchpad("g")
+    out = accumulate_scratchpad_delta(
+        base,
+        add_facts=["- see `src/a.py` for hook", "- dup `src/a.py` second"],
+        dedupe_paths=True,
+    )
+    assert "src/a.py" in out
+    assert out.count("src/a.py") == 1

--- a/tests/agent/test_edge_working_memory.py
+++ b/tests/agent/test_edge_working_memory.py
@@ -9,10 +9,13 @@ from agent.edge_scratchpad_delta import accumulate_scratchpad_delta
 from agent.edge_working_memory import (
     EdgeCompressGuardError,
     absorb_assistant_scratchpad_update,
+    begin_edge_turn_injection,
     append_compaction_delta_to_scratchpad,
     default_scratchpad,
+    edge_scratchpad_for_injection,
     effective_compression_trigger_tokens,
     extract_compression_summary_text,
+    format_edge_working_memory_injection,
     merge_focus_topic_with_scratchpad,
     maybe_edge_flush_mid_turn,
     validate_edge_compress_guard,
@@ -69,6 +72,27 @@ def test_absorb_assistant_scratchpad_update():
     )
     assert a._edge_scratchpad.startswith("### CRIT")
     assert "**Goal:** G" in a._edge_scratchpad
+
+
+def test_turn_injection_freeze_ignores_mid_turn_mutations():
+    """API injection must stay byte-stable across mid-turn scratchpad updates."""
+
+    class A:
+        edge_mode = True
+        _edge_scratchpad = default_scratchpad("original goal")
+
+    a = A()
+    begin_edge_turn_injection(a)
+    first = format_edge_working_memory_injection(edge_scratchpad_for_injection(a))
+    absorb_assistant_scratchpad_update(
+        a,
+        "### CRIT\n- **Goal:** mutated mid-turn\n",
+    )
+    assert "**Goal:** mutated mid-turn" in a._edge_scratchpad
+    second = format_edge_working_memory_injection(edge_scratchpad_for_injection(a))
+    assert first == second
+    assert "original goal" in first
+    assert "mutated mid-turn" not in second
 
 
 def test_absorb_trims_after_crlf_markdown_separator():

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1355,6 +1355,8 @@ def _build_child_agent(
         openrouter_min_coding_score=child_openrouter_min_coding_score,
         tool_progress_callback=child_progress_cb,
         iteration_budget=None,  # fresh budget per subagent
+        edge_mode=getattr(parent_agent, "edge_mode", False),
+        local_context_budget=int(getattr(parent_agent, "local_context_budget", 4000)),
         **child_optional_kwargs,
     )
     child._print_fn = getattr(parent_agent, "_print_fn", None)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1374,6 +1374,18 @@ def _build_child_agent(
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
+    if getattr(parent_agent, "edge_mode", False):
+        child._edge_scratchpad = getattr(parent_agent, "_edge_scratchpad", "") or ""
+        child._edge_failed_signatures = {
+            str(x).lower()
+            for x in (getattr(parent_agent, "_edge_failed_signatures", None) or set())
+        }
+        try:
+            from agent.edge_fault_damper import resync_edge_failed_signatures
+
+            resync_edge_failed_signatures(child)
+        except Exception:
+            pass
     # Stable sidebar marker: delegate subagent sessions must stay out of
     # session pickers even when a parent delete orphans them (parent_session_id
     # → NULL). Mirrors /branch's ``_branched_from`` pattern — see

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4147,6 +4147,28 @@ def _cfg_max_turns(cfg: dict, default: int) -> int:
     return int(agent_cfg.get("max_turns") or cfg.get("max_turns") or default)
 
 
+def _cfg_edge_mode(cfg: dict) -> bool:
+    env_raw = os.environ.get("HERMES_TUI_EDGE_MODE", "").strip().lower()
+    if env_raw in ("1", "true", "yes", "on"):
+        return True
+    agent_cfg = cfg.get("agent") or {}
+    return bool(agent_cfg.get("edge_mode", False))
+
+
+def _cfg_local_context_budget(cfg: dict, default: int = 4000) -> int:
+    raw = os.environ.get("HERMES_TUI_LOCAL_CONTEXT_BUDGET", "").strip()
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+    agent_cfg = cfg.get("agent") or {}
+    try:
+        return int(agent_cfg.get("local_context_budget", default))
+    except (TypeError, ValueError):
+        return default
+
+
 def _parse_tui_skills_env() -> list[str]:
     raw = os.environ.get("HERMES_TUI_SKILLS", "")
     skills: list[str] = []
@@ -4217,6 +4239,8 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "platform": "tui",
         "session_db": _get_db(),
         "fallback_model": _agent_fallback_model(agent),
+        "edge_mode": getattr(agent, "edge_mode", False),
+        "local_context_budget": int(getattr(agent, "local_context_budget", 4000)),
     }
 
 
@@ -4666,6 +4690,8 @@ def _make_agent(
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         fallback_model=_load_fallback_model(),
+        edge_mode=_cfg_edge_mode(cfg),
+        local_context_budget=_cfg_local_context_budget(cfg),
         **_agent_cbs(sid),
     )
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4148,20 +4148,11 @@ def _cfg_max_turns(cfg: dict, default: int) -> int:
 
 
 def _cfg_edge_mode(cfg: dict) -> bool:
-    env_raw = os.environ.get("HERMES_TUI_EDGE_MODE", "").strip().lower()
-    if env_raw in ("1", "true", "yes", "on"):
-        return True
     agent_cfg = cfg.get("agent") or {}
     return bool(agent_cfg.get("edge_mode", False))
 
 
 def _cfg_local_context_budget(cfg: dict, default: int = 4000) -> int:
-    raw = os.environ.get("HERMES_TUI_LOCAL_CONTEXT_BUDGET", "").strip()
-    if raw:
-        try:
-            return int(raw)
-        except ValueError:
-            pass
     agent_cfg = cfg.get("agent") or {}
     try:
         return int(agent_cfg.get("local_context_budget", default))


### PR DESCRIPTION
## Summary

Follow-up layer for edge / local-SLM mode, stacked on the foundation in #27470.

- **Working-memory scratchpad** (`agent/edge_working_memory.py`): dense markdown state persisted in SessionDB (`edge_working_memory`), injected ephemerally into the current user turn at API-call time, absorbed from assistant output, and updated with compaction deltas.
- **Earlier flush knob**: `edge_context_flush_ratio` scales the compression trigger threshold (default `0.82`) without breaking anti-thrash logic.
- **Fault damper** (`agent/edge_fault_damper.py`): optional repeat-failure blocking for identical tool+signature failures (`edge_max_consecutive_tool_failures`, `0` = off).
- **Mid-turn flush hooks**: optional `edge_flush_assistant_rounds` / `edge_flush_token_soft_limit`.
- **Delegation**: subagents inherit parent scratchpad + failed-signature set.

## Stacking / merge plan

This branch currently includes **both** commits from #27470 and this layer (`feat/edge-native-optimization` + scratchpad). **Draft until #27470 merges.**

After #27470 lands on `main`:
1. Rebase `feat/edge-scratchpad-memory` onto `upstream/main`
2. Force-push and mark this PR ready for review (diff should shrink to layer-2 only)

## Depends on

- #27470 — edge-native foundation (JSON-aware truncation, compression cap, config wiring)

## Test plan

- [ ] `tests/agent/test_edge_working_memory.py`
- [ ] `tests/agent/test_edge_fault_damper.py`
- [ ] Regression: `tests/agent/test_edge_mode.py`, `TestEdgeModeCompressionThreshold`
- [ ] Manual: enable `agent.edge_mode`, verify scratchpad persists across `/resume`, compaction appends delta, fault damper blocks repeated failing terminal calls when configured


Made with [Cursor](https://cursor.com)