### PR TITLE
feat(plugins): observable gateway token stream (on_stream_delta/segment/end hooks)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -747,6 +747,13 @@ can:
 - Register Python-callback lifecycle hooks:
   `pre_tool_call`, `post_tool_call`, `pre_llm_call`, `post_llm_call`,
   `on_session_start`, `on_session_end`
+- Observe the live gateway token stream:
+  `on_stream_delta`, `on_stream_segment`, `on_stream_end` (fired by
+  `gateway/stream_consumer.py` as a turn streams to a chat platform).
+  Observers only — return values are ignored. Callbacks run synchronously on
+  the stream worker thread and MUST be non-blocking (enqueue and return);
+  the per-token path is gated on `has_hook()` so it is free when unused. Lets
+  a plugin mirror tokens to its own side-channel/SSE without patching core.
 - Register new tools via `ctx.register_tool(...)`
 - Register CLI subcommands via `ctx.register_cli_command(...)` — the
   plugin's argparse tree is wired into `hermes` at startup so

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -320,9 +320,33 @@ class GatewayStreamConsumer:
             return True
         return any(sent.strip() == target for sent in self._delivered_commentary_texts)
 
+    def _emit_stream_event(self, hook_name: str, **payload: Any) -> None:
+        """Fire a gateway streaming observer hook — best-effort and cheap.
+
+        Lets plugins observe the live token stream (deltas, segment breaks,
+        completion) without patching core streaming, e.g. to mirror tokens to
+        an external side-channel/SSE. Gated on ``has_hook`` so the per-token
+        path costs nothing when no plugin is listening. Callbacks run
+        synchronously on this (worker) thread and must be non-blocking.
+        """
+        try:
+            from hermes_cli.plugins import has_hook, invoke_hook
+            if not has_hook(hook_name):
+                return
+            invoke_hook(
+                hook_name,
+                chat_id=self.chat_id,
+                metadata=self.metadata,
+                message_id=self._message_id,
+                **payload,
+            )
+        except Exception:
+            logger.debug("stream observer hook %s failed", hook_name, exc_info=True)
+
     def on_segment_break(self) -> None:
         """Finalize the current stream segment and start a fresh message."""
         self._queue.put(_NEW_SEGMENT)
+        self._emit_stream_event("on_stream_segment")
 
     def on_commentary(self, text: str) -> None:
         """Queue a completed interim assistant commentary message."""
