### PR TITLE
fix(gateway): preserve external supervisor ownership

### DIFF
--- a/gateway/restart.py
+++ b/gateway/restart.py
@@ -1,4 +1,7 @@
-"""Shared gateway restart constants and parsing helpers."""
+"""Shared gateway restart constants and supervisor detection helpers."""
+
+import os
+from collections.abc import Mapping
 
 from hermes_cli.config import DEFAULT_CONFIG
 
@@ -12,9 +15,34 @@ GATEWAY_SERVICE_RESTART_EXIT_CODE = 75
 # restarting the gateway.  See #51228.
 GATEWAY_FATAL_CONFIG_EXIT_CODE = 78
 
+# Set by ``hermes gateway run --external-supervisor``. Unlike systemd's
+# INVOCATION_ID and launchd's XPC_SERVICE_NAME, this survives wrappers that
+# intentionally replace the child environment (for example ``sudo env -i``).
+EXTERNAL_GATEWAY_SUPERVISOR_ENV = "HERMES_GATEWAY_EXTERNAL_SUPERVISOR"
+
 DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT = float(
     DEFAULT_CONFIG["agent"]["restart_drain_timeout"]
 )
+
+
+def is_gateway_supervisor_process(
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Return whether this gateway process is owned by a supervisor."""
+    env = os.environ if environ is None else environ
+    if env.get("INVOCATION_ID"):
+        return True
+    if env.get("HERMES_S6_SUPERVISED_CHILD"):
+        return True
+    xpc_service = env.get("XPC_SERVICE_NAME", "")
+    if xpc_service and xpc_service != "0":
+        return True
+    return str(env.get(EXTERNAL_GATEWAY_SUPERVISOR_ENV, "")).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 def parse_restart_drain_timeout(raw: object) -> float:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1313,15 +1313,12 @@ class GatewaySlashCommandsMixin:
         # us.  The detached subprocess approach (setsid + bash) doesn't work
         # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
         # exits when the gateway dies, taking the detached helper with it).
-        # systemd sets INVOCATION_ID; launchd sets XPC_SERVICE_NAME to the
-        # job label.  Without the launchd check, macOS /restart takes the
-        # detached path and exits 0, which KeepAlive.SuccessfulExit=false
-        # treats as a deliberate stop — the gateway stays dead until next
-        # login.  Interactive macOS shells inherit XPC_SERVICE_NAME=0, so
-        # "0" must count as not-under-launchd.
-        _under_service = bool(os.environ.get("INVOCATION_ID")) or os.environ.get(
-            "XPC_SERVICE_NAME", "0"
-        ) not in ("", "0")
+        # Native supervisor markers cover direct systemd/launchd starts. The
+        # explicit marker covers wrappers such as ``sudo env -i`` that strip
+        # those markers before execing the foreground gateway.
+        from gateway.restart import is_gateway_supervisor_process
+
+        _under_service = is_gateway_supervisor_process()
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
         if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -33,7 +33,9 @@ from gateway.status import terminate_pid
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_FATAL_CONFIG_EXIT_CODE,
+    EXTERNAL_GATEWAY_SUPERVISOR_ENV,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
+    is_gateway_supervisor_process,
     parse_restart_drain_timeout,
 )
 from hermes_cli.config import (
@@ -694,6 +696,22 @@ def _capture_gateway_argv(pid: int) -> list[str] | None:
     except Exception:
         pass
     return argv
+
+
+def _prepare_profile_gateway_update_restart(profile: str, pid: int) -> str | None:
+    """Choose who relaunches a profile gateway after ``hermes update``.
+
+    A gateway started with ``--external-supervisor`` must exit back to that
+    manager. Starting Hermes's detached watcher as well would escape the
+    manager and race its replacement process. Ordinary foreground gateways
+    retain the existing detached-watcher behavior.
+    """
+    argv = _capture_gateway_argv(pid)
+    if argv and "--external-supervisor" in argv:
+        return "external-supervisor"
+    if launch_detached_profile_gateway_restart(profile, pid):
+        return "detached"
+    return None
 
 
 def launch_detached_gateway_restart_by_cmdline(
@@ -4503,15 +4521,10 @@ def _running_under_gateway_supervisor() -> bool:
       - launchd sets ``XPC_SERVICE_NAME`` to the job label for jobs it spawns;
         interactive shells inherit the sentinel ``"0"`` instead.
       - the s6-overlay container longrun exports ``HERMES_S6_SUPERVISED_CHILD``.
+      - wrapped services can opt in with ``--external-supervisor`` when their
+        launcher strips the native systemd/launchd marker.
     """
-    if os.environ.get("INVOCATION_ID"):
-        return True
-    if os.environ.get("HERMES_S6_SUPERVISED_CHILD"):
-        return True
-    xpc_service = os.environ.get("XPC_SERVICE_NAME", "")
-    if xpc_service and xpc_service != "0":
-        return True
-    return False
+    return is_gateway_supervisor_process()
 
 
 def _guard_named_profile_under_multiplexer(force: bool = False) -> None:
@@ -6543,6 +6556,8 @@ def _gateway_command_inner(args):
     if subcmd is None or subcmd == "run":
         if _maybe_redirect_run_to_s6_supervision(args):
             return  # unreachable; execvp doesn't return
+        if getattr(args, "external_supervisor", False):
+            os.environ[EXTERNAL_GATEWAY_SUPERVISOR_ENV] = "1"
         verbose = getattr(args, "verbose", 0)
         quiet = getattr(args, "quiet", False)
         replace = getattr(args, "replace", False)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10469,7 +10469,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _ensure_user_systemd_env,
                 find_gateway_pids,
                 find_profile_gateway_processes,
-                launch_detached_profile_gateway_restart,
+                _prepare_profile_gateway_update_restart,
                 _get_service_pids,
                 _graceful_restart_via_sigusr1,
                 _wait_for_gateway_exit,
@@ -10651,6 +10651,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             restarted_services = []
             killed_pids = set()
             relaunched_profiles = []
+            externally_supervised_profiles = []
 
             # --- Systemd services (Linux) ---
             # Discover all hermes-gateway* units (default + profiles)
@@ -10982,7 +10983,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 if proc.pid in manual_pids
             }
             for pid, proc in profile_processes.items():
