### PR TITLE
feat(api): resolve configured session identities early

### DIFF
--- a/contributors/emails/g@georgio.co
+++ b/contributors/emails/g@georgio.co
@@ -1,0 +1,2 @@
+rungmc357
+# PR #65102 API canonical session identity

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -974,6 +974,10 @@ class GatewayConfig:
     # historical serve-all behavior; [] serves only the default profile.
     multiplex_profile_allowlist: Optional[List[str]] = None
 
+    # Explicit API-client aliases for native gateway conversation identities.
+    # Values are SessionSource-shaped mappings validated at API request time.
+    session_key_aliases: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
     # Opt-in systemd event-loop watchdog. Zero preserves Type=simple and
     # disables sd_notify at runtime.
     systemd_watchdog_seconds: int = 0
@@ -1122,6 +1126,7 @@ class GatewayConfig:
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "multiplex_profiles": self.multiplex_profiles,
             "multiplex_profile_allowlist": self.multiplex_profile_allowlist,
+            "session_key_aliases": self.session_key_aliases,
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
             "loop_watchdog": self.loop_watchdog,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
@@ -1193,6 +1198,15 @@ class GatewayConfig:
             multiplex_profile_allowlist = nested_gateway.get(
                 "multiplex_profile_allowlist"
             )
+        nested_gateway = data.get("gateway") if isinstance(data.get("gateway"), dict) else {}
+        session_key_aliases_raw = data.get("session_key_aliases")
+        if session_key_aliases_raw is None:
+            session_key_aliases_raw = nested_gateway.get("session_key_aliases")
+        session_key_aliases = (
+            dict(session_key_aliases_raw)
+            if isinstance(session_key_aliases_raw, dict)
+            else {}
+        )
         if "systemd_watchdog_seconds" in data:
             systemd_watchdog_raw = data.get("systemd_watchdog_seconds")
             systemd_watchdog_key = "systemd_watchdog_seconds"
@@ -1267,6 +1281,7 @@ class GatewayConfig:
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             multiplex_profile_allowlist=multiplex_profile_allowlist,
+            session_key_aliases=session_key_aliases,
             systemd_watchdog_seconds=systemd_watchdog_seconds,
             loop_watchdog=loop_watchdog,
             max_concurrent_sessions=max_concurrent_sessions,
@@ -1437,10 +1452,15 @@ def load_gateway_config() -> GatewayConfig:
                     gw_data["multiplex_profiles"] = gateway_section["multiplex_profiles"]
                 if "max_concurrent_sessions" in gateway_section:
                     gw_data["max_concurrent_sessions"] = gateway_section["max_concurrent_sessions"]
+                if "session_key_aliases" in gateway_section:
+                    gw_data["session_key_aliases"] = gateway_section["session_key_aliases"]
                 if "systemd_watchdog_seconds" in gateway_section:
                     gw_data["systemd_watchdog_seconds"] = gateway_section[
                         "systemd_watchdog_seconds"
                     ]
+
+            if "session_key_aliases" in yaml_cfg:
+                gw_data["session_key_aliases"] = yaml_cfg["session_key_aliases"]
 
             if "max_concurrent_sessions" in yaml_cfg:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -926,6 +926,10 @@ class GatewayConfig:
     # gateway behaves exactly as before — single HERMES_HOME, no profile stamping.
     multiplex_profiles: bool = False
 
+    # Explicit API-client aliases for native gateway conversation identities.
+    # Values are SessionSource-shaped mappings validated at API request time.
+    session_key_aliases: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
     # Opt-in systemd event-loop watchdog. Zero preserves Type=simple and
     # disables sd_notify at runtime.
     systemd_watchdog_seconds: int = 0
@@ -1070,6 +1074,7 @@ class GatewayConfig:
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "max_concurrent_sessions": self.max_concurrent_sessions,
             "multiplex_profiles": self.multiplex_profiles,
+            "session_key_aliases": self.session_key_aliases,
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
             "loop_watchdog": self.loop_watchdog,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
@@ -1134,6 +1139,14 @@ class GatewayConfig:
         thread_sessions_per_user = data.get("thread_sessions_per_user")
         multiplex_profiles = data.get("multiplex_profiles")
         nested_gateway = data.get("gateway") if isinstance(data.get("gateway"), dict) else {}
+        session_key_aliases_raw = data.get("session_key_aliases")
+        if session_key_aliases_raw is None:
+            session_key_aliases_raw = nested_gateway.get("session_key_aliases")
+        session_key_aliases = (
+            dict(session_key_aliases_raw)
+            if isinstance(session_key_aliases_raw, dict)
+            else {}
+        )
         if "systemd_watchdog_seconds" in data:
             systemd_watchdog_raw = data.get("systemd_watchdog_seconds")
             systemd_watchdog_key = "systemd_watchdog_seconds"
@@ -1207,6 +1220,7 @@ class GatewayConfig:
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
+            session_key_aliases=session_key_aliases,
             systemd_watchdog_seconds=systemd_watchdog_seconds,
             loop_watchdog=loop_watchdog,
             max_concurrent_sessions=max_concurrent_sessions,
@@ -1365,10 +1379,15 @@ def load_gateway_config() -> GatewayConfig:
                     gw_data["multiplex_profiles"] = gateway_section["multiplex_profiles"]
                 if "max_concurrent_sessions" in gateway_section:
                     gw_data["max_concurrent_sessions"] = gateway_section["max_concurrent_sessions"]
+                if "session_key_aliases" in gateway_section:
+                    gw_data["session_key_aliases"] = gateway_section["session_key_aliases"]
                 if "systemd_watchdog_seconds" in gateway_section:
                     gw_data["systemd_watchdog_seconds"] = gateway_section[
                         "systemd_watchdog_seconds"
                     ]
