### PR TITLE
fix(gateway): import PairingStore in _start_secondary_profile_adapters

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8660,6 +8660,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Record served profiles in runtime status for `hermes status`.
         try:
             from gateway.status import write_runtime_status
+            from gateway.pairing import PairingStore
             served = [active] + sorted(self._profile_adapters.keys())
             # Per-profile PairingStores so authz_mixin can route pairing
             # checks to the right whitelist. The active profile gets a store

--- a/tests/gateway/test_multiplex_pairing_stores.py
+++ b/tests/gateway/test_multiplex_pairing_stores.py
@@ -1,0 +1,85 @@
+"""Regression: per-profile PairingStore creation in _start_secondary_profile_adapters.
+
+``gateway/run.py`` referenced ``PairingStore`` at method scope in
+``_start_secondary_profile_adapters`` while the class's only import was
+method-local inside ``__init__`` — a ``NameError`` at runtime, silently
+swallowed by the enclosing ``try/except``, so multiplexing gateways never
+created per-profile pairing stores and authz pairing checks for secondary
+profiles fell through to the global whitelist.
+
+These tests drive the REAL method (bound onto a bare runner) with the
+profile-enumeration and adapter-startup collaborators stubbed, and assert
+the per-profile stores actually materialize.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from gateway.run import GatewayRunner
+
+
+def _bare_runner(multiplex: bool = True):
+    runner = object.__new__(GatewayRunner)
+    runner.config = MagicMock(multiplex_profiles=multiplex)
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    runner.pairing_stores = {}
+    return runner
+
+
+def test_secondary_profile_pairing_stores_created(tmp_path, monkeypatch):
+    """The served-profiles loop must create a PairingStore per profile.
+
+    Pre-fix this silently did nothing: the ``PairingStore(profile=name)``
+    reference raised NameError inside the swallowed try/except.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir()
+
+    runner = _bare_runner()
+
+    async def _no_secondary(profile_name, profile_home, claimed):
+        return 0
+
+    runner._start_one_profile_adapters = _no_secondary
+    runner._adapter_credential_fingerprint = lambda adapter: None
+
+    with patch("hermes_cli.profiles.profiles_to_serve", return_value=[
+        ("coder", tmp_path / ".hermes" / "profiles" / "coder"),
+    ]), patch("hermes_cli.profiles.get_active_profile_name", return_value="default"):
+        runner._profile_adapters["coder"] = {}
+        asyncio.run(runner._start_secondary_profile_adapters())
+
+    # Both the active profile and the served secondary get a store.
+    assert "default" in runner.pairing_stores, (
+        "active profile PairingStore missing — the NameError swallow is back"
+    )
+    assert "coder" in runner.pairing_stores, (
+        "secondary profile PairingStore missing — the NameError swallow is back"
+    )
+
+
+def test_pairing_store_scoped_to_profile_dir(tmp_path, monkeypatch):
+    """The created store must live under the profile's pairing directory."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir()
+
+    runner = _bare_runner()
+
+    async def _no_secondary(profile_name, profile_home, claimed):
+        return 0
+
+    runner._start_one_profile_adapters = _no_secondary
+    runner._adapter_credential_fingerprint = lambda adapter: None
+
+    with patch("hermes_cli.profiles.profiles_to_serve", return_value=[
+        ("ops", tmp_path / ".hermes" / "profiles" / "ops"),
+    ]), patch("hermes_cli.profiles.get_active_profile_name", return_value="default"):
+        runner._profile_adapters["ops"] = {}
+        asyncio.run(runner._start_secondary_profile_adapters())
+
+    store = runner.pairing_stores["ops"]
+    assert store.profile == "ops"
+    assert "profiles/ops/pairing" in str(store._dir).replace("\\", "/"), (
+        f"store not profile-scoped: {store._dir}"
+    )


### PR DESCRIPTION
## Summary

Multiplexed gateways now actually create per-profile pairing stores — previously a swallowed `NameError` silently skipped them, so authz pairing checks for secondary profiles fell through to the global whitelist.

**Root cause:** `_start_secondary_profile_adapters` in `gateway/run.py` references `PairingStore(profile=name)`, but the class's only import in the file is method-local inside `__init__`. The reference raised `NameError` at runtime, caught by the enclosing `try/except` ("could not record served_profiles", debug-level) — which also masked the `served_profiles` runtime-status write for `hermes status`.

## Changes

- `gateway/run.py`: one-line local import (`from gateway.pairing import PairingStore`) alongside the existing `write_runtime_status` import
- `tests/gateway/test_multiplex_pairing_stores.py` (new): regression tests driving the real `_start_secondary_profile_adapters` — per-profile stores materialize for both active and secondary profiles, and land under `profiles/<name>/pairing/`

## Validation

| | Without import | With import |
|---|---|---|
| `test_multiplex_pairing_stores.py` | 2 failed | 2 passed |

Verified red-then-green by stashing the fix and re-running.

Credit: surfaced during the profile-routing sweep by @CocaKova's PR #61689, which includes the same fix as part of a larger Matrix routing feature.

## Infographic

![PairingStore NameError fix infographic](https://v3b.fal.media/files/b/0aa26041/kDgXg6c1Fiv7Yu3uZFbNW_NTBx8D9y.png)
