### PR TITLE
fix(cli): read .env as utf-8-sig so a BOM doesn't drop the first key

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -341,7 +341,11 @@ def _sanitize_loaded_credentials() -> None:
 
 def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
     try:
-        load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
+        # utf-8-sig strips a leading UTF-8 BOM if present (PowerShell 5.1
+        # Set-Content -Encoding UTF8 / Notepad) and is a no-op for BOM-less
+        # UTF-8. Plain "utf-8" would keep U+FEFF on the first key name and
+        # silently drop it from os.environ under its canonical name.
+        load_dotenv(dotenv_path=path, override=override, encoding="utf-8-sig")
     except UnicodeDecodeError:
         load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
     # Strip non-ASCII characters from credential env vars that were just

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -347,7 +347,11 @@ def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
         # silently drop it from os.environ under its canonical name.
         load_dotenv(dotenv_path=path, override=override, encoding="utf-8-sig")
     except UnicodeDecodeError:
-        load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
+        # utf-8-sig can't strip a BOM once we fall back to latin-1 decode.
+        raw = path.read_bytes()
+        if raw.startswith(codecs.BOM_UTF8):
+            raw = raw[len(codecs.BOM_UTF8) :]
+        load_dotenv(stream=io.StringIO(raw.decode("latin-1")), override=override)
     # Strip non-ASCII characters from credential env vars that were just
     # loaded.  API keys must be pure ASCII since they're sent as HTTP
     # header values (httpx encodes headers as ASCII).  Non-ASCII chars

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -263,10 +263,22 @@ def _load_hermes_env() -> None:
     env_path = home / ".env"
     if load_dotenv and env_path.exists():
         try:
-            load_dotenv(str(env_path), override=True, encoding="utf-8")
+            # utf-8-sig strips a leading UTF-8 BOM if present (PowerShell 5.1
+            # Set-Content -Encoding UTF8 / Notepad) and is a no-op for
+            # BOM-less UTF-8. Plain "utf-8" would keep U+FEFF on the first
+            # key name and silently drop it from os.environ under its
+            # canonical name.
+            load_dotenv(str(env_path), override=True, encoding="utf-8-sig")
         except UnicodeDecodeError:
             try:
-                load_dotenv(str(env_path), override=True, encoding="latin-1")
+                # utf-8-sig can't strip a BOM once we fall back to latin-1.
+                import codecs
+                import io
+
+                raw = env_path.read_bytes()
+                if raw.startswith(codecs.BOM_UTF8):
+                    raw = raw[len(codecs.BOM_UTF8) :]
+                load_dotenv(stream=io.StringIO(raw.decode("latin-1")), override=True)
             except Exception:
                 pass
         except Exception:

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -6,21 +6,92 @@ import sys
 from hermes_cli.env_loader import load_hermes_dotenv
 
 
