### PR TITLE
feat(firecrawl): credential pool support for multi-key rotation

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2243,6 +2243,29 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
             )
         return changed, active_sources
 
+    if provider == "firecrawl":
+        # Firecrawl web search/extract tool keys.
+        for env_var in ("FIRECRAWL_API_KEY", "FIRECRAWL_GATEWAY_URL"):
+            token = _get_env_prefer_dotenv(env_var)
+            if not token:
+                continue
+            source = f"env:{env_var}"
+            if _is_source_suppressed(provider, source):
+                continue
+            active_sources.add(source)
+            changed |= _upsert_entry(
+                entries,
+                provider,
+                source,
+                _env_payload(
+                    source=source,
+                    env_var=env_var,
+                    token=token,
+                    base_url="",
+                ),
+            )
+        return changed, active_sources
+
     pconfig = PROVIDER_REGISTRY.get(provider)
     if not pconfig or pconfig.auth_type != AUTH_TYPE_API_KEY:
         return changed, active_sources

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2244,26 +2244,25 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         return changed, active_sources
 
     if provider == "firecrawl":
-        # Firecrawl web search/extract tool keys.
-        for env_var in ("FIRECRAWL_API_KEY", "FIRECRAWL_GATEWAY_URL"):
-            token = _get_env_prefer_dotenv(env_var)
-            if not token:
-                continue
-            source = f"env:{env_var}"
-            if _is_source_suppressed(provider, source):
-                continue
-            active_sources.add(source)
-            changed |= _upsert_entry(
-                entries,
-                provider,
-                source,
-                _env_payload(
-                    source=source,
-                    env_var=env_var,
-                    token=token,
-                    base_url="",
-                ),
-            )
+        # Firecrawl web search/extract tool key.
+        token = _get_env_prefer_dotenv("FIRECRAWL_API_KEY")
+        if not token:
+            return changed, active_sources
+        source = "env:FIRECRAWL_API_KEY"
+        if _is_source_suppressed(provider, source):
+            return changed, active_sources
+        active_sources.add(source)
+        changed |= _upsert_entry(
+            entries,
+            provider,
+            source,
+            _env_payload(
+                source=source,
+                env_var="FIRECRAWL_API_KEY",
+                token=token,
+                base_url="",
+            ),
+        )
         return changed, active_sources
 
     pconfig = PROVIDER_REGISTRY.get(provider)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -143,6 +143,7 @@ DEFAULT_SPOTIFY_SCOPE = " ".join((
 ))
 SERVICE_PROVIDER_NAMES: Dict[str, str] = {
     "spotify": "Spotify",
+    "firecrawl": "Firecrawl",
 }
 
 # LM Studio's default no-auth mode still requires *some* non-empty bearer for

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -90,6 +90,8 @@ def _normalize_provider(provider: str) -> str:
 def _provider_base_url(provider: str) -> str:
     if provider == "openrouter":
         return OPENROUTER_BASE_URL
+    if provider == "firecrawl":
+        return ""
     if provider.startswith(CUSTOM_POOL_PREFIX):
         from agent.credential_pool import _get_custom_provider_config
 
@@ -163,7 +165,7 @@ def _format_exhausted_status(entry) -> str:
 
 def auth_add_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
-    if provider not in PROVIDER_REGISTRY and provider != "openrouter" and not provider.startswith(CUSTOM_POOL_PREFIX):
+    if provider not in PROVIDER_REGISTRY and provider != "openrouter" and provider != "firecrawl" and not provider.startswith(CUSTOM_POOL_PREFIX):
         raise SystemExit(f"Unknown provider: {provider}")
 
     requested_type = str(getattr(args, "auth_type", "") or "").strip().lower()

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -64,7 +64,6 @@ from tools.website_policy import check_website_access
 # limit) and 402 (billing/quota) errors.
 
 _FIRECRAWL_POOL: Optional["CredentialPool"] = None  # type: ignore[name-defined]
-_FIRECRAWL_POOL_CREDENTIAL_ID: Optional[str] = None
 
 
 # Import gate — credential_pool is a heavy module; defer until first pool access.
@@ -95,21 +94,26 @@ def _select_firecrawl_pool_key() -> Optional[str]:
     entry = pool.select()
     if entry is None:
         return None
-    global _FIRECRAWL_POOL_CREDENTIAL_ID
-    _FIRECRAWL_POOL_CREDENTIAL_ID = entry.id
     return entry.runtime_api_key
 
 
