### PR TITLE
fix(state): make async-first state.db bootstrap atomic and canonical

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -17,6 +17,7 @@ Key design decisions:
 import asyncio
 import json
 import logging
+import os
 import random
 import re
 import sqlite3
@@ -30,6 +31,12 @@ from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
+
+# Keep the pristine constructor for the isolated in-memory DDL parser. Tests
+# and embedders may replace ``sqlite3.connect`` to simulate filesystem/runtime
+# capabilities; that must affect the live DB connection, not redirect the
+# parser's private ``:memory:`` database onto the live file.
+_SQLITE_CONNECT = sqlite3.connect
 
 
 def workspace_key(row: Dict[str, Any]) -> Optional[str]:
@@ -141,6 +148,16 @@ T = TypeVar("T")
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
 SCHEMA_VERSION = 21
+STATE_SCHEMA_READINESS_KEY = "canonical_schema_readiness_v1"
+
+# Canonical schema initialization is serialized by SQLite itself on the
+# database object. This deliberately avoids adjacent advisory lock files:
+# those are not portable to every NFS/SMB/FUSE path where SQLite's rollback
+# journal works, and pathname-derived locks do not unify hard-link aliases.
+_STATE_SCHEMA_TRANSACTION_TIMEOUT_S = 30.0
+_STATE_SCHEMA_TRANSACTION_POLL_MIN_S = 0.020
+_STATE_SCHEMA_TRANSACTION_POLL_MAX_S = 0.150
+_STATE_DB_PATH_RETRY_LIMIT = 8
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
 # Search queries do not need to be arbitrarily large, and bounding them keeps
@@ -168,6 +185,13 @@ _WAL_INCOMPAT_MARKERS = (
     "not authorized",         # Some FUSE mounts block WAL pragma outright
 )
 
+# ``PRAGMA journal_mode=WAL`` needs a write lock but does not reliably honour
+# the connection busy timeout while changing mode. Concurrent first opens
+# therefore retry here before the existing network-filesystem DELETE fallback.
+_WAL_SET_MAX_RETRIES = 15
+_WAL_SET_RETRY_MIN_S = 0.020
+_WAL_SET_RETRY_MAX_S = 0.150
+
 # Last SessionDB() init error, per-process.  Surfaced in /resume and
 # related slash-command error strings so users know WHY the DB is
 # unavailable instead of getting a bare "Session database not available."
@@ -184,14 +208,187 @@ _last_init_error_lock = threading.Lock()
 _wal_fallback_warned_paths: set[str] = set()
 _wal_fallback_warned_lock = threading.Lock()
 
-_FTS_TRIGGERS = (
+_BASE_FTS_TRIGGERS = (
     "messages_fts_insert",
     "messages_fts_delete",
     "messages_fts_update",
+)
+_TRIGRAM_FTS_TRIGGERS = (
     "messages_fts_trigram_insert",
     "messages_fts_trigram_delete",
     "messages_fts_trigram_update",
 )
+_FTS_TRIGGERS = _BASE_FTS_TRIGGERS + _TRIGRAM_FTS_TRIGGERS
+
+
+class StateDBAliasError(RuntimeError):
+    """Raised before schema mutation when state.db has an unsafe hard-link alias."""
+
+
+class StateDBSerializationUnavailableError(TimeoutError):
+    """SQLite could not provide the bounded database-object schema lease."""
+
+
+def canonical_schema_readiness_token(
+    schema_version: int,
+    schema_cookie: int,
+    fts_enabled: bool,
+    trigram_enabled: bool,
+) -> str:
+    """Bind canonical readiness to SQLite's transactional schema cookie."""
+    return ":".join(
+        (
+            str(schema_version),
+            str(schema_cookie),
+            "1" if fts_enabled else "0",
+            "1" if trigram_enabled else "0",
+        )
+    )
+
+
+def _canonical_state_db_path(db_path: Path) -> Path:
+    """Return one normalized path identity, resolving symlinks when possible."""
+    return Path(db_path).expanduser().resolve(strict=False)
+
+
+def _open_state_db_anchor(db_path: Path) -> tuple[int, os.stat_result]:
+    """Open a stable identity anchor and reject existing hard-link aliases.
+
+    The descriptor is not an advisory lock. It only lets callers prove that
+    the SQLite connection they opened still corresponds to the current
+    pathname after readiness/schema work. A missing file is created empty;
+    no SQLite header, schema, or row is written before alias validation.
+    """
+    fd = os.open(db_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        identity = os.fstat(fd)
+        if identity.st_nlink > 1:
+            raise StateDBAliasError(
+                f"state.db hard-link alias is unsupported: {db_path} "
+                f"has {identity.st_nlink} names"
+            )
+        return fd, identity
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _state_db_anchor_matches_path(anchor_fd: int, db_path: Path) -> bool:
+    """True only while *db_path* still names the anchored database object."""
+    anchor = os.fstat(anchor_fd)
+    if anchor.st_nlink > 1:
+        raise StateDBAliasError(
+            f"state.db hard-link alias is unsupported: {db_path} "
+            f"has {anchor.st_nlink} names"
+        )
+    try:
+        current = os.stat(db_path)
+    except FileNotFoundError:
+        return False
+    if current.st_nlink > 1:
+        raise StateDBAliasError(
+            f"state.db hard-link alias is unsupported: {db_path} "
+            f"has {current.st_nlink} names"
+        )
+    return os.path.samestat(anchor, current)
+
+
+_STATE_SCHEMA_ACTIVE_CONNECTIONS: dict[int, sqlite3.Connection] = {}
+_STATE_SCHEMA_ACTIVE_CONNECTIONS_LOCK = threading.Lock()
+
+
+def _register_schema_connection(conn: sqlite3.Connection) -> None:
+    with _STATE_SCHEMA_ACTIVE_CONNECTIONS_LOCK:
+        _STATE_SCHEMA_ACTIVE_CONNECTIONS[id(conn)] = conn
+
+
+def _end_schema_transaction(conn: sqlite3.Connection) -> None:
+    with _STATE_SCHEMA_ACTIVE_CONNECTIONS_LOCK:
+        _STATE_SCHEMA_ACTIVE_CONNECTIONS.pop(id(conn), None)
+
+
+def _close_inherited_schema_connections() -> None:
+    """Drop parent schema descriptors in a POSIX fork child before user code."""
+    global _STATE_SCHEMA_ACTIVE_CONNECTIONS_LOCK
+    inherited = list(_STATE_SCHEMA_ACTIVE_CONNECTIONS.values())
+    _STATE_SCHEMA_ACTIVE_CONNECTIONS.clear()
+    _STATE_SCHEMA_ACTIVE_CONNECTIONS_LOCK = threading.Lock()
+    for conn in inherited:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_close_inherited_schema_connections)
+
+
+def _begin_schema_transaction(conn: sqlite3.Connection) -> None:
+    """Acquire SQLite's database-object write lease with a bounded wait."""
+    _register_schema_connection(conn)
+    deadline = time.monotonic() + _STATE_SCHEMA_TRANSACTION_TIMEOUT_S
+    try:
+        while True:
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                return
+            except sqlite3.OperationalError as exc:
+                message = str(exc).lower()
+                if "locked" not in message and "busy" not in message:
+                    raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise StateDBSerializationUnavailableError(
+                        "state schema transaction unavailable before timeout; "
+                        "the SQLite backend may not support database-object "
+                        "locking or another live holder did not release it"
+                    ) from exc
+                time.sleep(
+                    min(
+                        remaining,
+                        random.uniform(
+                            _STATE_SCHEMA_TRANSACTION_POLL_MIN_S,
+                            _STATE_SCHEMA_TRANSACTION_POLL_MAX_S,
+                        ),
+                    )
+                )
+    except BaseException:
+        _end_schema_transaction(conn)
+        raise
+
+
+def _execute_script_statements(cursor: sqlite3.Cursor, script: str) -> None:
+    """Execute a SQL script without sqlite3.executescript's implicit COMMIT."""
+    pending: list[str] = []
+    for line in script.splitlines(keepends=True):
+        pending.append(line)
+        statement = "".join(pending)
+        if sqlite3.complete_statement(statement):
+            if statement.strip():
+                cursor.execute(statement)
+            pending.clear()
+    remainder = "".join(pending)
+    if remainder.strip():
+        raise sqlite3.OperationalError("incomplete canonical schema statement")
+
+
+def _is_exact_duplicate_column_race(
+    cursor: sqlite3.Cursor,
+    table_name: str,
+    target_column: str,
+    exc: sqlite3.OperationalError,
+) -> bool:
+    """Accept only SQLite's exact duplicate error after a fresh target probe."""
+    if str(exc) != f"duplicate column name: {target_column}":
+        return False
+    safe_table = table_name.replace('"', '""')
+    rows = cursor.execute(f'PRAGMA table_info("{safe_table}")').fetchall()
+    return any(
+        (row[1] if isinstance(row, (tuple, list)) else row["name"])
+        == target_column
+        for row in rows
+    )
 
 
 def _set_last_init_error(msg: Optional[str]) -> None:
@@ -422,23 +619,37 @@ def apply_wal_with_fallback(
     except sqlite3.OperationalError:
         pass
 
-    try:
-        conn.execute("PRAGMA journal_mode=WAL")
-        _apply_macos_checkpoint_barrier(conn)
-        _enforce_macos_synchronous_full(conn)
-        return "wal"
-    except sqlite3.OperationalError as exc:
-        msg = str(exc).lower()
-        if not any(marker in msg for marker in _WAL_INCOMPAT_MARKERS):
-            # Unrelated OperationalError — don't silently swallow.
-            raise
-        # Don't downgrade if another process already set WAL on disk.
-        existing = _on_disk_journal_mode(conn)
-        if existing == "wal":
-            raise
-        _log_wal_fallback_once(db_label, exc)
-        conn.execute("PRAGMA journal_mode=DELETE")
-        return "delete"
+    last_lock_error: Optional[sqlite3.OperationalError] = None
+    for attempt in range(_WAL_SET_MAX_RETRIES):
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            _apply_macos_checkpoint_barrier(conn)
+            _enforce_macos_synchronous_full(conn)
+            return "wal"
+        except sqlite3.OperationalError as exc:
+            msg = str(exc).lower()
+            if "locked" in msg or "busy" in msg:
+                last_lock_error = exc
+                if attempt < _WAL_SET_MAX_RETRIES - 1:
+                    time.sleep(
+                        random.uniform(
+                            _WAL_SET_RETRY_MIN_S,
+                            _WAL_SET_RETRY_MAX_S,
+                        )
+                    )
+                    continue
+                raise
+            if not any(marker in msg for marker in _WAL_INCOMPAT_MARKERS):
+                # Unrelated OperationalError — don't silently swallow.
+                raise
+            # Don't downgrade if another process already set WAL on disk.
+            existing = _on_disk_journal_mode(conn)
+            if existing == "wal":
+                raise
+            _log_wal_fallback_once(db_label, exc)
+            conn.execute("PRAGMA journal_mode=DELETE")
+            return "delete"
+    raise last_lock_error or sqlite3.OperationalError("database is locked")
 
 
 def _log_wal_fallback_once(db_label: str, exc: Exception) -> None:
@@ -1009,7 +1220,7 @@ class SessionDB:
     _IMPORT_MAX_TOTAL_BYTES = 25 * 1024 * 1024
 
     def __init__(self, db_path: Path = None, read_only: bool = False):
-        self.db_path = db_path or DEFAULT_DB_PATH
+        self.db_path = _canonical_state_db_path(db_path or DEFAULT_DB_PATH)
         self.read_only = read_only
 
         self._lock = threading.Lock()
@@ -1041,22 +1252,59 @@ class SessionDB:
             self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
             def _connect_and_init():
-                self._conn = sqlite3.connect(
-                    str(self.db_path),
-                    check_same_thread=False,
-                    # Short timeout — application-level retry with random
-                    # jitter handles contention instead of sitting in
-                    # SQLite's internal busy handler for up to 30s.
-                    timeout=1.0,
-                    # auto-starts transactions on DML, which conflicts with
-                    # our explicit BEGIN IMMEDIATE.  None = we manage
-                    # transactions ourselves.
-                    isolation_level=None,
+                for attempt in range(_STATE_DB_PATH_RETRY_LIMIT):
+                    anchor_fd, _ = _open_state_db_anchor(self.db_path)
+                    try:
+                        self._conn = sqlite3.connect(
+                            str(self.db_path),
+                            check_same_thread=False,
+                            # Keep each SQLite busy wait within the outer
+                            # schema-transaction deadline.
+                            timeout=max(
+                                0.01,
+                                min(30.0, _STATE_SCHEMA_TRANSACTION_TIMEOUT_S),
+                            ),
+                            # None = explicit transaction ownership below.
+                            isolation_level=None,
+                        )
+                        self._conn.row_factory = sqlite3.Row
+                        self._conn.execute("PRAGMA foreign_keys=ON")
+                        self._init_schema()
+                        apply_wal_with_fallback(self._conn, db_label="state.db")
+                        if _state_db_anchor_matches_path(anchor_fd, self.db_path):
+                            return
+                    except BaseException as exc:
+                        alias_error = None
+                        try:
+                            stale = not _state_db_anchor_matches_path(
+                                anchor_fd, self.db_path
+                            )
+                        except StateDBAliasError as alias_exc:
+                            stale = False
+                            alias_error = alias_exc
+                        if self._conn is not None:
+                            try:
+                                _end_schema_transaction(self._conn)
+                                self._conn.close()
+                            finally:
+                                self._conn = None
+                        if alias_error is not None:
+                            raise alias_error from exc
+                        if stale and attempt < _STATE_DB_PATH_RETRY_LIMIT - 1:
+                            continue
+                        raise
+                    else:
+                        # The pathname changed after this connection opened.
+                        # Close the stale inode before retrying the current path.
+                        if self._conn is not None:
+                            self._conn.close()
+                            self._conn = None
+                    finally:
+                        os.close(anchor_fd)
+                raise RuntimeError(
+                    f"state.db pathname kept changing during initialization: "
+                    f"{self.db_path}"
                 )
-                self._conn.row_factory = sqlite3.Row
-                apply_wal_with_fallback(self._conn, db_label="state.db")
-                self._conn.execute("PRAGMA foreign_keys=ON")
-                self._init_schema()
 
             try:
                 _connect_and_init()
@@ -1166,12 +1414,15 @@ class SessionDB:
                 pass
 
     @staticmethod
-    def _fts_trigger_count(cursor: sqlite3.Cursor) -> int:
-        placeholders = ",".join("?" for _ in _FTS_TRIGGERS)
+    def _fts_trigger_count(
+        cursor: sqlite3.Cursor,
+        trigger_names: tuple[str, ...] = _FTS_TRIGGERS,
+    ) -> int:
+        placeholders = ",".join("?" for _ in trigger_names)
         row = cursor.execute(
             f"SELECT COUNT(*) FROM sqlite_master "
             f"WHERE type = 'trigger' AND name IN ({placeholders})",
-            _FTS_TRIGGERS,
+            trigger_names,
         ).fetchone()
         return int(row[0] if not isinstance(row, sqlite3.Row) else row[0])
 
@@ -1203,6 +1454,19 @@ class SessionDB:
         )
 
     def _fts_table_probe(self, cursor: sqlite3.Cursor, table_name: str) -> Optional[bool]:
+        schema_row = cursor.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table_name,),
+        ).fetchone()
+        if schema_row is None:
+            return False
+        schema_sql = schema_row[0] if not isinstance(schema_row, sqlite3.Row) else schema_row[0]
+        normalized_schema = " ".join(str(schema_sql or "").lower().split())
+        if (
+            "create virtual table" not in normalized_schema
+            or "using fts5" not in normalized_schema
+        ):
+            return False
         try:
             cursor.execute(f"SELECT * FROM {table_name} LIMIT 0")
             return True
