### PR TITLE
fix(gateway): suppress intentional-silence markers on the queued-follow-up send

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20150,14 +20150,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 pass
                         except Exception as e:
                             logger.debug("Stream consumer wait before queued message failed: %s", e)
-                    _previewed = bool(result.get("response_previewed"))
-                    first_response = result.get("final_response", "")
+                    # The queued branch needs raw ``result`` for interruption,
+                    # history, and recursion state, but delivery must use the
+                    # finalized task result. The latter contains empty/failure
+                    # normalization and any final response processing applied by
+                    # _run_agent_task; sending the raw copy bypasses those steps.
+                    _delivery_result = response if isinstance(response, dict) else (result or {})
+                    _previewed = bool(_delivery_result.get("response_previewed"))
+                    first_response = _delivery_result.get("final_response", "")
                     _already_streamed = _stream_confirmed_final_delivery(
                         _sc,
                         first_response,
                         previewed=_previewed,
                     )
-                    if first_response and not _already_streamed:
+                    # Apply the same predicate as the normal completed-turn path.
+                    # This direct queued-send branch predates intentional-silence
+                    # filtering, so without this check it leaks the literal marker.
+                    try:
+                        from gateway.response_filters import is_intentional_silence_agent_result
+                        _intentional_silence = is_intentional_silence_agent_result(
+                            _delivery_result, first_response,
+                        )
+                    except Exception:
+                        _intentional_silence = False
+                    if _intentional_silence:
+                        logger.info(
+                            "Queued follow-up for session %s: suppressing intentional silence marker before continuing.",
+                            session_key or "?",
+                        )
+                    elif first_response and not _already_streamed:
                         try:
                             logger.info(
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -697,6 +697,48 @@ class QueuedCommentaryAgent:
         }
 
 
+class QueuedSilenceAgent:
+    """First turn is intentionally silent; queued follow-up still runs."""
+
+    calls = 0
+
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls += 1
+        return {
+            "final_response": "NO_REPLY" if type(self).calls == 1 else "follow-up processed",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class QueuedFailedEmptyAgent:
+    """First turn fails empty; its normalized error must send before follow-up."""
+
+    calls = 0
+
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls += 1
+        if type(self).calls == 1:
+            return {
+                "final_response": "",
+                "messages": [],
+                "api_calls": 1,
+                "failed": True,
+                "error": "provider exploded",
+            }
+        return {
+            "final_response": "follow-up processed",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class BackgroundReviewAgent:
     def __init__(self, **kwargs):
         self.background_review_callback = kwargs.get("background_review_callback")
@@ -1088,6 +1130,52 @@ async def test_run_agent_queued_message_does_not_treat_commentary_as_final(monke
     assert result["final_response"] == "final response 2"
     assert "I'll inspect the repo first." in sent_texts
     assert "final response 1" in sent_texts
+
+
+@pytest.mark.asyncio
+async def test_run_agent_suppresses_silent_first_turn_and_processes_queued_followup(
+    monkeypatch, tmp_path,
+):
+    """Regression: queued direct-send must not leak NO_REPLY to the channel."""
+    QueuedSilenceAgent.calls = 0
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedSilenceAgent,
+        session_id="sess-queued-silence",
+        pending_text="queued follow-up",
+        platform=Platform.SLACK,
+        chat_id="C123",
+        thread_id="1712345678.000100",
+    )
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert QueuedSilenceAgent.calls == 2
+    assert result["final_response"] == "follow-up processed"
+    assert "NO_REPLY" not in sent_texts
+
+
+@pytest.mark.asyncio
+async def test_run_agent_sends_normalized_failure_before_queued_followup(
+    monkeypatch, tmp_path,
+):
+    """Queued delivery uses finalized output, not the raw empty agent result."""
+    QueuedFailedEmptyAgent.calls = 0
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedFailedEmptyAgent,
+        session_id="sess-queued-failed-empty",
+        pending_text="queued follow-up",
+        platform=Platform.SLACK,
+        chat_id="C123",
+        thread_id="1712345678.000100",
+    )
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert QueuedFailedEmptyAgent.calls == 2
+    assert result["final_response"] == "follow-up processed"
+    assert any("The request failed: provider exploded" in text for text in sent_texts)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

A successful turn that intentionally returns exactly `NO_REPLY` leaks the literal control marker into the channel when a second message is queued before the first turn finishes. Reported by an enterprise deployment on Slack (v0.18.2): first message correctly resolved to silence, second message arrived mid-turn, the gateway logged `final stream delivery not confirmed; sending first response before continuing`, and the bot posted raw `NO_REPLY` 380ms later.

## Root cause

Two features landed at different times and never met:

- the queued-follow-up recovery send (`ff071fc74`) delivers `final_response` directly through `adapter.send(...)` so a legitimate first response isn't lost when a follow-up interrupts it
- exact silence suppression (`293c04fef`, #30644 class) was added later on the normal delivery path only

The queued branch in `_run_agent_inner` never consulted `is_intentional_silence_agent_result(...)`, so the control marker sailed through. Correct for normal text, wrong for control markers.

## The fix

Use the finalized task result for the queued recovery delivery rather than the earlier raw `result_holder` copy, then apply the existing `is_intentional_silence_agent_result(...)` predicate before sending. No new marker list, filter, or delivery abstraction.

Using finalized output matters for a second reason found during review: an empty failed first turn has already been converted into a useful error message by `_run_agent_task`. The raw result is still empty, so the old queued branch silently dropped that error and moved straight to the follow-up. Delivery now sees the same normalized response as the normal completed-turn path.

The existing contract stays intact:

- suppress only successful turns whose whole response is an exact marker
- prose that merely mentions `NO_REPLY` still sends
- failed results are never silently swallowed
- streaming-confirmed delivery still skips the resend
- the control turn stays in persisted history for role alternation
- interruption, history, callback release, and recursive queue state still use the existing raw result and are unchanged

Two integration regressions run the real Slack `_run_agent` queued-follow-up flow. One asserts `NO_REPLY` never reaches the adapter and the second turn still completes. The other asserts an empty failed first turn sends its normalized error before the follow-up. Existing response-filter tests cover every supported marker, prose mentions, and failed-result semantics.

## How to test

```bash
python -m pytest \
  tests/gateway/test_run_progress_topics.py::test_run_agent_suppresses_silent_first_turn_and_processes_queued_followup \
  tests/gateway/test_run_progress_topics.py::test_run_agent_sends_normalized_failure_before_queued_followup -q
python -m pytest tests/gateway/test_gateway_silence_tokens.py \
                 tests/gateway/test_response_filters.py \
                 tests/gateway/test_stream_consumer_silence.py \
                 tests/gateway/test_run_progress_topics.py -q
```

Full `tests/gateway/` run: 8976 passed; the handful of failures present are identical on clean `main` (verified in a separate worktree at the same base) and unrelated to this change.

