### PR TITLE
fix(yuanbao): declare SUPPORTS_MESSAGE_EDITING=False + tier-low default

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -171,6 +171,7 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "wecom":           _TIER_LOW,
     "wecom_callback":  _TIER_LOW,
     "dingtalk":        _TIER_LOW,
+    "yuanbao":         _TIER_LOW,  # Yuanbao has no message edit endpoint
 
     # Tier 4 — batch or non-interactive delivery
     "email":           _TIER_MINIMAL,

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -4865,6 +4865,9 @@ class YuanbaoAdapter(BasePlatformAdapter):
     """Yuanbao AI Bot adapter backed by a persistent WebSocket connection."""
 
     PLATFORM = Platform.YUANBAO
+    # Yuanbao has no message-edit endpoint: every progress/status bubble is a
+    # permanent message, so streaming (which edits in place) must be skipped.
+    SUPPORTS_MESSAGE_EDITING = False
     MAX_TEXT_CHUNK: int = 4000  # Yuanbao single message character limit
     splits_long_messages = True  # send() auto-chunks via truncate_message(MAX_TEXT_CHUNK)
     MEDIA_MAX_SIZE_MB: int = 50  # Max media file size in MB for upload validation

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -136,7 +136,15 @@ class TestPlatformDefaults:
         """Signal, BlueBubbles, etc. default to 'off' tool progress."""
         from gateway.display_config import resolve_display_setting
 
-        for plat in ("signal", "bluebubbles", "weixin", "wecom", "dingtalk", "whatsapp_cloud"):
+        for plat in (
+            "signal",
+            "bluebubbles",
+            "weixin",
+            "wecom",
+            "dingtalk",
+            "whatsapp_cloud",
+            "yuanbao",
+        ):
             assert resolve_display_setting({}, plat, "tool_progress") == "off", plat
 
 
@@ -167,6 +175,74 @@ class TestPlatformDefaults:
         assert resolve_display_setting({}, "slack", "tool_progress") == "off"
         assert resolve_display_setting({}, "slack", "long_running_notifications") is False
         assert resolve_display_setting({}, "slack", "busy_ack_detail") is False
+
+
+# ---------------------------------------------------------------------------
+# Yuanbao (Tencent 腾讯元宝) — no edit support → TIER_LOW
+# ---------------------------------------------------------------------------
+
+class TestYuanbaoDefaults:
+    """Yuanbao adapter has no ``edit_message``, so display defaults must align
+    with the TIER_LOW platforms (signal / bluebubbles / weixin / wecom /
+    dingtalk). Every progress/status message on Yuanbao is permanent, so
+    surfacing live tool progress or interim chatter would spam the chat with
+    separate, undeletable bubbles — the exact failure mode TIER_LOW exists to
+    avoid."""
+
+    # YB-001: adapter declares it cannot edit messages (capability flag, C1).
+    def test_yb001_adapter_declares_no_message_editing(self):
+        """``YuanbaoAdapter.SUPPORTS_MESSAGE_EDITING`` must be False.
+
+        Yuanbao's API exposes no message-edit endpoint, so the adapter must
+        advertise this so the rest of the system knows each bubble is
+        permanent and avoids edit-based UX (tool_progress grouping, progress
+        edits, cleanup_progress edits, etc.).
+        """
+        from gateway.platforms.yuanbao import YuanbaoAdapter
+
+        assert YuanbaoAdapter.SUPPORTS_MESSAGE_EDITING is False
+
+    # YB-002: interim_assistant_messages defaults to False on yuanbao.
+    def test_yb002_interim_assistant_messages_defaults_off(self):
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "yuanbao", "interim_assistant_messages") is False
+
+    # YB-003: every TIER_LOW key resolves identically for yuanbao (full-field
+    # alignment, parameterised over _TIER_LOW).
+    def test_yb003_all_tier_low_keys_align(self):
+        from gateway.display_config import _TIER_LOW, resolve_display_setting
+
+        for key, expected in _TIER_LOW.items():
+            assert (
+                resolve_display_setting({}, "yuanbao", key) == expected
+            ), f"yuanbao key {key!r}: expected {expected!r}, got {resolve_display_setting({}, 'yuanbao', key)!r}"
+
+    # YB-004: explicit user config still overrides the TIER_LOW default.
+    def test_yb004_explicit_config_wins(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"interim_assistant_messages": True}}
+        assert (
+            resolve_display_setting(config, "yuanbao", "interim_assistant_messages") is True
+        )
+
+    # YB-005: an explicit ``display.platforms.yuanbao.streaming`` opt-in is
+    # honoured by the resolver, but the adapter still declares no edit support —
+    # so the run-layer setup guard (gateway/run.py, "skip streaming for
+    # non-editable platform") skips streaming rather than emitting a partial
+    # first message that could never be edited into the final answer.
+    def test_yb005_explicit_streaming_optin_still_blocked_by_no_edit(self):
+        from gateway.display_config import resolve_display_setting
+        from gateway.platforms.yuanbao import YuanbaoAdapter
+
+        config = {"display": {"platforms": {"yuanbao": {"streaming": True}}}}
+        # The opt-in is reachable at the resolver layer…
+        assert resolve_display_setting(config, "yuanbao", "streaming") is True
+        # …but the adapter cannot edit, so edit-based streaming would only
+        # emit permanent partials. SUPPORTS_MESSAGE_EDITING is exactly the
+        # flag the run-layer guard checks before constructing the consumer.
+        assert YuanbaoAdapter.SUPPORTS_MESSAGE_EDITING is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# fix(yuanbao): declare SUPPORTS_MESSAGE_EDITING=False + tier-low default