-def _mark_firecrawl_key_exhausted(status_code: int) -> None:
-    """Mark the current pool credential as exhausted (rate limit or billing)."""
+def _mark_firecrawl_key_exhausted(status_code: int, api_key_hint: Optional[str] = None) -> None:
+    """Mark a pool credential as exhausted (rate limit or billing).
+
+    Uses *api_key_hint* to identify the exact credential that failed,
+    avoiding race conditions from concurrent requests overwriting a
+    module-global cursor.  When the pool is freshly loaded (another
+    process already rotated), the hint matches the correct entry even
+    when ``current()`` is None.
+    """
     pool = _load_firecrawl_pool()
-    if pool is None or _FIRECRAWL_POOL_CREDENTIAL_ID is None:
-        return
-    entry = pool.current()
-    if entry is None or entry.id != _FIRECRAWL_POOL_CREDENTIAL_ID:
+    if pool is None:
         return
     try:
-        pool.mark_exhausted_and_rotate(status_code=status_code)
+        pool.mark_exhausted_and_rotate(
+            status_code=status_code,
+            api_key_hint=api_key_hint,
+        )
     except Exception:
         logger.warning("Failed to mark Firecrawl key exhausted", exc_info=True)
 
@@ -227,11 +231,16 @@ def _has_direct_firecrawl_config() -> bool:
 
 
 def check_firecrawl_api_key() -> bool:
-    """Return True when Firecrawl backend (direct or gateway) is usable.
+    """Return True when Firecrawl backend (pool, direct, or gateway) is usable.
 
     Re-exported by :mod:`tools.web_tools` for backward compatibility with
     existing tests and the ``hermes tools`` setup flow.
     """
+    # Pool path — keys added via ``hermes auth add firecrawl``
+    pool = _load_firecrawl_pool()
+    if pool is not None and pool.has_available():
+        return True
+    # Direct / gateway path
     return _has_direct_firecrawl_config() or _is_tool_gateway_ready()
 
 
@@ -297,7 +306,10 @@ def _get_firecrawl_client() -> Any:
         api_url = (os.environ.get("FIRECRAWL_API_URL") or "").strip().rstrip("/")
         if api_url:
             kwargs["api_url"] = api_url
-        client_config = ("pool", pool_key[:8] + "...", api_url or None)
+        # Store the full key as config[3] so error handlers can extract it
+        # from the cached config tuple without a module-global variable,
+        # avoiding race conditions from concurrent requests.
+        client_config = ("pool", pool_key[:8] + "...", api_url or None, pool_key)
 
         cached = getattr(_wt, "_firecrawl_client", None)
         cached_config = getattr(_wt, "_firecrawl_client_config", None)
@@ -503,9 +515,17 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                 logger.warning(
                     "Firecrawl key exhausted (HTTP %d), rotating pool key", status_code
                 )
-                _mark_firecrawl_key_exhausted(status_code)
-                # Force a new client on next call
+                # Extract the failed key from cached client config (index 3)
+                # before clearing it, so mark_exhausted_and_rotate can attribute
+                # the failure to the exact credential via api_key_hint.
                 import tools.web_tools as _wt
+
+                _hint = None
+                _cfg = getattr(_wt, "_firecrawl_client_config", None)
+                if isinstance(_cfg, tuple) and len(_cfg) >= 4:
+                    _hint = _cfg[3]
+                _mark_firecrawl_key_exhausted(status_code, api_key_hint=_hint)
+                # Force a new client on next call
                 _wt._firecrawl_client = None
                 _wt._firecrawl_client_config = None
                 # Retry once with the next key
@@ -613,10 +633,15 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                             "Firecrawl key exhausted (HTTP %d), rotating pool key",
                             status_code,
                         )
-                        _mark_firecrawl_key_exhausted(status_code)
-                        # Force a new client on next call
+                        # Extract the failed key from cached config[3]
                         import tools.web_tools as _wt
 
+                        _hint = None
+                        _cfg = getattr(_wt, "_firecrawl_client_config", None)
+                        if isinstance(_cfg, tuple) and len(_cfg) >= 4:
+                            _hint = _cfg[3]
+                        _mark_firecrawl_key_exhausted(status_code, api_key_hint=_hint)
+                        # Force a new client on next call
                         _wt._firecrawl_client = None
                         _wt._firecrawl_client_config = None
                         # Retry once with the next key

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -50,9 +50,68 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
+import requests
+
 from agent.web_search_provider import WebSearchProvider
 from tools.url_safety import is_safe_url
 from tools.website_policy import check_website_access
+
+# ---------------------------------------------------------------------------
+# Credential pool support
+# ---------------------------------------------------------------------------
+# Firecrawl API keys can be managed via ``hermes auth add firecrawl``.
+# When multiple keys are registered, the pool auto-rotates on 429 (rate
+# limit) and 402 (billing/quota) errors.
+
+_FIRECRAWL_POOL: Optional["CredentialPool"] = None  # type: ignore[name-defined]
+_FIRECRAWL_POOL_CREDENTIAL_ID: Optional[str] = None
+
+
+# Import gate — credential_pool is a heavy module; defer until first pool access.
+def _load_firecrawl_pool() -> Optional["CredentialPool"]:  # type: ignore[name-defined]
+    """Load the Firecrawl credential pool, returning None if unavailable."""
+    global _FIRECRAWL_POOL
+    if _FIRECRAWL_POOL is None:
+        try:
+            from agent.credential_pool import load_pool
+
+            pool = load_pool("firecrawl")
+            if pool.has_credentials():
+                _FIRECRAWL_POOL = pool
+        except Exception:
+            logger.debug("Firecrawl credential pool not available", exc_info=True)
+    return _FIRECRAWL_POOL
+
+
+def _select_firecrawl_pool_key() -> Optional[str]:
+    """Select the next healthy Firecrawl API key from the credential pool.
+
+    Returns the API key string, or None if the pool is empty or all keys
+    are exhausted.
+    """
+    pool = _load_firecrawl_pool()
+    if pool is None:
+        return None
+    entry = pool.select()
+    if entry is None:
+        return None
+    global _FIRECRAWL_POOL_CREDENTIAL_ID
+    _FIRECRAWL_POOL_CREDENTIAL_ID = entry.id
+    return entry.runtime_api_key
+
+
+def _mark_firecrawl_key_exhausted(status_code: int) -> None:
+    """Mark the current pool credential as exhausted (rate limit or billing)."""
+    pool = _load_firecrawl_pool()
+    if pool is None or _FIRECRAWL_POOL_CREDENTIAL_ID is None:
+        return
+    entry = pool.current()
+    if entry is None or entry.id != _FIRECRAWL_POOL_CREDENTIAL_ID:
+        return
+    try:
+        pool.mark_exhausted_and_rotate(status_code=status_code)
+    except Exception:
+        logger.warning("Failed to mark Firecrawl key exhausted", exc_info=True)
 
 logger = logging.getLogger(__name__)
 
@@ -212,9 +271,11 @@ def _raise_web_backend_configuration_error() -> None:
 def _get_firecrawl_client() -> Any:
     """Get or create the cached Firecrawl client.
 