+
+            if "session_key_aliases" in yaml_cfg:
+                gw_data["session_key_aliases"] = yaml_cfg["session_key_aliases"]
 
             if "max_concurrent_sessions" in yaml_cfg:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -83,7 +83,13 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+from gateway.session import (
+    SessionSource,
+    build_session_context,
+    build_session_context_prompt,
+    build_session_key,
+)
 from gateway.platforms.base import (
     MEDIA_TAG_CLEANUP_RE,
     BasePlatformAdapter,
@@ -1178,17 +1184,18 @@ class _IdempotencyCache:
 
     async def get_or_set(self, key: str, fingerprint: str, compute_coro):
         self._purge()
-        item = self._store.get(key)
-        if item and item["fp"] == fingerprint:
+        cache_key = (key, fingerprint)
+        item = self._store.get(cache_key)
+        if item:
             return item["resp"]
 
-        inflight_key = (key, fingerprint)
+        inflight_key = cache_key
         task = self._inflight.get(inflight_key)
         if task is None:
             async def _compute_and_store():
                 resp = await compute_coro()
                 import time as _t
-                self._store[key] = {"resp": resp, "fp": fingerprint, "ts": _t.time()}
+                self._store[cache_key] = {"resp": resp, "ts": _t.time()}
                 self._purge()
                 return resp
 
@@ -1207,10 +1214,48 @@ class _IdempotencyCache:
 _idem_cache = _IdempotencyCache()
 
 
-def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
+def _make_request_fingerprint(
+    body: Dict[str, Any],
+    keys: List[str],
+    *,
+    namespace: Optional[Dict[str, Any]] = None,
+) -> str:
     from hashlib import sha256
+
     subset = {k: body.get(k) for k in keys}
-    return sha256(repr(subset).encode("utf-8")).hexdigest()
+    if namespace is not None:
+        subset["__hermes_identity__"] = namespace
+    encoded = json.dumps(
+        subset,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return sha256(encoded).hexdigest()
+
+
+def _api_idempotency_namespace(
+    gateway_session_key: Optional[str],
+    session_source: Optional[SessionSource],
+) -> Dict[str, Any]:
+    """Return the trusted request identity that scopes idempotency reuse."""
+    source = None
+    if session_source is not None:
+        source = {
+            "platform": session_source.platform.value,
+            "chat_id": session_source.chat_id,
+            "chat_type": session_source.chat_type,
+            "user_id": session_source.user_id,
+            "thread_id": session_source.thread_id,
+            "parent_chat_id": session_source.parent_chat_id,
+            "profile": session_source.profile,
+            "scope_id": session_source.scope_id,
+        }
+    return {
+        "profile": _api_request_profile.get(),
+        "session_key": gateway_session_key,
+        "source": source,
+    }
 
 
 def _derive_chat_session_id(
@@ -1997,17 +2042,17 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _parse_session_key_header(
         self, request: "web.Request"
-    ) -> tuple[Optional[str], Optional["web.Response"]]:
+    ) -> tuple[Optional[str], Optional[SessionSource], Optional["web.Response"]]:
         """Extract and validate the ``X-Hermes-Session-Key`` header.
 
         The session key is a stable per-channel identifier that scopes
-        long-term memory (e.g. Honcho sessions) across transcripts.  It
-        is independent of ``X-Hermes-Session-Id``: callers may send
-        either, both, or neither.
+        long-term memory (e.g. Honcho sessions) across transcripts. It is
+        independent of ``X-Hermes-Session-Id``: callers may send either,
+        both, or neither.
 
-        Returns ``(session_key, None)`` on success (with an empty/absent
-        header yielding ``None`` for the key), or ``(None, error_response)``
-        on validation failure.
+        Returns ``(session_key, native_source, None)`` on success. Native
+        source identity exists only for an exact operator-configured alias and
+        stays request-local; it is never cached on the adapter.
 
         Security: like session continuation, accepting a caller-supplied
         memory scope requires API-key authentication so that an
@@ -2016,14 +2061,14 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         raw = request.headers.get("X-Hermes-Session-Key", "").strip()
         if not raw:
-            return None, None
+            return None, None, None
 
         if not self._api_key:
             logger.warning(
                 "X-Hermes-Session-Key rejected: no API key configured. "
                 "Set API_SERVER_KEY to enable long-term memory scoping."
             )
-            return None, web.json_response(
+            return None, None, web.json_response(
                 _openai_error(
                     "X-Hermes-Session-Key requires API key authentication. "
                     "Configure API_SERVER_KEY to enable this feature."
@@ -2034,18 +2079,69 @@ class APIServerAdapter(BasePlatformAdapter):
         # Reject control characters that could enable header injection on
         # the echo path.
         if re.search(r'[\r\n\x00]', raw):
-            return None, web.json_response(
+            return None, None, web.json_response(
                 {"error": {"message": "Invalid session key", "type": "invalid_request_error"}},
                 status=400,
             )
 
         if len(raw) > self._MAX_SESSION_HEADER_LEN:
-            return None, web.json_response(
+            return None, None, web.json_response(
                 {"error": {"message": "Session key too long", "type": "invalid_request_error"}},
                 status=400,
             )
 
-        return raw, None
+        return self._resolve_api_session_identity(raw)
+
+    def _resolve_api_session_identity(
+        self, presented_key: Optional[str]
+    ) -> tuple[Optional[str], Optional[SessionSource], Optional["web.Response"]]:
+        """Resolve an explicit API alias before any agent/session construction.
+
+        A caller cannot synthesize native identity: only an exact configured
+        alias is promoted. Unconfigured keys retain legacy API-server behavior.
+        """
+        config = load_gateway_config()
+        aliases = config.session_key_aliases
+        if not presented_key or presented_key not in aliases:
+            return presented_key, None, None
+        raw = aliases[presented_key]
+        try:
+            if not isinstance(raw, dict):
+                raise ValueError("mapping required")
+            platform = Platform(raw.get("platform"))
+            chat_id = raw.get("chat_id")
+            chat_type = raw.get("chat_type", "dm")
+            if (
+                platform in {Platform.API_SERVER, Platform.WEBHOOK}
+                or not isinstance(chat_id, str)
+                or not chat_id.strip()
+            ):
+                raise ValueError("native platform and chat_id required")
+            if not isinstance(chat_type, str) or not chat_type.strip():
+                raise ValueError("chat_type required")
+            if raw.get("profile") is not None or raw.get("scope_id") is not None:
+                raise ValueError("profile and scope_id aliases are not yet supported")
+            for name in ("thread_id", "user_id", "parent_chat_id"):
+                if raw.get(name) is not None and not isinstance(raw[name], str):
+                    raise ValueError(f"{name} must be a string")
+            request_profile = _api_request_profile.get()
+            source = SessionSource(
+                platform=platform, chat_id=chat_id, chat_type=chat_type,
+                thread_id=raw.get("thread_id"), user_id=raw.get("user_id"),
+                parent_chat_id=raw.get("parent_chat_id"),
+                profile=request_profile,
+            )
+            return build_session_key(
+                source,
+                group_sessions_per_user=config.group_sessions_per_user,
+                thread_sessions_per_user=config.thread_sessions_per_user,
+                profile=request_profile,
+            ), source, None
+        except (TypeError, ValueError):
+            return None, None, web.json_response(
+                _openai_error("Configured session key alias is invalid", code="invalid_session_alias"),
+                status=400,
+            )
 
     # ------------------------------------------------------------------
     # Session DB helper
@@ -2486,6 +2582,7 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None,
+        session_source: Optional[SessionSource] = None,
         route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None,
         confirmed_runtime_lock: bool = False,
@@ -2756,7 +2853,25 @@ class APIServerAdapter(BasePlatformAdapter):
             self._last_resolved_model["*"] = model
 
         user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        agent_platform = session_source.platform.value if session_source else "api_server"
+        enabled_toolsets = sorted(_get_platform_tools(user_config, agent_platform))
+
+        if session_source is not None:
+            session_context = build_session_context(
+                session_source,
+                load_gateway_config(),
+            )
+            redact_pii = bool(
+                ((_load_gateway_config().get("privacy") or {}).get("redact_pii", False))
+            )
+            context_prompt = build_session_context_prompt(
+                session_context,
+                redact_pii=redact_pii,
+            )
+            if ephemeral_system_prompt:
+                ephemeral_system_prompt = f"{context_prompt}\n\n{ephemeral_system_prompt}"
+            else:
+                ephemeral_system_prompt = context_prompt
 
         max_iterations = _current_max_iterations()
 
@@ -2778,7 +2893,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "ephemeral_system_prompt": ephemeral_system_prompt or None,
             "enabled_toolsets": enabled_toolsets,
             "session_id": session_id,
-            "platform": "api_server",
+            "platform": agent_platform,
             "stream_delta_callback": stream_delta_callback,
             "tool_progress_callback": tool_progress_callback,
             "tool_start_callback": tool_start_callback,
@@ -3466,7 +3581,7 @@ class APIServerAdapter(BasePlatformAdapter):
     @_admit_api_agent_request
     async def _handle_session_chat(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions/{session_id}/chat — one synchronous agent turn."""
-        gateway_session_key, key_err = self._parse_session_key_header(request)
+        gateway_session_key, session_source, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
         session_id = request.match_info["session_id"]
@@ -3546,6 +3661,7 @@ class APIServerAdapter(BasePlatformAdapter):
             route_source=runtime_request.get("route_source") or "global",
             confirmed_runtime_lock=lock_active,
             **agent_overrides,
+            session_source=session_source,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
@@ -3583,7 +3699,7 @@ class APIServerAdapter(BasePlatformAdapter):
     @_admit_api_agent_request
     async def _handle_session_chat_stream(self, request: "web.Request") -> "web.StreamResponse":
         """POST /api/sessions/{session_id}/chat/stream — SSE wrapper over _run_agent."""
-        gateway_session_key, key_err = self._parse_session_key_header(request)
+        gateway_session_key, session_source, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
         session_id = request.match_info["session_id"]
@@ -3711,6 +3827,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     route_source=runtime_request.get("route_source") or "global",
                     confirmed_runtime_lock=lock_active,
                     **agent_overrides,
+                    session_source=session_source,
                 )
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
@@ -3898,7 +4015,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # is independent of X-Hermes-Session-Id: the key persists across
         # transcripts while the id rotates when the caller starts a new
         # transcript (i.e. /new semantics).  See _parse_session_key_header.
-        gateway_session_key, key_err = self._parse_session_key_header(request)
+        gateway_session_key, session_source, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
 
@@ -4067,6 +4184,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
+                session_source=session_source,
                 route=route,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
@@ -4088,6 +4206,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
+                session_source=session_source,
                 route=route,
             )
 
@@ -4096,6 +4215,10 @@ class APIServerAdapter(BasePlatformAdapter):
             fp = _make_request_fingerprint(
                 body,
                 keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
+                namespace=_api_idempotency_namespace(
+                    gateway_session_key,
+                    session_source,
+                ),
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
@@ -5012,7 +5135,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return limited
 
         # Long-term memory scope header (see chat_completions for details).
-        gateway_session_key, key_err = self._parse_session_key_header(request)
+        gateway_session_key, session_source, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
 
@@ -5184,6 +5307,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
+                session_source=session_source,
                 route=route,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
@@ -5219,6 +5343,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
+                session_source=session_source,
                 route=route,
             )
 
@@ -5236,6 +5361,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     "model_options",
                     "tools",
                 ],
+                namespace=_api_idempotency_namespace(
+                    gateway_session_key,
+                    session_source,
+                ),
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -5885,6 +6014,7 @@ class APIServerAdapter(BasePlatformAdapter):
         chat_id: str = "",
         session_key: str = "",
         session_id: str = "",
