### PR TITLE
Desktop: send the gateway's own Origin on gateway WebSocket upgrades

### DIFF
--- a/apps/desktop/electron/gateway-ws-origin.test.ts
+++ b/apps/desktop/electron/gateway-ws-origin.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for electron/gateway-ws-origin.ts.
+ *
+ * The pure rewrite decision behind the renderer's gateway-WS same-origin
+ * handshake: which URLs count as gateway WS upgrades, what Origin value they
+ * get, and that everything else passes through untouched.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { applyGatewayWsOrigin, gatewayWsOrigin } from './gateway-ws-origin'
+
+// --- gatewayWsOrigin: matching ---
+
+test('gatewayWsOrigin maps gateway WS endpoints to their own web origin', () => {
+  assert.equal(gatewayWsOrigin('ws://100.64.0.7:9119/api/ws?ticket=abc'), 'http://100.64.0.7:9119')
+  assert.equal(gatewayWsOrigin('ws://100.64.0.7:9119/api/pub?channel=c1'), 'http://100.64.0.7:9119')
+  assert.equal(gatewayWsOrigin('ws://100.64.0.7:9119/api/events?channel=c1'), 'http://100.64.0.7:9119')
+  assert.equal(gatewayWsOrigin('wss://gw.example.com/api/ws?ticket=abc'), 'https://gw.example.com')
+})
+
+test('gatewayWsOrigin supports path prefixes and trailing slashes', () => {
+  assert.equal(gatewayWsOrigin('wss://box.tailnet.ts.net/hermes/api/ws?ticket=t'), 'https://box.tailnet.ts.net')
+  assert.equal(gatewayWsOrigin('ws://127.0.0.1:9119/api/ws/'), 'http://127.0.0.1:9119')
+})
+
+test('gatewayWsOrigin ignores non-WS schemes and non-gateway paths', () => {
+  assert.equal(gatewayWsOrigin('http://100.64.0.7:9119/api/ws'), null)
+  assert.equal(gatewayWsOrigin('ws://100.64.0.7:9119/api/pty'), null)
+  assert.equal(gatewayWsOrigin('ws://100.64.0.7:9119/api/wsx'), null)
+  assert.equal(gatewayWsOrigin('ws://example.com/chat'), null)
+  assert.equal(gatewayWsOrigin('not a url'), null)
+  assert.equal(gatewayWsOrigin(''), null)
+  assert.equal(gatewayWsOrigin(null), null)
+})
+
+// --- applyGatewayWsOrigin: header rewrite ---
+
+test('applyGatewayWsOrigin replaces the Origin header for gateway upgrades', () => {
+  const headers = applyGatewayWsOrigin('ws://100.64.0.7:9119/api/ws?ticket=t', {
+    Origin: 'http://127.0.0.1:5174',
+    'User-Agent': 'test'
+  })
+
+  assert.deepEqual(headers, { Origin: 'http://100.64.0.7:9119', 'User-Agent': 'test' })
+})
+
+test('applyGatewayWsOrigin removes any casing of the original Origin key', () => {
+  const headers = applyGatewayWsOrigin('ws://100.64.0.7:9119/api/ws', { origin: 'http://127.0.0.1:5174' })
+
+  assert.deepEqual(headers, { Origin: 'http://100.64.0.7:9119' })
+})
+
+test('applyGatewayWsOrigin stamps Origin even when the handshake carried none', () => {
+  const headers = applyGatewayWsOrigin('ws://100.64.0.7:9119/api/ws', {})
+
+  assert.deepEqual(headers, { Origin: 'http://100.64.0.7:9119' })
+})
+
+test('applyGatewayWsOrigin returns null for non-gateway requests (pass through)', () => {
+  assert.equal(applyGatewayWsOrigin('wss://example.com/socket', { Origin: 'http://127.0.0.1:5174' }), null)
+  assert.equal(applyGatewayWsOrigin('https://gw.example.com/api/ws', { Origin: 'http://127.0.0.1:5174' }), null)
+})
+
+test('applyGatewayWsOrigin does not mutate the input headers', () => {
+  const input = { Origin: 'http://127.0.0.1:5174' }
+
+  applyGatewayWsOrigin('ws://100.64.0.7:9119/api/ws', input)
+
+  assert.deepEqual(input, { Origin: 'http://127.0.0.1:5174' })
+})

