### PR TITLE
fix(gateway): send restart feedback before gateway shutdown (#65057)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1323,6 +1323,17 @@ class GatewaySlashCommandsMixin:
             "XPC_SERVICE_NAME", "0"
         ) not in ("", "0")
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+
+        # Send feedback to the user before restarting the gateway, so they
+        # see confirmation even if the restart (50ms later) cuts delivery.
+        _restart_feedback = t("gateway.draining", count=active_agents) if active_agents else t("gateway.restart.restarting")
+        try:
+            adapter = self.adapters.get(event.source.platform) if event.source else None
+            if adapter:
+                await adapter.send(chat_id=event.source.chat_id, content=_restart_feedback)
+        except Exception:
+            logger.debug("Failed to send pre-restart feedback", exc_info=True)
+
         if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)
         else:


### PR DESCRIPTION
## Summary\n\nWhen a user sends /restart, the gateway shuts down immediately without any visible feedback. The restart task sleeps only 50ms before calling stop(), which can cut off message delivery.\n\n## Fix\n\nSend a feedback message directly via the platform adapter *before* calling request_restart(), so the user sees confirmation regardless of timing.\n\nCloses #65057