@@ -1229,10 +1493,14 @@ class SessionDB:
         if status is None:
             return False
         try:
+            if status is False:
+                # A normal table with a canonical FTS name is corruption of a
+                # derived object, not user data. Replace it transactionally.
+                cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
             # Run even when the virtual table exists so any dropped or missing
             # triggers are recreated after a previous no-FTS5 runtime disabled
             # them to keep message writes working.
-            cursor.executescript(ddl)
+            _execute_script_statements(cursor, ddl)
             return True
         except sqlite3.OperationalError as exc:
             if not self._is_fts5_unavailable_error(exc):
@@ -1355,11 +1623,22 @@ class SessionDB:
         with self._lock:
             if self._conn:
                 try:
-                    self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-                except Exception as exc:
-                    logger.debug("WAL checkpoint (TRUNCATE) at close failed: %s", exc)
-                self._conn.close()
-                self._conn = None
+                    # A checkpoint cannot run inside a transaction. Roll back
+                    # any abandoned caller/schema transaction before the
+                    # controlled close-time TRUNCATE.
+                    if self._conn.in_transaction is True:
+                        self._conn.rollback()
+                    _end_schema_transaction(self._conn)
+                    try:
+                        self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                    except Exception as exc:
+                        logger.debug(
+                            "WAL checkpoint (TRUNCATE) at close failed: %s", exc
+                        )
+                finally:
+                    _end_schema_transaction(self._conn)
+                    self._conn.close()
+                    self._conn = None
 
     @staticmethod
     def _parse_schema_columns(schema_sql: str) -> Dict[str, Dict[str, str]]:
@@ -1374,7 +1653,7 @@ class SessionDB:
         Adding a column to SCHEMA_SQL is all that's needed; the
         reconciliation loop picks it up automatically.
         """
-        ref = sqlite3.connect(":memory:")
+        ref = _SQLITE_CONNECT(":memory:")
         try:
             ref.executescript(schema_sql)
             table_columns: Dict[str, Dict[str, str]] = {}
@@ -1440,12 +1719,17 @@ class SessionDB:
                             f'ALTER TABLE "{table_name}" ADD COLUMN "{safe_name}" {col_type}'
                         )
                     except sqlite3.OperationalError as exc:
-                        # Expected: "duplicate column name" from a race or
-                        # re-run.  Unexpected: "Cannot add a NOT NULL column
-                        # with default value NULL" from a schema mistake.
-                        # Log at DEBUG so it's visible in agent.log.
+                        if not _is_exact_duplicate_column_race(
+                            cursor,
+                            table_name,
+                            col_name,
+                            exc,
+                        ):
+                            raise
                         logger.debug(
-                            "reconcile %s.%s: %s", table_name, col_name, exc,
+                            "reconcile %s.%s completed concurrently",
+                            table_name,
+                            col_name,
                         )
 
     def _init_schema(self):
@@ -1461,9 +1745,11 @@ class SessionDB:
         The schema_version table is retained for future data migrations
         (transforming existing rows) which cannot be handled declaratively.
         """
