### PR TITLE
fix(feishu): route card callbacks as structured events

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -11,7 +11,7 @@ Supports:
 - Processing status reactions: Typing while working, removed on success,
   swapped for CrossMark on failure
 - Reaction events routed as synthetic text events (matches openclaw)
-- Interactive card button-click events routed as synthetic COMMAND events
+- Interactive card callbacks routed as structured synthetic text events
 - Webhook anomaly tracking (matches openclaw createWebhookAnomalyTracker)
 - Verification token validation as second auth layer (matches openclaw)
 
@@ -3007,55 +3007,85 @@ class FeishuAdapter(BasePlatformAdapter):
         return False
 
     async def _handle_card_action_event(self, data: Any) -> None:
-        """Route Feishu interactive card button clicks as synthetic COMMAND events."""
+        """Route custom Feishu card callbacks as structured agent text events.
+
+        Card callbacks do not carry a real Feishu message id that can be used
+        as a reply target.  They must also not masquerade as ``/card`` slash
+        commands: the gateway command router consumes unknown slash commands
+        before the agent can inspect their structured payload.
+        """
         event = getattr(data, "event", None)
         token = str(getattr(event, "token", "") or "")
-        if token and self._is_card_action_duplicate(token):
-            logger.debug("[Feishu] Dropping duplicate card action token: %s", token)
+        if not token:
+            logger.debug("[Feishu] Card action missing callback token, dropping")
             return
 
         context = getattr(event, "context", None)
         chat_id = str(getattr(context, "open_chat_id", "") or "")
+        source_message_id = str(getattr(context, "open_message_id", "") or "")
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
         if not chat_id or not open_id:
             logger.debug("[Feishu] Card action missing chat_id or operator open_id, dropping")
             return
 
-        action = getattr(event, "action", None)
-        action_tag = str(getattr(action, "tag", "") or "button")
-        action_value = getattr(action, "value", {}) or {}
+        callback_id = f"feishu-card-{hashlib.sha256(token.encode('utf-8')).hexdigest()[:24]}"
+        if self._is_card_action_duplicate(token):
+            logger.debug("[Feishu] Dropping duplicate card action: %s", callback_id)
+            return
 
-        synthetic_text = f"/card {action_tag}"
-        if action_value:
-            try:
-                synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
-            except Exception:
-                pass
+        try:
+            action = getattr(event, "action", None)
+            action_tag = str(getattr(action, "tag", "") or "button")
+            action_value = getattr(action, "value", {}) or {}
+            form_value = getattr(action, "form_value", {}) or {}
+            payload = {
+                "event_type": "card.action.trigger",
+                "event_id": callback_id,
+                "source_message_id": source_message_id,
+                "operator_id": open_id,
+                "action_tag": action_tag,
+                "action_value": action_value,
+                "form_value": form_value,
+            }
+            synthetic_text = "[Feishu card action]\n" + json.dumps(payload, ensure_ascii=False, default=str)
 
-        sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
-        sender_profile = await self._resolve_sender_profile(sender_id)
-        chat_info = await self.get_chat_info(chat_id)
-        source = self.build_source(
-            chat_id=chat_id,
-            chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type="group"),
-            user_id=sender_profile["user_id"],
-            user_name=sender_profile["user_name"],
-            thread_id=None,
-            user_id_alt=sender_profile["user_id_alt"],
-        )
-        synthetic_event = MessageEvent(
-            text=synthetic_text,
-            message_type=MessageType.COMMAND,
-            source=source,
-            raw_message=data,
-            message_id=token or str(uuid.uuid4()),
-            channel_prompt=self._resolve_channel_prompt(chat_id),
-            timestamp=datetime.now(),
-        )
-        logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)
-        await self._handle_message_with_guards(synthetic_event)
+            sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
+            sender_profile = await self._resolve_sender_profile(sender_id)
+            chat_info = await self.get_chat_info(chat_id)
+            source = self.build_source(
+                chat_id=chat_id,
+                chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
+                chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type="group"),
+                user_id=sender_profile["user_id"],
+                user_name=sender_profile["user_name"],
+                thread_id=None,
+                user_id_alt=sender_profile["user_id_alt"],
+            )
+            synthetic_event = MessageEvent(
+                text=synthetic_text,
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=data,
+                # The callback token is not an open_message_id. Leaving this empty
+                # makes delivery send a new chat message instead of replying to an
+                # invalid synthetic id.
+                message_id=None,
+                channel_prompt=self._resolve_channel_prompt(chat_id),
+                timestamp=datetime.now(),
+            )
+            logger.info(
+                "[Feishu] Routing card action %r from %s in %s as structured text event",
+                action_tag,
+                open_id,
+                chat_id,
+            )
+            await self._handle_message_with_guards(synthetic_event)
+        except Exception:
+            # A claim only becomes durable after dispatch succeeds. Releasing it
+            # lets Feishu retry the same callback instead of losing the event.
+            self._card_action_tokens.pop(token, None)
+            raise
 
     # =========================================================================
     # Per-chat serialization and typing indicator

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -1,5 +1,6 @@
 """Tests for Feishu interactive card approval buttons."""
 