--- a/apps/desktop/electron/gateway-ws-origin.ts
+++ b/apps/desktop/electron/gateway-ws-origin.ts
@@ -1,0 +1,92 @@
+/**
+ * gateway-ws-origin.ts
+ *
+ * Same-origin rewrite for the renderer's gateway WebSocket upgrades.
+ *
+ * The dashboard applies a DNS-rebinding Host/Origin guard to WebSocket
+ * upgrades (web_server.py `_ws_host_origin_reason`): when a browser Origin
+ * header is present, it must target the bound dashboard host, or the upgrade
+ * is refused with 403 BEFORE `accept()`. Chromium stamps the window's web
+ * origin on every WS handshake and the renderer cannot override it, so a
+ * renderer served from anywhere other than the gateway host can never pass
+ * that check:
+ *
+ *   - dev (`npm run dev`): the window is the Vite server, so the handshake
+ *     carries `Origin: http://127.0.0.1:5174` — a remote gateway bound to
+ *     another host closes the socket pre-accept and the app surfaces the
+ *     opaque "Could not connect to Hermes gateway". Every REST call keeps
+ *     working (those route through the main process's `net`, which sends no
+ *     Origin), which makes the failure look like a gateway-side WS bug.
+ *   - packaged: the window is `file://`, a non-web origin the server-side
+ *     guard already exempts — which is why this only bites source checkouts.
+ *
+ * The desktop shell owns its gateway connection (the credential — the
+ * single-use ticket minted over the authenticated cookie session — is the
+ * real auth boundary), so presenting the gateway's own origin is the honest
+ * native-client behavior and keeps the guard meaningful for real browsers.
+ *
+ * Kept electron-free (same pattern as connection-config.ts) so the rewrite
+ * decision is unit-testable; main.ts wires it into
+ * `session.defaultSession.webRequest.onBeforeSendHeaders`.
+ */
+
+// Gateway WS endpoints (web_server.py): the JSON-RPC sidecar plus the
+// chat-tab broadcast pair. Everything else — including arbitrary ws:// URLs a
+// session might embed — passes through untouched.
+const GATEWAY_WS_PATH_RE = /\/api\/(ws|pub|events)$/
+
+/**
+ * The same-origin value for a gateway WS endpoint URL, or null when the URL
+ * is not a gateway WS upgrade (wrong scheme or path) and must not be touched.
+ */
+function gatewayWsOrigin(rawUrl) {
+  let parsed
+
+  try {
+    parsed = new URL(String(rawUrl || ''))
+  } catch {
+    return null
+  }
+
+  if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+    return null
+  }
+
+  // Strip trailing slashes so `/api/ws/` matches too; path prefixes
+  // (`/hermes/api/ws`) match by design — the regex is anchored at the end.
+  if (!GATEWAY_WS_PATH_RE.test(parsed.pathname.replace(/\/+$/, ''))) {
+    return null
+  }
+
+  return `${parsed.protocol === 'wss:' ? 'https:' : 'http:'}//${parsed.host}`
+}
+
+/**
+ * Rewrite `headers`' Origin for a gateway WS upgrade to `rawUrl`.
+ *
+ * Returns a NEW headers object with the Origin replaced (any casing of the
+ * original key removed first — Chromium sends `Origin`, but don't rely on
+ * it), or null when the request is not a gateway WS upgrade and the caller
+ * should pass the original headers through unchanged.
+ */
+function applyGatewayWsOrigin(rawUrl, headers) {
+  const origin = gatewayWsOrigin(rawUrl)
+
+  if (!origin) {
+    return null
+  }
+
+  const next = { ...(headers || {}) }
+
+  for (const key of Object.keys(next)) {
+    if (key.toLowerCase() === 'origin') {
+      delete next[key]
+    }
+  }
+
+  next.Origin = origin
+
+  return next
+}
+
+export { applyGatewayWsOrigin, gatewayWsOrigin }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -67,6 +67,7 @@ import {
 } from './desktop-uninstall'
 import { installEmbedReferer } from './embed-referer'
 import { readDirForIpc } from './fs-read-dir'
