### PR TITLE
fix(tui): stop up-arrow from replacing prompt text with history when editing

### DIFF
--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -484,13 +484,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (key.upArrow && !cState.inputBuf.length) {
-      const inputSel = getInputSelection()
-      const cursor = inputSel && inputSel.start === inputSel.end ? inputSel.start : null
-
-      const noLineAbove =
-        !cState.input || (cursor !== null && cState.input.lastIndexOf('\n', Math.max(0, cursor - 1)) < 0)
-
-      if (noLineAbove) {
+      // Only cycle history when the input is empty.  When the user has typed
+      // text, up-arrow should navigate the cursor (handled by TextInput) or
+      // be a no-op — never silently replace the user's draft.
+      if (!cState.input) {
         cycleQueue(1) || cycleHistory(-1)
 
         return
@@ -498,11 +495,11 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
 
     if (key.downArrow && !cState.inputBuf.length) {
-      const inputSel = getInputSelection()
-      const cursor = inputSel && inputSel.start === inputSel.end ? inputSel.start : null
-      const noLineBelow = !cState.input || (cursor !== null && cState.input.indexOf('\n', cursor) < 0)
+      const noLineBelow = !cState.input || cState.input.indexOf('\n', cState.input.length - 1) < 0
 
-      if (noLineBelow || cState.historyIdx !== null) {
+      // Down-arrow cycles history only when already browsing history or when
+      // the input is entirely single-line with no line below.
+      if (cState.historyIdx !== null || (noLineBelow && !cState.input)) {
         cycleQueue(-1) || cycleHistory(1)
 
         return

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1056,6 +1056,8 @@ export function TextInput({
         if (next !== null) {
           moveCursor(next, k.shift)
 
+          event.stopImmediatePropagation()
+
           return
         }
 


### PR DESCRIPTION
Fixes #65015

## Problem

Pressing the up arrow key while editing a prompt in the web dashboard (GUI Mode) silently replaces the entire prompt text with the previous history entry. This is data loss — the user's draft content is destroyed without warning.

The root cause was in `useInputHandlers.ts`: the global keyboard handler fires before the `TextInput` component's handler (parent listeners fire before child listeners in Ink). It would check whether there was a `\n` character before the cursor position to decide whether to cycle history, but this check would incorrectly trigger on single-line inputs or visually-wrapped prompts where no actual newline exists.

## Fix

Two changes:

1. **`useInputHandlers.ts`**: Only cycle history on up/down arrow when the input is empty. When the user has typed text, the arrow keys should navigate the cursor (handled by `TextInput`) or be a no-op — never silently replace the user's draft.

2. **`textInput.tsx`**: Call `event.stopImmediatePropagation()` when successfully navigating the cursor with arrow keys, preventing any later-registered handlers from processing the same event.

## Behavior

- **Empty prompt**: Up/down arrows cycle history as before
- **Prompt with text**: Up/down arrows navigate the cursor within the text (multi-line) or are no-ops (single-line)