+        source: Optional[SessionSource] = None,
     ) -> list:
         """Bind session contextvars for an API-server agent run.
 
@@ -5904,8 +6034,12 @@ class APIServerAdapter(BasePlatformAdapter):
         from gateway.session_context import set_session_vars
 
         return set_session_vars(
-            platform="api_server",
-            chat_id=chat_id,
+            platform=source.platform.value if source else "api_server",
+            chat_id=source.chat_id if source else chat_id,
+            chat_type=(source.chat_type or "") if source else "",
+            thread_id=(source.thread_id or "") if source else "",
+            user_id=(source.user_id or "") if source else "",
+            profile=(source.profile or "") if source else "",
             session_key=session_key,
             session_id=session_id,
             async_delivery=False,
@@ -5927,6 +6061,7 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None,
+        session_source: Optional[SessionSource] = None,
         route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None,
         requested_runtime: Optional[Dict[str, Any]] = None,
@@ -5972,6 +6107,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     chat_id=session_id or "",
                     session_key=gateway_session_key or session_id or "",
                     session_id=session_id or "",
+                    source=session_source,
                 )
                 agent = None
                 try:
@@ -5986,6 +6122,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         requested_model=requested_model,
                         requested_provider=requested_provider,
                         model_options=model_options,
+                        session_source=session_source,
                         route=route,
                         session_model=session_model,
                         confirmed_runtime_lock=confirmed_runtime_lock,
@@ -6256,7 +6393,7 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
         # Long-term memory scope header (see chat_completions for details).
-        gateway_session_key, key_err = self._parse_session_key_header(request)
+        gateway_session_key, session_source, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
 
@@ -6415,6 +6552,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         requested_model=agent_overrides.get("requested_model"),
                         requested_provider=agent_overrides.get("requested_provider"),
                         model_options=agent_overrides.get("model_options"),
+                        session_source=session_source,
                         route=route,
                     )
                 self._active_run_agents[run_id] = agent
@@ -6476,8 +6614,13 @@ class APIServerAdapter(BasePlatformAdapter):
                                 # background delegations stay forced-sync
                                 # (no wake target).
                                 chat_id=session_id or "",
-                                session_key=approval_session_key,
+                                # Keep Hermes runtime identity canonical when
+                                # the presented API key resolves to a configured
+                                # native source. Approval routing remains scoped
+                                # independently by approval_session_key above.
+                                session_key=gateway_session_key or approval_session_key,
                                 session_id=session_id or "",
+                                source=session_source,
                             )
                             register_gateway_notify(approval_session_key, _approval_notify)
                             # /v1/runs runs its own agent lifecycle (no

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -84,7 +84,13 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+from gateway.session import (
+    SessionSource,
+    build_session_context,
+    build_session_context_prompt,
+    build_session_key,
+)
 from gateway.platforms.base import (
     MEDIA_TAG_CLEANUP_RE,
     BasePlatformAdapter,
@@ -1227,17 +1233,18 @@ class _IdempotencyCache:
 
     async def get_or_set(self, key: str, fingerprint: str, compute_coro):
         self._purge()
-        item = self._store.get(key)
-        if item and item["fp"] == fingerprint:
+        cache_key = (key, fingerprint)
+        item = self._store.get(cache_key)
+        if item:
             return item["resp"]
 
-        inflight_key = (key, fingerprint)
+        inflight_key = cache_key
         task = self._inflight.get(inflight_key)
         if task is None:
             async def _compute_and_store():
                 resp = await compute_coro()
                 import time as _t
-                self._store[key] = {"resp": resp, "fp": fingerprint, "ts": _t.time()}
+                self._store[cache_key] = {"resp": resp, "ts": _t.time()}
                 self._purge()
                 return resp
 
@@ -1256,10 +1263,48 @@ class _IdempotencyCache:
 _idem_cache = _IdempotencyCache()
 
 
-def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
+def _make_request_fingerprint(
+    body: Dict[str, Any],
+    keys: List[str],
+    *,
+    namespace: Optional[Dict[str, Any]] = None,
+) -> str:
     from hashlib import sha256
+
     subset = {k: body.get(k) for k in keys}
-    return sha256(repr(subset).encode("utf-8")).hexdigest()
+    if namespace is not None:
+        subset["__hermes_identity__"] = namespace
+    encoded = json.dumps(
+        subset,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return sha256(encoded).hexdigest()
+
+
+def _api_idempotency_namespace(
+    gateway_session_key: Optional[str],
+    session_source: Optional[SessionSource],
+) -> Dict[str, Any]:
+    """Return the trusted request identity that scopes idempotency reuse."""
+    source = None
+    if session_source is not None:
+        source = {
+            "platform": session_source.platform.value,
+            "chat_id": session_source.chat_id,
+            "chat_type": session_source.chat_type,
+            "user_id": session_source.user_id,
+            "thread_id": session_source.thread_id,
+            "parent_chat_id": session_source.parent_chat_id,
+            "profile": session_source.profile,
+            "scope_id": session_source.scope_id,
+        }
+    return {
+        "profile": _api_request_profile.get(),
+        "session_key": gateway_session_key,
+        "source": source,
+    }
 
 
 def _derive_chat_session_id(
@@ -2116,17 +2161,17 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _parse_session_key_header(
         self, request: "web.Request"
-    ) -> tuple[Optional[str], Optional["web.Response"]]:
+    ) -> tuple[Optional[str], Optional[SessionSource], Optional["web.Response"]]:
         """Extract and validate the ``X-Hermes-Session-Key`` header.
 
         The session key is a stable per-channel identifier that scopes
-        long-term memory (e.g. Honcho sessions) across transcripts.  It
-        is independent of ``X-Hermes-Session-Id``: callers may send
-        either, both, or neither.
+        long-term memory (e.g. Honcho sessions) across transcripts. It is
+        independent of ``X-Hermes-Session-Id``: callers may send either,
+        both, or neither.
 
-        Returns ``(session_key, None)`` on success (with an empty/absent
-        header yielding ``None`` for the key), or ``(None, error_response)``
-        on validation failure.
+        Returns ``(session_key, native_source, None)`` on success. Native
+        source identity exists only for an exact operator-configured alias and
+        stays request-local; it is never cached on the adapter.
 
         Security: like session continuation, accepting a caller-supplied
         memory scope requires API-key authentication so that an
@@ -2135,14 +2180,14 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         raw = request.headers.get("X-Hermes-Session-Key", "").strip()
         if not raw:
-            return None, None
+            return None, None, None
 
         if not self._api_key:
             logger.warning(
                 "X-Hermes-Session-Key rejected: no API key configured. "
                 "Set API_SERVER_KEY to enable long-term memory scoping."
             )