## 问题（双重漏配）

Yuanbao（腾讯元宝）adapter 存在两处配置缺失，导致在无 message-edit 能力的平台上错误地启用流式编辑，产生大量永久性进度气泡：

1. **adapter 未声明 `SUPPORTS_MESSAGE_EDITING = False`**
   `YuanbaoAdapter` 没有像 `WeixinAdapter` / `SignalAdapter` / `BlueBubblesAdapter` 那样声明该标志，`getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)` 回退为默认值 `True`，`run.py` 据此认为平台支持原地编辑，于是走 streaming-in-place 路径——而 Yuanbao 协议根本没有 edit-message endpoint，每一次 cursor/进度更新都被当作一条新消息永久落盘。

2. **`_PLATFORM_DEFAULTS` 漏配 yuanbao 条目**
   `gateway/display_config.py` 的 `_PLATFORM_DEFAULTS` 字典里没有 `"yuanbao"` 键，`resolve_display_setting()` 找不到平台默认 tier，`interim_assistant_messages` / `tool_progress` 等开关无法被 tier-low 策略正确收敛。

## 根因分析：`SUPPORTS_MESSAGE_EDITING` 的影响面

该标志在 `gateway/run.py` 两处决定流式渲染策略（两处机制略有不同，最终效果一致：send-final-only）：

| 位置 | 默认（漏配 True） | 修复后（False） |
|------|------|--------|
| `run.py:17086`（主回复路径） | `_effective_cursor = scfg.cursor`（保留游标） | `_effective_cursor = ""`（清空游标，stream consumer 走 buffer-only，结束时发一条 final） |
| `run.py:18504`（状态/long-running 路径） | 构造 stream consumer | `raise RuntimeError("skip streaming for non-editable platform")` → 被外层 `except` 捕获 → `_stream_consumer = None` → 走 send-final-only |

两处最终都让 Yuanbao 不再在每个 token 增量上 `edit_message`（协议无此 endpoint，调用必失败），而是只在结束时发一条最终消息——这对「无 edit endpoint」的平台是唯一正确的行为，且与 weixin/qqbot/signal/bluebubbles 完全同路径。

## 修复（adapter + tier 双补）

### 改动 1：`gateway/platforms/yuanbao.py`

