### PR TITLE
feat(skills): add bounded query-ranked discovery

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1676,17 +1676,15 @@ def build_skills_system_prompt(
                     index_lines.append(f"    - {name}")
 
         result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
+            "## Skills (mandatory routing check)\n"
+            "Before replying, review the skill index. Load a skill with skill_view(name) when it "
+            "directly matches the task or its procedures, constraints, or user conventions are "
+            "likely to change how you execute. If several skills look plausible or the compact "
+            "descriptions are insufficient, call skills_list(query=\"task summary\", limit=5), "
+            "then load "
+            "only the best matches. Do not load tangential skills. Do not reload identical skill "
+            "content already present in the conversation. If no skill clearly matches, proceed "
+            "without loading one.\n"
             "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
             "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
@@ -1700,8 +1698,6 @@ def build_skills_system_prompt(
             "<available_skills>\n"
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
             + hidden_note
         )
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1718,8 +1718,15 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         try:
-            from tools.skills_tool import _find_all_skills, _sort_skills
-            skills = _sort_skills(_find_all_skills(skip_disabled=False))
+            from tools.skills_tool import (
+                _find_all_skills,
+                _public_skill_metadata,
+                _sort_skills,
+            )
+            skills = [
+                _public_skill_metadata(skill)
+                for skill in _sort_skills(_find_all_skills(skip_disabled=False))
+            ]
         except Exception:
             logger.exception("GET /v1/skills failed")
             return web.json_response(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13572,7 +13572,7 @@ class SkillToggle(BaseModel):
 
 @app.get("/api/skills")
 async def get_skills(profile: Optional[str] = None):
-    from tools.skills_tool import _find_all_skills
+    from tools.skills_tool import _find_all_skills, _public_skill_metadata
     from hermes_cli.skills_config import get_disabled_skills
     from tools.skill_usage import (
         _read_bundled_manifest_names,
@@ -13583,7 +13583,10 @@ async def get_skills(profile: Optional[str] = None):
     with _profile_scope(profile):
         config = load_config()
         disabled = get_disabled_skills(config)
-        skills = _find_all_skills(skip_disabled=True)
+        skills = [
+            _public_skill_metadata(skill)
+            for skill in _find_all_skills(skip_disabled=True)
+        ]
         usage = load_usage()
         # Set-based provenance (same classification as skill_usage.provenance,
         # without a per-skill manifest read): hub > bundled > agent, where

--- a/tests/agent/test_skill_routing_policy.py
+++ b/tests/agent/test_skill_routing_policy.py
@@ -1,0 +1,23 @@
+from agent.prompt_builder import (
+    build_skills_system_prompt,
+    clear_skills_system_prompt_cache,
+)
+
+
+def test_skill_routing_policy_is_selective_and_search_aware(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    skill_dir = tmp_path / "skills" / "tools" / "python-debug"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: python-debug\ndescription: Debug Python scripts\n---\n",
+        encoding="utf-8",
+    )
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+
+    result = build_skills_system_prompt()
+
+    assert "mandatory routing check" in result
+    assert 'skills_list(query="task summary", limit=5)' in result
+    assert "Do not reload identical skill content" in result
+    assert "If no skill clearly matches, proceed without loading one" in result
+    assert "Err on the side of loading" not in result

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -976,7 +976,14 @@ class TestSkillsEndpoint:
     @pytest.mark.asyncio
     async def test_skills_returns_list_envelope(self, adapter):
         fake_skills = [
-            {"name": "github", "description": "GitHub workflow skill", "category": "github"},
+            {
+                "name": "github",
+                "description": "GitHub workflow skill",
+                "category": "github",
+                "_routing_terms": ("pull request",),
+                "_search_text": ("github", "pull request", "github", "workflow"),
+                "_search_tokens": (("github",), ("pull", "request"), ("github",), ("workflow",)),
+            },
             {"name": "ascii-art", "description": "ASCII art generation", "category": "creative"},
         ]
         with patch(
@@ -992,7 +999,7 @@ class TestSkillsEndpoint:
                 names = sorted(s["name"] for s in data["data"])
                 assert names == ["ascii-art", "github"]
                 for entry in data["data"]:
-                    assert set(entry.keys()) >= {"name", "description", "category"}
+                    assert set(entry) == {"name", "description", "category"}
 
     @pytest.mark.asyncio
     async def test_skills_handles_enumeration_failure(self, adapter):

--- a/tests/hermes_cli/test_web_server_skills_profiles.py
+++ b/tests/hermes_cli/test_web_server_skills_profiles.py
@@ -63,6 +63,28 @@ def _load_cfg(home):
 
 
 class TestProfileScopedSkills:
+    def test_skills_list_does_not_expose_private_search_metadata(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        from tools import skills_tool
+
+        original = skills_tool._find_all_skills
+
+        def with_private_metadata(*args, **kwargs):
+            skills = original(*args, **kwargs)
+            for skill in skills:
+                skill["_routing_terms"] = ("private trigger",)
+                skill["_search_text"] = ("private",)
+                skill["_search_tokens"] = (("private",),)
+            return skills
+
+        monkeypatch.setattr(skills_tool, "_find_all_skills", with_private_metadata)
+        resp = client.get("/api/skills")
+
+        assert resp.status_code == 200
+        for skill in resp.json():
+            assert not any(key.startswith("_") for key in skill)
+
     def test_skills_list_scopes_to_requested_profile(self, client, isolated_profiles):
         resp = client.get("/api/skills", params={"profile": "worker_alpha"})
         assert resp.status_code == 200

--- a/tests/tools/test_skills_tool_search.py
+++ b/tests/tools/test_skills_tool_search.py
@@ -60,6 +60,19 @@ def test_query_uses_private_routing_hints_without_leaking_them(tmp_path):
     assert set(result["skills"][0]) == {"name", "description", "category"}
 
 
+def test_query_supports_legacy_top_level_tags(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(
+            tmp_path,
+            "inventory-audit",
+            description="Audit inventory records",
+            extra="tags: [warehouse, stocktake]\n",
+        )
+        result = json.loads(skills_list(query="warehouse stocktake"))
+
+    assert result["skills"][0]["name"] == "inventory-audit"
+
+
 def test_query_matches_unicode_casefolded_metadata(tmp_path):
     with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
         _make_skill(tmp_path, "cafe-tools", description="Gestiona pedidos de CAFÉ")

--- a/tests/tools/test_skills_tool_search.py
+++ b/tests/tools/test_skills_tool_search.py
@@ -1,0 +1,171 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tools.skills_tool import SKILLS_LIST_SCHEMA, _SKILLS_CACHE, skills_list
+
+
+def _make_skill(
+    root,
+    name,
+    *,
+    description=None,
+    category=None,
+    extra="",
+):
+    directory = root / category / name if category else root / name
+    directory.mkdir(parents=True)
+    description = description if description is not None else f"Description for {name}."
+    (directory / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n{extra}---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_discovery_cache():
+    _SKILLS_CACHE.clear()
+    yield
+    _SKILLS_CACHE.clear()
+
+
+def test_query_ranks_exact_name_first_and_limits_results(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "postgres-backup", description="Back up SQL databases")
+        _make_skill(tmp_path, "generic-backup", description="Back up local files")
+        result = json.loads(skills_list(query="postgres backup", limit=1))
+
+    assert result["query"] == "postgres backup"
+    assert result["total_matches"] == 2
+    assert [skill["name"] for skill in result["skills"]] == ["postgres-backup"]
+
+
+def test_query_uses_private_routing_hints_without_leaking_them(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(
+            tmp_path,
+            "parcel-status",
+            category="logistics",
+            description="Track parcel delivery status",
+            extra=(
+                "metadata:\n"
+                "  hermes:\n"
+                "    triggers: [courier, tracking number]\n"
+            ),
+        )
+        result = json.loads(skills_list(query="courier tracking number"))
+
+    assert result["skills"][0]["name"] == "parcel-status"
+    assert set(result["skills"][0]) == {"name", "description", "category"}
+
+
+def test_query_matches_unicode_casefolded_metadata(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "cafe-tools", description="Gestiona pedidos de CAFÉ")
+        result = json.loads(skills_list(query="cafe\u0301"))
+
+    assert result["skills"][0]["name"] == "cafe-tools"
+
+
+def test_category_filter_is_applied_before_query_ranking(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "finance-python", category="finance", description="Python finance")
+        _make_skill(
+            tmp_path,
+            "development-python",
+            category="development",
+            description="Python application development",
+        )
+        result = json.loads(skills_list(category="finance", query="python"))
+
+    assert [skill["name"] for skill in result["skills"]] == ["finance-python"]
+    assert result["categories"] == ["finance"]
+
+
+def test_query_abstains_without_lexical_evidence(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "python", description="Python development")
+        result = json.loads(skills_list(query="quantum entanglement"))
+
+    assert result["skills"] == []
+    assert result["total_matches"] == 0
+
+
+def test_query_limits_are_clamped(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        for index in range(3):
+            _make_skill(tmp_path, f"python-{index}", description="Python automation")
+        minimum = json.loads(skills_list(query="python", limit=0))
+        maximum = json.loads(skills_list(query="python", limit=1000))
+
+    assert minimum["count"] == 1
+    assert maximum["count"] == 3
+
+
+def test_exact_name_cannot_be_displaced_by_trigger_stuffing(tmp_path):
+    triggers = ", ".join(f"python topic {index}" for index in range(40))
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "python", description="Python development")
+        _make_skill(
+            tmp_path,
+            "keyword-stuffer",
+            description="Unrelated metadata test",
+            extra=f"triggers: [{triggers}]\n",
+        )
+        result = json.loads(skills_list(query="python"))
+
+    assert result["skills"][0]["name"] == "python"
+
+
+def test_exact_stopword_name_still_matches(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "the", description="Deliberately unusual name")
+        result = json.loads(skills_list(query="the"))
+
+    assert [skill["name"] for skill in result["skills"]] == ["the"]
+
+
+def test_malformed_routing_metadata_is_ignored(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(
+            tmp_path,
+            "safe-skill",
+            description="Safe database maintenance",
+            extra="triggers: {unexpected: mapping}\nmetadata:\n  hermes: invalid\n",
+        )
+        result = json.loads(skills_list(query="database"))
+
+    assert result["skills"][0]["name"] == "safe-skill"
+
+
+def test_query_echo_and_work_are_bounded(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "needle", description="Find a bounded needle")
+        result = json.loads(skills_list(query="needle " + "x" * 10_000))
+
+    assert len(result["query"]) == 500
+
+
+def test_large_catalog_is_stable_and_bounded(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        for index in range(500):
+            _make_skill(
+                tmp_path,
+                f"catalog-{index:03d}",
+                description=f"Shared automation target-{index:03d}",
+            )
+        first = json.loads(skills_list(query="automation target-321", limit=10))
+        second = json.loads(skills_list(query="automation target-321", limit=10))
+
+    assert first["count"] == 10
+    assert first["total_matches"] == 500
+    assert first["skills"][0]["name"] == "catalog-321"
+    assert first["skills"] == second["skills"]
+
+
+def test_schema_exposes_bounded_query_search():
+    properties = SKILLS_LIST_SCHEMA["parameters"]["properties"]
+    assert properties["query"]["maxLength"] == 500
+    assert properties["limit"]["minimum"] == 1
+    assert properties["limit"]["maximum"] == 50

--- a/tests/tools/test_skills_tool_search.py
+++ b/tests/tools/test_skills_tool_search.py
@@ -169,3 +169,11 @@ def test_schema_exposes_bounded_query_search():
     assert properties["query"]["maxLength"] == 500
     assert properties["limit"]["minimum"] == 1
     assert properties["limit"]["maximum"] == 50
+
+
+def test_no_query_preserves_legacy_hint(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "python", description="Python development")
+        result = json.loads(skills_list())
+
+    assert result["hint"] == "Use skill_view(name) to see full content, tags, and linked files"

--- a/tests/tools/test_skills_tool_search.py
+++ b/tests/tools/test_skills_tool_search.py
@@ -3,7 +3,13 @@ from unittest.mock import patch
 
 import pytest
 
-from tools.skills_tool import SKILLS_LIST_SCHEMA, _SKILLS_CACHE, skills_list
+from tools.skills_tool import (
+    SKILLS_LIST_SCHEMA,
+    _SKILLS_CACHE,
+    _find_all_skills,
+    skills_list,
+)
+from tools.registry import registry
 
 
 def _make_skill(
@@ -60,6 +66,19 @@ def test_query_uses_private_routing_hints_without_leaking_them(tmp_path):
     assert set(result["skills"][0]) == {"name", "description", "category"}
 
 
+def test_cached_search_index_is_immutable(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(
+            tmp_path,
+            "database-helper",
+            description="PostgreSQL backup recovery",
+        )
+        discovered = _find_all_skills()
+
+    with pytest.raises(TypeError):
+        discovered[0]["_search_tokens"][3] = ()
+
+
 def test_query_supports_legacy_top_level_tags(tmp_path):
     with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
         _make_skill(
@@ -79,6 +98,14 @@ def test_query_matches_unicode_casefolded_metadata(tmp_path):
         result = json.loads(skills_list(query="cafe\u0301"))
 
     assert result["skills"][0]["name"] == "cafe-tools"
+
+
+def test_query_matches_metadata_without_requiring_diacritics(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "coffee-orders", description="Gestiona pedidos de CAFÉ")
+        result = json.loads(skills_list(query="cafe"))
+
+    assert result["skills"][0]["name"] == "coffee-orders"
 
 
 def test_category_filter_is_applied_before_query_ranking(tmp_path):
@@ -175,6 +202,72 @@ def test_large_catalog_is_stable_and_bounded(tmp_path):
     assert first["total_matches"] == 500
     assert first["skills"][0]["name"] == "catalog-321"
     assert first["skills"] == second["skills"]
+
+
+def test_query_categories_cover_all_matches_before_limit(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(
+            tmp_path,
+            "python-api",
+            category="development",
+            description="Python API development",
+        )
+        _make_skill(
+            tmp_path,
+            "python-models",
+            category="mlops",
+            description="Python model training",
+        )
+        result = json.loads(skills_list(query="python", limit=1))
+
+    assert result["count"] == 1
+    assert result["total_matches"] == 2
+    assert result["categories"] == ["development", "mlops"]
+
+
+def test_query_substrings_do_not_cross_token_boundaries(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "task-management", description="Coordinate project work")
+        result = json.loads(skills_list(query="ask"))
+
+    assert result["skills"] == []
+    assert result["total_matches"] == 0
+
+
+def test_stopword_only_query_abstains_without_exact_name_or_routing_match(tmp_path):
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+        _make_skill(tmp_path, "theming", description="Use themes for the interface")
+        _make_skill(tmp_path, "workflow", description="Use this when automating work")
+        result = json.loads(skills_list(query="the use of"))
+
+    assert result["skills"] == []
+    assert result["total_matches"] == 0
+
+
+def test_registry_handler_uses_live_hermes_home_without_resolver_mock(
+    monkeypatch, tmp_path
+):
+    hermes_home = tmp_path / "hermes-home"
+    skills_dir = hermes_home / "skills"
+    _make_skill(
+        skills_dir,
+        "warehouse-audit",
+        category="operations",
+        description="Audit warehouse inventory",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _SKILLS_CACHE.clear()
+
+    entry = registry.get_entry("skills_list")
+    assert entry is not None
+    result = json.loads(
+        entry.handler({"query": "warehouse inventory", "limit": 1}, task_id="e2e-test")
+    )
+
+    assert result["success"] is True
+    assert result["count"] == 1
+    assert result["skills"][0]["name"] == "warehouse-audit"
+    assert result["categories"] == ["operations"]
 
 
 def test_schema_exposes_bounded_query_search():

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -163,6 +163,7 @@ def _frontmatter_routing_terms(frontmatter: Dict[str, Any]) -> tuple[str, ...]:
     values: list[Any] = []
     for raw in (
         frontmatter.get("triggers"),
+        frontmatter.get("tags"),
         hermes.get("triggers"),
         hermes.get("tags"),
     ):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -107,6 +107,8 @@ _SKILLS_CACHE_KEY_FILTERED = "filtered"
 _SKILL_SEARCH_DEFAULT_LIMIT = 10
 _SKILL_SEARCH_MAX_LIMIT = 50
 _SKILL_SEARCH_MAX_QUERY_CHARS = 500
+_SKILL_SEARCH_FIELDS = ("name", "routing", "category", "description")
+_SKILL_SEARCH_FIELD_WEIGHTS = (8.0, 5.0, 3.0, 1.0)
 _SKILL_SEARCH_STOPWORDS = frozenset(
     {
         "a",
@@ -138,8 +140,14 @@ _SKILL_SEARCH_STOPWORDS = frozenset(
 
 
 def _normalise_search_text(value: Any) -> str:
-    """Return stable, Unicode-aware text for lexical skill search."""
-    text = unicodedata.normalize("NFKC", str(value or "")).casefold()
+    """Return stable, casefolded, accent-insensitive text for lexical search."""
+    text = str(value or "").casefold()
+    if not text.isascii():
+        text = unicodedata.normalize("NFKD", text)
+        text = "".join(
+            character for character in text if unicodedata.category(character) != "Mn"
+        )
+        text = unicodedata.normalize("NFKC", text)
     return " ".join(text.replace("_", " ").replace("-", " ").replace("/", " ").split())
 
 
@@ -151,6 +159,35 @@ def _search_tokens(value: Any) -> tuple[str, ...]:
         for token in re.findall(r"[^\W_]+(?:\+\+|#)?", normalised, flags=re.UNICODE)
         if len(token) > 1 and token not in _SKILL_SEARCH_STOPWORDS
     )
+
+
+def _contains_token_phrase(needle: str, haystack: str) -> bool:
+    """Return whether a normalized phrase occurs on complete token boundaries."""
+    needle_parts = needle.split()
+    haystack_parts = haystack.split()
+    if not needle_parts or len(needle_parts) > len(haystack_parts):
+        return False
+    width = len(needle_parts)
+    return any(
+        haystack_parts[index : index + width] == needle_parts
+        for index in range(len(haystack_parts) - width + 1)
+    )
+
+
+def _build_search_fields(
+    name: Any,
+    routing_terms: tuple[str, ...],
+    category: Any,
+    description: Any,
+) -> tuple[tuple[str, ...], tuple[tuple[str, ...], ...]]:
+    """Precompute the immutable lexical index stored with a discovery record."""
+    text = (
+        _normalise_search_text(name),
+        _normalise_search_text(" ".join(routing_terms)),
+        _normalise_search_text(category),
+        _normalise_search_text(description),
+    )
+    return text, tuple(_search_tokens(value) for value in text)
 
 
 def _frontmatter_routing_terms(frontmatter: Dict[str, Any]) -> tuple[str, ...]:
@@ -835,12 +872,18 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
                 category = _get_category_from_path(skill_md)
 
+                routing_terms = _frontmatter_routing_terms(frontmatter)
+                search_text, search_tokens = _build_search_fields(
+                    name, routing_terms, category, description
+                )
                 seen_names.add(name)
                 skills.append({
                     "name": name,
                     "description": description,
                     "category": category,
-                    "_routing_terms": _frontmatter_routing_terms(frontmatter),
+                    "_routing_terms": routing_terms,
+                    "_search_text": search_text,
+                    "_search_tokens": search_tokens,
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:
@@ -890,50 +933,65 @@ def _rank_skills_for_query(
     if not query_text:
         return []
 
-    records: list[tuple[Dict[str, Any], Dict[str, tuple[str, ...]], Dict[str, str]]] = []
+    records: list[
+        tuple[Dict[str, Any], tuple[tuple[str, ...], ...], tuple[str, ...]]
+    ] = []
     document_frequency = {token: 0 for token in query_tokens}
 
     for skill in skills:
         routing_terms = tuple(skill.get("_routing_terms") or ())
-        field_text = {
-            "name": _normalise_search_text(skill.get("name", "")),
-            "routing": _normalise_search_text(" ".join(routing_terms)),
-            "category": _normalise_search_text(skill.get("category", "")),
-            "description": _normalise_search_text(skill.get("description", "")),
-        }
-        field_tokens = {key: _search_tokens(value) for key, value in field_text.items()}
-        document_tokens = set().union(*(set(value) for value in field_tokens.values()))
+        field_text = skill.get("_search_text")
+        field_tokens = skill.get("_search_tokens")
+        if (
+            not isinstance(field_text, tuple)
+            or len(field_text) != len(_SKILL_SEARCH_FIELDS)
+            or not isinstance(field_tokens, tuple)
+            or len(field_tokens) != len(_SKILL_SEARCH_FIELDS)
+        ):
+            field_text, field_tokens = _build_search_fields(
+                skill.get("name", ""),
+                routing_terms,
+                skill.get("category", ""),
+                skill.get("description", ""),
+            )
+        document_tokens = set().union(*(set(value) for value in field_tokens))
         for token in query_tokens & document_tokens:
             document_frequency[token] += 1
         records.append((skill, field_tokens, field_text))
 
-    field_weights = {
-        "name": 8.0,
-        "routing": 5.0,
-        "category": 3.0,
-        "description": 1.0,
-    }
     catalog_size = max(1, len(records))
     scored: list[tuple[float, str, str, Dict[str, Any]]] = []
 
     for skill, field_tokens, field_text in records:
         score = 0.0
-        for field, tokens in field_tokens.items():
+        for index, tokens in enumerate(field_tokens):
             matched = query_tokens & set(tokens)
             for token in matched:
                 frequency = document_frequency[token]
                 idf = math.log(1.0 + (catalog_size - frequency + 0.5) / (frequency + 0.5))
-                score += field_weights[field] * idf
+                score += _SKILL_SEARCH_FIELD_WEIGHTS[index] * idf
 
-        name_text = field_text["name"]
+        name_text = field_text[0]
         if query_text == name_text:
             score += 100.0
-        elif query_text in name_text or name_text in query_text:
+        elif query_tokens and (
+            _contains_token_phrase(query_text, name_text)
+            or _contains_token_phrase(name_text, query_text)
+        ):
             score += 24.0
 
         if any(
             term_text
-            and (term_text in query_text or query_text in term_text)
+            and (
+                term_text == query_text
+                or (
+                    query_tokens
+                    and (
+                        _contains_token_phrase(term_text, query_text)
+                        or _contains_token_phrase(query_text, term_text)
+                    )
+                )
+            )
             for term_text in (
                 _normalise_search_text(term)
                 for term in skill.get("_routing_terms") or ()
@@ -1012,9 +1070,11 @@ def skills_list(
 
         query_text = str(query or "").strip()[:_SKILL_SEARCH_MAX_QUERY_CHARS]
         total_matches = None
+        category_source = all_skills
         if query_text:
             all_skills = _rank_skills_for_query(all_skills, query_text)
             total_matches = len(all_skills)
+            category_source = all_skills
             try:
                 result_limit = int(limit) if limit is not None else _SKILL_SEARCH_DEFAULT_LIMIT
             except (TypeError, ValueError):
@@ -1037,7 +1097,7 @@ def skills_list(
 
         # Extract unique categories
         categories = sorted(
-            {s.get("category") for s in all_skills if s.get("category")}
+            {s.get("category") for s in category_source if s.get("category")}
         )
 
         return json.dumps(

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -68,7 +68,9 @@ Usage:
 
 import json
 import logging
+import math
 import time
+import unicodedata
 
 from hermes_constants import get_hermes_home, display_hermes_home
 import os
@@ -101,6 +103,85 @@ _SKILLS_CACHE: dict = {}          # {cache_key: (signature, timestamp, skills_li
 _SKILLS_CACHE_TTL_SECONDS = 30.0
 _SKILLS_CACHE_KEY_DISABLED = "with_disabled"
 _SKILLS_CACHE_KEY_FILTERED = "filtered"
+
+_SKILL_SEARCH_DEFAULT_LIMIT = 10
+_SKILL_SEARCH_MAX_LIMIT = 50
+_SKILL_SEARCH_MAX_QUERY_CHARS = 500
+_SKILL_SEARCH_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "in",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "that",
+        "the",
+        "this",
+        "to",
+        "use",
+        "using",
+        "when",
+        "with",
+    }
+)
+
+
+def _normalise_search_text(value: Any) -> str:
+    """Return stable, Unicode-aware text for lexical skill search."""
+    text = unicodedata.normalize("NFKC", str(value or "")).casefold()
+    return " ".join(text.replace("_", " ").replace("-", " ").replace("/", " ").split())
+
+
+def _search_tokens(value: Any) -> tuple[str, ...]:
+    """Tokenize skill metadata without language-specific dependencies."""
+    normalised = _normalise_search_text(value)
+    return tuple(
+        token
+        for token in re.findall(r"[^\W_]+(?:\+\+|#)?", normalised, flags=re.UNICODE)
+        if len(token) > 1 and token not in _SKILL_SEARCH_STOPWORDS
+    )
+
+
+def _frontmatter_routing_terms(frontmatter: Dict[str, Any]) -> tuple[str, ...]:
+    """Extract optional discovery hints while keeping them out of tool output."""
+    metadata = frontmatter.get("metadata")
+    metadata = metadata if isinstance(metadata, dict) else {}
+    hermes = metadata.get("hermes")
+    hermes = hermes if isinstance(hermes, dict) else {}
+
+    values: list[Any] = []
+    for raw in (
+        frontmatter.get("triggers"),
+        hermes.get("triggers"),
+        hermes.get("tags"),
+    ):
+        if isinstance(raw, str):
+            values.append(raw)
+        elif isinstance(raw, (list, tuple)):
+            values.extend(raw)
+
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        term = value.strip()
+        key = _normalise_search_text(term)
+        if key and key not in seen:
+            seen.add(key)
+            result.append(term)
+    return tuple(result)
 
 
 def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
@@ -758,6 +839,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     "name": name,
                     "description": description,
                     "category": category,
+                    "_routing_terms": _frontmatter_routing_terms(frontmatter),
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:
@@ -782,7 +864,104 @@ def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
 
 
-def skills_list(category: str = None, task_id: str = None) -> str:
+def _public_skill_metadata(skill: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the stable public projection of an internal discovery record."""
+    return {
+        "name": skill["name"],
+        "description": skill.get("description", ""),
+        "category": skill.get("category"),
+    }
+
+
+def _rank_skills_for_query(
+    skills: List[Dict[str, Any]], query: str
+) -> List[Dict[str, Any]]:
+    """Rank skill metadata with a deterministic, dependency-free fielded scorer.
+
+    Name, optional routing terms, category, and description are weighted in
+    that order. IDF downweights catalog-wide words, while exact phrases give
+    precise skill names and author-provided triggers a deterministic boost.
+    Skills with no lexical evidence abstain instead of returning arbitrary
+    alphabetic matches.
+    """
+    query_text = _normalise_search_text(query[:_SKILL_SEARCH_MAX_QUERY_CHARS])
+    query_tokens = set(_search_tokens(query_text))
+    if not query_text:
+        return []
+
+    records: list[tuple[Dict[str, Any], Dict[str, tuple[str, ...]], Dict[str, str]]] = []
+    document_frequency = {token: 0 for token in query_tokens}
+
+    for skill in skills:
+        routing_terms = tuple(skill.get("_routing_terms") or ())
+        field_text = {
+            "name": _normalise_search_text(skill.get("name", "")),
+            "routing": _normalise_search_text(" ".join(routing_terms)),
+            "category": _normalise_search_text(skill.get("category", "")),
+            "description": _normalise_search_text(skill.get("description", "")),
+        }
+        field_tokens = {key: _search_tokens(value) for key, value in field_text.items()}
+        document_tokens = set().union(*(set(value) for value in field_tokens.values()))
+        for token in query_tokens & document_tokens:
+            document_frequency[token] += 1
+        records.append((skill, field_tokens, field_text))
+
+    field_weights = {
+        "name": 8.0,
+        "routing": 5.0,
+        "category": 3.0,
+        "description": 1.0,
+    }
+    catalog_size = max(1, len(records))
+    scored: list[tuple[float, str, str, Dict[str, Any]]] = []
+
+    for skill, field_tokens, field_text in records:
+        score = 0.0
+        for field, tokens in field_tokens.items():
+            matched = query_tokens & set(tokens)
+            for token in matched:
+                frequency = document_frequency[token]
+                idf = math.log(1.0 + (catalog_size - frequency + 0.5) / (frequency + 0.5))
+                score += field_weights[field] * idf
+
+        name_text = field_text["name"]
+        if query_text == name_text:
+            score += 100.0
+        elif query_text in name_text or name_text in query_text:
+            score += 24.0
+
+        if any(
+            term_text
+            and (term_text in query_text or query_text in term_text)
+            for term_text in (
+                _normalise_search_text(term)
+                for term in skill.get("_routing_terms") or ()
+            )
+        ):
+            # One bounded phrase bonus: repeated/overlapping trigger metadata
+            # must not outrank an exact skill-name champion by stuffing terms.
+            score += 16.0
+
+        if score > 0.0:
+            scored.append(
+                (
+                    score,
+                    str(skill.get("category") or ""),
+                    str(skill.get("name") or ""),
+                    skill,
+                )
+            )
+
+    scored.sort(key=lambda item: (-item[0], item[1], item[2]))
+    return [item[3] for item in scored]
+
+
+def skills_list(
+    category: Optional[str] = None,
+    task_id: Optional[str] = None,
+    query: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> str:
     """
     List all available skills (progressive disclosure tier 1 - minimal metadata).
 
@@ -791,6 +970,8 @@ def skills_list(category: str = None, task_id: str = None) -> str:
 
     Args:
         category: Optional category filter (e.g., "mlops")
+        query: Optional lexical query ranked across skill metadata
+        limit: Maximum query matches to return (1-50, default 10)
         task_id: Optional task identifier used to probe the active backend
 
     Returns:
@@ -828,8 +1009,22 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         if category:
             all_skills = [s for s in all_skills if s.get("category") == category]
 
-        # Sort by category then name
-        all_skills = _sort_skills(all_skills)
+        query_text = str(query or "").strip()[:_SKILL_SEARCH_MAX_QUERY_CHARS]
+        total_matches = None
+        if query_text:
+            all_skills = _rank_skills_for_query(all_skills, query_text)
+            total_matches = len(all_skills)
+            try:
+                result_limit = int(limit) if limit is not None else _SKILL_SEARCH_DEFAULT_LIMIT
+            except (TypeError, ValueError):
+                result_limit = _SKILL_SEARCH_DEFAULT_LIMIT
+            result_limit = max(1, min(result_limit, _SKILL_SEARCH_MAX_LIMIT))
+            all_skills = all_skills[:result_limit]
+        else:
+            # Preserve the historical full-list order when no query is supplied.
+            all_skills = _sort_skills(all_skills)
+
+        public_skills = [_public_skill_metadata(skill) for skill in all_skills]
 
         # Extract unique categories
         categories = sorted(
@@ -839,10 +1034,19 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         return json.dumps(
             {
                 "success": True,
-                "skills": all_skills,
+                "skills": public_skills,
                 "categories": categories,
-                "count": len(all_skills),
-                "hint": "Use skill_view(name) to see full content, tags, and linked files",
+                "count": len(public_skills),
+                "hint": (
+                    "Use skill_view(name) to load a result"
+                    if public_skills
+                    else "No lexical matches. Retry with skill, category, or domain keywords."
+                ),
+                **(
+                    {"query": query_text, "total_matches": total_matches}
+                    if query_text
+                    else {}
+                ),
             },
             ensure_ascii=False,
         )
@@ -1683,14 +1887,25 @@ if __name__ == "__main__":
 
 SKILLS_LIST_SCHEMA = {
     "name": "skills_list",
-    "description": "List available skills (name + description). Use skill_view(name) to load full content.",
+    "description": "List available skills or rank them for a task with query. Returns name + description; use skill_view(name) to load full content.",
     "parameters": {
         "type": "object",
         "properties": {
             "category": {
                 "type": "string",
                 "description": "Optional category filter to narrow results",
-            }
+            },
+            "query": {
+                "type": "string",
+                "maxLength": _SKILL_SEARCH_MAX_QUERY_CHARS,
+                "description": "Optional task or keywords used to rank relevant skills",
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": _SKILL_SEARCH_MAX_LIMIT,
+                "description": "Maximum query matches to return (default 10)",
+            },
         },
         "required": [],
     },
@@ -1720,7 +1935,10 @@ registry.register(
     toolset="skills",
     schema=SKILLS_LIST_SCHEMA,
     handler=lambda args, **kw: skills_list(
-        category=args.get("category"), task_id=kw.get("task_id")
+        category=args.get("category"),
+        query=args.get("query"),
+        limit=args.get("limit"),
+        task_id=kw.get("task_id"),
     ),
     check_fn=check_skills_requirements,
     emoji="📚",

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1025,6 +1025,14 @@ def skills_list(
             all_skills = _sort_skills(all_skills)
 
         public_skills = [_public_skill_metadata(skill) for skill in all_skills]
+        if query_text:
+            hint = (
+                "Use skill_view(name) to load a result"
+                if public_skills
+                else "No lexical matches. Retry with skill, category, or domain keywords."
+            )
+        else:
+            hint = "Use skill_view(name) to see full content, tags, and linked files"
 
         # Extract unique categories
         categories = sorted(
@@ -1037,11 +1045,7 @@ def skills_list(
                 "skills": public_skills,
                 "categories": categories,
                 "count": len(public_skills),
-                "hint": (
-                    "Use skill_view(name) to load a result"
-                    if public_skills
-                    else "No lexical matches. Retry with skill, category, or domain keywords."
-                ),
+                "hint": hint,
                 **(
                     {"query": query_text, "total_matches": total_matches}
                     if query_text

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -132,10 +132,16 @@ applies if you have it on.
 Skills use a token-efficient loading pattern:
 
 ```
-Level 0: skills_list()           → [{name, description, category}, ...]   (~3k tokens)
-Level 1: skill_view(name)        → Full content + metadata       (varies)
-Level 2: skill_view(name, path)  → Specific reference file       (varies)
+Level 0: skills_list()                 → All skill metadata
+         skills_list(query="task")    → Top 10 lexical matches
+Level 1: skill_view(name)              → Full content + metadata (varies)
+Level 2: skill_view(name, path)        → Specific reference file (varies)
 ```
+
+Query search ranks visible skills by name, optional routing hints, category,
+and description. It is local, deterministic, and adds no model or network
+call. Use `limit` (1–50) to change the number of matches. A query with no
+lexical evidence returns an empty list instead of unrelated results.
 
 The agent only loads the full skill content when it actually needs it.
 
@@ -150,6 +156,7 @@ platforms: [macos, linux]     # Optional — restrict to specific OS platforms
 metadata:
   hermes:
     tags: [python, automation]
+    triggers: [automate python, python workflow]  # Optional search hints
     category: devops
     fallback_for_toolsets: [web]    # Optional — conditional activation (see below)
     requires_toolsets: [terminal]   # Optional — conditional activation (see below)


### PR DESCRIPTION
## Summary

- extend the existing `skills_list` tool with optional `query` and `limit` parameters
- rank visible skills locally with deterministic fielded inverse-document-frequency scoring over name, routing hints, category, and description
- precompute an immutable lexical index inside the existing discovery cache
- preserve exact-name precedence, cap phrase boosts, bound query/result sizes, and abstain when there is no lexical evidence
- make the static skill-routing prompt selective: load direct matches, search when ambiguous, avoid tangential or duplicate loads, and proceed normally when nothing matches
- document query search and optional `metadata.hermes.tags` / `metadata.hermes.triggers` hints

This adds no tool, dependency, model call, network call, config key, or mid-conversation prompt mutation. The system prompt remains byte-stable for the conversation.

## Why

The full `skills_list()` payload in a real 128-skill profile was 39,650 bytes. Compact descriptions in the static prompt are intentionally bounded, so an agent that cannot confidently identify a skill needs a cheap discovery path without receiving the whole catalog again.

This extends the existing tool rather than adding core surface. `skills_list(query="spreadsheet formulas", limit=5)` returns only evidence-backed candidates; `skills_list()` without a query remains backward-compatible.

## Ranking contract

1. Apply existing visibility, platform, requirement, disabled-skill, and category filters first.
2. Normalize Unicode deterministically, casefold, strip diacritics, and tokenize without language-specific dependencies.
3. Weight exact name > name tokens > routing hints > category > description.
4. Downweight catalog-wide terms with IDF.
5. Require complete token boundaries for phrase bonuses.
6. Cap phrase bonuses so repeated trigger metadata cannot displace an exact-name match.
7. Sort ties deterministically by category and name.
8. Return no candidates when every score is zero.

Query length is capped at 500 characters. Query results default to 10 and are capped at 50. Private routing/index metadata never appears in tool output.

## Adversarial-review hardening

- `categories` now describes all query matches before `limit`, matching its documented semantics.
- `ask` no longer receives a phrase bonus from `task-management`.
- stopword-only queries abstain unless an exact name or routing term matches.
- `cafe` matches indexed `CAFÉ` metadata.
- normalized search fields/tokens are immutable tuples, preventing cache poisoning through a shallow discovery record copy.
- a registry-level test exercises the real handler with live `HERMES_HOME` resolution and no resolver mock.

## Evaluation

Frozen pre-development replay: 292 historical user-message / observed-`skill_view` pairs nested in 164 sessions. Explicit skill names and linked-file views are excluded; no prompt text or session identifier is exported.

| Metric | Counterfactual unweighted ranker | Fielded IDF |
|---|---:|---:|
| Top-10 | 28.77% | **44.52%** |
| MRR | 0.1038 | **0.2254** |

- top-10 gain: +15.75 percentage points (+54.76% relative)
- session-cluster bootstrap 95% CI: **+9.66 to +21.89 points** (50,000 replicates, fixed seed)
- MRR cluster-bootstrap gain CI: **0.0885–0.1562**
- 65 fielded-only vs 19 baseline-only top-10 successes
- unclustered exact McNemar p = 4.75e-7 is retained only as descriptive; cluster-resampled intervals are the primary inference

Independent frozen authored-body proxy: 63 cases from 125 mapped skill documents, with indexed frontmatter and exact skill-name mentions excluded.

- top-10: **80.95% vs 65.08%**
- paired bootstrap gain CI: **+4.76 to +28.57 points**
- 13 fielded-only vs 3 baseline-only; exact paired McNemar p = 0.0213
- lower-cutoff intervals include zero at this sample size

## Algorithm comparison

An untuned BM25F candidate (`k1=1.2`, `b=0.75`, existing field weights) and RRF (`k=60`) were evaluated but not promoted:

- historical top-10: fielded-IDF 44.52%, BM25F 42.12%, RRF 42.12%
- authored top-10: fielded-IDF 80.95%, BM25F/RRF 82.54%

BM25F improved the smaller authored proxy but regressed the larger historical proxy; RRF did not dominate. The simpler deterministic ranker remains the candidate pending prospectively frozen canary data.

## Payload and runtime

- queried response: 2,838.7 bytes mean vs 39,650 bytes for the full list (**-92.84%**)
- no-query response: byte-identical to pre-rollout commit `8b209e0dd` for the same live catalog (`sha256 86e63ea9...6613c4` in the final live-repo verification)
- one warm-cache in-process `skills_list(query, limit=10)` call, including ranking and JSON serialization: **6.351 ms mean**, 13.667 ms p95 over 5,000 trials after 500 warmups
- environment: CPython 3.13.13, macOS 26.6 arm64, Apple M2 Pro, 16 GiB RAM

## Verification

- `639 passed, 2 skipped` across `tests/tools/test_skills*.py`, `tests/tools/test_skill_view*.py`, `tests/agent/test_skill_routing_policy.py`, and `tests/agent/test_prompt_builder.py`
- Ruff, `compileall`, diff whitespace checks, and live registry dispatch pass
- synthetic 1,000-skill stress: 10,000 sequential + 8,000 calls across 32 threads
- 1,000 exact-name checks, 0 failures; 0 exceptions; deterministic bounded top-10 output
- adversarial shapes include Unicode, NUL, punctuation-only, 10,000-character, path-traversal-shaped, SQL-shaped, and stopword-only inputs

## Limitations

1. Historical labels are a retrospective behavioral proxy, not randomized task success.
2. The comparison baseline is a **counterfactual unweighted lexical-overlap ranker**. Hermes previously emitted the full catalog and had no old-system top-k ranker.
3. The 292 observations are nested in 164 sessions; this is why cluster-bootstrap intervals, not the naive p-value, are primary.
4. The authored corpus reduces label leakage but remains repository-document-derived.
5. Results come from one installation/catalog; external validity is unknown.
6. Payload reduction applies only when `query` is supplied. No-query compatibility intentionally retains the full payload.
7. Local warm-cache latency excludes model, network, tool transport, and cold-start time.
8. Production task-success claims require the scheduled 14-day canary and prospectively defined metrics.

## Reproduction

```bash
python -m pytest \
  tests/tools/test_skills*.py \
  tests/tools/test_skill_view*.py \
  tests/agent/test_skill_routing_policy.py \
  tests/agent/test_prompt_builder.py -q
ruff check agent/prompt_builder.py tools/skills_tool.py \
  tests/tools/test_skills_tool_search.py \
  tests/agent/test_skill_routing_policy.py
```