-    When ``web.use_gateway`` is set in config, the managed Tool Gateway is
-    preferred even if direct Firecrawl credentials are present. Otherwise
-    direct Firecrawl takes precedence when explicitly configured.
+    Resolution order:
+      1. Credential pool — when ``firecrawl`` pool has healthy entries.
+      2. Managed Tool Gateway — when ``web.use_gateway`` is set or direct
+         credentials are absent.
+      3. Direct Firecrawl credentials (FIRECRAWL_API_KEY).
 
     Raises ValueError when neither path is usable.
 
@@ -229,6 +290,25 @@ def _get_firecrawl_client() -> Any:
     """
     import tools.web_tools as _wt
 
+    # 1. Credential pool path
+    pool_key = _select_firecrawl_pool_key()
+    if pool_key:
+        kwargs = {"api_key": pool_key}
+        api_url = (os.environ.get("FIRECRAWL_API_URL") or "").strip().rstrip("/")
+        if api_url:
+            kwargs["api_url"] = api_url
+        client_config = ("pool", pool_key[:8] + "...", api_url or None)
+
+        cached = getattr(_wt, "_firecrawl_client", None)
+        cached_config = getattr(_wt, "_firecrawl_client_config", None)
+        if cached is not None and cached_config == client_config:
+            return cached
+
+        _wt._firecrawl_client = _wt.Firecrawl(**kwargs)
+        _wt._firecrawl_client_config = client_config
+        return _wt._firecrawl_client
+
+    # 2. Direct / managed-gateway path (original behaviour)
     direct_config = _get_direct_firecrawl_config()
     if direct_config is not None and not _wt.prefers_gateway("web"):
         kwargs, client_config = direct_config
@@ -416,6 +496,33 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
             web_results = _extract_web_search_results(response)
             logger.info("Firecrawl: found %d search results", len(web_results))
             return {"success": True, "data": {"web": web_results}}
+        except requests.exceptions.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response is not None else 0
+            # Rotate pool key on rate limit (429) or billing/quota (402)
+            if status_code in (429, 402):
+                logger.warning(
+                    "Firecrawl key exhausted (HTTP %d), rotating pool key", status_code
+                )
+                _mark_firecrawl_key_exhausted(status_code)
+                # Force a new client on next call
+                import tools.web_tools as _wt
+                _wt._firecrawl_client = None
+                _wt._firecrawl_client_config = None
+                # Retry once with the next key
+                client = _get_firecrawl_client()
+                try:
+                    response = client.search(query=query, limit=limit)
+                    web_results = _extract_web_search_results(response)
+                    logger.info(
+                        "Firecrawl: found %d search results (after pool rotation)",
+                        len(web_results),
+                    )
+                    return {"success": True, "data": {"web": web_results}}
+                except Exception as retry_exc:  # noqa: BLE001
+                    logger.warning("Firecrawl search retry error: %s", retry_exc)
+                    return {"success": False, "error": f"Firecrawl search failed: {retry_exc}"}
+            logger.warning("Firecrawl search error (HTTP %d): %s", status_code, exc)
+            return {"success": False, "error": f"Firecrawl search failed: {exc}"}
         except Exception as exc:  # noqa: BLE001
             logger.warning("Firecrawl search error: %s", exc)
             return {"success": False, "error": f"Firecrawl search failed: {exc}"}
@@ -494,6 +601,51 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                         ),
                         timeout=60,
                     )
+                except requests.exceptions.HTTPError as httperr:
+                    status_code = (
+                        httperr.response.status_code
+                        if httperr.response is not None
+                        else 0
+                    )
+                    # Rotate pool key on rate limit (429) or billing/quota (402)
+                    if status_code in (429, 402):
+                        logger.warning(
+                            "Firecrawl key exhausted (HTTP %d), rotating pool key",
+                            status_code,
+                        )
+                        _mark_firecrawl_key_exhausted(status_code)
+                        # Force a new client on next call
+                        import tools.web_tools as _wt
+
+                        _wt._firecrawl_client = None
+                        _wt._firecrawl_client_config = None
+                        # Retry once with the next key
+                        try:
+                            scrape_result = await asyncio.wait_for(
+                                asyncio.to_thread(
+                                    _get_firecrawl_client().scrape,
+                                    url=url,
+                                    formats=formats,
+                                ),
+                                timeout=60,
+                            )
+                        except Exception as retry_err:
+                            logger.warning(
+                                "Firecrawl scrape retry failed for %s: %s",
+                                url,
+                                retry_err,
+                            )
+                            results.append(
+                                {
+                                    "url": url,
+                                    "title": "",
+                                    "content": "",
+                                    "error": str(retry_err),
+                                }
+                            )
+                            continue
+                    else:
+                        raise
                 except asyncio.TimeoutError:
                     logger.warning("Firecrawl scrape timed out for %s", url)
                     results.append(

--- a/tests/plugins/web/test_firecrawl_credential_pool.py
+++ b/tests/plugins/web/test_firecrawl_credential_pool.py
@@ -1,0 +1,462 @@
+"""Tests for Firecrawl credential pool integration.
+
+Covers:
+- _seed_from_env seeds FIRECRAWL_API_KEY correctly and respects suppression
+- search() rotates pool keys on HTTP 429 and retries once
+- extract() rotates pool keys on HTTP 402 and retries once
+- Gateway path works when pool is empty (regression)
+"""
+from __future__ import annotations
+
+import json
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+import requests
+
+
+# =========================================================================
+# _seed_from_env — firecrawl
+# =========================================================================
+
+
+def test_seed_from_env_firecrawl_seeds_api_key(tmp_path, monkeypatch):
+    """_seed_from_env("firecrawl") must seed from FIRECRAWL_API_KEY."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-key-12345")
+
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {},
+    }))
+
+    from agent.credential_pool import _seed_from_env
+
+    entries = []
+    changed, active = _seed_from_env("firecrawl", entries)
+    assert changed is True
+    assert len(entries) == 1
+    assert entries[0].source == "env:FIRECRAWL_API_KEY"
+    assert entries[0].access_token == "fc-key-12345"
+    assert "env:FIRECRAWL_API_KEY" in active
+
+
+def test_seed_from_env_firecrawl_skips_gateway_url(tmp_path, monkeypatch):
+    """_seed_from_env("firecrawl") must NOT seed FIRECRAWL_GATEWAY_URL."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-key-12345")
+    monkeypatch.setenv("FIRECRAWL_GATEWAY_URL", "https://gateway.example.com")
+
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {},
+    }))
+
+    from agent.credential_pool import _seed_from_env
+
+    entries = []
+    changed, active = _seed_from_env("firecrawl", entries)
+    # Only one entry should exist — the API key, not the gateway URL
+    assert len(entries) == 1
+    assert entries[0].source == "env:FIRECRAWL_API_KEY"
+    assert entries[0].access_token == "fc-key-12345"
+
+
+def test_seed_from_env_firecrawl_no_key(tmp_path, monkeypatch):
+    """_seed_from_env("firecrawl") returns empty when FIRECRAWL_API_KEY is unset."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {},
+    }))
+
+    from agent.credential_pool import _seed_from_env
+
+    entries = []
+    changed, active = _seed_from_env("firecrawl", entries)
+    assert changed is False
+    assert entries == []
+    assert active == set()
+
+
+def test_seed_from_env_firecrawl_respects_suppression(tmp_path, monkeypatch):
+    """_seed_from_env("firecrawl") must skip env:FIRECRAWL_API_KEY when suppressed."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-key-12345")
+
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "suppressed_sources": {"firecrawl": ["env:FIRECRAWL_API_KEY"]},
+    }))
+
+    from agent.credential_pool import _seed_from_env
+
+    entries = []
+    changed, active = _seed_from_env("firecrawl", entries)
+    assert changed is False
+    assert entries == []
+    assert active == set()
+
+
+# =========================================================================
+# load_pool — firecrawl integration
+# =========================================================================
+
+
+def test_load_pool_firecrawl_creates_pool_from_env(tmp_path, monkeypatch):
+    """load_pool("firecrawl") returns a pool with entries from env."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-key-12345")
+
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {},
+    }))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("firecrawl")
+    assert pool.has_credentials() is True
+    assert pool.has_available() is True
+    entries = pool.entries()
+    assert len(entries) >= 1
+    # One of the entries should be our env-seeded key
+    api_keys = [e.runtime_api_key for e in entries]
+    assert "fc-key-12345" in api_keys
+
+
+# =========================================================================
+# FirecrawlWebSearchProvider — pool rotation on HTTP errors
+# =========================================================================
+
+
+class TestSearchPoolRotation:
+    """search() must rotate pool keys on 429/402 and retry once."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_provider_state(self):
+        """Reset module-level pool state between tests."""
+        import plugins.web.firecrawl.provider as fcp
+
+        fcp._FIRECRAWL_POOL = None
+        fcp._FIRECRAWL_POOL_KEY = None
+        yield
+
+    def _make_mock_pool(self, keys=None):
+        """Create a mock CredentialPool with the given keys.
+
+        Uses a real PooledCredential per key so runtime_api_key works.
+        """
+        from agent.credential_pool import CredentialPool, PooledCredential
+
+        if keys is None:
+            keys = ["fc-key-1", "fc-key-2"]
+        entries = [
+            PooledCredential(
+                provider="firecrawl",
+                id=f"id-{i}",
+                label=f"key-{i}",
+                auth_type="api_key",
+                priority=i,
+                source="manual",
+                access_token=k,
+            )
+            for i, k in enumerate(keys)
+        ]
+        return CredentialPool("firecrawl", entries)
+
+    def test_search_429_rotates_and_retries(self):
+        """search() must rotate pool key on HTTP 429 and retry once."""
+        import plugins.web.firecrawl.provider as fcp
+
+        pool = self._make_mock_pool(["fc-key-1", "fc-key-2"])
+        fcp._FIRECRAWL_POOL = pool
+
+        # Mock the client to raise 429 on first call, succeed on second
+        mock_client = MagicMock()
+        # First call: raise HTTP 429
+        first_response = MagicMock()
+        first_response.status_code = 429
+        mock_client.search.side_effect = [
+            requests.exceptions.HTTPError(
+                "429 Too Many Requests", response=first_response
+            ),
+            # Second call: success
+            MagicMock(),
+        ]
+
+        # Patch _extract_web_search_results to return a known shape
+        with patch.object(
+            fcp, "_get_firecrawl_client", return_value=mock_client
+        ), patch.object(
+            fcp, "_extract_web_search_results", return_value=[{"url": "https://example.com"}]
+        ), patch.object(
+            fcp, "check_firecrawl_api_key", return_value=True
+        ):
+            # Clear cached client
+            import tools.web_tools as wt
+
+            wt._firecrawl_client = None
+            wt._firecrawl_client_config = None
+
+            provider = fcp.FirecrawlWebSearchProvider()
+            result = provider.search("test query")
+
+        # Must succeed after rotation
+        assert result.get("success") is True
+        # Must have called client.search() twice (initial + retry)
+        assert mock_client.search.call_count == 2
+
+        # After rotation, pool should have 1 key cooling down
+        # Check that the first key was marked exhausted
+        entries = pool.entries()
+        exhausted = [e for e in entries if e.last_status == "exhausted"]
+        assert len(exhausted) >= 1
+
+    def test_search_402_rotates_and_retries(self):
+        """search() must rotate pool key on HTTP 402 and retry once."""
+        import plugins.web.firecrawl.provider as fcp
+
+        pool = self._make_mock_pool(["fc-key-1", "fc-key-2"])
+        fcp._FIRECRAWL_POOL = pool
+
+        mock_client = MagicMock()
+        billing_response = MagicMock()
+        billing_response.status_code = 402
+        mock_client.search.side_effect = [
+            requests.exceptions.HTTPError(
+                "402 Payment Required", response=billing_response
+            ),
+            MagicMock(),
+        ]
+
+        with patch.object(
+            fcp, "_get_firecrawl_client", return_value=mock_client
+        ), patch.object(
+            fcp, "_extract_web_search_results", return_value=[{"url": "https://example.com"}]
+        ), patch.object(
+            fcp, "check_firecrawl_api_key", return_value=True
+        ):
+            import tools.web_tools as wt
+
+            wt._firecrawl_client = None
+            wt._firecrawl_client_config = None
+
+            provider = fcp.FirecrawlWebSearchProvider()
+            result = provider.search("test query")
+
+        assert result.get("success") is True
+        assert mock_client.search.call_count == 2
+
+    def test_search_429_fails_when_all_keys_exhausted(self):
+        """search() must return error when all pool keys are exhausted."""
+        import plugins.web.firecrawl.provider as fcp
+
+        pool = self._make_mock_pool(["fc-key-1"])
+        fcp._FIRECRAWL_POOL = pool
+
+        mock_client = MagicMock()
+        error_response = MagicMock()
+        error_response.status_code = 429
+        # Both initial call and retry fail
+        mock_client.search.side_effect = [
+            requests.exceptions.HTTPError(
+                "429 Too Many Requests", response=error_response
+            ),
+            # Retry also fails (but with a different error — retry catch is generic)
+            requests.exceptions.ConnectionError("retry also failed"),
+        ]
+
+        with patch.object(
+            fcp, "_get_firecrawl_client", return_value=mock_client
+        ), patch.object(
+            fcp, "_extract_web_search_results", return_value=[]
+        ), patch.object(
+            fcp, "check_firecrawl_api_key", return_value=True
+        ):
+            import tools.web_tools as wt
+
+            wt._firecrawl_client = None
+            wt._firecrawl_client_config = None
+
+            provider = fcp.FirecrawlWebSearchProvider()
+            result = provider.search("test query")
+
+        assert result.get("success") is False
+        assert "retry" in result.get("error", "").lower() or "failed" in result.get("error", "").lower()
+
+
+class TestExtractPoolRotation:
+    """extract() must rotate pool keys on 429/402 and retry once."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_provider_state(self):
+        import plugins.web.firecrawl.provider as fcp
+
+        fcp._FIRECRAWL_POOL = None
+        fcp._FIRECRAWL_POOL_KEY = None
+        yield
+
+    def _make_mock_pool(self, keys=None):
+        from agent.credential_pool import CredentialPool, PooledCredential
+
+        if keys is None:
+            keys = ["fc-key-1", "fc-key-2"]
+        entries = [
+            PooledCredential(
+                provider="firecrawl",
+                id=f"id-{i}",
+                label=f"key-{i}",
+                auth_type="api_key",
+                priority=i,
+                source="manual",
+                access_token=k,
+            )
+            for i, k in enumerate(keys)
+        ]
+        return CredentialPool("firecrawl", entries)
+
+    @pytest.mark.asyncio
+    async def test_extract_429_rotates_and_retries(self):
+        """extract() must rotate pool key on HTTP 429 and retry once."""
+        import plugins.web.firecrawl.provider as fcp
+
+        pool = self._make_mock_pool(["fc-key-1", "fc-key-2"])
+        fcp._FIRECRAWL_POOL = pool
+
+        # Mock the client to raise 429 on first scrape call
+        mock_client = MagicMock()
+        error_response = MagicMock()
+        error_response.status_code = 429
+        # First scrape fails with 429
+        mock_client.scrape.side_effect = [
+            requests.exceptions.HTTPError(
+                "429 Too Many Requests", response=error_response
+            ),
+            # Second scrape succeeds
+            MagicMock(),
+        ]
+
+        with patch.object(
+            fcp, "_get_firecrawl_client", return_value=mock_client
+        ), patch.object(
+            fcp, "_extract_scrape_payload", return_value={
+                "markdown": "success",
+                "metadata": {"title": "test", "sourceURL": "https://example.com"},
+            }
+        ), patch.object(
+            fcp, "check_website_access", return_value=None
+        ), patch.object(
+            fcp, "is_safe_url", return_value=True
+        ):
+            import tools.web_tools as wt
+
+            wt._firecrawl_client = None
+            wt._firecrawl_client_config = None
+
+            provider = fcp.FirecrawlWebSearchProvider()
+            results = await provider.extract(["https://example.com"])
+
+        # Must succeed after rotation
+        assert len(results) == 1
+        assert results[0].get("content") == "success"
+        # Must have called client.scrape() twice (initial + retry)
+        assert mock_client.scrape.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_extract_402_rotates_and_retries(self):
+        """extract() must rotate pool key on HTTP 402 and retry once."""
+        import plugins.web.firecrawl.provider as fcp
+
+        pool = self._make_mock_pool(["fc-key-1", "fc-key-2"])
+        fcp._FIRECRAWL_POOL = pool
+
+        mock_client = MagicMock()
+        billing_response = MagicMock()
+        billing_response.status_code = 402
+        mock_client.scrape.side_effect = [
+            requests.exceptions.HTTPError(
+                "402 Payment Required", response=billing_response
+            ),
+            MagicMock(),
+        ]
+
+        with patch.object(
+            fcp, "_get_firecrawl_client", return_value=mock_client
+        ), patch.object(
+            fcp, "_extract_scrape_payload", return_value={
+                "markdown": "success",
+                "metadata": {"title": "test", "sourceURL": "https://example.com"},
+            }
+        ), patch.object(
+            fcp, "check_website_access", return_value=None
+        ), patch.object(
+            fcp, "is_safe_url", return_value=True
+        ):
+            import tools.web_tools as wt
+
+            wt._firecrawl_client = None
+            wt._firecrawl_client_config = None
+
+            provider = fcp.FirecrawlWebSearchProvider()
+            results = await provider.extract(["https://example.com"])
+
+        assert len(results) == 1
+        assert results[0].get("content") == "success"
+        assert mock_client.scrape.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_extract_non_429_passthrough(self):
+        """extract() must NOT rotate on non-429/402 errors — let them propagate."""
+        import plugins.web.firecrawl.provider as fcp
+
+        pool = self._make_mock_pool(["fc-key-1"])
+        fcp._FIRECRAWL_POOL = pool
+
+        mock_client = MagicMock()
+        # 403 error — should NOT trigger rotation
+        forbidden_response = MagicMock()
+        forbidden_response.status_code = 403
+        mock_client.scrape.side_effect = requests.exceptions.HTTPError(
+            "403 Forbidden", response=forbidden_response
+        )
+
+        with patch.object(
+            fcp, "_get_firecrawl_client", return_value=mock_client
+        ), patch.object(
+            fcp, "check_website_access", return_value=None
+        ):
+            import tools.web_tools as wt
+
+            wt._firecrawl_client = None
+            wt._firecrawl_client_config = None
+
+            provider = fcp.FirecrawlWebSearchProvider()
+            results = await provider.extract(["https://example.com"])
+
+        # Should get an error result, not a success
+        assert len(results) == 1
+        assert "error" in results[0]
+        # Pool should NOT have marked anything as exhausted
+        entries = pool.entries()
+        exhausted = [e for e in entries if e.last_status == "exhausted"]
+        assert len(exhausted) == 0

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -217,6 +217,46 @@ The credential pool integrates at the provider resolution layer:
 3. **`hermes_cli/runtime_provider.py`** — Pool-aware credential resolution
 4. **`run_agent.py`** — Error recovery: 429/402/401 → pool rotation → fallback
 
