### PR TITLE
fix(nemo-relay): harden native and CLI integration

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4433,7 +4433,7 @@ def _print_version_info(*, check_updates: bool = True) -> None:
 
 def cmd_version(args):
     """Show version."""
-    _print_version_info(check_updates=True)
+    _print_version_info(check_updates=sys.stdout.isatty())
 
 
 def cmd_uninstall(args):

--- a/plugins/observability/nemo_relay/README.md
+++ b/plugins/observability/nemo_relay/README.md
@@ -495,6 +495,14 @@ Hermes tool call
       -> Hermes tool dispatcher next_call(...)
 ```
 
+For OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages, Hermes
+passes the matching public NeMo Relay codec to the managed LLM boundary. This
+lets request and response interceptors operate on Relay's normalized provider
+representation while preserving the original provider response object when no
+interceptor changes it. Hermes retains the legacy untyped path when the
+installed Relay version does not expose these codecs or the provider protocol
+is unsupported.
+
 The plugin still emits observer marks for sessions, turns, approvals, and
 subagents. When adaptive managed execution is active, it skips manual
 `llm.call` and `tools.call` observer spans to avoid duplicate LLM/tool events

--- a/plugins/observability/nemo_relay/__init__.py
+++ b/plugins/observability/nemo_relay/__init__.py
@@ -20,10 +20,10 @@ logger = logging.getLogger(__name__)
 _INIT_FAILED = object()
 _LOCK = threading.RLock()
 _RUNTIME: "_Runtime | object | None" = None
-_RELAY_LLM_SURFACE_BY_API_MODE = {
-    "anthropic_messages": "anthropic.messages",
-    "chat_completions": "openai.chat_completions",
-    "codex_responses": "openai.responses",
+_RELAY_LLM_PROTOCOL_BY_API_MODE = {
+    "anthropic_messages": ("anthropic.messages", "AnthropicMessagesCodec"),
+    "chat_completions": ("openai.chat_completions", "OpenAIChatCodec"),
+    "codex_responses": ("openai.responses", "OpenAIResponsesCodec"),
 }
 
 
@@ -448,6 +448,7 @@ class _Runtime:
         state = self.ensure_session(kwargs)
         request_body = _jsonable(kwargs.get("request") or {})
         request = self.nemo_relay.LLMRequest({}, request_body)
+        codec = _relay_llm_codec(self.nemo_relay, kwargs)
         next_call = kwargs.get("next_call")
         if not callable(next_call):
             return request_body
@@ -458,6 +459,9 @@ class _Runtime:
 
         def _make_managed(impl: Callable[[Any], Any]) -> Any:
             async def _managed_execute() -> Any:
+                codec_kwargs = {}
+                if codec is not None:
+                    codec_kwargs = {"codec": codec, "response_codec": codec}
                 result = self.nemo_relay.llm.execute(
                     _relay_llm_surface(kwargs),
                     request,
@@ -473,6 +477,7 @@ class _Runtime:
                     ),
                     metadata=_metadata(kwargs),
                     model_name=str(kwargs.get("model") or ""),
+                    **codec_kwargs,
                 )
                 if inspect.isawaitable(result):
                     return await result
@@ -481,7 +486,11 @@ class _Runtime:
             return _managed_execute()
 
         return self._run_managed_with_downstream_preservation(
-            next_call, _normalize, _llm_response_payload, _make_managed, preserve_raw_response=True
+            next_call,
+            _normalize,
+            _jsonable if codec is not None else _llm_response_payload,
+            _make_managed,
+            preserve_raw_response=True,
         )
 
     def execute_tool(self, kwargs: dict[str, Any]) -> Any:
@@ -1035,10 +1044,18 @@ def _tool_key(kwargs: dict[str, Any]) -> str:
 
 def _relay_llm_surface(kwargs: dict[str, Any]) -> str:
     api_mode = str(kwargs.get("api_mode") or "").strip().lower()
-    return _RELAY_LLM_SURFACE_BY_API_MODE.get(
-        api_mode,
-        str(kwargs.get("provider") or "llm"),
-    )
+    protocol = _RELAY_LLM_PROTOCOL_BY_API_MODE.get(api_mode)
+    return protocol[0] if protocol is not None else str(kwargs.get("provider") or "llm")
+
+
+def _relay_llm_codec(nemo_relay: Any, kwargs: dict[str, Any]) -> Any | None:
+    """Construct Relay's public codec for Hermes' resolved wire protocol."""
+
+    api_mode = str(kwargs.get("api_mode") or "").strip().lower()
+    protocol = _RELAY_LLM_PROTOCOL_BY_API_MODE.get(api_mode)
+    codecs = getattr(nemo_relay, "codecs", None)
+    codec_type = getattr(codecs, protocol[1], None) if protocol is not None else None
+    return codec_type() if callable(codec_type) else None
 
 
 def _metadata(kwargs: dict[str, Any]) -> dict[str, Any]:

--- a/tests/cli/test_version_command.py
+++ b/tests/cli/test_version_command.py
@@ -2,8 +2,11 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from cli import HermesCLI
 from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command
+from hermes_cli.main import cmd_version
 
 
 def test_version_command_is_registered():
@@ -26,3 +29,16 @@ def test_process_command_version_prints_version_info():
         assert cli_obj.process_command("/version") is True
 
     mock_print.assert_called_once_with(check_updates=True)
+
+
+@pytest.mark.parametrize(("is_tty", "check_updates"), [(True, True), (False, False)])
+def test_top_level_version_only_checks_updates_for_interactive_stdout(
+    is_tty, check_updates
+):
+    with (
+        patch("hermes_cli.main.sys.stdout.isatty", return_value=is_tty),
+        patch("hermes_cli.main._print_version_info") as mock_print,
+    ):
+        cmd_version(None)
+
+    mock_print.assert_called_once_with(check_updates=check_updates)

--- a/tests/plugins/test_nemo_relay_plugin.py
+++ b/tests/plugins/test_nemo_relay_plugin.py
@@ -36,6 +36,11 @@ class _FakeNemoRelay:
             call_end=self._llm_call_end,
             execute=self._llm_execute,
         )
+        self.codecs = SimpleNamespace(
+            AnthropicMessagesCodec=lambda: _FakeRelayCodec("anthropic_messages"),
+            OpenAIChatCodec=lambda: _FakeRelayCodec("openai_chat"),
+            OpenAIResponsesCodec=lambda: _FakeRelayCodec("openai_responses"),
+        )
         self.tools = SimpleNamespace(
             call=self._tool_call,
             call_end=self._tool_call_end,
@@ -126,6 +131,11 @@ class _FakeLLMRequest:
     def __init__(self, headers, content):
         self.headers = headers
         self.content = content
+
+
+class _FakeRelayCodec:
+    def __init__(self, name):
+        self.name = name
 
 
 class _FakeAtofExporterConfig:
@@ -671,35 +681,31 @@ environment_ref = "../environments/worker-fixture"
 
 
 @pytest.mark.parametrize(
-    ("provider", "api_mode", "expected_surface", "should_rewrite"),
+    ("provider", "api_mode", "expected_surface", "expected_codec"),
     [
-        ("custom", "chat_completions", "openai.chat_completions", True),
-        ("openai-codex", "codex_responses", "openai.responses", True),
-        ("anthropic", "anthropic_messages", "anthropic.messages", True),
-        ("custom", "anthropic_messages", "anthropic.messages", True),
-        ("bedrock", "bedrock_converse", "bedrock", False),
+        ("custom", "chat_completions", "openai.chat_completions", "openai_chat"),
+        ("openai-codex", "codex_responses", "openai.responses", "openai_responses"),
+        ("anthropic", "anthropic_messages", "anthropic.messages", "anthropic_messages"),
+        ("custom", "anthropic_messages", "anthropic.messages", "anthropic_messages"),
+        ("bedrock", "bedrock_converse", "bedrock", None),
     ],
 )
-def test_nemo_relay_managed_llm_uses_wire_protocol_for_interceptor_dispatch(
+def test_nemo_relay_managed_llm_passes_wire_protocol_codecs(
     tmp_path,
     monkeypatch,
     provider,
     api_mode,
     expected_surface,
-    should_rewrite,
+    expected_codec,
 ):
     fake = _FakeNemoRelay()
-    supported_surfaces = {
-        "anthropic.messages",
-        "openai.chat_completions",
-        "openai.responses",
-    }
 
     def execute(name, request, func, **kwargs):
         fake.events.append(("llm.execute.start", name, request.content, kwargs))
         content = dict(request.content)
-        if name in supported_surfaces:
-            content["rewritten_for"] = name
+        codec = kwargs.get("codec")
+        if codec is not None:
+            content["rewritten_for"] = codec.name
         result = func(_FakeLLMRequest(request.headers, content))
         fake.events.append(("llm.execute.end", name, result, kwargs))
         return result
@@ -723,9 +729,15 @@ def test_nemo_relay_managed_llm_uses_wire_protocol_for_interceptor_dispatch(
     assert execute_start[1] == expected_surface
     assert execute_start[3]["metadata"]["provider"] == provider
     assert execute_start[3]["metadata"]["api_mode"] == api_mode
-    if should_rewrite:
-        assert result["rewritten_for"] == expected_surface
+    codec = execute_start[3].get("codec")
+    response_codec = execute_start[3].get("response_codec")
+    if expected_codec is not None:
+        assert codec.name == expected_codec
+        assert response_codec is codec
+        assert result["rewritten_for"] == expected_codec
     else:
+        assert codec is None
+        assert response_codec is None
         assert "rewritten_for" not in result
 
 
@@ -761,8 +773,43 @@ def test_nemo_relay_managed_llm_returns_post_next_interceptor_result(tmp_path, m
     )
 
     assert result["post_next_interceptor"] is True
-    assert result["assistant_message"]["content"] == "raw"
+    assert result["choices"][0]["message"]["content"] == "raw"
     assert result is not raw_response
+
+
+def test_nemo_relay_managed_llm_keeps_legacy_response_shape_without_codecs(
+    tmp_path, monkeypatch
+):
+    fake = _FakeNemoRelay()
+    del fake.codecs
+    plugin = _fresh_plugin(monkeypatch, fake)
+    _enable_dynamic_plugin(tmp_path, monkeypatch)
+    raw_response = SimpleNamespace(
+        model="fixture",
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(role="assistant", content="raw", tool_calls=[]),
+                finish_reason="stop",
+            )
+        ],
+        usage=None,
+    )
+
+    result = plugin.on_llm_execution_middleware(
+        session_id="s1",
+        provider="openai",
+        api_mode="chat_completions",
+        model="fixture",
+        request={"messages": []},
+        next_call=lambda request: raw_response,
+    )
+
+    execute_start = next(
+        event for event in fake.events if event[0] == "llm.execute.start"
+    )
+    assert "codec" not in execute_start[3]
+    assert "response_codec" not in execute_start[3]
+    assert result is raw_response
 
 
 def test_nemo_relay_managed_tool_returns_post_interceptor_result(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- select NeMo Relay's public request/response codec from Hermes' resolved `api_mode`
- pass the same codec to both sides of the managed LLM boundary
- preserve the original provider response object when Relay does not change it
- retain the existing untyped behavior for older Relay versions and unsupported provider protocols
- keep non-interactive `hermes --version` probes offline while preserving update checks for interactive users
- document the managed codec behavior

## Why

The managed LLM integration already used protocol-specific execution names such as `openai.chat_completions`, but that name is telemetry identity rather than codec selection. As a result, Relay request interceptors could receive an unannotated request when Hermes ran through the native Python integration.

Explicitly passing Relay-owned codecs makes the managed boundary protocol-aware without adding a Hermes translation layer.

Relay also validates Hermes through a five-second, captured `hermes --version` probe. A source checkout previously performed a synchronous network update check for that non-interactive command, which could time out in a fresh isolated runtime home. Automated probes now remain local and deterministic; interactive version commands still report update availability.

## Validation

- `61 passed` across the NeMo Relay plugin and version-command tests
- Ruff checks pass for all modified Python files
- a fresh isolated-home `hermes --version` probe completes in 0.53 seconds without a network update check
- real Relay 0.6 codec smoke confirms a normalized request reaches the interceptor and the unchanged SDK response retains object identity
- Fabric native-plugin and unmodified `nemo-relay run --agent hermes` smokes both complete with the same concrete dynamic plugin and each emit:
  - one canonical `nemo_relay.llm.optimization` contribution
  - a matching response optimization summary
  - 132 prompt/total tokens saved in the deterministic fixture

The local model has no pricing entry, so the smoke summaries are correctly partial for pricing while token evidence is complete.