### PR TITLE
fix(desktop): show +/- summary on collapsed review folders

### DIFF
--- a/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
@@ -218,6 +218,7 @@ function ReviewDirRow({
         <span className="min-w-0 flex-1 truncate" title={node.name}>
           {node.name}
         </span>
+        {!open && <DiffCount added={node.added} className="text-[0.64rem] leading-4" removed={node.removed} />}
       </div>
       {open && node.children && (
         <ReviewNodeList animate={animate} depth={depth + 1} motion={useMotion} nodes={node.children} />


### PR DESCRIPTION
## What does this PR do?

The review pane's folder tree rows (`ReviewDirRow`) never rendered a `DiffCount`, so a collapsed folder gave no indication of the total additions/deletions inside it. The tree builder (`buildReviewTree` in `tree-data.ts`) already aggregates `added`/`removed` onto directory nodes (verified by existing tests in `tree-data.test.ts`) — this just renders them.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/right-sidebar/review/file-tree.tsx`: Added `<DiffCount>` to `ReviewDirRow`, matching the styling already used by `ReviewFileRow` (`text-[0.64rem] leading-4`).

## How to Test

1. Open the desktop app with a session in a git repo that has changed files across multiple folders.
2. Open the review pane.
3. Collapse a folder — it should now show `+N −M` summarizing all files inside.
4. Expand the folder — the summary disappears

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've run `npx vitest run src/app/right-sidebar/review/` and all tests pass
- [x] ESLint clean on the changed file
- [x] No new typecheck errors (pre-existing errors in unrelated `@assistant-ui` files are not affected)

# Screenshots
## Before
<img width="247" height="112" alt="image psd(11)" src="https://github.com/user-attachments/assets/7546b3c4-c0de-402c-9978-617511740b22" />

## After
<img width="247" height="115" alt="image" src="https://github.com/user-attachments/assets/cf3c5589-e758-44c1-b9fe-3ef99ce2b477" />

<img width="238" height="219" alt="image psd(10)" src="https://github.com/user-attachments/assets/0fe102e8-41d3-4551-aafd-93c4c4581c17" />