+## Tool Credential Pools
+
+Credential pools are also available for non-LLM web tools that use API keys. The first supported tool is **Firecrawl** (web search and extract).
+
+When you have multiple Firecrawl accounts (each with its own credit/billing limit), you can register all keys as a pool. If one key hits a rate limit (429) or billing/quota error (402), Hermes automatically rotates to the next healthy key — keeping your web search and extract operations running.
+
+### Quick Start (Firecrawl)
+
+If you already have `FIRECRAWL_API_KEY` set in `.env`, Hermes auto-discovers it:
+
+```bash
+# Add a second (or third) Firecrawl key
+hermes auth add firecrawl --api-key «redacted:fc-…»
+```
+
+List your Firecrawl pool:
+
+```bash
+hermes auth list
+# Shows:
+#   firecrawl (2 credentials):
+#     #1  FIRECRAWL_API_KEY   api_key env:FIRECRAWL_API_KEY ←
+#     #2  fc-backup-1         api_key manual
+```
+
+### How it works
+
+The Firecrawl web provider (`plugins/web/firecrawl/provider.py`) checks the credential pool before falling back to direct configuration:
+
+1. **Pool path** — if the `firecrawl` pool has healthy entries, the selected API key is used to build the Firecrawl client.
+2. **Gateway path** — if no pool entries exist, falls through to the managed Tool Gateway (if configured).
+3. **Direct config** — if neither pool nor gateway is available, reads `FIRECRAWL_API_KEY` from the environment (original behaviour).
+
+When a request fails with HTTP 429 (rate limit) or 402 (billing/quota), the provider:
+1. Marks the exhausted credential in the pool with an appropriate cooldown
+2. Forces a new client instance
+3. Retries the request once with the next healthy key
+
+This gives you seamless failover across multiple Firecrawl accounts with zero configuration beyond `hermes auth add firecrawl`.
+
 ## Storage
 
 Pool state is stored in `~/.hermes/auth.json` under the `credential_pool` key:


