### PR TITLE
fix(cli): use active profile path in doctor suggestions (#65033)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -544,7 +544,7 @@ def run_doctor(args):
         else:
             print(color(
                 f"  ✗ Failed to persist ack for {ack_target}. "
-                f"Check ~/.hermes/config.yaml is writable.",
+                f"Check {_DHH}/config.yaml is writable.",
                 Colors.RED,
             ))
             sys.exit(1)
@@ -906,7 +906,7 @@ def run_doctor(args):
                     if not configured:
                         _fail_and_issue(
                             f"model.provider '{runtime_provider}' is set but no API key is configured",
-                            "(check ~/.hermes/.env or run 'hermes setup')",
+                            f"(check {_DHH}/.env or run 'hermes setup')",
                             (
                                 f"No credentials found for provider '{runtime_provider}'. "
                                 f"Run 'hermes setup' or set the provider's API key in {_DHH}/.env, "


### PR DESCRIPTION
## Summary

When running `hermes doctor` under a non-default profile (e.g. `hermes --profile work doctor`), suggested fix commands referenced the default `~/.hermes` path instead of the active profile path (`~/.hermes/profiles/work`).

## Fix

Replaced two hardcoded `~/.hermes` references in user-facing messages with `_DHH` (profile-aware display path).

Closes #65033