+import { applyGatewayWsOrigin } from './gateway-ws-origin'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { scanGitRepos } from './git-repo-scan'
 import {
@@ -9530,6 +9531,20 @@ app.on('open-url', (event, url) => {
   handleDeepLink(url)
 })
 
+// Present the gateway's own origin on the renderer's gateway-WS handshakes so
+// the dashboard's Host/Origin guard accepts the upgrade. Without this, a
+// renderer served from anywhere other than the gateway host (the Vite dev
+// server in `npm run dev`) is refused pre-accept with 403 and remote mode
+// surfaces the opaque "Could not connect to Hermes gateway" — while REST keeps
+// working, because main-process requests carry no Origin. The rewrite decision
+// lives in gateway-ws-origin.ts (electron-free, unit-tested); scoped to
+// ws/wss upgrades of the gateway endpoints only.
+function installGatewayWsOrigin() {
+  session.defaultSession.webRequest.onBeforeSendHeaders({ urls: ['ws://*/*', 'wss://*/*'] }, (details, callback) => {
+    callback({ requestHeaders: applyGatewayWsOrigin(details.url, details.requestHeaders) ?? details.requestHeaders })
+  })
+}
+
 app.whenReady().then(() => {
   const systemCa = installWindowsSystemCaTrust(tls)
 
@@ -9550,6 +9565,7 @@ app.whenReady().then(() => {
   installMediaPermissions()
   registerMediaProtocol()
   installEmbedReferer()
+  installGatewayWsOrigin()
   registerDeepLinkProtocol()
   ensureWslWindowsFonts()
   configureSpellChecker()


### PR DESCRIPTION
## Problem

The dashboard applies a DNS-rebinding Host/Origin guard to WebSocket upgrades (`_ws_host_origin_reason` in web_server.py): when the handshake carries an Origin header, it must match the bound dashboard host, or the upgrade is refused with 403 before `accept()`.

Chromium stamps the window's web origin on every WebSocket handshake and the page cannot override it. When the desktop app runs from a source checkout (`npm run dev`), the renderer is served by Vite at `http://127.0.0.1:5174`, so every gateway WS upgrade carries that as its Origin. Against a remote gateway bound to another host, the socket is closed pre-accept and the app surfaces the opaque "Could not connect to Hermes gateway" — while every REST call keeps working, because those route through the Electron main process, which sends no Origin at all. That combination (REST green, WS dead) makes this miserable to debug: the gateway auth log shows ws-tickets being minted, but no `ws accepted` line ever follows in tui_gateway logs.

I hit this connecting the desktop app on my laptop to the gateway on my home server over my tailnet. Isolating it down:

- mint a ticket, attempt the WS upgrade with `Origin: http://127.0.0.1:5174` → **HTTP 403**
- same flow with no Origin header → **101 Switching Protocols**, `gateway.ready` arrives

Packaged builds don't hit this because their window is `file://`, a non-web origin the server-side guard already exempts. So this only affects running from source — which is exactly how you iterate on desktop ↔ remote gateway setups.

## Fix

The desktop shell owns its gateway connection, and the real auth boundary is the credential (the single-use ws-ticket minted over the authenticated cookie session). So the handshake now presents the gateway's own origin — the same trust statement the `file://` exemption already makes for packaged builds:

- `electron/gateway-ws-origin.ts` — pure, electron-free rewrite decision (same pattern as connection-config.ts): only `ws:`/`wss:` upgrades whose path ends in `/api/ws`, `/api/pub`, or `/api/events` get their Origin replaced with the target's own origin; everything else passes through untouched. Path prefixes (`/hermes/api/ws`) work.
- `main.ts` wires it into `session.defaultSession.webRequest.onBeforeSendHeaders`, filtered to `ws://*/*` / `wss://*/*`.

Nothing changes for real browsers hitting the dashboard; the server-side guard stays fully meaningful for them.

Related: #62301 adds a server-side allowed-hosts opt-in whose allowlist also feeds the WS origin check, so it can work around this too — but a native client shouldn't need server configuration to talk to its own configured gateway. Both changes stand on their own.

## Testing

- `npm run typecheck` clean
- 8 new unit tests in `electron/gateway-ws-origin.test.ts`; the full electron vitest project passes (422 tests)
- Verified live: dev-mode desktop on my laptop ↔ `hermes serve` on my home server over Tailscale. Before the change the gateway logged ticket mints but never `ws accepted`; with it the upgrade is accepted and the app connects and streams normally.