@@ -376,12 +400,14 @@ class GatewayStreamConsumer:
         """
         if text:
             self._queue.put(text)
+            self._emit_stream_event("on_stream_delta", delta=text)
         elif text is None:
             self.on_segment_break()
 
     def finish(self) -> None:
         """Signal that the stream is complete."""
         self._queue.put(_DONE)
+        self._emit_stream_event("on_stream_end", reason="done")
 
     # ── Think-block filtering ────────────────────────────────────────
     # Models like MiniMax emit inline <think>...</think> blocks in their

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -212,6 +212,22 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    # Gateway streaming observer hooks. Fired by the gateway stream consumer
+    # (gateway/stream_consumer.py) as a turn streams to a chat platform, so a
+    # plugin can observe the live token stream — mirror it to an external
+    # side-channel/SSE, drive metrics, etc. — without patching core streaming.
+    # Observers only: return values are ignored. Callbacks run SYNCHRONOUSLY on
+    # the stream worker thread and MUST be non-blocking (enqueue and return);
+    # a slow callback throttles delivery to the user. The per-token path is
+    # gated on has_hook(), so it costs nothing when no plugin is listening.
+    #
+    # Common kwargs: chat_id: str, metadata: dict | None (platform/session
+    #   routing), message_id: str | None (the platform message id once sent).
+    #   on_stream_delta adds: delta: str (the token text just streamed).
+    #   on_stream_end adds:   reason: str ("done").
+    "on_stream_delta",
+    "on_stream_segment",
+    "on_stream_end",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/tests/gateway/test_stream_observer_hooks.py
+++ b/tests/gateway/test_stream_observer_hooks.py
@@ -1,0 +1,110 @@
+"""Gateway streaming observer hooks (on_stream_delta / on_stream_segment /
+on_stream_end).
+
+These let a plugin observe the live token stream a turn produces on a chat
+platform — e.g. to mirror tokens to its own side-channel/SSE — without
+patching core streaming. They are fired from the stream consumer's producer
+API and are gated on ``has_hook`` so the per-token path is free when no
+plugin is listening.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_cli.plugins as plugins
+from gateway.stream_consumer import GatewayStreamConsumer
+
+
+@pytest.fixture
+def recorded_stream_events():
+    """Register recording callbacks for the three stream hooks on the global
+    plugin manager and remove exactly them afterwards (test isolation)."""
+    mgr = plugins.get_plugin_manager()
+    events = []
+    added = {}
+    for hook in ("on_stream_delta", "on_stream_segment", "on_stream_end"):
+        def _cb(_hook=hook, **kw):
+            events.append((_hook, kw))
+        mgr._hooks.setdefault(hook, []).append(_cb)
+        added[hook] = _cb
+    try:
+        yield events
+    finally:
+        for hook, cb in added.items():
+            try:
+                mgr._hooks.get(hook, []).remove(cb)
+            except ValueError:
+                pass
+
+
+def _consumer(metadata=None, message_id="m-1"):
+    sc = GatewayStreamConsumer(SimpleNamespace(), "chat-9", metadata=metadata)
+    sc._message_id = message_id
+    return sc
+
+
+def test_producer_api_fires_stream_hooks_in_order(recorded_stream_events):
+    sc = _consumer(metadata={"platform": "matrix", "session": "s1"})
+
+    sc.on_delta("hello")
+    sc.on_segment_break()
+    sc.finish()
+
+    names = [name for name, _ in recorded_stream_events]
+    assert names == ["on_stream_delta", "on_stream_segment", "on_stream_end"]
+
+    delta_kw = recorded_stream_events[0][1]
+    assert delta_kw["delta"] == "hello"
+    assert delta_kw["chat_id"] == "chat-9"
+    assert delta_kw["metadata"] == {"platform": "matrix", "session": "s1"}
+    assert delta_kw["message_id"] == "m-1"
+
+    assert recorded_stream_events[2][1]["reason"] == "done"
+
+
+def test_delta_hook_not_fired_for_empty_or_boundary_delta(recorded_stream_events):
+    sc = _consumer()
+
+    sc.on_delta("")        # empty: nothing queued, no delta event
+    sc.on_delta(None)      # tool boundary: routes to segment break, not delta
+
+    names = [name for name, _ in recorded_stream_events]
+    assert "on_stream_delta" not in names
+    assert names == ["on_stream_segment"]
+
+
+def test_streaming_still_queues_when_no_hook_registered(monkeypatch):
+    """The gate must short-circuit before invoke_hook when nothing listens, and
+    normal streaming (queueing the delta) must be unaffected."""
+    called = []
+    monkeypatch.setattr(plugins, "has_hook", lambda name: False)
+    monkeypatch.setattr(
+        plugins, "invoke_hook", lambda *a, **k: called.append((a, k))
+    )
+
+    sc = _consumer()
+    sc.on_delta("hello")
+
+    assert called == []                     # gated out — invoke_hook never ran
+    assert sc._queue.get_nowait() == "hello"  # delta still queued for delivery
+
+
+def test_hook_callback_exception_does_not_break_streaming(monkeypatch):
+    """A misbehaving observer must not break token delivery."""
+    mgr = plugins.get_plugin_manager()
+
+    def _boom(**kw):
+        raise RuntimeError("bad plugin")
+
+    mgr._hooks.setdefault("on_stream_delta", []).append(_boom)
+    try:
+        sc = _consumer()
+        sc.on_delta("hello")  # must not raise
+        assert sc._queue.get_nowait() == "hello"
+    finally:
+        mgr._hooks.get("on_stream_delta", []).remove(_boom)
+
+
+def test_stream_hooks_are_registered_valid_hooks():
+    for hook in ("on_stream_delta", "on_stream_segment", "on_stream_end"):
+        assert hook in plugins.VALID_HOOKS

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -608,12 +608,17 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |
+| [`on_stream_delta`](/user-guide/features/hooks#on_stream_delta) | Gateway only — a token delta is queued for delivery to the chat platform | `chat_id: str, metadata: dict \| None, message_id: str \| None, delta: str` | ignored |
+| [`on_stream_segment`](/user-guide/features/hooks#on_stream_segment) | Gateway only — the stream finalizes a segment and starts a fresh message | `chat_id: str, metadata: dict \| None, message_id: str \| None` | ignored |
+| [`on_stream_end`](/user-guide/features/hooks#on_stream_end) | Gateway only — the turn's stream completes | `chat_id: str, metadata: dict \| None, message_id: str \| None, reason: str` | ignored |
 
 Most hooks are fire-and-forget observers — their return values are ignored. The exception is `pre_llm_call`, which can inject context into the conversation.
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 
 The kanban lifecycle hooks fire **after** the board DB change commits, so a callback always sees durable state and can never hold the SQLite write lock. Because kanban workers run as separate `hermes -p <profile> chat -q` subprocesses, `kanban_task_claimed` fires in the **dispatcher** process while `kanban_task_completed` / `kanban_task_blocked` fire in the **worker** process — hook in the dispatcher to observe every transition centrally, or in the worker for per-task in-session context.
+
+The `on_stream_*` streaming hooks fire in the **gateway only** (never in CLI sessions), from `gateway/stream_consumer.py` as a turn streams to a chat platform. They are observers only — return values are ignored, and they fire after the existing queue writes, so observing never alters what the user receives. Callbacks run **synchronously on the stream worker thread** and must be non-blocking (enqueue and return); the per-token path is gated on `has_hook()`, so it costs nothing when no plugin is listening.
 
 ### `pre_llm_call` context injection
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -395,6 +395,9 @@ def register(ctx):
 | [`transform_tool_result`](#transform_tool_result) | After any tool returns, before the result is handed back to the model | `str` to replace the result, `None` to leave unchanged |
 | [`transform_terminal_output`](#transform_terminal_output) | Inside the `terminal` tool, before truncation/ANSI-strip/redact | `str` to replace the raw output, `None` to leave unchanged |
 | [`transform_llm_output`](#transform_llm_output) | After the tool-calling loop completes, before the final response is delivered | `str` to replace the response text, `None`/empty to leave unchanged |
+| [`on_stream_delta`](#on_stream_delta) | Gateway only — a token delta is queued for delivery to the chat platform | ignored |
+| [`on_stream_segment`](#on_stream_segment) | Gateway only — the stream finalizes a segment and starts a fresh message | ignored |
+| [`on_stream_end`](#on_stream_end) | Gateway only — the turn's stream completes | ignored |
 
 ---
 
@@ -1278,6 +1281,79 @@ def register(ctx):
 ```
 
 The hook is guarded on a non-empty, non-interrupted response — it will not fire on stop-button interrupts or empty turns. Exceptions are logged as warnings and do not break agent execution.
+
+---
+
+### `on_stream_delta`
+
+Fires **once per token delta** as a turn streams to a chat platform, letting a plugin observe the live token stream — mirror it to an external side-channel (SSE/WebSocket) for an alternate client, drive streaming metrics — without patching core streaming.
+
+:::note Gateway only
+The three `on_stream_*` hooks are fired by the gateway stream consumer. They never fire in CLI sessions.
+:::
+
+**Callback signature:**
+
+```python
+def my_callback(chat_id: str, metadata: dict | None, message_id: str | None, delta: str, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `chat_id` | `str` | The platform chat/channel/room the stream is delivering to. |
+| `metadata` | `dict \| None` | Platform/session routing metadata for the chat (e.g. workspace or thread/topic routing), when the adapter provides it. |
+| `message_id` | `str \| None` | Platform message ID of the in-flight streamed message once the first flush has been sent; `None` before that. |
+| `delta` | `str` | The token text just streamed (always non-empty). |
+
+**Fires:** In `gateway/stream_consumer.py`, from the producer API (`on_delta`), **after** the text is queued for the delivery worker — observing never alters what the user receives. The per-token path is gated on `has_hook()`, so it costs nothing when no plugin is listening.
+
+**Return value:** Ignored — all three `on_stream_*` hooks are observers only.
+
+:::warning Synchronous — must be non-blocking
+Callbacks run **synchronously on the stream worker thread**; a slow callback throttles visible delivery to the user. Enqueue and return — hand the delta to your own queue, buffer, or thread; never do network I/O inline.
+:::
+
+---
+
+### `on_stream_segment`
+
+Fires when the stream **finalizes the current segment and starts a fresh platform message** — e.g. an interim commentary boundary or a long-message split.
+
+**Callback signature:**
+
+```python
+def my_callback(chat_id: str, metadata: dict | None, message_id: str | None, **kwargs):
+```
+
+Parameters are the shared streaming fields described under [`on_stream_delta`](#on_stream_delta): `chat_id`, `metadata`, and the `message_id` of the segment being finalized (`None` if nothing was sent yet).
+
+**Fires:** In `gateway/stream_consumer.py`, from the producer API (`on_segment_break`), after the segment boundary is queued.
+
+**Return value:** Ignored. Same gateway-only scope and synchronous/non-blocking requirement as [`on_stream_delta`](#on_stream_delta).
+
+---
+
+### `on_stream_end`
+
+Fires **once per turn** when the stream completes and the final message is about to be committed.
+
+**Callback signature:**
+
+```python
+def my_callback(chat_id: str, metadata: dict | None, message_id: str | None, reason: str, **kwargs):
+```
+
+Parameters are the shared streaming fields described under [`on_stream_delta`](#on_stream_delta), plus:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `reason` | `str` | Why the stream ended. Currently always `"done"`; treat unknown values as terminal. |
+
+**Fires:** In `gateway/stream_consumer.py`, from the producer API (`finish`), after the completion marker is queued.
+
+**Return value:** Ignored. Same gateway-only scope and synchronous/non-blocking requirement as [`on_stream_delta`](#on_stream_delta).
+
+**Use cases:** Close out a mirrored side-channel stream, flush buffered deltas, record per-turn streaming latency.
 
 ---
 


### PR DESCRIPTION
Adds three generic observer hooks fired by the gateway stream consumer as a turn streams to a chat platform:

| hook | when | kwargs |
|------|------|--------|
| `on_stream_delta` | per token | `chat_id, metadata, message_id, delta` |
| `on_stream_segment` | segment boundary | `chat_id, metadata, message_id` |
| `on_stream_end` | stream complete | `chat_id, metadata, message_id, reason` |

They let a plugin observe the live token stream — mirror it to an external side-channel/SSE, drive streaming metrics, bridge an alternate client — entirely from the standard plugin surface, **without patching core streaming**.

### Why
This is the generic-surface follow-up to #57091, which was correctly closed under the "no third-party-product integrations in the core tree" policy. That bridge needed live token deltas, which the plugin surface did not expose — so it patched `stream_consumer.py`. Per AGENTS.md — *"if a plugin needs a capability the framework doesn't expose, expand the generic plugin surface (new hook, new ctx method) — never hardcode plugin-specific logic into core"* — the right fix is a generic hook, not a special-cased route. A standalone Keryx live-streaming plugin (published separately, installed under `~/.hermes/plugins/`) is the concrete consumer, so this is not speculative infrastructure. It is equally usable by any streaming observer (logging, metrics, alternate transports).

### Design / safety
- Fired from the **producer API** (`on_delta` / `on_segment_break` / `finish`), after the existing queue writes — **no internal worker-loop behavior changes**.
- **Observers only** — return values are ignored; a hook cannot alter or suppress delivery.
- Per-token path is gated on `has_hook()`, so it costs nothing when no plugin is listening.
- Callbacks run synchronously on the stream worker thread and must be non-blocking (documented); a raising callback is isolated by `invoke_hook` and cannot break token delivery.

### Tests
`tests/gateway/test_stream_observer_hooks.py`: firing order + payloads, no delta event on empty/boundary text, gated no-op when unregistered (streaming path unaffected), callback-exception isolation, `VALID_HOOKS` membership. 5 passed; existing stream-consumer + suppression suites (174) unchanged. AGENTS.md plugin-hooks list updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)