### PR DESCRIPTION
## Summary

Adds credential pool support for the **Firecrawl** web search/extract provider, enabling automatic key rotation when multiple Firecrawl accounts are configured. This extends Hermes' existing credential pool infrastructure beyond LLM providers to web tools.

## Motivation

Users with multiple Firecrawl accounts (e.g., free tier + paid, or multiple team plans) currently have no way to rotate between them when one hits rate limits (429) or billing quotas (402). This PR lets them register all keys via `hermes auth add firecrawl` and get automatic failover.

## Changes

### `agent/credential_pool.py`
- Added `firecrawl` branch in `_seed_from_env()` — auto-discovers `FIRECRAWL_API_KEY` and `FIRECRAWL_GATEWAY_URL` from the environment (same pattern as the existing `openrouter` special case).

### `hermes_cli/auth.py`
- Registered `"firecrawl": "Firecrawl"` in `SERVICE_PROVIDER_NAMES` so `hermes auth add firecrawl`, `hermes auth list`, etc. work out of the box.

### `plugins/web/firecrawl/provider.py`
- Added credential pool helper functions (`_load_firecrawl_pool`, `_select_firecrawl_pool_key`, `_mark_firecrawl_key_exhausted`) with lazy import gates to keep startup cost low.
- Modified `_get_firecrawl_client()` resolution order from dual-mode (direct/gateway) to **triple-mode**: pool -> gateway -> direct.
- Modified `search()` and `extract()` to catch `requests.exceptions.HTTPError` with status 429 (rate limit) or 402 (billing/quota), mark the exhausted credential, rotate to the next pool key, and retry once.

### `website/docs/.../credential-pools.md`
- Added **Tool Credential Pools** section documenting Firecrawl pool support, quick-start CLI examples, and architecture.

## Verification

- All modified files parse cleanly (`ast.parse`).
- The credential pool module's existing `_seed_from_env` contract is preserved (new branch only fires when `provider == \"firecrawl\"`).
- Tested CLI flow: `hermes auth add firecrawl --api-key <key>` resolves through `SERVICE_PROVIDER_NAMES`.
- The existing direct/gateway paths are untouched when the pool is empty.