+import hashlib
 import importlib.util
 import json
 import sys
@@ -64,7 +65,7 @@ def _make_card_action_data(
     return SimpleNamespace(
         event=SimpleNamespace(
             token=token,
-            context=SimpleNamespace(open_chat_id=chat_id),
+            context=SimpleNamespace(open_chat_id=chat_id, open_message_id="om_card_123"),
             operator=SimpleNamespace(open_id=open_id),
             action=SimpleNamespace(
                 tag="button",
@@ -412,10 +413,10 @@ class TestResolveApproval:
 # ===========================================================================
 
 class TestNonApprovalCardAction:
-    """Non-approval card actions should still route as synthetic commands."""
+    """Non-approval card actions should reach the agent as structured text events."""
 
     @pytest.mark.asyncio
-    async def test_routes_as_synthetic_command(self):
+    async def test_routes_button_as_structured_text_without_reply_target(self):
         adapter = _make_adapter()
 
         data = _make_card_action_data(
@@ -435,7 +436,99 @@ class TestNonApprovalCardAction:
 
         mock_handle.assert_called_once()
         event = mock_handle.call_args[0][0]
-        assert "/card button" in event.text
+        assert event.message_type.value == "text"
+        assert event.message_id is None
+        assert event.text.startswith("[Feishu card action]\n")
+        payload = json.loads(event.text.split("\n", 1)[1])
+        event_id = payload.pop("event_id")
+        assert event_id == f"feishu-card-{hashlib.sha256(b'tok_normal').hexdigest()[:24]}"
+        assert payload == {
+            "event_type": "card.action.trigger",
+            "source_message_id": "om_card_123",
+            "operator_id": "ou_user1",
+            "action_tag": "button",
+            "action_value": {"custom_action": "something_else"},
+            "form_value": {},
+        }
+        assert "tok_normal" not in event.text
+
+    @pytest.mark.asyncio
+    async def test_routes_form_values_for_free_text_decision(self):
+        adapter = _make_adapter()
+        data = _make_card_action_data(
+            action_value={"governance_id": "DEC-1"},
+            token="tok_form",
+        )
+        data.event.action.form_value = {
+            "decision": "approve_investigation",
+            "comment": "先核验 7 天，再决定是否实现",
+        }
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        event = mock_handle.call_args[0][0]
+        payload = json.loads(event.text.split("\n", 1)[1])
+        assert payload["action_value"] == {"governance_id": "DEC-1"}
+        assert payload["form_value"] == {
+            "decision": "approve_investigation",
+            "comment": "先核验 7 天，再决定是否实现",
+        }
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_same_token_without_logging_token(self, caplog):
+        adapter = _make_adapter()
+        data = _make_card_action_data({}, token="tok_private_duplicate")
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+            caplog.at_level("DEBUG"),
+        ):
+            await adapter._handle_card_action_event(data)
+            await adapter._handle_card_action_event(data)
+
+        mock_handle.assert_awaited_once()
+        assert "tok_private_duplicate" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_releases_dedup_claim_when_dispatch_fails(self):
+        adapter = _make_adapter()
+        data = _make_card_action_data({}, token="tok_retry")
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
+            patch.object(
+                adapter, "_handle_message_with_guards", new_callable=AsyncMock,
+                side_effect=[RuntimeError("dispatch failed"), None],
+            ) as mock_handle,
+        ):
+            with pytest.raises(RuntimeError, match="dispatch failed"):
+                await adapter._handle_card_action_event(data)
+            await adapter._handle_card_action_event(data)
+
+        assert mock_handle.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_missing_token_fails_closed(self):
+        adapter = _make_adapter()
+        data = _make_card_action_data({}, token="")
+        with patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle:
+            await adapter._handle_card_action_event(data)
+        mock_handle.assert_not_awaited()
 
 
 # ===========================================================================

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -277,17 +277,29 @@ Grant the `application:bot.basic_info:read` scope to display peer bot names; wit
 
 ## Interactive Card Actions
 
-When users click buttons or interact with interactive cards sent by the bot, the adapter routes these as synthetic `/card` command events:
+When users interact with non-approval custom cards sent by the bot, the adapter routes the callback to the agent as a structured text event instead of a synthetic slash command. The event text starts with `[Feishu card action]` followed by a JSON payload:
 
-- Button clicks become: `/card button {"key": "value", ...}`
-- The action's `value` payload from the card definition is included as JSON.
-- Card actions are deduplicated with a 15-minute window to prevent double processing.
+```json
+{
+  "event_type": "card.action.trigger",
+  "event_id": "feishu-card-...",
+  "source_message_id": "om_...",
+  "operator_id": "ou_...",
+  "action_tag": "button",
+  "action_value": {"key": "value"},
+  "form_value": {"field": "submitted value"}
+}
+```
 
-Gateway-driven update prompts use a native Feishu `Yes` / `No` card instead of falling back to plain text replies. When `hermes update --gateway` needs confirmation, the adapter records the selected answer in Hermes's `.update_response` file and replaces the card inline with a resolved state.
+- `action_value` contains the action's `value` payload from the card definition.
+- `form_value` contains values submitted by form controls on the card.
+- `source_message_id` identifies the originating card message for agent context, but is not used as a reply target.
+- `event_id` is a stable identifier derived from the callback token; the raw token is not exposed to the agent or written to duplicate logs.
+- Card actions are deduplicated with a 15-minute window. A failed dispatch releases its claim so Feishu can retry the callback.
 
-Card action events are dispatched with `MessageType.COMMAND`, so they flow through the normal command processing pipeline.
+These synthetic events use `MessageType.TEXT` and leave `message_id` unset. The agent's response is therefore delivered as a new chat message instead of attempting to reply with a callback token or another invalid message ID.
 
-This is also how **command approval** works — when the agent needs to run a dangerous command, it sends an interactive card with Allow Once / Session / Always / Deny buttons. The user clicks a button, and the card action callback delivers the approval decision back to the agent.
+**Command approval** and gateway-driven update prompts use dedicated callback paths instead of the structured text event above. Approval cards expose Allow Once / Session / Always / Deny actions. Update prompts use a native Feishu `Yes` / `No` card, record the selected answer in Hermes's `.update_response` file, and replace the card inline with a resolved state.
 
 ### Required Feishu App Configuration
 


### PR DESCRIPTION
## Summary

- route non-approval Feishu Card 2.0 callbacks as structured text events instead of synthetic `/card` commands
- preserve `source_message_id`, operator, action, and form values while keeping callback tokens out of agent payloads and logs
- use a stable SHA-256-derived event ID, fail closed when the token is missing, deduplicate callbacks, and release failed dispatch claims for retry
- leave synthetic `message_id` unset so delivery sends a new chat message instead of replying to an invalid callback token
- preserve dedicated approval and update-prompt callback paths
- document the structured event contract and delivery semantics

## Relationship to related PRs

- #6422 promotes `context.open_message_id` to the delivery reply anchor. This PR preserves it as `source_message_id` in the structured agent payload while deliberately leaving synthetic `message_id` unset. The tradeoff is new-message delivery instead of an anchored reply.
- #43048 covers additional SDK parsing and session-source issues on the same callback path. This PR's independent additions are the structured payload (including `form_value`), token-safe deterministic event IDs, fail-closed token handling, sanitized duplicate logging, and retry-safe dedup claims.
- #46670 changes approval authorization. This PR leaves the dedicated approval and update-prompt callback paths unchanged.

## Verification

- `scripts/run_tests.sh tests/gateway/test_feishu_approval_buttons.py -q`: 42 passed
- `ruff check plugins/platforms/feishu/adapter.py tests/gateway/test_feishu_approval_buttons.py`: passed
- `python -m py_compile plugins/platforms/feishu/adapter.py tests/gateway/test_feishu_approval_buttons.py`: passed
- `git diff --check origin/main...HEAD`: passed

## Security

- raw callback tokens are neither included in structured payloads nor written to duplicate logs
- token-less callbacks fail closed
- failed dispatches release the dedup claim so a Feishu retry is not permanently discarded