-            return None, web.json_response(
+            return None, None, web.json_response(
                 _openai_error(
                     "X-Hermes-Session-Key requires API key authentication. "
                     "Configure API_SERVER_KEY to enable this feature."
@@ -2153,18 +2198,69 @@ class APIServerAdapter(BasePlatformAdapter):
         # Reject control characters that could enable header injection on
         # the echo path.
         if re.search(r'[\r\n\x00]', raw):
-            return None, web.json_response(
+            return None, None, web.json_response(
                 {"error": {"message": "Invalid session key", "type": "invalid_request_error"}},
                 status=400,
             )
 
         if len(raw) > self._MAX_SESSION_HEADER_LEN:
-            return None, web.json_response(
+            return None, None, web.json_response(
                 {"error": {"message": "Session key too long", "type": "invalid_request_error"}},
                 status=400,
             )
 
-        return raw, None
+        return self._resolve_api_session_identity(raw)
+
+    def _resolve_api_session_identity(
+        self, presented_key: Optional[str]
+    ) -> tuple[Optional[str], Optional[SessionSource], Optional["web.Response"]]:
+        """Resolve an explicit API alias before any agent/session construction.
+
+        A caller cannot synthesize native identity: only an exact configured
+        alias is promoted. Unconfigured keys retain legacy API-server behavior.
+        """
+        config = load_gateway_config()
+        aliases = config.session_key_aliases
+        if not presented_key or presented_key not in aliases:
+            return presented_key, None, None
+        raw = aliases[presented_key]
+        try:
+            if not isinstance(raw, dict):
+                raise ValueError("mapping required")
+            platform = Platform(raw.get("platform"))
+            chat_id = raw.get("chat_id")
+            chat_type = raw.get("chat_type", "dm")
+            if (
+                platform in {Platform.API_SERVER, Platform.WEBHOOK}
+                or not isinstance(chat_id, str)
+                or not chat_id.strip()
+            ):
+                raise ValueError("native platform and chat_id required")
+            if not isinstance(chat_type, str) or not chat_type.strip():
+                raise ValueError("chat_type required")
+            if raw.get("profile") is not None or raw.get("scope_id") is not None:
+                raise ValueError("profile and scope_id aliases are not yet supported")
+            for name in ("thread_id", "user_id", "parent_chat_id"):
+                if raw.get(name) is not None and not isinstance(raw[name], str):
+                    raise ValueError(f"{name} must be a string")
+            request_profile = _api_request_profile.get()
+            source = SessionSource(
+                platform=platform, chat_id=chat_id, chat_type=chat_type,
+                thread_id=raw.get("thread_id"), user_id=raw.get("user_id"),
+                parent_chat_id=raw.get("parent_chat_id"),
+                profile=request_profile,
+            )
+            return build_session_key(
+                source,
+                group_sessions_per_user=config.group_sessions_per_user,
+                thread_sessions_per_user=config.thread_sessions_per_user,
+                profile=request_profile,
+            ), source, None
+        except (TypeError, ValueError):
+            return None, None, web.json_response(
+                _openai_error("Configured session key alias is invalid", code="invalid_session_alias"),
+                status=400,
+            )
 
     # ------------------------------------------------------------------
     # Session DB helper
@@ -2605,6 +2701,7 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None,
+        session_source: Optional[SessionSource] = None,
         route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None,
         confirmed_runtime_lock: bool = False,
@@ -2872,7 +2969,25 @@ class APIServerAdapter(BasePlatformAdapter):
             self._last_resolved_model["*"] = model
 
         user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        agent_platform = session_source.platform.value if session_source else "api_server"
+        enabled_toolsets = sorted(_get_platform_tools(user_config, agent_platform))
+
+        if session_source is not None:
+            session_context = build_session_context(
+                session_source,
+                load_gateway_config(),
+            )
+            redact_pii = bool(
+                ((_load_gateway_config().get("privacy") or {}).get("redact_pii", False))
+            )
+            context_prompt = build_session_context_prompt(
+                session_context,
+                redact_pii=redact_pii,
+            )
+            if ephemeral_system_prompt:
+                ephemeral_system_prompt = f"{context_prompt}\n\n{ephemeral_system_prompt}"
+            else:
+                ephemeral_system_prompt = context_prompt
 
         max_iterations = _current_max_iterations()
 
@@ -2908,7 +3023,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "ephemeral_system_prompt": ephemeral_system_prompt or None,
             "enabled_toolsets": enabled_toolsets,
             "session_id": session_id,
-            "platform": "api_server",
+            "platform": agent_platform,
             "stream_delta_callback": stream_delta_callback,
             "tool_progress_callback": tool_progress_callback,
             "tool_start_callback": tool_start_callback,
@@ -3661,7 +3776,7 @@ class APIServerAdapter(BasePlatformAdapter):
     @_admit_api_agent_request
     async def _handle_session_chat(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions/{session_id}/chat — one synchronous agent turn."""
-        gateway_session_key, key_err = self._parse_session_key_header(request)
+        gateway_session_key, session_source, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
         session_id = request.match_info["session_id"]
@@ -3741,6 +3856,7 @@ class APIServerAdapter(BasePlatformAdapter):
             route_source=runtime_request.get("route_source") or "global",
             confirmed_runtime_lock=lock_active,
             **agent_overrides,
+            session_source=session_source,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
@@ -3778,7 +3894,7 @@ class APIServerAdapter(BasePlatformAdapter):
     @_admit_api_agent_request
     async def _handle_session_chat_stream(self, request: "web.Request") -> "web.StreamResponse":
         """POST /api/sessions/{session_id}/chat/stream — SSE wrapper over _run_agent."""
-        gateway_session_key, key_err = self._parse_session_key_header(request)
+        gateway_session_key, session_source, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
         session_id = request.match_info["session_id"]
@@ -3914,6 +4030,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     route_source=runtime_request.get("route_source") or "global",
                     confirmed_runtime_lock=lock_active,
                     **agent_overrides,
+                    session_source=session_source,
                 )
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
@@ -4161,7 +4278,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # is independent of X-Hermes-Session-Id: the key persists across
         # transcripts while the id rotates when the caller starts a new
         # transcript (i.e. /new semantics).  See _parse_session_key_header.
-        gateway_session_key, key_err = self._parse_session_key_header(request)
+        gateway_session_key, session_source, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
 
@@ -4331,6 +4448,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
+                session_source=session_source,
                 route=route,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
@@ -4352,6 +4470,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
+                session_source=session_source,
                 route=route,
             )
 
@@ -4360,6 +4479,10 @@ class APIServerAdapter(BasePlatformAdapter):
             fp = _make_request_fingerprint(
                 body,
                 keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
+                namespace=_api_idempotency_namespace(
+                    gateway_session_key,
+                    session_source,
+                ),
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
@@ -5269,7 +5392,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return limited
 
         # Long-term memory scope header (see chat_completions for details).
-        gateway_session_key, key_err = self._parse_session_key_header(request)
+        gateway_session_key, session_source, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
 
@@ -5442,6 +5565,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
+                session_source=session_source,
                 route=route,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
@@ -5477,6 +5601,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
+                session_source=session_source,
                 route=route,
             )
 
@@ -5494,6 +5619,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     "model_options",
                     "tools",
                 ],
+                namespace=_api_idempotency_namespace(
+                    gateway_session_key,
+                    session_source,
+                ),
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -6171,6 +6300,7 @@ class APIServerAdapter(BasePlatformAdapter):
         chat_id: str = "",
         session_key: str = "",
         session_id: str = "",
+        source: Optional[SessionSource] = None,
     ) -> list:
         """Bind session contextvars for an API-server agent run.
 
@@ -6190,8 +6320,12 @@ class APIServerAdapter(BasePlatformAdapter):
         from gateway.session_context import set_session_vars
 
         return set_session_vars(
-            platform="api_server",
-            chat_id=chat_id,
+            platform=source.platform.value if source else "api_server",
+            chat_id=source.chat_id if source else chat_id,
+            chat_type=(source.chat_type or "") if source else "",
+            thread_id=(source.thread_id or "") if source else "",
+            user_id=(source.user_id or "") if source else "",
+            profile=(source.profile or "") if source else "",
             session_key=session_key,
             session_id=session_id,
             async_delivery=False,
@@ -6214,6 +6348,7 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None,
+        session_source: Optional[SessionSource] = None,
         route: Optional[Dict[str, Any]] = None,
         session_model: Optional[str] = None,
         requested_runtime: Optional[Dict[str, Any]] = None,
@@ -6263,6 +6398,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     chat_id=session_id or "",
                     session_key=gateway_session_key or session_id or "",
                     session_id=session_id or "",
+                    source=session_source,
                 )
                 agent = None
                 try:
@@ -6277,6 +6413,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         requested_model=requested_model,
                         requested_provider=requested_provider,
                         model_options=model_options,
+                        session_source=session_source,
                         route=route,
                         session_model=session_model,
                         confirmed_runtime_lock=confirmed_runtime_lock,
@@ -6563,7 +6700,7 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
         # Long-term memory scope header (see chat_completions for details).
-        gateway_session_key, key_err = self._parse_session_key_header(request)
+        gateway_session_key, session_source, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
 
@@ -6722,6 +6859,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         requested_model=agent_overrides.get("requested_model"),
                         requested_provider=agent_overrides.get("requested_provider"),
                         model_options=agent_overrides.get("model_options"),
+                        session_source=session_source,
                         route=route,
                     )
                 self._active_run_agents[run_id] = agent
@@ -6783,8 +6921,13 @@ class APIServerAdapter(BasePlatformAdapter):
                                 # background delegations stay forced-sync
                                 # (no wake target).
                                 chat_id=session_id or "",
-                                session_key=approval_session_key,
+                                # Keep Hermes runtime identity canonical when
+                                # the presented API key resolves to a configured
+                                # native source. Approval routing remains scoped
+                                # independently by approval_session_key above.
+                                session_key=gateway_session_key or approval_session_key,
                                 session_id=session_id or "",
+                                source=session_source,
                             )
                             register_gateway_notify(approval_session_key, _approval_notify)
                             # /v1/runs runs its own agent lifecycle (no

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -122,6 +122,24 @@ class TestResponseStore:
 
 class TestIdempotencyCache:
     @pytest.mark.asyncio
+    async def test_completed_entries_are_partitioned_by_fingerprint(self):
+        cache = _IdempotencyCache()
+        calls = 0
+
+        async def compute():
+            nonlocal calls
+            calls += 1
+            return f"response-{calls}"
+
+        first = await cache.get_or_set("idem-key", "identity-a", compute)
+        second = await cache.get_or_set("idem-key", "identity-b", compute)
+        first_replay = await cache.get_or_set("idem-key", "identity-a", compute)
+
+        assert first == first_replay == "response-1"
+        assert second == "response-2"
+        assert calls == 2
+
+    @pytest.mark.asyncio
     async def test_concurrent_same_key_and_fingerprint_runs_once(self):
         cache = _IdempotencyCache()
         gate = asyncio.Event()
@@ -2380,6 +2398,113 @@ class TestSessionKeyHeader:
     gateway's session_key / session_id split.
     """
 
+    @pytest.mark.asyncio
+    async def test_session_key_passed_to_agent_and_echoed(self, auth_adapter):
+        """X-Hermes-Session-Key reaches _run_agent as gateway_session_key and is echoed back."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "X-Hermes-Session-Key": "webui:user-42",
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert resp.headers.get("X-Hermes-Session-Key") == "webui:user-42"
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["gateway_session_key"] == "webui:user-42"
+
+    @pytest.mark.asyncio
+    async def test_session_key_independent_of_session_id(self, auth_adapter):
+        """Both headers coexist: key scopes memory, id scopes transcript."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = []
+        auth_adapter._session_db = mock_db
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "X-Hermes-Session-Key": "channel-abc",
+                        "X-Hermes-Session-Id": "transcript-xyz",
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert resp.headers.get("X-Hermes-Session-Key") == "channel-abc"
+            assert resp.headers.get("X-Hermes-Session-Id") == "transcript-xyz"
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["gateway_session_key"] == "channel-abc"
+            assert call_kwargs["session_id"] == "transcript-xyz"
+
+    @pytest.mark.asyncio
+    async def test_session_key_absent_yields_none(self, auth_adapter):
+        """Omitting the header passes gateway_session_key=None and doesn't echo."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert "X-Hermes-Session-Key" not in resp.headers
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["gateway_session_key"] is None
+
+    @pytest.mark.asyncio
+    async def test_session_key_rejected_without_api_key(self, adapter):
+        """Without API_SERVER_KEY, accepting a caller-supplied memory scope is unsafe — reject with 403."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Session-Key": "whatever"},
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_session_key_rejects_control_chars(self, auth_adapter):
+        """Header injection via \\r\\n must be rejected by the server-side validator.
+
+        Note: aiohttp client refuses to SEND a header containing CR/LF
+        (that check fires before the request leaves the client), so we
+        can't reach this code path through TestClient.  Test the helper
+        directly instead with a raw request that bypasses client-side
+        validation.
+        """
+        mock_request = MagicMock()
+        mock_request.headers = {"X-Hermes-Session-Key": "bad\rvalue"}
+        key, source, err = auth_adapter._parse_session_key_header(mock_request)
+        assert key is None
+        assert source is None
+        assert err is not None
+        assert err.status == 400
+
+    @pytest.mark.asyncio
+    async def test_session_key_rejects_oversized(self, auth_adapter):
+        """Session keys longer than the cap are rejected."""
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Session-Key": "x" * 1000, "Authorization": "Bearer sk-secret"},
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert resp.status == 400
 
     @pytest.mark.asyncio
     async def test_session_key_threads_into_create_agent(self, auth_adapter):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -122,6 +122,24 @@ class TestResponseStore:
 
 class TestIdempotencyCache:
     @pytest.mark.asyncio
+    async def test_completed_entries_are_partitioned_by_fingerprint(self):
+        cache = _IdempotencyCache()
+        calls = 0
+
+        async def compute():
+            nonlocal calls
+            calls += 1
+            return f"response-{calls}"
+
+        first = await cache.get_or_set("idem-key", "identity-a", compute)
+        second = await cache.get_or_set("idem-key", "identity-b", compute)
+        first_replay = await cache.get_or_set("idem-key", "identity-a", compute)
+
+        assert first == first_replay == "response-1"
+        assert second == "response-2"
+        assert calls == 2
+
+    @pytest.mark.asyncio
     async def test_concurrent_same_key_and_fingerprint_runs_once(self):
         cache = _IdempotencyCache()
         gate = asyncio.Event()
@@ -2371,6 +2389,113 @@ class TestSessionKeyHeader:
     gateway's session_key / session_id split.
     """
 
+    @pytest.mark.asyncio
+    async def test_session_key_passed_to_agent_and_echoed(self, auth_adapter):
+        """X-Hermes-Session-Key reaches _run_agent as gateway_session_key and is echoed back."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "X-Hermes-Session-Key": "webui:user-42",
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert resp.headers.get("X-Hermes-Session-Key") == "webui:user-42"
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["gateway_session_key"] == "webui:user-42"
+
+    @pytest.mark.asyncio
+    async def test_session_key_independent_of_session_id(self, auth_adapter):
+        """Both headers coexist: key scopes memory, id scopes transcript."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = []
+        auth_adapter._session_db = mock_db
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "X-Hermes-Session-Key": "channel-abc",
+                        "X-Hermes-Session-Id": "transcript-xyz",
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert resp.headers.get("X-Hermes-Session-Key") == "channel-abc"
+            assert resp.headers.get("X-Hermes-Session-Id") == "transcript-xyz"
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["gateway_session_key"] == "channel-abc"
+            assert call_kwargs["session_id"] == "transcript-xyz"
+
+    @pytest.mark.asyncio
+    async def test_session_key_absent_yields_none(self, auth_adapter):
+        """Omitting the header passes gateway_session_key=None and doesn't echo."""
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert "X-Hermes-Session-Key" not in resp.headers
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["gateway_session_key"] is None
+
+    @pytest.mark.asyncio
+    async def test_session_key_rejected_without_api_key(self, adapter):
+        """Without API_SERVER_KEY, accepting a caller-supplied memory scope is unsafe — reject with 403."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Session-Key": "whatever"},
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_session_key_rejects_control_chars(self, auth_adapter):
+        """Header injection via \\r\\n must be rejected by the server-side validator.
+
+        Note: aiohttp client refuses to SEND a header containing CR/LF
+        (that check fires before the request leaves the client), so we
+        can't reach this code path through TestClient.  Test the helper
+        directly instead with a raw request that bypasses client-side
+        validation.
+        """
+        mock_request = MagicMock()
+        mock_request.headers = {"X-Hermes-Session-Key": "bad\rvalue"}
+        key, source, err = auth_adapter._parse_session_key_header(mock_request)
+        assert key is None
+        assert source is None
+        assert err is not None
+        assert err.status == 400
+
+    @pytest.mark.asyncio
+    async def test_session_key_rejects_oversized(self, auth_adapter):
+        """Session keys longer than the cap are rejected."""
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Session-Key": "x" * 1000, "Authorization": "Bearer sk-secret"},
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert resp.status == 400
 
     @pytest.mark.asyncio
     async def test_session_key_threads_into_create_agent(self, auth_adapter):

--- a/tests/gateway/test_api_session_aliases.py
+++ b/tests/gateway/test_api_session_aliases.py
@@ -1,0 +1,844 @@
+"""Integration coverage for configured API session-key aliases."""
+
+import asyncio
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms import api_server as api_server_module
+from gateway.platforms.api_server import APIServerAdapter
+from gateway.session import SessionSource, build_session_key
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def alias_adapter(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        """gateway:
+  session_key_aliases:
+    mobile-telegram:
+      platform: telegram
+      chat_id: configured-chat
+      chat_type: dm
+      thread_id: configured-thread
+      user_id: configured-user
+    desktop-discord:
+      platform: discord
+      chat_id: discord-channel
+      chat_type: group
+      thread_id: discord-thread
+    recursive:
+      platform: webhook
+      chat_id: not-native
+    unsupported-profile:
+      platform: telegram
+      chat_id: configured-chat
+      profile: work
+    unsupported-scope-a:
+      platform: slack
+      chat_id: C123
+      chat_type: group
+      scope_id: T-A
+    unsupported-scope-b:
+      platform: slack
+      chat_id: C123
+      chat_type: group
+      scope_id: T-B
+""",
+        encoding="utf-8",
+    )
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("session-one", "api_server")
+    adapter = APIServerAdapter(
+        PlatformConfig(enabled=True, extra={"key": "sk-test"})
+    )
+    adapter._session_db = db
+    try:
+        yield adapter
+    finally:
+        close = getattr(db, "close", None)
+        if callable(close):
+            close()
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_post(
+        "/api/sessions/{session_id}/chat", adapter._handle_session_chat
+    )
+    app.router.add_post(
+        "/api/sessions/{session_id}/chat/stream",
+        adapter._handle_session_chat_stream,
+    )
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post("/v1/responses", adapter._handle_responses)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    return app
+
+
+def _expected_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="configured-chat",
+        chat_type="dm",
+        thread_id="configured-thread",
+        user_id="configured-user",
+    )
+
+
+def test_alias_binding_propagates_group_chat_type_and_clears_it():
+    from gateway.session_context import clear_session_vars, get_session_env
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="configured-group",
+        chat_type="group",
+        thread_id="configured-topic",
+        user_id="configured-user",
+    )
+    tokens = APIServerAdapter._bind_api_server_session(
+        source=source,
+        session_key=build_session_key(source),
+        session_id="group-session",
+    )
+    try:
+        assert get_session_env("HERMES_SESSION_CHAT_TYPE") == "group"
+    finally:
+        clear_session_vars(tokens)
+
+    assert get_session_env("HERMES_SESSION_CHAT_TYPE") == ""
+
+
+def _patch_agent_runtime(monkeypatch, captured):
+    class FakeAgent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+        session_id = "agent-session"
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def run_conversation(self, **_kwargs):
+            from gateway.session_context import get_session_env
+            from tools.approval import get_current_session_key
+
+            captured["runtime_session_key"] = get_session_env("HERMES_SESSION_KEY")
+            captured["approval_session_key"] = get_current_session_key()
+            captured["platform"] = get_session_env("HERMES_SESSION_PLATFORM")
+            captured["chat_id"] = get_session_env("HERMES_SESSION_CHAT_ID")
+            captured["chat_type"] = get_session_env("HERMES_SESSION_CHAT_TYPE")
+            captured["thread_id"] = get_session_env("HERMES_SESSION_THREAD_ID")
+            captured["user_id"] = get_session_env("HERMES_SESSION_USER_ID")
+            stream_delta_callback = captured.get("stream_delta_callback")
+            if stream_delta_callback is not None:
+                stream_delta_callback("ok")
+            return {"final_response": "ok", "completed": True}
+
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+    monkeypatch.setattr(
+        "gateway.run._resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_key": "«redacted:sk-…»",
+            "base_url": "https://example.invalid/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "test/model")
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_reasoning_config",
+        staticmethod(lambda model="": {}),
+    )
+    monkeypatch.setattr(
+        "gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None)
+    )
+    monkeypatch.setattr("gateway.run._current_max_iterations", lambda: 90)
+
+
+@pytest.mark.asyncio
+async def test_configured_alias_reaches_all_run_agent_http_surfaces(alias_adapter):
+    expected_source = _expected_source()
+    expected_key = build_session_key(expected_source)
+    run_agent = AsyncMock(
+        return_value=(
+            {"final_response": "ok", "completed": True, "session_id": "session-one"},
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+    )
+    alias_adapter._run_agent = run_agent
+    headers = {
+        "Authorization": "Bearer sk-test",
+        "X-Hermes-Session-Key": "mobile-telegram",
+    }
+    cases = [
+        ("/api/sessions/session-one/chat", {"message": "hello"}),
+        ("/api/sessions/session-one/chat/stream", {"message": "hello"}),
+        (
+            "/v1/chat/completions",
+            {
+                "model": "test",
+                "messages": [{"role": "user", "content": "hello"}],
+                "platform": "discord",
+                "chat_id": "attacker-selected-chat",
+                "profile": "attacker-selected-profile",
+            },
+        ),
+        ("/v1/responses", {"model": "test", "input": "hello"}),
+    ]
+
+    async with TestClient(TestServer(_create_app(alias_adapter))) as client:
+        for path, payload in cases:
+            run_agent.reset_mock()
+            response = await client.post(path, json=payload, headers=headers)
+            assert response.status == 200
+            await response.read()
+            run_agent.assert_awaited_once()
+            assert run_agent.await_args is not None
+            kwargs = run_agent.await_args.kwargs
+            assert kwargs["gateway_session_key"] == expected_key
+            assert kwargs["session_source"] == expected_source
+
+
+@pytest.mark.asyncio
+async def test_chat_idempotency_is_partitioned_by_resolved_alias_identity(
+    alias_adapter, monkeypatch
+):
+    monkeypatch.setattr(
+        api_server_module,
+        "_idem_cache",
+        api_server_module._IdempotencyCache(),
+    )
+    calls = []
+
+    async def run_agent(**kwargs):
+        source = kwargs["session_source"]
+        calls.append(kwargs["gateway_session_key"])
+        return (
+            {
+                "final_response": source.platform.value,
+                "completed": True,
+                "session_id": "session-one",
+            },
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+
+    alias_adapter._run_agent = AsyncMock(side_effect=run_agent)
+    payload = {
+        "model": "test",
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    base_headers = {
+        "Authorization": "Bearer sk-test",
+        "Idempotency-Key": "shared-idempotency-key",
+    }
+
+    async with TestClient(TestServer(_create_app(alias_adapter))) as client:
+        mobile = await client.post(
+            "/v1/chat/completions",
+            json=payload,
+            headers={**base_headers, "X-Hermes-Session-Key": "mobile-telegram"},
+        )
+        desktop = await client.post(
+            "/v1/chat/completions",
+            json=payload,
+            headers={**base_headers, "X-Hermes-Session-Key": "desktop-discord"},
+        )
+        mobile_replay = await client.post(
+            "/v1/chat/completions",
+            json=payload,
+            headers={**base_headers, "X-Hermes-Session-Key": "mobile-telegram"},
+        )
+
+        assert mobile.status == desktop.status == mobile_replay.status == 200
+        mobile_data = await mobile.json()
+        desktop_data = await desktop.json()
+        replay_data = await mobile_replay.json()
+
+    assert mobile_data["choices"][0]["message"]["content"] == "telegram"
+    assert desktop_data["choices"][0]["message"]["content"] == "discord"
+    assert replay_data["choices"][0]["message"]["content"] == "telegram"
+    assert calls == [
+        build_session_key(_expected_source()),
+        build_session_key(
+            SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="discord-channel",
+                chat_type="group",
+                thread_id="discord-thread",
+            )
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_responses_idempotency_is_partitioned_by_resolved_alias_identity(
+    alias_adapter, monkeypatch
+):
+    monkeypatch.setattr(
+        api_server_module,
+        "_idem_cache",
+        api_server_module._IdempotencyCache(),
+    )
+    calls = []
+
+    async def run_agent(**kwargs):
+        source = kwargs["session_source"]
+        calls.append(kwargs["gateway_session_key"])
+        text = source.platform.value
+        return (
+            {
+                "final_response": text,
+                "completed": True,
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": text},
+                ],
+            },
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+
+    alias_adapter._run_agent = AsyncMock(side_effect=run_agent)
+    payload = {"model": "test", "input": "hello"}
+    base_headers = {
+        "Authorization": "Bearer sk-test",
+        "Idempotency-Key": "shared-idempotency-key",
+    }
+
+    async with TestClient(TestServer(_create_app(alias_adapter))) as client:
+        mobile = await client.post(
+            "/v1/responses",
+            json=payload,
+            headers={**base_headers, "X-Hermes-Session-Key": "mobile-telegram"},
+        )
+        desktop = await client.post(
+            "/v1/responses",
+            json=payload,
+            headers={**base_headers, "X-Hermes-Session-Key": "desktop-discord"},
+        )
+        mobile_replay = await client.post(
+            "/v1/responses",
+            json=payload,
+            headers={**base_headers, "X-Hermes-Session-Key": "mobile-telegram"},
+        )
+
+        assert mobile.status == desktop.status == mobile_replay.status == 200
+        mobile_data = await mobile.json()
+        desktop_data = await desktop.json()
+        replay_data = await mobile_replay.json()
+
+    def output_text(data):
+        return data["output"][0]["content"][0]["text"]
+
+    assert output_text(mobile_data) == "telegram"
+    assert output_text(desktop_data) == "discord"
+    assert output_text(replay_data) == "telegram"
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_configured_alias_reaches_runs_agent_construction(alias_adapter):
+    expected_source = _expected_source()
+    expected_key = build_session_key(expected_source)
+
+    class FakeAgent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+        session_id = "run-session"
+
+        def run_conversation(self, **_kwargs):
+            return {"final_response": "ok", "completed": True}
+
+    create_agent = MagicMock(return_value=FakeAgent())
+    alias_adapter._create_agent = create_agent
+    headers = {
+        "Authorization": "Bearer sk-test",
+        "X-Hermes-Session-Key": "mobile-telegram",
+    }
+
+    async with TestClient(TestServer(_create_app(alias_adapter))) as client:
+        response = await client.post(
+            "/v1/runs", json={"input": "hello"}, headers=headers
+        )
+        assert response.status == 202
+        await response.read()
+        tasks = list(alias_adapter._background_tasks)
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    create_agent.assert_called_once()
+    kwargs = create_agent.call_args.kwargs
+    assert kwargs["gateway_session_key"] == expected_key
+    assert kwargs["session_source"] == expected_source
+
+
+@pytest.mark.asyncio
+async def test_runs_alias_injects_native_context_and_preserves_instructions(
+    alias_adapter, monkeypatch
+):
+    captured = {}
+    _patch_agent_runtime(monkeypatch, captured)
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools", lambda _config, _platform: set()
+    )
+    headers = {
+        "Authorization": "Bearer sk-test",
+        "X-Hermes-Session-Key": "mobile-telegram",
+    }
+
+    async with TestClient(TestServer(_create_app(alias_adapter))) as client:
+        response = await client.post(
+            "/v1/runs",
+            json={"input": "hello", "instructions": "Keep this caller instruction."},
+            headers=headers,
+        )
+        assert response.status == 202
+        await response.read()
+        tasks = list(alias_adapter._background_tasks)
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    prompt = captured["ephemeral_system_prompt"]
+    assert "## Current Session Context" in prompt
+    assert "Telegram" in prompt
+    assert "configured-chat" in prompt
+    assert "configured-thread" in prompt
+    assert prompt.endswith("Keep this caller instruction.")
+    canonical_key = build_session_key(_expected_source())
+    assert captured["runtime_session_key"] == canonical_key
+    assert captured["approval_session_key"]
+    assert captured["approval_session_key"] != canonical_key
+    assert captured["chat_type"] == "dm"
+
+
+@pytest.mark.asyncio
+async def test_named_profile_alias_uses_scoped_config_and_native_key_policy(
+    alias_adapter, monkeypatch
+):
+    default_config = GatewayConfig(
+        multiplex_profiles=True,
+        session_key_aliases={
+            "shared-alias": {
+                "platform": "telegram",
+                "chat_id": "default-chat",
+                "chat_type": "dm",
+            }
+        },
+    )
+    coder_config = GatewayConfig(
+        multiplex_profiles=True,
+        group_sessions_per_user=False,
+        session_key_aliases={
+            "shared-alias": {
+                "platform": "telegram",
+                "chat_id": "coder-group",
+                "chat_type": "group",
+                "user_id": "coder-user",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        api_server_module,
+        "load_gateway_config",
+        lambda: (
+            coder_config
+            if api_server_module._api_request_profile.get() == "coder"
+            else default_config
+        ),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex: [("default", None), ("coder", None)],
+    )
+    monkeypatch.setattr(
+        alias_adapter, "_profile_scope", lambda _profile: nullcontext()
+    )
+    monkeypatch.setattr(alias_adapter, "_expected_api_key", lambda: "sk-test")
+    alias_adapter.gateway_runner = SimpleNamespace(config=default_config)
+    alias_adapter._run_agent = AsyncMock(
+        return_value=({"final_response": "ok", "completed": True}, {})
+    )
+
+    app = web.Application(
+        middlewares=[alias_adapter._make_profile_prefix_middleware()]
+    )
+    app.router.add_post(
+        "/p/{profile}/v1/responses", alias_adapter._handle_responses
+    )
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            "/p/coder/v1/responses",
+            headers={
+                "Authorization": "Bearer sk-test",
+                "X-Hermes-Session-Key": "shared-alias",
+            },
+            json={"model": "hermes", "input": "hello"},
+        )
+
+    assert response.status == 200
+    assert alias_adapter._run_agent.await_args is not None
+    kwargs = alias_adapter._run_agent.await_args.kwargs
+    expected_source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="coder-group",
+        chat_type="group",
+        user_id="coder-user",
+        profile="coder",
+    )
+    assert kwargs["session_source"] == expected_source
+    assert kwargs["gateway_session_key"] == build_session_key(
+        expected_source,
+        group_sessions_per_user=False,
+        thread_sessions_per_user=False,
+        profile="coder",
+    )
+
+
+@pytest.mark.asyncio
+async def test_idempotency_is_partitioned_by_active_request_profile(
+    alias_adapter, monkeypatch
+):
+    default_config = GatewayConfig(
+        multiplex_profiles=True,
+        session_key_aliases={
+            "shared-alias": {
+                "platform": "telegram",
+                "chat_id": "default-chat",
+                "chat_type": "dm",
+            }
+        },
+    )
+    coder_config = GatewayConfig(
+        multiplex_profiles=True,
+        session_key_aliases={
+            "shared-alias": {
+                "platform": "telegram",
+                "chat_id": "coder-chat",
+                "chat_type": "dm",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        api_server_module,
+        "load_gateway_config",
+        lambda: (
+            coder_config
+            if api_server_module._api_request_profile.get() == "coder"
+            else default_config
+        ),
+    )
+    monkeypatch.setattr(
+        api_server_module,
+        "_idem_cache",
+        api_server_module._IdempotencyCache(),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex: [("default", None), ("coder", None)],
+    )
+    monkeypatch.setattr(alias_adapter, "_profile_scope", lambda _profile: nullcontext())
+    monkeypatch.setattr(alias_adapter, "_expected_api_key", lambda: "sk-test")
+    alias_adapter.gateway_runner = SimpleNamespace(config=default_config)
+    calls = []
+
+    async def run_agent(**kwargs):
+        calls.append(kwargs["gateway_session_key"])
+        return (
+            {"final_response": kwargs["session_source"].chat_id, "completed": True},
+            {},
+        )
+
+    alias_adapter._run_agent = AsyncMock(side_effect=run_agent)
+    app = web.Application(middlewares=[alias_adapter._make_profile_prefix_middleware()])
+    app.router.add_post("/p/{profile}/v1/responses", alias_adapter._handle_responses)
+    headers = {
+        "Authorization": "Bearer sk-test",
+        "X-Hermes-Session-Key": "shared-alias",
+        "Idempotency-Key": "same-profile-idempotency-key",
+    }
+    payload = {"model": "hermes", "input": "hello"}
+
+    async with TestClient(TestServer(app)) as client:
+        default = await client.post(
+            "/p/default/v1/responses", headers=headers, json=payload
+        )
+        coder = await client.post(
+            "/p/coder/v1/responses", headers=headers, json=payload
+        )
+        default_replay = await client.post(
+            "/p/default/v1/responses", headers=headers, json=payload
+        )
+
+        assert default.status == coder.status == default_replay.status == 200
+
+    assert len(calls) == 2
+    assert calls[0] != calls[1]
+
+
+@pytest.mark.asyncio
+async def test_discord_alias_uses_canonical_source(alias_adapter):
+    run_agent = AsyncMock(
+        return_value=(
+            {"final_response": "ok", "completed": True},
+            {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        )
+    )
+    alias_adapter._run_agent = run_agent
+    discord_source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="discord-channel",
+        chat_type="group",
+        thread_id="discord-thread",
+    )
+
+    async with TestClient(TestServer(_create_app(alias_adapter))) as client:
+        response = await client.post(
+            "/v1/responses",
+            json={"input": "hello"},
+            headers={
+                "Authorization": "Bearer sk-test",
+                "X-Hermes-Session-Key": "desktop-discord",
+            },
+        )
+        assert response.status == 200
+        await response.read()
+
+    assert run_agent.await_args is not None
+    kwargs = run_agent.await_args.kwargs
+    assert kwargs["session_source"] == discord_source
+    assert kwargs["gateway_session_key"] == build_session_key(discord_source)
+
+
+@pytest.mark.asyncio
+async def test_profile_and_scope_aliases_fail_closed(alias_adapter):
+    alias_adapter._run_agent = AsyncMock()
+    headers = {"Authorization": "Bearer sk-test"}
+
+    async with TestClient(TestServer(_create_app(alias_adapter))) as client:
+        for alias in ("unsupported-profile", "unsupported-scope-a", "unsupported-scope-b"):
+            response = await client.post(
+                "/v1/responses",
+                json={"input": "hello"},
+                headers={**headers, "X-Hermes-Session-Key": alias},
+            )
+            assert response.status == 400
+            payload = await response.json()
+            assert payload["error"]["code"] == "invalid_session_alias"
+
+    alias_adapter._run_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_key_stays_api_server_and_invalid_alias_fails_closed(alias_adapter):
+    run_agent = AsyncMock(
+        return_value=(
+            {"final_response": "ok", "completed": True},
+            {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        )
+    )
+    alias_adapter._run_agent = run_agent
+    app = _create_app(alias_adapter)
+
+    async with TestClient(TestServer(app)) as client:
+        unknown = await client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hello"}]},
+            headers={
+                "Authorization": "Bearer sk-test",
+                "X-Hermes-Session-Key": "unconfigured-client-key",
+            },
+        )
+        assert unknown.status == 200
+        assert run_agent.await_args is not None
+        kwargs = run_agent.await_args.kwargs
+        assert kwargs["gateway_session_key"] == "unconfigured-client-key"
+        assert kwargs["session_source"] is None
+
+        invalid = await client.post(
+            "/v1/responses",
+            json={"input": "hello"},
+            headers={
+                "Authorization": "Bearer sk-test",
+                "X-Hermes-Session-Key": "recursive",
+            },
+        )
+        assert invalid.status == 400
+        payload = await invalid.json()
+        assert payload["error"]["code"] == "invalid_session_alias"
+
+
+@pytest.mark.asyncio
+async def test_configured_alias_is_rejected_when_api_auth_is_disabled(
+    alias_adapter,
+):
+    unauthenticated_adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    unauthenticated_adapter._session_db = alias_adapter._session_db
+    run_agent = AsyncMock()
+    setattr(unauthenticated_adapter, "_run_agent", run_agent)
+
+    async with TestClient(
+        TestServer(_create_app(unauthenticated_adapter))
+    ) as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hello"}]},
+            headers={"X-Hermes-Session-Key": "mobile-telegram"},
+        )
+
+    assert response.status == 403
+    run_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streaming_routes_bind_native_identity_and_clear_it_afterward(
+    alias_adapter, monkeypatch
+):
+    headers = {
+        "Authorization": "Bearer sk-test",
+        "X-Hermes-Session-Key": "mobile-telegram",
+    }
+    expected_key = build_session_key(_expected_source())
+    chat_capture = {}
+    responses_capture = {}
+    unconfigured_capture = {}
+
+    async with TestClient(TestServer(_create_app(alias_adapter))) as client:
+        _patch_agent_runtime(monkeypatch, chat_capture)
+        chat = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": True,
+            },
+            headers=headers,
+        )
+        assert chat.status == 200
+        assert "[DONE]" in await chat.text()
+
+        _patch_agent_runtime(monkeypatch, responses_capture)
+        responses = await client.post(
+            "/v1/responses",
+            json={"model": "test", "input": "hello", "stream": True},
+            headers=headers,
+        )
+        assert responses.status == 200
+        assert "response.completed" in await responses.text()
+
+        _patch_agent_runtime(monkeypatch, unconfigured_capture)
+        unconfigured = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": True,
+            },
+            headers={
+                "Authorization": "Bearer sk-test",
+                "X-Hermes-Session-Key": "unconfigured-client-key",
+            },
+        )
+        assert unconfigured.status == 200
+        assert "[DONE]" in await unconfigured.text()
+
+    assert chat_capture["runtime_session_key"] == expected_key
+    assert responses_capture["runtime_session_key"] == expected_key
+    assert chat_capture["platform"] == responses_capture["platform"] == "telegram"
+    assert chat_capture["chat_type"] == responses_capture["chat_type"] == "dm"
+    assert unconfigured_capture["runtime_session_key"] == "unconfigured-client-key"
+    assert unconfigured_capture["platform"] == "api_server"
+    assert unconfigured_capture["chat_type"] == ""
+    assert unconfigured_capture["chat_id"].startswith("api-")
+    assert unconfigured_capture["chat_id"] != "configured-chat"
+    assert unconfigured_capture["thread_id"] == ""
+    assert unconfigured_capture["user_id"] == ""
+
+
+@pytest.mark.asyncio
+async def test_native_alias_binds_platform_toolset_and_context(alias_adapter, monkeypatch):
+    expected_source = _expected_source()
+    expected_key = build_session_key(expected_source)
+    observed = {}
+
+    class FakeAgent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+        session_id = "agent-session"
+
+        def run_conversation(self, **_kwargs):
+            from gateway.session_context import get_session_env
+
+            observed["platform"] = get_session_env("HERMES_SESSION_PLATFORM")
+            observed["chat_id"] = get_session_env("HERMES_SESSION_CHAT_ID")
+            observed["chat_type"] = get_session_env("HERMES_SESSION_CHAT_TYPE")
+            observed["thread_id"] = get_session_env("HERMES_SESSION_THREAD_ID")
+            observed["user_id"] = get_session_env("HERMES_SESSION_USER_ID")
+            observed["profile"] = get_session_env("HERMES_SESSION_PROFILE")
+            observed["session_key"] = get_session_env("HERMES_SESSION_KEY")
+            return {"final_response": "ok", "completed": True}
+
+    def fake_create_agent(**kwargs):
+        observed["create_kwargs"] = kwargs
+        return FakeAgent()
+
+    monkeypatch.setattr(alias_adapter, "_create_agent", fake_create_agent)
+    result, _usage = await alias_adapter._run_agent(
+        user_message="hello",
+        conversation_history=[],
+        session_id="agent-session",
+        gateway_session_key=expected_key,
+        session_source=expected_source,
+    )
+
+    assert result["final_response"] == "ok"
+    assert observed["platform"] == "telegram"
+    assert observed["chat_id"] == "configured-chat"
+    assert observed["chat_type"] == "dm"
+    assert observed["thread_id"] == "configured-thread"
+    assert observed["user_id"] == "configured-user"
+    assert observed["profile"] == ""
+    assert observed["session_key"] == expected_key
+    assert observed["create_kwargs"]["session_source"] == expected_source
+
+
+def test_native_alias_selects_native_agent_platform_toolset_and_prompt(
+    alias_adapter, monkeypatch
+):
+    captured = {}
+    _patch_agent_runtime(monkeypatch, captured)
+    selected_platforms = []
+
+    def fake_platform_tools(_config, platform):
+        selected_platforms.append(platform)
+        return {f"toolset-{platform}"}
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools", fake_platform_tools
+    )
+    source = _expected_source()
+    canonical_key = build_session_key(source, profile=source.profile)
+
+    alias_adapter._create_agent(
+        ephemeral_system_prompt="Keep this caller instruction.",
+        gateway_session_key=canonical_key,
+        session_source=source,
+    )
+
+    assert selected_platforms == ["telegram"]
+    assert captured["enabled_toolsets"] == ["toolset-telegram"]
+    assert captured["platform"] == "telegram"
+    assert captured["gateway_session_key"] == canonical_key
+    prompt = captured["ephemeral_system_prompt"]
+    assert "## Current Session Context" in prompt
+    assert "configured-chat" in prompt
+    assert "configured-thread" in prompt
+    assert prompt.endswith("Keep this caller instruction.")

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -398,6 +398,7 @@ class TestLoadGatewayConfig:
         assert config.multiplex_profiles is True
 
     def test_multiplex_allowlist_from_nested_gateway_section(self, tmp_path, monkeypatch):
+    def test_session_key_aliases_from_nested_gateway_section(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         (hermes_home / "config.yaml").write_text(
@@ -407,6 +408,10 @@ class TestLoadGatewayConfig:
             "    - Worker\n"
             "    - worker\n"
             "    - guest\n",
+            "  session_key_aliases:\n"
+            "    mobile:\n"
+            "      platform: telegram\n"
+            "      chat_id: '12345'\n",
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
@@ -415,6 +420,9 @@ class TestLoadGatewayConfig:
 
         assert config.multiplex_profiles is True
         assert config.multiplex_profile_allowlist == ["worker", "guest"]
+        assert config.session_key_aliases == {
+            "mobile": {"platform": "telegram", "chat_id": "12345"}
+        }
 
     def test_discord_websocket_health_settings_seed_platform_extra(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -397,6 +397,25 @@ class TestLoadGatewayConfig:
 
         assert config.multiplex_profiles is True
 
+    def test_session_key_aliases_from_nested_gateway_section(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "gateway:\n"
+            "  session_key_aliases:\n"
+            "    mobile:\n"
+            "      platform: telegram\n"
+            "      chat_id: '12345'\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.session_key_aliases == {
+            "mobile": {"platform": "telegram", "chat_id": "12345"}
+        }
+
     def test_discord_websocket_health_settings_seed_platform_extra(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -501,6 +501,26 @@ X-Hermes-Session-Key: agent:main:webui:dm:user-42
 
 Rules: max 256 chars, control characters (`\r`, `\n`, `\x00`) are rejected, and the value is echoed back on responses (JSON + SSE). `/v1/capabilities` advertises support via `"session_key_header": "X-Hermes-Session-Key"`. Without the key, Honcho's `per-session` strategy produces a different scope per `session_id` — exactly the behavior Hermes had before.
 
+### Configured native session aliases
+
+An operator can map an authenticated API session key to an existing native conversation identity:
+
+```yaml
+gateway:
+  session_key_aliases:
+    mobile-telegram:
+      platform: telegram
+      chat_id: "12345"
+      chat_type: dm
+      thread_id: "42" # optional topic/thread
+```
+
+A request with `X-Hermes-Session-Key: mobile-telegram` then uses the canonical session key, platform toolset, and chat/thread context built by the existing gateway session machinery. Alias values may also set `user_id` and `parent_chat_id`.
+
+Aliases are scoped to the currently running Hermes profile. `profile` and `scope_id` alias fields are rejected with `400 invalid_session_alias` until API turns can enter the native profile runtime scope and canonical session keys can represent workspace scope without collisions.
+
+Aliases are operator-controlled configuration, not request fields. Unknown session keys retain normal API-server behavior. The identity seam applies consistently to session chat, session chat streaming, Chat Completions, Responses, and Runs. It does not send the API response to the native platform.
+
 ## System Prompt Handling
 
 When a frontend sends a `system` message (Chat Completions) or `instructions` field (Responses API), hermes-agent **layers it on top** of its core system prompt. Your agent keeps all its tools, memory, and skills — the frontend's system prompt adds extra instructions.

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -499,6 +499,26 @@ X-Hermes-Session-Key: agent:main:webui:dm:user-42
 
 Rules: max 256 chars, control characters (`\r`, `\n`, `\x00`) are rejected, and the value is echoed back on responses (JSON + SSE). `/v1/capabilities` advertises support via `"session_key_header": "X-Hermes-Session-Key"`. Without the key, Honcho's `per-session` strategy produces a different scope per `session_id` — exactly the behavior Hermes had before.
 
+### Configured native session aliases
+
+An operator can map an authenticated API session key to an existing native conversation identity:
+
+```yaml
+gateway:
+  session_key_aliases:
+    mobile-telegram:
+      platform: telegram
+      chat_id: "12345"
+      chat_type: dm
+      thread_id: "42" # optional topic/thread
+```
+
+A request with `X-Hermes-Session-Key: mobile-telegram` then uses the canonical session key, platform toolset, and chat/thread context built by the existing gateway session machinery. Alias values may also set `user_id` and `parent_chat_id`.
+
+Aliases are scoped to the currently running Hermes profile. `profile` and `scope_id` alias fields are rejected with `400 invalid_session_alias` until API turns can enter the native profile runtime scope and canonical session keys can represent workspace scope without collisions.
+
+Aliases are operator-controlled configuration, not request fields. Unknown session keys retain normal API-server behavior. The identity seam applies consistently to session chat, session chat streaming, Chat Completions, Responses, and Runs. It does not send the API response to the native platform.
+
 ## System Prompt Handling
 
 When a frontend sends a `system` message (Chat Completions) or `instructions` field (Responses API), hermes-agent **layers it on top** of its core system prompt. Your agent keeps all its tools, memory, and skills — the frontend's system prompt adds extra instructions.


### PR DESCRIPTION
## Summary

Resolve configured API session-key aliases into canonical native-platform identities before agent construction.

This lets API-originated turns use the same platform identity, toolset selection, prompt context, and session namespace as the configured Telegram or Discord destination without trusting caller-supplied routing fields.

## Behavior

- Loads `gateway.session_key_aliases` from the real `config.yaml` gateway section.
- Resolves aliases request-locally with no shared mutable identity cache.
- Threads canonical identity through all five API turn surfaces:
  - session chat
  - session chat stream
  - Chat Completions
  - Responses
  - Runs
- Uses the canonical native platform for toolset and prompt-context selection.
- Keeps unknown keys on existing API-server behavior.
- Rejects configured aliases that resolve to recursive or unsupported destinations.
- Rejects `profile` aliases until API turns can enter the native profile runtime scope.
- Rejects `scope_id` aliases until canonical session keys represent workspace scope without collisions.
- Ignores caller-supplied platform, chat, and profile fields for canonical routing.

Aliases are scoped to the currently running Hermes profile. Stable session-ID overrides are intentionally not added because current API session semantics do not provide a safe, consistent override contract across these surfaces.

## Tests

Current-main identity/API/config matrix: **177 passed** after independent security review. The review's final blocker—missing `chat_type` in API-bound native session context—was repaired at the shared binding seam and covered for direct group context, `/v1/runs`, streaming aliases, and ordinary API defaults.

Coverage includes:

- Telegram and Discord aliases
- all five API surfaces
- authenticated fail-closed handling for profile and scoped-platform aliases
- spoof resistance
- toolset and prompt-context selection
- malformed aliases
- default compatibility

Also verified with Ruff, compileall, `git diff --check`, committed-tree checks, and exact-SHA re-review. Fresh required CI is green on the published head.