-                if not launch_detached_profile_gateway_restart(proc.profile, pid):
+                restart_mode = _prepare_profile_gateway_update_restart(
+                    proc.profile, pid
+                )
+                if restart_mode is None:
                     continue
                 # Prefer a graceful SIGUSR1 drain so in-flight agent runs
                 # finish before the watcher respawns the gateway.  If the
@@ -11022,7 +11026,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # live when the new gateway polls.
                 _wait_for_gateway_exit(timeout=5.0, force_after=None)
                 killed_pids.add(pid)
-                relaunched_profiles.append(proc.profile)
+                if restart_mode == "external-supervisor":
+                    externally_supervised_profiles.append(proc.profile)
+                else:
+                    relaunched_profiles.append(proc.profile)
 
             for pid in manual_pids:
                 if pid in profile_processes:
@@ -11040,7 +11047,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 if relaunched_profiles:
                     names = ", ".join(relaunched_profiles)
                     print(f"  ✓ Restarting manual gateway profile(s): {names}")
-                unmapped_count = len(killed_pids) - len(relaunched_profiles)
+                if externally_supervised_profiles:
+                    names = ", ".join(externally_supervised_profiles)
+                    print(
+                        "  ✓ Handed gateway profile(s) back to their external "
+                        f"supervisor: {names}"
+                    )
+                unmapped_count = (
+                    len(killed_pids)
+                    - len(relaunched_profiles)
+                    - len(externally_supervised_profiles)
+                )
                 if unmapped_count:
                     print(f"  → Stopped {unmapped_count} manual gateway process(es)")
                     print("    Restart manually: hermes gateway run")

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -85,6 +85,16 @@ def build_gateway_parser(
             "gateway's exit code. No effect outside an s6 container."
         ),
     )
+    gateway_run.add_argument(
+        "--external-supervisor",
+        action="store_true",
+        help=(
+            "Declare that an external process manager owns this foreground "
+            "gateway. In-chat restarts and updates exit back to that manager "
+            "instead of spawning a detached replacement. Use this when a "
+            "launchd/systemd wrapper strips its native environment markers."
+        ),
+    )
     add_accept_hooks_flag(gateway_run)
     add_accept_hooks_flag(gateway_parser)
 

--- a/tests/gateway/test_restart_service_detection.py
+++ b/tests/gateway/test_restart_service_detection.py
@@ -20,6 +20,7 @@ import pytest
 
 import gateway.run as gateway_run
 from gateway.platforms.base import MessageEvent, MessageType
+from gateway.restart import EXTERNAL_GATEWAY_SUPERVISOR_ENV
 from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
 
 
@@ -37,6 +38,8 @@ def _make_runner_with_mock_restart(tmp_path, monkeypatch):
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
     monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+    monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+    monkeypatch.delenv(EXTERNAL_GATEWAY_SUPERVISOR_ENV, raising=False)
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)
     return runner
