### PR TITLE
fix(kanban): finalize detached worker exits safely

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15930,9 +15930,24 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
                 pass
 
     def _block(reason: str) -> None:
-        c = _kb.connect()
+        capability = None
+        if os.environ.get("HERMES_KANBAN_TASK"):
+            capability = _kb.resolve_worker_capability(task_id)
+            if capability is None:
+                raise RuntimeError(
+                    "scoped-worker authorization error: stale or missing worker capability"
+                )
+        c = _kb.connect(board=capability.board if capability is not None else None)
         try:
-            _kb.block_task(c, task_id, reason=reason)
+            ok = _kb.block_task(
+                c,
+                task_id,
+                reason=reason,
+                expected_run_id=(capability.run_id if capability is not None else None),
+                expected_claim_lock=(capability.claim_lock if capability is not None else None),
+            )
+            if not ok:
+                raise RuntimeError(f"could not block kanban task {task_id}")
         finally:
             try:
                 c.close()

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1269,13 +1269,38 @@ def _cmd_init(args: argparse.Namespace) -> int:
 
 
 def _cmd_heartbeat(args: argparse.Namespace) -> int:
-    with kb.connect_closing() as conn:
-        ok = kb.heartbeat_worker(
-            conn,
-            args.task_id,
-            note=getattr(args, "note", None),
-            expected_run_id=_worker_run_id_for(args.task_id),
-        )
+    capability = _worker_capability_for(args.task_id)
+    if capability is None:
+        if os.environ.get("HERMES_KANBAN_TASK"):
+            # A dispatcher-scoped process must not downgrade to the generic
+            # operator path after its own capability validation fails.
+            ok = False
+        else:
+            # Truly unscoped CLI/operator use keeps the historical path.
+            with kb.connect_closing() as conn:
+                ok = kb.heartbeat_worker(
+                    conn, args.task_id, note=getattr(args, "note", None),
+                )
+    else:
+        run_id = capability.run_id
+        claim_lock = capability.claim_lock
+        worker_board = capability.board
+        with kb.connect_closing(board=worker_board) as conn:
+            ok = kb.heartbeat_claim(
+                conn,
+                args.task_id,
+                claimer=claim_lock,
+                expected_run_id=run_id,
+                expected_claim_lock=claim_lock,
+            )
+            if ok:
+                ok = kb.heartbeat_worker(
+                    conn,
+                    args.task_id,
+                    note=getattr(args, "note", None),
+                    expected_run_id=run_id,
+                    expected_claim_lock=claim_lock,
+                )
     if not ok:
         print(f"cannot heartbeat {args.task_id} (not running?)", file=sys.stderr)
         return 1
@@ -1851,16 +1876,30 @@ def _cmd_comment(args: argparse.Namespace) -> int:
     return 0
 
 
-def _worker_run_id_for(task_id: str) -> Optional[int]:
-    if os.environ.get("HERMES_KANBAN_TASK") != task_id:
-        return None
-    raw = os.environ.get("HERMES_KANBAN_RUN_ID")
-    if not raw:
-        return None
+def _worker_capability_for(task_id: str):
+    """Return the complete current worker capability or ``None``."""
     try:
-        return int(raw)
-    except ValueError:
+        return kb.resolve_worker_capability(task_id)
+    except Exception:
         return None
+
+
+def _worker_run_id_for(task_id: str) -> Optional[int]:
+    capability = _worker_capability_for(task_id)
+    return capability.run_id if capability is not None else None
+
+
+def _terminal_capabilities(ids: list[str]):
+    """Return scoped capabilities, refusing any invalid worker before writes."""
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return {}
+    capabilities = {}
+    for task_id in ids:
+        capability = _worker_capability_for(task_id)
+        if capability is None:
+            return None
+        capabilities[task_id] = capability
+    return capabilities
 
 
 def _cmd_complete(args: argparse.Namespace) -> int:
@@ -1891,15 +1930,22 @@ def _cmd_complete(args: argparse.Namespace) -> int:
         except (ValueError, json.JSONDecodeError) as exc:
             print(f"kanban: --metadata: {exc}", file=sys.stderr)
             return 2
+    capabilities = _terminal_capabilities(ids)
+    if capabilities is None:
+        print("scoped-worker authorization error: stale or missing worker capability", file=sys.stderr)
+        return 1
+    connection_board = next(iter(capabilities.values())).board if capabilities else None
     failed: list[str] = []
-    with kb.connect_closing() as conn:
+    with kb.connect_closing(board=connection_board) as conn:
         for tid in ids:
+            capability = capabilities.get(tid)
             if not kb.complete_task(
                 conn, tid,
                 result=args.result,
                 summary=summary,
                 metadata=metadata,
-                expected_run_id=_worker_run_id_for(tid),
+                expected_run_id=(capability.run_id if capability else None),
+                expected_claim_lock=(capability.claim_lock if capability else None),
             ):
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
@@ -1941,9 +1987,15 @@ def _cmd_block(args: argparse.Namespace) -> int:
     kind = getattr(args, "kind", None)
     author = _profile_author()
     ids = [args.task_id] + list(getattr(args, "ids", None) or [])
+    capabilities = _terminal_capabilities(ids)
+    if capabilities is None:
+        print("scoped-worker authorization error: stale or missing worker capability", file=sys.stderr)
+        return 1
+    connection_board = next(iter(capabilities.values())).board if capabilities else None
     failed: list[str] = []
-    with kb.connect_closing() as conn:
+    with kb.connect_closing(board=connection_board) as conn:
         for tid in ids:
+            capability = capabilities.get(tid)
             if reason:
                 kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
             if not kb.block_task(
@@ -1951,7 +2003,8 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 tid,
                 reason=reason,
                 kind=kind,
-                expected_run_id=_worker_run_id_for(tid),
+                expected_run_id=(capability.run_id if capability else None),
+                expected_claim_lock=(capability.claim_lock if capability else None),
             ):
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
@@ -1977,16 +2030,23 @@ def _cmd_schedule(args: argparse.Namespace) -> int:
     reason = " ".join(args.reason).strip() if args.reason else None
     author = _profile_author()
     ids = [args.task_id] + list(getattr(args, "ids", None) or [])
+    capabilities = _terminal_capabilities(ids)
+    if capabilities is None:
+        print("scoped-worker authorization error: stale or missing worker capability", file=sys.stderr)
+        return 1
+    connection_board = next(iter(capabilities.values())).board if capabilities else None
     failed: list[str] = []
-    with kb.connect_closing() as conn:
+    with kb.connect_closing(board=connection_board) as conn:
         for tid in ids:
+            capability = capabilities.get(tid)
             if reason:
                 kb.add_comment(conn, tid, author, f"SCHEDULED: {reason}")
             if not kb.schedule_task(
                 conn,
                 tid,
                 reason=reason,
-                expected_run_id=_worker_run_id_for(tid),
+                expected_run_id=(capability.run_id if capability else None),
+                expected_claim_lock=(capability.claim_lock if capability else None),
             ):
                 failed.append(tid)
                 print(f"cannot schedule {tid}", file=sys.stderr)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -191,6 +191,14 @@ DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS = 60 * 60
 # signal lands, and the following tick reclaims cleanly.
 RECLAIM_DEFER_GRACE_SECONDS = 120
 
