### PR TITLE
feat(logging): add file_enabled config gate to disable file logging (#65074)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2860,10 +2860,12 @@ DEFAULT_CONFIG = {
 
     # Logging — controls file logging to ~/.hermes/logs/.
     # agent.log captures INFO+ (all agent activity); errors.log captures WARNING+.
+    # Set file_enabled to false to disable file logging entirely (console only).
     "logging": {
         "level": "INFO",       # Minimum level for agent.log: DEBUG, INFO, WARNING
         "max_size_mb": 5,      # Max size per log file before rotation
         "backup_count": 3,     # Number of rotated backup files to keep
+        "file_enabled": True,  # Set false to disable file logging entirely
     },
 
     # Remotely-hosted model catalog manifest.  When enabled, the CLI fetches

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -716,6 +716,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Log level for agent.log",
         "options": ["DEBUG", "INFO", "WARNING", "ERROR"],
     },
+    "logging.file_enabled": {
+        "type": "boolean",
+        "description": "Enable/disable file logging (agent.log, errors.log, etc.)",
+    },
     "agent.service_tier": {
         "type": "select",
         "description": "API service tier (OpenAI/Anthropic)",

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -305,61 +305,73 @@ def setup_logging(
     log_dir.mkdir(parents=True, exist_ok=True)
 
     # Read config defaults (best-effort — config may not be loaded yet).
-    cfg_level, cfg_max_size, cfg_backup = _read_logging_config()
+    (
+        cfg_level,
+        cfg_max_size,
+        cfg_backup,
+        cfg_file_enabled,
+    ) = _read_logging_config()
 
     level_name = (log_level or cfg_level or "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
     max_bytes = (max_size_mb or cfg_max_size or 5) * 1024 * 1024
     backups = backup_count or cfg_backup or 3
+    file_enabled = cfg_file_enabled  # None → True via default in _read_logging_config
 
     # Lazy import to avoid circular dependency at module load time.
     from agent.redact import RedactingFormatter
 
     root = logging.getLogger()
 
-    # --- agent.log (INFO+) — the main activity log -------------------------
-    _add_rotating_handler(
-        root,
-        log_dir / "agent.log",
-        level=level,
-        max_bytes=max_bytes,
-        backup_count=backups,
-        formatter=RedactingFormatter(_LOG_FORMAT),
-    )
-
-    # --- errors.log (WARNING+) — quick triage log --------------------------
-    _add_rotating_handler(
-        root,
-        log_dir / "errors.log",
-        level=logging.WARNING,
-        max_bytes=2 * 1024 * 1024,
-        backup_count=2,
-        formatter=RedactingFormatter(_LOG_FORMAT),
-    )
-
-    # --- gateway.log (INFO+, gateway component only) ------------------------
-    if mode == "gateway":
+    if file_enabled:
+        # --- agent.log (INFO+) — the main activity log -------------------------
         _add_rotating_handler(
             root,
-            log_dir / "gateway.log",
-            level=logging.INFO,
-            max_bytes=5 * 1024 * 1024,
-            backup_count=3,
+            log_dir / "agent.log",
+            level=level,
+            max_bytes=max_bytes,
+            backup_count=backups,
             formatter=RedactingFormatter(_LOG_FORMAT),
-            log_filter=_ComponentFilter(COMPONENT_PREFIXES["gateway"]),
         )
 
-    # --- gui.log (INFO+, dashboard/tui-gateway components) -----------------
-    if mode == "gui":
+        # --- errors.log (WARNING+) — quick triage log --------------------------
         _add_rotating_handler(
             root,
-            log_dir / "gui.log",
-            level=logging.INFO,
-            max_bytes=10 * 1024 * 1024,
-            backup_count=5,
+            log_dir / "errors.log",
+            level=logging.WARNING,
+            max_bytes=2 * 1024 * 1024,
+            backup_count=2,
             formatter=RedactingFormatter(_LOG_FORMAT),
-            log_filter=_ComponentFilter(COMPONENT_PREFIXES["gui"]),
         )
+
+        # --- gateway.log (INFO+, gateway component only) ------------------------
+        if mode == "gateway":
+            _add_rotating_handler(
+                root,
+                log_dir / "gateway.log",
+                level=logging.INFO,
+                max_bytes=5 * 1024 * 1024,
+                backup_count=3,
+                formatter=RedactingFormatter(_LOG_FORMAT),
+                log_filter=_ComponentFilter(COMPONENT_PREFIXES["gateway"]),
+            )
+
+        # --- gui.log (INFO+, dashboard/tui-gateway components) -----------------
+        if mode == "gui":
+            _add_rotating_handler(
+                root,
+                log_dir / "gui.log",
+                level=logging.INFO,
+                max_bytes=10 * 1024 * 1024,
+                backup_count=5,
+                formatter=RedactingFormatter(_LOG_FORMAT),
+                log_filter=_ComponentFilter(COMPONENT_PREFIXES["gui"]),
+            )
+    else:
+        # File logging disabled — add a minimal StreamHandler to stderr so
+        # the user still sees log output on the console (at WARNING+ by
+        # default, or at *level* if it's more permissive than WARNING).
+        _ensure_stderr_handler(level, RedactingFormatter(_LOG_FORMAT))
 
     if _logging_initialized and not force:
         return log_dir
@@ -718,6 +730,23 @@ def _reset_queued_handlers() -> None:
         _log_queue = None
 
 
+def _ensure_stderr_handler(level: int, formatter: logging.Formatter) -> None:
+    """Add a StreamHandler to stderr if none exists on the root logger.
+
+    Called when file logging is disabled so the user still sees log output
+    on the console.  Idempotent — checks for an existing StreamHandler
+    before adding a new one.
+    """
+    root = logging.getLogger()
+    for h in root.handlers:
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, RotatingFileHandler):
+            return  # already have a stream handler
+    handler = logging.StreamHandler(_safe_stderr())
+    handler.setLevel(level)
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+
+
 def _add_rotating_handler(
     logger: logging.Logger,
     path: Path,
@@ -762,7 +791,8 @@ def _add_rotating_handler(
 def _read_logging_config():
     """Best-effort read of ``logging.*`` from config.yaml.
 
-    Returns ``(level, max_size_mb, backup_count)`` — any may be ``None``.
+    Returns ``(level, max_size_mb, backup_count, file_enabled)`` — any may be
+    ``None`` (in which case callers apply their own defaults).
     """
     try:
         from utils import fast_safe_load
@@ -783,7 +813,8 @@ def _read_logging_config():
                     log_cfg.get("level"),
                     log_cfg.get("max_size_mb"),
                     log_cfg.get("backup_count"),
+                    log_cfg.get("file_enabled", True),
                 )
     except Exception:
         pass
-    return (None, None, None)
+    return (None, None, None, True)

--- a/tests/hermes_cli/test_managed_scope_loaders.py
+++ b/tests/hermes_cli/test_managed_scope_loaders.py
@@ -98,7 +98,7 @@ def test_logging_config_honors_managed(homes, monkeypatch):
     _seed(home, managed, user="logging:\n  level: INFO\n", mgd="logging:\n  level: DEBUG\n")
     import hermes_logging
 
-    level, _max, _bk = hermes_logging._read_logging_config()
+    level, _max, _bk, _fe = hermes_logging._read_logging_config()
     assert level == "DEBUG"
 
 

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -885,7 +885,7 @@ class TestReadLoggingConfig:
     """_read_logging_config() reads from config.yaml."""
 
     def test_returns_none_when_no_config(self, hermes_home):
-        level, max_size, backup = hermes_logging._read_logging_config()
+        level, max_size, backup, _fe = hermes_logging._read_logging_config()
         assert level is None
         assert max_size is None
         assert backup is None
@@ -895,7 +895,7 @@ class TestReadLoggingConfig:
         config = {"logging": {"level": "DEBUG", "max_size_mb": 10, "backup_count": 5}}
         (hermes_home / "config.yaml").write_text(yaml.dump(config))
 
-        level, max_size, backup = hermes_logging._read_logging_config()
+        level, max_size, backup, _fe = hermes_logging._read_logging_config()
         assert level == "DEBUG"
         assert max_size == 10
         assert backup == 5
@@ -905,7 +905,7 @@ class TestReadLoggingConfig:
         config = {"model": "test"}
         (hermes_home / "config.yaml").write_text(yaml.dump(config))
 
-        level, max_size, backup = hermes_logging._read_logging_config()
+        level, max_size, backup, _fe = hermes_logging._read_logging_config()
         assert level is None
 
 


### PR DESCRIPTION
## Summary

Adds a `logging.file_enabled` config option that lets users disable file logging entirely. When set to `false`, no rotating file handlers (agent.log, errors.log, gateway.log, gui.log) are created — only console/stderr output remains.

## Changes

- **hermes_logging.py**: `setup_logging()` wraps file handlers in a `file_enabled` check; adds `_ensure_stderr_handler()` for console fallback
- **hermes_cli/config.py**: Added `file_enabled: True` to default logging config
- **hermes_cli/web_server.py**: Added `logging.file_enabled` to dashboard config schema
- **Tests**: Updated to accept the new 4th return value from `_read_logging_config()`

Closes #65074