### PR TITLE
docs(yuanbao): align the zh-Hans verbose-logging command with the English page

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/yuanbao.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/yuanbao.md
@@ -244,7 +244,7 @@ Please analyze this document
 1. 检查 gateway 日志中的错误模式
 2. 在连接设置中增加心跳超时时间
 3. 确保到元宝 API 的网络连接稳定
-4. 考虑启用详细日志：`HERMES_LOG_LEVEL=debug`
+4. 考虑启用详细日志：`hermes gateway run -vv`
 
 ## 访问控制
 
@@ -302,7 +302,7 @@ platforms:
 启用 debug 日志以排查连接问题：
 
 ```bash
-HERMES_LOG_LEVEL=debug hermes gateway
+hermes gateway run -vv
 ```
 
 ## 与其他功能集成


### PR DESCRIPTION
## Problem

The Yuanbao page told users to enable verbose logging with an environment variable that does not exist — `HERMES_LOG_LEVEL=debug hermes gateway`. `HERMES_LOG_LEVEL` is not read anywhere in the codebase (`hermes_logging.py` contains no `getenv`/`environ` call at all), so the copy-pasteable command was inert: someone troubleshooting a Yuanbao connection drop got no debug output and `agent.log` stayed at INFO.

## Rebased and narrowed — main already fixed the English page

Since this PR was opened, `main` corrected the **English** page to `hermes gateway run -vv` (`run_gateway(verbose=...)`: 0=WARNING, 1=INFO, 2+=DEBUG). The **zh-Hans mirror was not updated with it** and still carries the dead variable in both places:

- `website/i18n/zh-Hans/.../user-guide/messaging/yuanbao.md:247` — `` 考虑启用详细日志：`HERMES_LOG_LEVEL=debug` ``
- `website/i18n/zh-Hans/.../user-guide/messaging/yuanbao.md:305` — `HERMES_LOG_LEVEL=debug hermes gateway`

This PR is rebased onto that fix and narrowed to the one remaining site. The original `logging.level: DEBUG` remedy is **dropped** in favour of main's `hermes gateway run -vv` wording, so the two language versions agree rather than documenting two different mechanisms. The diff is now 1 file, 2 lines.

## Verification

`git grep HERMES_LOG_LEVEL` across the whole tree returns nothing after this change — this was the last reference. `hermes gateway run -vv` is confirmed live: `hermes_cli/gateway.py:4918` `run_gateway(verbose: int = 0, ...)`, documented in-place as *"Stderr log verbosity count added on top of default WARNING (0=WARNING, 1=INFO, 2+=DEBUG)"*.