在 `YuanbaoAdapter` 的 `PLATFORM = Platform.YUANBAO` 之后新增类属性：

```python
    PLATFORM = Platform.YUANBAO
    # Yuanbao has no message-edit endpoint: every progress/status bubble is a
    # permanent message, so streaming (which edits in place) must be skipped.
    SUPPORTS_MESSAGE_EDITING = False
```

注释风格对齐 `gateway/platforms/weixin.py:1146-1148`。

### 改动 2：`gateway/display_config.py`

在 `_PLATFORM_DEFAULTS` 的 Tier 3 区块（`"dingtalk": _TIER_LOW,` 之后、`# Tier 4` 之前）新增：

```python
    "dingtalk":        _TIER_LOW,
    "yuanbao":         _TIER_LOW,  # Yuanbao has no message edit endpoint
```

对齐风格与同列 `_TIER_LOW` 条目（`signal` / `weixin` / `wecom` / `dingtalk`）一致。

## Before / After 对照

| 维度 | 修复前 | 修复后 |
|------|--------|--------|
| `YuanbaoAdapter.SUPPORTS_MESSAGE_EDITING` | 未定义 → `getattr` 回退 `True` | 显式 `False` |
| `run.py` 流式策略 | 原地编辑（`_effective_cursor` 保留游标） | send-final-only（游标清空，只发最终消息） |
| 进度气泡 | 每条 token 增量 = 一条永久消息 → 刷屏 | 单条最终消息 |
| `resolve_display_setting({}, 'yuanbao', 'interim_assistant_messages')` | 找不到 tier，行为未定义 | `False`（tier-low 收敛） |
| `tool_progress` 通知 | 未被 tier-low 关闭，重复落盘 | tier-low 关闭 |

实测确认（`.venv/bin/python`）：
```
flag= False          # YuanbaoAdapter.SUPPORTS_MESSAGE_EDITING
interim= False       # resolve_display_setting interim_assistant_messages
```

## 与 PR #65100（qqbot）的关系

- **同类问题，独立分支**：qqbot PR 同样为 `QQBotAdapter` 补 `SUPPORTS_MESSAGE_EDITING = False`（见 `gateway/platforms/qqbot/adapter.py:158`），根因一致——adapter 未声明标志 + tier 漏配。
- **本 PR 是双补**：qqbot PR 是「同类前例」，本次在 Yuanbao 上做了完全对应的 adapter+tier 双补，模式与注释风格与 weixin/signal/bluebubbles/qqbot 保持一致。
- **无冲突**：基于最新 main（`6020b9f4f`），独立于 qqbot PR 分支，`display_config.py` 当前无 qqbot 行，本 PR 只新增 yuanbao 行，不触碰任何其他平台条目。

## tier 设计依据（为何 `_TIER_LOW`）

参考 `display_config.py` 既有约定：

- **Tier 3（`_TIER_LOW`）= 无 edit 支持，进度消息永久化**。注释原文：`# Tier 3 — no edit support, progress messages are permanent`。
- Tier-low 关闭 `interim_assistant_messages` / `tool_progress` 等会「逐条落盘」的开关，避免在无 edit 能力的平台上刷屏。
- Yuanbao 协议层无 message-edit endpoint（与 signal / weixin / wecom / dingtalk 同类），天然落入 Tier 3。
- 不进 Tier 4（`_TIER_MINIMAL`）：Yuanbao 是双向交互式 AI bot（非 batch/email/sms 类单向投递），保留 medium 级别的交互能力，仅关闭会刷屏的进度类通知。

## 范围

- 只改 `gateway/platforms/yuanbao.py` + `gateway/display_config.py` 两文件。
- 不触碰 `_GLOBAL_DEFAULTS` / `_TIER_*` 定义 / 其他平台条目 / `edit_message` 实现 / 其他 adapter。
- ruff 0.15.10：`All checks passed!`
- 无重复 PR：本分支 `fix/yuanbao-no-edit-support-and-tier-low` 独立，不与 qqbot PR 重叠。