+def test_utf8_bom_does_not_mangle_first_key(tmp_path, monkeypatch):
+    """A leading UTF-8 BOM must not prefix the first key name in os.environ.
+
+    PowerShell 5.1 ``Set-Content -Encoding UTF8`` and Windows Notepad write
+    a BOM (EF BB BF). With encoding=utf-8, python-dotenv keeps U+FEFF on the
+    first key so the canonical name is absent and callers see "not configured".
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_bytes(
+        b"\xef\xbb\xbfFIRST_KEY=first-value\nSECOND_KEY=second-value\n"
+    )
+
+    monkeypatch.delenv("FIRST_KEY", raising=False)
+    monkeypatch.delenv("SECOND_KEY", raising=False)
+    monkeypatch.delenv("\ufeffFIRST_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("FIRST_KEY") == "first-value"
+    assert os.getenv("SECOND_KEY") == "second-value"
+    assert os.environ.get("\ufeffFIRST_KEY") is None
 
 
+def test_bomless_utf8_env_still_loads(tmp_path, monkeypatch):
+    """BOM-less UTF-8 .env files must keep loading after utf-8-sig."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("OPENAI_API_KEY=sk-plain\nSECOND_KEY=ok\n", encoding="utf-8")
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("SECOND_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("OPENAI_API_KEY") == "sk-plain"
+    assert os.getenv("SECOND_KEY") == "ok"
 
 
+def test_latin1_env_falls_back(tmp_path, monkeypatch):
+    """Invalid UTF-8 bytes must still load via the latin-1 fallback."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    # 0xE9 is "é" in latin-1 and not a valid UTF-8 lead sequence alone.
+    env_file.write_bytes(b"LATIN1_VALUE=caf\xe9\n")
+
+    monkeypatch.delenv("LATIN1_VALUE", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("LATIN1_VALUE") == "café"
 
 
+def test_utf8_bom_preserves_first_api_key_name(tmp_path, monkeypatch):
+    """Real-world case: BOM + first line is a provider API key name."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_bytes(
+        b"\xef\xbb\xbfANTHROPIC_API_KEY=sk-test-123\nSECOND_KEY=ok\n"
+    )
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("SECOND_KEY", raising=False)
+    monkeypatch.delenv("\ufeffANTHROPIC_API_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("ANTHROPIC_API_KEY") == "sk-test-123"
+    assert os.getenv("SECOND_KEY") == "ok"
+    assert os.environ.get("\ufeffANTHROPIC_API_KEY") is None
 
 
 # ---------------------------------------------------------------------------
 # UTF-16 / UTF-32 .env sanitizer coverage
 #
-# Scope note: intentionally NO UTF-8-BOM assertions here. UTF-8 BOM handling
-# for _load_dotenv_with_fallback is #65124's un-merged fix; a test here would
-# couple the PRs. This suite covers only the sanitizer rewrite path for
-# UTF-16/32 (and UTF-8 / cp1252 regression guards for that path).
+# UTF-8 BOM handling for _load_dotenv_with_fallback is covered above (#65124).
+# This section covers the sanitizer rewrite path for UTF-16/32 (and UTF-8 /
+# cp1252 regression guards for that path).
 # ---------------------------------------------------------------------------
 
 

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -86,6 +86,90 @@ def test_utf8_bom_preserves_first_api_key_name(tmp_path, monkeypatch):
     assert os.environ.get("\ufeffANTHROPIC_API_KEY") is None
 
 
+def test_utf8_bom_plus_invalid_utf8_preserves_first_key(tmp_path, monkeypatch):
+    """BOM + non-UTF-8 body must load via latin-1 without mangling the first key.
+
+    utf-8-sig only applies on the primary path. When invalid UTF-8 forces the
+    latin-1 fallback, a leading EF BB BF would otherwise become part of the
+    first key name under latin-1 and drop the canonical name.
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    # BOM + valid first key + latin-1 é (0xE9) in a later value.
+    env_file.write_bytes(
+        b"\xef\xbb\xbfANTHROPIC_API_KEY=sk-test-123\nBAD=caf\xe9\n"
+    )
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("BAD", raising=False)
+    monkeypatch.delenv("\ufeffANTHROPIC_API_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("ANTHROPIC_API_KEY") == "sk-test-123"
+    assert os.getenv("BAD") == "café"
+    assert os.environ.get("\ufeffANTHROPIC_API_KEY") is None
+
+def test_bomless_latin1_env_still_loads(tmp_path, monkeypatch):
+    """BOM-less cp1252/latin-1 .env files must keep loading after the BOM strip."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_bytes(b"LATIN1_VALUE=caf\xe9\nOTHER=ok\n")
+
+    monkeypatch.delenv("LATIN1_VALUE", raising=False)
+    monkeypatch.delenv("OTHER", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("LATIN1_VALUE") == "café"
+    assert os.getenv("OTHER") == "ok"
+
+def test_latin1_fallback_stream_honors_override(tmp_path, monkeypatch):
+    """Stream-based latin-1 fallback must honor override= identically to dotenv_path."""
+    from hermes_cli.env_loader import _load_dotenv_with_fallback
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    # Invalid UTF-8 forces the stream/latin-1 path.
+    env_file.write_bytes(b"OVERRIDE_PROBE=from-file\nLATIN1_VALUE=caf\xe9\n")
+
+    monkeypatch.setenv("OVERRIDE_PROBE", "from-shell")
+    monkeypatch.delenv("LATIN1_VALUE", raising=False)
+
+    # override=False: shell value must win (same as dotenv_path form).
+    _load_dotenv_with_fallback(env_file, override=False)
+    assert os.getenv("OVERRIDE_PROBE") == "from-shell"
+    assert os.getenv("LATIN1_VALUE") == "café"
+
+    # override=True: file value must win (user-env path).
+    _load_dotenv_with_fallback(env_file, override=True)
+    assert os.getenv("OVERRIDE_PROBE") == "from-file"
+    assert os.getenv("LATIN1_VALUE") == "café"
+
+def test_latin1_fallback_stream_preserves_interpolation(tmp_path, monkeypatch):
+    """Stream/latin-1 path must still expand ${VAR} like the dotenv_path form."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    # 0xE9 forces latin-1 fallback; ${FOO} must still expand.
+    env_file.write_bytes(b"FOO=bar\nBAR=${FOO}\nLATIN1_VALUE=caf\xe9\n")
+
+    monkeypatch.delenv("FOO", raising=False)
+    monkeypatch.delenv("BAR", raising=False)
+    monkeypatch.delenv("LATIN1_VALUE", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("FOO") == "bar"
+    assert os.getenv("BAR") == "bar"
+    assert os.getenv("LATIN1_VALUE") == "café"
+
 # ---------------------------------------------------------------------------
 # UTF-16 / UTF-32 .env sanitizer coverage
 #

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -234,3 +234,144 @@ def test_load_hermes_env_bridges_config_yaml_scalars(tmp_path, monkeypatch):
     assert os.environ.get("TELEGRAM_HOME_CHANNEL") == "5550001111"
 
 
+def test_load_hermes_env_utf8_bom_preserves_first_key(tmp_path, monkeypatch):
+    """A leading UTF-8 BOM must not mangle the first .env key name.
+
+    PowerShell 5.1 `Set-Content -Encoding UTF8` and Notepad prepend a BOM
+    (EF BB BF). With encoding=utf-8, python-dotenv kept U+FEFF on the first
+    key, so the credential never appeared under its canonical name and
+    `hermes send` failed to authenticate.
+    """
+    import os
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_bytes(
+        b"\xef\xbb\xbfSEND_BOM_BOT_TOKEN=tok-first\nSEND_BOM_SECOND=two\n"
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SEND_BOM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("SEND_BOM_SECOND", raising=False)
+
+    from importlib import reload
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    send_cmd._load_hermes_env()
+
+    assert os.environ.get("SEND_BOM_BOT_TOKEN") == "tok-first"
+    assert os.environ.get("SEND_BOM_SECOND") == "two"
+    assert "\ufeff" + "SEND_BOM_BOT_TOKEN" not in os.environ
+
+def test_load_hermes_env_bomless_utf8_still_loads(tmp_path, monkeypatch):
+    """BOM-less UTF-8 .env files must keep loading after the utf-8-sig switch."""
+    import os
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_bytes(b"SEND_PLAIN_TOKEN=plain-val\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SEND_PLAIN_TOKEN", raising=False)
+
+    from importlib import reload
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    send_cmd._load_hermes_env()
+
+    assert os.environ.get("SEND_PLAIN_TOKEN") == "plain-val"
+
+def test_load_hermes_env_latin1_fallback_still_loads(tmp_path, monkeypatch):
+    """Invalid UTF-8 bytes must still load via the latin-1 fallback path,
+    and a leading BOM must be stripped before the latin-1 decode so the
+    first key keeps its canonical name."""
+    import os
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    # BOM + valid first key + latin-1 é (0xE9, invalid UTF-8 alone) in a
+    # later value — forces the UnicodeDecodeError → latin-1 stream path.
+    (hermes_home / ".env").write_bytes(
+        b"\xef\xbb\xbfSEND_L1_TOKEN=tok-l1\nSEND_L1_NOTE=caf\xe9\n"
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SEND_L1_TOKEN", raising=False)
+    monkeypatch.delenv("SEND_L1_NOTE", raising=False)
+
+    from importlib import reload
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    send_cmd._load_hermes_env()
+
+    assert os.environ.get("SEND_L1_TOKEN") == "tok-l1"
+    assert os.environ.get("SEND_L1_NOTE") == "caf\xe9"
+    assert "\ufeff" + "SEND_L1_TOKEN" not in os.environ
+
+def test_load_hermes_env_latin1_fallback_overrides_shell(tmp_path, monkeypatch):
+    """The stream-based latin-1 fallback must keep override=True semantics:
+    the .env value wins over a stale shell export, same as the primary path."""
+    import os
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    # 0xE9 forces the UnicodeDecodeError \u2192 latin-1 stream fallback.
+    (hermes_home / ".env").write_bytes(b"SEND_OVR_TOKEN=caf\xe9-file\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SEND_OVR_TOKEN", "stale-shell-value")
+
+    from importlib import reload
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    send_cmd._load_hermes_env()
+
+    assert os.environ.get("SEND_OVR_TOKEN") == "caf\xe9-file"
+
+def test_load_hermes_env_fallback_read_error_is_swallowed(tmp_path, monkeypatch):
+    """An I/O error inside the latin-1 fallback must not escape \u2014 the send
+    path is best-effort by design and must never crash on a broken .env."""
+    from pathlib import Path
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    # Invalid UTF-8 so the fallback (and its read_bytes call) is reached.
+    (hermes_home / ".env").write_bytes(b"SEND_ERR_TOKEN=caf\xe9\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    def _boom(self):
+        raise OSError("disk went away")
+
+    monkeypatch.setattr(Path, "read_bytes", _boom)
+
+    from importlib import reload
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    # Should not raise.
+    send_cmd._load_hermes_env()
+
+def test_load_hermes_env_bom_only_env_is_noop(tmp_path, monkeypatch):
+    """A .env containing only a BOM must load zero vars without error."""
+    import os
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_bytes(b"\xef\xbb\xbf")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from importlib import reload
+    import hermes_cli.config as _hc_config
+    reload(_hc_config)
+
+    before = dict(os.environ)
+    send_cmd._load_hermes_env()
+
+    added = {k: v for k, v in os.environ.items() if k not in before}
+    assert "\ufeff" not in "".join(added)


### PR DESCRIPTION
## Summary

Fixes #65123.

A UTF-8 BOM (`EF BB BF`) at the start of a profile `.env` caused python-dotenv to store the **first** key under a mangled name (or drop it entirely on the latin-1 fallback). Canonical `os.environ.get("ANTHROPIC_API_KEY")` (and any other first key) returned `None` with no error - Hermes looked unconfigured.

**Three** read paths are now BOM-safe:

| Path | Trigger | Fix |
|------|---------|-----|
| **Shared loader, primary** (`env_loader._load_dotenv_with_fallback`) | Valid UTF-8 (with or without BOM) | `encoding="utf-8-sig"` strips a leading UTF-8 BOM; no-op for BOM-less UTF-8 |
| **Shared loader, fallback** | `UnicodeDecodeError` (invalid UTF-8 / cp1252 body) | Read bytes, strip `codecs.BOM_UTF8` if present, `latin-1` decode, `load_dotenv(stream=…, override=…)` |
| **`hermes send` private loader** (`send_cmd._load_hermes_env`) | Same two cases | Same two-path fix mirrored in place (per sweeper review) |

`utf-8-sig` cannot help on the latin-1 path - once we re-decode as latin-1, the BOM bytes become part of the first key name (`ï»¿ANTHROPIC_API_KEY`). The fallback must strip the BOM at the **byte** level before decoding.

### Why this is not only the primary path

PowerShell 5.1 `Set-Content -Encoding UTF8` / Notepad write a BOM. If the rest of the file is pure UTF-8, the primary path alone is enough. But a common mixed case - BOM + a latin-1/cp1252 value such as `café` (`0xE9`) - raises `UnicodeDecodeError` on the primary path and previously fell through to:

```python
load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
```

which kept `EF BB BF` on the first key. That is the gap this PR closes.

### What changed

**`hermes_cli/env_loader.py` - `_load_dotenv_with_fallback`**

1. Primary: `encoding="utf-8-sig"` (was `"utf-8"`).
2. Fallback: strip leading UTF-8 BOM from raw bytes, then `load_dotenv(stream=io.StringIO(raw.decode("latin-1")), override=override)`.

`override=` is forwarded identically to the `dotenv_path` form (python-dotenv passes it through either way). Interpolation defaults (`interpolate=True`) are unchanged.

**`hermes_cli/send_cmd.py` - `_load_hermes_env`** (added per sweeper review)

Standalone `hermes send` had the same defect via its private loader (`encoding="utf-8"` primary, plain `latin-1` fallback). The same two-path fix is applied **in place** rather than delegating to `load_hermes_dotenv`, because the private loader is deliberately not equivalent to the shared one:

- it resolves the home via `get_hermes_home()` (honors the context-local profile override and the Windows `LOCALAPPDATA\hermes` default; `load_hermes_dotenv` reads `HERMES_HOME` env or `~/.hermes` only), and
- it intentionally skips the shared loader's side effects - sanitize rewrite-in-place of `.env`, `.op.env`/project-env loads, external secret-source pulls (Bitwarden, with network + stderr status lines), and managed-scope env - to keep `hermes send` fast and side-effect-minimal, as its docstring documents.

Consolidating the two loaders is a possible follow-up, not smuggled in here.

The decode step itself now behaves identically to the shared path for all three encodings (BOM'd UTF-8, BOM-less UTF-8, latin-1 ± BOM); pre-existing differences (hard-coded `override=True`, best-effort `except Exception: pass`) are unchanged and covered by tests.

Intentionally **not** in this PR: on-disk BOM rewriting in the sanitize pre-pass, `install.ps1` changes, or UTF-16 handling (pre-existing out-of-scope gap).

### Related surfaces (audited, not touched)

- `hermes_cli/config.py: load_env()` - already reads `utf-8-sig`; BOM-safe.
- `tools/environments/docker.py: _load_hermes_env_vars()` - delegates to `load_env()`; BOM-safe.
- `hermes_cli/managed_scope.py: _cached_read()` - opens the **managed** `.env`/`config.yaml` with plain `utf-8`; a BOM'd managed `.env` would mangle its first key the same way. Out of scope here (admin-provisioned file, separate surface); noting for a possible follow-up.

### Tests

Extended `tests/hermes_cli/test_env_loader.py` (14 tests on this branch) - unchanged from the previous revision:

1. BOM’d UTF-8 `.env` → canonical first key present; no `\ufeff`-prefixed key
2. BOM-less UTF-8 still loads
3. Invalid UTF-8 (BOM-less) still hits latin-1 fallback
4. BOM + first key is an API-key name (`ANTHROPIC_API_KEY`)
5. **BOM + invalid UTF-8** → canonical first key present, `BAD=café` preserved, no mangled key
6. BOM-less latin-1/cp1252 regression guard
7. Stream-path `override=True` / `override=False` parity
8. Stream-path `${VAR}` interpolation parity

Extended `tests/hermes_cli/test_send_cmd.py` (27 tests on this branch, 6 new), exercising the real `hermes send` env path (`_load_hermes_env` under a temp `HERMES_HOME`):

1. BOM’d first credential loads under its canonical name (no `\ufeff` key)
2. BOM-less UTF-8 regression guard
3. BOM + invalid UTF-8 → latin-1 fallback preserves the first key and the `café` value
4. latin-1 fallback keeps `override=True` semantics (file beats stale shell export)
5. I/O error inside the fallback is swallowed (send path is best-effort by design)
6. BOM-only `.env` is a silent no-op

```
venv/bin/python -m pytest tests/hermes_cli/test_send_cmd.py tests/hermes_cli/test_env_loader.py -q
# 41 passed  (27 send_cmd + 14 env_loader)
```

Local after rebase onto `a991dfc25`: 17 targeted BOM/dotenv/latin-1 tests pass; `scripts/check-windows-footguns.py` clean on both files. Broad `scripts/run_tests.sh` still shows pre-existing local macOS noise outside this PR's 4-file diff; GitHub CI on Linux is authoritative.

### Behavioral before / after

#### A) BOM + valid UTF-8 (primary path)

```bash
TMP=$(mktemp -d)
printf '\xef\xbb\xbfANTHROPIC_API_KEY=sk-test-123\nSECOND_KEY=ok\n' > "$TMP/.env"
HERMES_HOME="$TMP" venv/bin/python -c '
import os
from hermes_cli.env_loader import load_hermes_dotenv
load_hermes_dotenv()
print("canonical:", repr(os.environ.get("ANTHROPIC_API_KEY")))
print("mangled  :", repr(os.environ.get("\ufeffANTHROPIC_API_KEY")))
print("second   :", repr(os.environ.get("SECOND_KEY")))
'
```

| | Before | After |
|--|--------|-------|
| canonical | `None` | `'sk-test-123'` |
| mangled | `'sk-test-123'` | `None` |
| second | `'ok'` | `'ok'` |

#### B) BOM + invalid UTF-8 / latin-1 body (fallback path)

```bash
TMP=$(mktemp -d)
printf '\xef\xbb\xbfANTHROPIC_API_KEY=sk-test-123\nBAD=caf\xe9\n' > "$TMP/.env"
HERMES_HOME="$TMP" venv/bin/python -c '
import os
from hermes_cli.env_loader import load_hermes_dotenv
load_hermes_dotenv()
print("canonical:", repr(os.environ.get("ANTHROPIC_API_KEY")))
print("mangled  :", repr(os.environ.get("\ufeffANTHROPIC_API_KEY")))
print("bad      :", repr(os.environ.get("BAD")))
'
```

| | Before (utf-8-sig only) | After (both paths) |
|--|------------------------|--------------------|
| canonical | `None` | `'sk-test-123'` |
| mangled (`\ufeff…`) | `None` (latin-1 mangles as `ï»¿…`, not U+FEFF) | `None` |
| bad | `'café'` | `'café'` |

#### C) `hermes send` private loader (the sweeper's case)

```bash
TMP=$(mktemp -d)
printf '\xef\xbb\xbfTELEGRAM_BOT_TOKEN=tok-first\nSECOND=ok\n' > "$TMP/.env"
HERMES_HOME="$TMP" venv/bin/python -c '
import os
from hermes_cli.send_cmd import _load_hermes_env
_load_hermes_env()
print("canonical:", repr(os.environ.get("TELEGRAM_BOT_TOKEN")))
print("mangled  :", repr(os.environ.get("\ufeffTELEGRAM_BOT_TOKEN")))
'
```

| | Before | After |
|--|--------|-------|
| canonical | `None` | `'tok-first'` |
| mangled | `'tok-first'` | `None` |

### Platforms

- **macOS** (Darwin arm64): real repro + fix verification through `load_hermes_dotenv` and `send_cmd._load_hermes_env` for all paths.
- **Windows**: reasoned from Microsoft’s PowerShell 5.1 `Set-Content -Encoding UTF8` BOM contract + Windows editors writing UTF-8 with BOM; BOM reproduced at byte level. PS 5.1 was not executed on a Windows host in this run.
- `scripts/check-windows-footguns.py` on touched files: clean (exit 0).

### Related

- #62617 / #60895 harden other `.env` readers to `utf-8-sig`; this PR fixes the main `os.environ` load path they did not touch, including the latin-1 fallback half and the standalone `hermes send` loader.

https://claude.ai/code/session_01JPmJz5u1Bvtw4cCRvRWnYr

### Rebase note

Rebased onto `a991dfc25` (`upstream/main` = `a991dfc25daf68994c21d6adcdfbafb1b3dc23cf`) per the standing offer on #65123. New head: `f6f179a8e` (`f6f179a8e58b4a8abd351d835e8d09dc42fc5f7c`).

Prior head on GitHub before this push: `21a8f9c84`. Trivial test-file conflicts only (context drift vs the UTF-16/UTF-32 sanitizer suite already on main); no logic conflicts in `env_loader.py` or `send_cmd.py`.

### CI (at push time)

Post-rebase checks re-running on head `f6f179a8e`. Prior red on old tip: slice 3/8 infra timeout on unrelated `tests/agent/test_memory_user_id.py` (300s SIGKILL; 5844 other tests passed in that slice) plus `DIRTY` merge state from stale base. Local after rebase: 17 targeted BOM/dotenv/latin-1 tests pass; Windows footguns clean on both files; broad suite noise attributed to pre-existing local failures outside this PR's 4-file diff. Re-check the checks tab for the live rollup.

