### PR TITLE
fix(docs): disable fuzzy matching in docs search (exact word or prefix only)

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -62,6 +62,14 @@ const config: Config = {
           /^user-guide\/skills\/bundled\//,
           /^user-guide\/skills\/optional\//,
         ],
+        // Exact-or-prefix matching only (default is edit distance 1).
+        // With fuzzy distance 1, "keet" matched "meetings"/"keep" (one
+        // edit away after stemming), and multi-word typo queries against
+        // our ~14 MB index could stall the single-threaded search worker
+        // for 25s+, backing up every subsequent keystroke's search until
+        // the bar appeared dead. Distance 0 keeps "word or its extension"
+        // semantics (keet -> keet*) and removes the pathological scans.
+        fuzzyMatchingDistance: 0,
       }),
     ],
   ],


### PR DESCRIPTION
## Summary

Docs search now matches the exact word or its extension only (`keet` → `keet*`) — fuzzy edit-distance matching is disabled, which also removes the query explosion that could stall the search worker until the bar appeared dead.

Root cause: `@easyops-cn/docusaurus-search-local` defaults `fuzzyMatchingDistance: 1`, so every term also matched words one edit away.

Fixes two community reports:
1. **Wrong results** — searching `keet` returned "Microsoft Teams Meetings", "google_meet", "Keep the Model Loaded": `meet` and `keep` are one edit from `keet`, and the stemmer indexes "meetings" as "meet".
2. **Search stops functioning after a bit** — fuzzy matching multiplies the generated lunr queries (distance matrix × maybe-typing variants × leave-one-out terms; up to 210 queries per keystroke on multi-word input) and fuzzy `REQUIRED` terms are the expensive scan kind against our 14.4 MB index. Reproduced live on the production docs: a typo'd 3-word query stalled the single-threaded search Web Worker 25+ seconds, and every later keystroke's search queued behind it.

## Changes

- `website/docusaurus.config.ts`: set `fuzzyMatchingDistance: 0` on the search-local theme, with a comment documenting why.

## Validation

Ran the plugin's shipped `smartQueries`/`tokenize` code (v0.55.1 dist, unmodified) against the downloaded production `search-index.json`:

| Query | Before (distance 1) | After (distance 0) |
|---|---|---|
| `keet` | Teams Meetings / google_meet / Keep… (false hits) | no false hits |
| `cron`, `telegram` | correct | identical results |
| `memor` (prefix typing) | works | still works |
| worst-case multi-word typo | 210 queries, 365–532 ms per keystroke (25 s+ stall observed live) | 50–105 queries, 53–188 ms |

Also verified `npx docusaurus build` passes and the generated client constant is `fuzzyMatchingDistance = 0`.

## Infographic

![docs-search-exact-match](https://v3b.fal.media/files/b/0aa25f5b/ou4-Wg_edimDKcTiIe2Up_NsUfFh4m.png)
