### PR TITLE
feat(desktop): toggle hidden files in file browser

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -5,9 +5,11 @@ import { type NodeApi, type NodeRendererProps, type RowRendererProps, Tree, type
 import { TreeSkeleton } from '@/components/chat/skeletons'
 import { Codicon } from '@/components/ui/codicon'
 import { useResizeObserver } from '@/hooks/use-resize-observer'
+import { isEditableTarget } from '@/lib/keybinds/combo'
 import { cn } from '@/lib/utils'
 import { $repoChangeByPath, type RepoChangeKind } from '@/store/coding-status'
 import { $renamingPath, beginInlineRename } from '@/store/file-actions'
+import { $showHiddenFiles, isHiddenFileName, setShowHiddenFiles, toggleShowHiddenFiles } from '@/store/file-browser'
 import { $revealInTreeRequest } from '@/store/layout'
 
 import { FileEntryContextMenu, InlineRenameInput, isRenameShortcut } from '../file-actions'
@@ -59,6 +61,7 @@ export function ProjectTree({
   const treeRef = useRef<TreeApi<TreeNode> | null>(null)
   const [size, setSize] = useState({ height: 0, width: 0 })
   const changeByPath = useStore($repoChangeByPath)
+  const showHiddenFiles = useStore($showHiddenFiles)
 
   const syncTreeSize = useCallback(() => {
     const el = containerRef.current
@@ -107,6 +110,14 @@ export function ProjectTree({
       const rel = target.startsWith(root) ? target.slice(root.length).replace(/^[\\/]+/, '') : ''
       const segments = rel.split(/[\\/]/).filter(Boolean)
 
+      // An explicit "Reveal in Sidebar" intent wins over the presentation
+      // filter. Re-enable dotfiles before walking the tree so the requested
+      // node cannot disappear behind the user's current preference.
+      if (!showHiddenFiles && segments.some(isHiddenFileName)) {
+        setShowHiddenFiles(true)
+        await new Promise(resolve => requestAnimationFrame(() => resolve(undefined)))
+      }
+
       let acc = root
 
       for (let i = 0; i < segments.length - 1; i += 1) {
@@ -127,7 +138,7 @@ export function ProjectTree({
       // directly, no smooth scroll).
       treeRef.current?.scrollTo(target, 'start')
     },
-    [cwd, onLoadChildren, onNodeOpenChange]
+    [cwd, onLoadChildren, onNodeOpenChange, showHiddenFiles]
   )
 
   useEffect(
@@ -158,7 +169,20 @@ export function ProjectTree({
   // F2 / Enter on the selected row begins an inline rename. Capture-phase so it
   // beats arborist's own Enter-to-activate; skipped while an edit is in progress
   // (the editor input owns Enter/Esc then) and for placeholder rows.
-  const handleRenameShortcut = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+  const handleTreeShortcut = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    const toggleHiddenFiles =
+      event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey && event.key.toLowerCase() === 'h'
+
+    // Focus-scoped rather than global: Ctrl+H is Backspace in many terminals
+    // and must not be stolen from the composer or an inline rename field.
+    if (toggleHiddenFiles && !isEditableTarget(event.target)) {
+      event.preventDefault()
+      event.stopPropagation()
+      toggleShowHiddenFiles()
+
+      return
+    }
+
     if (!isRenameShortcut(event) || $renamingPath.get()) {
       return
     }
@@ -175,7 +199,7 @@ export function ProjectTree({
   }, [])
 
   return (
-    <div className="min-h-0 flex-1 overflow-hidden" onKeyDownCapture={handleRenameShortcut} ref={containerRef}>
+    <div className="min-h-0 flex-1 overflow-hidden" onKeyDownCapture={handleTreeShortcut} ref={containerRef}>
       {size.height > 0 && size.width > 0 ? (
         <Tree<TreeNode>
           childrenAccessor={node => (node?.isDirectory ? (node.children ?? []) : null)}

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -2,6 +2,7 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesReadDirResult } from '@/global'
+import { setShowHiddenFiles } from '@/store/file-browser'
 import { $connection } from '@/store/session'
 
 import { clearProjectDirCache, readProjectDir } from './ipc'
@@ -10,6 +11,7 @@ import { resetProjectTreeState, useProjectTree } from './use-project-tree'
 const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
 
 beforeEach(() => {
+  setShowHiddenFiles(true)
   $connection.set(null)
   resetProjectTreeState()
   readDir.mockReset()
@@ -18,6 +20,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  setShowHiddenFiles(true)
   $connection.set(null)
   resetProjectTreeState()
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
@@ -57,6 +60,54 @@ describe('useProjectTree', () => {
     expect(result.current.data.find(n => n.name === 'src')?.children).toBeUndefined()
     expect(result.current.data.find(n => n.name === 'src')?.isDirectory).toBe(true)
     expect(result.current.data.find(n => n.name === 'README.md')?.isDirectory).toBe(false)
+  })
+
+  it('filters cached dotfiles recursively and restores them without another directory read', async () => {
+    readDir.mockImplementation(async path => {
+      if (path === '/p') {
+        return ok([
+          { name: '.github', path: '/p/.github', isDirectory: true },
+          { name: 'src', path: '/p/src', isDirectory: true },
+          { name: '.env', path: '/p/.env', isDirectory: false },
+          { name: 'README.md', path: '/p/README.md', isDirectory: false }
+        ])
+      }
+
+      if (path === '/p/src') {
+        return ok([
+          { name: '.internal', path: '/p/src/.internal', isDirectory: false },
+          { name: 'index.ts', path: '/p/src/index.ts', isDirectory: false }
+        ])
+      }
+
+      throw new Error(`unexpected path ${path}`)
+    })
+
+    const { result } = renderHook(() => useProjectTree('/p'))
+
+    await waitFor(() => expect(result.current.data.length).toBe(4))
+    await act(async () => result.current.loadChildren('/p/src'))
+
+    expect(result.current.data.find(node => node.name === 'src')?.children?.map(node => node.name)).toEqual([
+      '.internal',
+      'index.ts'
+    ])
+
+    act(() => setShowHiddenFiles(false))
+
+    expect(result.current.data.map(node => node.name)).toEqual(['src', 'README.md'])
+    expect(result.current.data.find(node => node.name === 'src')?.children?.map(node => node.name)).toEqual([
+      'index.ts'
+    ])
+
+    act(() => setShowHiddenFiles(true))
+
+    expect(result.current.data.map(node => node.name)).toEqual(['.github', 'src', '.env', 'README.md'])
+    expect(result.current.data.find(node => node.name === 'src')?.children?.map(node => node.name)).toEqual([
+      '.internal',
+      'index.ts'
+    ])
+    expect(readDir).toHaveBeenCalledTimes(2)
   })
 
   it('records rootError when readDir returns an error', async () => {

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { atom } from 'nanostores'
 import { useCallback, useEffect, useMemo } from 'react'
 
+import { $showHiddenFiles, isHiddenFileName } from '@/store/file-browser'
 import { $connection } from '@/store/session'
 import { $workspaceChangeTick, consumeWorkspaceChange } from '@/store/workspace-events'
 
@@ -28,6 +29,37 @@ const ERROR_PLACEHOLDER_ID = '__error__'
 
 function makeNode(path: string, name: string, isDirectory: boolean): TreeNode {
   return { id: path, isDirectory, name }
+}
+
+/** Hide dotfiles without discarding the cached tree. Returning the original
+ * array when nothing changes preserves reference identity and avoids repainting
+ * large trees for a no-op filter pass. */
+function visibleTreeNodes(nodes: TreeNode[], showHiddenFiles: boolean): TreeNode[] {
+  if (showHiddenFiles) {
+    return nodes
+  }
+
+  let changed = false
+  const visible: TreeNode[] = []
+
+  for (const node of nodes) {
+    if (isHiddenFileName(node.name)) {
+      changed = true
+
+      continue
+    }
+
+    const children = node.children ? visibleTreeNodes(node.children, false) : node.children
+
+    if (children !== node.children) {
+      changed = true
+      visible.push({ ...node, children })
+    } else {
+      visible.push(node)
+    }
+  }
+
+  return changed ? visible : nodes
 }
 
 function patchNode(nodes: TreeNode[] | undefined | null, id: string, patch: (n: TreeNode) => TreeNode): TreeNode[] {
@@ -337,6 +369,7 @@ async function revalidateTree(cwd: string, change: { dirs: string[]; full: boole
  */
 export function useProjectTree(cwd: string): UseProjectTreeResult {
   const state = useStore($projectTree)
+  const showHiddenFiles = useStore($showHiddenFiles)
   const connection = useStore($connection)
   const workspaceTick = useStore($workspaceChangeTick)
   const connectionKey = `${connection?.mode || 'local'}:${connection?.profile || ''}:${connection?.baseUrl || ''}`
@@ -483,7 +516,7 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
     () => ({
       collapseAll,
       collapseNonce: state.cwd === cwd ? state.collapseNonce : 0,
-      data: state.cwd === cwd ? state.data : [],
+      data: state.cwd === cwd ? visibleTreeNodes(state.data, showHiddenFiles) : [],
       effectiveCwd: state.cwd === cwd && state.resolvedCwd ? state.resolvedCwd : cwd,
       loadChildren,
       openState: state.cwd === cwd ? state.openState : {},
@@ -498,6 +531,7 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       loadChildren,
       refreshRoot,
       setNodeOpen,
+      showHiddenFiles,
       state.collapseNonce,
       state.cwd,
       state.data,

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -5,15 +5,17 @@ import { useEffect, useState } from 'react'
 import { LanguageSwitcher } from '@/components/language-switcher'
 import { Button } from '@/components/ui/button'
 import { SegmentedControl } from '@/components/ui/segmented-control'
+import { Switch } from '@/components/ui/switch'
 import type { DesktopMarketplaceSearchItem } from '@/global'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
-import { Check, Download, Loader2, Palette, Trash2 } from '@/lib/icons'
+import { Check, Download, FolderOpen, Loader2, Palette, Trash2 } from '@/lib/icons'
 import { selectableCardClass } from '@/lib/selectable-card'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { $backdrop, setBackdrop } from '@/store/backdrop'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
+import { $showHiddenFiles, setShowHiddenFiles } from '@/store/file-browser'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
@@ -253,6 +255,7 @@ export function AppearanceSettings() {
   const translucency = useStore($translucency)
   const reactionsEnabled = useStore($reactionsEnabled)
   const backdrop = useStore($backdrop)
+  const showHiddenFiles = useStore($showHiddenFiles)
   const installs = useStore($marketplaceInstalls)
   const profiles = useStore($profiles)
   const activeProfileKey = normalizeProfileKey(useStore($activeGatewayProfile))
@@ -536,6 +539,25 @@ export function AppearanceSettings() {
             title={a.embedsTitle}
           />
         </div>
+      </div>
+
+      <div className="mt-6">
+        <SectionHeading icon={FolderOpen} title={a.fileBrowserTitle} />
+        <ListRow
+          action={
+            <Switch
+              aria-label={a.showHiddenFilesTitle}
+              checked={showHiddenFiles}
+              onCheckedChange={show => {
+                triggerHaptic('selection')
+                setShowHiddenFiles(show)
+              }}
+              size="xs"
+            />
+          }
+          description={a.showHiddenFilesDesc}
+          title={a.showHiddenFilesTitle}
+        />
       </div>
 
       <div className="mt-6">

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -228,6 +228,7 @@ export const ar = defineLocale({
       'view.toggleRightSidebar': 'تبديل متصفح الملفات',
       'view.toggleReview': 'تبديل لوحة المراجعة',
       'view.showFiles': 'إظهار متصفح الملفات',
+      'view.toggleHiddenFiles': 'إظهار / إخفاء الملفات المخفية',
       'view.showTerminal': 'إظهار الطرفية',
       'view.closeTab': 'إغلاق علامة التبويب',
       'view.reopenTab': 'إعادة فتح علامة التبويب المغلقة',
@@ -390,6 +391,10 @@ export const ar = defineLocale({
     appearance: {
       title: 'المظهر',
       intro: 'خصص مظهر Hermes Desktop.',
+      fileBrowserTitle: 'متصفح الملفات',
+      showHiddenFilesTitle: 'إظهار الملفات المخفية',
+      showHiddenFilesDesc:
+        'يتضمن الملفات النقطية مثل .env و.github. يبدّل Ctrl+H هذا الخيار عندما يكون التركيز على شجرة الملفات.',
       colorMode: 'نمط الألوان',
       colorModeDesc: 'اختر الوضع الفاتح أو الداكن أو اتبع النظام.',
       toolViewTitle: 'عرض الأدوات',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -260,6 +260,7 @@ export const en: Translations = {
       'view.toggleReview': 'Toggle review pane',
       'view.toggleStatusbar': 'Toggle status bar',
       'view.showFiles': 'Show file browser',
+      'view.toggleHiddenFiles': 'Show / hide hidden files',
       'view.showTerminal': 'Toggle terminal',
       'view.newTerminal': 'New terminal',
       'view.nextTerminal': 'Next terminal',
@@ -431,6 +432,10 @@ export const en: Translations = {
     appearance: {
       title: 'Appearance',
       intro: 'Desktop-only. Mode is brightness; theme is palette and chat chrome.',
+      fileBrowserTitle: 'File Browser',
+      showHiddenFilesTitle: 'Show Hidden Files',
+      showHiddenFilesDesc:
+        'Include dotfiles such as .env and .github. Ctrl+H toggles this while the file tree is focused.',
       colorMode: 'Color Mode',
       colorModeDesc: 'Pick a fixed mode or let Hermes follow your system setting.',
       toolViewTitle: 'Tool Call Display',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -204,6 +204,12 @@ export const ja = defineLocale({
     openStarmap: 'メモリグラフを開く'
   },
 
+  keybinds: {
+    actions: {
+      'view.toggleHiddenFiles': '隠しファイルの表示／非表示'
+    }
+  },
+
   language: {
     label: '言語',
     description: 'デスクトップインターフェイスの言語を選択します。',
@@ -307,6 +313,10 @@ export const ja = defineLocale({
       title: '外観',
       intro:
         'デスクトップ専用の表示設定です。モードは明るさ、テーマはアクセントカラーとチャット面のスタイルを制御します。',
+      fileBrowserTitle: 'ファイルブラウザ',
+      showHiddenFilesTitle: '隠しファイルを表示',
+      showHiddenFilesDesc:
+        '.env や .github などのドットファイルを表示します。ファイルツリーにフォーカス中は Ctrl+H で切り替えられます。',
       colorMode: 'カラーモード',
       colorModeDesc: '固定モードを選ぶか、Hermes をシステム設定に合わせます。',
       toolViewTitle: 'ツール呼び出しの表示',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -341,6 +341,9 @@ export interface Translations {
     appearance: {
       title: string
       intro: string
+      fileBrowserTitle: string
+      showHiddenFilesTitle: string
+      showHiddenFilesDesc: string
       colorMode: string
       colorModeDesc: string
       toolViewTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -198,6 +198,12 @@ export const zhHant = defineLocale({
     openStarmap: '開啟記憶圖譜'
   },
 
+  keybinds: {
+    actions: {
+      'view.toggleHiddenFiles': '顯示／隱藏隱藏檔案'
+    }
+  },
+
   language: {
     label: '語言',
     description: '選擇桌面介面的語言。',
@@ -299,6 +305,9 @@ export const zhHant = defineLocale({
     appearance: {
       title: '外觀',
       intro: '這些是僅限桌面端的顯示偏好。模式控制亮度；主題控制強調色與聊天介面樣式。',
+      fileBrowserTitle: '檔案瀏覽器',
+      showHiddenFilesTitle: '顯示隱藏檔案',
+      showHiddenFilesDesc: '顯示 .env、.github 等點檔案。檔案樹取得焦點時可按 Ctrl+H 切換。',
       colorMode: '色彩模式',
       colorModeDesc: '選擇固定模式，或讓 Hermes 跟隨系統設定。',
       toolViewTitle: '工具呼叫顯示',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -255,6 +255,7 @@ export const zh: Translations = {
       'view.toggleReview': '切换审查面板',
       'view.toggleStatusbar': '切换状态栏',
       'view.showFiles': '显示文件浏览器',
+      'view.toggleHiddenFiles': '显示/隐藏隐藏文件',
       'view.showTerminal': '显示终端',
       'view.terminalSelection': '将终端选区发送到输入框',
       'view.terminalCopy': '复制终端选区',
@@ -423,6 +424,9 @@ export const zh: Translations = {
     appearance: {
       title: '外观',
       intro: '这些是仅桌面端的显示偏好。模式控制明暗；主题控制强调色与对话界面样式。',
+      fileBrowserTitle: '文件浏览器',
+      showHiddenFilesTitle: '显示隐藏文件',
+      showHiddenFilesDesc: '显示 .env、.github 等点文件。文件树获得焦点时可按 Ctrl+H 切换。',
       colorMode: '颜色模式',
       colorModeDesc: '选择固定模式，或让 Hermes 跟随系统设置。',
       toolViewTitle: '工具调用显示',

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -234,6 +234,7 @@ export const KEYBIND_READONLY: readonly KeybindReadonly[] = [
   { id: 'composer.history', category: 'composer', keys: ['up', 'down'] },
   { id: 'composer.cancel', category: 'composer', keys: ['escape'] },
   // Fixed, context-local shortcuts surfaced for discoverability.
+  { id: 'view.toggleHiddenFiles', category: 'view', keys: ['ctrl+h'] },
   { id: 'view.terminalSelection', category: 'view', keys: ['mod+l'] },
   // Terminal clipboard. ⌘C/⌘V on macOS, Ctrl+Shift+C/V elsewhere — matching VS
   // Code. Plain Ctrl+C also copies when text is selected (Windows Terminal /

--- a/apps/desktop/src/store/file-browser.test.ts
+++ b/apps/desktop/src/store/file-browser.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const STORAGE_KEY = 'hermes.desktop.fileBrowser.showHiddenFiles'
+
+beforeEach(() => {
+  window.localStorage.clear()
+  vi.resetModules()
+})
+
+describe('file browser preferences', () => {
+  it('shows hidden files by default for backward compatibility', async () => {
+    const { $showHiddenFiles } = await import('./file-browser')
+
+    expect($showHiddenFiles.get()).toBe(true)
+  })
+
+  it('restores and persists the device-local preference', async () => {
+    window.localStorage.setItem(STORAGE_KEY, 'false')
+
+    const { $showHiddenFiles, setShowHiddenFiles, toggleShowHiddenFiles } = await import('./file-browser')
+
+    expect($showHiddenFiles.get()).toBe(false)
+
+    toggleShowHiddenFiles()
+    expect($showHiddenFiles.get()).toBe(true)
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('true')
+
+    setShowHiddenFiles(false)
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('false')
+  })
+
+  it('recognizes dotfiles without treating ordinary dotted names as hidden', async () => {
+    const { isHiddenFileName } = await import('./file-browser')
+
+    expect(isHiddenFileName('.env')).toBe(true)
+    expect(isHiddenFileName('.github')).toBe(true)
+    expect(isHiddenFileName('component.test.ts')).toBe(false)
+    expect(isHiddenFileName('.')).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/file-browser.ts
+++ b/apps/desktop/src/store/file-browser.ts
@@ -1,0 +1,20 @@
+import { Codecs, persistentAtom } from '@/lib/persisted'
+
+// Device-local presentation preference. The file browser is renderer-owned,
+// so this stays with the feature instead of becoming backend config that could
+// bleed across machines or profiles. Default true preserves existing behavior.
+const SHOW_HIDDEN_FILES_STORAGE_KEY = 'hermes.desktop.fileBrowser.showHiddenFiles'
+
+export const $showHiddenFiles = persistentAtom(SHOW_HIDDEN_FILES_STORAGE_KEY, true, Codecs.bool)
+
+export function isHiddenFileName(name: string): boolean {
+  return name.length > 1 && name.startsWith('.')
+}
+
+export function setShowHiddenFiles(show: boolean): void {
+  $showHiddenFiles.set(show)
+}
+
+export function toggleShowHiddenFiles(): void {
+  setShowHiddenFiles(!$showHiddenFiles.get())
+}


### PR DESCRIPTION
## What does this PR do?

Adds a device-local Desktop preference for showing or hiding dotfiles in the sidebar file browser.

- Keeps hidden files visible by default for backward compatibility.
- Adds Settings → Appearance → File Browser → Show Hidden Files.
- Adds a focus-scoped `Ctrl+H` shortcut while the file tree is focused, without stealing the key from the terminal, composer, or inline rename input.
- Surfaces that fixed shortcut through the current read-only keybind catalog; it is deliberately not registered as a global/rebindable action.
- Filters the renderer's cached tree recursively, so toggling visibility does not trigger extra filesystem reads and restores expanded content immediately.
- Makes an explicit Reveal in Sidebar request re-enable hidden files when the requested path contains a dotfile segment.
- Keeps the existing always-excluded noise directories (such as `.git`, `.venv`, and `node_modules`) unchanged.
- Includes strings for every current Desktop locale, including Arabic added on current `main`.

Fixes #64968

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor
- [x] ✅ Tests
- [ ] 📚 Documentation

## How was this tested?

Rebased onto current `main` at `98105f31f` and tested on macOS:

- `npm run test:ui -- src/store/file-browser.test.ts src/app/right-sidebar/files/use-project-tree.test.ts src/i18n/languages.test.ts` — 21 passed
- `npm run test:ui` — 357 files / 3,161 tests passed
- `npm run typecheck` — passed
- `npm run lint` — 0 errors (74 pre-existing warnings)
- Prettier check over all touched TypeScript/TSX files — passed
- `git diff --check upstream/main...HEAD` — passed

## Checklist

- [x] I have read the contributing guide and Desktop design/development docs.
- [x] I searched open and closed PRs by issue wording and implementation mechanism immediately before publishing; no competing implementation was found.
- [x] This PR is focused on one issue and does not add backend config or new core tool surface.
- [x] The preference is renderer-owned and device-local.
- [x] User-facing strings cover every current Desktop locale.
- [x] I added behavior-focused regression coverage for persistence, recursive filtering, and cache preservation.
- [x] The tree-local editable-target guard is preserved, so `Ctrl+H` is not stolen from text inputs.