@@ -83,3 +86,29 @@ async def test_restart_under_systemd_uses_service_path(tmp_path, monkeypatch):
     await runner._handle_restart_command(_make_restart_event())
 
     runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_with_external_supervisor_marker_uses_service_path(
+    tmp_path, monkeypatch
+):
+    """Wrapped supervisors can retain restart ownership without native markers."""
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+    monkeypatch.setenv(EXTERNAL_GATEWAY_SUPERVISOR_ENV, "1")
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", ["", "0", "false", "off"])
+async def test_false_external_supervisor_marker_keeps_detached_path(
+    value, tmp_path, monkeypatch
+):
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+    monkeypatch.setenv(EXTERNAL_GATEWAY_SUPERVISOR_ENV, value)
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=True, via_service=False)

--- a/tests/hermes_cli/test_gateway_external_supervisor.py
+++ b/tests/hermes_cli/test_gateway_external_supervisor.py
@@ -1,0 +1,82 @@
+"""Tests for explicit ownership by a wrapped external gateway supervisor."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_cli.gateway as gateway
+
+
+def _clear_native_supervisor_markers(monkeypatch):
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+
+
+def test_external_marker_identifies_supervisor_process(monkeypatch):
+    _clear_native_supervisor_markers(monkeypatch)
+    monkeypatch.setenv(gateway.EXTERNAL_GATEWAY_SUPERVISOR_ENV, "1")
+
+    assert gateway._running_under_gateway_supervisor() is True
+
+
+def test_gateway_run_external_supervisor_flag_marks_process(monkeypatch):
+    monkeypatch.delenv(gateway.EXTERNAL_GATEWAY_SUPERVISOR_ENV, raising=False)
+    monkeypatch.setattr(
+        gateway, "_maybe_redirect_run_to_s6_supervision", lambda _args: False
+    )
+    observed = []
+    monkeypatch.setattr(
+        gateway,
+        "run_gateway",
+        lambda *_args, **_kwargs: observed.append(
+            gateway.os.environ.get(gateway.EXTERNAL_GATEWAY_SUPERVISOR_ENV)
+        ),
+    )
+
+    gateway._gateway_command_inner(
+        SimpleNamespace(gateway_command="run", external_supervisor=True)
+    )
+
+    assert observed == ["1"]
+
+
+def test_update_hands_external_supervisor_gateway_back_without_watcher(monkeypatch):
+    monkeypatch.setattr(
+        gateway,
+        "_capture_gateway_argv",
+        lambda _pid: [
+            "python",
+            "-m",
+            "hermes_cli.main",
+            "gateway",
+            "run",
+            "--external-supervisor",
+        ],
+    )
+    monkeypatch.setattr(
+        gateway,
+        "launch_detached_profile_gateway_restart",
+        lambda *_args: pytest.fail("detached watcher must not be launched"),
+    )
+
+    assert gateway._prepare_profile_gateway_update_restart("work", 1234) == (
+        "external-supervisor"
+    )
+
+
+def test_update_keeps_detached_restart_for_ordinary_foreground_gateway(monkeypatch):
+    monkeypatch.setattr(
+        gateway,
+        "_capture_gateway_argv",
+        lambda _pid: ["python", "-m", "hermes_cli.main", "gateway", "run"],
+    )
+    calls = []
+    monkeypatch.setattr(
+        gateway,
+        "launch_detached_profile_gateway_restart",
+        lambda profile, pid: calls.append((profile, pid)) or True,
+    )
+
+    assert gateway._prepare_profile_gateway_update_restart("work", 1234) == "detached"
+    assert calls == [("work", 1234)]

--- a/tests/hermes_cli/test_subcommands_profile_gateway.py
+++ b/tests/hermes_cli/test_subcommands_profile_gateway.py
@@ -92,6 +92,12 @@ def test_gateway_accept_hooks_flag():
     assert ns.accept_hooks is True
 
 
+def test_gateway_run_accepts_external_supervisor_flag():
+    p = _gateway_parser()
+    ns = p.parse_args(["gateway", "run", "--external-supervisor"])
+    assert ns.external_supervisor is True
+
+
 def test_gateway_lifecycle_accepts_legacy_platform_flag():
     p = _gateway_parser()
     for action in ("start", "restart", "status"):

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -241,6 +241,14 @@ Options:
 | `--no-supervise` | On `run`: inside the s6-overlay Docker image, opt out of auto-supervision and use pre-s6 foreground semantics — gateway runs as the container's main process with no auto-restart. No-op outside the s6 image. Equivalent to setting `HERMES_GATEWAY_NO_SUPERVISE=1`. |
 | `--external-supervisor` | On `run`: declare that a wrapper-provided process manager owns the foreground gateway. Use this when `sudo`, `env -i`, or another wrapper strips launchd/systemd's native environment marker. In-chat restarts and updates exit back to that manager instead of spawning a detached replacement. |
 
+`--external-supervisor` is a restart-policy contract: an in-chat restart or
+service-restart update exits with status `75`, so the wrapper's supervisor must
+relaunch the gateway after that nonzero exit. For systemd, use
+`Restart=on-failure` or `Restart=always` and do not include `75` in
+`RestartPreventExitStatus`; for launchd, configure `KeepAlive` to relaunch after
+unsuccessful exits. Without that policy, a requested restart leaves the gateway
+stopped.
+
 `hermes gateway enroll` accepts `--token`, `--connector-url`, `--gateway-id`, and `--wake-url`. It exchanges the enrollment token with the connector and writes the resulting `GATEWAY_RELAY_ID`, `GATEWAY_RELAY_SECRET`, `GATEWAY_RELAY_DELIVERY_KEY`, optional `GATEWAY_RELAY_URL`, and (when `--wake-url` is given) `GATEWAY_RELAY_WAKE_URL` values to the active profile's `.env`.
 
 :::tip WSL users

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -239,6 +239,7 @@ Options:
 |--------|-------------|
 | `--all` | On `start` / `restart` / `stop`: act on **every profile's** gateway, not just the active `HERMES_HOME`. Useful if you run multiple profiles side-by-side and want to restart them all after `hermes update`. |
 | `--no-supervise` | On `run`: inside the s6-overlay Docker image, opt out of auto-supervision and use pre-s6 foreground semantics — gateway runs as the container's main process with no auto-restart. No-op outside the s6 image. Equivalent to setting `HERMES_GATEWAY_NO_SUPERVISE=1`. |
+| `--external-supervisor` | On `run`: declare that a wrapper-provided process manager owns the foreground gateway. Use this when `sudo`, `env -i`, or another wrapper strips launchd/systemd's native environment marker. In-chat restarts and updates exit back to that manager instead of spawning a detached replacement. |
 
 `hermes gateway enroll` accepts `--token`, `--connector-url`, `--gateway-id`, and `--wake-url`. It exchanges the enrollment token with the connector and writes the resulting `GATEWAY_RELAY_ID`, `GATEWAY_RELAY_SECRET`, `GATEWAY_RELAY_DELIVERY_KEY`, optional `GATEWAY_RELAY_URL`, and (when `--wake-url` is given) `GATEWAY_RELAY_WAKE_URL` values to the active profile's `.env`.
 


### PR DESCRIPTION
## Summary

- add `hermes gateway run --external-supervisor` for launchd/systemd wrappers that strip native supervisor markers
- route `/restart` back to that supervisor instead of starting Hermes's detached `setsid` replacement
- preserve the same ownership during `hermes update`, while keeping detached restart behavior for ordinary foreground gateways
- document the wrapper contract and centralize systemd/launchd/s6/explicit supervisor detection

Closes #64778.

## Root cause

The gateway already runs in the foreground, but restart ownership was inferred only from `INVOCATION_ID`, `XPC_SERVICE_NAME`, or the s6 child marker. A wrapper such as the reported `sudo -u ... env -i ... gateway run` removes launchd's `XPC_SERVICE_NAME`, so `/restart` classified the process as unsupervised and started a detached replacement. The update path independently classified the same PID as a manual gateway and installed its detached watcher before signaling the old process. Both paths could therefore escape launchd and race its `KeepAlive` replacement.

The new opt-in flag marks the foreground process as externally owned. `/restart` exits through the service restart path, and update routing recognizes the flag in each live profile gateway's argv so only that process is handed back to its manager. Unflagged foreground gateways retain the existing detached watcher.

For the reported wrapper, the supported command becomes:

```bash
python -m hermes_cli.main gateway run --external-supervisor
```

## Current-main proof

On `fcdc10a0f337`, the parser rejects `--external-supervisor`; with systemd/launchd markers absent, `/restart` calls `request_restart(detached=True, via_service=False)`, and update routing starts `launch_detached_profile_gateway_restart()` for the profile PID.

After this change, the explicit marker calls `request_restart(detached=False, via_service=True)`, update routing returns `external-supervisor` without invoking the detached watcher, and `XPC_SERVICE_NAME=0` plus ordinary unflagged foreground runs still take the detached path.

## Validation

- 330 tests passed across parser, supervisor detection, restart/drain/shutdown, update command/streaming, CLI update, and gateway restart-loop suites
- 184 tests passed in `test_gateway_service.py`; its four macOS-host systemd failures reproduce unchanged on an untouched worktree at the original exact base and fail before this diff's paths in `_preflight_user_systemd()`
- Ruff passed on all changed Python files
- Windows footgun diff scan passed
- `uv lock --check` passed
- `git diff --check` passed
- publish-range gitleaks scan passed

## Overlap audit

PR #55480 adds a FreeBSD rc.d child marker to the startup conflict guard. It does not cover wrapped launchd/systemd ownership, `/restart`, or update's detached watcher; its marker can be added to the shared detector independently. Draft PR #63181 only recommends an external supervisor for its separate Telegram Mini App foreground service.
