### PR TITLE
fix(mcp): recover closed stdio sessions after keepalive failures

### DIFF
--- a/tests/tools/test_mcp_empty_error_message.py
+++ b/tests/tools/test_mcp_empty_error_message.py
@@ -69,6 +69,22 @@ def test_broken_pipe_triggers_transport_recovery():
     assert _is_session_expired_error(BrokenPipeError()) is True
 
 
+def test_unrelated_anyio_resource_error_does_not_trigger_recovery():
+    """An AnyIO error whose type name merely contains 'Resource' but is not a
+    closed/broken/end-of-stream failure must NOT enter the reconnect path.
+
+    Matching every AnyIO 'Resource' exception would funnel unrelated errors
+    into transport churn (#65111 review).
+    """
+    # Mimic an unrelated anyio resource exception type name.
+    Unrelated = type(
+        "CapacityExceededResourceError",
+        (Exception,),
+        {"__module__": "anyio.streams.memory"},
+    )
+    assert _is_session_expired_error(Unrelated("no capacity")) is False
+
+
 # ---------------------------------------------------------------------------
 # Integration: error message format in _sanitize_error
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_empty_error_message.py
+++ b/tests/tools/test_mcp_empty_error_message.py
@@ -9,7 +9,7 @@ Fix: ``_exc_str()`` falls back to ``repr(exc)`` when ``str(exc)`` is empty.
 
 
 
-from tools.mcp_tool import _exc_str, _sanitize_error
+from tools.mcp_tool import _exc_str, _is_session_expired_error, _sanitize_error
 
 
 # ---------------------------------------------------------------------------
@@ -55,6 +55,18 @@ def test_exc_str_handles_closedresource_like_exception():
     result = _exc_str(exc)
     assert "ClosedResourceError" in result
     assert result != ""
+
+
+def test_closedresource_error_triggers_transport_recovery():
+    """Empty-message anyio transport failures must enter reconnect handling."""
+    from anyio import ClosedResourceError
+
+    assert _is_session_expired_error(ClosedResourceError()) is True
+
+
+def test_broken_pipe_triggers_transport_recovery():
+    """Pipe closure must enter the same transport recovery path."""
+    assert _is_session_expired_error(BrokenPipeError()) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1394,6 +1394,41 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    def test_parked_shutdown_on_closed_event_loop_does_not_raise(self):
+        """A parked MCP task woken after the event loop closed must return
+        'shutdown' instead of raising 'Event loop is closed' (#65111).
+
+        At process exit the loop can be closed before the parked
+        _wait_for_reconnect_or_shutdown finally-block runs; calling
+        task.cancel() on a dead loop re-raises RuntimeError via
+        call_soon -> _check_closed, which asyncio prints as an
+        'Exception ignored' traceback.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("srv")
+
+            # Simulate process shutdown: loop reports closed (not running).
+            real_loop = asyncio.get_event_loop()
+
+            class _ClosedLoop:
+                def is_closed(self):
+                    return True
+
+                def is_running(self):
+                    return False
+
+            asyncio.get_event_loop = lambda: _ClosedLoop()  # type: ignore[assignment]
+            try:
+                reason = await server._wait_for_reconnect_or_shutdown(timeout=0.01)
+            finally:
+                asyncio.get_event_loop = lambda: real_loop  # type: ignore[assignment]
+
+            assert reason == "shutdown"
+
+        asyncio.run(_test())
+
 
 # ---------------------------------------------------------------------------
 # discover_mcp_tools toolset injection

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1429,6 +1429,35 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    def test_parked_shutdown_on_no_current_event_loop_does_not_raise(self):
+        """If the event loop is already gone (no current loop in the thread),
+        the parked cleanup must return 'shutdown' instead of re-raising
+        asyncio.get_event_loop()'s 'no current event loop' error (#65111).
+
+        This is the failure mode seen when one Hermes session closes and the
+        loop is torn down before the parked _wait_for_reconnect_or_shutdown
+        finally-block runs.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("srv")
+
+            real_get = asyncio.get_event_loop
+
+            def _raises_no_loop():
+                raise RuntimeError("no current event loop in thread 'MainThread'")
+
+            asyncio.get_event_loop = _raises_no_loop  # type: ignore[assignment]
+            try:
+                reason = await server._wait_for_reconnect_or_shutdown(timeout=0.01)
+            finally:
+                asyncio.get_event_loop = real_get  # type: ignore[assignment]
+
+            assert reason == "shutdown"
+
+        asyncio.run(_test())
+
 
 # ---------------------------------------------------------------------------
 # discover_mcp_tools toolset injection

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1353,6 +1353,47 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    def test_keepalive_ping_waits_for_rpc_lock(self):
+        """Keepalive ping must not race an active MCP tool call."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("srv")
+            server.session = MagicMock()
+            server.session.send_ping = AsyncMock()
+
+            async with server._rpc_lock:
+                probe = asyncio.create_task(server._keepalive_probe())
+                await asyncio.sleep(0)
+                server.session.send_ping.assert_not_awaited()
+
+            await probe
+            server.session.send_ping.assert_awaited_once()
+
+        asyncio.run(_test())
+
+    def test_keepalive_list_tools_fallback_waits_for_rpc_lock(self):
+        """The no-ping fallback must use the same per-server RPC lock."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("srv")
+            server.session = MagicMock()
+            server._ping_unsupported = True
+            server.session.list_tools = AsyncMock(
+                return_value=SimpleNamespace(tools=[])
+            )
+
+            async with server._rpc_lock:
+                probe = asyncio.create_task(server._keepalive_probe())
+                await asyncio.sleep(0)
+                server.session.list_tools.assert_not_awaited()
+
+            await probe
+            server.session.list_tools.assert_awaited_once()
+
+        asyncio.run(_test())
+
 
 # ---------------------------------------------------------------------------
 # discover_mcp_tools toolset injection

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2199,6 +2199,16 @@ class MCPServerTask:
                 timeout=timeout,
             )
         finally:
+            # The event loop may already be closing/closed during process
+            # shutdown. At that point the parked task can still be woken by a
+            # pending timer; calling t.cancel() schedules on a closed loop
+            # (call_soon -> _check_closed) and raises
+            # "RuntimeError: Event loop is closed", which asyncio then prints
+            # as an "Exception ignored" traceback (#65111). Bail out of
+            # cleanup rather than touching the dead loop.
+            loop = asyncio.get_event_loop()
+            if getattr(loop, "is_closed", None) and loop.is_closed():
+                return "shutdown"
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
                     t.cancel()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2199,14 +2199,18 @@ class MCPServerTask:
                 timeout=timeout,
             )
         finally:
-            # The event loop may already be closing/closed during process
-            # shutdown. At that point the parked task can still be woken by a
-            # pending timer; calling t.cancel() schedules on a closed loop
-            # (call_soon -> _check_closed) and raises
-            # "RuntimeError: Event loop is closed", which asyncio then prints
-            # as an "Exception ignored" traceback (#65111). Bail out of
-            # cleanup rather than touching the dead loop.
-            loop = asyncio.get_event_loop()
+            # The event loop may already be closed (or have no current loop in
+            # this thread) during process shutdown. At that point the parked
+            # task can still be woken by a pending timer; calling t.cancel()
+            # schedules on a dead loop (call_soon -> _check_closed) and raises
+            # "Event loop is closed", and asyncio.get_event_loop() raises
+            # "no current event loop" — both of which asyncio then prints as
+            # an "Exception ignored" traceback (#65111). Bail out of cleanup
+            # rather than touching the dead/absent loop.
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                return "shutdown"
             if getattr(loop, "is_closed", None) and loop.is_closed():
                 return "shutdown"
             for t in (shutdown_task, reconnect_task):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2044,7 +2044,8 @@ class MCPServerTask:
         """
         if not self._ping_unsupported:
             try:
-                await asyncio.wait_for(self.session.send_ping(), timeout=30.0)
+                async with self._rpc_lock:
+                    await asyncio.wait_for(self.session.send_ping(), timeout=30.0)
                 return
             except Exception as exc:
                 # Only a "method not found" means ping is unsupported. Any
@@ -2064,7 +2065,8 @@ class MCPServerTask:
                 )
 
         # Fallback probe for servers without ping support.
-        await asyncio.wait_for(self.session.list_tools(), timeout=30.0)
+        async with self._rpc_lock:
+            await asyncio.wait_for(self.session.list_tools(), timeout=30.0)
 
     async def _wait_for_lifecycle_event(self) -> str:
         """Block until either _shutdown_event or _reconnect_event fires.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2150,7 +2150,7 @@ class MCPServerTask:
                         logger.warning(
                             "MCP server '%s' keepalive failed, "
                             "triggering reconnect: %s",
-                            self.name, exc,
+                            self.name, _exc_str(exc),
                         )
                         self._reconnect_event.set()
                         break