+        assert self._conn is not None
+        _begin_schema_transaction(self._conn)
         cursor = self._conn.cursor()
 
-        cursor.executescript(SCHEMA_SQL)
+        _execute_script_statements(cursor, SCHEMA_SQL)
 
         # ── Declarative column reconciliation ──────────────────────────
         # Diff live tables against SCHEMA_SQL and ADD any missing columns.
@@ -1487,7 +1773,7 @@ class SessionDB:
 
         # Deferred indexes that reference the reconciler-added ``active``
         # column (idx_messages_session_active) — same ordering constraint.
-        cursor.executescript(DEFERRED_INDEX_SQL)
+        _execute_script_statements(cursor, DEFERRED_INDEX_SQL)
 
         # Heal NULL ``active`` rows unconditionally on every startup.
         # On real-world DBs the reconciler-added ``active`` column can lack
@@ -1722,24 +2008,59 @@ class SessionDB:
             # FTS5 setup. Run the DDL even when the virtual table exists so
             # CREATE TRIGGER IF NOT EXISTS repairs trigger-only degradation from
             # an earlier no-FTS5 runtime.
-            triggers_need_repair = self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
+            base_was_ready = self._fts_table_probe(cursor, "messages_fts") is True
+            base_triggers_need_repair = self._fts_trigger_count(
+                cursor, _BASE_FTS_TRIGGERS
+            ) < len(_BASE_FTS_TRIGGERS)
             self._fts_enabled = self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL)
 
             # Trigram FTS5 for CJK/substring search. This is optional relative
             # to the main FTS table; if it cannot be created, CJK search falls
             # back to LIKE.
             if self._fts_enabled:
+                trigram_was_ready = (
+                    self._fts_table_probe(cursor, "messages_fts_trigram") is True
+                )
+                trigram_triggers_need_repair = self._fts_trigger_count(
+                    cursor, _TRIGRAM_FTS_TRIGGERS
+                ) < len(_TRIGRAM_FTS_TRIGGERS)
                 trigram_enabled = self._ensure_fts_schema(
                     cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
                 )
                 self._trigram_available = trigram_enabled
-                if triggers_need_repair:
+                if (
+                    not base_was_ready
+                    or base_triggers_need_repair
+                    or (
+                        trigram_enabled
+                        and (
+                            not trigram_was_ready
+                            or trigram_triggers_need_repair
+                        )
+                    )
+                ):
                     self._rebuild_fts_indexes(
                         cursor,
                         include_trigram=trigram_enabled,
                     )
 
-        self._conn.commit()
+        schema_cookie = int(cursor.execute("PRAGMA schema_version").fetchone()[0])
+        readiness_token = canonical_schema_readiness_token(
+            SCHEMA_VERSION,
+            schema_cookie,
+            self._fts_enabled,
+            self._trigram_available,
+        )
+        cursor.execute(
+            """INSERT INTO state_meta(key, value) VALUES (?, ?)
+               ON CONFLICT(key) DO UPDATE SET value = excluded.value""",
+            (STATE_SCHEMA_READINESS_KEY, readiness_token),
+        )
+
+        try:
+            self._conn.commit()
+        finally:
+            _end_schema_transaction(self._conn)
 
     # =========================================================================
     # Session lifecycle
@@ -7191,6 +7512,12 @@ class SessionDB:
                 (error[:500], session_id),
             )
         self._execute_write(_do)
+
+
+def initialize_state_db(db_path: Optional[Path] = None) -> None:
+    """Create or reconcile the one canonical state.db schema."""
+    db = SessionDB() if db_path is None else SessionDB(db_path=db_path)
+    db.close()
 
 
 class AsyncSessionDB:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -55,10 +55,10 @@ class _NoFtsExistingTableConnection(sqlite3.Connection):
 class _NoTrigramCursor(sqlite3.Cursor):
     """Simulate a SQLite build with FTS5 but without the trigram tokenizer."""
 
-    def executescript(self, sql_script):
-        if "tokenize='trigram'" in sql_script:
+    def execute(self, sql, parameters=()):
+        if "tokenize='trigram'" in sql:
             raise sqlite3.OperationalError("no such tokenizer: trigram")
-        return super().executescript(sql_script)
+        return super().execute(sql, parameters)
 
 
 class _NoTrigramConnection(sqlite3.Connection):

