### PR TITLE
fix(kanban): handle archive reason argument

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -18,10 +18,13 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import shlex
+import shutil
 import sys
 import time
 from pathlib import Path
+
 from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
@@ -670,6 +673,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_archive = sub.add_parser("archive", help="Archive one or more tasks")
     p_archive.add_argument("task_ids", nargs="*",
                            help="Task ids to archive (default mode)")
+    p_archive.add_argument(
+        "--reason",
+        default=None,
+        help="Optional audit-trail reason recorded on the archived event.",
+    )
     p_archive.add_argument(
         "--rm",
         dest="purge_ids",
@@ -2368,12 +2376,17 @@ def _cmd_promote(args: argparse.Namespace) -> int:
 def _cmd_archive(args: argparse.Namespace) -> int:
     ids = list(args.task_ids or [])
     purge_ids = list(getattr(args, "purge_ids", None) or [])
+    reason = (getattr(args, "reason", None) or "").strip() or None
     if ids and purge_ids:
         print("choose either task_ids to archive or --rm archived task_ids", file=sys.stderr)
         return 1
     if not ids and not purge_ids:
         print("at least one task_id is required", file=sys.stderr)
         return 1
+    if ids and not purge_ids:
+        ids, reason = _normalize_archive_args(ids, reason)
+        if not ids:
+            return 2
     failed: list[str] = []
     with kb.connect_closing() as conn:
         if purge_ids:
@@ -2385,12 +2398,52 @@ def _cmd_archive(args: argparse.Namespace) -> int:
                     print(f"Deleted {tid}")
             return 0 if not failed else 1
         for tid in ids:
-            if not kb.archive_task(conn, tid):
+            if not kb.archive_task(conn, tid, reason=reason):
                 failed.append(tid)
                 print(f"cannot archive {tid}", file=sys.stderr)
             else:
                 print(f"Archived {tid}")
     return 0 if not failed else 1
+
+
+_TASK_ID_RE = re.compile(r"^t_[A-Za-z0-9]+$")
+
+
+def _normalize_archive_args(
+    ids: list[str],
+    reason: Optional[str],
+) -> tuple[list[str], Optional[str]]:
+    """Normalize archive args and support the historical positional reason.
+
+    ``archive`` used to accept ``nargs='*'`` task ids only. When users typed
+    ``archive t_abc 'done for now'``, argparse treated the reason as another
+    task id, yielding a misleading ``cannot archive done for now`` error after
+    successfully archiving the real task. Keep bulk task-id archiving intact,
+    but interpret ``<one task id> <free-form words>`` as a legacy positional
+    reason and prefer the explicit ``--reason`` flag going forward.
+    """
+    if len(ids) <= 1:
+        return ids, reason
+    first, rest = ids[0], ids[1:]
+    if not _TASK_ID_RE.match(first):
+        return ids, reason
+    rest_are_task_ids = [_TASK_ID_RE.match(item) is not None for item in rest]
+    if all(rest_are_task_ids):
+        return ids, reason
+    if not any(rest_are_task_ids):
+        if reason:
+            print(
+                "kanban: archive reason provided both positionally and via --reason",
+                file=sys.stderr,
+            )
+            return [], reason
+        return [first], " ".join(rest).strip() or None
+    print(
+        "kanban: archive accepts either task ids or a single task id plus a reason; "
+        "use --reason for bulk archive reasons",
+        file=sys.stderr,
+    )
+    return [], reason
 
 
 def _cmd_tail(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -10,12 +10,13 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import shlex
+import shutil
 import sys
 import time
 from pathlib import Path
-from typing import Optional
-
+from typing import Any, Optional
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_db_connect as kbc
 from hermes_cli import kanban_db_dispatch as kbd
@@ -1042,6 +1043,7 @@ def _cmd_promote(args: argparse.Namespace) -> int:
 def _cmd_archive(args: argparse.Namespace) -> int:
     ids = list(args.task_ids or [])
     purge_ids = list(getattr(args, "purge_ids", None) or [])
+    reason = (getattr(args, "reason", None) or "").strip() or None
     if ids and purge_ids:
         return _err("choose either task_ids to archive or --rm archived task_ids")
     if not ids and not purge_ids:
@@ -1050,7 +1052,7 @@ def _cmd_archive(args: argparse.Namespace) -> int:
         if purge_ids:
             return _bulk_apply(purge_ids, lambda tid: kb.delete_archived_task(conn, tid), lambda tid: f"Deleted {tid}",
                                lambda tid: f"cannot delete {tid} (must already be archived)")
-        return _bulk_apply(ids, lambda tid: kb.archive_task(conn, tid),
+        return _bulk_apply(ids, lambda tid: kb.archive_task(conn, tid, reason=reason),
                            lambda tid: f"Archived {tid}", lambda tid: f"cannot archive {tid}")
 
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1040,6 +1040,37 @@ def _cmd_promote(args: argparse.Namespace) -> int:
     return 0 if not failed else 1
 
 
+_TASK_ID_RE = re.compile(r"^t_[A-Za-z0-9]+$")
+
+
+def _normalize_archive_args(
+    ids: list[str],
+    reason: Optional[str],
+) -> tuple[list[str], Optional[str]]:
+    """Normalize archive args and support the historical positional reason.
+
+    ``archive`` used to accept ``nargs='*'`` task ids only. When users typed
+    ``archive t_abc 'done for now'``, argparse treated the reason as another
+    task id, yielding a misleading ``cannot archive done for now`` error after
+    successfully archiving the real task. Keep bulk task-id archiving intact,
+    but interpret ``<one task id> <free-form words>`` as a legacy positional
+    reason and prefer the explicit ``--reason`` flag going forward.
+    """
+    if len(ids) <= 1:
+        return ids, reason
+    first, rest = ids[0], ids[1:]
+    if not _TASK_ID_RE.match(first):
+        return ids, reason
+    rest_are_task_ids = [_TASK_ID_RE.match(item) is not None for item in rest]
+    if all(rest_are_task_ids):
+        return ids, reason
+    if not any(rest_are_task_ids):
+        if reason:
+            return [], reason
+        return [first], " ".join(rest).strip() or None
+    return [], reason
+
+
 def _cmd_archive(args: argparse.Namespace) -> int:
     ids = list(args.task_ids or [])
     purge_ids = list(getattr(args, "purge_ids", None) or [])
@@ -1048,6 +1079,10 @@ def _cmd_archive(args: argparse.Namespace) -> int:
         return _err("choose either task_ids to archive or --rm archived task_ids")
     if not ids and not purge_ids:
         return _err("at least one task_id is required")
+    if ids and not purge_ids:
+        ids, reason = _normalize_archive_args(ids, reason)
+        if not ids:
+            return 1
     with kbc.connect_closing() as conn:
         if purge_ids:
             return _bulk_apply(purge_ids, lambda tid: kb.delete_archived_task(conn, tid), lambda tid: f"Deleted {tid}",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6053,7 +6053,12 @@ def decompose_triage_task(
     return child_ids
 
 
-def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def archive_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+) -> bool:
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -6071,7 +6076,8 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
-        _append_event(conn, task_id, "archived", None, run_id=run_id)
+        payload = {"reason": reason} if reason else None
+        _append_event(conn, task_id, "archived", payload, run_id=run_id)
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3480,7 +3480,12 @@ def specify_triage_task(
     return True
 
 
-def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def archive_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+) -> bool:
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -3494,7 +3499,8 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             conn, task_id, outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
-        _append_event(conn, task_id, "archived", None, run_id=run_id)
+        payload = {"reason": reason} if reason else None
+        _append_event(conn, task_id, "archived", payload, run_id=run_id)
     # ``archived`` parents no longer block children; promote them now.
     recompute_ready(conn)
     # Reap the workspace on archive too (never-completed tasks kept it forever).

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -336,6 +336,8 @@ _SPECS = [
         _arg("task_ids", nargs="*", help="Task ids to archive (default mode)"),
         _arg("--rm", dest="purge_ids", nargs="+",
              help="Permanently delete already-archived task ids from the board"),
+        _arg("--reason", default=None,
+             help="Optional reason recorded on the archived event (quote multi-word reasons)"),
     ], help="Archive one or more tasks"),
     _cmd("tail", [_TASK_ID, _arg("--interval", type=float, default=1.0)], help="Follow a task's event stream"),
     _cmd("dispatch", [

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -159,6 +159,25 @@ def test_run_slash_block_unblock_cycle(kanban_home):
     assert "Unblocked" in kc.run_slash(f"unblock {tid}")
 
 
+def test_run_slash_archive_accepts_legacy_positional_reason(kanban_home):
+    out = kc.run_slash("create 'x' --assignee alice")
+    import re
+    m = re.search(r"(t_[a-f0-9]+)", out)
+    assert m
+    tid = m.group(1)
+
+    out = kc.run_slash(f"archive {tid} 'stale scratch task'")
+
+    assert out == f"Archived {tid}"
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+    assert task is not None
+    assert task.status == "archived"
+    archived = [event for event in events if event.kind == "archived"][-1]
+    assert archived.payload == {"reason": "stale scratch task"}
+
+
 def test_run_slash_json_output(kanban_home):
     out = kc.run_slash("create 'jsontask' --assignee alice --json")
     payload = json.loads(out)

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -178,6 +178,31 @@ def test_run_slash_archive_accepts_legacy_positional_reason(kanban_home):
     assert archived.payload == {"reason": "stale scratch task"}
 
 
+def test_run_slash_archive_accepts_explicit_reason_for_multiple_ids(kanban_home):
+    import re
+
+    out1 = kc.run_slash("create 'scratch one' --assignee alice")
+    out2 = kc.run_slash("create 'scratch two' --assignee bob")
+    m1 = re.search(r"(t_[a-f0-9]+)", out1)
+    m2 = re.search(r"(t_[a-f0-9]+)", out2)
+    assert m1
+    assert m2
+    tid1 = m1.group(1)
+    tid2 = m2.group(1)
+
+    out = kc.run_slash(f"archive {tid1} {tid2} --reason 'stale scratch batch'")
+
+    assert out.splitlines() == [f"Archived {tid1}", f"Archived {tid2}"]
+    with kb.connect() as conn:
+        for tid in (tid1, tid2):
+            task = kb.get_task(conn, tid)
+            events = kb.list_events(conn, tid)
+            assert task is not None
+            assert task.status == "archived"
+            archived = [event for event in events if event.kind == "archived"][-1]
+            assert archived.payload == {"reason": "stale scratch batch"}
+
+
 def test_run_slash_json_output(kanban_home):
     out = kc.run_slash("create 'jsontask' --assignee alice --json")
     payload = json.loads(out)

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -170,6 +170,52 @@ def test_run_slash_reclaim_running_task(kanban_home):
     assert "ready" in out2.lower()
 
 
+# ---------------------------------------------------------------------------
+# archive --reason (audit-trail reason on the archived event)
+# ---------------------------------------------------------------------------
+
+def test_run_slash_archive_accepts_legacy_positional_reason(kanban_home):
+    out = kc.run_slash("create 'x' --assignee alice")
+    import re
+    m = re.search(r"(t_[a-f0-9]+)", out)
+    assert m
+    tid = m.group(1)
+
+    out = kc.run_slash(f"archive {tid} 'stale scratch task'")
+
+    assert out == f"Archived {tid}"
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+    assert task is not None
+    assert task.status == "archived"
+    archived = [event for event in events if event.kind == "archived"][-1]
+    assert archived.payload == {"reason": "stale scratch task"}
+
+
+def test_run_slash_archive_accepts_explicit_reason_for_multiple_ids(kanban_home):
+    import re
+
+    out1 = kc.run_slash("create 'scratch one' --assignee alice")
+    out2 = kc.run_slash("create 'scratch two' --assignee bob")
+    m1 = re.search(r"(t_[a-f0-9]+)", out1)
+    m2 = re.search(r"(t_[a-f0-9]+)", out2)
+    assert m1
+    assert m2
+    tid1 = m1.group(1)
+    tid2 = m2.group(1)
+
+    out = kc.run_slash(f"archive {tid1} {tid2} --reason 'stale scratch batch'")
+
+    assert out.splitlines() == [f"Archived {tid1}", f"Archived {tid2}"]
+    with kb.connect() as conn:
+        for tid in (tid1, tid2):
+            task = kb.get_task(conn, tid)
+            events = kb.list_events(conn, tid)
+            assert task is not None
+            assert task.status == "archived"
+            archived = [event for event in events if event.kind == "archived"][-1]
+            assert archived.payload == {"reason": "stale scratch batch"}
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -687,7 +687,7 @@ hermes kanban comment <id> "<text>" [--author NAME]
 hermes kanban complete <id>... [--result "..."]
 hermes kanban block <id> "<reason>" [--ids <id>...]
 hermes kanban unblock <id>...
-hermes kanban archive <id>...
+hermes kanban archive <id>... [--reason "..."]
 
 hermes kanban tail <id>                                # follow a single task's event stream
 hermes kanban watch [--assignee P] [--tenant T]        # live stream ALL events to the terminal
@@ -714,6 +714,8 @@ hermes kanban gc [--event-retention-days N]            # workspaces + old events
 ```
 
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
+
+`hermes kanban archive <id>... --reason "..."` records why one or more tasks were hidden from the default board. The reason is stored on each `archived` event so `tail`, `watch`, and dashboards can show the archive rationale later. A single-task legacy form (`hermes kanban archive <id> "reason text"`) is still accepted, but use `--reason` for new scripts and for bulk archives.
 
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.
 
@@ -944,7 +946,7 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `dependency_wait` | `{reason, kind}` | Worker blocked with `kind=dependency` — the task is only waiting on another task, so it routes to `todo` (parent-gated, auto-promoted) instead of `blocked`. No human needed. |
 | `block_loop_detected` | `{reason, kind, recurrences, limit}` | A task was unblocked and re-blocked for the same reason `BLOCK_RECURRENCE_LIMIT` times (default 2). Instead of landing in `blocked` again — where a cron would keep unblocking it — it routes to `triage` for a human decision, breaking the unblock↔re-block loop. |
 | `unblocked` | — | `blocked → ready` (or `todo` if parents are still open), either manually or via `/unblock`. Resets the dispatcher's `consecutive_failures` but deliberately preserves `block_recurrences` so the loop breaker keeps its memory. `run_id` is `NULL`. |
-| `archived` | — | Hidden from the default board. If the task was still running, carries the `run_id` of the run that was reclaimed as a side effect. |
+| `archived` | `{reason: ...}` | Hidden from the default board. If archived with `--reason`, the payload records that reason. If the task was still running, carries the `run_id` of the run that was reclaimed as a side effect. |
 
 **Edits** (human-driven changes that aren't transitions):
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -815,7 +815,7 @@ hermes kanban comment <id> "<text>" [--author NAME]
 hermes kanban complete <id>... [--result "..."]
 hermes kanban block <id> "<reason>" [--ids <id>...]
 hermes kanban unblock <id>...
-hermes kanban archive <id>...
+hermes kanban archive <id>... [--reason "..."]
 
 hermes kanban request-review <id> [--summary "..."] [--metadata JSON] [--reviewer PROFILE]
 hermes kanban request-changes <id> "<required changes>"               # active reviewer -> implementer
@@ -847,6 +847,8 @@ hermes kanban gc [--event-retention-days N]            # workspaces + old events
 ```
 
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
+
+`hermes kanban archive <id>... --reason "..."` records why one or more tasks were hidden from the default board. The reason is stored on each `archived` event so `tail`, `watch`, and dashboards can show the archive rationale later. A single-task legacy form (`hermes kanban archive <id> "reason text"`) is still accepted, but use `--reason` for new scripts and for bulk archives.
 
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.
 
@@ -1221,7 +1223,7 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `dependency_wait` | `{reason, kind}` | Worker blocked with `kind=dependency` — the task is only waiting on another task, so it routes to `todo` (parent-gated, auto-promoted) instead of `blocked`. No human needed. |
 | `block_loop_detected` | `{reason, kind, recurrences, limit}` | A task was unblocked and re-blocked for the same reason `BLOCK_RECURRENCE_LIMIT` times (default 2). Instead of landing in `blocked` again — where a cron would keep unblocking it — it routes to `triage` for a human decision, breaking the unblock↔re-block loop. |
 | `unblocked` | — | `blocked → ready` (or `todo` if parents are still open), either manually or via `/unblock`. Resets the dispatcher's `consecutive_failures` but deliberately preserves `block_recurrences` so the loop breaker keeps its memory. `run_id` is `NULL`. |
-| `archived` | — | Hidden from the default board. If the task was still running, carries the `run_id` of the run that was reclaimed as a side effect. |
+| `archived` | `{reason: ...}` | Hidden from the default board. If archived with `--reason`, the payload records that reason. If the task was still running, carries the `run_id` of the run that was reclaimed as a side effect. |
 
 **Edits** (human-driven changes that aren't transitions):
 


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes kanban archive <task_id> "reason text"` so the reason is no longer treated as a second task id.

The archive command now:
- accepts an explicit `--reason` flag
- preserves the historical single-task positional reason form for compatibility
- records the archive reason on the `archived` task event
- avoids the misleading `cannot archive <reason>` error from issue #65099

## Related Issue

Fixes #65099

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban.py`: add `archive --reason`, normalize the legacy positional reason form, and pass the reason to the DB layer.
- `hermes_cli/kanban_db.py`: allow `archive_task(..., reason=...)` and store the reason in the archived event payload.
- `tests/hermes_cli/test_kanban_cli.py`: add a regression test for `archive <task_id> 'reason text'`.

## How to Test

1. Create a task.
2. Run `hermes kanban archive <task_id> "stale scratch task"`.
3. Confirm output is only `Archived <task_id>` and the archived event payload contains the reason.

Verification run locally:

```bash
PYTHONPATH=. /tmp/hermes-pr-venv/bin/python -m pytest tests/hermes_cli/test_kanban_cli.py -q -o 'addopts='
# 48 passed in 2.41s
```

Also ran:

```bash
git diff --check
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted test output:

```text
48 passed in 2.41s
```