@@ -3547,11 +3547,22 @@ def _is_session_expired_error(exc: BaseException) -> bool:
     """
     if isinstance(exc, InterruptedError):
         return False
+    exc_type = type(exc)
+    exc_name = exc_type.__name__
+    exc_module = getattr(exc_type, "__module__", "")
+    if (
+        exc_name in {"ClosedResourceError", "BrokenResourceError", "EndOfStream"}
+        or (exc_module.startswith("anyio") and "Resource" in exc_name)
+        or isinstance(exc, (BrokenPipeError, EOFError))
+    ):
+        return True
     # Exception messages vary across SDK versions + server
     # implementations, so match on a small allow-list of stable
-    # substrings rather than exception type.  Kept narrow to avoid
-    # false positives on unrelated server errors.
-    msg = str(exc).lower()
+    # substrings rather than exception type.  Some transport exceptions
+    # (notably anyio.ClosedResourceError) have an empty ``str(exc)``;
+    # use the shared diagnostic formatter so their type name remains
+    # visible to the classifier as well as to logs.
+    msg = _exc_str(exc).lower()
     if not msg:
         return False
     return any(marker in msg for marker in _SESSION_EXPIRED_MARKERS)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3559,10 +3559,16 @@ def _is_session_expired_error(exc: BaseException) -> bool:
         return False
     exc_type = type(exc)
     exc_name = exc_type.__name__
-    exc_module = getattr(exc_type, "__module__", "")
+    # Only the explicit closed/broken/end-of-stream transport types count as a
+    # reconnectable expiry. We must NOT match every AnyIO error whose type name
+    # merely contains "Resource" (e.g. CapacityExceededResourceError or other
+    # unrelated resource exceptions) — that would funnel unrelated errors into
+    # the reconnect-and-retry path and churn the transport. ClosedResourceError
+    # and BrokenResourceError are caught by exact name below; EndOfStream and
+    # the stdlib pipe/EOF errors cover the rest.
     if (
-        exc_name in {"ClosedResourceError", "BrokenResourceError", "EndOfStream"}
-        or (exc_module.startswith("anyio") and "Resource" in exc_name)
+        exc_name
+        in {"ClosedResourceError", "BrokenResourceError", "EndOfStream"}
         or isinstance(exc, (BrokenPipeError, EOFError))
     ):
         return True


### PR DESCRIPTION
## Summary

Follow-up to #62811 and replacement for #64989.

#62811 confirms the same MCP failure class: keepalive and an active RPC can interfere on the single JSON-RPC stream, causing a wedged/closed transport, false reconnects, and failed tool calls. This PR keeps the `_rpc_lock` serialization from #64989 and adds the missing transport-recovery path for the resulting closed-stream exceptions.

## Changes

- Preserve `_rpc_lock` serialization for keepalive `ping` / `list_tools` probes.
- Classify empty-message transport exceptions (`anyio.ClosedResourceError`, `BrokenResourceError`, `EndOfStream`, `BrokenPipeError`, `EOFError`) as reconnectable transport failures.
- Use the diagnostic exception formatter in keepalive logs so the failure type is not lost.
- Add regression tests for closed-resource and broken-pipe classification.

The existing reconnect path remains bounded: one reconnect/retry at the tool-call layer, the existing reconnect budget, circuit breaker, and parked self-probe behavior remain unchanged.

## Validation

- 278 targeted MCP/reconnect tests passed.
- `py_compile` passed.
- `git diff --check` passed.

Refs: #62811, closes #64989
