### PR TITLE
docs: default Codex to GPT-5.6 Sol and tier fallbacks

### DIFF
--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -11,7 +11,7 @@ MOA_MARKER_PREFIX = "__HERMES_MOA_TURN_V1__"
 DEFAULT_MOA_PRESET_NAME = "default"
 
 DEFAULT_MOA_REFERENCE_MODELS: list[dict[str, str]] = [
-    {"provider": "openai-codex", "model": "gpt-5.5"},
+    {"provider": "openai-codex", "model": "gpt-5.6-sol"},
     {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"},
 ]
 

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -84,7 +84,7 @@ compression:
   threshold: 0.50            # Fraction of context window (default: 0.50 = 50%)
   target_ratio: 0.20         # How much of threshold to keep as tail (default: 0.20)
   protect_last_n: 20         # Minimum protected tail messages (default: 20)
-  codex_gpt55_autoraise: true  # gpt-5.5 on Codex OAuth: raise trigger to 85% (default: true)
+  codex_gpt55_autoraise: true  # GPT-5.4/5.5/5.6 on Codex OAuth: raise trigger to 85% (default: true)
   codex_gpt55_autoraise_notice: true  # Show the one-time autoraise notice (default: true)
   codex_app_server_auto: native  # native|hermes|off for Codex app-server thread compaction
 
@@ -104,24 +104,25 @@ auxiliary:
 | `target_ratio` | `0.20` | 0.10-0.80 | Controls tail protection token budget: `threshold_tokens × target_ratio` |
 | `protect_last_n` | `20` | ≥1 | Minimum number of recent messages always preserved |
 | `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
-| `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for gpt-5.5 on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |
-| `codex_gpt55_autoraise_notice` | `true` | bool | Show the one-time Codex gpt-5.5 autoraise notice. Set `false` to keep the 85% autoraise but suppress the banner |
+| `codex_gpt55_autoraise` | `true` | bool | Raise the trigger to 85% for GPT-5.4, GPT-5.5, and GPT-5.6 family models on the ChatGPT Codex OAuth route (see below). Set `false` to keep the global `threshold` |
+| `codex_gpt55_autoraise_notice` | `true` | bool | Show the one-time Codex autoraise notice. Set `false` to keep the 85% autoraise but suppress the banner |
 | `codex_app_server_auto` | `native` | `native`, `hermes`, `off` | Thread-compaction mode for Codex app-server sessions (see below) |
 
-### Codex gpt-5.5 threshold autoraise
+### Codex GPT-5.4/5.5/5.6 threshold autoraise
 
-The ChatGPT Codex OAuth backend hard-caps gpt-5.5 at a **272K** context window
-(the same slug exposes 1.05M on OpenAI's direct API and OpenRouter, and 400K on
-GitHub Copilot). At the default 50% trigger, compaction would fire at ~136K —
-half the window the model can actually use. When the active route is Codex
-OAuth (`provider: openai-codex`) and the model is gpt-5.5, Hermes raises the
-trigger to **85%** (~231K) and shows a notice with the opt-out command. The
-notice is shown once per profile — a marker under `$HERMES_HOME`
-(`.codex_gpt55_autoraise_notice`) records that it ran, so repeated agent/session
-inits (e.g. every inbound gateway message) don't re-emit it; if the raised
-threshold later changes it re-notifies once. Only this exact route is affected;
-gpt-5.5 on any other provider keeps your global `threshold`. To opt back down to
-the global value:
+The ChatGPT Codex OAuth backend hard-caps GPT-5.4, GPT-5.5, and GPT-5.6
+family models at a **272K** context window (the same slugs can expose larger
+windows on OpenAI's direct API, OpenRouter, or GitHub Copilot). At the default
+50% trigger, compaction would fire at ~136K — half the window the model can
+actually use. When the active route is Codex OAuth (`provider: openai-codex`)
+and the model is in one of those families, Hermes raises the trigger to **85%**
+(~231K) and shows a notice with the opt-out command. The notice is shown once
+per profile — a marker under `$HERMES_HOME` (`.codex_gpt55_autoraise_notice`)
+records that it ran, so repeated agent/session inits (e.g. every inbound
+gateway message) don't re-emit it; if the raised threshold later changes it
+re-notifies once. The config key name is historical; only the Codex OAuth route
+is affected, and the same model families on other providers keep your global
+`threshold`. To opt back down to the global value:
 
 ```bash
 hermes config set compression.codex_gpt55_autoraise false

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -161,7 +161,7 @@ fallback_providers:
 ```yaml
 fallback_providers:
   - provider: openai-codex
-    model: gpt-5.3-codex
+    model: gpt-5.6-sol
 ```
 
 ### Where Fallback Works

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -157,12 +157,24 @@ fallback_providers:
     key_env: LOCAL_API_KEY
 ```
 
-**Codex OAuth as fallback:**
+**Capability-matched Codex OAuth fallback for GPT-5.6 Sol:**
+
 ```yaml
+model:
+  provider: openai-codex
+  default: gpt-5.6-sol
+
 fallback_providers:
   - provider: openai-codex
-    model: gpt-5.6-sol
+    model: gpt-5.6-terra
+  - provider: openai-codex
+    model: gpt-5.5
 ```
+
+Keep primary fallbacks close to the main model's capability tier. GPT-5.6
+Luna and GPT-5.4 Mini are optimized for inexpensive bounded work; configure
+them as auxiliary models rather than silently reducing the main agent's
+intelligence during failover.
 
 ### Where Fallback Works
 
@@ -257,6 +269,32 @@ auxiliary:
 ```
 
 Every task above follows the same **provider / model / base_url** pattern. Each task can also declare its own `fallback_chain`; if omitted, `provider: auto` uses the top-level `fallback_providers` chain before Hermes' built-in auxiliary discovery chain.
+
+For Codex OAuth, GPT-5.6 Luna is the fast, low-cost tier for bounded side
+tasks. Use low reasoning for short labels and drafts, and medium reasoning for
+summaries or judgments where losing a detail would be expensive:
+
+```yaml
+auxiliary:
+  title_generation:
+    provider: openai-codex
+    model: gpt-5.6-luna
+    reasoning_effort: low
+
+  compression:
+    provider: openai-codex
+    model: gpt-5.6-luna
+    reasoning_effort: medium
+
+  approval:
+    provider: openai-codex
+    model: gpt-5.6-luna
+    reasoning_effort: medium
+```
+
+The same split applies to the other auxiliary slots: use low effort for
+title/profile/label generation and medium effort for compression, approval,
+curation, task decomposition, vision, and web extraction.
 
 Context compression is configured under `auxiliary.compression`:
 

--- a/website/docs/user-guide/features/mixture-of-agents.md
+++ b/website/docs/user-guide/features/mixture-of-agents.md
@@ -79,7 +79,7 @@ moa:
     default:
       reference_models:
         - provider: openai-codex
-          model: gpt-5.5
+          model: gpt-5.6-sol
         - provider: openrouter
           model: deepseek/deepseek-v4-pro
       aggregator:
@@ -96,7 +96,7 @@ moa:
 
 Default preset:
 
-- reference: `openai-codex:gpt-5.5`
+- reference: `openai-codex:gpt-5.6-sol`
 - reference: `openrouter:deepseek/deepseek-v4-pro`
 - aggregator / acting model: `openrouter:anthropic/claude-opus-4.8`
 


### PR DESCRIPTION
## Summary
- switch the default MoA Codex reference from `gpt-5.5` to `gpt-5.6-sol`
- document capability-matched main fallback for Sol: `gpt-5.6-terra` then `gpt-5.5`
- document `gpt-5.6-luna` as the low-cost auxiliary tier, with low reasoning for short labels/drafts and medium reasoning for fidelity- or safety-sensitive side tasks
- align context-compression docs with the existing GPT-5.4/5.5/5.6 Codex OAuth autoraise behavior

## Why these tiers
OpenAI's GPT-5.6 release reports:

- Coding Agent Index: Sol 80, Terra 77.4, GPT-5.5 76.4, Luna 74.6
- Intelligence Index: Sol 58.9, Terra 55, GPT-5.5 54.8, Luna 51.2
- Codex credits per 1M input/output tokens: Sol 125/750, Terra 62.5/375, Luna 25/150, GPT-5.5 125/750

Terra and GPT-5.5 preserve frontier-class main-agent quality. Luna is the bounded-work tier: one-fifth of Sol's Codex credits, with a 272K text+image window.

Sources:
- https://openai.com/index/gpt-5-6/
- https://help.openai.com/en/articles/20001106-codex-rate-card

## Verification
- `uv run --with pytest --with pyyaml --with rich --with requests --with httpx python -m pytest tests/hermes_cli/test_moa_config.py tests/hermes_cli/test_codex_models.py tests/agent/test_arcee_trinity_overrides.py -q -o 'addopts='` — 112 passed
- live Codex catalog probe confirmed Sol, Terra, Luna, and GPT-5.5 at 272K context with text+image input
- direct Terra and GPT-5.5 route probes returned `ROUTE_OK`
- direct Luna low-effort, medium-effort, and vision probes succeeded
- `git diff --check`
- markdownlint comparison: touched document has 96 existing-style violations versus 97 on the base revision; no new violation introduced