--- a/tests/tools/test_async_delegation_state_schema.py
+++ b/tests/tools/test_async_delegation_state_schema.py
@@ -1,0 +1,883 @@
+"""Canonical state.db bootstrap coverage for async delegation startup."""
+
+import hashlib
+import json
+import multiprocessing
+import os
+import queue
+import sqlite3
+import threading
+import time
+import traceback
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+import hermes_state
+from hermes_state import SCHEMA_VERSION, SessionDB
+from tools import async_delegation as ad
+from tools.process_registry import ProcessRegistry
+
+
+_CANONICAL_TABLES = {
+    "schema_version",
+    "sessions",
+    "messages",
+    "session_model_usage",
+    "state_meta",
+    "gateway_routing",
+    "compression_locks",
+    "messages_fts",
+}
+_COMPLETE_TABLES = _CANONICAL_TABLES | {"async_delegations"}
+_ASYNC_COLUMNS = {
+    "owner_pid",
+    "owner_started_at",
+    "task_json",
+    "delivery_claim",
+    "delivery_claimed_at",
+}
+_BASE_FTS_TRIGGERS = {
+    "messages_fts_insert",
+    "messages_fts_delete",
+    "messages_fts_update",
+}
+_TRIGRAM_FTS_TRIGGERS = {
+    "messages_fts_trigram_insert",
+    "messages_fts_trigram_delete",
+    "messages_fts_trigram_update",
+}
+
+_ASYNC_ONLY_SCHEMA = """
+CREATE TABLE async_delegations (
+    delegation_id TEXT PRIMARY KEY,
+    origin_session TEXT NOT NULL,
+    origin_ui_session_id TEXT NOT NULL DEFAULT '',
+    parent_session_id TEXT,
+    state TEXT NOT NULL,
+    dispatched_at REAL NOT NULL,
+    completed_at REAL,
+    updated_at REAL NOT NULL,
+    event_json TEXT,
+    result_json TEXT,
+    delivery_state TEXT NOT NULL DEFAULT 'pending',
+    delivery_attempts INTEGER NOT NULL DEFAULT 0,
+    delivered_at REAL
+);
+"""
+
+
+def _table_names(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+
+
+def _assert_complete_schema(db_path):
+    assert _COMPLETE_TABLES <= _table_names(db_path)
+    assert _ASYNC_COLUMNS <= _column_names(db_path, "async_delegations")
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()
+    assert row == (SCHEMA_VERSION,)
+
+
+def _column_names(db_path, table_name):
+    with sqlite3.connect(db_path) as conn:
+        return {
+            row[1]
+            for row in conn.execute(f'PRAGMA table_info("{table_name}")')
+        }
+
+
+def _trigger_names(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+            )
+        }
+
+
+def _sqlite_master_sql(db_path, object_name):
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name = ?", (object_name,)
+        ).fetchone()
+    return None if row is None else row[0]
+
+
+@pytest.fixture(autouse=True)
+def _reset_async_delegation_state():
+    ad._reset_for_tests()
+    yield
+    ad._reset_for_tests()
+
+
+def _process_schema_worker(kind, home, start_event, ready_queue, result_queue):
+    """Run one production startup path in a fresh spawned interpreter."""
+    os.environ["HERMES_HOME"] = str(home)
+    ready_queue.put({"worker": kind, "pid": os.getpid()})
+    try:
+        if not start_event.wait(timeout=15):
+            raise TimeoutError("timed out waiting for synchronized process start")
+        if kind == "session":
+            db = SessionDB(db_path=home / "state.db")
+            db.close()
+            result = None
+        elif kind == "async":
+            result = ad.restore_undelivered_completions(queue.Queue())
+        else:  # pragma: no cover - test harness guard
+            raise ValueError(f"unknown worker kind: {kind}")
+        result_queue.put({"worker": kind, "ok": True, "result": result})
+    except BaseException as exc:
+        result_queue.put(
+            {
+                "worker": kind,
+                "ok": False,
+                "error": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc(),
+            }
+        )
+
+
+def _run_process_schema_case(ctx, home, worker_kinds):
+    start_event = ctx.Event()
+    ready_queue = ctx.Queue()
+    result_queue = ctx.Queue()
+    processes = [
+        ctx.Process(
+            target=_process_schema_worker,
+            args=(kind, home, start_event, ready_queue, result_queue),
+        )
+        for kind in worker_kinds
+    ]
+    try:
+        for process in processes:
+            process.start()
+        ready = [ready_queue.get(timeout=20) for _ in processes]
+        start_event.set()
+        for process in processes:
+            process.join(timeout=30)
+
+        outcomes = []
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+                outcomes.append(
+                    {
+                        "worker": "unknown",
+                        "ok": False,
+                        "error": f"child {process.pid} timed out",
+                        "traceback": "",
+                    }
+                )
+        while len(outcomes) < len(processes):
+            try:
+                outcomes.append(result_queue.get(timeout=2))
+            except queue.Empty:
+                break
+        if len(outcomes) < len(processes):
+            outcomes.append(
+                {
+                    "worker": "unknown",
+                    "ok": False,
+                    "error": "child exited without publishing a startup result",
+                    "traceback": "",
+                }
+            )
+        return {
+            "ready": ready,
+            "exitcodes": [process.exitcode for process in processes],
+            "outcomes": outcomes,
+        }
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=5)
+        for process_queue in (ready_queue, result_queue):
+            process_queue.close()
+            process_queue.join_thread()
+
+
+def _prepare_async_only_db(db_path):
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(_ASYNC_ONLY_SCHEMA)
+        conn.execute(
+            """INSERT INTO async_delegations (
+                   delegation_id, origin_session, state, dispatched_at,
+                   updated_at, delivery_state
+               ) VALUES (?, ?, ?, ?, ?, ?)""",
+            ("deleg_existing", "origin", "completed", 1.0, 2.0, "delivered"),
+        )
+
+
+def _assert_existing_delegation_preserved(db_path):
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT origin_session, state, delivery_state "
+            "FROM async_delegations WHERE delegation_id = ?",
+            ("deleg_existing",),
+        ).fetchone()
+    assert row == ("origin", "completed", "delivered")
+
+
+def _patch_async_connect_with_journal_failure(monkeypatch, reason):
+    real_connect = sqlite3.connect
+    opened = []
+
+    class _TrackedConnection(sqlite3.Connection):
+        tracker: dict
+
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            normalized = sql.lower().replace(" ", "")
+            if "journal_mode=wal" in normalized:
+                self.tracker["wal_attempts"] += 1
+                raise sqlite3.OperationalError(reason)
+            if "journal_mode=delete" in normalized:
+                self.tracker["delete_attempts"] += 1
+            return super().execute(sql, *args, **kwargs)
+
+        def close(self):  # type: ignore[override]
+            self.tracker["closed"] = True
+            return super().close()
+
+    def tracked_connect(path, *args, **kwargs):
+        tracker = {"wal_attempts": 0, "delete_attempts": 0, "closed": False}
+        kwargs["factory"] = _TrackedConnection
+        conn = real_connect(path, *args, **kwargs)
+        setattr(conn, "tracker", tracker)
+        opened.append((conn, tracker))
+        return conn
+
+    monkeypatch.setattr(ad.sqlite3, "connect", tracked_connect)
+    return opened
+
+
+def _schema_transaction_holder(db_path, ready_event, release_event, crash):
+    conn = sqlite3.connect(db_path, timeout=0.1, isolation_level=None)
+    try:
+        hermes_state._begin_schema_transaction(conn)
+        ready_event.set()
+        if not release_event.wait(timeout=15):
+            raise TimeoutError("schema-transaction test holder timed out")
+        if crash:
+            os._exit(0)
+        conn.rollback()
+    finally:
+        conn.close()
+
+
+def test_process_registry_bootstrap_initializes_canonical_schema_when_db_missing(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+    assert not db_path.exists()
+
+    ProcessRegistry()
+
+    _assert_complete_schema(db_path)
+
+
+def test_process_registry_bootstrap_initializes_canonical_schema_for_zero_byte_db(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+    db_path.touch()
+    assert db_path.stat().st_size == 0
+
+    ProcessRegistry()
+
+    _assert_complete_schema(db_path)
+
+
+def test_process_registry_bootstrap_upgrades_async_only_db_without_losing_rows(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(_ASYNC_ONLY_SCHEMA)
+        conn.execute(
+            """INSERT INTO async_delegations (
+                   delegation_id, origin_session, state, dispatched_at,
+                   updated_at, delivery_state
+               ) VALUES (?, ?, ?, ?, ?, ?)""",
+            ("deleg_existing", "origin", "completed", 1.0, 2.0, "delivered"),
+        )
+
+    ProcessRegistry()
+
+    _assert_complete_schema(db_path)
+    assert {
+        "owner_pid",
+        "owner_started_at",
+        "task_json",
+        "delivery_claim",
+        "delivery_claimed_at",
+    } <= _column_names(db_path, "async_delegations")
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT origin_session, state, delivery_state "
+            "FROM async_delegations WHERE delegation_id = ?",
+            ("deleg_existing",),
+        ).fetchone()
+    assert row == ("origin", "completed", "delivered")
+
+
+def test_concurrent_session_and_async_first_open_produces_complete_schema(
+    tmp_path, monkeypatch
+):
+    for attempt in range(10):
+        home = tmp_path / f"attempt-{attempt}"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        db_path = home / "state.db"
+        start = threading.Barrier(2)
+
+        def open_session_db():
+            start.wait(timeout=5)
+            db = SessionDB(db_path=db_path)
+            db.close()
+
+        def restore_async_delegations():
+            start.wait(timeout=5)
+            assert ad.restore_undelivered_completions(queue.Queue()) == 0
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(open_session_db),
+                executor.submit(restore_async_delegations),
+            ]
+            for future in futures:
+                future.result(timeout=15)
+
+        _assert_complete_schema(db_path)
+
+
+def test_session_crud_works_after_async_first_startup(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+
+    assert ad.restore_undelivered_completions(queue.Queue()) == 0
+
+    db = SessionDB(db_path=db_path)
+    try:
+        db.create_session("after-async", source="cli", model="test-model")
+        message_id = db.append_message(
+            "after-async", role="user", content="persisted after async startup"
+        )
+
+        assert message_id > 0
+        session = db.get_session("after-async")
+        assert session is not None
+        assert session["model"] == "test-model"
+        messages = db.get_messages("after-async")
+        assert [message["content"] for message in messages] == [
+            "persisted after async startup"
+        ]
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize(
+    ("initial_state", "worker_kinds"),
+    [
+        ("missing", ("session", "async")),
+        ("missing", ("async", "async")),
+        ("async-only", ("session", "async")),
+        ("async-only", ("async", "async")),
+    ],
+    ids=[
+        "missing-session-async",
+        "missing-async-async",
+        "async-only-session-async",
+        "async-only-async-async",
+    ],
+)
+def test_separate_process_startup_matrix(
+    tmp_path, initial_state, worker_kinds
+):
+    """Every child must start cleanly and leave one complete shared schema.
+
+    CI uses one iteration for a quick regression. Acceptance stress sets
+    ``HERMES_SCHEMA_PROCESS_ITERATIONS=100`` for 400 synchronized fresh-home
+    cases (800 separately spawned child interpreters).
+    """
+    iterations = int(os.environ.get("HERMES_SCHEMA_PROCESS_ITERATIONS", "1"))
+    assert iterations > 0
+    ctx = multiprocessing.get_context("spawn")
+    failures = []
+
+    for attempt in range(iterations):
+        home = tmp_path / f"attempt-{attempt}"
+        db_path = home / "state.db"
+        if initial_state == "async-only":
+            _prepare_async_only_db(db_path)
+
+        result = _run_process_schema_case(ctx, home, worker_kinds)
+        child_errors = [
+            outcome for outcome in result["outcomes"] if not outcome.get("ok")
+        ]
+        abnormal_exits = [
+            exitcode for exitcode in result["exitcodes"] if exitcode != 0
+        ]
+        try:
+            _assert_complete_schema(db_path)
+            if initial_state == "async-only":
+                _assert_existing_delegation_preserved(db_path)
+        except BaseException:
+            child_errors.append(
+                {
+                    "worker": "schema-inspection",
+                    "ok": False,
+                    "error": "final schema or preserved-row assertion failed",
+                    "traceback": traceback.format_exc(),
+                }
+            )
+        if child_errors or abnormal_exits:
+            failures.append(
+                {
+                    "attempt": attempt,
+                    "initial_state": initial_state,
+                    "worker_kinds": worker_kinds,
+                    "abnormal_exits": abnormal_exits,
+                    "result": result,
+                }
+            )
+
+    assert not failures, json.dumps(failures, indent=2, sort_keys=True)
+
+
+@pytest.mark.parametrize("replacement_mode", ["unlink", "atomic-replace"])
+def test_same_path_db_replacement_reestablishes_canonical_schema(
+    tmp_path, monkeypatch, replacement_mode
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+
+    with ad._connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone() == (0,)
+    _assert_complete_schema(db_path)
+
+    if replacement_mode == "unlink":
+        db_path.unlink()
+        _prepare_async_only_db(db_path)
+    else:
+        replacement = tmp_path / "replacement.db"
+        _prepare_async_only_db(replacement)
+        os.replace(replacement, db_path)
+
+    assert ad.restore_undelivered_completions(queue.Queue()) == 0
+    _assert_complete_schema(db_path)
+    _assert_existing_delegation_preserved(db_path)
+
+
+def test_replacement_between_open_and_readiness_reopens_current_object(
+    tmp_path, monkeypatch
+):
+    """A connection opened before atomic replacement must never be returned."""
+    iterations = int(os.environ.get("HERMES_SCHEMA_REPLACEMENT_ITERATIONS", "1"))
+    assert iterations > 0
+
+    for attempt in range(iterations):
+        home = tmp_path / f"attempt-{attempt}"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        db_path = home / "state.db"
+        initial = SessionDB(db_path=db_path)
+        initial.close()
+        stale_observer = sqlite3.connect(db_path)
+
+        replacement = home / "replacement.db"
+        _prepare_async_only_db(replacement)
+        opened = threading.Event()
+        resume = threading.Event()
+        real_open = ad._open_with_wal
+        first_open = True
+        outcome = {}
+
+        def paused_open(path):
+            nonlocal first_open
+            conn = real_open(path)
+            if first_open:
+                first_open = False
+                opened.set()
+                assert resume.wait(timeout=15)
+            return conn
+
+        def async_writer():
+            try:
+                with ad._connect() as conn:
+                    conn.execute(
+                        """INSERT INTO async_delegations
+                           (delegation_id, origin_session, state, dispatched_at,
+                            updated_at, delivery_state)
+                           VALUES ('deleg_current', 'origin', 'completed', 1, 2,
+                                   'delivered')"""
+                    )
+                    conn.commit()
+                outcome["ok"] = True
+            except BaseException:
+                outcome["traceback"] = traceback.format_exc()
+
+        monkeypatch.setattr(ad, "_open_with_wal", paused_open)
+        worker = threading.Thread(target=async_writer)
+        worker.start()
+        assert opened.wait(timeout=15)
+        os.replace(replacement, db_path)
+        resume.set()
+        worker.join(timeout=30)
+        assert not worker.is_alive()
+        assert outcome == {"ok": True}, outcome.get("traceback")
+
+        _assert_complete_schema(db_path)
+        _assert_existing_delegation_preserved(db_path)
+        with sqlite3.connect(db_path) as current:
+            assert current.execute(
+                "SELECT COUNT(*) FROM async_delegations "
+                "WHERE delegation_id = 'deleg_current'"
+            ).fetchone() == (1,)
+        assert stale_observer.execute(
+            "SELECT COUNT(*) FROM async_delegations "
+            "WHERE delegation_id = 'deleg_current'"
+        ).fetchone() == (0,)
+        stale_observer.close()
+
+
+@pytest.mark.parametrize(
+    "damage",
+    ["missing-table", "missing-trigger", "wrong-table"],
+)
+def test_current_version_supported_fts_damage_is_repaired(
+    tmp_path, monkeypatch, damage
+):
+    iterations = int(os.environ.get("HERMES_SCHEMA_FTS_REPAIR_ITERATIONS", "1"))
+    assert iterations > 0
+
+    for attempt in range(iterations):
+        home = tmp_path / damage / f"attempt-{attempt}"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        db_path = home / "state.db"
+        db = SessionDB(db_path=db_path)
+        if not db._fts_enabled:
+            db.close()
+            pytest.skip("SQLite runtime has no base FTS5 support")
+        db.close()
+
+        with sqlite3.connect(db_path) as conn:
+            if damage in {"missing-table", "wrong-table"}:
+                for trigger in _BASE_FTS_TRIGGERS:
+                    conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+                conn.execute("DROP TABLE messages_fts")
+            if damage == "missing-trigger":
+                conn.execute("DROP TRIGGER messages_fts_update")
+            elif damage == "wrong-table":
+                conn.execute("CREATE TABLE messages_fts(content TEXT)")
+            assert conn.execute(
+                "SELECT version FROM schema_version LIMIT 1"
+            ).fetchone() == (SCHEMA_VERSION,)
+
+        with ad._connect() as conn:
+            assert conn.execute("SELECT * FROM messages_fts LIMIT 0").fetchall() == []
+
+        master_sql = (_sqlite_master_sql(db_path, "messages_fts") or "").lower()
+        assert "create virtual table" in master_sql
+        assert "using fts5" in master_sql
+        assert _BASE_FTS_TRIGGERS <= _trigger_names(db_path)
+
+
+def test_readiness_does_not_require_optional_trigram_when_tokenizer_is_missing(
+    tmp_path
+):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.close()
+    with sqlite3.connect(db_path) as conn:
+        for trigger in _TRIGRAM_FTS_TRIGGERS:
+            conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+        conn.execute("DROP TABLE IF EXISTS messages_fts_trigram")
+
+    real_connect = sqlite3.connect
+
+    class _NoTrigramConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            normalized = sql.lower().replace(" ", "")
+            if "temp._hermes_fts_trigram_probeusingfts5" in normalized:
+                raise sqlite3.OperationalError("no such tokenizer: trigram")
+            return super().execute(sql, *args, **kwargs)
+
+    conn = real_connect(db_path, factory=_NoTrigramConnection)
+    try:
+        assert ad._canonical_schema_ready(conn, SCHEMA_VERSION)
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("reason", ["locking protocol", "not authorized"])
+def test_async_wal_open_uses_shared_delete_fallback(tmp_path, monkeypatch, reason):
+    opened = _patch_async_connect_with_journal_failure(monkeypatch, reason)
+
+    conn = ad._open_with_wal(tmp_path / "network-fs.db")
+    try:
+        assert opened[0][1] == {
+            "wal_attempts": 1,
+            "delete_attempts": 1,
+            "closed": False,
+        }
+        conn.execute("CREATE TABLE usable_after_fallback (id INTEGER)")
+    finally:
+        conn.close()
+
+
+def test_async_wal_open_does_not_downgrade_existing_wal(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "already-wal.db"
+    with sqlite3.connect(db_path, isolation_level=None) as primer:
+        assert primer.execute("PRAGMA journal_mode=WAL").fetchone() == ("wal",)
+        primer.execute("CREATE TABLE preserved (id INTEGER)")
+
+    opened = _patch_async_connect_with_journal_failure(
+        monkeypatch, "locking protocol"
+    )
+    conn = ad._open_with_wal(db_path)
+    conn.close()
+
+    assert opened[0][1]["wal_attempts"] == 0
+    assert opened[0][1]["delete_attempts"] == 0
+    with sqlite3.connect(db_path) as check:
+        assert check.execute("PRAGMA journal_mode").fetchone() == ("wal",)
+
+
+def test_async_wal_open_propagates_unrelated_error_and_closes_connection(
+    tmp_path, monkeypatch
+):
+    opened = _patch_async_connect_with_journal_failure(
+        monkeypatch, "no such table: unrelated"
+    )
+
+    with pytest.raises(sqlite3.OperationalError, match="no such table: unrelated"):
+        ad._open_with_wal(tmp_path / "broken.db")
+
+    assert opened[0][1] == {
+        "wal_attempts": 1,
+        "delete_attempts": 0,
+        "closed": True,
+    }
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "disk I/O error during ALTER",
+        "disk I/O error after duplicate column name: owner_pid",
+        "duplicate column name: another_column",
+    ],
+)
+def test_canonical_reconcile_propagates_non_exact_duplicate_errors(
+    tmp_path, monkeypatch, error_message
+):
+    db_path = tmp_path / "state.db"
+    _prepare_async_only_db(db_path)
+    real_connect = sqlite3.connect
+
+    class _AlterFailsCursor(sqlite3.Cursor):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            normalized = sql.lower().replace('"', "")
+            if "alter table async_delegations add column owner_pid" in normalized:
+                raise sqlite3.OperationalError(error_message)
+            return super().execute(sql, *args, **kwargs)
+
+    class _AlterFailsConnection(sqlite3.Connection):
+        def cursor(self, *args, **kwargs):  # type: ignore[override]
+            kwargs["factory"] = _AlterFailsCursor
+            return super().cursor(*args, **kwargs)
+
+    def gated_connect(database, *args, **kwargs):
+        if str(database) == str(db_path):
+            kwargs["factory"] = _AlterFailsConnection
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(hermes_state.sqlite3, "connect", gated_connect)
+    with pytest.raises(sqlite3.OperationalError) as exc_info:
+        SessionDB(db_path=db_path)
+    assert str(exc_info.value) == error_message
+
+
+@pytest.mark.parametrize(
+    ("message", "columns", "accepted"),
+    [
+        ("duplicate column name: owner_pid", {"owner_pid"}, True),
+        ("duplicate column name: owner_pid", set(), False),
+        ("duplicate column name: another_column", {"owner_pid"}, False),
+        ("disk I/O error after duplicate column name: owner_pid", {"owner_pid"}, False),
+        ("DUPLICATE COLUMN NAME: owner_pid", {"owner_pid"}, False),
+    ],
+)
+def test_duplicate_column_race_requires_exact_target_and_fresh_pragma(
+    message, columns, accepted
+):
+    conn = sqlite3.connect(":memory:")
+    try:
+        declared = ", ".join(f'"{name}" INTEGER' for name in sorted(columns))
+        conn.execute(f"CREATE TABLE async_delegations ({declared or 'id INTEGER'})")
+        assert hermes_state._is_exact_duplicate_column_race(
+            conn.cursor(),
+            "async_delegations",
+            "owner_pid",
+            sqlite3.OperationalError(message),
+        ) is accepted
+    finally:
+        conn.close()
+
+
+def test_sqlite_serializer_ignores_unsupported_adjacent_flock(
+    tmp_path, monkeypatch
+):
+    import errno
+    import fcntl
+
+    def unsupported(*_args, **_kwargs):
+        raise OSError(errno.EOPNOTSUPP, "Operation not supported")
+
+    monkeypatch.setattr(fcntl, "flock", unsupported)
+    db_path = tmp_path / "shared" / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.close()
+    _assert_complete_schema(db_path)
+    assert not db_path.with_name(f"{db_path.name}.schema.lock").exists()
+
+
+def test_symlink_and_normalized_paths_use_one_canonical_database(tmp_path):
+    target = tmp_path / "real" / "state.db"
+    target.parent.mkdir()
+    alias = tmp_path / "state-link.db"
+    alias.symlink_to(target)
+
+    db = SessionDB(db_path=alias)
+    try:
+        assert db.db_path == target.resolve()
+    finally:
+        db.close()
+    _assert_complete_schema(target)
+    assert not alias.with_name(f"{alias.name}.schema.lock").exists()
+
+
+def test_hardlink_alias_is_rejected_before_mutation(tmp_path):
+    iterations = int(os.environ.get("HERMES_SCHEMA_ALIAS_ITERATIONS", "1"))
+    assert iterations > 0
+
+    for attempt in range(iterations):
+        home = tmp_path / f"attempt-{attempt}"
+        primary = home / "state.db"
+        alias = home / "alternate.db"
+        db = SessionDB(db_path=primary)
+        db.close()
+        try:
+            os.link(primary, alias)
+        except OSError as exc:
+            pytest.skip(f"hard links unavailable: {exc}")
+
+        before = hashlib.sha256(primary.read_bytes()).hexdigest()
+        with pytest.raises(hermes_state.StateDBAliasError, match="hard-link alias"):
+            SessionDB(db_path=alias)
+        after = hashlib.sha256(primary.read_bytes()).hexdigest()
+        assert after == before
+        assert not alias.with_name(f"{alias.name}-wal").exists()
+        assert not alias.with_name(f"{alias.name}-journal").exists()
+        assert os.path.samefile(primary, alias)
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="POSIX fork required")
+def test_posix_fork_child_waits_for_parent_schema_transaction(tmp_path):
+    db_path = tmp_path / "state.db"
+    initial = SessionDB(db_path=db_path)
+    initial.close()
+    holder = sqlite3.connect(db_path, timeout=0.1, isolation_level=None)
+    hermes_state._begin_schema_transaction(holder)
+
+    ctx = multiprocessing.get_context("fork")
+    started = ctx.Event()
+    entered = ctx.Event()
+
+    def fork_child():
+        started.set()
+        db = SessionDB(db_path=db_path)
+        db.close()
+        entered.set()
+
+    child = ctx.Process(target=fork_child)
+    child.start()
+    try:
+        assert started.wait(timeout=10)
+        assert not entered.wait(timeout=0.3), (
+            "fork child entered schema initialization before parent release"
+        )
+        holder.rollback()
+        assert entered.wait(timeout=15)
+    finally:
+        if holder.in_transaction:
+            holder.rollback()
+        holder.close()
+        child.join(timeout=15)
+        if child.is_alive():
+            child.terminate()
+            child.join(timeout=5)
+    assert child.exitcode == 0
+
+
+def test_schema_transaction_wait_is_bounded(tmp_path, monkeypatch):
+    ctx = multiprocessing.get_context("spawn")
+    ready_event = ctx.Event()
+    release_event = ctx.Event()
+    db_path = tmp_path / "state.db"
+    holder = ctx.Process(
+        target=_schema_transaction_holder,
+        args=(db_path, ready_event, release_event, False),
+    )
+    holder.start()
+    try:
+        assert ready_event.wait(timeout=15)
+        monkeypatch.setattr(
+            hermes_state, "_STATE_SCHEMA_TRANSACTION_TIMEOUT_S", 0.2
+        )
+        started = time.monotonic()
+        with pytest.raises(TimeoutError, match="state schema transaction"):
+            SessionDB(db_path=db_path)
+        assert time.monotonic() - started < 2
+    finally:
+        release_event.set()
+        holder.join(timeout=15)
+        if holder.is_alive():
+            holder.terminate()
+            holder.join(timeout=5)
+    assert holder.exitcode == 0
+
+
+def test_schema_transaction_recovers_after_owner_process_exits(tmp_path):
+    ctx = multiprocessing.get_context("spawn")
+    ready_event = ctx.Event()
+    release_event = ctx.Event()
+    db_path = tmp_path / "state.db"
+    holder = ctx.Process(
+        target=_schema_transaction_holder,
+        args=(db_path, ready_event, release_event, True),
+    )
+    holder.start()
+    assert ready_event.wait(timeout=15)
+    release_event.set()
+    holder.join(timeout=15)
+    assert holder.exitcode == 0
+
+    db = SessionDB(db_path=db_path)
+    db.close()
+    _assert_complete_schema(db_path)
+    assert not db_path.with_name(f"{db_path.name}.schema.lock").exists()

--- a/tests/tools/test_async_delegation_state_schema.py
+++ b/tests/tools/test_async_delegation_state_schema.py
@@ -271,6 +271,7 @@ def _schema_transaction_holder(db_path, ready_event, release_event, crash):
         if crash:
             os._exit(0)
         conn.rollback()
+        hermes_state._end_schema_transaction(conn)
     finally:
         conn.close()
 
@@ -487,6 +488,7 @@ def test_replacement_between_open_and_readiness_reopens_current_object(
     """A connection opened before atomic replacement must never be returned."""
     iterations = int(os.environ.get("HERMES_SCHEMA_REPLACEMENT_ITERATIONS", "1"))
     assert iterations > 0
+    production_open = ad._open_with_wal
 
     for attempt in range(iterations):
         home = tmp_path / f"attempt-{attempt}"
@@ -500,13 +502,12 @@ def test_replacement_between_open_and_readiness_reopens_current_object(
         _prepare_async_only_db(replacement)
         opened = threading.Event()
         resume = threading.Event()
-        real_open = ad._open_with_wal
         first_open = True
         outcome = {}
 
         def paused_open(path):
             nonlocal first_open
-            conn = real_open(path)
+            conn = production_open(path)
             if first_open:
                 first_open = False
                 opened.set()
@@ -595,24 +596,34 @@ def test_current_version_supported_fts_damage_is_repaired(
 
 
 def test_readiness_does_not_require_optional_trigram_when_tokenizer_is_missing(
-    tmp_path
+    tmp_path, monkeypatch
 ):
     db_path = tmp_path / "state.db"
-    db = SessionDB(db_path=db_path)
-    db.close()
-    with sqlite3.connect(db_path) as conn:
-        for trigger in _TRIGRAM_FTS_TRIGGERS:
-            conn.execute(f"DROP TRIGGER IF EXISTS {trigger}")
-        conn.execute("DROP TABLE IF EXISTS messages_fts_trigram")
-
     real_connect = sqlite3.connect
 
+    class _NoTrigramCursor(sqlite3.Cursor):
+        def execute(self, sql, parameters=()):  # type: ignore[override]
+            if "tokenize='trigram'" in sql:
+                raise sqlite3.OperationalError("no such tokenizer: trigram")
+            return super().execute(sql, parameters)
+
     class _NoTrigramConnection(sqlite3.Connection):
+        def cursor(self, factory=None):
+            return super().cursor(factory or _NoTrigramCursor)
+
         def execute(self, sql, *args, **kwargs):  # type: ignore[override]
             normalized = sql.lower().replace(" ", "")
             if "temp._hermes_fts_trigram_probeusingfts5" in normalized:
                 raise sqlite3.OperationalError("no such tokenizer: trigram")
             return super().execute(sql, *args, **kwargs)
+
+    def connect_without_trigram(*args, **kwargs):
+        kwargs["factory"] = _NoTrigramConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(hermes_state.sqlite3, "connect", connect_without_trigram)
+    db = SessionDB(db_path=db_path)
+    db.close()
 
     conn = real_connect(db_path, factory=_NoTrigramConnection)
     try:
@@ -797,41 +808,53 @@ def test_hardlink_alias_is_rejected_before_mutation(tmp_path):
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="POSIX fork required")
-def test_posix_fork_child_waits_for_parent_schema_transaction(tmp_path):
-    db_path = tmp_path / "state.db"
-    initial = SessionDB(db_path=db_path)
-    initial.close()
-    holder = sqlite3.connect(db_path, timeout=0.1, isolation_level=None)
-    hermes_state._begin_schema_transaction(holder)
-
+@pytest.mark.parametrize("child_kind", ["session", "async"])
+def test_posix_fork_child_waits_for_parent_schema_transaction(
+    tmp_path, monkeypatch, child_kind
+):
+    iterations = int(os.environ.get("HERMES_SCHEMA_FORK_ITERATIONS", "1"))
+    assert iterations > 0
     ctx = multiprocessing.get_context("fork")
-    started = ctx.Event()
-    entered = ctx.Event()
+    for attempt in range(iterations):
+        home = tmp_path / child_kind / f"attempt-{attempt}"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        db_path = home / "state.db"
+        initial = SessionDB(db_path=db_path)
+        initial.close()
+        holder = sqlite3.connect(db_path, timeout=0.1, isolation_level=None)
+        hermes_state._begin_schema_transaction(holder)
+        started = ctx.Event()
+        entered = ctx.Event()
 
-    def fork_child():
-        started.set()
-        db = SessionDB(db_path=db_path)
-        db.close()
-        entered.set()
+        def fork_child():
+            started.set()
+            if child_kind == "session":
+                db = SessionDB(db_path=db_path)
+                db.close()
+            else:
+                ad.restore_undelivered_completions(queue.Queue())
+            entered.set()
 
-    child = ctx.Process(target=fork_child)
-    child.start()
-    try:
-        assert started.wait(timeout=10)
-        assert not entered.wait(timeout=0.3), (
-            "fork child entered schema initialization before parent release"
-        )
-        holder.rollback()
-        assert entered.wait(timeout=15)
-    finally:
-        if holder.in_transaction:
+        child = ctx.Process(target=fork_child)
+        child.start()
+        try:
+            assert started.wait(timeout=10)
+            assert not entered.wait(timeout=0.05), (
+                "fork child entered schema initialization before parent release"
+            )
             holder.rollback()
-        holder.close()
-        child.join(timeout=15)
-        if child.is_alive():
-            child.terminate()
-            child.join(timeout=5)
-    assert child.exitcode == 0
+            hermes_state._end_schema_transaction(holder)
+            assert entered.wait(timeout=15)
+        finally:
+            if holder.in_transaction:
+                holder.rollback()
+            hermes_state._end_schema_transaction(holder)
+            holder.close()
+            child.join(timeout=15)
+            if child.is_alive():
+                child.terminate()
+                child.join(timeout=5)
+        assert child.exitcode == 0
 
 
 def test_schema_transaction_wait_is_bounded(tmp_path, monkeypatch):
@@ -881,3 +904,129 @@ def test_schema_transaction_recovers_after_owner_process_exits(tmp_path):
     db.close()
     _assert_complete_schema(db_path)
     assert not db_path.with_name(f"{db_path.name}.schema.lock").exists()
+
+@pytest.mark.parametrize("bootstrap_kind", ["session", "async"])
+def test_bootstrap_keeps_periodic_checkpoint_passive(
+    tmp_path, monkeypatch, bootstrap_kind
+):
+    """Canonical and async-first bootstrap must retain periodic PASSIVE mode."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+    real_connect = sqlite3.connect
+    checkpoint_calls = []
+
+    class _CheckpointTracingConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            normalized = sql.lower().replace(" ", "")
+            if "wal_checkpoint(" in normalized:
+                checkpoint_calls.append((normalized, self.in_transaction))
+            return super().execute(sql, *args, **kwargs)
+
+    def tracing_connect(*args, **kwargs):
+        kwargs["factory"] = _CheckpointTracingConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(hermes_state.sqlite3, "connect", tracing_connect)
+    if bootstrap_kind == "async":
+        conn = ad._connect()
+        conn.close()
+
+    db = SessionDB(db_path=db_path)
+    start = len(checkpoint_calls)
+    try:
+        for index in range(db._CHECKPOINT_EVERY_N_WRITES):
+            db._execute_write(
+                lambda conn, current=index: conn.execute(
+                    "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+                    (f"checkpoint-{current}", "test", float(current)),
+                )
+            )
+
+        periodic_calls = checkpoint_calls[start:]
+        assert periodic_calls == [("pragmawal_checkpoint(passive)", False)]
+    finally:
+        db.close()
+
+    assert checkpoint_calls[-1] == ("pragmawal_checkpoint(truncate)", False)
+    with real_connect(db_path) as check:
+        assert check.execute("PRAGMA quick_check").fetchone() == ("ok",)
+
+
+def test_failed_passive_checkpoint_preserves_schema_and_ownership(
+    tmp_path, monkeypatch, caplog
+):
+    """A periodic checkpoint failure cannot partially mutate canonical schema."""
+    db_path = tmp_path / "state.db"
+    real_connect = sqlite3.connect
+    inject_failure = False
+
+    class _CheckpointFailureConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            normalized = sql.lower().replace(" ", "")
+            if inject_failure and "wal_checkpoint(passive)" in normalized:
+                raise sqlite3.OperationalError("injected PASSIVE checkpoint failure")
+            return super().execute(sql, *args, **kwargs)
+
+    def failure_connect(*args, **kwargs):
+        kwargs["factory"] = _CheckpointFailureConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(hermes_state.sqlite3, "connect", failure_connect)
+    db = SessionDB(db_path=db_path)
+    db.create_session("checkpoint-owner", source="test")
+    inject_failure = True
+    try:
+        with caplog.at_level("WARNING"):
+            db._try_wal_checkpoint()
+        assert "injected PASSIVE checkpoint failure" in caplog.text
+        assert hermes_state._STATE_SCHEMA_ACTIVE_CONNECTIONS == {}
+    finally:
+        inject_failure = False
+        db.close()
+
+    _assert_complete_schema(db_path)
+    with real_connect(db_path) as check:
+        assert check.execute("PRAGMA quick_check").fetchone() == ("ok",)
+        assert check.execute(
+            "SELECT COUNT(*) FROM sessions WHERE id = 'checkpoint-owner'"
+        ).fetchone() == (1,)
+        assert ad._canonical_schema_ready(check, SCHEMA_VERSION)
+
+
+def test_close_rolls_back_schema_transaction_before_checkpoint(tmp_path, monkeypatch):
+    """Close-time TRUNCATE never runs inside an abandoned schema transaction."""
+    db_path = tmp_path / "state.db"
+    real_connect = sqlite3.connect
+    checkpoint_states = []
+
+    class _TransactionTracingConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            normalized = sql.lower().replace(" ", "")
+            if "wal_checkpoint(" in normalized:
+                checkpoint_states.append((normalized, self.in_transaction))
+            return super().execute(sql, *args, **kwargs)
+
+    def tracing_connect(*args, **kwargs):
+        kwargs["factory"] = _TransactionTracingConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(hermes_state.sqlite3, "connect", tracing_connect)
+    db = SessionDB(db_path=db_path)
+    conn = db._conn
+    assert conn is not None
+    hermes_state._begin_schema_transaction(conn)
+    conn.execute("CREATE TABLE partial_schema_marker (id INTEGER)")
+    assert conn.in_transaction is True
+    assert id(conn) in hermes_state._STATE_SCHEMA_ACTIVE_CONNECTIONS
+
+    checkpoint_states.clear()
+    db.close()
+
+    assert checkpoint_states == [("pragmawal_checkpoint(truncate)", False)]
+    assert hermes_state._STATE_SCHEMA_ACTIVE_CONNECTIONS == {}
+    with real_connect(db_path) as check:
+        assert check.execute("PRAGMA quick_check").fetchone() == ("ok",)
+        assert check.execute(
+            "SELECT COUNT(*) FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'partial_schema_marker'"
+        ).fetchone() == (0,)

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 import threading
 import time
@@ -78,50 +79,157 @@ _MAX_RETAINED_COMPLETED = 50
 _DURABLE_RETENTION_SECONDS = 7 * 24 * 60 * 60
 _MAX_DURABLE_PENDING = 1000
 _DB_LOCK = threading.Lock()
+_FTS_CAPABILITY_CACHE: dict[tuple[str, type], tuple[bool, bool]] = {}
 
 
 def _db_path():
     return get_hermes_home() / "state.db"
 
 
-def _connect() -> sqlite3.Connection:
-    path = _db_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
+def _open_with_wal(path) -> sqlite3.Connection:
+    """Open *path* with the canonical state layer's journal semantics."""
     conn = sqlite3.connect(path, timeout=10)
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute(
-        """CREATE TABLE IF NOT EXISTS async_delegations (
-            delegation_id TEXT PRIMARY KEY,
-            origin_session TEXT NOT NULL,
-            origin_ui_session_id TEXT NOT NULL DEFAULT '',
-            parent_session_id TEXT,
-            state TEXT NOT NULL,
-            dispatched_at REAL NOT NULL,
-            completed_at REAL,
-            updated_at REAL NOT NULL,
-            event_json TEXT,
-            result_json TEXT,
-            delivery_state TEXT NOT NULL DEFAULT 'pending',
-            delivery_attempts INTEGER NOT NULL DEFAULT 0,
-            delivered_at REAL,
-            owner_pid INTEGER,
-            owner_started_at INTEGER,
-            task_json TEXT,
-            delivery_claim TEXT,
-            delivery_claimed_at REAL
-        )"""
+    try:
+        from hermes_state import apply_wal_with_fallback
+
+        apply_wal_with_fallback(conn, db_label="state.db")
+        return conn
+    except BaseException:
+        conn.close()
+        raise
+
+
+def _fts_capabilities(conn: sqlite3.Connection) -> tuple[bool, bool]:
+    """Return (base FTS5, optional trigram tokenizer) for this runtime."""
+    cache_key = (sqlite3.sqlite_version, type(conn))
+    cached = _FTS_CAPABILITY_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+    try:
+        conn.execute("DROP TABLE IF EXISTS temp._hermes_fts5_probe")
+        conn.execute("CREATE VIRTUAL TABLE temp._hermes_fts5_probe USING fts5(x)")
+        conn.execute("DROP TABLE temp._hermes_fts5_probe")
+    except sqlite3.OperationalError as exc:
+        if "no such module" in str(exc).lower() and "fts5" in str(exc).lower():
+            result = (False, False)
+            _FTS_CAPABILITY_CACHE[cache_key] = result
+            return result
+        raise
+
+    try:
+        conn.execute("DROP TABLE IF EXISTS temp._hermes_fts_trigram_probe")
+        conn.execute(
+            "CREATE VIRTUAL TABLE temp._hermes_fts_trigram_probe "
+            "USING fts5(x, tokenize='trigram')"
+        )
+        conn.execute("DROP TABLE temp._hermes_fts_trigram_probe")
+        result = (True, True)
+        _FTS_CAPABILITY_CACHE[cache_key] = result
+        return result
+    except sqlite3.OperationalError as exc:
+        if "no such tokenizer: trigram" in str(exc).lower():
+            result = (True, False)
+            _FTS_CAPABILITY_CACHE[cache_key] = result
+            return result
+        raise
+
+
+def _canonical_schema_ready(
+    conn: sqlite3.Connection,
+    schema_version: int,
+) -> bool:
+    """Validate the transactional schema-cookie token for this capability set."""
+    from hermes_state import (
+        STATE_SCHEMA_READINESS_KEY,
+        canonical_schema_readiness_token,
     )
-    columns = {row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")}
-    for name, sql_type in (
-        ("owner_pid", "INTEGER"),
-        ("owner_started_at", "INTEGER"),
-        ("task_json", "TEXT"),
-        ("delivery_claim", "TEXT"),
-        ("delivery_claimed_at", "REAL"),
-    ):
-        if name not in columns:
-            conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
-    return conn
+
+    try:
+        base_fts, trigram_fts = _fts_capabilities(conn)
+        row = conn.execute(
+            """SELECT
+                   (SELECT version FROM schema_version LIMIT 1),
+                   (SELECT value FROM state_meta WHERE key = ?)""",
+            (STATE_SCHEMA_READINESS_KEY,),
+        ).fetchone()
+        if row is None or row[0] is None or row[1] is None:
+            return False
+        schema_cookie = int(conn.execute("PRAGMA schema_version").fetchone()[0])
+        expected = canonical_schema_readiness_token(
+            schema_version,
+            schema_cookie,
+            base_fts,
+            trigram_fts,
+        )
+        return int(row[0]) == schema_version and str(row[1]) == expected
+    except (sqlite3.DatabaseError, TypeError, ValueError):
+        return False
+
+
+def _connect() -> sqlite3.Connection:
+    from hermes_state import (
+        SCHEMA_VERSION,
+        _STATE_DB_PATH_RETRY_LIMIT,
+        _begin_schema_transaction,
+        _canonical_state_db_path,
+        _end_schema_transaction,
+        _open_state_db_anchor,
+        _state_db_anchor_matches_path,
+        initialize_state_db,
+    )
+
+    path = _canonical_state_db_path(_db_path())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    for attempt in range(_STATE_DB_PATH_RETRY_LIMIT):
+        anchor_fd, _ = _open_state_db_anchor(path)
+        conn = None
+        stale = False
+        schema_transaction = False
+        try:
+            conn = _open_with_wal(path)
+            _begin_schema_transaction(conn)
+            schema_transaction = True
+            ready = _canonical_schema_ready(conn, SCHEMA_VERSION)
+            stale = not _state_db_anchor_matches_path(anchor_fd, path)
+            conn.commit()
+            _end_schema_transaction(conn)
+            schema_transaction = False
+            if ready and not stale:
+                return conn
+        except BaseException:
+            try:
+                stale = not _state_db_anchor_matches_path(anchor_fd, path)
+            except BaseException:
+                if conn is not None:
+                    if schema_transaction:
+                        try:
+                            conn.rollback()
+                        finally:
+                            _end_schema_transaction(conn)
+                    conn.close()
+                raise
+            if conn is not None:
+                if schema_transaction:
+                    try:
+                        conn.rollback()
+                    finally:
+                        _end_schema_transaction(conn)
+                conn.close()
+            if stale and attempt < _STATE_DB_PATH_RETRY_LIMIT - 1:
+                continue
+            raise
+        finally:
+            os.close(anchor_fd)
+
+        if conn is not None:
+            conn.close()
+        if stale:
+            continue
+        initialize_state_db(path)
+
+    raise RuntimeError(
+        f"state.db pathname kept changing during async bootstrap: {path}"
+    )
 
 
 def _persist_dispatch(record: Dict[str, Any]) -> None:


### PR DESCRIPTION
## What does this PR do?

Async delegation can be the first process to open the shared `state.db` during startup. Today that path can create only `async_delegations`; if no `SessionDB` has opened yet, the database exists without the canonical session tables and schema metadata. The WebUI session-prefix optimization cannot prove a prefix against that partial schema, so it correctly treats the result as unprovable and falls back to an authoritative full `Session.load()` on every request. Large sessions therefore pay for the full read repeatedly.

This PR makes every first opener converge on one atomic canonical schema. `SessionDB` remains the only DDL and migration owner, while async delegation calls the canonical initializer and reopens/revalidates instead of maintaining a second schema. The WebUI's conservative fallback is unchanged.

The bootstrap contract now covers:

- SQLite `BEGIN IMMEDIATE` serialization around statement-by-statement canonical DDL, reconciliation, FTS repair, readiness-token write, and one final commit. No adjacent pathname lock is created.
- Stable database-object identity checks before and after initialization. A stale handle is closed and reopened if the pathname is replaced; normalized paths and symlinks canonicalize, while hard-link aliases fail closed before mutation.
- A persisted readiness token bound to the application schema version, SQLite schema cookie, and available FTS/trigram capabilities. Supported FTS damage routes back through canonical repair; runtimes without optional trigram support use an explicit capability profile.
- Fork-child cleanup for inherited schema transactions and SQLite descriptors. Constructor, async, failure, and close paths unregister ownership, roll back partial work, and close descriptors.
- Narrow duplicate-column recovery: only SQLite's exact case-sensitive `duplicate column name: <target>` message is accepted, and only after a fresh `PRAGMA table_info` confirms that target. Every other error propagates.
- Explicit bounded `StateDBSerializationUnavailableError` before schema mutation when a backend cannot provide SQLite database-object locking.
- The shared `apply_wal_with_fallback()` path for async connections. The implementation also preserves #64607's periodic `PASSIVE` checkpoint behavior, controlled `TRUNCATE` on close/pre-VACUUM, checkpoint logging, and rollback-before-close ordering.

## Related Issue

Refs #64491, whose async WAL-helper change overlaps one part of this broader bootstrap fix. This branch also builds on merged #64607 and preserves its checkpoint contract. No canonical issue covering the async-first partial-schema bug was found, so this PR intentionally does not use `Closes` or `Fixes`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: owns atomic canonical initialization, schema transactions, readiness/capability tokens, object identity and alias checks, fork cleanup, exact duplicate handling, and transaction-safe checkpoint cleanup.
- `tools/async_delegation.py`: uses the shared WAL helper, validates readiness while holding the SQLite lease, delegates repair to the canonical initializer, and rejects stale/replaced objects.
- `tests/tools/test_async_delegation_state_schema.py`: adds missing/zero-byte/async-only bootstrap, process race, replacement, FTS repair, fork, alias, duplicate, timeout, rollback, and checkpoint-integration coverage.
- `tests/test_hermes_state.py`: updates the no-trigram test double for statement-by-statement transactional DDL.

These are the only four changed paths. There are no WebUI, auth, configuration, dependency, release, or deployment changes.

## How to Test

The behavioral test commit was run first against unmodified current-main production blobs, then against the implementation:

| Gate | Result |
|---|---:|
| Current-main predecessor RED (`tests/tools/test_async_delegation_state_schema.py`) | expected RED: 29 failed / 5 passed |
| Final schema/bootstrap + checkpoint strategy + WAL fallback | 61/61 passed |
| New PASSIVE/close/rollback checkpoint integration cases | 4/4 passed |
| Bounded process/replacement/FTS/alias/fork matrix | 39/39 passed in 39.31 s |
| Focused state/WAL/process/async/malformed/shared-consumer suites | 812/812 passed across 9 files |
| Independent rollback, schema-cookie, lock-order, identity, descriptor, and fork invariants | passed |
| Ruff, byte compilation, `git diff --check`, changed-path, merge-marker, debugger-hook, and Windows-footgun checks | passed |

The bounded matrix exercised 100 fresh homes / 200 spawned children, 50 same-path replacements, 75 supported FTS repairs, 50 hard-link rejections, and 100 POSIX fork children.

Steady-state performance stayed within the pre-set 2.0× median gate for 100 opens per path and revision:

| Run order | `SessionDB` ratio | Async ratio |
|---|---:|---:|
| Base first | 1.9997× | 1.8370× |
| Candidate first confirmation | 1.2894× | 1.3378× |

Platform checks used the exact final source:

- Linux local storage and WSL `/mnt/c`: PASS (schema 21, WAL, row preservation, all async columns, cleanup).
- Native Windows 11 NTFS: PASS with fresh CPython 3.12.13 / SQLite 3.50.4.
- Accessible Windows UNC/9P: direct file read/write worked, but SQLite could not acquire the database-object lease. The code returned the bounded unsupported-backend error before canonical DDL, created no adjacent lock, and cleaned up. This backend is explicitly unsupported.
- No positive claim is made for unavailable NFS/CIFS or macOS hosts.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(state):` then `fix(state):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (the focused 812-test state/WAL/process matrix is green; a monolithic full-suite run is not claimed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, WSL-mounted Windows storage, and native Windows 11 NTFS; unsupported UNC behavior was also exercised

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; runtime behavior is covered by source comments and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config change
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema change

## Screenshots / Logs

Not applicable; this is a runtime/database change. No live deployment, database migration, live-checkout edit, or service restart was performed.
