### PR TITLE
fix(photon): hide Windows sidecar console window

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -129,6 +129,33 @@ def _coerce_port(value: Any, default: int) -> int:
         return default
 
 
+def _windows_hidden_startupinfo():
+    """Return STARTUPINFO that keeps Windows console subprocesses hidden."""
+    if sys.platform != "win32":
+        return None
+    startupinfo = subprocess.STARTUPINFO()
+    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    startupinfo.wShowWindow = getattr(subprocess, "SW_HIDE", 0)
+    return startupinfo
+
+
+def _sidecar_popen_kwargs() -> Dict[str, Any]:
+    """Return platform-specific Popen kwargs for the long-lived sidecar."""
+    if sys.platform != "win32":
+        return {"start_new_session": True}
+    kwargs: Dict[str, Any] = {
+        "creationflags": (
+            subprocess.CREATE_NEW_PROCESS_GROUP
+            | subprocess.DETACHED_PROCESS
+            | subprocess.CREATE_NO_WINDOW
+        ),
+    }
+    startupinfo = _windows_hidden_startupinfo()
+    if startupinfo is not None:
+        kwargs["startupinfo"] = startupinfo
+    return kwargs
+
+
 def check_requirements() -> bool:
     """Return True when both Python deps and the Node sidecar are available."""
     if not HTTPX_AVAILABLE:
@@ -972,7 +999,7 @@ class PhotonAdapter(BasePlatformAdapter):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=env,
-            start_new_session=(sys.platform != "win32"),
+            **_sidecar_popen_kwargs(),
         )
 
         # Pump sidecar stderr/stdout into our logger so users see crashes.

--- a/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
+++ b/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
@@ -169,3 +169,84 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
     kwargs = spawned["kwargs"]
     assert kwargs["stdin"] is subprocess.PIPE
     assert kwargs["env"]["PHOTON_SIDECAR_WATCH_STDIN"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_start_sidecar_hides_node_window_on_windows(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Windows sidecar spawn must suppress the visible Node console window."""
+    adapter = _make_adapter(monkeypatch)
+
+    async def _no_reap() -> None:
+        pass
+
+    monkeypatch.setattr(adapter, "_reap_stale_sidecar", _no_reap)
+    (tmp_path / "node_modules").mkdir()
+    monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", tmp_path)
+    monkeypatch.setattr(photon_adapter.sys, "platform", "win32")
+
+    class _FakeStartupInfo:
+        def __init__(self) -> None:
+            self.dwFlags = 0
+            self.wShowWindow = None
+
+    monkeypatch.setattr(
+        photon_adapter.subprocess, "STARTUPINFO", _FakeStartupInfo, raising=False
+    )
+    monkeypatch.setattr(
+        photon_adapter.subprocess, "STARTF_USESHOWWINDOW", 0x00000001, raising=False
+    )
+    monkeypatch.setattr(photon_adapter.subprocess, "SW_HIDE", 0, raising=False)
+    monkeypatch.setattr(
+        photon_adapter.subprocess,
+        "CREATE_NEW_PROCESS_GROUP",
+        0x00000200,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        photon_adapter.subprocess,
+        "DETACHED_PROCESS",
+        0x00000008,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        photon_adapter.subprocess,
+        "CREATE_NO_WINDOW",
+        0x08000000,
+        raising=False,
+    )
+
+    spawned: Dict[str, Any] = {}
+
+    class _FakeProc:
+        pid = 999
+        stdout = None
+        stdin = None
+
+        @staticmethod
+        def poll() -> None:
+            return None
+
+    def _fake_popen(cmd: List[str], **kwargs: Any) -> _FakeProc:
+        spawned["cmd"] = cmd
+        spawned["kwargs"] = kwargs
+        return _FakeProc()
+
+    monkeypatch.setattr(photon_adapter.subprocess, "Popen", _fake_popen)
+
+    class _HealthyClient(_ProbeClient):
+        async def post(self, *a: Any, **k: Any) -> Any:
+            class _Resp:
+                status_code = 200
+
+            return _Resp()
+
+    monkeypatch.setattr(photon_adapter.httpx, "AsyncClient", _HealthyClient)
+
+    await adapter._start_sidecar()
+
+    kwargs = spawned["kwargs"]
+    assert kwargs["creationflags"] == 0x08000000 | 0x00000008 | 0x00000200
+    assert kwargs["startupinfo"].dwFlags == 0x00000001
+    assert kwargs["startupinfo"].wShowWindow == 0


### PR DESCRIPTION
## Summary
- hide the long-lived Photon/iMessage Node sidecar console on Windows
- keep POSIX behavior unchanged with `start_new_session=True`
- add regression coverage for the Windows sidecar spawn kwargs

## Why
When Photon messages are enabled from Hermes Desktop on Windows, the sidecar is expected to keep running in the background. Today it can also create a visible blank Windows Terminal/conhost window for `node.exe`, which is distracting and looks like an app error. `start_new_session` does not detach or hide console windows on Windows, so the sidecar needs explicit Windows process flags and hidden `STARTUPINFO`.

## Validation
- `python -m py_compile plugins/platforms/photon/adapter.py`
- `git diff --check`
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/plugins/platforms/photon/test_sidecar_lifecycle.py -k "start_sidecar"`

Note: the full `test_sidecar_lifecycle.py` file currently has unrelated Windows failures in the orphan-reaping tests, which expect signal behavior that is not exercised by this patch. The two sidecar startup tests pass.