### PR TITLE
fix(skills_hub): add ignore_errors=True to shutil.rmtree and exist_ok=True to mkdir

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3555,8 +3555,8 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
 
     dest = _quarantine_dir() / skill_name
     if dest.exists():
-        shutil.rmtree(dest)
-    dest.mkdir(parents=True)
+        shutil.rmtree(dest, ignore_errors=True)
+    dest.mkdir(parents=True, exist_ok=True)
 
     for rel_path, file_content in validated_files:
         file_dest = dest.joinpath(*rel_path.split("/"))


### PR DESCRIPTION
## Summary

Add `ignore_errors=True` to `shutil.rmtree` and `exist_ok=True` to `mkdir` in `_write_to_quarantine`.

## Problem

`shutil.rmtree(dest)` in `tools/skills_hub.py:3558` can crash with `PermissionError` or `OSError` when quarantine directories contain read-only files (e.g. from git checkouts or other tools) or when a race condition leaves stale entries. This crashes the entire skill installation flow. Every other `shutil.rmtree` in the codebase uses `ignore_errors=True`; this one was the sole exception.

Additionally, if `rmtree` partially fails and leaves the directory, the subsequent `mkdir(parents=True)` without `exist_ok=True` will also crash with `FileExistsError`.

## Fix

- `shutil.rmtree(dest, ignore_errors=True)` — consistent with all other rmtree calls in the repo
- `dest.mkdir(parents=True, exist_ok=True)` — resilient after rmtree partial failure

## Testing
- Syntax check passed (py_compile)
- Behavior verified