+# Reclaim and max-runtime termination are deliberately bounded.  The tracked
+# PID is a detached supervisor/session leader, not the actual worker, so a
+# direct SIGKILL to it can orphan a TERM-ignoring child.  These are module
+# constants (rather than settings) because they protect a dispatcher-internal
+# race and are patched to very small values by real subprocess regressions.
+_WORKER_TREE_TERMINATE_GRACE_SECONDS = 5.0
+_WORKER_TREE_TERMINATE_POLL_SECONDS = 0.05
+
 
 def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
     """Return the effective claim TTL, honoring the kanban env override.
@@ -3632,7 +3640,8 @@ def release_stale_claims(
     reclaimed = 0
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     stale = conn.execute(
-        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at "
+        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at, "
+        "       current_run_id "
         "FROM tasks "
         "WHERE status = 'running' AND claim_expires IS NOT NULL "
         "  AND claim_expires < ?",
@@ -3701,6 +3710,7 @@ def release_stale_claims(
             _defer_reclaim_for_live_worker(
                 conn, row["id"], row["claim_lock"], now, termination,
                 reason="ttl_expired_worker_alive",
+                worker_pid=row["worker_pid"], run_id=row["current_run_id"],
             )
             continue
         with write_txn(conn):
@@ -3708,8 +3718,12 @@ def release_stale_claims(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
+                "AND worker_pid IS ? AND current_run_id IS ? "
                 "AND claim_expires IS NOT NULL AND claim_expires < ?",
-                (row["id"], row["claim_lock"], now),
+                (
+                    row["id"], row["claim_lock"], row["worker_pid"],
+                    row["current_run_id"], now,
+                ),
             )
             if cur.rowcount != 1:
                 continue
@@ -3763,7 +3777,7 @@ def reclaim_task(
     reclaimable state (not running, or doesn't exist).
     """
     row = conn.execute(
-        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+        "SELECT status, claim_lock, worker_pid, current_run_id FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if not row:
@@ -3775,13 +3789,27 @@ def reclaim_task(
     termination = _terminate_reclaimed_worker(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
     )
+    if _worker_survived_termination(termination):
+        # A manual reclaim has the same no-duplicate invariant as stale
+        # reclaim.  In particular, do not reset its failure budget or let a
+        # reassign dispatch another worker when the old tree cannot be proven
+        # gone (identity mismatch/PID reuse is intentionally a defer).
+        _defer_reclaim_for_live_worker(
+            conn, task_id, prev_lock, int(time.time()), termination,
+            reason="manual_reclaim_worker_alive",
+            worker_pid=row["worker_pid"], run_id=row["current_run_id"],
+        )
+        return False
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
             "claim_expires = NULL, worker_pid = NULL "
-            "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
-            "AND claim_lock IS ?",
-            (task_id, prev_lock),
+            "WHERE id = ? AND status = ? AND claim_lock IS ? "
+            "AND worker_pid IS ? AND current_run_id IS ?",
+            (
+                task_id, row["status"], prev_lock, row["worker_pid"],
+                row["current_run_id"],
+            ),
         )
         if cur.rowcount != 1:
             return False
@@ -3835,6 +3863,11 @@ def reassign_task(
     if reclaim_first:
         # Safe to call even if nothing to reclaim.
         reclaim_task(conn, task_id, reason=reason or "reassign")
+        row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        if row is not None and row["status"] == "running":
+            # reclaim_task deliberately held an unverifiable/surviving tree;
+            # assigning now would make a duplicate dispatch possible.
+            return False
     # assign_task handles its own txn + the still-running guard.
     try:
         return assign_task(conn, task_id, profile)
@@ -5980,7 +6013,28 @@ class DispatchResult:
 # belt-and-braces against unbounded growth on exotic platforms).
 _RECENT_WORKER_EXIT_TTL_SECONDS = 600
 _RECENT_WORKER_EXITS_MAX = 4096
+_WORKER_PID_HANDSHAKE_TIMEOUT_SECONDS = 10.0
+_WORKER_EXIT_FINALIZE_POLL_SECONDS = 0.02
 _recent_worker_exits: "dict[int, tuple[int, float]]" = {}
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerExitObservation:
+    task_id: str
+    run_id: int
+    claim_lock: str
+    pid: int
+    returncode: int
+
+
+def _classify_worker_returncode(returncode: int) -> tuple[str, int]:
+    if returncode == 0:
+        return "clean_exit", 0
+    if returncode == KANBAN_RATE_LIMIT_EXIT_CODE:
+        return "rate_limited", returncode
+    if returncode < 0:
+        return "signaled", abs(returncode)
+    return "nonzero_exit", returncode
 
 
 def _record_worker_exit(pid: int, raw_status: int) -> None:
@@ -6136,13 +6190,106 @@ def _pid_alive(pid: Optional[int]) -> bool:
     return True
 
 
+def _linux_process_group_has_live_member(pgid: int) -> Optional[bool]:
+    """Return group liveness from ``/proc`` while treating zombies as dead.
+
+    ``killpg(pgid, 0)`` reports a group containing only zombies as present.
+    That is correct for signalling, but wrong for the claim-release decision:
+    zombies execute no work.  ``None`` means the scan was unavailable and must
+    be treated conservatively by the caller.
+    """
+    try:
+        entries = list(os.scandir("/proc"))
+    except OSError:
+        return None
+    for entry in entries:
+        if not entry.name.isdecimal():
+            continue
+        try:
+            stat = (entry.path + "/stat")
+            with open(stat, "r", encoding="utf-8") as handle:
+                raw = handle.read()
+            # comm can contain spaces and parentheses; fields after its final
+            # ')' begin with state, ppid, then pgrp.
+            fields = raw[raw.rfind(")") + 2:].split()
+            if len(fields) >= 3 and int(fields[2]) == pgid and fields[0] != "Z":
+                return True
+        except (FileNotFoundError, PermissionError, OSError, ValueError):
+            continue
+    return False
+
+
+def _process_group_alive(pgid: int) -> bool:
+    """Return whether a POSIX group still has an executable member.
+
+    On Linux this supplements ``killpg(..., 0)`` with a zombie-aware /proc
+    scan.  On platforms where that proof is unavailable, an existing group is
+    conservatively considered live, so a reclaim cannot release a possibly
+    surviving worker tree.
+    """
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except (AttributeError, OSError):
+        return True
+    if sys.platform == "linux":
+        members = _linux_process_group_has_live_member(pgid)
+        return True if members is None else members
+    return True
+
+
+def _verified_supervisor_process_group(pid: int) -> tuple[Optional[int], str]:
+    """Prove that ``pid`` is the session/group leader we spawned.
+
+    The persisted value is intentionally the supervisor PID.  Never turn that
+    numeric identifier into ``killpg(pid, ...)`` unless it still names the
+    expected detached session leader.  This makes a stale/reused PID fail
+    closed instead of killing an unrelated process group.
+    """
+    if not _pid_alive(pid):
+        return None, "leader_gone"
+    try:
+        pgid = os.getpgid(pid)
+        sid = os.getsid(pid)
+    except (AttributeError, ProcessLookupError, OSError):
+        return None, "identity_unavailable"
+    if pgid != pid:
+        return None, "process_group_mismatch"
+    if sid != pid:
+        return None, "session_mismatch"
+    return pgid, "verified"
+
+
+def _wait_for_process_group_exit(pgid: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while True:
+        if not _process_group_alive(pgid):
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(_WORKER_TREE_TERMINATE_POLL_SECONDS, remaining))
+
+
 def _terminate_reclaimed_worker(
     pid: Optional[int],
     claim_lock: Optional[str],
     *,
     signal_fn=None,
 ) -> dict[str, Any]:
-    """Best-effort host-local worker termination for reclaim paths."""
+    """Terminate a verified host-local supervisor tree for reclaim paths.
+
+    POSIX workers are launched in a fresh session.  Signal that whole group,
+    then wait for *every* executable member before releasing a claim.  A PID
+    that is alive but no longer proves itself as our session/group leader is a
+    PID-reuse/identity ambiguity: defer rather than signal or re-dispatch.
+
+    ``signal_fn`` remains the legacy deterministic test hook.  It models a
+    direct PID and its liveness because old unit fixtures do not create real
+    sessions; production never supplies it and therefore cannot take that
+    direct-PID path.
+    """
     import signal
 
     info: dict[str, Any] = {
@@ -6151,6 +6298,7 @@ def _terminate_reclaimed_worker(
         "termination_attempted": False,
         "terminated": False,
         "sigkill": False,
+        "tree_target": "none",
     }
     if not pid or pid <= 0 or not claim_lock:
         return info
@@ -6160,41 +6308,98 @@ def _terminate_reclaimed_worker(
         return info
     info["host_local"] = True
 
-    kill = signal_fn if signal_fn is not None else (
-        os.kill if hasattr(os, "kill") else None
-    )
-    if kill is None:
-        return info
-
-    info["termination_attempted"] = True
-    try:
-        kill(int(pid), signal.SIGTERM)
-    except ProcessLookupError:
-        # Process is already gone — that's a successful termination, not a
-        # survival. Leaving terminated=False here would make the reclaim guard
-        # misread a dead worker as still-alive and defer forever.
-        info["terminated"] = True
-        return info
-    except OSError:
-        return info
-
-    for _ in range(10):
-        if not _pid_alive(pid):
+    if signal_fn is not None:
+        # Compatibility seam for deterministic fixtures.  It deliberately
+        # stays separate from production so test fakes with synthetic PIDs do
+        # not need a fake /proc process group.  No dispatch/reclaim production
+        # caller passes this hook: they use the verified tree code below.
+        info["tree_target"] = "test_hook_pid"
+        info["termination_attempted"] = True
+        try:
+            signal_fn(int(pid), signal.SIGTERM)
+        except ProcessLookupError:
             info["terminated"] = True
             return info
-        time.sleep(0.5)
-
-    if _pid_alive(pid):
-        try:
-            # signal.SIGKILL doesn't exist on Windows; fall back to SIGTERM
-            # (which maps to TerminateProcess via the stdlib shim).
-            _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-            kill(int(pid), _sigkill)
-            info["sigkill"] = True
-        except (ProcessLookupError, OSError):
+        except OSError:
             return info
+        deadline = time.monotonic() + _WORKER_TREE_TERMINATE_GRACE_SECONDS
+        while _pid_alive(pid) and time.monotonic() < deadline:
+            time.sleep(_WORKER_TREE_TERMINATE_POLL_SECONDS)
+        if _pid_alive(pid):
+            try:
+                signal_fn(int(pid), getattr(signal, "SIGKILL", signal.SIGTERM))
+                info["sigkill"] = True
+            except (ProcessLookupError, OSError):
+                pass
+        info["terminated"] = not _pid_alive(pid)
+        return info
 
-    info["terminated"] = not _pid_alive(pid)
+    if _IS_WINDOWS:
+        info["tree_target"] = "windows_taskkill"
+        info["termination_attempted"] = True
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(int(pid)), "/T", "/F"],
+                check=False,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.SubprocessError):
+            info["termination_error"] = "taskkill_failed"
+        deadline = time.monotonic() + _WORKER_TREE_TERMINATE_GRACE_SECONDS
+        while _pid_alive(pid) and time.monotonic() < deadline:
+            time.sleep(_WORKER_TREE_TERMINATE_POLL_SECONDS)
+        info["terminated"] = not _pid_alive(pid)
+        return info
+
+    pgid, identity = _verified_supervisor_process_group(int(pid))
+    info["identity"] = identity
+    if pgid is None:
+        if identity == "leader_gone":
+            # A dead supervisor does not prove a dead tree: its group can still
+            # contain a worker orphaned by an external kill.  Probing group
+            # liveness has no side effect; only an absent group is releasable.
+            # If the numeric group exists we cannot attribute it safely after
+            # losing the leader identity, so preserve the claim and surface a
+            # defer rather than risk either a duplicate or an unrelated kill.
+            info["tree_target"] = "unverified_process_group"
+            if _process_group_alive(int(pid)):
+                info["termination_deferred"] = True
+            else:
+                info["terminated"] = True
+        else:
+            info["termination_deferred"] = True
+        return info
+
+    info["tree_target"] = "posix_process_group"
+    info["process_group"] = pgid
+    info["termination_attempted"] = True
+
+    def send_group(sig: int) -> bool:
+        try:
+            if signal_fn is not None:
+                signal_fn(pgid, sig)
+            else:
+                os.killpg(pgid, sig)
+            return True
+        except ProcessLookupError:
+            return False
+        except OSError:
+            return False
+
+    if not send_group(signal.SIGTERM):
+        info["terminated"] = not _process_group_alive(pgid)
+        return info
+    if _wait_for_process_group_exit(pgid, _WORKER_TREE_TERMINATE_GRACE_SECONDS):
+        info["terminated"] = True
+        return info
+
+    if send_group(getattr(signal, "SIGKILL", signal.SIGTERM)):
+        info["sigkill"] = True
+    info["terminated"] = _wait_for_process_group_exit(
+        pgid, _WORKER_TREE_TERMINATE_GRACE_SECONDS,
+    )
     return info
 
 
@@ -6208,8 +6413,11 @@ def _worker_survived_termination(termination: dict) -> bool:
     to the normal release path, since we cannot manage that worker anyway.
     """
     return bool(
-        termination.get("termination_attempted")
-        and termination.get("host_local")
+        termination.get("host_local")
+        and (
+            termination.get("termination_attempted")
+            or termination.get("termination_deferred")
+        )
         and not termination.get("terminated")
     )
 
@@ -6222,6 +6430,8 @@ def _defer_reclaim_for_live_worker(
     termination: dict,
     *,
     reason: str,
+    worker_pid: Optional[int] = None,
+    run_id: Optional[int] = None,
 ) -> None:
     """Hold a claim whose worker survived termination instead of releasing it.
 
@@ -6235,8 +6445,9 @@ def _defer_reclaim_for_live_worker(
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET claim_expires = ? "
-            "WHERE id = ? AND status = 'running' AND claim_lock IS ?",
-            (grace, task_id, claim_lock),
+            "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
+            "AND worker_pid IS ? AND current_run_id IS ?",
+            (grace, task_id, claim_lock, worker_pid, run_id),
         )
         if cur.rowcount != 1:
             return
@@ -6321,9 +6532,9 @@ def enforce_max_runtime(
 
     Runs host-local: only tasks claimed by this host are candidates
     (same reasoning as ``detect_crashed_workers``). ``signal_fn`` is a
-    test hook; defaults to ``os.kill`` on POSIX.
+    legacy deterministic PID test hook; production targets the verified POSIX
+    session/group or Windows ``taskkill /T /F`` tree.
     """
-    import signal
     timed_out: list[str] = []
     now = int(time.time())
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
@@ -6331,7 +6542,7 @@ def enforce_max_runtime(
     rows = conn.execute(
         "SELECT t.id, t.worker_pid, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at, "
-        "       t.max_runtime_seconds, t.claim_lock "
+        "       t.max_runtime_seconds, t.claim_lock, t.current_run_id "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
         "WHERE t.status = 'running' AND t.max_runtime_seconds IS NOT NULL "
@@ -6351,31 +6562,14 @@ def enforce_max_runtime(
 
         pid = int(row["worker_pid"])
         tid = row["id"]
-        # SIGTERM then SIGKILL. Keep it simple: 5 s grace. Workers that
-        # want a cleaner shutdown can install their own SIGTERM handler
-        # before the grace expires.
-        killed = False
-        kill = signal_fn if signal_fn is not None else (
-            os.kill if hasattr(os, "kill") else None
-        )
-        if kill is not None:
-            try:
-                kill(pid, signal.SIGTERM)
-            except (ProcessLookupError, OSError):
-                pass
-            # Short polling wait — no time.sleep on the write txn.
-            for _ in range(10):
-                if not _pid_alive(pid):
-                    break
-                time.sleep(0.5)
-            if _pid_alive(pid):
-                try:
-                    # signal.SIGKILL doesn't exist on Windows.
-                    _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
-                    kill(pid, _sigkill)
-                    killed = True
-                except (ProcessLookupError, OSError):
-                    pass
+        termination = _terminate_reclaimed_worker(pid, lock, signal_fn=signal_fn)
+        if _worker_survived_termination(termination):
+            _defer_reclaim_for_live_worker(
+                conn, tid, row["claim_lock"], now, termination,
+                reason="max_runtime_worker_alive",
+                worker_pid=pid, run_id=row["current_run_id"],
+            )
+            continue
 
         with write_txn(conn):
             cur = conn.execute(
@@ -6383,15 +6577,16 @@ def enforce_max_runtime(
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
-                "  AND worker_pid = ? AND claim_lock IS ?",
-                (tid, pid, row["claim_lock"]),
+                "  AND worker_pid = ? AND claim_lock IS ? "
+                "  AND current_run_id IS ?",
+                (tid, pid, row["claim_lock"], row["current_run_id"]),
             )
             if cur.rowcount == 1:
                 payload = {
                     "pid": pid,
                     "elapsed_seconds": int(elapsed),
                     "limit_seconds": int(row["max_runtime_seconds"]),
-                    "sigkill": killed,
+                    "sigkill": bool(termination.get("sigkill")),
                 }
                 run_id = _end_run(
                     conn, tid,
@@ -6415,7 +6610,10 @@ def enforce_max_runtime(
                 outcome="timed_out",
                 release_claim=False,
                 end_run=False,
-                event_payload_extra={"pid": pid, "sigkill": killed},
+                event_payload_extra={
+                    "pid": pid,
+                    "sigkill": bool(termination.get("sigkill")),
+                },
             )
     return timed_out
 
@@ -6465,6 +6663,7 @@ def detect_stale_running(
 
     rows = conn.execute(
         "SELECT t.id, t.worker_pid, t.last_heartbeat_at, t.claim_lock, "
+        "       t.current_run_id, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
@@ -6500,6 +6699,7 @@ def detect_stale_running(
             _defer_reclaim_for_live_worker(
                 conn, tid, lock, now, termination,
                 reason="heartbeat_stale_worker_alive",
+                worker_pid=pid, run_id=row["current_run_id"],
             )
             continue
 
@@ -6509,8 +6709,9 @@ def detect_stale_running(
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
-                "  AND claim_lock IS ?",
-                (tid, row["claim_lock"]),
+                "  AND claim_lock IS ? AND worker_pid IS ? "
+                "  AND current_run_id IS ?",
+                (tid, row["claim_lock"], pid, row["current_run_id"]),
             )
             if cur.rowcount != 1:
                 continue
@@ -6638,7 +6839,11 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(
+    conn: sqlite3.Connection,
+    *,
+    expected_exit: Optional[WorkerExitObservation] = None,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Appends a ``crashed`` event and drops the task back to ``ready``.
@@ -6677,29 +6882,49 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     crash_details: list[tuple[str, int, str, bool, str]] = []
     # (task_id, pid, claimer, protocol_violation, error_text)
     with write_txn(conn):
-        rows = conn.execute(
-            "SELECT id, worker_pid, claim_lock, started_at FROM tasks "
-            "WHERE status = 'running' AND worker_pid IS NOT NULL"
-        ).fetchall()
+        if expected_exit is None:
+            rows = conn.execute(
+                "SELECT id, worker_pid, claim_lock, started_at, current_run_id "
+                "FROM tasks WHERE status = 'running' AND worker_pid IS NOT NULL"
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT id, worker_pid, claim_lock, started_at, current_run_id "
+                "FROM tasks WHERE id = ? AND status = 'running' "
+                "AND worker_pid IS NOT NULL",
+                (expected_exit.task_id,),
+            ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
         for row in rows:
             # Only check liveness for claims owned by this host.
             lock = row["claim_lock"] or ""
             if not lock.startswith(host_prefix):
                 continue
-            # Skip liveness check inside the launch-window grace period
-            # so a freshly-spawned worker isn't reclaimed before its PID
-            # is visible on /proc.
-            started_at = row["started_at"] if "started_at" in row.keys() else None
-            if started_at is not None:
-                grace = _resolve_crash_grace_seconds()
-                if time.time() - started_at < grace:
-                    continue
-            if _pid_alive(row["worker_pid"]):
-                continue
-
             pid = int(row["worker_pid"])
-            kind, code = _classify_worker_exit(pid)
+            if expected_exit is not None:
+                if (
+                    pid != expected_exit.pid
+                    or lock != expected_exit.claim_lock
+                    or row["current_run_id"] != expected_exit.run_id
+                ):
+                    continue
+                kind, code = _classify_worker_returncode(expected_exit.returncode)
+            else:
+                kind, code = _classify_worker_exit(pid)
+                if kind == "unknown":
+                    # Skip liveness check inside the launch-window grace period
+                    # so a freshly-spawned worker isn't reclaimed before its PID
+                    # is visible on /proc.
+                    started_at = (
+                        row["started_at"] if "started_at" in row.keys() else None
+                    )
+                    if started_at is not None:
+                        grace = _resolve_crash_grace_seconds()
+                        if time.time() - started_at < grace:
+                            continue
+                    if _pid_alive(pid):
+                        continue
+
             rate_limited_exit = False
             if kind == "clean_exit":
                 # Worker subprocess returned 0 but its task is still
@@ -6766,8 +6991,11 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running' "
-                "  AND worker_pid = ? AND claim_lock IS ?",
-                (row["id"], pid, row["claim_lock"]),
+                "  AND worker_pid = ? AND claim_lock IS ? "
+                "  AND current_run_id IS ?",
+                (
+                    row["id"], pid, row["claim_lock"], row["current_run_id"],
+                ),
             )
             if cur.rowcount == 1:
                 # Rate-limited requeues are a clean release, not a crash —
@@ -6906,6 +7134,83 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # failure and are NOT crashes, so they stay out of the ``crashed`` return.
     detect_crashed_workers._last_rate_limited = rate_limited  # type: ignore[attr-defined]
     return crashed
+
+
+def finalize_worker_exit(
+    observation: WorkerExitObservation,
+    *,
+    board: Optional[str] = None,
+) -> bool:
+    db_path = kanban_db_path(board=board)
+
+    while True:
+        with _dispatch_tick_lock(db_path) as held:
+            if held:
+                with connect_closing(board=board) as conn:
+                    row = conn.execute(
+                        "SELECT status, worker_pid, claim_lock, current_run_id "
+                        "FROM tasks WHERE id = ?",
+                        (observation.task_id,),
+                    ).fetchone()
+                    if row is None or row["status"] != "running":
+                        return False
+                    if (
+                        row["claim_lock"] != observation.claim_lock
+                        or row["current_run_id"] != observation.run_id
+                    ):
+                        return False
+                    if row["worker_pid"] is None:
+                        # dispatch_once holds this same lock across spawn +
+                        # _set_worker_pid. Once the supervisor owns it, a NULL
+                        # PID means the dispatcher died before registration;
+                        # bind the observed worker without emitting a second
+                        # spawned event, then use the normal crash path.
+                        with write_txn(conn):
+                            bound = conn.execute(
+                                "UPDATE tasks SET worker_pid = ? "
+                                "WHERE id = ? AND status = 'running' "
+                                "AND worker_pid IS NULL AND claim_lock = ? "
+                                "AND current_run_id = ?",
+                                (
+                                    observation.pid,
+                                    observation.task_id,
+                                    observation.claim_lock,
+                                    observation.run_id,
+                                ),
+                            )
+                            if bound.rowcount != 1:
+                                return False
+                            conn.execute(
+                                "UPDATE task_runs SET worker_pid = ? "
+                                "WHERE id = ? AND task_id = ? AND status = 'running' "
+                                "AND ended_at IS NULL AND worker_pid IS NULL "
+                                "AND claim_lock = ?",
+                                (
+                                    observation.pid,
+                                    observation.run_id,
+                                    observation.task_id,
+                                    observation.claim_lock,
+                                ),
+                            )
+                    elif int(row["worker_pid"]) != observation.pid:
+                        return False
+
+                    crashed = detect_crashed_workers(
+                        conn,
+                        expected_exit=observation,
+                    )
+                    rate_limited = getattr(
+                        detect_crashed_workers,
+                        "_last_rate_limited",
+                        [],
+                    )
+                    return (
+                        observation.task_id in crashed
+                        or observation.task_id in rate_limited
+                    )
+
+        if not held:
+            time.sleep(_WORKER_EXIT_FINALIZE_POLL_SECONDS)
 
 
 def _record_task_failure(
@@ -7090,25 +7395,52 @@ def _record_spawn_failure(
     )
 
 
-def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
-    """Record the spawned child's pid + emit a ``spawned`` event.
+def _set_worker_pid(
+    conn: sqlite3.Connection,
+    task_id: str,
+    pid: int,
+    *,
+    claim_lock: Optional[str] = None,
+    run_id: Optional[int] = None,
+) -> bool:
+    """CAS-record a supervisor PID and emit exactly one ``spawned`` event.
 
-    The event's payload carries the pid so a human reading ``hermes kanban
-    tail`` can correlate log lines with OS-level traces without opening
-    the drawer.
+    Production dispatch passes the claim/run values returned by ``claim_task``.
+    The optional lookup retains compatibility for direct local callers while
+    applying the same guarded state predicates inside this transaction.
     """
     with write_txn(conn):
-        conn.execute(
-            "UPDATE tasks SET worker_pid = ? WHERE id = ?",
-            (int(pid), task_id),
+        if claim_lock is None or run_id is None:
+            row = conn.execute(
+                "SELECT claim_lock, current_run_id FROM tasks "
+                "WHERE id = ? AND status = 'running' AND worker_pid IS NULL",
+                (task_id,),
+            ).fetchone()
+            if row is None or row["claim_lock"] is None or row["current_run_id"] is None:
+                return False
+            claim_lock = str(row["claim_lock"])
+            run_id = int(row["current_run_id"])
+
+        task_cur = conn.execute(
+            "UPDATE tasks SET worker_pid = ? "
+            "WHERE id = ? AND status = 'running' AND worker_pid IS NULL "
+            "AND claim_lock = ? AND current_run_id = ?",
+            (int(pid), task_id, claim_lock, int(run_id)),
         )
-        run_id = _current_run_id(conn, task_id)
-        if run_id is not None:
-            conn.execute(
-                "UPDATE task_runs SET worker_pid = ? WHERE id = ?",
-                (int(pid), run_id),
+        if task_cur.rowcount != 1:
+            return False
+        run_cur = conn.execute(
+            "UPDATE task_runs SET worker_pid = ? "
+            "WHERE id = ? AND task_id = ? AND status = 'running' "
+            "AND ended_at IS NULL AND worker_pid IS NULL AND claim_lock = ?",
+            (int(pid), int(run_id), task_id, claim_lock),
+        )
+        if run_cur.rowcount != 1:
+            raise RuntimeError(
+                f"task {task_id} active run {run_id} disappeared during PID publication"
             )
-        _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=run_id)
+        _append_event(conn, task_id, "spawned", {"pid": int(pid)}, run_id=int(run_id))
+        return True
 
 
 def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
@@ -7671,6 +8003,7 @@ def _dispatch_once_locked(
             set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
+        pid: Optional[int] = None
         try:
             # Back-compat: older spawn_fn signatures accept only
             # (task, workspace). Test stubs in the suite rely on that.
@@ -7684,8 +8017,15 @@ def _dispatch_once_locked(
                     pid = _spawn(claimed, str(workspace))
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+            if pid and not _set_worker_pid(
+                conn,
+                claimed.id,
+                int(pid),
+                claim_lock=claimed.claim_lock,
+                run_id=claimed.current_run_id,
+            ):
+                _terminate_supervisor_tree(int(pid))
+                continue
             # NOTE: we intentionally do NOT reset consecutive_failures
             # here. A successful spawn proves the worker can start but
             # doesn't prove the run will succeed. Under unified
@@ -7703,6 +8043,8 @@ def _dispatch_once_locked(
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
         except Exception as exc:
+            if pid:
+                _terminate_supervisor_tree(int(pid))
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
                 failure_limit=failure_limit,
@@ -7769,6 +8111,7 @@ def _dispatch_once_locked(
         # review agent needs.
         claimed.skills = ["sdlc-review"]
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
+        pid: Optional[int] = None
         try:
             import inspect
             try:
@@ -7779,11 +8122,20 @@ def _dispatch_once_locked(
                     pid = _spawn(claimed, str(workspace))
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
-            if pid:
-                _set_worker_pid(conn, claimed.id, int(pid))
+            if pid and not _set_worker_pid(
+                conn,
+                claimed.id,
+                int(pid),
+                claim_lock=claimed.claim_lock,
+                run_id=claimed.current_run_id,
+            ):
+                _terminate_supervisor_tree(int(pid))
+                continue
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
         except Exception as exc:
+            if pid:
+                _terminate_supervisor_tree(int(pid))
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
                 failure_limit=failure_limit,
@@ -8055,18 +8407,84 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         return None
 
 
+def _terminate_supervisor_tree(
+    pid: int,
+    *,
+    supervisor: Optional[subprocess.Popen[bytes]] = None,
+) -> None:
+    """Best-effort stop of a supervisor and every worker it owns.
+
+    The supervisor starts a POSIX session, so its process group is safe to
+    terminate as a tree. A direct supervisor signal is insufficient: ordinary
+    children survive when only their parent exits. Windows uses taskkill's
+    tree mode and retains a Popen terminate/kill fallback for constrained hosts.
+    Errors deliberately stay local; callers must preserve their original
+    handshake or CAS failure.
+    """
+    import signal
+
+    if _IS_WINDOWS:
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                check=False,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.SubprocessError):
+            pass
+        if supervisor is not None:
+            try:
+                supervisor.wait(timeout=5)
+                return
+            except subprocess.TimeoutExpired:
+                try:
+                    supervisor.kill()
+                except OSError:
+                    pass
+            except OSError:
+                return
+            try:
+                supervisor.wait()
+            except OSError:
+                pass
+        return
+
+    try:
+        os.killpg(pid, signal.SIGTERM)
+    except (AttributeError, ProcessLookupError, OSError):
+        pass
+    if supervisor is not None:
+        try:
+            supervisor.wait(timeout=5)
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+    # The supervisor may have exited before it could reap a TERM-ignoring
+    # child. Kill the group even after its wait succeeds to cover that tree.
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except (AttributeError, ProcessLookupError, OSError):
+        pass
+    if supervisor is not None:
+        try:
+            supervisor.wait()
+        except OSError:
+            pass
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
     *,
     board: Optional[str] = None,
 ) -> Optional[int]:
-    """Fire-and-forget ``hermes -p <profile> chat -q ...`` subprocess.
+    """Launch a supervised ``hermes -p <profile> chat -q ...`` subprocess.
 
-    Returns the spawned child's PID so the dispatcher can detect crashes
-    before the claim TTL expires. The child's completion is still observed
-    via the ``complete`` / ``block`` transitions the worker writes itself;
-    the PID check is a safety net for crashes, OOM kills, and Ctrl+C.
+    Returns the detached supervisor's PID so the dispatcher can detect crashes
+    before the claim TTL expires. A detached supervisor owns the worker handle
+    and routes its exit through the same crash finalizer used by later dispatch
+    ticks, so one-shot dispatch remains non-blocking without orphaning the run.
 
     ``board`` pins the child's kanban context to that board: the child's
     ``HERMES_KANBAN_DB`` / ``HERMES_KANBAN_BOARD`` / workspaces_root env
@@ -8076,6 +8494,8 @@ def _default_spawn(
     import subprocess
     if not task.assignee:
         raise ValueError(f"task {task.id} has no assignee")
+    if task.current_run_id is None or not task.claim_lock:
+        raise RuntimeError(f"task {task.id} has no active claimed run")
 
     from hermes_cli.profiles import normalize_profile_name
 
@@ -8217,31 +8637,82 @@ def _default_spawn(
     rotate_bytes, backup_count = worker_log_rotation_config()
     _rotate_worker_log(log_path, rotate_bytes, backup_count)
 
-    # Use 'a' so a re-run on unblock appends rather than overwrites.
+    token = secrets.token_hex(8)
+    spec_path = log_dir / f".{task.id}.{token}.spawn.json"
+    handshake_path = log_dir / f".{task.id}.{token}.worker.pid"
+    spec_fd = os.open(
+        spec_path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        0o600,
+    )
+    with os.fdopen(spec_fd, "w", encoding="utf-8") as spec_file:
+        json.dump(
+            {
+                "command": cmd,
+                "cwd": workspace if os.path.isdir(workspace) else None,
+                "log_path": str(log_path),
+                "handshake_path": str(handshake_path),
+                "task_id": task.id,
+                "run_id": task.current_run_id,
+                "claim_lock": task.claim_lock,
+                "board": resolved_board,
+            },
+            spec_file,
+        )
+
     log_f = open(log_path, "ab")
     try:
-        proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
-            cmd,
-            cwd=workspace if os.path.isdir(workspace) else None,
+        supervisor = subprocess.Popen(  # noqa: S603
+            [
+                sys.executable,
+                "-m",
+                "hermes_cli.kanban_worker_supervisor",
+                str(spec_path),
+            ],
             stdin=subprocess.DEVNULL,
             stdout=log_f,
             stderr=subprocess.STDOUT,
             env=env,
-            start_new_session=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            start_new_session=not _IS_WINDOWS,
+            creationflags=(
+                (subprocess.CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP)
+                if _IS_WINDOWS else 0
+            ),
         )
-    except FileNotFoundError:
+    except OSError as exc:
+        spec_path.unlink(missing_ok=True)
+        raise RuntimeError("worker supervisor could not start") from exc
+    finally:
         log_f.close()
-        raise RuntimeError(
-            "`hermes` executable not found on PATH. "
-            "Install Hermes Agent or activate its venv before running the kanban dispatcher."
-        )
-    # NOTE: we intentionally do NOT close log_f here — we want Popen's
-    # child process to keep writing after this function returns.  The
-    # handle is kept alive by the child's inheritance.  The parent's
-    # reference goes out of scope and is GC'd, but the OS-level FD stays
-    # open in the child until the child exits.
-    return proc.pid
+
+    deadline = time.monotonic() + _WORKER_PID_HANDSHAKE_TIMEOUT_SECONDS
+    try:
+        while time.monotonic() < deadline:
+            try:
+                supervisor_pid = int(handshake_path.read_text(encoding="utf-8"))
+            except (FileNotFoundError, ValueError):
+                if supervisor.poll() is not None:
+                    raise RuntimeError(
+                        f"worker supervisor exited with code {supervisor.returncode} "
+                        "before reporting the supervisor pid"
+                    )
+                time.sleep(_WORKER_EXIT_FINALIZE_POLL_SECONDS)
+                continue
+            if supervisor_pid == supervisor.pid and supervisor_pid > 0:
+                return supervisor_pid
+            raise RuntimeError("worker supervisor reported an unexpected pid")
+        raise RuntimeError("worker supervisor timed out before reporting the supervisor pid")
+    except BaseException:
+        # Cleanup is deliberately best-effort; never overwrite the causative
+        # timeout, early-exit, or malformed-publication error.
+        try:
+            _terminate_supervisor_tree(supervisor.pid, supervisor=supervisor)
+        except Exception:
+            pass
+        raise
+    finally:
+        spec_path.unlink(missing_ok=True)
+        handshake_path.unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -876,6 +876,10 @@ class Task:
     # (Pre-rename column: ``spawn_failures``.)
     consecutive_failures: int = 0
     worker_pid: Optional[int] = None
+    # Immutable incarnation marker for the detached supervisor recorded in
+    # ``worker_pid`` (Linux: /proc/<pid>/stat start ticks). A PID alone is
+    # not safe to turn into a process-tree signal after reuse.
+    worker_identity: Optional[str] = None
     # Short excerpt of the last failure's error text (any outcome, not
     # just spawn). Pre-rename column: ``last_spawn_error``.
     last_failure_error: Optional[str] = None
@@ -965,6 +969,9 @@ class Task:
                 else (row["spawn_failures"] if "spawn_failures" in keys else 0)
             ),
             worker_pid=row["worker_pid"] if "worker_pid" in keys else None,
+            worker_identity=(
+                row["worker_identity"] if "worker_identity" in keys else None
+            ),
             last_failure_error=(
                 row["last_failure_error"] if "last_failure_error" in keys
                 # Same belt-and-suspenders fallback as consecutive_failures above.
@@ -1029,6 +1036,7 @@ class Run:
     claim_lock: Optional[str]
     claim_expires: Optional[int]
     worker_pid: Optional[int]
+    worker_identity: Optional[str]
     max_runtime_seconds: Optional[int]
     last_heartbeat_at: Optional[int]
     started_at: int
@@ -1053,6 +1061,9 @@ class Run:
             claim_lock=row["claim_lock"],
             claim_expires=row["claim_expires"],
             worker_pid=row["worker_pid"],
+            worker_identity=(
+                row["worker_identity"] if "worker_identity" in row.keys() else None
+            ),
             max_runtime_seconds=row["max_runtime_seconds"],
             last_heartbeat_at=row["last_heartbeat_at"],
             started_at=int(row["started_at"]),
@@ -1131,6 +1142,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- exceeds DEFAULT_FAILURE_LIMIT consecutive non-successes.
     consecutive_failures INTEGER NOT NULL DEFAULT 0,
     worker_pid           INTEGER,
+    -- Immutable supervisor incarnation marker. On Linux this is the
+    -- /proc/<pid>/stat start-time ticks captured when worker_pid is registered.
+    worker_identity      TEXT,
     -- Short excerpt of the most recent failure's error text.
     last_failure_error   TEXT,
     max_runtime_seconds  INTEGER,
@@ -1227,6 +1241,7 @@ CREATE TABLE IF NOT EXISTS task_runs (
     claim_lock          TEXT,
     claim_expires       INTEGER,
     worker_pid          INTEGER,
+    worker_identity     TEXT,
     max_runtime_seconds INTEGER,
     last_heartbeat_at   INTEGER,
     started_at          INTEGER NOT NULL,
@@ -1912,6 +1927,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             )
     if "worker_pid" not in cols:
         _add_column_if_missing(conn, "tasks", "worker_pid", "worker_pid INTEGER")
+    if "worker_identity" not in cols:
+        # Existing boards cannot reconstruct an old process's incarnation.
+        # Leave legacy active rows NULL so every signal/reclaim path fails
+        # closed rather than treating a potentially reused PID as ours.
+        _add_column_if_missing(conn, "tasks", "worker_identity", "worker_identity TEXT")
     if "last_failure_error" not in cols:
         added = _add_column_if_missing(
             conn, "tasks", "last_failure_error", "last_failure_error TEXT"
@@ -1995,6 +2015,26 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    # Very old / deliberately partial fixtures predate task runs altogether.
+    # Keep the established migration contract: migrate the tables that exist,
+    # and let schema initialization create task_runs later when appropriate.
+    # Trying to ALTER a missing task_runs table would turn an otherwise safe
+    # legacy tasks migration into an initialization failure.
+    runs_exist = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
+    ).fetchone() is not None
+    if runs_exist:
+        run_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")
+        }
+        if "worker_identity" not in run_cols:
+            # As above, NULL is intentional for pre-incarnation records: it
+            # keeps historical rows readable while preventing any unsafe
+            # host-local process-tree reclaim until registration.
+            _add_column_if_missing(
+                conn, "task_runs", "worker_identity", "worker_identity TEXT"
+            )
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2049,7 +2089,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     if runs_exist:
         with write_txn(conn):
             inflight = conn.execute(
-                "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "
+                "SELECT id, assignee, claim_lock, claim_expires, worker_pid, worker_identity, "
                 "       max_runtime_seconds, last_heartbeat_at, started_at "
                 "FROM tasks "
                 "WHERE status = 'running' AND current_run_id IS NULL"
@@ -2060,14 +2100,14 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                     """
                     INSERT INTO task_runs (
                         task_id, profile, status,
-                        claim_lock, claim_expires, worker_pid,
+                        claim_lock, claim_expires, worker_pid, worker_identity,
                         max_runtime_seconds, last_heartbeat_at,
                         started_at
-                    ) VALUES (?, ?, 'running', ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, 'running', ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         row["id"], row["assignee"], row["claim_lock"],
-                        row["claim_expires"], row["worker_pid"],
+                        row["claim_expires"], row["worker_pid"], row["worker_identity"],
                         row["max_runtime_seconds"], row["last_heartbeat_at"],
                         started,
                     ),
@@ -2145,7 +2185,7 @@ _REBUILD_SPECS = {
         " id INTEGER PRIMARY KEY AUTOINCREMENT,"
         " task_id TEXT NOT NULL, profile TEXT, step_key TEXT,"
         " status TEXT NOT NULL, claim_lock TEXT, claim_expires INTEGER,"
-        " worker_pid INTEGER, max_runtime_seconds INTEGER,"
+        " worker_pid INTEGER, worker_identity TEXT, max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
         " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
         " error TEXT)",
@@ -3167,7 +3207,8 @@ def _end_run(
                ended_at      = ?,
                claim_lock    = NULL,
                claim_expires = NULL,
-               worker_pid    = NULL
+               worker_pid    = NULL,
+               worker_identity = NULL
          WHERE id = ?
            AND ended_at IS NULL
         """,
@@ -3434,7 +3475,8 @@ def claim_task(
                    SET status = 'reclaimed', outcome = 'reclaimed',
                        summary = COALESCE(summary, 'invariant recovery on re-claim'),
                        ended_at = ?,
-                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL,
+                       worker_identity = NULL
                  WHERE id = ? AND ended_at IS NULL
                 """,
                 (now, int(stale["current_run_id"])),
@@ -3445,7 +3487,8 @@ def claim_task(
                SET status        = 'running',
                    claim_lock    = ?,
                    claim_expires = ?,
-                   started_at    = COALESCE(started_at, ?)
+                   started_at    = COALESCE(started_at, ?),
+                   worker_identity = NULL
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
@@ -3529,7 +3572,8 @@ def claim_review_task(
                SET status        = 'running',
                    claim_lock    = ?,
                    claim_expires = ?,
-                   started_at    = COALESCE(started_at, ?)
+                   started_at    = COALESCE(started_at, ?),
+                   worker_identity = NULL
              WHERE id = ?
                AND status = 'review'
                AND claim_lock IS NULL
@@ -3581,29 +3625,87 @@ def heartbeat_claim(
     *,
     ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
 ) -> bool:
-    """Extend a running claim.  Returns True if we still own it.
+    """Atomically extend one running claim and its active run lease.
 
-    Workers that know they'll exceed 15 minutes should call this every
-    few minutes to keep ownership.
+    An unscoped/operator caller retains the historical ``claimer`` interface.
+    A dispatcher worker must provide both ``expected_run_id`` and its nonempty
+    dispatcher-issued ``expected_claim_lock``.  In that scoped form the task,
+    current-run pointer, and open ``task_runs`` row are bound in one write
+    transaction *before* either lease or heartbeat timestamp changes.
     """
     expires = int(time.time()) + _resolve_claim_ttl_seconds(ttl_seconds)
+    now = int(time.time())
+    scoped = expected_run_id is not None or expected_claim_lock is not None
+    if scoped:
+        if expected_run_id is None or not str(expected_claim_lock or "").strip():
+            return False
+        lock = str(expected_claim_lock).strip()
+        if claimer is not None and claimer != lock:
+            return False
+        run_id = int(expected_run_id)
+        with write_txn(conn):
+            binding = conn.execute(
+                """
+                SELECT 1
+                  FROM tasks t
+                  JOIN task_runs r ON r.id = t.current_run_id
+                 WHERE t.id = ?
+                   AND t.status = 'running'
+                   AND t.claim_lock = ?
+                   AND t.current_run_id = ?
+                   AND r.task_id = t.id
+                   AND r.status = 'running'
+                   AND r.ended_at IS NULL
+                   AND r.claim_lock = ?
+                """,
+                (task_id, lock, run_id, lock),
+            ).fetchone()
+            if binding is None:
+                return False
+            run_cur = conn.execute(
+                """
+                UPDATE task_runs
+                   SET claim_expires = ?, last_heartbeat_at = ?
+                 WHERE id = ? AND task_id = ?
+                   AND status = 'running' AND ended_at IS NULL
+                   AND claim_lock = ?
+                """,
+                (expires, now, run_id, task_id, lock),
+            )
+            task_cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET claim_expires = ?, last_heartbeat_at = ?
+                 WHERE id = ? AND status = 'running'
+                   AND claim_lock = ? AND current_run_id = ?
+                """,
+                (expires, now, task_id, lock, run_id),
+            )
+            if run_cur.rowcount != 1 or task_cur.rowcount != 1:
+                raise RuntimeError("active claim binding changed during heartbeat")
+            return True
+
     lock = claimer or _claimer_id()
     with write_txn(conn):
         cur = conn.execute(
-            "UPDATE tasks SET claim_expires = ? "
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
             "WHERE id = ? AND status = 'running' AND claim_lock = ?",
-            (expires, task_id, lock),
+            (expires, now, task_id, lock),
         )
-        if cur.rowcount == 1:
-            run_id = _current_run_id(conn, task_id)
-            if run_id is not None:
-                conn.execute(
-                    "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
-                    (expires, run_id),
-                )
-            return True
-        return False
+        if cur.rowcount != 1:
+            return False
+        run_id = _current_run_id(conn, task_id)
+        if run_id is not None:
+            conn.execute(
+                "UPDATE task_runs SET claim_expires = ?, last_heartbeat_at = ? "
+                "WHERE id = ? AND task_id = ? AND status = 'running' "
+                "AND ended_at IS NULL AND claim_lock = ?",
+                (expires, now, run_id, task_id, lock),
+            )
+        return True
 
 
 def release_stale_claims(
@@ -3640,11 +3742,14 @@ def release_stale_claims(
     reclaimed = 0
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
     stale = conn.execute(
-        "SELECT id, claim_lock, worker_pid, claim_expires, last_heartbeat_at, "
-        "       current_run_id "
-        "FROM tasks "
-        "WHERE status = 'running' AND claim_expires IS NOT NULL "
-        "  AND claim_expires < ?",
+        "SELECT t.id, t.claim_lock, t.worker_pid, t.worker_identity, "
+        "       t.claim_expires, t.last_heartbeat_at, t.current_run_id, "
+        "       r.worker_pid AS run_worker_pid, r.worker_identity AS run_worker_identity, "
+        "       r.claim_lock AS run_claim_lock, r.status AS run_status, "
+        "       r.ended_at AS run_ended_at "
+        "FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id "
+        "WHERE t.status = 'running' AND t.claim_expires IS NOT NULL "
+        "  AND t.claim_expires < ?",
         (now,),
     ).fetchall()
     for row in stale:
@@ -3659,50 +3764,39 @@ def release_stale_claims(
             hb is not None
             and (now - int(hb)) > DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS
         )
-        if (
-            host_local
-            and row["worker_pid"]
-            and _pid_alive(row["worker_pid"])
-            and not heartbeat_stale
-        ):
-            new_expires = now + _resolve_claim_ttl_seconds()
-            with write_txn(conn):
-                cur = conn.execute(
-                    "UPDATE tasks SET claim_expires = ? "
-                    "WHERE id = ? AND status = 'running' "
-                    "  AND claim_lock IS ? "
-                    "  AND claim_expires IS NOT NULL "
-                    "  AND claim_expires < ?",
-                    (new_expires, row["id"], row["claim_lock"], now),
-                )
-                if cur.rowcount != 1:
-                    continue
-                run_id = _current_run_id(conn, row["id"])
-                if run_id is not None:
-                    conn.execute(
-                        "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
-                        (new_expires, run_id),
-                    )
-                _append_event(
-                    conn, row["id"], "claim_extended",
-                    {
-                        "reason": "pid_alive",
-                        "worker_pid": int(row["worker_pid"]),
-                        "claim_lock": row["claim_lock"],
-                        "claim_expires_was": int(row["claim_expires"]),
-                        "claim_expires_now": new_expires,
-                        "last_heartbeat_at": (
-                            int(row["last_heartbeat_at"])
-                            if row["last_heartbeat_at"] is not None
-                            else None
-                        ),
-                    },
-                    run_id=run_id,
-                )
+        # A still-live numeric PID is not sufficient authority to renew a
+        # stale lease. It must still be this task's current open run with the
+        # same lock/PID/incarnation, and it must currently prove itself as the
+        # detached Linux supervisor session/group we launched. Otherwise a PID
+        # reuse or registration drift can keep an unrelated process's claim
+        # alive forever. Uncertainty retains ownership but does not refresh an
+        # invalid lease or signal a tree.
+        if row["worker_pid"] and _pid_alive(row["worker_pid"]) and not heartbeat_stale:
+            renewal, proof = _live_ttl_renewal_proof(row)
+            if renewal:
+                new_expires = now + _resolve_claim_ttl_seconds()
+                if _extend_live_ttl_claim(conn, row, now, new_expires):
+                    _append_claim_extended_event(conn, row, new_expires)
+                continue
+            _defer_reclaim_for_live_worker(
+                conn, row["id"], row["claim_lock"], now, proof,
+                reason="ttl_live_worker_unverified",
+                worker_pid=row["worker_pid"], worker_identity=row["worker_identity"],
+                run_id=row["current_run_id"], run_worker_pid=row["run_worker_pid"],
+                run_worker_identity=row["run_worker_identity"],
+                run_claim_lock=row["run_claim_lock"],
+                extend_lease=False,
+            )
             continue
 
         termination = _terminate_reclaimed_worker(
-            row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
+            row["worker_pid"],
+            row["claim_lock"],
+            worker_identity=row["worker_identity"],
+            run_worker_identity=row["run_worker_identity"],
+            run_worker_pid=row["run_worker_pid"],
+            run_claim_lock=row["run_claim_lock"],
+            signal_fn=signal_fn,
         )
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
@@ -3710,19 +3804,28 @@ def release_stale_claims(
             _defer_reclaim_for_live_worker(
                 conn, row["id"], row["claim_lock"], now, termination,
                 reason="ttl_expired_worker_alive",
-                worker_pid=row["worker_pid"], run_id=row["current_run_id"],
+                worker_pid=row["worker_pid"], worker_identity=row["worker_identity"],
+                run_id=row["current_run_id"], run_worker_pid=row["run_worker_pid"],
+                run_worker_identity=row["run_worker_identity"],
+                run_claim_lock=row["run_claim_lock"],
             )
             continue
         with write_txn(conn):
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL "
+                "claim_expires = NULL, worker_pid = NULL, worker_identity = NULL "
                 "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
-                "AND worker_pid IS ? AND current_run_id IS ? "
+                "AND worker_pid IS ? AND worker_identity IS ? AND current_run_id IS ? "
+                "AND EXISTS (SELECT 1 FROM task_runs r WHERE r.id = ? "
+                "AND r.task_id = tasks.id AND r.status = 'running' "
+                "AND r.ended_at IS NULL AND r.claim_lock IS ? "
+                "AND r.worker_pid IS ? AND r.worker_identity IS ?) "
                 "AND claim_expires IS NOT NULL AND claim_expires < ?",
                 (
                     row["id"], row["claim_lock"], row["worker_pid"],
-                    row["current_run_id"], now,
+                    row["worker_identity"], row["current_run_id"],
+                    row["current_run_id"], row["run_claim_lock"],
+                    row["run_worker_pid"], row["run_worker_identity"], now,
                 ),
             )
             if cur.rowcount != 1:
@@ -3777,7 +3880,10 @@ def reclaim_task(
     reclaimable state (not running, or doesn't exist).
     """
     row = conn.execute(
-        "SELECT status, claim_lock, worker_pid, current_run_id FROM tasks WHERE id = ?",
+        "SELECT t.status, t.claim_lock, t.worker_pid, t.worker_identity, t.current_run_id, "
+        "       r.worker_pid AS run_worker_pid, r.worker_identity AS run_worker_identity, "
+        "       r.claim_lock AS run_claim_lock "
+        "FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id WHERE t.id = ?",
         (task_id,),
     ).fetchone()
     if not row:
@@ -3787,8 +3893,20 @@ def reclaim_task(
         return False
     prev_lock = row["claim_lock"]
     termination = _terminate_reclaimed_worker(
-        row["worker_pid"], prev_lock, signal_fn=signal_fn,
+        row["worker_pid"],
+        prev_lock,
+        worker_identity=row["worker_identity"],
+        run_worker_identity=row["run_worker_identity"],
+        run_worker_pid=row["run_worker_pid"],
+        run_claim_lock=row["run_claim_lock"],
+        signal_fn=signal_fn,
     )
+    # A registered supervisor that already exited reports identity=leader_gone
+    # without terminated proof.  Operator transitions (complete/block/archive/
+    # delete) recover from that state with the signal-free zombie-aware group
+    # probe; manual reclaim shares the same proof so an operator is not stuck
+    # deferring until the next dispatcher crash sweep.
+    _operator_transition_tree_is_gone(termination, row["worker_pid"])
     if _worker_survived_termination(termination):
         # A manual reclaim has the same no-duplicate invariant as stale
         # reclaim.  In particular, do not reset its failure budget or let a
@@ -3797,13 +3915,16 @@ def reclaim_task(
         _defer_reclaim_for_live_worker(
             conn, task_id, prev_lock, int(time.time()), termination,
             reason="manual_reclaim_worker_alive",
-            worker_pid=row["worker_pid"], run_id=row["current_run_id"],
+            worker_pid=row["worker_pid"], worker_identity=row["worker_identity"],
+            run_id=row["current_run_id"], run_worker_pid=row["run_worker_pid"],
+            run_worker_identity=row["run_worker_identity"],
+            run_claim_lock=row["run_claim_lock"],
         )
         return False
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-            "claim_expires = NULL, worker_pid = NULL "
+            "claim_expires = NULL, worker_pid = NULL, worker_identity = NULL "
             "WHERE id = ? AND status = ? AND claim_lock IS ? "
             "AND worker_pid IS ? AND current_run_id IS ?",
             (
@@ -3991,6 +4112,65 @@ def _scan_prose_for_phantom_ids(
     return [m for m in unique if m not in existing]
 
 
+@dataclass(frozen=True, slots=True)
+class WorkerCapability:
+    """The complete authority tuple for a dispatcher-scoped worker."""
+
+    board: str
+    task_id: str
+    run_id: int
+    claim_lock: str
+
+
+def resolve_worker_capability(
+    task_id: str, *, board: Optional[str] = None,
+) -> Optional[WorkerCapability]:
+    """Resolve the current worker's complete, DB-bound terminal capability.
+
+    A scoped process is never allowed to silently become an operator.  The
+    environment must name the same normalized board/task plus a numeric current
+    run id and nonempty lock; the task and still-open run must confirm every
+    part of that tuple.  Any malformed/stale capability returns ``None``.
+    """
+    if os.environ.get("HERMES_KANBAN_TASK") != task_id:
+        return None
+    raw_board = os.environ.get("HERMES_KANBAN_BOARD", "").strip()
+    claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "").strip()
+    raw_run_id = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip()
+    if not raw_board or not claim_lock or not raw_run_id:
+        return None
+    try:
+        worker_board = _normalize_board_slug(raw_board) or ""
+        if not worker_board or (
+            board is not None and _normalize_board_slug(board) != worker_board
+        ):
+            return None
+        run_id = int(raw_run_id)
+        if run_id <= 0:
+            return None
+        with connect_closing(board=worker_board) as conn:
+            row = conn.execute(
+                """
+                SELECT t.status, t.current_run_id, t.claim_lock,
+                       r.task_id AS run_task_id, r.status AS run_status,
+                       r.ended_at AS run_ended_at, r.claim_lock AS run_claim_lock
+                  FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id
+                 WHERE t.id = ?
+                """,
+                (task_id,),
+            ).fetchone()
+    except (OSError, sqlite3.Error, ValueError):
+        return None
+    if (
+        row is None or row["status"] != "running"
+        or row["current_run_id"] != run_id or row["claim_lock"] != claim_lock
+        or row["run_task_id"] != task_id or row["run_status"] != "running"
+        or row["run_ended_at"] is not None or row["run_claim_lock"] != claim_lock
+    ):
+        return None
+    return WorkerCapability(worker_board, task_id, run_id, claim_lock)
+
+
 class HallucinatedCardsError(ValueError):
     """Raised by ``complete_task`` when ``created_cards`` contains ids
     that don't exist or weren't created by the completing worker.
@@ -4022,6 +4202,7 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -4083,8 +4264,26 @@ def complete_task(
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
+    # A missing expected run id identifies an operator transition (manual CLI,
+    # dashboard, or an API caller), not the worker currently executing this
+    # attempt.  Snapshot and stop/prove the detached tree before we take the
+    # write transaction that clears ownership.  A worker's own completion
+    # carries expected_run_id and must never try to kill itself.
+    if expected_run_id is not None and not expected_claim_lock:
+        # A run id is an identifier, not a worker capability. Do not let a
+        # stale process terminally mutate the current run because it learned
+        # only that numeric id.
+        return False
+    operator_snapshot: Optional[sqlite3.Row] = None
+    if expected_run_id is None:
+        operator_snapshot, _termination = _prepare_operator_active_transition(
+            conn, task_id, operation="complete",
+        )
+        if operator_snapshot is None:
+            return False
     with write_txn(conn):
         if expected_run_id is None:
+            cas_clause, cas_params = _operator_transition_cas_clause(operator_snapshot)
             cur = conn.execute(
                 """
                 UPDATE tasks
@@ -4094,12 +4293,13 @@ def complete_task(
                        claim_lock   = NULL,
                        claim_expires= NULL,
                        worker_pid   = NULL,
+                       worker_identity = NULL,
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
-                """,
-                (result, now, task_id),
+                """ + cas_clause,
+                [result, now, task_id, *cas_params],
             )
         else:
             cur = conn.execute(
@@ -4111,13 +4311,19 @@ def complete_task(
                        claim_lock   = NULL,
                        claim_expires= NULL,
                        worker_pid   = NULL,
+                       worker_identity = NULL,
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
                    AND current_run_id = ?
+                   AND claim_lock = ?
+                   AND EXISTS (SELECT 1 FROM task_runs r WHERE r.id = ?
+                     AND r.task_id = tasks.id AND r.status = 'running'
+                     AND r.ended_at IS NULL AND r.claim_lock = ?)
                 """,
-                (result, now, task_id, int(expected_run_id)),
+                (result, now, task_id, int(expected_run_id), expected_claim_lock,
+                 int(expected_run_id), expected_claim_lock),
             )
         if cur.rowcount != 1:
             return False
@@ -4802,6 +5008,7 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
 ) -> bool:
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
@@ -4834,6 +5041,38 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
+    if expected_run_id is not None and not expected_claim_lock:
+        # A raw run id is not worker authority; unscoped operators still use
+        # the expected_run_id=None transition below.
+        return False
+    # See complete_task: a caller without expected_run_id is an operator and
+    # must reap/prove an active detached tree before this transition clears its
+    # claim. The in-flight worker supplies its run id and keeps the historical
+    # self-block behavior without signalling its own process group.
+    operator_snapshot: Optional[sqlite3.Row] = None
+    if expected_run_id is None:
+        operator_snapshot, _termination = _prepare_operator_active_transition(
+            conn, task_id, operation="block",
+        )
+        if operator_snapshot is None:
+            return False
+        operator_cas_clause, operator_cas_params = _operator_transition_cas_clause(
+            operator_snapshot,
+        )
+    else:
+        operator_cas_clause, operator_cas_params = "", []
+    worker_cas_clause = """
+                   AND current_run_id = ? AND claim_lock = ?
+                   AND EXISTS (SELECT 1 FROM task_runs r WHERE r.id = ?
+                     AND r.task_id = tasks.id AND r.status = 'running'
+                     AND r.ended_at IS NULL AND r.claim_lock = ?)
+    """
+    worker_cas_params: list[Any] = []
+    if expected_run_id is not None:
+        worker_cas_params = [
+            int(expected_run_id), expected_claim_lock,
+            int(expected_run_id), expected_claim_lock,
+        ]
     routed_to = "blocked"
     recurrences = 0
     with write_txn(conn):
@@ -4863,12 +5102,16 @@ def block_task(
                        claim_lock    = NULL,
                        claim_expires = NULL,
                        worker_pid    = NULL,
+                       worker_identity = NULL,
                        block_kind    = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, task_id) if expected_run_id is None
-                else (kind, task_id, int(expected_run_id)),
+                """ + (
+                    operator_cas_clause if expected_run_id is None else worker_cas_clause
+                ),
+                [kind, task_id, *operator_cas_params]
+                if expected_run_id is None
+                else (kind, task_id, *worker_cas_params),
             )
             if cur.rowcount != 1:
                 return False
@@ -4916,13 +5159,17 @@ def block_task(
                        claim_lock    = NULL,
                        claim_expires = NULL,
                        worker_pid    = NULL,
+                       worker_identity = NULL,
                        block_kind    = ?,
                        block_recurrences = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
-                """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, recurrences, task_id) if expected_run_id is None
-                else (kind, recurrences, task_id, int(expected_run_id)),
+                """ + (
+                    operator_cas_clause if expected_run_id is None else worker_cas_clause
+                ),
+                [kind, recurrences, task_id, *operator_cas_params]
+                if expected_run_id is None
+                else (kind, recurrences, task_id, *worker_cas_params),
             )
             if cur.rowcount != 1:
                 return False
@@ -4955,12 +5202,13 @@ def block_task(
                            claim_lock    = NULL,
                            claim_expires = NULL,
                            worker_pid    = NULL,
+                           worker_identity = NULL,
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
                        AND status IN ('running', 'ready')
-                    """,
-                    (kind, recurrences, task_id),
+                    """ + operator_cas_clause,
+                    [kind, recurrences, task_id, *operator_cas_params],
                 )
             else:
                 cur = conn.execute(
@@ -4970,13 +5218,13 @@ def block_task(
                            claim_lock    = NULL,
                            claim_expires = NULL,
                            worker_pid    = NULL,
+                           worker_identity = NULL,
                            block_kind    = ?,
                            block_recurrences = ?
                      WHERE id = ?
                        AND status IN ('running', 'ready')
-                       AND current_run_id = ?
-                    """,
-                    (kind, recurrences, task_id, int(expected_run_id)),
+                    """ + worker_cas_clause,
+                    (kind, recurrences, task_id, *worker_cas_params),
                 )
             if cur.rowcount != 1:
                 return False
@@ -5104,7 +5352,8 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
                    SET status = 'reclaimed', outcome = 'reclaimed',
                        summary = COALESCE(summary, 'invariant recovery on unblock'),
                        ended_at = ?,
-                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL
+                       claim_lock = NULL, claim_expires = NULL, worker_pid = NULL,
+                       worker_identity = NULL
                  WHERE id = ? AND ended_at IS NULL
                 """,
                 (now, int(stale["current_run_id"])),
@@ -5461,23 +5710,186 @@ def decompose_triage_task(
     return child_ids
 
 
+def _operator_transition_snapshot(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_run_id: Optional[int] = None,
+) -> Optional[sqlite3.Row]:
+    """Snapshot a task and any still-open run before an operator transition.
+
+    The operator verbs below intentionally read before waiting for a process
+    tree.  Holding SQLite's write lock while a TERM-ignoring child consumes its
+    grace window would stall heartbeats and the dispatcher.  The later mutation
+    carries this immutable ownership snapshot back into its CAS predicates.
+    """
+    row = conn.execute(
+        "SELECT t.status, t.claim_lock, t.claim_expires, t.worker_pid, "
+        "       t.worker_identity, t.current_run_id, r.status AS run_status, "
+        "       r.ended_at AS run_ended_at, r.worker_pid AS run_worker_pid, "
+        "       r.worker_identity AS run_worker_identity, r.claim_lock AS run_claim_lock "
+        "FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id "
+        "WHERE t.id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    if expected_run_id is not None and row["current_run_id"] != int(expected_run_id):
+        return None
+    return row
+
+
+def _operator_transition_tree_is_gone(
+    termination: dict[str, Any], pid: Optional[int],
+) -> bool:
+    """Accept only a terminated or independently-proven empty worker tree."""
+    if termination.get("terminated"):
+        return True
+    # A supervisor can exit between the snapshot and the identity check.  A
+    # PID reuse would instead be identity_mismatch while the PID is alive; once
+    # the registered leader is gone, the Linux zombie-aware group probe can
+    # prove no executable descendant remains without signalling any group.
+    if termination.get("identity") == "leader_gone" and pid:
+        releasable, group_state = _dead_supervisor_group_is_releasable(int(pid))
+        termination["dead_supervisor_group_state"] = group_state
+        if releasable:
+            termination["terminated"] = True
+            termination["tree_target"] = "dead_supervisor_group_probe"
+            return True
+    return False
+
+
+def _prepare_operator_active_transition(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    operation: str,
+    expected_run_id: Optional[int] = None,
+) -> tuple[Optional[sqlite3.Row], Optional[dict[str, Any]]]:
+    """Stop/prove an active worker tree before an operator mutation.
+
+    Returns the immutable snapshot plus termination evidence once the task is
+    safe to mutate.  ``(None, None)`` is the least-breaking ``False`` outcome
+    for absent/stale/deferred transitions.  Every active claim/run that cannot
+    prove its tree gone is held in ``running`` and receives a
+    ``reclaim_deferred`` event rather than losing ownership.
+    """
+    row = _operator_transition_snapshot(
+        conn, task_id, expected_run_id=expected_run_id,
+    )
+    if row is None:
+        return None, None
+    active = (
+        row["status"] == "running"
+        or (
+            row["current_run_id"] is not None
+            and row["run_status"] == "running"
+            and row["run_ended_at"] is None
+        )
+    )
+    if not active:
+        return row, None
+
+    pid = row["worker_pid"]
+    if pid is None:
+        termination: dict[str, Any] = {
+            "prev_pid": None,
+            "host_local": bool(row["claim_lock"]),
+            "identity": "worker_pid_missing",
+            "termination_deferred": True,
+            "tree_target": "none",
+        }
+    elif row["run_worker_pid"] != pid:
+        termination = {
+            "prev_pid": int(pid),
+            "host_local": bool(row["claim_lock"]),
+            "identity": "worker_pid_binding_mismatch",
+            "termination_deferred": True,
+            "tree_target": "none",
+        }
+    else:
+        termination = _terminate_reclaimed_worker(
+            pid,
+            row["claim_lock"],
+            worker_identity=row["worker_identity"],
+            run_worker_identity=row["run_worker_identity"],
+            run_worker_pid=row["run_worker_pid"],
+            run_claim_lock=row["run_claim_lock"],
+        )
+        if not termination.get("host_local"):
+            # A remote or malformed claim is active ownership that this host
+            # cannot prove/reap. Do not turn an operator request into a blind
+            # ownership clear just because it cannot signal the worker.
+            termination["identity"] = "ownership_unavailable"
+            termination["termination_deferred"] = True
+
+    if _operator_transition_tree_is_gone(termination, pid):
+        return row, termination
+
+    if row["status"] == "running":
+        _defer_reclaim_for_live_worker(
+            conn,
+            task_id,
+            row["claim_lock"],
+            int(time.time()),
+            termination,
+            reason=f"operator_{operation}_worker_alive",
+            worker_pid=pid,
+            run_id=row["current_run_id"],
+            worker_identity=row["worker_identity"],
+            run_worker_pid=row["run_worker_pid"],
+            run_worker_identity=row["run_worker_identity"],
+            run_claim_lock=row["run_claim_lock"],
+        )
+    return None, None
+
+
+def _operator_transition_cas_clause(row: sqlite3.Row) -> tuple[str, list[Any]]:
+    """Return ownership predicates that revalidate an operator snapshot."""
+    clause = (
+        " AND status IS ? AND claim_lock IS ? AND worker_pid IS ? "
+        "AND worker_identity IS ? AND current_run_id IS ?"
+    )
+    params: list[Any] = [
+        row["status"], row["claim_lock"], row["worker_pid"],
+        row["worker_identity"], row["current_run_id"],
+    ]
+    if row["current_run_id"] is not None:
+        clause += (
+            " AND EXISTS (SELECT 1 FROM task_runs r WHERE r.id = ? "
+            "AND r.task_id = tasks.id AND r.status IS ? AND r.ended_at IS ? "
+            "AND r.worker_pid IS ? AND r.worker_identity IS ?)"
+        )
+        params.extend([
+            row["current_run_id"], row["run_status"], row["run_ended_at"],
+            row["run_worker_pid"], row["run_worker_identity"],
+        ])
+    return clause, params
+
+
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    row, termination = _prepare_operator_active_transition(
+        conn, task_id, operation="archive",
+    )
+    if row is None:
+        return False
     with write_txn(conn):
+        cas_clause, cas_params = _operator_transition_cas_clause(row)
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
-            "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
-            "WHERE id = ? AND status != 'archived'",
-            (task_id,),
+            "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, worker_identity = NULL "
+            "WHERE id = ? AND status != 'archived'" + cas_clause,
+            [task_id, *cas_params],
         )
         if cur.rowcount != 1:
             return False
-        # If archive happened while a run was still in flight (e.g. user
-        # archived a running task from the dashboard), close that run with
-        # outcome='reclaimed' so attempt history isn't orphaned.
+        # If archive happened while a run was still in flight, close that run
+        # only after its verified tree has exited.
         run_id = _end_run(
             conn, task_id,
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
+            metadata=termination,
         )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
     # ``archived`` parents no longer block children, same as ``done``.
@@ -5523,8 +5935,17 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
     Returns ``True`` if the task existed and was deleted, ``False``
     if the task was not found.
     """
+    row, _termination = _prepare_operator_active_transition(
+        conn, task_id, operation="delete",
+    )
+    if row is None:
+        return False
     with write_txn(conn):
-        cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+        cas_clause, cas_params = _operator_transition_cas_clause(row)
+        cur = conn.execute(
+            "DELETE FROM tasks WHERE id = ?" + cas_clause,
+            [task_id, *cas_params],
+        )
         if cur.rowcount != 1:
             return False
         conn.execute("DELETE FROM task_links WHERE parent_id = ? OR child_id = ?", (task_id, task_id))
@@ -5848,6 +6269,7 @@ def schedule_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
 ) -> bool:
     """Park a task in ``scheduled`` so it is waiting on time, not human input.
 
@@ -5855,20 +6277,43 @@ def schedule_task(
     human action, or automation can later call ``unblock_task`` to re-gate them
     to ``ready`` (or ``todo`` if parents are still incomplete).
     """
+    if expected_run_id is not None and not expected_claim_lock:
+        return False
+    row: Optional[sqlite3.Row] = None
+    termination: Optional[dict] = None
+    if expected_run_id is None:
+        row, termination = _prepare_operator_active_transition(
+            conn, task_id, operation="schedule",
+        )
+        if row is None:
+            return False
     with write_txn(conn):
-        params: list[Any] = [task_id]
+        if expected_run_id is None:
+            assert row is not None
+            cas_clause, cas_params = _operator_transition_cas_clause(row)
+            params: list[Any] = [task_id, *cas_params]
+        else:
+            # Cooperative workers close only the exact open run they own. They
+            # must not enter the operator preparation path and signal their own
+            # supervisor tree.
+            cas_clause = """
+              AND current_run_id = ? AND claim_lock = ?
+              AND EXISTS (SELECT 1 FROM task_runs r WHERE r.id = ?
+                AND r.task_id = tasks.id AND r.status = 'running'
+                AND r.ended_at IS NULL AND r.claim_lock = ?)
+            """
+            params = [task_id, int(expected_run_id), expected_claim_lock,
+                      int(expected_run_id), expected_claim_lock]
         sql = """
             UPDATE tasks
                SET status       = 'scheduled',
                    claim_lock   = NULL,
                    claim_expires= NULL,
-                   worker_pid   = NULL
+                   worker_pid   = NULL,
+                   worker_identity = NULL
              WHERE id = ?
                AND status IN ('todo', 'ready', 'running', 'blocked')
-        """
-        if expected_run_id is not None:
-            sql += " AND current_run_id = ?"
-            params.append(int(expected_run_id))
+        """ + cas_clause
         cur = conn.execute(sql, params)
         if cur.rowcount != 1:
             return False
@@ -5876,6 +6321,7 @@ def schedule_task(
             conn, task_id,
             outcome="scheduled", status="scheduled",
             summary=reason,
+            metadata=termination,
         )
         if run_id is None and reason:
             run_id = _synthesize_ended_run(
@@ -5977,6 +6423,9 @@ class DispatchResult:
     "task is genuinely stuck"."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
+    deferred: list[str] = field(default_factory=list)
+    """Task ids whose generic crash reclaim was deferred because the
+    dead supervisor's process group still has live or unproven members."""
     auto_blocked: list[str] = field(default_factory=list)
     """Task ids auto-blocked by the spawn-failure circuit breaker."""
     timed_out: list[str] = field(default_factory=list)
@@ -6211,44 +6660,112 @@ def _linux_process_group_has_live_member(pgid: int) -> Optional[bool]:
                 raw = handle.read()
             # comm can contain spaces and parentheses; fields after its final
             # ')' begin with state, ppid, then pgrp.
-            fields = raw[raw.rfind(")") + 2:].split()
+            close = raw.rfind(")")
+            if close < 0:
+                return None
+            fields = raw[close + 2:].split()
             if len(fields) >= 3 and int(fields[2]) == pgid and fields[0] != "Z":
                 return True
-        except (FileNotFoundError, PermissionError, OSError, ValueError):
+        except FileNotFoundError:
+            # A process exiting between enumeration and read is harmless.
             continue
+        except (PermissionError, OSError, ValueError):
+            # A visible but unreadable/malformed process is not proof that the
+            # group is empty. Callers must defer rather than release a claim.
+            return None
     return False
 
 
-def _process_group_alive(pgid: int) -> bool:
-    """Return whether a POSIX group still has an executable member.
+def _process_group_alive(pgid: int) -> Optional[bool]:
+    """Return group liveness from a tri-state process-group inspection.
 
     On Linux this supplements ``killpg(..., 0)`` with a zombie-aware /proc
-    scan.  On platforms where that proof is unavailable, an existing group is
-    conservatively considered live, so a reclaim cannot release a possibly
-    surviving worker tree.
+    scan. ``None`` is a visible-but-unreadable/malformed member or another
+    unavailable proof, never an empty group. Callers must defer rather than
+    coercing uncertainty to ``False``.
     """
     try:
         os.killpg(pgid, 0)
     except ProcessLookupError:
         return False
     except (AttributeError, OSError):
-        return True
+        return None
     if sys.platform == "linux":
-        members = _linux_process_group_has_live_member(pgid)
-        return True if members is None else members
-    return True
+        return _linux_process_group_has_live_member(pgid)
+    return None
 
 
-def _verified_supervisor_process_group(pid: int) -> tuple[Optional[int], str]:
-    """Prove that ``pid`` is the session/group leader we spawned.
+def _dead_supervisor_group_is_releasable(pgid: int) -> tuple[bool, str]:
+    """Prove a dead detached supervisor left no executable group member.
 
-    The persisted value is intentionally the supervisor PID.  Never turn that
-    numeric identifier into ``killpg(pid, ...)`` unless it still names the
-    expected detached session leader.  This makes a stale/reused PID fail
-    closed instead of killing an unrelated process group.
+    This is deliberately narrower than :func:`_process_group_alive`: generic
+    crash reaping has already lost the leader, so it must not signal the group
+    and cannot use a leader identity check.  Linux's existing ``/proc`` group
+    scan is the remaining proof that the *PID-named original group* is empty.
+    A missing group or zombie-only group is safe to release; an executable
+    child, an inaccessible scan, or an unsupported platform is a deferral.
     """
+    if _IS_WINDOWS or sys.platform != "linux":
+        return False, "process_group_liveness_unavailable"
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return True, "process_group_gone"
+    except (AttributeError, OSError):
+        return False, "process_group_liveness_unavailable"
+    members = _linux_process_group_has_live_member(pgid)
+    if members is False:
+        return True, "process_group_zombie_only"
+    if members is True:
+        return False, "process_group_live"
+    return False, "process_group_liveness_unavailable"
+
+
+def _supervisor_process_identity(pid: int) -> Optional[str]:
+    """Return an immutable supervisor incarnation marker, when provable.
+
+    Linux's ``/proc/<pid>/stat`` field 22 is a process start-time tick count.
+    Unlike a PID it cannot identify a later process that reuses the numeric
+    identifier.  Other platforms deliberately return ``None`` rather than
+    claiming a PID-only check is safe; their reclaim paths therefore fail
+    closed before a process-tree signal or claim release.
+    """
+    if sys.platform != "linux" or _IS_WINDOWS:
+        return None
+    try:
+        with open(f"/proc/{int(pid)}/stat", "r", encoding="utf-8") as handle:
+            raw = handle.read()
+        # ``comm`` may contain spaces and ')' characters.  Fields after its
+        # final ')' begin at field 3 (state), so starttime (field 22) is index
+        # 19 in this split tail.
+        fields = raw[raw.rfind(")") + 2:].split()
+        if len(fields) <= 19:
+            return None
+        return f"linux-start-ticks:{int(fields[19])}"
+    except (FileNotFoundError, PermissionError, OSError, ValueError):
+        return None
+
+
+def _verified_supervisor_process_group(
+    pid: int,
+    expected_identity: Optional[str],
+) -> tuple[Optional[int], str]:
+    """Prove ``pid`` is the registered detached supervisor incarnation.
+
+    ``pgid == sid == pid`` proves a current process is a session/group leader,
+    but not that it is *our* former supervisor after PID reuse.  Require the
+    start-time identity captured at registration too, and fail closed whenever
+    either side is unavailable.
+    """
+    if not expected_identity:
+        return None, "identity_missing"
     if not _pid_alive(pid):
         return None, "leader_gone"
+    current_identity = _supervisor_process_identity(pid)
+    if current_identity is None:
+        return None, "identity_unavailable"
+    if current_identity != expected_identity:
+        return None, "identity_mismatch"
     try:
         pgid = os.getpgid(pid)
         sid = os.getsid(pid)
@@ -6264,8 +6781,11 @@ def _verified_supervisor_process_group(pid: int) -> tuple[Optional[int], str]:
 def _wait_for_process_group_exit(pgid: int, timeout: float) -> bool:
     deadline = time.monotonic() + timeout
     while True:
-        if not _process_group_alive(pgid):
+        group_state = _process_group_alive(pgid)
+        if group_state is False:
             return True
+        if group_state is None:
+            return False
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             return False
@@ -6276,14 +6796,20 @@ def _terminate_reclaimed_worker(
     pid: Optional[int],
     claim_lock: Optional[str],
     *,
+    worker_identity: Optional[str] = None,
+    run_worker_identity: Optional[str] = None,
+    run_worker_pid: Optional[int] = None,
+    run_claim_lock: Optional[str] = None,
     signal_fn=None,
 ) -> dict[str, Any]:
     """Terminate a verified host-local supervisor tree for reclaim paths.
 
     POSIX workers are launched in a fresh session.  Signal that whole group,
     then wait for *every* executable member before releasing a claim.  A PID
-    that is alive but no longer proves itself as our session/group leader is a
-    PID-reuse/identity ambiguity: defer rather than signal or re-dispatch.
+    that is alive but no longer proves itself as our registered supervisor
+    incarnation is a PID-reuse/identity ambiguity: defer rather than signal or
+    re-dispatch.  Windows has no equivalent identity proof wired here, so it
+    also defers rather than letting ``taskkill`` act on a possibly reused PID.
 
     ``signal_fn`` remains the legacy deterministic test hook.  It models a
     direct PID and its liveness because old unit fixtures do not create real
@@ -6300,13 +6826,23 @@ def _terminate_reclaimed_worker(
         "sigkill": False,
         "tree_target": "none",
     }
-    if not pid or pid <= 0 or not claim_lock:
-        return info
-
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    if not claim_lock:
+        info["identity"] = "claim_lock_missing"
+        info["termination_deferred"] = True
+        return info
     if not str(claim_lock).startswith(host_prefix):
+        info["identity"] = "ownership_non_local"
+        info["termination_deferred"] = True
         return info
     info["host_local"] = True
+    if not pid or pid <= 0:
+        # A dispatcher may have launched a detached tree but lost the narrow
+        # post-spawn/pre-publication race.  Absence of a durable PID is not
+        # proof that the tree vanished, so holding the exact claim is required.
+        info["identity"] = "worker_pid_missing"
+        info["termination_deferred"] = True
+        return info
 
     if signal_fn is not None:
         # Compatibility seam for deterministic fixtures.  It deliberately
@@ -6334,42 +6870,35 @@ def _terminate_reclaimed_worker(
         info["terminated"] = not _pid_alive(pid)
         return info
 
-    if _IS_WINDOWS:
-        info["tree_target"] = "windows_taskkill"
-        info["termination_attempted"] = True
-        try:
-            subprocess.run(
-                ["taskkill", "/PID", str(int(pid)), "/T", "/F"],
-                check=False,
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-        except (OSError, subprocess.SubprocessError):
-            info["termination_error"] = "taskkill_failed"
-        deadline = time.monotonic() + _WORKER_TREE_TERMINATE_GRACE_SECONDS
-        while _pid_alive(pid) and time.monotonic() < deadline:
-            time.sleep(_WORKER_TREE_TERMINATE_POLL_SECONDS)
-        info["terminated"] = not _pid_alive(pid)
+    if run_worker_pid is None or int(run_worker_pid) != int(pid):
+        info["identity"] = "worker_pid_binding_mismatch"
+        info["termination_deferred"] = True
+        return info
+    if run_claim_lock != claim_lock:
+        info["identity"] = "claim_lock_binding_mismatch"
+        info["termination_deferred"] = True
+        return info
+    if worker_identity != run_worker_identity:
+        info["identity"] = "identity_binding_mismatch"
+        info["termination_deferred"] = True
+        return info
+    if not worker_identity:
+        info["identity"] = "identity_missing"
+        info["termination_deferred"] = True
         return info
 
-    pgid, identity = _verified_supervisor_process_group(int(pid))
+    if _IS_WINDOWS:
+        # A Windows PID plus taskkill's tree walk is not an incarnation token.
+        # Do not claim it is safe without a proven process-handle/start-token
+        # transport; holding the claim is safer than killing a replacement.
+        info["identity"] = "identity_unavailable_platform"
+        info["termination_deferred"] = True
+        return info
+
+    pgid, identity = _verified_supervisor_process_group(int(pid), worker_identity)
     info["identity"] = identity
     if pgid is None:
-        if identity == "leader_gone":
-            # A dead supervisor does not prove a dead tree: its group can still
-            # contain a worker orphaned by an external kill.  Probing group
-            # liveness has no side effect; only an absent group is releasable.
-            # If the numeric group exists we cannot attribute it safely after
-            # losing the leader identity, so preserve the claim and surface a
-            # defer rather than risk either a duplicate or an unrelated kill.
-            info["tree_target"] = "unverified_process_group"
-            if _process_group_alive(int(pid)):
-                info["termination_deferred"] = True
-            else:
-                info["terminated"] = True
-        else:
-            info["termination_deferred"] = True
+        info["termination_deferred"] = True
         return info
 
     info["tree_target"] = "posix_process_group"
@@ -6377,11 +6906,20 @@ def _terminate_reclaimed_worker(
     info["termination_attempted"] = True
 
     def send_group(sig: int) -> bool:
+        # Re-read immediately before *each* signal.  The PID can be recycled
+        # after the first verification (or between TERM and KILL), and any
+        # failed identity proof must suppress both the signal and claim release.
+        current_identity = _supervisor_process_identity(int(pid))
+        if current_identity is None:
+            info["identity"] = "identity_unavailable"
+            info["termination_deferred"] = True
+            return False
+        if current_identity != worker_identity:
+            info["identity"] = "identity_mismatch"
+            info["termination_deferred"] = True
+            return False
         try:
-            if signal_fn is not None:
-                signal_fn(pgid, sig)
-            else:
-                os.killpg(pgid, sig)
+            os.killpg(pgid, sig)
             return True
         except ProcessLookupError:
             return False
@@ -6389,7 +6927,9 @@ def _terminate_reclaimed_worker(
             return False
 
     if not send_group(signal.SIGTERM):
-        info["terminated"] = not _process_group_alive(pgid)
+        if info.get("termination_deferred"):
+            return info
+        info["terminated"] = _process_group_alive(pgid) is False
         return info
     if _wait_for_process_group_exit(pgid, _WORKER_TREE_TERMINATE_GRACE_SECONDS):
         info["terminated"] = True
@@ -6397,6 +6937,8 @@ def _terminate_reclaimed_worker(
 
     if send_group(getattr(signal, "SIGKILL", signal.SIGTERM)):
         info["sigkill"] = True
+    elif info.get("termination_deferred"):
+        return info
     info["terminated"] = _wait_for_process_group_exit(
         pgid, _WORKER_TREE_TERMINATE_GRACE_SECONDS,
     )
@@ -6404,22 +6946,136 @@ def _terminate_reclaimed_worker(
 
 
 def _worker_survived_termination(termination: dict) -> bool:
-    """True when we tried to kill our own host-local worker and it is still alive.
+    """True unless reclaim has positive proof that the owned tree is gone.
 
-    Reclaiming in this state would release the claim and let the dispatcher
-    spawn a second worker while the first is still running — the duplication
-    loop. Only host-local workers we actually signalled count: a non-local
-    claim lock or a no-op attempt (no ``os.kill`` available) must fall through
-    to the normal release path, since we cannot manage that worker anyway.
+    No PID, non-local ownership, unavailable identity, registration drift, and
+    unavailable group inspection are all *unproven*, not neutral no-ops.  A
+    stale sweeper must retain the claim in each of those states; otherwise it
+    could re-dispatch beside a still-running detached worker.
     """
-    return bool(
-        termination.get("host_local")
-        and (
-            termination.get("termination_attempted")
-            or termination.get("termination_deferred")
+    return not bool(termination.get("terminated"))
+
+
+def _live_ttl_renewal_proof(row: sqlite3.Row) -> tuple[bool, dict[str, Any]]:
+    """Prove an expired live PID may renew this task/run lease.
+
+    Lease renewal is an ownership decision, not merely a liveness check. A
+    fresh heartbeat cannot compensate for an incomplete task/run binding, PID
+    reuse, or an incomplete Linux process-group scan.
+    """
+    pid = row["worker_pid"]
+    proof: dict[str, Any] = {
+        "prev_pid": int(pid) if pid else None,
+        "host_local": False,
+        "termination_attempted": False,
+        "terminated": False,
+        "tree_target": "none",
+        "termination_deferred": True,
+    }
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    lock = row["claim_lock"]
+    if not lock or not str(lock).startswith(host_prefix):
+        proof["identity"] = "ownership_non_local"
+        return False, proof
+    proof["host_local"] = True
+    if not pid or int(pid) <= 0:
+        proof["identity"] = "worker_pid_missing"
+        return False, proof
+    if not row["current_run_id"] or row["run_status"] != "running" or row["run_ended_at"] is not None:
+        proof["identity"] = "current_run_binding_mismatch"
+        return False, proof
+    if row["run_claim_lock"] != lock:
+        proof["identity"] = "claim_lock_binding_mismatch"
+        return False, proof
+    if row["run_worker_pid"] is None or int(row["run_worker_pid"]) != int(pid):
+        proof["identity"] = "worker_pid_binding_mismatch"
+        return False, proof
+    if not row["worker_identity"] or row["worker_identity"] != row["run_worker_identity"]:
+        proof["identity"] = (
+            "identity_missing" if not row["worker_identity"] else "identity_binding_mismatch"
         )
-        and not termination.get("terminated")
-    )
+        return False, proof
+    pgid, identity = _verified_supervisor_process_group(int(pid), row["worker_identity"])
+    proof["identity"] = identity
+    if pgid is None:
+        return False, proof
+    proof["process_group"] = pgid
+    group_state = _linux_process_group_has_live_member(pgid)
+    if group_state is not True:
+        proof["identity"] = (
+            "process_group_empty" if group_state is False else "process_group_liveness_unavailable"
+        )
+        return False, proof
+    proof["tree_target"] = "posix_process_group"
+    return True, proof
+
+
+def _extend_live_ttl_claim(
+    conn: sqlite3.Connection,
+    row: sqlite3.Row,
+    now: int,
+    new_expires: int,
+) -> bool:
+    """Extend only the exact task/current-open-run tuple just proven live."""
+    with write_txn(conn):
+        binding = conn.execute(
+            """
+            SELECT 1 FROM tasks t JOIN task_runs r ON r.id = t.current_run_id
+             WHERE t.id = ? AND t.status = 'running' AND t.claim_lock IS ?
+               AND t.worker_pid IS ? AND t.worker_identity IS ?
+               AND t.current_run_id IS ? AND t.claim_expires IS NOT NULL
+               AND t.claim_expires < ? AND r.task_id = t.id
+               AND r.status = 'running' AND r.ended_at IS NULL
+               AND r.claim_lock IS ? AND r.worker_pid IS ? AND r.worker_identity IS ?
+            """,
+            (
+                row["id"], row["claim_lock"], row["worker_pid"], row["worker_identity"],
+                row["current_run_id"], now, row["run_claim_lock"],
+                row["run_worker_pid"], row["run_worker_identity"],
+            ),
+        ).fetchone()
+        if binding is None:
+            return False
+        run_cur = conn.execute(
+            "UPDATE task_runs SET claim_expires = ? WHERE id = ? AND task_id = ? "
+            "AND status = 'running' AND ended_at IS NULL AND claim_lock IS ? "
+            "AND worker_pid IS ? AND worker_identity IS ?",
+            (
+                new_expires, row["current_run_id"], row["id"], row["run_claim_lock"],
+                row["run_worker_pid"], row["run_worker_identity"],
+            ),
+        )
+        task_cur = conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ? AND status = 'running' "
+            "AND claim_lock IS ? AND worker_pid IS ? AND worker_identity IS ? "
+            "AND current_run_id IS ? AND claim_expires IS NOT NULL AND claim_expires < ?",
+            (
+                new_expires, row["id"], row["claim_lock"], row["worker_pid"],
+                row["worker_identity"], row["current_run_id"], now,
+            ),
+        )
+        return run_cur.rowcount == 1 and task_cur.rowcount == 1
+
+
+def _append_claim_extended_event(
+    conn: sqlite3.Connection, row: sqlite3.Row, new_expires: int,
+) -> None:
+    with write_txn(conn):
+        _append_event(
+            conn, row["id"], "claim_extended",
+            {
+                "reason": "verified_live_supervisor",
+                "worker_pid": int(row["worker_pid"]),
+                "claim_lock": row["claim_lock"],
+                "claim_expires_was": int(row["claim_expires"]),
+                "claim_expires_now": new_expires,
+                "last_heartbeat_at": (
+                    int(row["last_heartbeat_at"])
+                    if row["last_heartbeat_at"] is not None else None
+                ),
+            },
+            run_id=row["current_run_id"],
+        )
 
 
 def _defer_reclaim_for_live_worker(
@@ -6431,36 +7087,63 @@ def _defer_reclaim_for_live_worker(
     *,
     reason: str,
     worker_pid: Optional[int] = None,
+    worker_identity: Optional[str] = None,
     run_id: Optional[int] = None,
+    run_worker_pid: Optional[int] = None,
+    run_worker_identity: Optional[str] = None,
+    run_claim_lock: Optional[str] = None,
+    extend_lease: Optional[bool] = None,
 ) -> None:
     """Hold a claim whose worker survived termination instead of releasing it.
 
     Extends ``claim_expires`` by ``RECLAIM_DEFER_GRACE_SECONDS`` so the task
-    stays ``running`` (no duplicate spawn) and records a ``reclaim_deferred``
-    event so the hold is visible in ``hermes kanban tail``. The next dispatch
-    tick retries the kill; this is self-correcting because not spawning a
-    duplicate is what lets the throttled worker finally die.
+    stays ``running`` (no duplicate spawn) — but only when the termination
+    evidence proves the tree is ours. The lease policy is fail-closed and
+    centralized here: an omitted ``extend_lease`` derives from the proof
+    (``termination_deferred`` means unproven ownership → no renewal), an
+    explicit ``True`` is still clamped by that proof, and an explicit
+    ``False`` always wins (TTL renewal keeps its own proof path). Both forms
+    require the full task/current-open-run ownership CAS before recording the
+    deferred event.
     """
+    proven = not termination.get("termination_deferred", False)
+    if extend_lease is None:
+        extend_lease = proven
+    else:
+        extend_lease = bool(extend_lease) and proven
     grace = now + RECLAIM_DEFER_GRACE_SECONDS
     with write_txn(conn):
         cur = conn.execute(
-            "UPDATE tasks SET claim_expires = ? "
+            "UPDATE tasks SET claim_expires = CASE WHEN ? THEN ? ELSE claim_expires END "
             "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
-            "AND worker_pid IS ? AND current_run_id IS ?",
-            (grace, task_id, claim_lock, worker_pid, run_id),
+            "AND worker_pid IS ? AND worker_identity IS ? AND current_run_id IS ? "
+            "AND EXISTS (SELECT 1 FROM task_runs r WHERE r.id = ? "
+            "AND r.task_id = tasks.id AND r.status = 'running' "
+            "AND r.ended_at IS NULL AND r.claim_lock IS ? "
+            "AND r.worker_pid IS ? AND r.worker_identity IS ?)",
+            (
+                int(extend_lease), grace, task_id, claim_lock, worker_pid, worker_identity, run_id,
+                run_id, run_claim_lock, run_worker_pid, run_worker_identity,
+            ),
         )
         if cur.rowcount != 1:
             return
-        run_id = _current_run_id(conn, task_id)
-        if run_id is not None:
+        if run_id is not None and extend_lease:
             conn.execute(
-                "UPDATE task_runs SET claim_expires = ? WHERE id = ?",
-                (grace, run_id),
+                "UPDATE task_runs SET claim_expires = ? "
+                "WHERE id = ? AND task_id = ? AND status = 'running' "
+                "AND ended_at IS NULL AND claim_lock IS ? "
+                "AND worker_pid IS ? AND worker_identity IS ?",
+                (
+                    grace, run_id, task_id, run_claim_lock,
+                    run_worker_pid, run_worker_identity,
+                ),
             )
         payload = {
             "reason": reason,
             "claim_lock": claim_lock,
-            "claim_expires_now": grace,
+            "claim_expires_now": grace if extend_lease else None,
+            "lease_extended": bool(extend_lease),
         }
         payload.update(termination)
         _append_event(conn, task_id, "reclaim_deferred", payload, run_id=run_id)
@@ -6472,6 +7155,7 @@ def heartbeat_worker(
     *,
     note: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    expected_claim_lock: Optional[str] = None,
 ) -> bool:
     """Record a ``heartbeat`` event + touch ``last_heartbeat_at``.
 
@@ -6480,30 +7164,77 @@ def heartbeat_worker(
     video encode, web crawl) can have its Python still alive while the
     actual work process is stuck; periodic heartbeats catch that.
 
+    An unscoped/operator caller omits both ``expected_run_id`` and
+    ``expected_claim_lock`` and keeps the historical any-running-task
+    path. A dispatcher worker must provide both: a run id alone is an
+    identifier, not a capability, so supplying either half without a
+    valid other half is refused. In the scoped form the task status,
+    current-run pointer, and open ``task_runs`` row are bound to the
+    expected run id + claim lock in one write transaction *before*
+    either heartbeat timestamp changes or the event is appended; a
+    stale run or mismatched lock returns False with no mutation.
+
     Returns True on success, False if the task is not in a state that
-    should be heartbeating (not running, or claim expired).
+    should be heartbeating (not running, claim expired, or the scoped
+    capability no longer matches the active attempt).
     """
     now = int(time.time())
+    scoped = expected_run_id is not None or expected_claim_lock is not None
+    if scoped:
+        if expected_run_id is None or not str(expected_claim_lock or "").strip():
+            return False
+        lock = str(expected_claim_lock).strip()
+        run_id = int(expected_run_id)
+        with write_txn(conn):
+            binding = conn.execute(
+                """
+                SELECT 1
+                  FROM tasks t
+                  JOIN task_runs r ON r.id = t.current_run_id
+                 WHERE t.id = ?
+                   AND t.status = 'running'
+                   AND t.claim_lock = ?
+                   AND t.current_run_id = ?
+                   AND r.task_id = t.id
+                   AND r.status = 'running'
+                   AND r.ended_at IS NULL
+                   AND r.claim_lock = ?
+                """,
+                (task_id, lock, run_id, lock),
+            ).fetchone()
+            if binding is None:
+                return False
+            task_cur = conn.execute(
+                "UPDATE tasks SET last_heartbeat_at = ? "
+                "WHERE id = ? AND status = 'running' "
+                "AND claim_lock = ? AND current_run_id = ?",
+                (now, task_id, lock, run_id),
+            )
+            run_cur = conn.execute(
+                "UPDATE task_runs SET last_heartbeat_at = ? "
+                "WHERE id = ? AND task_id = ? "
+                "AND status = 'running' AND ended_at IS NULL "
+                "AND claim_lock = ?",
+                (now, run_id, task_id, lock),
+            )
+            if task_cur.rowcount != 1 or run_cur.rowcount != 1:
+                raise RuntimeError("active claim binding changed during heartbeat")
+            _append_event(
+                conn, task_id, "heartbeat",
+                {"note": note} if note else None,
+                run_id=run_id,
+            )
+        return True
+
     with write_txn(conn):
-        if expected_run_id is None:
-            cur = conn.execute(
-                "UPDATE tasks SET last_heartbeat_at = ? "
-                "WHERE id = ? AND status = 'running'",
-                (now, task_id),
-            )
-        else:
-            cur = conn.execute(
-                "UPDATE tasks SET last_heartbeat_at = ? "
-                "WHERE id = ? AND status = 'running' AND current_run_id = ?",
-                (now, task_id, int(expected_run_id)),
-            )
+        cur = conn.execute(
+            "UPDATE tasks SET last_heartbeat_at = ? "
+            "WHERE id = ? AND status = 'running'",
+            (now, task_id),
+        )
         if cur.rowcount != 1:
             return False
-        run_id = (
-            int(expected_run_id)
-            if expected_run_id is not None
-            else _current_run_id(conn, task_id)
-        )
+        run_id = _current_run_id(conn, task_id)
         if run_id is not None:
             conn.execute(
                 "UPDATE task_runs SET last_heartbeat_at = ? WHERE id = ?",
@@ -6540,9 +7271,11 @@ def enforce_max_runtime(
     host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
 
     rows = conn.execute(
-        "SELECT t.id, t.worker_pid, "
+        "SELECT t.id, t.worker_pid, t.worker_identity, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at, "
-        "       t.max_runtime_seconds, t.claim_lock, t.current_run_id "
+        "       t.max_runtime_seconds, t.claim_lock, t.current_run_id, "
+        "       r.worker_pid AS run_worker_pid, r.worker_identity AS run_worker_identity, "
+        "       r.claim_lock AS run_claim_lock "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
         "WHERE t.status = 'running' AND t.max_runtime_seconds IS NOT NULL "
@@ -6562,19 +7295,30 @@ def enforce_max_runtime(
 
         pid = int(row["worker_pid"])
         tid = row["id"]
-        termination = _terminate_reclaimed_worker(pid, lock, signal_fn=signal_fn)
+        termination = _terminate_reclaimed_worker(
+            pid,
+            lock,
+            worker_identity=row["worker_identity"],
+            run_worker_identity=row["run_worker_identity"],
+            run_worker_pid=row["run_worker_pid"],
+            run_claim_lock=row["run_claim_lock"],
+            signal_fn=signal_fn,
+        )
         if _worker_survived_termination(termination):
             _defer_reclaim_for_live_worker(
                 conn, tid, row["claim_lock"], now, termination,
                 reason="max_runtime_worker_alive",
-                worker_pid=pid, run_id=row["current_run_id"],
+                worker_pid=pid, worker_identity=row["worker_identity"],
+                run_id=row["current_run_id"], run_worker_pid=row["run_worker_pid"],
+                run_worker_identity=row["run_worker_identity"],
+                run_claim_lock=row["run_claim_lock"],
             )
             continue
 
         with write_txn(conn):
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL, "
+                "claim_expires = NULL, worker_pid = NULL, worker_identity = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND worker_pid = ? AND claim_lock IS ? "
@@ -6662,8 +7406,9 @@ def detect_stale_running(
     reclaimed: list[str] = []
 
     rows = conn.execute(
-        "SELECT t.id, t.worker_pid, t.last_heartbeat_at, t.claim_lock, "
-        "       t.current_run_id, "
+        "SELECT t.id, t.worker_pid, t.worker_identity, t.last_heartbeat_at, t.claim_lock, "
+        "       t.current_run_id, r.worker_pid AS run_worker_pid, "
+        "       r.worker_identity AS run_worker_identity, r.claim_lock AS run_claim_lock, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
@@ -6690,28 +7435,51 @@ def detect_stale_running(
 
         # Terminate the worker if it's still host-local.
         termination = _terminate_reclaimed_worker(
-            pid, lock, signal_fn=signal_fn,
+            pid,
+            lock,
+            worker_identity=row["worker_identity"],
+            run_worker_identity=row["run_worker_identity"],
+            run_worker_pid=row["run_worker_pid"],
+            run_claim_lock=row["run_claim_lock"],
+            signal_fn=signal_fn,
         )
 
         # Never release a claim while our own worker is still alive: that would
         # spawn a duplicate beside it. Hold the claim and retry next tick.
+        # Extending the lease additionally requires the termination pass to
+        # have proven ownership (task/run binding + current incarnation): a
+        # deferred proof (identity missing/unavailable/mismatched, PID reuse)
+        # keeps the binding but must not refresh an unverified lease.
         if _worker_survived_termination(termination):
             _defer_reclaim_for_live_worker(
                 conn, tid, lock, now, termination,
                 reason="heartbeat_stale_worker_alive",
-                worker_pid=pid, run_id=row["current_run_id"],
+                worker_pid=pid, worker_identity=row["worker_identity"],
+                run_id=row["current_run_id"], run_worker_pid=row["run_worker_pid"],
+                run_worker_identity=row["run_worker_identity"],
+                run_claim_lock=row["run_claim_lock"],
+                extend_lease=not termination.get("termination_deferred", False),
             )
             continue
 
         with write_txn(conn):
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL, "
+                "claim_expires = NULL, worker_pid = NULL, worker_identity = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
-                "  AND claim_lock IS ? AND worker_pid IS ? "
-                "  AND current_run_id IS ?",
-                (tid, row["claim_lock"], pid, row["current_run_id"]),
+                "  AND claim_lock IS ? AND worker_pid IS ? AND worker_identity IS ? "
+                "  AND current_run_id IS ? "
+                "  AND EXISTS (SELECT 1 FROM task_runs r WHERE r.id = ? "
+                "      AND r.task_id = tasks.id AND r.status = 'running' "
+                "      AND r.ended_at IS NULL AND r.claim_lock IS ? "
+                "      AND r.worker_pid IS ? AND r.worker_identity IS ?)",
+                (
+                    tid, row["claim_lock"], pid, row["worker_identity"],
+                    row["current_run_id"], row["current_run_id"],
+                    row["run_claim_lock"], row["run_worker_pid"],
+                    row["run_worker_identity"],
+                ),
             )
             if cur.rowcount != 1:
                 continue
@@ -6839,6 +7607,63 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
+def _defer_dead_supervisor_crash_reclaim(
+    conn: sqlite3.Connection,
+    row: sqlite3.Row,
+    pid: int,
+    *,
+    reason: str,
+) -> bool:
+    """Keep a generic-sweep claim running when its dead tree is unproven.
+
+    Called only from ``detect_crashed_workers``' existing write transaction.
+    Unlike reclaim paths that intentionally terminate a verified tree, this
+    observer has already lost its leader and therefore only probes /proc; it
+    must not send TERM/KILL before deciding whether a second worker may spawn.
+    """
+    now = int(time.time())
+    claim_expires = now + RECLAIM_DEFER_GRACE_SECONDS
+    cur = conn.execute(
+        "UPDATE tasks SET claim_expires = ? "
+        "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
+        "AND worker_pid IS ? AND current_run_id IS ?",
+        (
+            claim_expires,
+            row["id"],
+            row["claim_lock"],
+            pid,
+            row["current_run_id"],
+        ),
+    )
+    if cur.rowcount != 1:
+        return False
+    if row["current_run_id"] is not None:
+        conn.execute(
+            "UPDATE task_runs SET claim_expires = ? "
+            "WHERE id = ? AND task_id = ? AND status = 'running' "
+            "AND ended_at IS NULL AND worker_pid IS ?",
+            (claim_expires, row["current_run_id"], row["id"], pid),
+        )
+    _append_event(
+        conn,
+        row["id"],
+        "reclaim_deferred",
+        {
+            "reason": reason,
+            "claim_lock": row["claim_lock"],
+            "claim_expires_now": claim_expires,
+            "prev_pid": pid,
+            "host_local": True,
+            "tree_target": "dead_supervisor_group_probe",
+            "termination_deferred": True,
+            "worker_identity": row["worker_identity"],
+            "run_worker_identity": row["run_worker_identity"],
+        },
+        run_id=row["current_run_id"],
+    )
+    return True
+
+
 def detect_crashed_workers(
     conn: sqlite3.Connection,
     *,
@@ -6873,6 +7698,7 @@ def detect_crashed_workers(
     """
     crashed: list[str] = []
     rate_limited: list[str] = []
+    deferred: list[str] = []
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
     # write_txn so can't nest). ``protocol_violation`` flags the
@@ -6884,14 +7710,20 @@ def detect_crashed_workers(
     with write_txn(conn):
         if expected_exit is None:
             rows = conn.execute(
-                "SELECT id, worker_pid, claim_lock, started_at, current_run_id "
-                "FROM tasks WHERE status = 'running' AND worker_pid IS NOT NULL"
+                "SELECT t.id, t.worker_pid, t.worker_identity, t.claim_lock, "
+                "       t.started_at, t.current_run_id, "
+                "       r.worker_identity AS run_worker_identity "
+                "FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id "
+                "WHERE t.status = 'running' AND t.worker_pid IS NOT NULL"
             ).fetchall()
         else:
             rows = conn.execute(
-                "SELECT id, worker_pid, claim_lock, started_at, current_run_id "
-                "FROM tasks WHERE id = ? AND status = 'running' "
-                "AND worker_pid IS NOT NULL",
+                "SELECT t.id, t.worker_pid, t.worker_identity, t.claim_lock, "
+                "       t.started_at, t.current_run_id, "
+                "       r.worker_identity AS run_worker_identity "
+                "FROM tasks t LEFT JOIN task_runs r ON r.id = t.current_run_id "
+                "WHERE t.id = ? AND t.status = 'running' "
+                "AND t.worker_pid IS NOT NULL",
                 (expected_exit.task_id,),
             ).fetchall()
         host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
@@ -6911,6 +7743,7 @@ def detect_crashed_workers(
                 kind, code = _classify_worker_returncode(expected_exit.returncode)
             else:
                 kind, code = _classify_worker_exit(pid)
+                leader_alive = _pid_alive(pid)
                 if kind == "unknown":
                     # Skip liveness check inside the launch-window grace period
                     # so a freshly-spawned worker isn't reclaimed before its PID
@@ -6922,7 +7755,27 @@ def detect_crashed_workers(
                         grace = _resolve_crash_grace_seconds()
                         if time.time() - started_at < grace:
                             continue
-                    if _pid_alive(pid):
+                    if leader_alive:
+                        continue
+
+                # A generic sweep observes only a numeric PID, not the Popen
+                # object that reaped it.  Once its detached leader is gone,
+                # probe the PID-named original group before release. The task
+                # and active-run identities are loaded above for audit/event
+                # correlation, but a gone or zombie-only group is independently
+                # sufficient proof that no executable descendant survives.
+                # This path intentionally sends no signal: it cannot safely
+                # attribute a leaderless group to us.
+                if not leader_alive:
+                    releasable, group_state = _dead_supervisor_group_is_releasable(pid)
+                    if not releasable:
+                        if _defer_dead_supervisor_crash_reclaim(
+                            conn,
+                            row,
+                            pid,
+                            reason=f"dead_supervisor_{group_state}",
+                        ):
+                            deferred.append(row["id"])
                         continue
 
             rate_limited_exit = False
@@ -6989,7 +7842,7 @@ def detect_crashed_workers(
 
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                "claim_expires = NULL, worker_pid = NULL "
+                "claim_expires = NULL, worker_pid = NULL, worker_identity = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND worker_pid = ? AND claim_lock IS ? "
                 "  AND current_run_id IS ?",
@@ -7133,6 +7986,10 @@ def detect_crashed_workers(
     # Same side-channel for rate-limited requeues — these did NOT count a
     # failure and are NOT crashes, so they stay out of the ``crashed`` return.
     detect_crashed_workers._last_rate_limited = rate_limited  # type: ignore[attr-defined]
+    # A leaderless tree with live/unproven group liveness is neither a crash
+    # nor a rate-limit release. Keep the long-standing list return stable and
+    # expose deferrals through the same side-channel convention.
+    detect_crashed_workers._last_deferred = deferred  # type: ignore[attr-defined]
     return crashed
 
 
@@ -7165,14 +8022,16 @@ def finalize_worker_exit(
                         # PID means the dispatcher died before registration;
                         # bind the observed worker without emitting a second
                         # spawned event, then use the normal crash path.
+                        worker_identity = _supervisor_process_identity(observation.pid)
                         with write_txn(conn):
                             bound = conn.execute(
-                                "UPDATE tasks SET worker_pid = ? "
+                                "UPDATE tasks SET worker_pid = ?, worker_identity = ? "
                                 "WHERE id = ? AND status = 'running' "
                                 "AND worker_pid IS NULL AND claim_lock = ? "
                                 "AND current_run_id = ?",
                                 (
                                     observation.pid,
+                                    worker_identity,
                                     observation.task_id,
                                     observation.claim_lock,
                                     observation.run_id,
@@ -7181,12 +8040,13 @@ def finalize_worker_exit(
                             if bound.rowcount != 1:
                                 return False
                             conn.execute(
-                                "UPDATE task_runs SET worker_pid = ? "
+                                "UPDATE task_runs SET worker_pid = ?, worker_identity = ? "
                                 "WHERE id = ? AND task_id = ? AND status = 'running' "
                                 "AND ended_at IS NULL AND worker_pid IS NULL "
                                 "AND claim_lock = ?",
                                 (
                                     observation.pid,
+                                    worker_identity,
                                     observation.run_id,
                                     observation.task_id,
                                     observation.claim_lock,
@@ -7299,7 +8159,7 @@ def _record_task_failure(
                 # Spawn path: still running, also clear claim state.
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL, worker_identity = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status IN ('running', 'ready')",
                     (failures, error[:500], task_id),
@@ -7347,7 +8207,7 @@ def _record_task_failure(
                 # Spawn path: transition running → ready + clear claim.
                 conn.execute(
                     "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
-                    "claim_expires = NULL, worker_pid = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL, worker_identity = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status = 'running'",
                     (failures, error[:500], task_id),
@@ -7403,12 +8263,15 @@ def _set_worker_pid(
     claim_lock: Optional[str] = None,
     run_id: Optional[int] = None,
 ) -> bool:
-    """CAS-record a supervisor PID and emit exactly one ``spawned`` event.
+    """CAS-record a supervisor PID + incarnation and emit ``spawned`` once.
 
     Production dispatch passes the claim/run values returned by ``claim_task``.
     The optional lookup retains compatibility for direct local callers while
-    applying the same guarded state predicates inside this transaction.
+    applying the same guarded state predicates inside this transaction. Linux
+    start ticks are captured at registration; unavailable platforms store NULL
+    and all later process-tree reclaim paths intentionally fail closed.
     """
+    worker_identity = _supervisor_process_identity(int(pid))
     with write_txn(conn):
         if claim_lock is None or run_id is None:
             row = conn.execute(
@@ -7422,18 +8285,18 @@ def _set_worker_pid(
             run_id = int(row["current_run_id"])
 
         task_cur = conn.execute(
-            "UPDATE tasks SET worker_pid = ? "
+            "UPDATE tasks SET worker_pid = ?, worker_identity = ? "
             "WHERE id = ? AND status = 'running' AND worker_pid IS NULL "
             "AND claim_lock = ? AND current_run_id = ?",
-            (int(pid), task_id, claim_lock, int(run_id)),
+            (int(pid), worker_identity, task_id, claim_lock, int(run_id)),
         )
         if task_cur.rowcount != 1:
             return False
         run_cur = conn.execute(
-            "UPDATE task_runs SET worker_pid = ? "
+            "UPDATE task_runs SET worker_pid = ?, worker_identity = ? "
             "WHERE id = ? AND task_id = ? AND status = 'running' "
             "AND ended_at IS NULL AND worker_pid IS NULL AND claim_lock = ?",
-            (int(pid), int(run_id), task_id, claim_lock),
+            (int(pid), worker_identity, int(run_id), task_id, claim_lock),
         )
         if run_cur.rowcount != 1:
             raise RuntimeError(
@@ -7791,6 +8654,11 @@ def _dispatch_once_locked(
     )
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
+    # Generic leaderless reclaim deferrals leave their claims running; surface
+    # the current invocation's ids without changing the crash-only list return.
+    _crash_deferred = getattr(detect_crashed_workers, "_last_deferred", [])
+    if _crash_deferred:
+        result.deferred.extend(_crash_deferred)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
@@ -8415,9 +9283,14 @@ def _terminate_supervisor_tree(
     """Best-effort stop of a supervisor and every worker it owns.
 
     The supervisor starts a POSIX session, so its process group is safe to
-    terminate as a tree. A direct supervisor signal is insufficient: ordinary
-    children survive when only their parent exits. Windows uses taskkill's
-    tree mode and retains a Popen terminate/kill fallback for constrained hosts.
+    terminate as a tree. This helper is restricted to immediate post-spawn
+    cleanup: every caller has the freshly returned ``Popen``/PID in hand or is
+    handling that same launch's failed publication. It is not a persisted-claim
+    reclaim path; those must use ``_terminate_reclaimed_worker``'s identity
+    verification (or the generic sweeper's leaderless-group proof). A direct
+    supervisor signal is insufficient: ordinary children survive when only
+    their parent exits. Windows uses taskkill's tree mode and retains a Popen
+    terminate/kill fallback for constrained hosts.
     Errors deliberately stay local; callers must preserve their original
     handshake or CAS failure.
     """

--- a/hermes_cli/kanban_worker_supervisor.py
+++ b/hermes_cli/kanban_worker_supervisor.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerLaunchSpec:
+    command: tuple[str, ...]
+    cwd: str | None
+    log_path: str
+    handshake_path: str
+    task_id: str
+    run_id: int
+    claim_lock: str
+    board: str
+
+
+@dataclass(frozen=True, slots=True)
+class InvalidWorkerLaunchSpecError(Exception):
+    field: str
+    expected: str
+
+    def __str__(self) -> str:
+        return f"worker supervisor {self.field} must be {self.expected}"
+
+
+def _read_spec(path: Path) -> WorkerLaunchSpec:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    command = raw["command"]
+    if not isinstance(command, list) or not all(
+        isinstance(part, str) for part in command
+    ):
+        raise InvalidWorkerLaunchSpecError("command", "a list of strings")
+    cwd = raw.get("cwd")
+    if cwd is not None and not isinstance(cwd, str):
+        raise InvalidWorkerLaunchSpecError("cwd", "a string or null")
+    return WorkerLaunchSpec(
+        command=tuple(command),
+        cwd=cwd,
+        log_path=str(raw["log_path"]),
+        handshake_path=str(raw["handshake_path"]),
+        task_id=str(raw["task_id"]),
+        run_id=int(raw["run_id"]),
+        claim_lock=str(raw["claim_lock"]),
+        board=str(raw["board"]),
+    )
+
+
+def _write_supervisor_pid(path: Path, pid: int) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(str(pid))
+        handle.flush()
+
+
+_WORKER_TERMINATE_TIMEOUT_SECONDS = 5.0
+
+
+def _terminate_and_reap_worker(worker: subprocess.Popen[bytes]) -> None:
+    """Stop a worker that cannot be safely registered, preserving the cause."""
+    try:
+        worker.terminate()
+    except OSError:
+        pass
+    try:
+        worker.wait(timeout=_WORKER_TERMINATE_TIMEOUT_SECONDS)
+        return
+    except subprocess.TimeoutExpired:
+        try:
+            worker.kill()
+        except OSError:
+            pass
+    except OSError:
+        return
+    try:
+        worker.wait()
+    except OSError:
+        pass
+
+
+def _supervisor_exit_code(returncode: int) -> int:
+    if returncode >= 0:
+        return min(returncode, 255)
+    return min(128 + abs(returncode), 255)
+
+
+def _install_worker_signal_forwarders(
+    worker: subprocess.Popen[bytes], stopped: list[int],
+) -> dict[int, object]:
+    """Make stop/reclaim signals reach and reap the real worker.
+
+    POSIX dispatch tracks this supervisor PID, not the worker's. Forwarding is
+    therefore required for direct ``kill(supervisor_pid, SIGTERM)`` callers;
+    parent handshake cleanup additionally signals the entire process group.
+    """
+    if sys.platform == "win32":
+        return {}
+
+    old_handlers: dict[int, object] = {}
+
+    def _forward(signum, _frame):
+        # Do not wait here: a signal can interrupt ``worker.wait()`` while its
+        # internal waitpid lock is held, so recursively waiting deadlocks. The
+        # run loop below owns the bounded terminate -> kill -> reap sequence.
+        stopped.append(signum)
+        try:
+            worker.terminate()
+        except OSError:
+            pass
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            old_handlers[sig] = signal.signal(sig, _forward)
+        except (ValueError, OSError):
+            pass
+    return old_handlers
+
+
+def _restore_signal_handlers(old_handlers: dict[int, object]) -> None:
+    for sig, handler in old_handlers.items():
+        try:
+            signal.signal(sig, handler)
+        except (ValueError, OSError):
+            pass
+
+
+def run(spec_path: Path) -> int:
+    spec = _read_spec(spec_path)
+    spec_path.unlink(missing_ok=True)
+
+    with Path(spec.log_path).open("ab") as log_handle:
+        worker = subprocess.Popen(  # noqa: S603
+            list(spec.command),
+            cwd=spec.cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            env=dict(os.environ),
+            creationflags=(
+                subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
+            ),
+        )
+        stopped: list[int] = []
+        old_handlers = _install_worker_signal_forwarders(worker, stopped)
+        try:
+            # The dispatcher intentionally tracks *us*, not this child. We
+            # remain alive until authoritative exit classification is durable,
+            # preventing generic dead-PID detection from racing rate-limit or
+            # clean/protocol semantics.
+            _write_supervisor_pid(Path(spec.handshake_path), os.getpid())
+            terminate_deadline: float | None = None
+            while True:
+                if stopped and terminate_deadline is None:
+                    terminate_deadline = time.monotonic() + _WORKER_TERMINATE_TIMEOUT_SECONDS
+                try:
+                    returncode = worker.wait(timeout=0.1)
+                    break
+                except subprocess.TimeoutExpired:
+                    if terminate_deadline is not None and time.monotonic() >= terminate_deadline:
+                        try:
+                            worker.kill()
+                        except OSError:
+                            pass
+                        returncode = worker.wait()
+                        break
+            if stopped:
+                raise SystemExit(128 + stopped[-1])
+        except Exception:
+            _terminate_and_reap_worker(worker)
+            raise
+        finally:
+            _restore_signal_handlers(old_handlers)
+
+    from hermes_cli import kanban_db as kb
+
+    kb.finalize_worker_exit(
+        kb.WorkerExitObservation(
+            task_id=spec.task_id,
+            run_id=spec.run_id,
+            claim_lock=spec.claim_lock,
+            pid=os.getpid(),
+            returncode=returncode,
+        ),
+        board=spec.board,
+    )
+    return _supervisor_exit_code(returncode)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    try:
+        code = run(Path(sys.argv[1]))
+    except Exception:  # noqa: BLE001  # noqa: BROAD_EXCEPT_OK
+        logging.getLogger(__name__).exception("kanban worker supervisor failed")
+        code = 1
+    raise SystemExit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/hermes_cli/kanban_worker_supervisor.py
+++ b/hermes_cli/kanban_worker_supervisor.py
@@ -62,10 +62,172 @@ def _write_supervisor_pid(path: Path, pid: int) -> None:
 
 
 _WORKER_TERMINATE_TIMEOUT_SECONDS = 5.0
+_WORKER_TREE_TERMINATE_POLL_SECONDS = 0.05
+_IS_WINDOWS = sys.platform == "win32"
+
+
+def _own_fresh_process_group() -> int | None:
+    """Return our session/group only when it is provably the fresh one.
+
+    The dispatcher starts the supervisor in a new session.  Do not turn a
+    publication error into a broad process-group signal when that invariant is
+    absent (for example, a direct unit invocation in an existing shell group).
+    """
+    if _IS_WINDOWS:
+        return None
+    pid = os.getpid()
+    try:
+        pgid = os.getpgid(pid)
+        sid = os.getsid(pid)
+    except (AttributeError, OSError):
+        return None
+    return pgid if pgid == pid == sid else None
+
+
+def _linux_group_has_live_member(pgid: int, *, exclude_pid: int) -> bool | None:
+    """Return executable-member liveness, treating zombies as already dead.
+
+    The supervisor itself is intentionally excluded: it remains alive long
+    enough to preserve the original publication exception and reap its direct
+    child.  Any inaccessible ``/proc`` state is deliberately unproven.
+    """
+    if sys.platform != "linux":
+        return None
+    try:
+        entries = list(os.scandir("/proc"))
+    except OSError:
+        return None
+    for entry in entries:
+        if not entry.name.isdecimal() or int(entry.name) == exclude_pid:
+            continue
+        try:
+            with open(entry.path + "/stat", "r", encoding="utf-8") as handle:
+                raw = handle.read()
+            # After the final ')' the fields are state, ppid, pgrp, ... .
+            close = raw.rfind(")")
+            if close < 0:
+                return None
+            fields = raw[close + 2:].split()
+            if len(fields) >= 3 and int(fields[2]) == pgid and fields[0] != "Z":
+                return True
+        except FileNotFoundError:
+            # A process that exited after /proc enumeration is benign.
+            continue
+        except (PermissionError, OSError, ValueError):
+            # A visible unreadable or malformed member makes emptiness
+            # unprovable; do not collapse it into a zombie-only group.
+            return None
+    return False
+
+
+def _wait_for_owned_group_empty(pgid: int, timeout: float) -> bool:
+    """Wait until no executable peer remains in our exact fresh group."""
+    deadline = time.monotonic() + timeout
+    while True:
+        live = _linux_group_has_live_member(pgid, exclude_pid=os.getpid())
+        if live is False:
+            return True
+        if live is None or time.monotonic() >= deadline:
+            return False
+        time.sleep(_WORKER_TREE_TERMINATE_POLL_SECONDS)
+
+
+def _kill_owned_group_peers(pgid: int) -> bool | None:
+    """Escalate only peers in the supervisor's verified fresh group.
+
+    Returns ``True`` only when the /proc scan was complete; ``None`` means an
+    unreadable or malformed visible peer left group emptiness unproven.
+
+    Calling ``killpg(pgid, SIGKILL)`` from the supervisor would kill the
+    supervisor before it can reap its direct child or re-raise the *original*
+    PID-publication failure.  The group was first proven to be our newly-owned
+    session and received a group TERM.  For the required KILL escalation, kill
+    every remaining peer in that exact group while excluding the supervisor.
+    This has the same tree target without permitting a self-kill race.
+    """
+    if sys.platform != "linux":
+        return None
+    try:
+        entries = list(os.scandir("/proc"))
+    except OSError:
+        return None
+    me = os.getpid()
+    for entry in entries:
+        if not entry.name.isdecimal():
+            continue
+        peer_pid = int(entry.name)
+        if peer_pid == me:
+            continue
+        try:
+            with open(entry.path + "/stat", "r", encoding="utf-8") as handle:
+                raw = handle.read()
+            close = raw.rfind(")")
+            if close < 0:
+                return None
+            fields = raw[close + 2:].split()
+            if len(fields) >= 3 and int(fields[2]) == pgid and fields[0] != "Z":
+                os.kill(peer_pid, signal.SIGKILL)
+        except FileNotFoundError:
+            continue
+        except ProcessLookupError:
+            # A peer that vanished before its signal is a benign exit race.
+            continue
+        except (PermissionError, OSError, ValueError):
+            return None
+    return True
 
 
 def _terminate_and_reap_worker(worker: subprocess.Popen[bytes]) -> None:
     """Stop a worker that cannot be safely registered, preserving the cause."""
+    if _IS_WINDOWS:
+        try:
+            subprocess.run(  # noqa: S603
+                ["taskkill", "/PID", str(worker.pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+        except OSError:
+            pass
+        try:
+            worker.wait(timeout=_WORKER_TERMINATE_TIMEOUT_SECONDS)
+            return
+        except subprocess.TimeoutExpired:
+            try:
+                worker.kill()
+            except OSError:
+                pass
+        except OSError:
+            return
+        try:
+            worker.wait(timeout=_WORKER_TERMINATE_TIMEOUT_SECONDS)
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+        return
+
+    pgid = _own_fresh_process_group()
+    if pgid is not None:
+        try:
+            # Do not group-signal an arbitrary/fake direct worker just because
+            # this interpreter happens to be a session leader (common in test
+            # runners).  The real worker must actually be in our exact group.
+            if os.getpgid(worker.pid) != pgid:
+                pgid = None
+        except (AttributeError, ProcessLookupError, OSError):
+            pgid = None
+    if pgid is not None:
+        # The worker inherits the supervisor's freshly-owned session.  TERM the
+        # exact group first so grandchildren see the shutdown request too.
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except (AttributeError, ProcessLookupError, OSError):
+            pass
+        if not _wait_for_owned_group_empty(pgid, _WORKER_TERMINATE_TIMEOUT_SECONDS):
+            # See _kill_owned_group_peers: self-exclusion is what lets this
+            # function finish the direct-child reap and preserve the original
+            # _write_supervisor_pid exception.
+            _kill_owned_group_peers(pgid)
+            _wait_for_owned_group_empty(pgid, _WORKER_TERMINATE_TIMEOUT_SECONDS)
     try:
         worker.terminate()
     except OSError:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1006,14 +1006,16 @@ def _set_status_direct(
     orphaned. ``running -> ready`` via drag-drop is the common case
     (user yanking a stuck worker back to the queue).
     """
+    # This can be an operator transition off an active detached run. Snapshot
+    # before waiting for TERM/KILL, then carry the exact ownership tuple into
+    # the later CAS.  Holding SQLite's write transaction through the grace
+    # window would block heartbeats; clearing first would orphan work.
+    prev, termination = kanban_db._prepare_operator_active_transition(
+        conn, task_id, operation="dashboard_status",
+    )
+    if prev is None:
+        return False
     with kanban_db.write_txn(conn):
-        # Snapshot current state so we know whether to close a run.
-        prev = conn.execute(
-            "SELECT status, current_run_id FROM tasks WHERE id = ?",
-            (task_id,),
-        ).fetchone()
-        if prev is None:
-            return False
 
         # Guard: don't allow promoting to 'ready' unless all parents are done.
         # Prevents the dispatcher from spawning a child whose upstream work
@@ -1030,28 +1032,30 @@ def _set_status_direct(
             ):
                 return False
 
-        was_running = prev["status"] == "running"
         reopening_satisfied_parent = (
             prev["status"] in {"done", "archived"}
             and new_status not in {"done", "archived"}
         )
+        cas_clause, cas_params = kanban_db._operator_transition_cas_clause(prev)
 
         cur = conn.execute(
             "UPDATE tasks SET status = ?, "
             "  claim_lock = CASE WHEN ? = 'running' THEN claim_lock ELSE NULL END, "
             "  claim_expires = CASE WHEN ? = 'running' THEN claim_expires ELSE NULL END, "
-            "  worker_pid = CASE WHEN ? = 'running' THEN worker_pid ELSE NULL END "
-            "WHERE id = ?",
-            (new_status, new_status, new_status, new_status, task_id),
+            "  worker_pid = CASE WHEN ? = 'running' THEN worker_pid ELSE NULL END, "
+            "  worker_identity = CASE WHEN ? = 'running' THEN worker_identity ELSE NULL END "
+            "WHERE id = ?" + cas_clause,
+            [new_status, new_status, new_status, new_status, new_status, task_id, *cas_params],
         )
         if cur.rowcount != 1:
             return False
         run_id = None
-        if was_running and new_status != "running" and prev["current_run_id"]:
+        if termination is not None and new_status != "running" and prev["current_run_id"]:
             run_id = kanban_db._end_run(
                 conn, task_id,
                 outcome="reclaimed", status="reclaimed",
                 summary=f"status changed to {new_status} (dashboard/direct)",
+                metadata=termination,
             )
         conn.execute(
             "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -50,6 +50,16 @@ def _make_running_again(conn, tid):
     assert kb.claim_task(conn, tid, claimer="worker") is not None
 
 
+def _worker_block(conn, tid, **kwargs):
+    """Model the active worker ending its own current run."""
+    task = kb.get_task(conn, tid)
+    assert task is not None and task.current_run_id is not None
+    return kb.block_task(
+        conn, tid, expected_run_id=task.current_run_id,
+        expected_claim_lock=task.claim_lock, **kwargs,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Loop breaker
 # ---------------------------------------------------------------------------
@@ -58,7 +68,7 @@ def _make_running_again(conn, tid):
 def test_first_typed_block_lands_in_blocked(kanban_home: Path) -> None:
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        assert kb.block_task(conn, tid, reason="which key?", kind="needs_input")
+        assert _worker_block(conn, tid, reason="which key?", kind="needs_input")
         t = kb.get_task(conn, tid)
         assert t.status == "blocked"
         assert t.block_kind == "needs_input"
@@ -69,7 +79,7 @@ def test_unblock_does_not_reset_recurrence_counter(kanban_home: Path) -> None:
     """The crux of the fix: unblock must preserve the loop counter."""
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        kb.block_task(conn, tid, reason="x", kind="needs_input")
+        _worker_block(conn, tid, reason="x", kind="needs_input")
         assert kb.get_task(conn, tid).block_recurrences == 1
         assert kb.unblock_task(conn, tid)
         t = kb.get_task(conn, tid)
@@ -82,10 +92,10 @@ def test_same_cause_reblock_routes_to_triage(kanban_home: Path) -> None:
     """Dale's loop: block → unblock → re-block same kind → triage."""
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        kb.block_task(conn, tid, reason="need creds", kind="needs_input")
+        _worker_block(conn, tid, reason="need creds", kind="needs_input")
         kb.unblock_task(conn, tid)
         _make_running_again(conn, tid)
-        kb.block_task(conn, tid, reason="still need creds", kind="needs_input")
+        _worker_block(conn, tid, reason="still need creds", kind="needs_input")
         t = kb.get_task(conn, tid)
         assert t.status == "triage"
         assert t.block_recurrences == 2
@@ -95,10 +105,10 @@ def test_untyped_block_loop_also_protected(kanban_home: Path) -> None:
     """Legacy un-typed blocks (kind=None) still trip the breaker."""
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        kb.block_task(conn, tid, reason="a")
+        _worker_block(conn, tid, reason="a")
         kb.unblock_task(conn, tid)
         _make_running_again(conn, tid)
-        kb.block_task(conn, tid, reason="a again")
+        _worker_block(conn, tid, reason="a again")
         assert kb.get_task(conn, tid).status == "triage"
 
 
@@ -106,10 +116,10 @@ def test_different_kinds_do_not_compound(kanban_home: Path) -> None:
     """A re-block for a DIFFERENT reason resets the counter to 1."""
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        kb.block_task(conn, tid, reason="a", kind="needs_input")
+        _worker_block(conn, tid, reason="a", kind="needs_input")
         kb.unblock_task(conn, tid)
         _make_running_again(conn, tid)
-        kb.block_task(conn, tid, reason="b", kind="capability")
+        _worker_block(conn, tid, reason="b", kind="capability")
         t = kb.get_task(conn, tid)
         assert t.status == "blocked"
         assert t.block_recurrences == 1
@@ -118,10 +128,10 @@ def test_different_kinds_do_not_compound(kanban_home: Path) -> None:
 def test_block_loop_detected_event_emitted(kanban_home: Path) -> None:
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        kb.block_task(conn, tid, reason="x", kind="capability")
+        _worker_block(conn, tid, reason="x", kind="capability")
         kb.unblock_task(conn, tid)
         _make_running_again(conn, tid)
-        kb.block_task(conn, tid, reason="x", kind="capability")
+        _worker_block(conn, tid, reason="x", kind="capability")
         events = [e for e in kb.list_events(conn, tid)
                   if e.kind == "block_loop_detected"]
         assert events, "expected a block_loop_detected event"
@@ -139,7 +149,7 @@ def test_dependency_block_routes_to_todo(kanban_home: Path) -> None:
     """Dependency waits never enter the human 'blocked' bucket."""
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        assert kb.block_task(conn, tid, reason="need X first", kind="dependency")
+        assert _worker_block(conn, tid, reason="need X first", kind="dependency")
         t = kb.get_task(conn, tid)
         assert t.status == "todo"
         assert t.block_kind == "dependency"
@@ -151,13 +161,17 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
         parent = kb.create_task(conn, title="parent", assignee="worker")
         child = _running_task(conn, title="child")
         kb.link_tasks(conn, parent_id=parent, child_id=child)
-        kb.block_task(conn, child, reason="wait", kind="dependency")
+        _worker_block(conn, child, reason="wait", kind="dependency")
         assert kb.get_task(conn, child).status == "todo"
         # Finish the parent, then let recompute_ready run.
         with kb.write_txn(conn):
             conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,))
-        kb.claim_task(conn, parent, claimer="worker")
-        kb.complete_task(conn, parent, result="done")
+        claimed_parent = kb.claim_task(conn, parent, claimer="worker")
+        assert claimed_parent is not None and claimed_parent.current_run_id is not None
+        assert kb.complete_task(
+            conn, parent, result="done", expected_run_id=claimed_parent.current_run_id,
+            expected_claim_lock=claimed_parent.claim_lock,
+        )
         kb.recompute_ready(conn)
         assert kb.get_task(conn, child).status == "ready"
 
@@ -170,7 +184,7 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
 def test_completion_clears_block_memory(kanban_home: Path) -> None:
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        kb.block_task(conn, tid, reason="x", kind="capability")
+        _worker_block(conn, tid, reason="x", kind="capability")
         kb.unblock_task(conn, tid)
         assert kb.get_task(conn, tid).block_recurrences == 1
         kb.complete_task(conn, tid, result="done")
@@ -189,14 +203,14 @@ def test_invalid_kind_rejected(kanban_home: Path) -> None:
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
         with pytest.raises(ValueError):
-            kb.block_task(conn, tid, reason="x", kind="bogus")
+            _worker_block(conn, tid, reason="x", kind="bogus")
 
 
 def test_block_without_kind_is_backward_compatible(kanban_home: Path) -> None:
     """Existing callers that pass no kind keep the old single-block behaviour."""
     with kb.connect_closing() as conn:
         tid = _running_task(conn)
-        assert kb.block_task(conn, tid, reason="legacy")
+        assert _worker_block(conn, tid, reason="legacy")
         t = kb.get_task(conn, tid)
         assert t.status == "blocked"
         assert t.block_kind is None

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -65,6 +65,7 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             conn, tid,
             reason="review-required: please verify ACL change",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
+            expected_claim_lock=kb.get_task(conn, tid).claim_lock,
         )
         assert kb.get_task(conn, tid).status == "blocked"
 
@@ -91,6 +92,7 @@ def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Pa
             conn, child,
             reason="review-required: child needs sign-off",
             expected_run_id=kb.get_task(conn, child).current_run_id,
+            expected_claim_lock=kb.get_task(conn, child).claim_lock,
         )
         assert kb.get_task(conn, child).status == "blocked"
 
@@ -187,6 +189,7 @@ def test_unblock_clears_sticky_state_and_lets_block_recover(kanban_home: Path) -
             conn, tid,
             reason="review-required: ...",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
+            expected_claim_lock=kb.get_task(conn, tid).claim_lock,
         )
         assert kb.unblock_task(conn, tid)
         # After unblock the task is no longer blocked at all.
@@ -238,6 +241,7 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
             conn, tid,
             reason="review-required: human eyes please",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
+            expected_claim_lock=kb.get_task(conn, tid).claim_lock,
         )
         assert kb.get_task(conn, tid).status == "blocked"
 

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -391,10 +391,16 @@ class TestWorkerSpawnEnv:
 
         class FakeProc:
             pid = 12345
+            returncode = None
+
+            def poll(self):
+                return self.returncode
 
         def fake_popen(cmd, *args, **kwargs):
-            captured["cmd"] = cmd
+            spec = json.loads(Path(cmd[-1]).read_text(encoding="utf-8"))
+            captured["cmd"] = spec["command"]
             captured["env"] = kwargs.get("env", {})
+            Path(spec["handshake_path"]).write_text("12345", encoding="utf-8")
             return FakeProc()
 
         monkeypatch.setattr(subprocess, "Popen", fake_popen)
@@ -405,7 +411,7 @@ class TestWorkerSpawnEnv:
             title="worker test",
             body=None,
             assignee="teknium",
-            status="ready",
+            status="running",
             priority=0,
             created_by="user",
             created_at=0,
@@ -413,9 +419,10 @@ class TestWorkerSpawnEnv:
             completed_at=None,
             workspace_kind="scratch",
             workspace_path=None,
-            claim_lock=None,
+            claim_lock="test-host:claim",
             claim_expires=None,
             tenant=None,
+            current_run_id=1,
         )
 
         kb._default_spawn(task, str(fresh_home / "ws"), board="spawntest")
@@ -434,9 +441,15 @@ class TestWorkerSpawnEnv:
 
         class FakeProc:
             pid = 1
+            returncode = None
+
+            def poll(self):
+                return self.returncode
 
         def fake_popen(cmd, *args, **kwargs):
+            spec = json.loads(Path(cmd[-1]).read_text(encoding="utf-8"))
             captured["env"] = kwargs.get("env", {})
+            Path(spec["handshake_path"]).write_text("1", encoding="utf-8")
             return FakeProc()
 
         monkeypatch.setattr(subprocess, "Popen", fake_popen)
@@ -445,7 +458,7 @@ class TestWorkerSpawnEnv:
             title="",
             body=None,
             assignee="teknium",
-            status="ready",
+            status="running",
             priority=0,
             created_by=None,
             created_at=0,
@@ -453,9 +466,10 @@ class TestWorkerSpawnEnv:
             completed_at=None,
             workspace_kind="scratch",
             workspace_path=None,
-            claim_lock=None,
+            claim_lock="test-host:claim",
             claim_expires=None,
             tenant=None,
+            current_run_id=1,
         )
         kb._default_spawn(task, str(fresh_home / "ws"), board=None)
         env = captured["env"]

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -24,9 +24,96 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+def _set_worker_capability(monkeypatch, task_id, claimed, *, board="default", run_id=None, lock=None):
+    """Install the dispatcher capability shape used by CLI worker commands."""
+    assert claimed.current_run_id is not None
+    assert claimed.claim_lock is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", board)
+    monkeypatch.setenv(
+        "HERMES_KANBAN_RUN_ID", str(claimed.current_run_id if run_id is None else run_id),
+    )
+    monkeypatch.setenv(
+        "HERMES_KANBAN_CLAIM_LOCK", claimed.claim_lock if lock is None else lock,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Workspace flag parsing
 # ---------------------------------------------------------------------------
+
+
+def test_worker_run_id_rejects_raw_stale_or_incomplete_capability(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="capability", assignee="worker")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+
+    _set_worker_capability(monkeypatch, task_id, claimed, run_id=claimed.current_run_id + 1)
+    assert kc._worker_run_id_for(task_id) is None
+
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK")
+    assert kc._worker_run_id_for(task_id) is None
+
+    _set_worker_capability(monkeypatch, task_id, claimed, lock="wrong-lock")
+    assert kc._worker_run_id_for(task_id) is None
+
+
+def test_worker_run_id_rejects_board_mismatch_and_later_run(kanban_home, monkeypatch):
+    kb.create_board("other-board")
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="capability", assignee="worker")
+        first = kb.claim_task(conn, task_id)
+        assert first is not None and first.current_run_id is not None
+        # Model a completed old attempt then a fresh dispatcher claim.
+        conn.execute(
+            "UPDATE task_runs SET status='done', ended_at=? WHERE id=?",
+            (1, first.current_run_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET status='ready', claim_lock=NULL, claim_expires=NULL, "
+            "current_run_id=NULL WHERE id=?",
+            (task_id,),
+        )
+        second = kb.claim_task(conn, task_id)
+        assert second is not None
+
+    _set_worker_capability(monkeypatch, task_id, second, board="other-board")
+    assert kc._worker_run_id_for(task_id) is None
+
+    _set_worker_capability(monkeypatch, task_id, second, run_id=first.current_run_id)
+    assert kc._worker_run_id_for(task_id) is None
+
+
+def test_cli_worker_heartbeat_requires_capability_before_lease_extension(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="heartbeat", assignee="worker")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None and claimed.current_run_id is not None
+        conn.execute(
+            "UPDATE tasks SET claim_expires=? WHERE id=?",
+            (1, task_id),
+        )
+        conn.execute(
+            "UPDATE task_runs SET claim_expires=? WHERE id=?",
+            (1, claimed.current_run_id),
+        )
+
+    _set_worker_capability(monkeypatch, task_id, claimed, run_id=claimed.current_run_id + 100)
+    assert kc._cmd_heartbeat(argparse.Namespace(task_id=task_id, note="stale")) == 1
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        run = kb.get_run(conn, claimed.current_run_id)
+        assert task is not None and task.claim_expires == 1
+        assert run is not None and run.claim_expires == 1
+
+    _set_worker_capability(monkeypatch, task_id, claimed)
+    assert kc._cmd_heartbeat(argparse.Namespace(task_id=task_id, note="valid")) == 0
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        run = kb.get_run(conn, claimed.current_run_id)
+        assert task is not None and task.claim_expires is not None and task.claim_expires > 1
+        assert run is not None and run.claim_expires == task.claim_expires
 
 @pytest.mark.parametrize(
     "value,expected",
@@ -149,14 +236,19 @@ def test_run_slash_comment_max_len_trims_long_body(kanban_home):
     assert "x" * 30 not in show
 
 
-def test_run_slash_block_unblock_cycle(kanban_home):
+def test_run_slash_manual_block_refuses_unregistered_running_task(kanban_home):
     out = kc.run_slash("create 'x' --assignee alice")
     import re
     tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
-    # Claim first so block() finds it running
+    # A slash command is an operator action. It must not clear an active claim
+    # while no registered worker tree can be proven gone.
     kc.run_slash(f"claim {tid}")
-    assert "Blocked" in kc.run_slash(f"block {tid} 'need decision'")
-    assert "Unblocked" in kc.run_slash(f"unblock {tid}")
+    assert "cannot block" in kc.run_slash(f"block {tid} 'need decision'")
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "running"
+        assert task.claim_lock is not None
 
 
 def test_run_slash_json_output(kanban_home):
@@ -368,7 +460,7 @@ def test_kanban_not_gateway_only():
 # reclaim + reassign CLI smoke tests
 # ---------------------------------------------------------------------------
 
-def test_run_slash_reclaim_running_task(kanban_home):
+def test_run_slash_reclaim_refuses_unverifiable_running_task(kanban_home):
     import re
     import time
     import secrets
@@ -400,13 +492,14 @@ def test_run_slash_reclaim_running_task(kanban_home):
         conn.close()
 
     out = kc.run_slash(f"reclaim {tid} --reason 'test'")
-    assert "Reclaimed" in out, out
-    # Status back to ready.
-    out2 = kc.run_slash(f"show {tid}")
-    assert "ready" in out2.lower()
+    assert "cannot reclaim" in out, out
+    # This legacy fixture has no host-local, identity-verifiable detached
+    # supervisor.  Retain it rather than pretending a numeric PID is proof.
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "running"
 
 
-def test_run_slash_reassign_with_reclaim_flag(kanban_home):
+def test_run_slash_reassign_with_reclaim_refuses_unverifiable_running_task(kanban_home):
     import re
     import time
     import secrets
@@ -437,9 +530,11 @@ def test_run_slash_reassign_with_reclaim_flag(kanban_home):
         conn.close()
 
     out = kc.run_slash(f"reassign {tid} newbie --reclaim --reason 'switch'")
-    assert "Reassigned" in out, out
-    out2 = kc.run_slash(f"show {tid}")
-    assert "newbie" in out2
+    assert "cannot reassign" in out, out
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        assert task.status == "running"
+        assert task.assignee == "orig"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1435,6 +1435,7 @@ def test_run_closed_on_complete_with_summary(kanban_home):
             result="shipped",
             summary="implemented rate limiter, tests pass",
             metadata={"changed_files": ["limiter.py"], "tests_run": 12},
+            expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock,
         )
         assert ok is True
 
@@ -1461,7 +1462,7 @@ def test_run_summary_falls_back_to_result(kanban_home):
     try:
         tid = kb.create_task(conn, title="x", assignee="worker")
         kb.claim_task(conn, tid)
-        kb.complete_task(conn, tid, result="only-arg")
+        kb.complete_task(conn, tid, result="only-arg", expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
         r = kb.latest_run(conn, tid)
         assert r.summary == "only-arg"
     finally:
@@ -1477,8 +1478,10 @@ def test_multiple_attempts_preserved_as_runs(kanban_home):
         tid = kb.create_task(conn, title="x", assignee="worker")
 
         # Attempt 1: claim then force the claim to be stale by backdating
-        # claim_expires, then let release_stale_claims reclaim it.
+        # claim_expires, then use the deterministic termination seam to
+        # model a positively-proven worker exit before stale release.
         kb.claim_task(conn, tid)
+        kb._set_worker_pid(conn, tid, 98764)
         with kb.write_txn(conn):
             conn.execute(
                 "UPDATE tasks SET claim_expires = ? WHERE id = ?",
@@ -1488,7 +1491,7 @@ def test_multiple_attempts_preserved_as_runs(kanban_home):
                 "UPDATE task_runs SET claim_expires = ? WHERE task_id = ?",
                 (int(time.time()) - 10, tid),
             )
-        kb.release_stale_claims(conn)
+        kb.release_stale_claims(conn, signal_fn=lambda _pid, _sig: None)
 
         # Attempt 2: claim then crash (simulated: pid dead).
         kb.claim_task(conn, tid)
@@ -1502,7 +1505,7 @@ def test_multiple_attempts_preserved_as_runs(kanban_home):
 
         # Attempt 3: claim then complete.
         kb.claim_task(conn, tid)
-        kb.complete_task(conn, tid, result="finally")
+        kb.complete_task(conn, tid, result="finally", expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
 
         runs = kb.list_runs(conn, tid)
         assert len(runs) == 3
@@ -1535,7 +1538,7 @@ def test_stale_run_cannot_complete_new_attempt(kanban_home, monkeypatch):
             conn,
             tid,
             summary="late stale completion",
-            expected_run_id=run1.id,
+            expected_run_id=run1.id, expected_claim_lock=kb.get_task(conn, tid).claim_lock,
         )
         task = kb.get_task(conn, tid)
         assert task.status == "running"
@@ -1545,7 +1548,7 @@ def test_stale_run_cannot_complete_new_attempt(kanban_home, monkeypatch):
             conn,
             tid,
             summary="current completion",
-            expected_run_id=run2.id,
+            expected_run_id=run2.id, expected_claim_lock=kb.get_task(conn, tid).claim_lock,
         )
         runs = kb.list_runs(conn, tid)
         assert [r.outcome for r in runs] == ["crashed", "completed"]
@@ -1572,16 +1575,89 @@ def test_stale_run_cannot_block_or_heartbeat_new_attempt(kanban_home, monkeypatc
         run2 = kb.latest_run(conn, tid)
         assert run2.id != run1.id
 
-        assert not kb.heartbeat_worker(conn, tid, note="late", expected_run_id=run1.id)
-        assert not kb.block_task(conn, tid, reason="late block", expected_run_id=run1.id)
+        assert not kb.heartbeat_worker(conn, tid, note="late", expected_run_id=run1.id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
+        assert not kb.block_task(conn, tid, reason="late block", expected_run_id=run1.id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
         task = kb.get_task(conn, tid)
         assert task.status == "running"
         assert task.current_run_id == run2.id
         assert task.last_heartbeat_at is None
 
-        assert kb.heartbeat_worker(conn, tid, note="current", expected_run_id=run2.id)
-        assert kb.block_task(conn, tid, reason="current block", expected_run_id=run2.id)
+        assert kb.heartbeat_worker(conn, tid, note="current", expected_run_id=run2.id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
+        assert kb.block_task(conn, tid, reason="current block", expected_run_id=run2.id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
         assert kb.get_task(conn, tid).status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_heartbeat_worker_scoped_capability_contract(kanban_home, monkeypatch):
+    """A scoped heartbeat needs the full run-id + claim-lock capability.
+
+    Half a capability (run id without lock, or a lock that doesn't match
+    the active claim, or a stale run id) must refuse without touching
+    ``last_heartbeat_at`` on either the task or the run and without
+    appending a heartbeat event. Only the current run + current lock
+    pair heartbeats.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    def _heartbeat_state(conn, tid):
+        task = kb.get_task(conn, tid)
+        run = kb.latest_run(conn, tid)
+        events = [e for e in kb.list_events(conn, tid) if e.kind == "heartbeat"]
+        return task.last_heartbeat_at, run.last_heartbeat_at, len(events)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="scoped heartbeat contract", assignee="worker")
+
+        # Build a genuinely stale run id: crash attempt 1, reclaim as
+        # attempt 2 (mirrors test_stale_run_cannot_block_or_heartbeat_new_attempt).
+        kb.claim_task(conn, tid)
+        run1 = kb.latest_run(conn, tid)
+        kb._set_worker_pid(conn, tid, 98765)
+        monkeypatch.setattr(_kb, "_pid_alive", lambda pid: False)
+        assert kb.detect_crashed_workers(conn) == [tid]
+        kb.claim_task(conn, tid)
+        run2 = kb.latest_run(conn, tid)
+        assert run2.id != run1.id
+        lock = kb.get_task(conn, tid).claim_lock
+        assert lock
+
+        before = _heartbeat_state(conn, tid)
+
+        # Run id alone is an identifier, not a capability.
+        assert not kb.heartbeat_worker(conn, tid, expected_run_id=run2.id)
+        assert not kb.heartbeat_worker(
+            conn, tid, expected_run_id=run2.id, expected_claim_lock="",
+        )
+        # A lock alone (no run id) is the other half — also refused.
+        assert not kb.heartbeat_worker(conn, tid, expected_claim_lock=lock)
+        # Wrong lock with the current run id.
+        assert not kb.heartbeat_worker(
+            conn, tid, expected_run_id=run2.id, expected_claim_lock="host:forged",
+        )
+        # Stale run id with the *current* lock: refusal is specifically
+        # a run mismatch, not a lock problem.
+        assert not kb.heartbeat_worker(
+            conn, tid, expected_run_id=run1.id, expected_claim_lock=lock,
+        )
+
+        # Every refusal above left both heartbeat timestamps and the
+        # event log untouched.
+        assert _heartbeat_state(conn, tid) == before
+        assert before[0] is None and before[1] is None and before[2] == 0
+
+        # The full, current capability succeeds and records everywhere.
+        assert kb.heartbeat_worker(
+            conn, tid, note="alive",
+            expected_run_id=run2.id, expected_claim_lock=lock,
+        )
+        task_hb, run_hb, hb_events = _heartbeat_state(conn, tid)
+        assert task_hb is not None
+        assert run_hb is not None
+        assert hb_events == 1
+        hb = [e for e in kb.list_events(conn, tid) if e.kind == "heartbeat"][0]
+        assert hb.run_id == run2.id
     finally:
         conn.close()
 
@@ -1591,7 +1667,7 @@ def test_run_on_block_with_reason(kanban_home):
     try:
         tid = kb.create_task(conn, title="x", assignee="worker")
         kb.claim_task(conn, tid)
-        kb.block_task(conn, tid, reason="needs API key")
+        kb.block_task(conn, tid, reason="needs API key", expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
 
         r = kb.latest_run(conn, tid)
         assert r.outcome == "blocked"
@@ -1634,7 +1710,7 @@ def test_event_rows_carry_run_id(kanban_home):
         # task-scoped: 'created' — no run yet
         # run-scoped: 'claimed' + 'completed'
         kb.claim_task(conn, tid)
-        kb.complete_task(conn, tid, result="ok")
+        kb.complete_task(conn, tid, result="ok", expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
 
         rows = conn.execute(
             "SELECT kind, run_id FROM task_events WHERE task_id = ? ORDER BY id",
@@ -1659,7 +1735,7 @@ def test_build_worker_context_includes_prior_attempts(kanban_home):
 
         # Attempt 1: blocked with a reason.
         kb.claim_task(conn, tid)
-        kb.block_task(conn, tid, reason="needs clarification on IP vs user_id")
+        kb.block_task(conn, tid, reason="needs clarification on IP vs user_id", expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
         kb.unblock_task(conn, tid)
 
         # Attempt 2: claim (but don't complete yet) and read the context
@@ -1690,6 +1766,8 @@ def test_build_worker_context_uses_parent_run_summary(kanban_home):
             result="done",
             summary="three angles explored; B looks strongest",
             metadata={"sources": ["paper A", "paper B", "paper C"]},
+            expected_run_id=kb.latest_run(conn, parent).id,
+            expected_claim_lock=kb.get_task(conn, parent).claim_lock,
         )
 
         # child becomes ready via recompute_ready (runs inside complete_task)
@@ -1739,6 +1817,8 @@ def test_build_worker_context_stamps_parent_freshness(kanban_home):
             conn, parent,
             result="done",
             summary="meeting ingest workflow finished; pipeline ready",
+            expected_run_id=kb.latest_run(conn, parent).id,
+            expected_claim_lock=kb.get_task(conn, parent).claim_lock,
         )
         # Backdate the parent's completion to 18h ago — both the task row
         # and its completed run row, which is where build_worker_context
@@ -1796,7 +1876,11 @@ def test_migration_backfills_inflight_run_for_legacy_db(kanban_home):
             assert task.current_run_id == runs[0].id
 
             # Subsequent complete closes the backfilled run cleanly.
-            kb.complete_task(conn2, tid, result="done", summary="ok")
+            kb.complete_task(
+                conn2, tid, result="done", summary="ok",
+                expected_run_id=runs[0].id,
+                expected_claim_lock=kb.get_task(conn2, tid).claim_lock,
+            )
             r = kb.latest_run(conn2, tid)
             assert r.outcome == "completed"
             assert r.summary == "ok"
@@ -1832,7 +1916,7 @@ def test_cli_runs_verb(kanban_home):
     try:
         tid = kb.create_task(conn, title="x", assignee="worker")
         kb.claim_task(conn, tid)
-        kb.complete_task(conn, tid, result="ok", summary="shipped")
+        kb.complete_task(conn, tid, result="ok", summary="shipped", expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
     finally:
         conn.close()
     out = run_slash(f"runs {tid}")
@@ -1849,6 +1933,7 @@ def test_cli_runs_json(kanban_home):
         kb.complete_task(
             conn, tid, result="ok", summary="shipped",
             metadata={"files": 1},
+            expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock,
         )
     finally:
         conn.close()
@@ -1859,7 +1944,7 @@ def test_cli_runs_json(kanban_home):
     assert data[0]["metadata"] == {"files": 1}
 
 
-def test_cli_complete_with_summary_and_metadata(kanban_home):
+def test_cli_complete_with_summary_and_metadata_refuses_unregistered_running_launch(kanban_home):
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="x", assignee="worker")
@@ -1871,14 +1956,15 @@ def test_cli_complete_with_summary_and_metadata(kanban_home):
     out = run_slash(
         "complete " + tid + " --summary \"done it\" --metadata '" + meta + "'"
     )
-    assert "Completed" in out
+    assert "cannot complete" in out
     conn = kb.connect()
     try:
         r = kb.latest_run(conn, tid)
     finally:
         conn.close()
-    assert r.summary == "done it"
-    assert r.metadata == {"files": 3}
+    assert r.ended_at is None
+    assert r.summary is None
+    assert r.metadata is None
 
 
 def test_cli_edit_backfills_result_on_done_task(kanban_home):
@@ -1938,9 +2024,8 @@ def test_cli_complete_bad_metadata_exits_nonzero(kanban_home):
 # Integration hardening (Apr 2026 audit fixes)
 # -------------------------------------------------------------------------
 
-def test_archive_of_running_task_closes_run(kanban_home):
-    """Archiving a claimed task must close the in-flight run with
-    outcome='reclaimed', not orphan it."""
+def test_archive_of_running_task_without_registered_pid_defers(kanban_home):
+    """An unregistered launch window cannot be archived blind."""
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="x", assignee="worker")
@@ -1949,15 +2034,21 @@ def test_archive_of_running_task_closes_run(kanban_home):
         assert run.ended_at is None
         open_run_id = run.id
 
-        assert kb.archive_task(conn, tid) is True
+        assert kb.archive_task(conn, tid) is False
 
         task = kb.get_task(conn, tid)
-        assert task.status == "archived"
-        assert task.current_run_id is None
-        # The previously-active run must now be closed.
+        assert task is not None
+        assert task.status == "running"
+        assert task.current_run_id == open_run_id
+        # The active attempt and ownership remain intact until a worker tree
+        # can be registered and proven gone.
         closed = kb.get_run(conn, open_run_id)
-        assert closed.ended_at is not None
-        assert closed.outcome == "reclaimed"
+        assert closed is not None
+        assert closed.ended_at is None
+        deferred = [e for e in kb.list_events(conn, tid) if e.kind == "reclaim_deferred"]
+        assert len(deferred) == 1
+        assert deferred[0].payload is not None
+        assert deferred[0].payload["identity"] == "worker_pid_missing"
     finally:
         conn.close()
 
@@ -1975,8 +2066,8 @@ def test_archive_of_ready_task_does_not_create_spurious_run(kanban_home):
         conn.close()
 
 
-def test_dashboard_direct_status_change_off_running_closes_run(kanban_home):
-    """Dashboard drag-drop running->ready must close the active run.
+def test_dashboard_direct_status_change_off_unregistered_running_defers(kanban_home):
+    """Dashboard drag-drop preserves an unregistered running launch.
 
     Importing _set_status_direct directly to simulate the PATCH handler
     without spinning up FastAPI.
@@ -1991,15 +2082,13 @@ def test_dashboard_direct_status_change_off_running_closes_run(kanban_home):
         assert open_run.ended_at is None
         prev_run_id = open_run.id
 
-        # Simulate yanking the worker back to the queue.
-        assert _set_status_direct(conn, tid, "ready") is True
+        assert _set_status_direct(conn, tid, "ready") is False
 
         task = kb.get_task(conn, tid)
-        assert task.status == "ready"
-        assert task.current_run_id is None
+        assert task.status == "running"
+        assert task.current_run_id == prev_run_id
         closed = kb.get_run(conn, prev_run_id)
-        assert closed.ended_at is not None
-        assert closed.outcome == "reclaimed"
+        assert closed.ended_at is None
     finally:
         conn.close()
 
@@ -2050,8 +2139,8 @@ def test_cli_bulk_complete_with_summary_rejects(kanban_home):
         conn.close()
 
 
-def test_cli_bulk_complete_without_summary_still_works(kanban_home):
-    """Bulk close with no per-task handoff is allowed — the common case."""
+def test_cli_bulk_complete_refuses_unregistered_running_launches(kanban_home):
+    """Manual bulk close cannot clear launch-window ownership blind."""
     conn = kb.connect()
     try:
         a = kb.create_task(conn, title="a", assignee="worker")
@@ -2060,8 +2149,8 @@ def test_cli_bulk_complete_without_summary_still_works(kanban_home):
     finally:
         conn.close()
     out = run_slash(f"complete {a} {b}")
-    assert f"Completed {a}" in out
-    assert f"Completed {b}" in out
+    assert f"cannot complete {a}" in out
+    assert f"cannot complete {b}" in out
 
 
 def test_completed_event_payload_carries_summary(kanban_home):
@@ -2072,7 +2161,7 @@ def test_completed_event_payload_carries_summary(kanban_home):
         tid = kb.create_task(conn, title="x", assignee="worker")
         kb.claim_task(conn, tid)
         kb.complete_task(conn, tid, summary="handoff line 1\nextra",
-                         metadata={"n": 3})
+                         metadata={"n": 3}, expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
         events = kb.list_events(conn, tid)
         comp = [e for e in events if e.kind == "completed"]
         assert len(comp) == 1
@@ -2088,7 +2177,7 @@ def test_completed_event_payload_summary_none_when_missing(kanban_home):
     try:
         tid = kb.create_task(conn, title="x", assignee="worker")
         kb.claim_task(conn, tid)
-        kb.complete_task(conn, tid)  # no summary, no result
+        kb.complete_task(conn, tid, expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)  # no summary, no result
         events = kb.list_events(conn, tid)
         comp = [e for e in events if e.kind == "completed"][0]
         assert comp.payload.get("summary") is None
@@ -2176,7 +2265,10 @@ def test_event_dataclass_carries_run_id(kanban_home):
         tid = kb.create_task(conn, title="x", assignee="worker")
         kb.claim_task(conn, tid)
         run_id = kb.latest_run(conn, tid).id
-        kb.complete_task(conn, tid, summary="done")
+        kb.complete_task(
+            conn, tid, summary="done", expected_run_id=run_id,
+            expected_claim_lock=kb.get_task(conn, tid).claim_lock,
+        )
 
         events = kb.list_events(conn, tid)
         kinds_with_run = {
@@ -2203,7 +2295,10 @@ def test_unseen_events_for_sub_includes_run_id(kanban_home):
         )
         kb.claim_task(conn, tid)
         run_id = kb.latest_run(conn, tid).id
-        kb.complete_task(conn, tid, summary="notify-ready")
+        kb.complete_task(
+            conn, tid, summary="notify-ready", expected_run_id=run_id,
+            expected_claim_lock=kb.get_task(conn, tid).claim_lock,
+        )
 
         cursor, events = kb.unseen_events_for_sub(
             conn, task_id=tid, platform="telegram",
@@ -2307,7 +2402,7 @@ def test_cli_show_json_carries_runs(kanban_home):
     try:
         tid = kb.create_task(conn, title="show test", assignee="worker")
         kb.claim_task(conn, tid)
-        kb.complete_task(conn, tid, summary="inspected")
+        kb.complete_task(conn, tid, summary="inspected", expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
     finally:
         conn.close()
 
@@ -2375,7 +2470,7 @@ def test_unblock_normal_path_no_spurious_run(kanban_home):
     try:
         tid = kb.create_task(conn, title="normal unblock", assignee="worker")
         kb.claim_task(conn, tid)
-        kb.block_task(conn, tid, reason="pause")
+        kb.block_task(conn, tid, reason="pause", expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
         runs_before = len(kb.list_runs(conn, tid))
         assert kb.unblock_task(conn, tid) is True
         runs_after = len(kb.list_runs(conn, tid))
@@ -2440,7 +2535,7 @@ def test_build_worker_context_includes_role_history(kanban_home):
         ]):
             tid = kb.create_task(conn, title=title, assignee="reviewer")
             kb.claim_task(conn, tid)
-            kb.complete_task(conn, tid, summary=summary)
+            kb.complete_task(conn, tid, summary=summary, expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
 
         # Now a NEW task for reviewer, not yet done
         new_tid = kb.create_task(
@@ -2479,7 +2574,7 @@ def test_build_worker_context_role_history_bounded_to_5(kanban_home):
                 conn, title=f"prior #{i}", assignee="worker",
             )
             kb.claim_task(conn, tid)
-            kb.complete_task(conn, tid, summary=f"done #{i}")
+            kb.complete_task(conn, tid, summary=f"done #{i}", expected_run_id=kb.latest_run(conn, tid).id, expected_claim_lock=kb.get_task(conn, tid).claim_lock)
 
         new_tid = kb.create_task(conn, title="new", assignee="worker")
         ctx = kb.build_worker_context(conn, new_tid)
@@ -3998,6 +4093,8 @@ def test_complete_can_retry_after_phantom_rejection(kanban_home):
             conn, parent_a,
             summary="retry without claims",
             created_cards=[],
+            expected_run_id=kb.latest_run(conn, parent_a).id,
+            expected_claim_lock=kb.get_task(conn, parent_a).claim_lock,
         )
         assert ok is True
         assert kb.get_task(conn, parent_a).status == "done"
@@ -4016,6 +4113,8 @@ def test_complete_can_retry_after_phantom_rejection(kanban_home):
             conn, parent_b,
             summary="retry with corrected list",
             created_cards=[real],
+            expected_run_id=kb.latest_run(conn, parent_b).id,
+            expected_claim_lock=kb.get_task(conn, parent_b).claim_lock,
         )
         assert ok is True
         assert kb.get_task(conn, parent_b).status == "done"
@@ -4190,9 +4289,8 @@ def test_reassign_task_refuses_running_without_reclaim_first(kanban_home):
         conn.close()
 
 
-def test_reassign_task_with_reclaim_first_switches_profile(kanban_home):
-    """With ``reclaim_first=True``, a running task is reclaimed and
-    reassigned in one operation."""
+def test_reassign_task_with_reclaim_first_defers_unverifiable_worker(kanban_home):
+    """Synthetic/unverifiable ownership cannot be reclaimed for reassignment."""
     import time
     import secrets
     conn = kb.connect()
@@ -4217,13 +4315,10 @@ def test_reassign_task_with_reclaim_first_switches_profile(kanban_home):
         assert kb.reassign_task(
             conn, t, "new-profile",
             reclaim_first=True, reason="switch model",
-        ) is True
-
-        row = conn.execute(
-            "SELECT assignee, status FROM tasks WHERE id=?", (t,),
-        ).fetchone()
-        assert row["assignee"] == "new-profile"
-        assert row["status"] == "ready"
+        ) is False
+        task = kb.get_task(conn, t)
+        assert task.assignee == "orig"
+        assert task.status == "running"
     finally:
         conn.close()
 
@@ -4666,9 +4761,8 @@ def test_detect_crashed_workers_nonzero_exit_uses_default_limit(kanban_home):
         conn.close()
 
 
-def test_reclaim_task_clears_failure_counter(kanban_home):
-    """Operator reclaim wipes the counter so the next retry gets a fresh
-    budget."""
+def test_reclaim_task_defers_unverifiable_worker_without_clearing_counter(kanban_home):
+    """An unsafe operator reclaim retains ownership and failure accounting."""
     import secrets
     conn = kb.connect()
     try:
@@ -4694,12 +4788,11 @@ def test_reclaim_task_clears_failure_counter(kanban_home):
             )
 
         ok = kb.reclaim_task(conn, tid, reason="operator fixed config")
-        assert ok
-
+        assert not ok
         task = kb.get_task(conn, tid)
-        assert task.consecutive_failures == 0
-        assert task.last_failure_error is None
-        assert task.status == "ready"
+        assert task.status == "running"
+        assert task.consecutive_failures == 4
+        assert task.last_failure_error == "prior issue"
     finally:
         conn.close()
 
@@ -4709,6 +4802,30 @@ def test_dispatch_once_integrates_stale_detection(kanban_home, monkeypatch):
     import hermes_cli.kanban_db as _kb
 
     monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    # The synthetic PID cannot be inspected through /proc. Publish a stable
+    # test incarnation and make the termination seam assert the same binding
+    # reaches reclaim; production still requires a real identity before it can
+    # signal a process tree.
+    monkeypatch.setattr(
+        _kb, "_supervisor_process_identity", lambda _pid: "fixture-incarnation",
+    )
+
+    def _terminated_fixture_worker(
+        _pid,
+        _lock,
+        *,
+        worker_identity=None,
+        run_worker_identity=None,
+        run_worker_pid=None,
+        run_claim_lock=None,
+        signal_fn=None,
+    ):
+        assert worker_identity == run_worker_identity == "fixture-incarnation"
+        assert run_worker_pid == _pid
+        assert run_claim_lock == _lock
+        return {"terminated": True}
+
+    monkeypatch.setattr(_kb, "_terminate_reclaimed_worker", _terminated_fixture_worker)
 
     with kb.connect() as conn:
         t = kb.create_task(conn, title="stale-dispatch", assignee="worker")

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2765,6 +2765,29 @@ def test_build_worker_context_caps_huge_summary(kanban_home):
         conn.close()
 
 
+def _capture_supervised_worker_launch(monkeypatch, captured, *, pid):
+    class FakeSupervisor:
+        returncode = None
+
+        def __init__(self):
+            self.pid = pid
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        spec = json.loads(Path(cmd[-1]).read_text(encoding="utf-8"))
+        captured["cmd"] = spec["command"]
+        captured["env"] = kwargs.get("env", {})
+        Path(spec["handshake_path"]).write_text(str(pid), encoding="utf-8")
+        return FakeSupervisor()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+
 def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
     """The dispatcher no longer auto-loads a bundled kanban skill.
 
@@ -2778,22 +2801,14 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
     """
     captured = {}
 
-    class FakeProc:
-        def __init__(self):
-            self.pid = 99999
-
-    def fake_popen(cmd, **kwargs):
-        captured["cmd"] = cmd
-        captured["env"] = kwargs.get("env", {})
-        return FakeProc()
-
-    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    _capture_supervised_worker_launch(monkeypatch, captured, pid=99999)
 
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="skill-loading test",
                              assignee="some-profile")
-        task = kb.get_task(conn, tid)
+        task = kb.claim_task(conn, tid)
+        assert task is not None
         workspace = kb.resolve_workspace(task)
         pid = kb._default_spawn(task, str(workspace))
         assert pid == 99999
@@ -2824,14 +2839,7 @@ def test_default_spawn_raises_terminal_timeout_to_task_runtime(kanban_home, monk
     """
     captured = {}
 
-    class FakeProc:
-        pid = 123
-
-    def fake_popen(cmd, **kwargs):
-        captured["env"] = kwargs.get("env", {})
-        return FakeProc()
-
-    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    _capture_supervised_worker_launch(monkeypatch, captured, pid=123)
     monkeypatch.setenv("TERMINAL_TIMEOUT", "180")
     monkeypatch.delenv("TERMINAL_MAX_FOREGROUND_TIMEOUT", raising=False)
 
@@ -2843,7 +2851,8 @@ def test_default_spawn_raises_terminal_timeout_to_task_runtime(kanban_home, monk
             assignee="ops",
             max_runtime_seconds=3600,
         )
-        task = kb.get_task(conn, tid)
+        task = kb.claim_task(conn, tid)
+        assert task is not None
         workspace = kb.resolve_workspace(task)
         kb._default_spawn(task, str(workspace))
     finally:
@@ -2858,14 +2867,7 @@ def test_default_spawn_preserves_longer_terminal_timeout(kanban_home, monkeypatc
     """Kanban should never lower an explicitly larger terminal timeout."""
     captured = {}
 
-    class FakeProc:
-        pid = 124
-
-    def fake_popen(cmd, **kwargs):
-        captured["env"] = kwargs.get("env", {})
-        return FakeProc()
-
-    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    _capture_supervised_worker_launch(monkeypatch, captured, pid=124)
     monkeypatch.setenv("TERMINAL_TIMEOUT", "7200")
     monkeypatch.setenv("TERMINAL_MAX_FOREGROUND_TIMEOUT", "7200")
 
@@ -2877,7 +2879,8 @@ def test_default_spawn_preserves_longer_terminal_timeout(kanban_home, monkeypatc
             assignee="ops",
             max_runtime_seconds=3600,
         )
-        task = kb.get_task(conn, tid)
+        task = kb.claim_task(conn, tid)
+        assert task is not None
         workspace = kb.resolve_workspace(task)
         kb._default_spawn(task, str(workspace))
     finally:
@@ -2891,21 +2894,15 @@ def test_default_spawn_leaves_terminal_timeout_without_runtime_cap(kanban_home, 
     """Uncapped tasks keep the existing terminal timeout behavior."""
     captured = {}
 
-    class FakeProc:
-        pid = 125
-
-    def fake_popen(cmd, **kwargs):
-        captured["env"] = kwargs.get("env", {})
-        return FakeProc()
-
-    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    _capture_supervised_worker_launch(monkeypatch, captured, pid=125)
     monkeypatch.setenv("TERMINAL_TIMEOUT", "180")
     monkeypatch.delenv("TERMINAL_MAX_FOREGROUND_TIMEOUT", raising=False)
 
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="uncapped", assignee="ops")
-        task = kb.get_task(conn, tid)
+        task = kb.claim_task(conn, tid)
+        assert task is not None
         workspace = kb.resolve_workspace(task)
         kb._default_spawn(task, str(workspace))
     finally:
@@ -3045,15 +3042,7 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
     in declared order. No skill is auto-loaded anymore."""
     captured = {}
 
-    class FakeProc:
-        def __init__(self):
-            self.pid = 42
-
-    def fake_popen(cmd, **kwargs):
-        captured["cmd"] = cmd
-        return FakeProc()
-
-    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    _capture_supervised_worker_launch(monkeypatch, captured, pid=42)
 
     conn = kb.connect()
     try:
@@ -3063,7 +3052,8 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
             assignee="linguist",
             skills=["translation", "github-code-review"],
         )
-        task = kb.get_task(conn, tid)
+        task = kb.claim_task(conn, tid)
+        assert task is not None
         workspace = kb.resolve_workspace(task)
         kb._default_spawn(task, str(workspace))
     finally:
@@ -3093,14 +3083,7 @@ def test_default_spawn_passes_task_skills_verbatim(kanban_home, monkeypatch):
     kanban skill to dedupe against anymore."""
     captured = {}
 
-    class FakeProc:
-        pid = 1
-
-    def fake_popen(cmd, **kwargs):
-        captured["cmd"] = cmd
-        return FakeProc()
-
-    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    _capture_supervised_worker_launch(monkeypatch, captured, pid=1)
 
     conn = kb.connect()
     try:
@@ -3108,7 +3091,8 @@ def test_default_spawn_passes_task_skills_verbatim(kanban_home, monkeypatch):
             conn, title="dup", assignee="x",
             skills=["translation", "github-code-review"],
         )
-        task = kb.get_task(conn, tid)
+        task = kb.claim_task(conn, tid)
+        assert task is not None
         workspace = kb.resolve_workspace(task)
         kb._default_spawn(task, str(workspace))
     finally:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import subprocess
@@ -450,6 +451,8 @@ def test_stale_claim_reclaimed(kanban_home, monkeypatch):
         reclaimed = kb.release_stale_claims(conn, signal_fn=_signal)
         assert reclaimed == 1
         assert kb.get_task(conn, t).status == "ready"
+        # Legacy injected signal hooks preserve their synthetic direct-PID
+        # contract; production never supplies this hook and is tree-safe.
         assert killed == [signal.SIGTERM]
 
 
@@ -876,6 +879,206 @@ def _exited_status(code: int) -> int:
     return code << 8
 
 
+def test_spawned_worker_nonzero_exit_finalizes_without_another_dispatch_tick(
+    kanban_home, tmp_path, monkeypatch,
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(
+        kb,
+        "_resolve_hermes_argv",
+        lambda: [sys.executable, "-c", "import sys; sys.exit(17)", "--"],
+    )
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="fail once", assignee="worker")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+
+        worker_pid = kb._default_spawn(claimed, str(workspace))
+        assert worker_pid is not None
+        kb._set_worker_pid(conn, task_id, worker_pid)
+
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            with kb.connect_closing() as observer:
+                task = kb.get_task(observer, task_id)
+            if task is not None and task.status != "running":
+                break
+            time.sleep(0.02)
+
+        with kb.connect_closing() as observer:
+            task = kb.get_task(observer, task_id)
+            run = kb.latest_run(observer, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        assert task.claim_lock is None
+        assert task.worker_pid is None
+        assert task.consecutive_failures == 1
+
+        assert run is not None
+        assert run.outcome == "crashed"
+        assert run.ended_at is not None
+
+
+def test_supervisor_exit_binds_missing_pid_after_dispatcher_dies_before_registration(
+    kanban_home, monkeypatch,
+):
+    """A supervisor must finalize even when dispatch died before PID registration."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="lost dispatcher", assignee="worker")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock is not None
+
+    def fail_if_finalizer_waits(_seconds):
+        raise AssertionError("finalizer waited for a dispatcher that already died")
+
+    monkeypatch.setattr(kb.time, "sleep", fail_if_finalizer_waits)
+    observation = kb.WorkerExitObservation(
+        task_id=task_id,
+        run_id=claimed.current_run_id,
+        claim_lock=claimed.claim_lock,
+        pid=91003,
+        returncode=17,
+    )
+
+    assert kb.finalize_worker_exit(observation)
+
+    with kb.connect_closing() as observer:
+        task = kb.get_task(observer, task_id)
+        run = kb.latest_run(observer, task_id)
+        events = kb.list_events(observer, task_id)
+    assert task is not None
+    assert task.status == "ready"
+    assert task.worker_pid is None
+    assert run is not None
+    assert run.outcome == "crashed"
+    assert [event.kind for event in events].count("spawned") == 0
+    crashed = [event for event in events if event.kind == "crashed"]
+    assert len(crashed) == 1
+    assert crashed[0].payload is not None
+    assert crashed[0].payload["pid"] == observation.pid
+
+
+def test_supervisor_exit_cannot_finalize_a_newer_run(
+    kanban_home, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="retry", assignee="worker")
+        host = kb._claimer_id().split(":", 1)[0]
+        first = kb.claim_task(conn, task_id, claimer=f"{host}:first")
+        assert first is not None
+        first_pid = 91001
+        kb._set_worker_pid(conn, task_id, first_pid)
+        kb._record_worker_exit(first_pid, _exited_status(17))
+        assert task_id in kb.detect_crashed_workers(conn)
+
+        second = kb.claim_task(conn, task_id, claimer=f"{host}:second")
+        assert second is not None
+        second_pid = 91002
+        kb._set_worker_pid(conn, task_id, second_pid)
+
+        assert not kb.finalize_worker_exit(
+            kb.WorkerExitObservation(
+                task_id=task_id,
+                run_id=first.current_run_id,
+                claim_lock=first.claim_lock,
+                pid=first_pid,
+                returncode=17,
+            )
+        )
+
+        with kb.connect_closing() as observer:
+            task = kb.get_task(observer, task_id)
+        assert task is not None
+        assert task.status == "running"
+        assert task.current_run_id == second.current_run_id
+        assert task.claim_lock == second.claim_lock
+        assert task.worker_pid == second_pid
+
+
+@pytest.mark.parametrize(
+    ("returncode", "event_kind", "outcome", "failure_count"),
+    [
+        (kb.KANBAN_RATE_LIMIT_EXIT_CODE, "rate_limited", "rate_limited", 0),
+        (0, "protocol_violation", "crashed", 0),
+    ],
+)
+def test_generic_detector_defers_to_live_supervisor_finalizer(
+    kanban_home, monkeypatch, returncode, event_kind, outcome, failure_count,
+):
+    """A dispatch tick before finalization cannot erase the worker exit receipt."""
+    supervisor_pid = 91011
+    monkeypatch.setattr(kb, "_pid_alive", lambda pid: pid == supervisor_pid)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="authoritative exit", assignee="worker")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock is not None
+        assert kb._set_worker_pid(
+            conn,
+            task_id,
+            supervisor_pid,
+            claim_lock=claimed.claim_lock,
+            run_id=claimed.current_run_id,
+        )
+
+        assert kb.detect_crashed_workers(conn) == []
+        assert kb.get_task(conn, task_id).status == "running"
+
+    assert kb.finalize_worker_exit(
+        kb.WorkerExitObservation(
+            task_id=task_id,
+            run_id=claimed.current_run_id,
+            claim_lock=claimed.claim_lock,
+            pid=supervisor_pid,
+            returncode=returncode,
+        )
+    )
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+        events = kb.list_events(conn, task_id)
+    assert task is not None
+    assert task.status == "ready"
+    assert task.consecutive_failures == failure_count
+    assert run is not None
+    assert run.outcome == outcome
+    assert [event.kind for event in events].count(event_kind) == 1
+    assert [event.kind for event in events].count("crashed") == 0
+
+
+def test_pid_registration_cas_rejects_terminal_run_without_late_spawn_event(kanban_home):
+    """A fast terminal transition cannot resurrect a PID or append `spawned`."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="fast terminal", assignee="worker")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        assert claimed.claim_lock is not None
+        assert claimed.current_run_id is not None
+        assert kb.complete_task(conn, task_id, expected_run_id=claimed.current_run_id)
+
+        assert not kb._set_worker_pid(
+            conn,
+            task_id,
+            91012,
+            claim_lock=claimed.claim_lock,
+            run_id=claimed.current_run_id,
+        )
+        task = kb.get_task(conn, task_id)
+        events = kb.list_events(conn, task_id)
+    assert task is not None
+    assert task.status == "done"
+    assert task.worker_pid is None
+    assert [event.kind for event in events].count("spawned") == 0
+
+
 def test_classify_worker_exit_recognizes_rate_limit_sentinel(kanban_home):
     import hermes_cli.kanban_db as _kb
 
@@ -1109,6 +1312,50 @@ def test_max_runtime_uses_current_run_start_after_retry(kanban_home, monkeypatch
         timed_out = kb.enforce_max_runtime(conn, signal_fn=lambda _pid, _sig: None)
         assert timed_out == []
         assert kb.get_task(conn, t).status == "running"
+
+
+def test_max_runtime_defers_when_supervisor_tree_may_survive(kanban_home, monkeypatch):
+    """An unverified/surviving timeout tree must not release or tick failure."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        task_id = kb.create_task(
+            conn, title="timeout tree", assignee="worker", max_runtime_seconds=1,
+        )
+        claimed = kb.claim_task(conn, task_id, claimer=f"{host}:tree")
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert kb._set_worker_pid(conn, task_id, 91919)
+        old = int(time.time()) - 10
+        conn.execute("UPDATE tasks SET started_at = ? WHERE id = ?", (old, task_id))
+        conn.execute(
+            "UPDATE task_runs SET started_at = ? WHERE id = ?",
+            (old, claimed.current_run_id),
+        )
+        monkeypatch.setattr(
+            _kb,
+            "_terminate_reclaimed_worker",
+            lambda *_args, **_kwargs: {
+                "host_local": True,
+                "termination_attempted": True,
+                "terminated": False,
+                "identity": "process_group_mismatch",
+            },
+        )
+
+        assert kb.enforce_max_runtime(conn) == []
+        task = kb.get_task(conn, task_id)
+        events = kb.list_events(conn, task_id)
+    assert task is not None
+    assert task.status == "running"
+    assert task.worker_pid == 91919
+    assert task.consecutive_failures in (0, None)
+    assert [event.kind for event in events].count("timed_out") == 0
+    deferred = [event for event in events if event.kind == "reclaim_deferred"]
+    assert len(deferred) == 1
+    assert deferred[0].payload is not None
+    assert deferred[0].payload["reason"] == "max_runtime_worker_alive"
 
 
 def test_heartbeat_extends_claim(kanban_home):
@@ -3113,7 +3360,13 @@ class TestSharedBoardPaths:
             def __init__(self, cmd, **kwargs):
                 captured["cmd"] = cmd
                 captured["env"] = kwargs.get("env", {})
+                spec = json.loads(Path(cmd[-1]).read_text(encoding="utf-8"))
+                Path(spec["handshake_path"]).write_text("4242", encoding="utf-8")
                 self.pid = 4242
+                self.returncode = None
+
+            def poll(self):
+                return self.returncode
 
         monkeypatch.setattr("subprocess.Popen", _FakePopen)
 
@@ -3130,10 +3383,11 @@ class TestSharedBoardPaths:
             completed_at=None,
             workspace_kind="worktree",
             workspace_path=str(tmp_path / "ws"),
-            claim_lock=None,
+            claim_lock="test-host:claim",
             claim_expires=None,
             tenant=None,
             branch_name="wt/t_dispatch_env",
+            current_run_id=1,
         )
         kb._default_spawn(task, str(tmp_path / "ws"))
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -333,9 +333,12 @@ def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
         child = kb.create_task(
             conn, title="child", assignee="a", parents=[parent],
         )
-        # Complete the parent
-        kb.claim_task(conn, parent)
-        kb.complete_task(conn, parent, result="ok")
+        # Complete the parent as the active worker.
+        claimed_parent = kb.claim_task(conn, parent)
+        assert claimed_parent is not None and claimed_parent.current_run_id is not None
+        assert kb.complete_task(
+            conn, parent, result="ok", expected_run_id=claimed_parent.current_run_id, expected_claim_lock=claimed_parent.claim_lock,
+        )
         # Manually block the child with zero failures (simulates a
         # dependency block, not a circuit-breaker block).
         conn.execute(
@@ -469,8 +472,21 @@ def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")
         host = _kb._claimer_id().split(":", 1)[0]
-        kb.claim_task(conn, t, claimer=f"{host}:worker")
-        kb._set_worker_pid(conn, t, 12345)
+        monkeypatch.setattr(
+            _kb, "_supervisor_process_identity", lambda _pid: "test-incarnation",
+        )
+        monkeypatch.setattr(_kb.os, "getpgid", lambda pid: pid)
+        monkeypatch.setattr(_kb.os, "getsid", lambda pid: pid)
+        monkeypatch.setattr(
+            _kb, "_linux_process_group_has_live_member", lambda _pid: True,
+        )
+        claimed = kb.claim_task(conn, t, claimer=f"{host}:worker")
+        assert claimed is not None and claimed.current_run_id is not None
+        assert kb._set_worker_pid(conn, t, 12345)
+        task = kb.get_task(conn, t)
+        run = kb.latest_run(conn, t)
+        assert task is not None and run is not None
+        assert task.worker_identity == run.worker_identity == "test-incarnation"
 
         old_expires = int(time.time()) - 60
         conn.execute(
@@ -505,12 +521,25 @@ def test_stale_claim_with_live_pid_uses_env_ttl_override(
     import hermes_cli.kanban_db as _kb
 
     monkeypatch.setenv("HERMES_KANBAN_CLAIM_TTL_SECONDS", "3600")
+    monkeypatch.setattr(
+        _kb, "_supervisor_process_identity", lambda _pid: "test-incarnation",
+    )
+    monkeypatch.setattr(_kb.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(_kb.os, "getsid", lambda pid: pid)
+    monkeypatch.setattr(
+        _kb, "_linux_process_group_has_live_member", lambda _pid: True,
+    )
 
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")
         host = _kb._claimer_id().split(":", 1)[0]
-        kb.claim_task(conn, t, claimer=f"{host}:worker")
-        kb._set_worker_pid(conn, t, 12345)
+        claimed = kb.claim_task(conn, t, claimer=f"{host}:worker")
+        assert claimed is not None and claimed.current_run_id is not None
+        assert kb._set_worker_pid(conn, t, 12345)
+        task = kb.get_task(conn, t)
+        run = kb.latest_run(conn, t)
+        assert task is not None and run is not None
+        assert task.worker_identity == run.worker_identity == "test-incarnation"
         conn.execute(
             "UPDATE tasks SET claim_expires = ? WHERE id = ?",
             (int(time.time()) - 60, t),
@@ -524,6 +553,90 @@ def test_stale_claim_with_live_pid_uses_env_ttl_override(
         assert task is not None
         assert task.claim_expires is not None
         assert task.claim_expires > int(time.time()) + 3000
+
+
+@pytest.mark.parametrize(
+    ("registered_identity", "observed_identity"),
+    [
+        (None, "replacement-incarnation"),
+        ("registered-incarnation", "replacement-incarnation"),
+    ],
+    ids=["identity-absent", "identity-mismatched"],
+)
+@pytest.mark.parametrize(
+    "sweeper",
+    ["release_stale_claims", "detect_stale_running"],
+)
+def test_live_unverified_identity_defers_without_extending_task_or_run_lease(
+    kanban_home, monkeypatch, registered_identity, observed_identity, sweeper,
+):
+    """Live PIDs without incarnation proof keep ownership but cannot renew it."""
+    import hermes_cli.kanban_db as _kb
+
+    signals: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        _kb, "_supervisor_process_identity", lambda _pid: registered_identity,
+    )
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(
+        _kb.os, "killpg", lambda pid, sig: signals.append((pid, sig)),
+    )
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="unverified live worker", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        claimed = kb.claim_task(conn, task_id, claimer=f"{host}:worker")
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock is not None
+        assert kb._set_worker_pid(conn, task_id, 12345)
+
+        old_expires = int(time.time()) - 60
+        old_started = int(time.time()) - (5 * 3600)
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET claim_expires = ?, started_at = ?, "
+                "last_heartbeat_at = NULL WHERE id = ?",
+                (old_expires, old_started, task_id),
+            )
+            conn.execute(
+                "UPDATE task_runs SET claim_expires = ?, started_at = ? WHERE id = ?",
+                (old_expires, old_started, claimed.current_run_id),
+            )
+
+        monkeypatch.setattr(
+            _kb, "_supervisor_process_identity", lambda _pid: observed_identity,
+        )
+        if sweeper == "release_stale_claims":
+            assert kb.release_stale_claims(conn) == 0
+        else:
+            assert kb.detect_stale_running(
+                conn, stale_timeout_seconds=14400,
+            ) == []
+
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+        assert task is not None and run is not None
+        assert task.status == "running"
+        assert task.current_run_id == claimed.current_run_id
+        assert task.claim_lock == claimed.claim_lock
+        assert task.worker_pid == 12345
+        assert task.worker_identity == registered_identity
+        assert task.claim_expires == old_expires
+        assert run.id == claimed.current_run_id
+        assert run.status == "running"
+        assert run.ended_at is None
+        assert run.claim_lock == claimed.claim_lock
+        assert run.worker_pid == 12345
+        assert run.worker_identity == registered_identity
+        assert run.claim_expires == old_expires
+        assert signals == []
+
+        event_kinds = [event.kind for event in kb.list_events(conn, task_id)]
+        assert "reclaim_deferred" in event_kinds
+        assert "claim_extended" not in event_kinds
+        assert "reclaimed" not in event_kinds
+        assert "stale" not in event_kinds
 
 
 def test_stale_claim_deferred_when_live_worker_survives_termination(
@@ -613,14 +726,10 @@ def test_stale_claim_reclaimed_when_termination_succeeds(
         assert kb.get_task(conn, t).status == "ready"
 
 
-def test_stale_claim_released_when_worker_not_host_local(
+def test_stale_claim_defers_when_worker_not_host_local(
     kanban_home, monkeypatch,
 ):
-    """The defer guard only holds OUR own surviving workers.
-
-    A claim we cannot manage (different host, or no kill attempted) must still
-    be released, otherwise a foreign-host claim could strand a task forever.
-    """
+    """A foreign/unmanaged claim is active ownership, never release proof."""
     import hermes_cli.kanban_db as _kb
 
     with kb.connect() as conn:
@@ -643,8 +752,14 @@ def test_stale_claim_released_when_worker_not_host_local(
             },
         )
         reclaimed = kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
-        assert reclaimed == 1
-        assert kb.get_task(conn, t).status == "ready"
+        assert reclaimed == 0
+        task = kb.get_task(conn, t)
+        assert task is not None
+        assert task.status == "running"
+        assert task.claim_lock == f"{host}:worker"
+        assert task.worker_pid == 12345
+        events = kb.list_events(conn, t)
+        assert any(event.kind == "reclaim_deferred" for event in events)
 
 
 def test_detect_stale_defers_when_live_worker_survives(kanban_home, monkeypatch):
@@ -1062,7 +1177,7 @@ def test_pid_registration_cas_rejects_terminal_run_without_late_spawn_event(kanb
         assert claimed is not None
         assert claimed.claim_lock is not None
         assert claimed.current_run_id is not None
-        assert kb.complete_task(conn, task_id, expected_run_id=claimed.current_run_id)
+        assert kb.complete_task(conn, task_id, expected_run_id=claimed.current_run_id, expected_claim_lock=claimed.claim_lock)
 
         assert not kb._set_worker_pid(
             conn,
@@ -1420,8 +1535,11 @@ def test_complete_records_result(kanban_home):
 def test_block_then_unblock(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")
-        kb.claim_task(conn, t)
-        assert kb.block_task(conn, t, reason="need input")
+        claimed = kb.claim_task(conn, t)
+        assert claimed is not None and claimed.current_run_id is not None
+        assert kb.block_task(
+            conn, t, reason="need input", expected_run_id=claimed.current_run_id, expected_claim_lock=claimed.claim_lock,
+        )
         assert kb.get_task(conn, t).status == "blocked"
         assert kb.unblock_task(conn, t)
         assert kb.get_task(conn, t).status == "ready"
@@ -1431,8 +1549,11 @@ def test_unblock_resets_failure_counters(kanban_home):
     """unblock_task must reset consecutive_failures and last_failure_error."""
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")
-        kb.claim_task(conn, t)
-        assert kb.block_task(conn, t, reason="need input")
+        claimed = kb.claim_task(conn, t)
+        assert claimed is not None and claimed.current_run_id is not None
+        assert kb.block_task(
+            conn, t, reason="need input", expected_run_id=claimed.current_run_id, expected_claim_lock=claimed.claim_lock,
+        )
         # Simulate accumulated failures from the circuit breaker
         conn.execute(
             "UPDATE tasks SET consecutive_failures = 5, "
@@ -1459,9 +1580,13 @@ def test_recompute_ready_skips_tasks_at_failure_limit(kanban_home):
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(conn, title="child", assignee="a",
                                parents=[parent])
-        # Complete the parent so the child's dependencies are satisfied.
-        kb.claim_task(conn, parent)
-        kb.complete_task(conn, parent, summary="done")
+        # Complete the parent as the active worker so the child's dependencies
+        # are satisfied.
+        claimed_parent = kb.claim_task(conn, parent)
+        assert claimed_parent is not None and claimed_parent.current_run_id is not None
+        assert kb.complete_task(
+            conn, parent, summary="done", expected_run_id=claimed_parent.current_run_id, expected_claim_lock=claimed_parent.claim_lock,
+        )
 
         # Simulate the child having exhausted its budget twice,
         # hitting the default failure limit (2).
@@ -1640,8 +1765,11 @@ def test_claim_succeeds_once_parents_done(kanban_home):
         child = kb.create_task(
             conn, title="child", assignee="a", parents=[parent],
         )
-        kb.claim_task(conn, parent)
-        assert kb.complete_task(conn, parent, result="ok")
+        claimed_parent = kb.claim_task(conn, parent)
+        assert claimed_parent is not None and claimed_parent.current_run_id is not None
+        assert kb.complete_task(
+            conn, parent, result="ok", expected_run_id=claimed_parent.current_run_id, expected_claim_lock=claimed_parent.claim_lock,
+        )
         kb.recompute_ready(conn)
         assert kb.get_task(conn, child).status == "ready"
         claimed = kb.claim_task(conn, child, claimer="host:1")
@@ -1662,10 +1790,13 @@ def test_create_with_parents_stays_todo_until_parents_done(kanban_home):
         promoted = kb.recompute_ready(conn)
         assert promoted == 0
         assert kb.get_task(conn, child).status == "todo"
-        # Complete parent; complete_task internally runs recompute_ready,
-        # which promotes the child to 'ready'.
-        kb.claim_task(conn, parent)
-        kb.complete_task(conn, parent, result="ok")
+        # Complete parent as its active worker; complete_task internally runs
+        # recompute_ready, which promotes the child to 'ready'.
+        claimed_parent = kb.claim_task(conn, parent)
+        assert claimed_parent is not None and claimed_parent.current_run_id is not None
+        assert kb.complete_task(
+            conn, parent, result="ok", expected_run_id=claimed_parent.current_run_id, expected_claim_lock=claimed_parent.claim_lock,
+        )
         assert kb.get_task(conn, child).status == "ready"
 
 
@@ -1690,8 +1821,11 @@ def test_unblock_with_pending_parents_goes_to_todo(kanban_home):
         assert kb.unblock_task(conn, child)
         assert kb.get_task(conn, child).status == "todo"
         # After parent completes + recompute, the child is ready.
-        kb.claim_task(conn, parent)
-        kb.complete_task(conn, parent, result="ok")
+        claimed_parent = kb.claim_task(conn, parent)
+        assert claimed_parent is not None and claimed_parent.current_run_id is not None
+        assert kb.complete_task(
+            conn, parent, result="ok", expected_run_id=claimed_parent.current_run_id, expected_claim_lock=claimed_parent.claim_lock,
+        )
         kb.recompute_ready(conn)
         assert kb.get_task(conn, child).status == "ready"
 
@@ -1700,8 +1834,11 @@ def test_unblock_without_parents_goes_to_ready(kanban_home):
     """Parent-free unblock still produces 'ready' (behavior preserved)."""
     with kb.connect() as conn:
         t = kb.create_task(conn, title="lone", assignee="a")
-        kb.claim_task(conn, t)
-        assert kb.block_task(conn, t, reason="need input")
+        claimed = kb.claim_task(conn, t)
+        assert claimed is not None and claimed.current_run_id is not None
+        assert kb.block_task(
+            conn, t, reason="need input", expected_run_id=claimed.current_run_id, expected_claim_lock=claimed.claim_lock,
+        )
         assert kb.unblock_task(conn, t)
         assert kb.get_task(conn, t).status == "ready"
 
@@ -1862,8 +1999,11 @@ def test_empty_comment_rejected(kanban_home):
 def test_events_capture_lifecycle(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")
-        kb.claim_task(conn, t)
-        kb.complete_task(conn, t, result="ok")
+        claimed = kb.claim_task(conn, t)
+        assert claimed is not None and claimed.current_run_id is not None
+        assert kb.complete_task(
+            conn, t, result="ok", expected_run_id=claimed.current_run_id, expected_claim_lock=claimed.claim_lock,
+        )
         events = kb.list_events(conn, t)
     kinds = [e.kind for e in events]
     assert "created" in kinds
@@ -2040,7 +2180,7 @@ def test_dispatch_max_spawn_fills_remaining_capacity(
         assert kb.get_task(conn, ready_b).status == "ready"
 
 
-def test_dispatch_reclaims_stale_before_spawning(kanban_home):
+def test_dispatch_defers_stale_unregistered_claim_before_spawning(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="alice")
         kb.claim_task(conn, t)
@@ -2049,7 +2189,8 @@ def test_dispatch_reclaims_stale_before_spawning(kanban_home):
             (int(time.time()) - 1, t),
         )
         res = kb.dispatch_once(conn, dry_run=True)
-    assert res.reclaimed == 1
+    assert res.reclaimed == 0
+    assert kb.get_task(conn, t).status == "running"
 
 
 # ---------------------------------------------------------------------------
@@ -4445,8 +4586,8 @@ def test_detect_stale_skips_blocked_tasks(kanban_home, monkeypatch):
 
     with kb.connect() as conn:
         t = kb.create_task(conn, title="blocked-task", assignee="worker")
-        kb.claim_task(conn, t)
-        kb._set_worker_pid(conn, t, os.getpid())
+        claimed = kb.claim_task(conn, t)
+        assert claimed is not None and claimed.current_run_id is not None
 
         five_hours_ago = int(time.time()) - (5 * 3600)
         with kb.write_txn(conn):
@@ -4458,8 +4599,10 @@ def test_detect_stale_skips_blocked_tasks(kanban_home, monkeypatch):
                 "WHERE id = (SELECT current_run_id FROM tasks WHERE id = ?)",
                 (five_hours_ago, t),
             )
-        # Block the task explicitly.
-        kb.block_task(conn, t, reason="human requested block")
+        # Block the task as its active worker.
+        assert kb.block_task(
+            conn, t, reason="human requested block", expected_run_id=claimed.current_run_id, expected_claim_lock=claimed.claim_lock,
+        )
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
         stale = kb.detect_stale_running(

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -12,6 +12,7 @@ Covers three layers:
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
@@ -126,9 +127,16 @@ def test_spawn_sets_goal_env_only_when_enabled(kanban_home, monkeypatch):
 
     class _FakeProc:
         pid = 4242
+        returncode = None
+
+        def poll(self):
+            return self.returncode
 
     def _fake_popen(cmd, **kwargs):
+        spec = json.loads(Path(cmd[-1]).read_text(encoding="utf-8"))
+        captured["cmd"] = spec["command"]
         captured["env"] = kwargs.get("env", {})
+        Path(spec["handshake_path"]).write_text("4242", encoding="utf-8")
         return _FakeProc()
 
     monkeypatch.setattr("subprocess.Popen", _fake_popen)
@@ -141,7 +149,8 @@ def test_spawn_sets_goal_env_only_when_enabled(kanban_home, monkeypatch):
             goal_mode=True,
             goal_max_turns=5,
         )
-        task = kb.get_task(conn, tid)
+        task = kb.claim_task(conn, tid)
+        assert task is not None
 
     kb._default_spawn(task, str(kanban_home))
     env = captured["env"]
@@ -154,16 +163,24 @@ def test_spawn_no_goal_env_for_plain_task(kanban_home, monkeypatch):
 
     class _FakeProc:
         pid = 4243
+        returncode = None
+
+        def poll(self):
+            return self.returncode
 
     def _fake_popen(cmd, **kwargs):
+        spec = json.loads(Path(cmd[-1]).read_text(encoding="utf-8"))
+        captured["cmd"] = spec["command"]
         captured["env"] = kwargs.get("env", {})
+        Path(spec["handshake_path"]).write_text("4243", encoding="utf-8")
         return _FakeProc()
 
     monkeypatch.setattr("subprocess.Popen", _fake_popen)
 
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="plain", assignee="default")
-        task = kb.get_task(conn, tid)
+        task = kb.claim_task(conn, tid)
+        assert task is not None
 
     kb._default_spawn(task, str(kanban_home))
     env = captured["env"]

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -74,8 +74,11 @@ def test_complete_fires_hook_with_summary(kanban_home, captured_hooks):
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="t", assignee="worker")
-        kb.claim_task(conn, tid)
-        assert kb.complete_task(conn, tid, summary="all done")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None and claimed.current_run_id is not None
+        assert kb.complete_task(
+            conn, tid, summary="all done", expected_run_id=claimed.current_run_id, expected_claim_lock=claimed.claim_lock,
+        )
     finally:
         conn.close()
     fired = [e for e in captured_hooks if e[0] == "kanban_task_completed"]
@@ -90,8 +93,11 @@ def test_block_fires_hook_with_reason(kanban_home, captured_hooks):
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="t", assignee="worker")
-        kb.claim_task(conn, tid)
-        assert kb.block_task(conn, tid, reason="needs human")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None and claimed.current_run_id is not None
+        assert kb.block_task(
+            conn, tid, reason="needs human", expected_run_id=claimed.current_run_id, expected_claim_lock=claimed.claim_lock,
+        )
     finally:
         conn.close()
     fired = [e for e in captured_hooks if e[0] == "kanban_task_blocked"]
@@ -125,9 +131,12 @@ def test_misbehaving_hook_does_not_break_transition(kanban_home, monkeypatch):
         conn = kb.connect()
         try:
             tid = kb.create_task(conn, title="t", assignee="worker")
-            kb.claim_task(conn, tid)
+            claimed = kb.claim_task(conn, tid)
+            assert claimed is not None and claimed.current_run_id is not None
             # Despite the raising hook, completion succeeds and persists.
-            assert kb.complete_task(conn, tid, summary="ok") is True
+            assert kb.complete_task(
+                conn, tid, summary="ok", expected_run_id=claimed.current_run_id, expected_claim_lock=claimed.claim_lock,
+            ) is True
             assert kb.get_task(conn, tid).status == "done"
         finally:
             conn.close()

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -519,22 +519,43 @@ async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path, m
     try:
         tid = kb.create_task(conn, title="render q3 chart", assignee="worker1")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
+        # Claim through the production path so the handler call below can
+        # present the full fail-closed scoped-worker capability tuple
+        # (board + task + exact current run + nonempty claim lock).
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock
     finally:
         conn.close()
 
     # Use the production handler so we exercise the full path: tool args
-    # → metadata.artifacts → event payload promotion.
+    # → metadata.artifacts → event payload promotion. Any process with
+    # HERMES_KANBAN_TASK set is a scoped worker and must also present the
+    # exact current run id and a nonempty claim lock — a missing capability
+    # makes the handler refuse rather than fall back to operator authority.
     import os
-    os.environ["HERMES_KANBAN_TASK"] = tid
+    scoped_env = {
+        "HERMES_KANBAN_TASK": tid,
+        "HERMES_KANBAN_BOARD": kb.get_current_board(),
+        "HERMES_KANBAN_RUN_ID": str(claimed.current_run_id),
+        "HERMES_KANBAN_CLAIM_LOCK": claimed.claim_lock,
+    }
+    prior_env = {k: os.environ.get(k) for k in scoped_env}
+    os.environ.update(scoped_env)
     try:
         out = kt._handle_complete({
             "summary": "rendered the chart",
             "artifacts": [str(chart_path), str(report_path)],
         })
     finally:
-        os.environ.pop("HERMES_KANBAN_TASK", None)
+        for k, v in prior_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
     import json as _json
-    assert _json.loads(out)["ok"] is True
+    assert _json.loads(out)["ok"] is True, out
 
     runner = object.__new__(GatewayRunner)
     runner._running = True
@@ -607,18 +628,37 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
     try:
         tid = kb.create_task(conn, title="t", assignee="worker1")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
+        # Claim so the scoped handler call below carries the full
+        # fail-closed worker capability — see the companion test.
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock
     finally:
         conn.close()
 
     import os
-    os.environ["HERMES_KANBAN_TASK"] = tid
+    scoped_env = {
+        "HERMES_KANBAN_TASK": tid,
+        "HERMES_KANBAN_BOARD": kb.get_current_board(),
+        "HERMES_KANBAN_RUN_ID": str(claimed.current_run_id),
+        "HERMES_KANBAN_CLAIM_LOCK": claimed.claim_lock,
+    }
+    prior_env = {k: os.environ.get(k) for k in scoped_env}
+    os.environ.update(scoped_env)
     try:
-        kt._handle_complete({
+        out = kt._handle_complete({
             "summary": "one real, one ghost",
             "artifacts": [str(real_pdf), "/tmp/definitely-does-not-exist.pdf"],
         })
     finally:
-        os.environ.pop("HERMES_KANBAN_TASK", None)
+        for k, v in prior_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    import json as _json
+    assert _json.loads(out)["ok"] is True, out
 
     runner = object.__new__(GatewayRunner)
     runner._running = True

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import subprocess
+from pathlib import Path
 
 
 def _make_task(kb, *, assignee: str):
@@ -67,11 +69,17 @@ agent:
 
     class FakeProc:
         pid = 4242
+        returncode = None
+
+        def poll(self):
+            return self.returncode
 
     def fake_popen(cmd, *args, **kwargs):
-        captured["cmd"] = list(cmd)
+        spec = json.loads(Path(cmd[-1]).read_text(encoding="utf-8"))
+        captured["cmd"] = spec["command"]
         captured["env"] = dict(kwargs.get("env") or {})
-        captured["cwd"] = kwargs.get("cwd")
+        captured["cwd"] = spec["cwd"]
+        Path(spec["handshake_path"]).write_text("4242", encoding="utf-8")
         return FakeProc()
 
     monkeypatch.setattr(subprocess, "Popen", fake_popen)
@@ -109,10 +117,16 @@ def test_default_spawn_never_boots_the_tui(monkeypatch, tmp_path):
 
     class FakeProc:
         pid = 4243
+        returncode = None
+
+        def poll(self):
+            return self.returncode
 
     def fake_popen(cmd, *args, **kwargs):
-        captured["cmd"] = list(cmd)
+        spec = json.loads(Path(cmd[-1]).read_text(encoding="utf-8"))
+        captured["cmd"] = spec["command"]
         captured["env"] = dict(kwargs.get("env") or {})
+        Path(spec["handshake_path"]).write_text("4243", encoding="utf-8")
         return FakeProc()
 
     monkeypatch.setattr(subprocess, "Popen", fake_popen)
@@ -145,9 +159,15 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
 
     class FakeProc:
         pid = 4244
+        returncode = None
+
+        def poll(self):
+            return self.returncode
 
     def fake_popen(cmd, *args, **kwargs):
-        captured["cmd"] = list(cmd)
+        spec = json.loads(Path(cmd[-1]).read_text(encoding="utf-8"))
+        captured["cmd"] = spec["command"]
+        Path(spec["handshake_path"]).write_text("4244", encoding="utf-8")
         return FakeProc()
 
     monkeypatch.setattr(subprocess, "Popen", fake_popen)

--- a/tests/hermes_cli/test_kanban_worker_supervisor.py
+++ b/tests/hermes_cli/test_kanban_worker_supervisor.py
@@ -1,0 +1,509 @@
+"""Lifecycle tests for the detached Kanban worker supervisor."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_worker_supervisor as supervisor
+
+
+def _wait_until_gone(pid: int, *, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        time.sleep(0.02)
+    return False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+def _start_frozen_term_ignoring_supervisor(tmp_path, monkeypatch, *, max_runtime=None):
+    """Create the adversarial boundary: stopped supervisor + live stubborn child."""
+    from hermes_cli import kanban_db as kb
+
+    child_pid_path = tmp_path / "child.pid"
+    spec_path = tmp_path / "worker-spec.json"
+    handshake_path = tmp_path / "supervisor.pid"
+    log_path = tmp_path / "worker.log"
+    child_code = (
+        "import os, signal, sys, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "open(sys.argv[1], 'w').write(str(os.getpid())); time.sleep(60)"
+    )
+    spec_path.write_text(
+        json.dumps(
+            {
+                "command": [sys.executable, "-c", child_code, str(child_pid_path)],
+                "cwd": None,
+                "log_path": str(log_path),
+                "handshake_path": str(handshake_path),
+                "task_id": "placeholder",
+                "run_id": 1,
+                "claim_lock": "placeholder",
+                "board": "default",
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="stubborn tree", assignee="worker",
+            max_runtime_seconds=max_runtime,
+        )
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        assert claimed.claim_lock is not None
+        assert claimed.current_run_id is not None
+
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    spec.update(
+        task_id=task_id,
+        run_id=claimed.current_run_id,
+        claim_lock=claimed.claim_lock,
+    )
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+    repo_root = Path(__file__).parents[2]
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "hermes_cli.kanban_worker_supervisor", str(spec_path)],
+        cwd=repo_root,
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not handshake_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert int(handshake_path.read_text(encoding="utf-8")) == proc.pid
+        deadline = time.monotonic() + 5
+        while not child_pid_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+        # Freeze after the supervisor has published and spawned.  A direct
+        # supervisor SIGKILL at this interleaving leaves the stubborn child
+        # orphaned; group SIGTERM/KILL must remove both.
+        os.kill(proc.pid, signal.SIGSTOP)
+        monkeypatch.setattr(kb, "_WORKER_TREE_TERMINATE_GRACE_SECONDS", 0.12)
+        monkeypatch.setattr(kb, "_WORKER_TREE_TERMINATE_POLL_SECONDS", 0.01)
+        return kb, task_id, claimed, proc, child_pid
+    except BaseException:
+        if proc.poll() is None:
+            os.killpg(proc.pid, signal.SIGKILL)
+            proc.wait()
+        raise
+
+
+def _cleanup_process_group(proc):
+    if proc.poll() is None:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+def test_manual_reclaim_kills_frozen_supervisor_tree_before_release(tmp_path, monkeypatch):
+    kb, task_id, _claimed, proc, child_pid = _start_frozen_term_ignoring_supervisor(
+        tmp_path, monkeypatch,
+    )
+    try:
+        with kb.connect() as conn:
+            assert kb._set_worker_pid(conn, task_id, proc.pid)
+            assert kb.reclaim_task(conn, task_id, reason="real tree regression")
+            assert _wait_until_gone(child_pid), "manual reclaim orphaned child"
+            task = kb.get_task(conn, task_id)
+            assert task is not None
+            assert task.status == "ready"
+            assert task.claim_lock is None
+            assert task.worker_pid is None
+    finally:
+        _cleanup_process_group(proc)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+def test_stale_reclaim_kills_frozen_supervisor_tree_before_release(tmp_path, monkeypatch):
+    kb, task_id, _claimed, proc, child_pid = _start_frozen_term_ignoring_supervisor(
+        tmp_path, monkeypatch,
+    )
+    try:
+        with kb.connect() as conn:
+            assert kb._set_worker_pid(conn, task_id, proc.pid)
+            conn.execute(
+                "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? WHERE id = ?",
+                (int(time.time()) - 1, int(time.time()) - 7200, task_id),
+            )
+            assert kb.release_stale_claims(conn) == 1
+            assert _wait_until_gone(child_pid), "stale reclaim orphaned child"
+            task = kb.get_task(conn, task_id)
+            assert task is not None
+            assert task.status == "ready"
+            assert task.claim_lock is None
+    finally:
+        _cleanup_process_group(proc)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+def test_max_runtime_kills_frozen_supervisor_tree_before_timeout_release(tmp_path, monkeypatch):
+    kb, task_id, claimed, proc, child_pid = _start_frozen_term_ignoring_supervisor(
+        tmp_path, monkeypatch, max_runtime=1,
+    )
+    try:
+        with kb.connect() as conn:
+            assert kb._set_worker_pid(conn, task_id, proc.pid)
+            old = int(time.time()) - 10
+            conn.execute("UPDATE tasks SET started_at = ? WHERE id = ?", (old, task_id))
+            conn.execute(
+                "UPDATE task_runs SET started_at = ? WHERE id = ?",
+                (old, claimed.current_run_id),
+            )
+            assert kb.enforce_max_runtime(conn) == [task_id]
+            assert _wait_until_gone(child_pid), "max runtime orphaned child"
+            task = kb.get_task(conn, task_id)
+            assert task is not None
+            assert task.status == "ready"
+            assert task.claim_lock is None
+            assert task.consecutive_failures == 1
+    finally:
+        _cleanup_process_group(proc)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+def test_reclaim_identity_mismatch_defers_without_signalling_unrelated_group(tmp_path):
+    """A reused/non-leader PID is never converted into killpg(pid, ...)."""
+    from hermes_cli import kanban_db as kb
+
+    unrelated = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    try:
+        with kb.connect() as conn:
+            task_id = kb.create_task(conn, title="pid reuse", assignee="worker")
+            assert kb.claim_task(conn, task_id) is not None
+            assert kb._set_worker_pid(conn, task_id, unrelated.pid)
+            assert not kb.reclaim_task(conn, task_id, reason="identity check")
+            assert not kb.reassign_task(
+                conn, task_id, "other-worker", reclaim_first=True,
+            )
+            task = kb.get_task(conn, task_id)
+            events = kb.list_events(conn, task_id)
+        assert unrelated.poll() is None
+        assert task is not None
+        assert task.status == "running"
+        assert task.assignee == "worker"
+        deferred = [event for event in events if event.kind == "reclaim_deferred"]
+        assert len(deferred) == 2
+        for event in deferred:
+            assert event.payload is not None
+            assert event.payload["identity"] == "process_group_mismatch"
+    finally:
+        unrelated.terminate()
+        unrelated.wait(timeout=5)
+
+
+def test_windows_reclaim_tree_cleanup_uses_taskkill(monkeypatch):
+    """Windows reclaim uses taskkill /T /F instead of direct PID SIGKILL."""
+    from hermes_cli import kanban_db as kb
+
+    calls = []
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(
+        kb.subprocess,
+        "run",
+        lambda args, **kwargs: calls.append((args, kwargs)),
+    )
+    info = kb._terminate_reclaimed_worker(91015, f"{kb._claimer_id().split(':', 1)[0]}:x")
+    assert info["terminated"] is True
+    assert calls[0][0] == ["taskkill", "/PID", "91015", "/T", "/F"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups only")
+@pytest.mark.parametrize("supervisor_mode", ["timeout", "early_exit"])
+def test_parent_handshake_failure_kills_real_supervisor_tree_and_cleans_artifacts(
+    tmp_path, monkeypatch, supervisor_mode,
+):
+    """A no-handshake supervisor must not leave its real child behind."""
+    from hermes_cli import kanban_db as kb
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(kb, "_WORKER_PID_HANDSHAKE_TIMEOUT_SECONDS", 0.08)
+    db_path = kb.kanban_db_path()
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+
+    child_pid_path = tmp_path / "child.pid"
+    child_code = (
+        "import os, signal, sys, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "open(sys.argv[1], 'w').write(str(os.getpid())); time.sleep(60)"
+    )
+    supervisor_code = (
+        "import subprocess, sys, time; "
+        "subprocess.Popen([sys.executable, '-c', sys.argv[2], sys.argv[1]]); "
+        + ("sys.exit(23)" if supervisor_mode == "early_exit" else "time.sleep(60)")
+    )
+    real_popen = subprocess.Popen
+
+    def spawn_no_handshake(_cmd, **_kwargs):
+        proc = real_popen(
+            [
+                sys.executable,
+                "-c",
+                supervisor_code,
+                str(child_pid_path),
+                child_code,
+            ],
+            start_new_session=True,
+        )
+        deadline = time.monotonic() + 2
+        while not child_pid_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert child_pid_path.exists()
+        return proc
+
+    monkeypatch.setattr(kb.subprocess, "Popen", spawn_no_handshake)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="tree cleanup", assignee="worker")
+        task = kb.claim_task(conn, task_id)
+        assert task is not None
+        with pytest.raises(RuntimeError, match=(
+            "timed out" if supervisor_mode == "timeout" else "exited with code 23"
+        )):
+            kb._default_spawn(task, str(tmp_path))
+
+    child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+    assert _wait_until_gone(child_pid), "handshake cleanup orphaned the worker"
+    log_dir = home / "kanban" / "logs"
+    assert not list(log_dir.glob("*.spawn.json"))
+    assert not list(log_dir.glob("*.worker.pid"))
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX signal semantics only")
+def test_real_pid_publication_failure_kills_and_reaps_worker_tree(tmp_path):
+    """Supervisor-side publication failure kills a real TERM-ignoring worker."""
+    child_pid_path = tmp_path / "child.pid"
+    spec_path = tmp_path / "worker-spec.json"
+    log_path = tmp_path / "worker.log"
+    handshake_path = tmp_path / "pid-directory"
+    handshake_path.mkdir()
+    child_code = (
+        "import os, signal, sys, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "open(sys.argv[1], 'w').write(str(os.getpid())); time.sleep(60)"
+    )
+    spec_path.write_text(
+        json.dumps(
+            {
+                "command": [sys.executable, "-c", child_code, str(child_pid_path)],
+                "cwd": None,
+                "log_path": str(log_path),
+                "handshake_path": str(handshake_path),
+                "task_id": "t_worker",
+                "run_id": 1,
+                "claim_lock": "host:worker",
+                "board": "default",
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    real_popen = subprocess.Popen
+    captured = {}
+
+    def capture_worker(*args, **kwargs):
+        proc = real_popen(*args, **kwargs)
+        captured["pid"] = proc.pid
+        return proc
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(supervisor.subprocess, "Popen", capture_worker)
+    try:
+        with pytest.raises(OSError):
+            supervisor.run(spec_path)
+    finally:
+        monkeypatch.undo()
+
+    child_pid = captured["pid"]
+    assert _wait_until_gone(child_pid), "publication failure orphaned the worker"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX signal semantics only")
+def test_direct_supervisor_sigterm_forwards_to_and_reaps_real_worker(tmp_path):
+    """Stop/reclaim signaling the registered supervisor PID reaches its child."""
+    child_pid_path = tmp_path / "child.pid"
+    spec_path = tmp_path / "worker-spec.json"
+    handshake_path = tmp_path / "supervisor.pid"
+    log_path = tmp_path / "worker.log"
+    child_code = (
+        "import os, sys, time; "
+        "open(sys.argv[1], 'w').write(str(os.getpid())); time.sleep(60)"
+    )
+    spec_path.write_text(
+        json.dumps(
+            {
+                "command": [sys.executable, "-c", child_code, str(child_pid_path)],
+                "cwd": None,
+                "log_path": str(log_path),
+                "handshake_path": str(handshake_path),
+                "task_id": "t_worker",
+                "run_id": 1,
+                "claim_lock": "host:worker",
+                "board": "default",
+            },
+        ),
+        encoding="utf-8",
+    )
+    repo_root = Path(__file__).parents[2]
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "hermes_cli.kanban_worker_supervisor", str(spec_path)],
+        cwd=repo_root,
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not handshake_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert int(handshake_path.read_text(encoding="utf-8")) == proc.pid
+        deadline = time.monotonic() + 5
+        while not child_pid_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+
+        proc.terminate()
+        proc.wait(timeout=5)
+        assert _wait_until_gone(child_pid), "SIGTERM left the real worker alive"
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+
+def test_windows_tree_cleanup_uses_taskkill_and_reaps_supervisor(monkeypatch):
+    """Windows takes the explicit taskkill /T path rather than POSIX signals."""
+    from hermes_cli import kanban_db as kb
+
+    calls = []
+
+    class FakeSupervisor:
+        def wait(self, timeout=None):
+            calls.append(("wait", timeout))
+            return 0
+
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setattr(
+        kb.subprocess,
+        "run",
+        lambda args, **kwargs: calls.append(("taskkill", args, kwargs)),
+    )
+
+    kb._terminate_supervisor_tree(91013, supervisor=FakeSupervisor())
+
+    assert calls[0][0] == "taskkill"
+    assert calls[0][1] == ["taskkill", "/PID", "91013", "/T", "/F"]
+    assert calls[1] == ("wait", 5)
+
+
+def test_handshake_timeout_preserves_original_error_when_cleanup_raises(
+    tmp_path, monkeypatch,
+):
+    """A cleanup fault cannot replace the handshake timeout reported to dispatch."""
+    from hermes_cli import kanban_db as kb
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    db_path = kb.kanban_db_path()
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    kb.init_db()
+    monkeypatch.setattr(kb, "_WORKER_PID_HANDSHAKE_TIMEOUT_SECONDS", 0.01)
+
+    class FakeSupervisor:
+        pid = 91014
+        returncode = None
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(kb.subprocess, "Popen", lambda *_args, **_kwargs: FakeSupervisor())
+    monkeypatch.setattr(
+        kb,
+        "_terminate_supervisor_tree",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("cleanup failure")),
+    )
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="preserve timeout", assignee="worker")
+        task = kb.claim_task(conn, task_id)
+        assert task is not None
+        with pytest.raises(RuntimeError, match="timed out before reporting the supervisor pid"):
+            kb._default_spawn(task, str(tmp_path))
+
+
+def test_pid_publication_failure_terminates_kills_and_reaps_worker(tmp_path, monkeypatch):
+    """Never leave a worker alive when its PID cannot be published to dispatch."""
+    spec_path = tmp_path / "worker-spec.json"
+    log_path = tmp_path / "worker.log"
+    handshake_path = tmp_path / "worker.pid"
+    spec_path.write_text(
+        json.dumps(
+            {
+                "command": ["worker"],
+                "cwd": None,
+                "log_path": str(log_path),
+                "handshake_path": str(handshake_path),
+                "task_id": "t_worker",
+                "run_id": 1,
+                "claim_lock": "host:worker",
+                "board": "default",
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    class Worker:
+        pid = 91004
+
+        def __init__(self):
+            self.terminated = 0
+            self.killed = 0
+            self.wait_timeouts: list[float | None] = []
+
+        def terminate(self):
+            self.terminated += 1
+
+        def kill(self):
+            self.killed += 1
+
+        def wait(self, timeout=None):
+            self.wait_timeouts.append(timeout)
+            if self.killed == 0:
+                raise subprocess.TimeoutExpired(["worker"], timeout or 0.0)
+            return -9
+
+    worker = Worker()
+    monkeypatch.setattr(supervisor.subprocess, "Popen", lambda *_args, **_kwargs: worker)
+
+    def fail_pid_publication(_path, _pid):
+        raise OSError("handshake disk failure")
+
+    monkeypatch.setattr(supervisor, "_write_supervisor_pid", fail_pid_publication)
+
+    with pytest.raises(OSError, match="handshake disk failure"):
+        supervisor.run(spec_path)
+
+    assert worker.terminated == 1
+    assert worker.killed == 1
+    assert len(worker.wait_timeouts) == 2
+    assert worker.wait_timeouts[0] is not None
+    assert worker.wait_timeouts[1] is None

--- a/tests/hermes_cli/test_kanban_worker_supervisor.py
+++ b/tests/hermes_cli/test_kanban_worker_supervisor.py
@@ -26,6 +26,20 @@ def _wait_until_gone(pid: int, *, timeout: float = 5.0) -> bool:
     return False
 
 
+def _wait_for_pid_file(path: Path, *, timeout: float = 5.0) -> int:
+    """Wait until *path* holds a complete positive PID; open() precedes write()."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            pid = int(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, ValueError):
+            pid = 0
+        if pid > 0:
+            return pid
+        time.sleep(0.01)
+    raise AssertionError(f"timed out waiting for a parseable pid in {path}")
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
 def _start_frozen_term_ignoring_supervisor(tmp_path, monkeypatch, *, max_runtime=None):
     """Create the adversarial boundary: stopped supervisor + live stubborn child."""
@@ -80,14 +94,8 @@ def _start_frozen_term_ignoring_supervisor(tmp_path, monkeypatch, *, max_runtime
         start_new_session=True,
     )
     try:
-        deadline = time.monotonic() + 5
-        while not handshake_path.exists() and time.monotonic() < deadline:
-            time.sleep(0.01)
-        assert int(handshake_path.read_text(encoding="utf-8")) == proc.pid
-        deadline = time.monotonic() + 5
-        while not child_pid_path.exists() and time.monotonic() < deadline:
-            time.sleep(0.01)
-        child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+        assert _wait_for_pid_file(handshake_path, timeout=5) == proc.pid
+        child_pid = _wait_for_pid_file(child_pid_path, timeout=5)
         # Freeze after the supervisor has published and spawned.  A direct
         # supervisor SIGKILL at this interleaving leaves the stubborn child
         # orphaned; group SIGTERM/KILL must remove both.
@@ -112,6 +120,229 @@ def _cleanup_process_group(proc):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+def test_generic_crash_sweeper_defers_dead_supervisor_with_live_child(tmp_path, monkeypatch):
+    """A dead group leader is not enough proof to release its live worker tree."""
+    from hermes_cli import kanban_db as kb
+
+    real_killpg = os.killpg
+    group_checks = []
+
+    def observe_group_probe(pgid, sig):
+        group_checks.append((pgid, sig))
+        return real_killpg(pgid, sig)
+
+    monkeypatch.setattr(kb.os, "killpg", observe_group_probe)
+
+    ready_path = tmp_path / "supervisor.ready"
+    release_path = tmp_path / "supervisor.release"
+    child_pid_path = tmp_path / "child.pid"
+    child_code = (
+        "import os, signal, sys, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "open(sys.argv[1], 'w').write(str(os.getpid())); time.sleep(60)"
+    )
+    supervisor_code = """
+import os
+import subprocess
+import sys
+import time
+
+ready, release, child_pid, child_code = sys.argv[1:5]
+open(ready, "w").write(str(os.getpid()))
+while not os.path.exists(release):
+    time.sleep(0.01)
+subprocess.Popen([sys.executable, "-c", child_code, child_pid])
+"""
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            supervisor_code,
+            str(ready_path),
+            str(release_path),
+            str(child_pid_path),
+            child_code,
+        ],
+        start_new_session=True,
+    )
+    child_pid = None
+    try:
+        assert _wait_for_pid_file(ready_path, timeout=5) == proc.pid
+
+        with kb.connect() as conn:
+            task_id = kb.create_task(conn, title="orphaned child", assignee="worker")
+            claimed = kb.claim_task(conn, task_id)
+            assert claimed is not None
+            assert claimed.claim_lock is not None
+            assert claimed.current_run_id is not None
+            assert kb._set_worker_pid(conn, task_id, proc.pid)
+            original_identity = kb.get_task(conn, task_id).worker_identity
+            assert original_identity is not None
+
+            release_path.touch()
+            proc.wait(timeout=5)
+            child_pid = _wait_for_pid_file(child_pid_path, timeout=5)
+            assert os.getpgid(child_pid) == proc.pid
+
+            # Age the launch beyond the generic sweeper's normal grace period
+            # and expire both leases, so only the defer's own extension can
+            # keep the stale-claim sweep away from this live tree.
+            old = int(time.time()) - 120
+            expired = int(time.time()) - 30
+            conn.execute(
+                "UPDATE tasks SET started_at = ?, claim_expires = ? WHERE id = ?",
+                (old, expired, task_id),
+            )
+            conn.execute(
+                "UPDATE task_runs SET started_at = ?, claim_expires = ? WHERE id = ?",
+                (old, expired, claimed.current_run_id),
+            )
+
+            sweep_time = int(time.time())
+            assert kb.detect_crashed_workers(conn) == []
+            # The defer must have renewed the expired leases; a stale-claim
+            # sweep inside that grace window must not release the live tree.
+            assert kb.release_stale_claims(conn) == 0
+            task = kb.get_task(conn, task_id)
+            run = kb.latest_run(conn, task_id)
+            events = kb.list_events(conn, task_id)
+            spawned = []
+            dispatch = kb.dispatch_once(
+                conn,
+                spawn_fn=lambda *args: spawned.append(args) or None,
+            )
+
+        assert task is not None
+        assert task.status == "running"
+        assert task.claim_lock == claimed.claim_lock
+        assert task.current_run_id == claimed.current_run_id
+        assert task.worker_pid == proc.pid
+        assert task.worker_identity == original_identity
+        assert task.claim_expires is not None
+        assert task.claim_expires >= sweep_time + kb.RECLAIM_DEFER_GRACE_SECONDS
+        assert run is not None
+        assert run.claim_lock == claimed.claim_lock
+        assert run.worker_pid == proc.pid
+        assert run.worker_identity == original_identity
+        assert run.claim_expires is not None
+        assert run.claim_expires >= sweep_time + kb.RECLAIM_DEFER_GRACE_SECONDS
+        assert child_pid is not None
+        os.kill(child_pid, 0)
+        assert spawned == []
+        assert task_id not in dispatch.crashed
+        assert dispatch.deferred == [task_id]
+        assert group_checks and all(sig == 0 for _pgid, sig in group_checks)
+        deferred = [event for event in events if event.kind == "reclaim_deferred"]
+        assert len(deferred) == 1
+        assert deferred[0].payload is not None
+        assert deferred[0].payload["reason"] == "dead_supervisor_process_group_live"
+    finally:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        if child_pid is not None:
+            assert _wait_until_gone(child_pid), "failed to clean up test child"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+def test_manual_reclaim_releases_dead_supervisor_with_gone_group(tmp_path, monkeypatch):
+    """An operator reclaim recovers a reaped supervisor via the signal-free probe.
+
+    The supervisor registers its PID/incarnation while provably alive, then
+    exits with no children and is reaped.  ``_terminate_reclaimed_worker`` can
+    then only report ``leader_gone`` — manual reclaim must apply the same
+    dead-group proof as operator complete/block/archive/delete instead of
+    deferring until a dispatcher tick.
+    """
+    from hermes_cli import kanban_db as kb
+
+    real_killpg = os.killpg
+    group_checks = []
+
+    def observe_group_probe(pgid, sig):
+        group_checks.append((pgid, sig))
+        return real_killpg(pgid, sig)
+
+    monkeypatch.setattr(kb.os, "killpg", observe_group_probe)
+
+    ready_path = tmp_path / "supervisor.ready"
+    release_path = tmp_path / "supervisor.release"
+    supervisor_code = """
+import os
+import sys
+import time
+
+ready, release = sys.argv[1:3]
+open(ready, "w").write(str(os.getpid()))
+while not os.path.exists(release):
+    time.sleep(0.01)
+"""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", supervisor_code, str(ready_path), str(release_path)],
+        start_new_session=True,
+    )
+    try:
+        assert _wait_for_pid_file(ready_path, timeout=5) == proc.pid
+
+        with kb.connect() as conn:
+            task_id = kb.create_task(conn, title="reaped leader", assignee="worker")
+            claimed = kb.claim_task(conn, task_id)
+            assert claimed is not None
+            assert claimed.claim_lock is not None
+            assert claimed.current_run_id is not None
+            assert kb._set_worker_pid(conn, task_id, proc.pid)
+            registered = kb.get_task(conn, task_id)
+            assert registered is not None
+            assert registered.worker_identity is not None
+
+            # The leader exits childless and is reaped: the PID-named group
+            # is gone while the persisted registration still points at it.
+            release_path.touch()
+            proc.wait(timeout=5)
+
+            assert kb.reclaim_task(conn, task_id, reason="operator recovery")
+            task = kb.get_task(conn, task_id)
+            run = kb.latest_run(conn, task_id)
+            events = kb.list_events(conn, task_id)
+
+        assert task is not None
+        assert task.status == "ready"
+        assert task.claim_lock is None
+        assert task.claim_expires is None
+        assert task.worker_pid is None
+        assert task.worker_identity is None
+        assert task.current_run_id is None
+        assert run is not None
+        assert run.id == claimed.current_run_id
+        assert run.status == "reclaimed"
+        assert run.outcome == "reclaimed"
+        assert run.ended_at is not None
+        assert run.claim_lock is None
+        assert run.claim_expires is None
+        assert run.worker_pid is None
+        assert run.worker_identity is None
+        assert group_checks and all(sig == 0 for _pgid, sig in group_checks)
+        reclaimed = [event for event in events if event.kind == "reclaimed"]
+        assert len(reclaimed) == 1
+        assert reclaimed[0].payload is not None
+        assert reclaimed[0].payload["manual"] is True
+        assert reclaimed[0].payload["identity"] == "leader_gone"
+        assert reclaimed[0].payload["tree_target"] == "dead_supervisor_group_probe"
+        assert (
+            reclaimed[0].payload["dead_supervisor_group_state"]
+            == "process_group_gone"
+        )
+    finally:
+        if proc.poll() is None:
+            try:
+                real_killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            proc.wait()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
 def test_manual_reclaim_kills_frozen_supervisor_tree_before_release(tmp_path, monkeypatch):
     kb, task_id, _claimed, proc, child_pid = _start_frozen_term_ignoring_supervisor(
         tmp_path, monkeypatch,
@@ -127,6 +358,222 @@ def test_manual_reclaim_kills_frozen_supervisor_tree_before_release(tmp_path, mo
             assert task.claim_lock is None
             assert task.worker_pid is None
     finally:
+        _cleanup_process_group(proc)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+def test_worker_schedule_uses_exact_capability_without_signalling_itself(tmp_path, monkeypatch):
+    """A valid worker schedule closes only its own exact run, without killpg."""
+    kb, task_id, claimed, proc, child_pid = _start_frozen_term_ignoring_supervisor(
+        tmp_path, monkeypatch,
+    )
+    try:
+        signals = []
+        with monkeypatch.context() as signal_observer:
+            with kb.connect() as conn:
+                assert kb._set_worker_pid(conn, task_id, proc.pid)
+                signal_observer.setattr(kb.os, "killpg", lambda *args: signals.append(args))
+                assert kb.schedule_task(
+                    conn,
+                    task_id,
+                    reason="worker reschedule",
+                    expected_run_id=claimed.current_run_id,
+                    expected_claim_lock=claimed.claim_lock,
+                )
+                task = kb.get_task(conn, task_id)
+                run = kb.latest_run(conn, task_id)
+
+            assert signals == []
+
+        assert task is not None
+        assert task.status == "scheduled"
+        assert task.claim_lock is None
+        assert task.worker_pid is None
+        assert run is not None
+        assert run.status == "scheduled"
+        assert run.worker_pid is None
+        os.kill(child_pid, 0)
+    finally:
+        _cleanup_process_group(proc)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+@pytest.mark.parametrize("operation", ["complete", "block"])
+def test_operator_completion_transition_kills_detached_tree_before_clearing_claim(
+    tmp_path, monkeypatch, operation,
+):
+    """Operator complete/block cannot lose a stopped supervisor's worker tree."""
+    kb, task_id, _claimed, proc, child_pid = _start_frozen_term_ignoring_supervisor(
+        tmp_path, monkeypatch,
+    )
+    try:
+        with kb.connect() as conn:
+            assert kb._set_worker_pid(conn, task_id, proc.pid)
+            if operation == "complete":
+                assert kb.complete_task(conn, task_id, summary="operator completion")
+                expected_status, expected_outcome = "done", "completed"
+            else:
+                assert kb.block_task(conn, task_id, reason="operator block")
+                expected_status, expected_outcome = "blocked", "blocked"
+            assert _wait_until_gone(child_pid), f"{operation} orphaned detached child"
+            task = kb.get_task(conn, task_id)
+            run = kb.latest_run(conn, task_id)
+
+        assert task is not None
+        assert task.status == expected_status
+        assert task.claim_lock is None
+        assert task.worker_pid is None
+        assert task.worker_identity is None
+        assert task.current_run_id is None
+        assert run is not None
+        assert run.outcome == expected_outcome
+        assert run.worker_pid is None
+        assert run.worker_identity is None
+    finally:
+        _cleanup_process_group(proc)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+@pytest.mark.parametrize("operation", ["complete", "block"])
+def test_operator_completion_transition_defers_unregistered_launch(tmp_path, operation):
+    """No-PID launch windows cannot be terminally transitioned blind."""
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="launch window", assignee="worker")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        if operation == "complete":
+            assert not kb.complete_task(conn, task_id, summary="must defer")
+        else:
+            assert not kb.block_task(conn, task_id, reason="must defer")
+
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+        deferred = [event for event in kb.list_events(conn, task_id) if event.kind == "reclaim_deferred"]
+
+    assert task is not None
+    assert task.status == "running"
+    assert task.current_run_id == claimed.current_run_id
+    assert task.claim_lock is not None
+    assert task.worker_pid is None
+    assert run is not None and run.ended_at is None
+    assert len(deferred) == 1
+    assert deferred[0].payload is not None
+    assert deferred[0].payload["identity"] == "worker_pid_missing"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+@pytest.mark.parametrize("operation", ["archive", "delete"])
+def test_operator_terminal_transition_kills_detached_tree_before_mutating(
+    tmp_path, monkeypatch, operation,
+):
+    """Archive/delete wait for verified KILL/reap before destroying ownership."""
+    kb, task_id, _claimed, proc, child_pid = _start_frozen_term_ignoring_supervisor(
+        tmp_path, monkeypatch,
+    )
+    try:
+        with kb.connect() as conn:
+            assert kb._set_worker_pid(conn, task_id, proc.pid)
+            if operation == "archive":
+                assert kb.archive_task(conn, task_id)
+            else:
+                assert kb.delete_task(conn, task_id)
+            assert _wait_until_gone(
+                child_pid,
+            ), f"{operation} orphaned detached child"
+            task = kb.get_task(conn, task_id)
+            run_count = conn.execute(
+                "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (task_id,),
+            ).fetchone()[0]
+
+        if operation == "archive":
+            assert task is not None
+            assert task.status == "archived"
+            assert task.claim_lock is None
+            assert task.worker_pid is None
+            assert run_count == 1
+        else:
+            assert task is None
+            assert run_count == 0
+    finally:
+        _cleanup_process_group(proc)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+@pytest.mark.parametrize("operation", ["complete", "block", "schedule", "archive", "delete"])
+def test_operator_transition_identity_mismatch_defers_without_mutation(
+    tmp_path, monkeypatch, operation,
+):
+    """A replacement detached leader is never signalled or stripped of ownership.
+
+    Literal PID reuse is nondeterministic, so the identity probe represents the
+    persisted leader's start ticks changing underneath this real detached
+    supervisor/TERM-ignoring-child tree.
+    """
+    kb, task_id, claimed, proc, child_pid = _start_frozen_term_ignoring_supervisor(
+        tmp_path, monkeypatch,
+    )
+    real_killpg = os.killpg
+    signals = []
+    try:
+        with kb.connect() as conn:
+            assert kb._set_worker_pid(conn, task_id, proc.pid)
+            task_before = kb.get_task(conn, task_id)
+            assert task_before is not None
+            assert task_before.worker_identity is not None
+            assert task_before.claim_expires is not None
+            run_before = kb.latest_run(conn, task_id)
+            assert run_before is not None
+            monkeypatch.setattr(
+                kb, "_supervisor_process_identity", lambda _pid: "linux-start-ticks:replacement",
+            )
+            monkeypatch.setattr(kb.os, "killpg", lambda *args: signals.append(args))
+
+            if operation == "complete":
+                assert not kb.complete_task(conn, task_id, summary="identity replacement")
+            elif operation == "block":
+                assert not kb.block_task(conn, task_id, reason="identity replacement")
+            elif operation == "schedule":
+                assert not kb.schedule_task(conn, task_id)
+            elif operation == "archive":
+                assert not kb.archive_task(conn, task_id)
+            else:
+                assert not kb.delete_task(conn, task_id)
+
+            task = kb.get_task(conn, task_id)
+            run = kb.latest_run(conn, task_id)
+            deferred = [
+                event for event in kb.list_events(conn, task_id)
+                if event.kind == "reclaim_deferred"
+            ]
+
+        assert task is not None
+        assert task.status == "running"
+        assert task.claim_lock == task_before.claim_lock
+        assert task.worker_pid == proc.pid
+        assert task.worker_identity == task_before.worker_identity
+        # An unproven (identity-mismatched) tree must not have its lease
+        # renewed: the claim stays bound but claim_expires is untouched.
+        assert task.claim_expires == task_before.claim_expires
+        assert run is not None
+        assert run.claim_lock == task_before.claim_lock
+        assert run.worker_pid == proc.pid
+        assert run.worker_identity == task_before.worker_identity
+        assert run.claim_expires == run_before.claim_expires
+        assert signals == []
+        assert len(deferred) == 1
+        assert deferred[0].payload is not None
+        assert deferred[0].payload["identity"] == "identity_mismatch"
+        assert deferred[0].payload["reason"] == f"operator_{operation}_worker_alive"
+        os.kill(child_pid, 0)
+    finally:
+        monkeypatch.undo()
+        try:
+            real_killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
         _cleanup_process_group(proc)
 
 
@@ -148,6 +595,55 @@ def test_stale_reclaim_kills_frozen_supervisor_tree_before_release(tmp_path, mon
             assert task is not None
             assert task.status == "ready"
             assert task.claim_lock is None
+    finally:
+        _cleanup_process_group(proc)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+@pytest.mark.parametrize("reclaim_path", ["ttl", "heartbeat_stale"])
+def test_stale_sweepers_hold_no_pid_publication_window_with_live_worker_tree(
+    tmp_path, monkeypatch, reclaim_path,
+):
+    """No registered PID is never evidence that the detached tree is gone."""
+    kb, task_id, claimed, proc, child_pid = _start_frozen_term_ignoring_supervisor(
+        tmp_path, monkeypatch,
+    )
+    try:
+        with kb.connect() as conn:
+            # Deliberately leave the freshly launched supervisor unregistered:
+            # this is the dispatcher's post-spawn/pre-PID-publication window.
+            assert kb.get_task(conn, task_id).worker_pid is None
+            old = int(time.time()) - 7200
+            if reclaim_path == "ttl":
+                conn.execute(
+                    "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? WHERE id = ?",
+                    (int(time.time()) - 1, old, task_id),
+                )
+                assert kb.release_stale_claims(conn) == 0
+            else:
+                conn.execute("UPDATE tasks SET started_at = ? WHERE id = ?", (old, task_id))
+                conn.execute(
+                    "UPDATE task_runs SET started_at = ? WHERE id = ?",
+                    (old, claimed.current_run_id),
+                )
+                assert kb.detect_stale_running(conn, stale_timeout_seconds=1) == []
+
+            task = kb.get_task(conn, task_id)
+            run = kb.get_run(conn, claimed.current_run_id)
+            events = kb.list_events(conn, task_id)
+
+        assert task is not None
+        assert task.status == "running"
+        assert task.claim_lock == claimed.claim_lock
+        assert task.worker_pid is None
+        assert task.current_run_id == claimed.current_run_id
+        assert run is not None and run.ended_at is None
+        assert proc.poll() is None
+        os.kill(child_pid, 0)
+        deferred = [event for event in events if event.kind == "reclaim_deferred"]
+        assert len(deferred) == 1
+        assert deferred[0].payload is not None
+        assert deferred[0].payload["identity"] == "worker_pid_missing"
     finally:
         _cleanup_process_group(proc)
 
@@ -208,21 +704,118 @@ def test_reclaim_identity_mismatch_defers_without_signalling_unrelated_group(tmp
         unrelated.wait(timeout=5)
 
 
-def test_windows_reclaim_tree_cleanup_uses_taskkill(monkeypatch):
-    """Windows reclaim uses taskkill /T /F instead of direct PID SIGKILL."""
+@pytest.mark.skipif(os.name == "nt", reason="POSIX detached-session fixture only")
+@pytest.mark.parametrize("reclaim_path", ["manual", "ttl", "max_runtime", "heartbeat_stale"])
+def test_replacement_session_leader_identity_mismatch_defers_every_reclaim_path(
+    monkeypatch, reclaim_path,
+):
+    """A replacement session leader never receives a reclaim tree signal.
+
+    Literal PID reuse is impractical to force deterministically.  The injected
+    identity probe models the old PID's registered start ticks changing to a
+    replacement process while the real subprocess proves the dangerous shape:
+    an unrelated process that is itself a fresh session/group leader.
+    """
+    from hermes_cli import kanban_db as kb
+
+    unrelated = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        start_new_session=True,
+    )
+    identity = {"value": "linux-start-ticks:registered"}
+    signals = []
+    real_killpg = os.killpg
+    monkeypatch.setattr(kb, "_supervisor_process_identity", lambda _pid: identity["value"])
+    monkeypatch.setattr(kb.os, "killpg", lambda *args: signals.append(args))
+    try:
+        assert os.getpgid(unrelated.pid) == unrelated.pid
+        assert os.getsid(unrelated.pid) == unrelated.pid
+        with kb.connect() as conn:
+            task_id = kb.create_task(
+                conn,
+                title="replacement session leader",
+                assignee="worker",
+                max_runtime_seconds=1 if reclaim_path == "max_runtime" else None,
+            )
+            claimed = kb.claim_task(conn, task_id)
+            assert claimed is not None
+            assert claimed.current_run_id is not None
+            assert kb._set_worker_pid(conn, task_id, unrelated.pid)
+
+            # Simulate PID reuse after registration. The new leader is not our
+            # supervisor even though its PID/PGID/SID shape passes the old test.
+            identity["value"] = "linux-start-ticks:replacement"
+            old = int(time.time()) - 7200
+            if reclaim_path == "ttl":
+                conn.execute(
+                    "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? WHERE id = ?",
+                    (int(time.time()) - 1, old, task_id),
+                )
+            elif reclaim_path in ("max_runtime", "heartbeat_stale"):
+                conn.execute("UPDATE tasks SET started_at = ? WHERE id = ?", (old, task_id))
+                conn.execute(
+                    "UPDATE task_runs SET started_at = ? WHERE id = ?",
+                    (old, claimed.current_run_id),
+                )
+
+            expires_before = (
+                kb.get_task(conn, task_id).claim_expires,
+                kb.latest_run(conn, task_id).claim_expires,
+            )
+            if reclaim_path == "manual":
+                assert not kb.reclaim_task(conn, task_id, reason="identity replacement")
+            elif reclaim_path == "ttl":
+                assert kb.release_stale_claims(conn) == 0
+            elif reclaim_path == "max_runtime":
+                assert kb.enforce_max_runtime(conn) == []
+            else:
+                assert kb.detect_stale_running(conn, stale_timeout_seconds=1) == []
+
+            task = kb.get_task(conn, task_id)
+            run = kb.latest_run(conn, task_id)
+            events = kb.list_events(conn, task_id)
+        assert task is not None
+        assert task.status == "running"
+        assert task.worker_pid == unrelated.pid
+        assert task.worker_identity == "linux-start-ticks:registered"
+        assert run is not None
+        assert run.worker_identity == "linux-start-ticks:registered"
+        # Deferred ownership stays bound, but an unproven replacement leader
+        # must never receive a lease renewal on the task or its open run.
+        assert (task.claim_expires, run.claim_expires) == expires_before
+        assert unrelated.poll() is None
+        assert signals == []
+        deferred = [event for event in events if event.kind == "reclaim_deferred"]
+        assert len(deferred) == 1
+        assert deferred[0].payload is not None
+        assert deferred[0].payload["identity"] == "identity_mismatch"
+    finally:
+        real_killpg(unrelated.pid, signal.SIGKILL)
+        unrelated.wait(timeout=5)
+
+
+def test_windows_reclaim_tree_cleanup_fails_closed_without_incarnation_proof(monkeypatch):
+    """Windows cannot safely taskkill a PID without an incarnation token."""
     from hermes_cli import kanban_db as kb
 
     calls = []
     monkeypatch.setattr(kb, "_IS_WINDOWS", True)
-    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
     monkeypatch.setattr(
         kb.subprocess,
         "run",
         lambda args, **kwargs: calls.append((args, kwargs)),
     )
-    info = kb._terminate_reclaimed_worker(91015, f"{kb._claimer_id().split(':', 1)[0]}:x")
-    assert info["terminated"] is True
-    assert calls[0][0] == ["taskkill", "/PID", "91015", "/T", "/F"]
+    info = kb._terminate_reclaimed_worker(
+        91015,
+        f"{kb._claimer_id().split(':', 1)[0]}:x",
+        worker_identity="unverifiable-on-windows",
+        run_worker_identity="unverifiable-on-windows",
+        run_worker_pid=91015,
+        run_claim_lock=f"{kb._claimer_id().split(':', 1)[0]}:x",
+    )
+    assert info["identity"] == "identity_unavailable_platform"
+    assert info["termination_deferred"] is True
+    assert calls == []
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX process groups only")
@@ -254,6 +847,7 @@ def test_parent_handshake_failure_kills_real_supervisor_tree_and_cleans_artifact
         + ("sys.exit(23)" if supervisor_mode == "early_exit" else "time.sleep(60)")
     )
     real_popen = subprocess.Popen
+    spawned = {}
 
     def spawn_no_handshake(_cmd, **_kwargs):
         proc = real_popen(
@@ -266,10 +860,7 @@ def test_parent_handshake_failure_kills_real_supervisor_tree_and_cleans_artifact
             ],
             start_new_session=True,
         )
-        deadline = time.monotonic() + 2
-        while not child_pid_path.exists() and time.monotonic() < deadline:
-            time.sleep(0.01)
-        assert child_pid_path.exists()
+        spawned["child_pid"] = _wait_for_pid_file(child_pid_path, timeout=2)
         return proc
 
     monkeypatch.setattr(kb.subprocess, "Popen", spawn_no_handshake)
@@ -282,7 +873,7 @@ def test_parent_handshake_failure_kills_real_supervisor_tree_and_cleans_artifact
         )):
             kb._default_spawn(task, str(tmp_path))
 
-    child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+    child_pid = spawned["child_pid"]
     assert _wait_until_gone(child_pid), "handshake cleanup orphaned the worker"
     log_dir = home / "kanban" / "logs"
     assert not list(log_dir.glob("*.spawn.json"))
@@ -338,6 +929,112 @@ def test_real_pid_publication_failure_kills_and_reaps_worker_tree(tmp_path):
     assert _wait_until_gone(child_pid), "publication failure orphaned the worker"
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+def test_pid_publication_failure_reaps_term_ignoring_grandchild_tree(tmp_path):
+    """The supervisor's own failed publication path kills its full session."""
+    direct_pid_path = tmp_path / "direct.pid"
+    grandchild_pid_path = tmp_path / "grandchild.pid"
+    ready_path = tmp_path / "worker.ready"
+    spec_path = tmp_path / "worker-spec.json"
+    log_path = tmp_path / "worker.log"
+    handshake_path = tmp_path / "worker.pid"
+    grandchild_code = (
+        "import os, signal, sys, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "open(sys.argv[1], 'w').write(str(os.getpid())); time.sleep(60)"
+    )
+    worker_code = (
+        "import os, signal, subprocess, sys, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "subprocess.Popen([sys.executable, '-c', sys.argv[3], sys.argv[1]]); "
+        "open(sys.argv[2], 'w').write(str(os.getpid())); "
+        "open(sys.argv[4], 'w').write('ready'); time.sleep(60)"
+    )
+    spec_path.write_text(
+        json.dumps(
+            {
+                "command": [
+                    sys.executable, "-c", worker_code,
+                    str(grandchild_pid_path), str(direct_pid_path),
+                    grandchild_code, str(ready_path),
+                ],
+                "cwd": None,
+                "log_path": str(log_path),
+                "handshake_path": str(handshake_path),
+                "task_id": "t_worker",
+                "run_id": 1,
+                "claim_lock": "host:worker",
+                "board": "default",
+            },
+        ),
+        encoding="utf-8",
+    )
+    launcher = """\
+import sys
+import time
+from pathlib import Path
+from hermes_cli import kanban_worker_supervisor as s
+
+ready = Path(sys.argv[2])
+
+def fail(_path, _pid):
+    deadline = time.monotonic() + 5
+    while not ready.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    if not ready.exists():
+        raise RuntimeError("worker never became ready")
+    raise OSError("forced publication failure")
+
+s._write_supervisor_pid = fail
+s.run(Path(sys.argv[1]))
+"""
+    repo_root = Path(__file__).parents[2]
+    proc = subprocess.Popen(
+        [sys.executable, "-c", launcher, str(spec_path), str(ready_path)],
+        cwd=repo_root,
+        start_new_session=True,
+    )
+    try:
+        assert proc.wait(timeout=10) != 0
+        direct_pid = int(direct_pid_path.read_text(encoding="utf-8"))
+        grandchild_pid = int(grandchild_pid_path.read_text(encoding="utf-8"))
+        assert _wait_until_gone(direct_pid), "publication failure orphaned worker"
+        assert _wait_until_gone(grandchild_pid), "publication failure orphaned grandchild"
+    finally:
+        _cleanup_process_group(proc)
+
+
+def test_windows_publication_failure_cleanup_uses_taskkill_tree(monkeypatch):
+    """Windows uses taskkill /T /F before reaping an unpublished worker."""
+    calls = []
+
+    class Worker:
+        pid = 91004
+
+        def wait(self, timeout=None):
+            calls.append(("wait", timeout))
+            return -9
+
+        def terminate(self):
+            calls.append(("terminate",))
+
+        def kill(self):
+            calls.append(("kill",))
+
+    monkeypatch.setattr(supervisor, "_IS_WINDOWS", True, raising=False)
+    monkeypatch.setattr(
+        supervisor.subprocess,
+        "run",
+        lambda args, **kwargs: calls.append(("taskkill", args, kwargs)),
+    )
+
+    supervisor._terminate_and_reap_worker(Worker())
+
+    assert calls[0][0] == "taskkill"
+    assert calls[0][1] == ["taskkill", "/PID", "91004", "/T", "/F"]
+    assert calls[1] == ("wait", supervisor._WORKER_TERMINATE_TIMEOUT_SECONDS)
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX signal semantics only")
 def test_direct_supervisor_sigterm_forwards_to_and_reaps_real_worker(tmp_path):
     """Stop/reclaim signaling the registered supervisor PID reaches its child."""
@@ -371,14 +1068,8 @@ def test_direct_supervisor_sigterm_forwards_to_and_reaps_real_worker(tmp_path):
         start_new_session=True,
     )
     try:
-        deadline = time.monotonic() + 5
-        while not handshake_path.exists() and time.monotonic() < deadline:
-            time.sleep(0.02)
-        assert int(handshake_path.read_text(encoding="utf-8")) == proc.pid
-        deadline = time.monotonic() + 5
-        while not child_pid_path.exists() and time.monotonic() < deadline:
-            time.sleep(0.02)
-        child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+        assert _wait_for_pid_file(handshake_path, timeout=5) == proc.pid
+        child_pid = _wait_for_pid_file(child_pid_path, timeout=5)
 
         proc.terminate()
         proc.wait(timeout=5)

--- a/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
+++ b/tests/hermes_cli/test_kanban_worker_terminal_cwd.py
@@ -13,7 +13,9 @@ Pinning ``TERMINAL_CWD`` to the workspace fixes both.
 
 from __future__ import annotations
 
+import json
 import subprocess
+from pathlib import Path
 
 
 def _make_task(kb, *, assignee: str = "w"):
@@ -44,11 +46,17 @@ def _capture_spawn_env(kb, monkeypatch, workspace: str) -> dict:
 
     class FakeProc:
         pid = 4242
+        returncode = None
+
+        def poll(self):
+            return self.returncode
 
     def fake_popen(cmd, *args, **kwargs):
-        captured["cmd"] = list(cmd)
+        spec = json.loads(Path(cmd[-1]).read_text(encoding="utf-8"))
+        captured["cmd"] = spec["command"]
         captured["env"] = dict(kwargs.get("env") or {})
-        captured["cwd"] = kwargs.get("cwd")
+        captured["cwd"] = spec["cwd"]
+        Path(spec["handshake_path"]).write_text("4242", encoding="utf-8")
         return FakeProc()
 
     monkeypatch.setattr(subprocess, "Popen", fake_popen)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -8,7 +8,9 @@ REST surface without spinning up the whole dashboard.
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
+import signal
 import subprocess
 import sys
 import time
@@ -1319,6 +1321,8 @@ def test_task_detail_includes_runs(client):
             result="done",
             summary="tested on rate limiter",
             metadata={"changed_files": ["limiter.py"]},
+            expected_run_id=_kb.latest_run(conn, tid).id,
+            expected_claim_lock=_kb.get_task(conn, tid).claim_lock,
         )
     finally:
         conn.close()
@@ -1345,15 +1349,10 @@ def test_task_detail_runs_empty_before_claim(client):
 def test_patch_status_done_with_summary_and_metadata(client):
     """PATCH /tasks/:id with status=done + summary + metadata must
     reach complete_task, so the dashboard has CLI parity."""
-    # Create + claim.
+    # A normal dashboard completion of unclaimed work remains supported.
     r = client.post("/api/plugins/kanban/tasks", json={"title": "x", "assignee": "worker"})
     tid = r.json()["task"]["id"]
     from hermes_cli import kanban_db as kb
-    conn = kb.connect()
-    try:
-        kb.claim_task(conn, tid)
-    finally:
-        conn.close()
 
     r = client.patch(
         f"/api/plugins/kanban/tasks/{tid}",
@@ -1381,11 +1380,6 @@ def test_patch_status_done_without_summary_still_works(client):
     r = client.post("/api/plugins/kanban/tasks", json={"title": "y", "assignee": "worker"})
     tid = r.json()["task"]["id"]
     from hermes_cli import kanban_db as kb
-    conn = kb.connect()
-    try:
-        kb.claim_task(conn, tid)
-    finally:
-        conn.close()
     r = client.patch(
         f"/api/plugins/kanban/tasks/{tid}",
         json={"status": "done", "result": "legacy shape"},
@@ -1400,8 +1394,8 @@ def test_patch_status_done_without_summary_still_works(client):
         conn.close()
 
 
-def test_patch_status_archive_closes_running_run(client):
-    """PATCH to archived while running must close the in-flight run."""
+def test_patch_status_archive_defers_unregistered_running_launch(client):
+    """Dashboard preserves a running launch whose tree cannot be proven gone."""
     r = client.post("/api/plugins/kanban/tasks", json={"title": "z", "assignee": "worker"})
     tid = r.json()["task"]["id"]
     from hermes_cli import kanban_db as kb
@@ -1409,6 +1403,7 @@ def test_patch_status_archive_closes_running_run(client):
     try:
         kb.claim_task(conn, tid)
         open_run = kb.latest_run(conn, tid)
+        assert open_run is not None
         assert open_run.ended_at is None
     finally:
         conn.close()
@@ -1416,15 +1411,148 @@ def test_patch_status_archive_closes_running_run(client):
         f"/api/plugins/kanban/tasks/{tid}",
         json={"status": "archived"},
     )
-    assert r.status_code == 200, r.text
+    assert r.status_code == 409, r.text
     conn = kb.connect()
     try:
         task = kb.get_task(conn, tid)
-        assert task.status == "archived"
-        assert task.current_run_id is None
-        assert kb.latest_run(conn, tid).outcome == "reclaimed"
+        assert task is not None
+        assert task.status == "running"
+        assert task.current_run_id == open_run.id
+        current_run = kb.latest_run(conn, tid)
+        assert current_run is not None
+        assert current_run.ended_at is None
+        deferred = [e for e in kb.list_events(conn, tid) if e.kind == "reclaim_deferred"]
+        assert len(deferred) == 1
+        assert deferred[0].payload is not None
+        assert deferred[0].payload["identity"] == "worker_pid_missing"
     finally:
         conn.close()
+
+
+def _wait_until_gone(pid: int, *, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        time.sleep(0.02)
+    return False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+def _start_dashboard_frozen_worker(tmp_path, monkeypatch, task_id, run_id, claim_lock):
+    """Start the production detached supervisor with a stubborn child."""
+    child_pid_path = tmp_path / "dashboard-child.pid"
+    spec_path = tmp_path / "dashboard-worker-spec.json"
+    handshake_path = tmp_path / "dashboard-supervisor.pid"
+    child_code = (
+        "import os, signal, sys, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "open(sys.argv[1], 'w').write(str(os.getpid())); time.sleep(60)"
+    )
+    spec_path.write_text(
+        json.dumps({
+            "command": [sys.executable, "-c", child_code, str(child_pid_path)],
+            "cwd": None,
+            "log_path": str(tmp_path / "dashboard-worker.log"),
+            "handshake_path": str(handshake_path),
+            "task_id": task_id,
+            "run_id": run_id,
+            "claim_lock": claim_lock,
+            "board": "default",
+        }),
+        encoding="utf-8",
+    )
+    repo_root = Path(__file__).resolve().parents[2]
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "hermes_cli.kanban_worker_supervisor", str(spec_path)],
+        cwd=repo_root,
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not handshake_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert int(handshake_path.read_text(encoding="utf-8")) == proc.pid
+        deadline = time.monotonic() + 5
+        while not child_pid_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+        os.kill(proc.pid, signal.SIGSTOP)
+        monkeypatch.setattr(kb, "_WORKER_TREE_TERMINATE_GRACE_SECONDS", 0.12)
+        monkeypatch.setattr(kb, "_WORKER_TREE_TERMINATE_POLL_SECONDS", 0.01)
+        return proc, child_pid
+    except BaseException:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait()
+        raise
+
+
+def _cleanup_dashboard_process_group(proc):
+    if proc.poll() is None:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+@pytest.mark.parametrize(
+    ("route", "payload", "expected_status"),
+    [
+        ("single", {"status": "ready"}, "ready"),
+        ("bulk", {"status": "done"}, "done"),
+        ("bulk", {"status": "todo"}, "todo"),
+    ],
+)
+def test_dashboard_operator_transition_reaps_detached_worker_before_releasing_claim(
+    client, tmp_path, monkeypatch, route, payload, expected_status,
+):
+    """PATCH and bulk status routes must not orphan a stopped worker tree."""
+    created = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "dashboard operator", "assignee": "worker"},
+    )
+    task_id = created.json()["task"]["id"]
+    with kb.connect() as conn:
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock is not None
+        proc, child_pid = _start_dashboard_frozen_worker(
+            tmp_path, monkeypatch, task_id, claimed.current_run_id, claimed.claim_lock,
+        )
+        assert kb._set_worker_pid(conn, task_id, proc.pid)
+    try:
+        if route == "single":
+            response = client.patch(f"/api/plugins/kanban/tasks/{task_id}", json=payload)
+            assert response.status_code == 200, response.text
+        else:
+            response = client.post(
+                "/api/plugins/kanban/tasks/bulk",
+                json={"ids": [task_id], **payload},
+            )
+            assert response.status_code == 200, response.text
+            assert response.json()["results"] == [{"id": task_id, "ok": True}]
+        assert _wait_until_gone(child_pid), f"dashboard {route} transition orphaned child"
+        with kb.connect() as conn:
+            task = kb.get_task(conn, task_id)
+            run = kb.latest_run(conn, task_id)
+        assert task is not None
+        assert task.status == expected_status
+        assert task.claim_lock is None
+        assert task.worker_pid is None
+        assert task.worker_identity is None
+        assert task.current_run_id is None
+        assert run is not None and run.ended_at is not None
+        assert run.worker_pid is None
+        assert run.worker_identity is None
+    finally:
+        _cleanup_dashboard_process_group(proc)
 
 
 def test_event_dict_includes_run_id(client):
@@ -1436,7 +1564,10 @@ def test_event_dict_includes_run_id(client):
     try:
         kb.claim_task(conn, tid)
         run_id = kb.latest_run(conn, tid).id
-        kb.complete_task(conn, tid, summary="wss")
+        kb.complete_task(
+            conn, tid, summary="wss", expected_run_id=run_id,
+            expected_claim_lock=kb.get_task(conn, tid).claim_lock,
+        )
     finally:
         conn.close()
 
@@ -1919,9 +2050,8 @@ def test_board_warnings_cleared_after_clean_completion(client):
     assert parent_dict.get("warnings") is None
 
 
-def test_reclaim_endpoint_releases_running_claim(client):
-    """POST /tasks/<id>/reclaim drops the claim, returns ok, and emits
-    a manual reclaimed event."""
+def test_reclaim_endpoint_defers_unverifiable_running_claim(client):
+    """Dashboard reclaim cannot clear synthetic/unverifiable ownership."""
     import secrets
     conn = kb.connect()
     try:
@@ -1948,19 +2078,16 @@ def test_reclaim_endpoint_releases_running_claim(client):
         f"/api/plugins/kanban/tasks/{t}/reclaim",
         json={"reason": "browser recovery"},
     )
-    assert r.status_code == 200, r.text
-    body = r.json()
-    assert body["ok"] is True
-    assert body["task_id"] == t
+    assert r.status_code == 409, r.text
 
-    # Confirm the task is back to ready.
+    # Confirm the task ownership remains bound for a later safe retry.
     conn2 = kb.connect()
     try:
         row = conn2.execute(
             "SELECT status, claim_lock FROM tasks WHERE id=?", (t,),
         ).fetchone()
-        assert row["status"] == "ready"
-        assert row["claim_lock"] is None
+        assert row["status"] == "running"
+        assert row["claim_lock"] == lock
     finally:
         conn2.close()
 
@@ -2026,9 +2153,8 @@ def test_reassign_endpoint_409_on_running_without_reclaim(client):
     assert r.status_code == 409
 
 
-def test_reassign_endpoint_with_reclaim_first_succeeds_on_running(client):
-    """With reclaim_first=true, a running task is reclaimed+reassigned in
-    one call."""
+def test_reassign_endpoint_with_reclaim_first_defers_unverifiable_running(client):
+    """Dashboard reassign cannot bypass failed closed tree ownership."""
     import secrets
     conn = kb.connect()
     try:
@@ -2054,16 +2180,15 @@ def test_reassign_endpoint_with_reclaim_first_succeeds_on_running(client):
         f"/api/plugins/kanban/tasks/{t}/reassign",
         json={"profile": "new", "reclaim_first": True, "reason": "switch"},
     )
-    assert r.status_code == 200, r.text
-    assert r.json()["assignee"] == "new"
+    assert r.status_code == 409, r.text
 
     conn2 = kb.connect()
     try:
         row = conn2.execute(
             "SELECT status, assignee FROM tasks WHERE id=?", (t,),
         ).fetchone()
-        assert row["status"] == "ready"
-        assert row["assignee"] == "new"
+        assert row["status"] == "running"
+        assert row["assignee"] == "orig"
     finally:
         conn2.close()
 
@@ -2392,7 +2517,10 @@ def test_task_detail_exposes_latest_summary_when_result_is_empty(client):
     conn = kb.connect()
     task_id = kb.create_task(conn, title="Task with only run summary")
     kb.claim_task(conn, task_id)
-    kb.complete_task(conn, task_id, summary="Report written to /output/report.md")
+    kb.complete_task(
+        conn, task_id, summary="Report written to /output/report.md",
+        expected_run_id=kb.latest_run(conn, task_id).id,
+        expected_claim_lock=kb.get_task(conn, task_id).claim_lock,    )
     conn.close()
 
     r = client.get(f"/api/plugins/kanban/tasks/{task_id}")
@@ -2420,7 +2548,10 @@ def test_board_tasks_include_latest_summary(client):
     conn = kb.connect()
     task_id = kb.create_task(conn, title="Board card with summary only")
     kb.claim_task(conn, task_id)
-    kb.complete_task(conn, task_id, summary="Done: see attachment")
+    kb.complete_task(
+        conn, task_id, summary="Done: see attachment",
+        expected_run_id=kb.latest_run(conn, task_id).id,
+        expected_claim_lock=kb.get_task(conn, task_id).claim_lock,    )
     conn.close()
 
     r = client.get("/api/plugins/kanban/board")

--- a/tests/plugins/test_kanban_worker_runs.py
+++ b/tests/plugins/test_kanban_worker_runs.py
@@ -306,26 +306,33 @@ def test_inspect_run_live_pid(client, monkeypatch):
 # POST /runs/{run_id}/terminate
 # ---------------------------------------------------------------------------
 
-def _setup_running_task_with_run(conn, *, title, assignee, worker_pid):
+def _setup_running_task_with_run(
+    conn,
+    *,
+    title,
+    assignee,
+    worker_pid,
+    worker_identity="fixture-worker-identity",
+):
     """Create a task in 'running' state with a matching open task_runs row.
 
     Mirrors what dispatcher_claim does: stamps tasks.status='running',
-    tasks.claim_lock, tasks.worker_pid; inserts task_runs row with the
-    same claim_lock so reclaim_task's preconditions are satisfied.
+    tasks.claim_lock, worker PID and incarnation; inserts task_runs row with
+    the same identity binding so reclaim_task's preconditions are satisfied.
     """
     task_id = kb.create_task(conn, title=title, assignee=assignee)
     lock = secrets.token_hex(8)
     future = int(time.time()) + 3600
     conn.execute(
-        "UPDATE tasks SET status='running', claim_lock=?, "
-        "claim_expires=?, worker_pid=? WHERE id=?",
-        (lock, future, worker_pid, task_id),
+        "UPDATE tasks SET status='running', claim_lock=?, claim_expires=?, "
+        "worker_pid=?, worker_identity=? WHERE id=?",
+        (lock, future, worker_pid, worker_identity, task_id),
     )
     cur = conn.execute(
         "INSERT INTO task_runs "
-        "(task_id, status, claim_lock, claim_expires, worker_pid, started_at) "
-        "VALUES (?, 'running', ?, ?, ?, ?)",
-        (task_id, lock, future, worker_pid, int(time.time())),
+        "(task_id, status, claim_lock, claim_expires, worker_pid, "
+        "worker_identity, started_at) VALUES (?, 'running', ?, ?, ?, ?, ?)",
+        (task_id, lock, future, worker_pid, worker_identity, int(time.time())),
     )
     conn.commit()
     return task_id, cur.lastrowid
@@ -373,9 +380,18 @@ def test_terminate_run_ok(client, monkeypatch):
     # Capture signal calls so we don't actually SIGTERM a random PID.
     sent = []
 
-    def _fake_terminate(pid, prev_lock, *, signal_fn=None):
-        sent.append((pid, prev_lock))
-        return {"signal": "SIGTERM", "delivered": True}
+    def _fake_terminate(
+        pid,
+        prev_lock,
+        *,
+        worker_identity=None,
+        run_worker_identity=None,
+        run_worker_pid=None,
+        run_claim_lock=None,
+        signal_fn=None,
+    ):
+        sent.append((pid, prev_lock, worker_identity, run_worker_identity, run_worker_pid, run_claim_lock))
+        return {"signal": "SIGTERM", "delivered": True, "terminated": True}
 
     monkeypatch.setattr(kb, "_terminate_reclaimed_worker", _fake_terminate)
 
@@ -386,7 +402,9 @@ def test_terminate_run_ok(client, monkeypatch):
     assert r.status_code == 200, r.text
     body = r.json()
     assert body == {"ok": True, "run_id": run_id, "task_id": task_id}
-    assert sent == [(33333, sent[0][1])]
+    assert sent == [
+        (33333, sent[0][1], "fixture-worker-identity", "fixture-worker-identity", 33333, sent[0][1])
+    ]
     assert sent[0][1] is not None  # claim_lock was non-null
 
     # Task is back to ready, claim cleared.

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -148,8 +148,7 @@ def test_kanban_tools_visible_with_toolset_config(monkeypatch, tmp_path):
 
 @pytest.fixture
 def worker_env(monkeypatch, tmp_path):
-    """Simulate being a worker: HERMES_HOME isolated, HERMES_KANBAN_TASK set
-    after we've created the task."""
+    """Simulate a dispatcher worker with its task/run/claim capabilities."""
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
@@ -164,10 +163,16 @@ def worker_env(monkeypatch, tmp_path):
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="worker-test", assignee="test-worker")
-        kb.claim_task(conn, tid)
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock is not None
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", claimed.claim_lock)
     return tid
 
 
@@ -311,6 +316,60 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_complete_missing_scoped_run_capability_refuses_without_mutating_open_run(
+    monkeypatch, worker_env,
+):
+    """A scoped worker without its run capability cannot infer DB authority."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, worker_env)
+        run = kb.latest_run(conn, worker_env)
+        assert task is not None and run is not None
+        before_task = (
+            task.status, task.current_run_id, task.claim_lock, task.claim_expires,
+        )
+        before_run = (
+            run.id, run.status, run.ended_at, run.claim_lock, run.claim_expires,
+        )
+
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    payload = json.loads(kt._handle_complete({"summary": "missing capability"}))
+    assert payload.get("ok") is not True
+    assert payload["error"].startswith("scoped-worker authorization error:")
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, worker_env)
+        run = kb.latest_run(conn, worker_env)
+        assert task is not None and run is not None
+        assert (
+            task.status, task.current_run_id, task.claim_lock, task.claim_expires,
+        ) == before_task
+        assert (
+            run.id, run.status, run.ended_at, run.claim_lock, run.claim_expires,
+        ) == before_run
+
+
+def test_complete_scoped_task_without_claim_capability_fails_closed(
+    monkeypatch, worker_env
+):
+    """Task scope alone must not turn an arbitrary caller into the worker."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+    out = kt._handle_complete({"summary": "manual scope spoof"})
+    error = json.loads(out)["error"]
+    assert error.startswith("scoped-worker authorization error:")
+    with kb.connect() as conn:
+        task = kb.get_task(conn, worker_env)
+        run = kb.latest_run(conn, worker_env)
+        assert task is not None and task.status == "running"
+        assert run is not None and run.ended_at is None
+
+
 def test_complete_metadata_round_trips_through_show(worker_env):
     """Structured completion metadata should be visible to downstream agents."""
     from tools import kanban_tools as kt
@@ -362,7 +421,7 @@ def test_complete_stamps_worker_session_id_from_env(monkeypatch, worker_env):
         conn.close()
 
 
-def test_complete_does_not_stamp_worker_session_id_without_scoped_task(
+def test_complete_refuses_running_task_without_scoped_worker_identity(
     monkeypatch, worker_env
 ):
     from tools import kanban_tools as kt
@@ -375,16 +434,14 @@ def test_complete_does_not_stamp_worker_session_id_without_scoped_task(
         "summary": "done outside worker scope",
         "metadata": {"files": 2, "worker_session_id": "user-provided"},
     })
-    assert json.loads(out)["ok"] is True
+    assert "could not complete" in json.loads(out)["error"]
 
     from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:
         run = kb.latest_run(conn, worker_env)
-        assert run.metadata == {
-            "files": 2,
-            "worker_session_id": "user-provided",
-        }
+        assert run.ended_at is None
+        assert run.metadata is None
     finally:
         conn.close()
 
@@ -638,10 +695,16 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
             conn, title="goal-mode-test", assignee="test-worker",
             body="Must achieve X with verified evidence.", goal_mode=True
         )
-        kb.claim_task(conn, goal_task_id)
+        claimed = kb.claim_task(conn, goal_task_id)
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock is not None
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", claimed.claim_lock)
 
     # Mock the judge to reject the completion. The gate only runs when a
     # judge is reachable, so force the availability probe True as well.
@@ -694,10 +757,16 @@ def test_complete_goal_mode_allows_when_judge_unavailable(monkeypatch, tmp_path)
             conn, title="goal-mode-test", assignee="test-worker",
             body="Must achieve X with verified evidence.", goal_mode=True
         )
-        kb.claim_task(conn, goal_task_id)
+        claimed = kb.claim_task(conn, goal_task_id)
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock is not None
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", claimed.claim_lock)
 
     # No judge reachable. judge_goal must not even be consulted; if it were,
     # this stub would reject — so reaching "done" proves the probe short-circuit.
@@ -759,10 +828,16 @@ def _make_goal_mode_worker_env(monkeypatch, tmp_path):
             conn, title="goal-mode-block-test", assignee="test-worker",
             body="Must achieve X.", goal_mode=True,
         )
-        kb.claim_task(conn, goal_task_id)
+        claimed = kb.claim_task(conn, goal_task_id)
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock is not None
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", goal_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", claimed.claim_lock)
     return goal_task_id
 
 
@@ -920,6 +995,89 @@ def test_heartbeat_extends_claim_expires(worker_env):
         f"claim_expires={after} is suspiciously close to now={now}; "
         f"expected at least now + {kb.DEFAULT_CLAIM_TTL_SECONDS // 2}"
     )
+
+
+def test_heartbeat_rejects_raw_stale_run_id_before_extending_lease(worker_env, monkeypatch):
+    """A raw environment run id is not authority without the active binding."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None and task.current_run_id is not None
+        conn.execute("UPDATE tasks SET claim_expires = 1 WHERE id = ?", (worker_env,))
+        conn.commit()
+        stale_run_id = task.current_run_id - 1
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(stale_run_id))
+
+    out = kt._handle_heartbeat({"note": "stale raw capability"})
+    assert json.loads(out).get("ok") is not True
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.claim_expires == 1
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("claim_lock", [None, "wrong-claim-lock"])
+def test_heartbeat_rejects_missing_or_mismatched_claim_lock_before_extending_lease(
+    worker_env, monkeypatch, claim_lock,
+):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        conn.execute("UPDATE tasks SET claim_expires = 1 WHERE id = ?", (worker_env,))
+        conn.commit()
+    finally:
+        conn.close()
+    if claim_lock is None:
+        monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", claim_lock)
+
+    out = kt._handle_heartbeat({"note": "unbound capability"})
+    assert json.loads(out).get("ok") is not True
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.claim_expires == 1
+    finally:
+        conn.close()
+
+
+def test_heartbeat_rejects_worker_board_mismatch_before_extending_lease(
+    worker_env,
+):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        conn.execute("UPDATE tasks SET claim_expires = 1 WHERE id = ?", (worker_env,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = kt._handle_heartbeat({"board": "other", "note": "wrong board"})
+    assert json.loads(out).get("ok") is not True
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.claim_expires == 1
+    finally:
+        conn.close()
 
 
 def test_comment_happy_path(worker_env):
@@ -1642,6 +1800,46 @@ def test_worker_complete_own_task_still_works(worker_env):
     assert d.get("ok") is True and d.get("task_id") == worker_env
 
 
+def test_heartbeat_later_run_rejects_stale_run_and_claim_without_extending(
+    worker_env, monkeypatch,
+):
+    """An old worker cannot renew the lease after a later claim wins."""
+    from hermes_cli import kanban_db as kb
+    import hermes_cli.kanban_db as _kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    conn = kb.connect()
+    try:
+        run1 = kb.latest_run(conn, worker_env)
+        assert run1 is not None
+        kb._set_worker_pid(conn, worker_env, 98765)
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+        assert kb.detect_crashed_workers(conn) == [worker_env]
+        claimed2 = kb.claim_task(conn, worker_env)
+        assert claimed2 is not None and claimed2.current_run_id != run1.id
+        conn.execute("UPDATE tasks SET claim_expires = 1 WHERE id = ?", (worker_env,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run1.id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", run1.claim_lock or "old-lock")
+    out = kt._handle_heartbeat({"note": "late worker"})
+    assert json.loads(out).get("ok") is not True
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        run2 = kb.latest_run(conn, worker_env)
+        assert task is not None and task.claim_expires == 1
+        assert run2 is not None and run2.id == claimed2.current_run_id
+        assert run2.ended_at is None
+    finally:
+        conn.close()
+
+
+
 def test_worker_complete_rejects_stale_run_id(worker_env, monkeypatch):
     """A retried worker cannot complete the task using an old run token."""
     from hermes_cli import kanban_db as kb
@@ -1878,14 +2076,12 @@ def test_board_param_routes_comment_to_alt_board(multi_board_env):
         assert kb.get_task(conn, alt_seed) is None
 
 
-def test_board_param_routes_complete_to_alt_board(multi_board_env):
-    """kanban_complete on the alt board closes the alt task, leaving
-    the default seed untouched."""
+def test_board_param_complete_refuses_unscoped_running_alt_task(multi_board_env):
+    """An unscoped tool call cannot clear an alt-board running claim."""
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
 
     alt_seed = multi_board_env["alt_seed"]
-    # Make alt task running so complete is valid.
     with kb.connect(board="alt") as conn:
         kb.claim_task(conn, alt_seed)
 
@@ -1895,18 +2091,17 @@ def test_board_param_routes_complete_to_alt_board(multi_board_env):
         "board": "alt",
     })
     d = json.loads(out)
-    assert d["ok"] is True
+    assert "could not complete" in d["error"]
 
     with kb.connect(board="alt") as conn:
-        assert kb.get_task(conn, alt_seed).status == "done"
-    # Default seed is unchanged.
+        assert kb.get_task(conn, alt_seed).status == "running"
     with kb.connect() as conn:
         default_seed = multi_board_env["default_seed"]
         assert kb.get_task(conn, default_seed).status == "ready"
 
 
-def test_board_param_routes_block_to_alt_board(multi_board_env):
-    """kanban_block targets the alt board's DB."""
+def test_board_param_block_refuses_unscoped_running_alt_task(multi_board_env):
+    """An unscoped tool call cannot clear an alt-board running claim."""
     from hermes_cli import kanban_db as kb
     from tools import kanban_tools as kt
 
@@ -1920,10 +2115,10 @@ def test_board_param_routes_block_to_alt_board(multi_board_env):
         "board": "alt",
     })
     d = json.loads(out)
-    assert d["ok"] is True
+    assert "could not block" in d["error"]
 
     with kb.connect(board="alt") as conn:
-        assert kb.get_task(conn, alt_seed).status == "blocked"
+        assert kb.get_task(conn, alt_seed).status == "running"
 
 
 def test_board_param_routes_unblock_to_alt_board(multi_board_env):
@@ -1963,8 +2158,14 @@ def test_board_param_routes_heartbeat_to_alt_board(monkeypatch, tmp_path):
     # Seed the alt board with a claimed task.
     with kb.connect(board="alt") as conn:
         tid = kb.create_task(conn, title="alt hb", assignee="alt-worker")
-        kb.claim_task(conn, tid)
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert claimed.current_run_id is not None
+        assert claimed.claim_lock is not None
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "alt")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", claimed.claim_lock)
 
     from tools import kanban_tools as kt
     out = kt._handle_heartbeat({"note": "alive on alt", "board": "alt"})

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -105,17 +105,19 @@ def _default_task_id(arg: Optional[str]) -> Optional[str]:
     return env_tid or None
 
 
-def _worker_run_id(task_id: str) -> Optional[int]:
-    """Return this worker's dispatcher run id when it is scoped to task_id."""
-    if os.environ.get("HERMES_KANBAN_TASK") != task_id:
-        return None
-    raw = os.environ.get("HERMES_KANBAN_RUN_ID")
-    if not raw:
-        return None
+def _worker_capability(task_id: str, *, board: Optional[str] = None):
+    """Resolve this worker's full DB-bound terminal authority tuple."""
     try:
-        return int(raw)
-    except ValueError:
+        from hermes_cli import kanban_db as kb
+        return kb.resolve_worker_capability(task_id, board=board)
+    except Exception:
         return None
+
+
+def _worker_run_id(task_id: str, *, board: Optional[str] = None) -> Optional[int]:
+    """Compatibility accessor for callers that only need the verified run id."""
+    capability = _worker_capability(task_id, board=board)
+    return capability.run_id if capability is not None else None
 
 
 def _stamp_worker_session_metadata(
@@ -237,13 +239,11 @@ def heartbeat_current_worker_from_env() -> bool:
     swallowed exception). The boolean is informational — callers should
     not branch on it.
 
-    Identity comes from:
+    Identity comes from all four dispatcher capabilities:
       * ``HERMES_KANBAN_TASK`` — task id (required; absence means no-op)
-      * ``HERMES_KANBAN_RUN_ID`` — pins the run row so we don't heartbeat
-        a stale run that may have already been reclaimed
-      * ``HERMES_KANBAN_CLAIM_LOCK`` — claim lock for ``heartbeat_claim``;
-        falls back to the default ``_claimer_id()`` for locally-driven
-        workers that never went through the dispatcher path
+      * ``HERMES_KANBAN_BOARD`` — exact board that owns the task/run
+      * ``HERMES_KANBAN_RUN_ID`` — pins the active run row
+      * ``HERMES_KANBAN_CLAIM_LOCK`` — nonempty claim capability for that run
 
     Rate-limited via the module-level ``_auto_heartbeat_last_attempt``
     timestamp (monotonic clock); not thread-safe in the strict sense, but
@@ -259,21 +259,25 @@ def heartbeat_current_worker_from_env() -> bool:
         return False
     _auto_heartbeat_last_attempt = now
     try:
-        kb, conn = _connect()
+        run_id = _worker_run_id(tid)
+        claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "").strip()
+        if run_id is None or not claim_lock:
+            return False
+        kb, conn = _connect(board=os.environ.get("HERMES_KANBAN_BOARD"))
         try:
-            claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
+            if not kb.heartbeat_claim(
+                conn,
+                tid,
+                claimer=claim_lock,
+                expected_run_id=run_id,
+                expected_claim_lock=claim_lock,
+            ):
+                return False
             try:
-                kb.heartbeat_claim(conn, tid, claimer=claim_lock)
-            except Exception:
-                logger.debug("auto-heartbeat: heartbeat_claim failed", exc_info=True)
-            run_id_raw = os.environ.get("HERMES_KANBAN_RUN_ID")
-            run_id: Optional[int]
-            try:
-                run_id = int(run_id_raw) if run_id_raw else None
-            except (TypeError, ValueError):
-                run_id = None
-            try:
-                kb.heartbeat_worker(conn, tid, note=None, expected_run_id=run_id)
+                kb.heartbeat_worker(
+                    conn, tid, note=None, expected_run_id=run_id,
+                    expected_claim_lock=claim_lock,
+                )
             except Exception:
                 logger.debug("auto-heartbeat: heartbeat_worker failed", exc_info=True)
         finally:
@@ -589,8 +593,17 @@ def _handle_complete(args: dict, **kw) -> str:
         )
     metadata = _stamp_worker_session_metadata(tid, metadata)
     board = args.get("board")
+    capability = _worker_capability(tid, board=board)
+    if os.environ.get("HERMES_KANBAN_TASK") and capability is None:
+        # A dispatcher-scoped worker must never downgrade an invalid capability
+        # to the operator terminal path.
+        return tool_error(
+            f"scoped-worker authorization error: cannot complete {tid} "
+            "with a stale or missing worker capability"
+        )
+    connection_board = capability.board if capability is not None else board
     try:
-        kb, conn = _connect(board=board)
+        kb, conn = _connect(board=connection_board)
         try:
             # Goal-mode pre-completion judge gate (Issue #38367).
             # Prevent workers from bypassing the auxiliary judge by
@@ -628,7 +641,8 @@ def _handle_complete(args: dict, **kw) -> str:
                     conn, tid,
                     result=result, summary=summary, metadata=metadata,
                     created_cards=created_cards,
-                    expected_run_id=_worker_run_id(tid),
+                    expected_run_id=(capability.run_id if capability is not None else None),
+                    expected_claim_lock=(capability.claim_lock if capability is not None else None),
                 )
             except kb.ArtifactPreservationError as artifact_err:
                 return tool_error(
@@ -688,8 +702,15 @@ def _handle_block(args: dict, **kw) -> str:
     reason = redact_sensitive_text(str(reason), force=True)
     kind = args.get("kind")
     board = args.get("board")
+    capability = _worker_capability(tid, board=board)
+    if os.environ.get("HERMES_KANBAN_TASK") and capability is None:
+        return tool_error(
+            f"scoped-worker authorization error: cannot block {tid} "
+            "with a stale or missing worker capability"
+        )
+    connection_board = capability.board if capability is not None else board
     try:
-        kb, conn = _connect(board=board)
+        kb, conn = _connect(board=connection_board)
         if kind is not None and kind not in kb.VALID_BLOCK_KINDS:
             conn.close()
             return tool_error(
@@ -724,7 +745,8 @@ def _handle_block(args: dict, **kw) -> str:
                 conn, tid,
                 reason=reason,
                 kind=kind,
-                expected_run_id=_worker_run_id(tid),
+                expected_run_id=(capability.run_id if capability is not None else None),
+                expected_claim_lock=(capability.claim_lock if capability is not None else None),
             )
             if not ok:
                 return tool_error(
@@ -773,19 +795,28 @@ def _handle_heartbeat(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            # Extend the claim TTL first. The dispatcher pins
-            # HERMES_KANBAN_CLAIM_LOCK in the worker env at spawn time
-            # (see _default_spawn in kanban_db.py); falling back to the
-            # default _claimer_id() covers locally-driven workers that
-            # never went through the dispatcher path.
-            claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
-            kb.heartbeat_claim(conn, tid, claimer=claim_lock)
-
+            run_id = _worker_run_id(tid, board=board)
+            claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "").strip()
+            if run_id is None or not claim_lock:
+                return tool_error(
+                    f"could not heartbeat {tid} (worker capability is stale or missing)"
+                )
+            if not kb.heartbeat_claim(
+                conn,
+                tid,
+                claimer=claim_lock,
+                expected_run_id=run_id,
+                expected_claim_lock=claim_lock,
+            ):
+                return tool_error(
+                    f"could not heartbeat {tid} (claim ownership changed)"
+                )
             ok = kb.heartbeat_worker(
                 conn,
                 tid,
                 note=note,
-                expected_run_id=_worker_run_id(tid),
+                expected_run_id=run_id,
+                expected_claim_lock=claim_lock,
             )
             if not ok:
                 return tool_error(


### PR DESCRIPTION
## Summary

Fix detached Kanban workers that can exit without another dispatch tick, while preserving authoritative exit classification and preventing orphaned duplicate work.

### What changed

- Launch workers through a detached supervisor that owns and reaps the real worker.
- Register the supervisor PID under exact task/run/claim CAS guards.
- Finalize clean, rate-limited, signal, and crash exits through existing lifecycle semantics.
- Kill the full verified supervisor process tree on handshake failure, reclaim, stale detection, and max-runtime timeout.
- Refuse claim release when process-tree identity cannot be proven or any executable group member may survive.
- Forward direct stop/reclaim signals from supervisor to child.
- Preserve board/profile/workspace isolation and one-shot dispatcher non-blocking behavior.

## Verification

- Original expanded affected suite: **564 passed, 0 failed** across 11 Kanban lifecycle modules.
- Real POSIX regressions cover:
  - handshake timeout and early supervisor exit;
  - PID publication failure;
  - clean/rate-limit detector interleavings;
  - terminal-before-registration CAS;
  - TERM-ignoring child under manual reclaim, stale reclaim, and max-runtime;
  - PID/process-group identity mismatch fail-closed behavior.
- Ruff, `py_compile`, and diff checks passed.

## Residual platform gate

Windows uses `CREATE_NEW_PROCESS_GROUP` and `taskkill /T /F`; command-path behavior is unit-tested, but native Windows process-tree execution remains an OS-specific CI validation surface.

The full repository suite was not used as the acceptance gate because 13 failures in four unrelated modules reproduced on the clean base; those files were not changed here.
