### PR TITLE
fix(kanban): hint at the owning board when a verb fails on a wrong-board id (#65101)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1905,7 +1905,13 @@ def _locate_task_on_other_board(
             other = meta.get("slug")
             if not other or other == active:
                 continue
-            other_conn = kb.connect(board=other)
+            # Connect via an explicit db_path, NOT ``board=other``: the
+            # dispatcher pins ``HERMES_KANBAN_DB`` into worker env, and
+            # ``connect(board=other)`` would honour that pin and reopen the
+            # active board's DB instead of ``other`` — so the owning board
+            # would never be found (#65101, #65128). ``board_db_path``
+            # ignores the env override and resolves ``other``'s DB directly.
+            other_conn = kb.connect(db_path=kb.board_db_path(other))
             try:
                 if kb.get_task(other_conn, tid) is not None:
                     return (tid, other)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -19,6 +19,7 @@ import contextlib
 import json
 import os
 import shlex
+import sqlite3
 import sys
 import time
 from pathlib import Path
@@ -983,6 +984,20 @@ def kanban_command(args: argparse.Namespace) -> int:
             return int(handler(args) or 0)
         except (ValueError, RuntimeError) as exc:
             print(f"kanban: {exc}", file=sys.stderr)
+            # A verb that raises "unknown task <id>" almost always means the
+            # id is real but on a different board (#65101). Attach the owning
+            # board + switch command rather than leaving the operator to guess.
+            message = str(exc)
+            if "unknown task" in message:
+                ids = _task_ids_from_unknown_task_message(message)
+                if ids:
+                    conn = kb.connect()
+                    try:
+                        hint = _cross_board_hint(conn, ids)
+                    finally:
+                        conn.close()
+                    if hint:
+                        print(hint, file=sys.stderr)
             return 1
 
 
@@ -1863,6 +1878,93 @@ def _worker_run_id_for(task_id: str) -> Optional[int]:
         return None
 
 
+def _locate_task_on_other_board(
+    conn: sqlite3.Connection,
+    task_ids: list[str],
+    *,
+    current_board: Optional[str] = None,
+) -> Optional[tuple[str, str]]:
+    """Find the first task id in ``task_ids`` that lives on another board.
+
+    Returns ``(task_id, owning_board_slug)`` for the first match, or ``None``
+    when every id is either on the current board (a state problem, not a
+    wrong-board problem) or absent from all boards.
+
+    The active board is taken from ``current_board`` when given, otherwise
+    resolved via :func:`kb.get_current_board`. ``conn`` is the connection to
+    that active board — used for a cheap "is it actually here?" check before
+    scanning other boards.
+    """
+    active = current_board if current_board is not None else kb.get_current_board()
+    for tid in task_ids:
+        # On the active board already → not a wrong-board miss; skip it so we
+        # don't send the operator off to switch boards for a task that's here.
+        if kb.get_task(conn, tid) is not None:
+            continue
+        for meta in kb.list_boards(include_archived=False):
+            other = meta.get("slug")
+            if not other or other == active:
+                continue
+            other_conn = kb.connect(board=other)
+            try:
+                if kb.get_task(other_conn, tid) is not None:
+                    return (tid, other)
+            finally:
+                other_conn.close()
+    return None
+
+
+def _cross_board_hint(
+    conn: sqlite3.Connection,
+    task_ids: list[str],
+    *,
+    current_board: Optional[str] = None,
+) -> Optional[str]:
+    """Actionable "wrong board" hint for a failed kanban verb (#65101).
+
+    Kanban verbs fail opaquely when the task id is real but lives on a
+    different board — the operator sees ``unknown task {id}`` or
+    ``cannot <verb> {id}`` with no hint that a ``boards switch`` would fix it,
+    and has been observed retrying the same command many times.
+
+    Returns a one-line hint naming the owning board and the exact switch
+    command, or ``None`` when no id in ``task_ids`` is on another board.
+    """
+    found = _locate_task_on_other_board(conn, task_ids, current_board=current_board)
+    if not found:
+        return None
+    tid, other = found
+    active = current_board if current_board is not None else kb.get_current_board()
+    return (
+        f"  → '{tid}' is on board '{other}', not on the active board "
+        f"'{active}'. Switch with: hermes kanban boards switch {other}"
+    )
+
+
+# Task ids in kanban look like ``t_<hex>``. Used to recover ids from the
+# ``unknown task <id>`` / ``unknown task(s): <id>, <id>`` error strings raised
+# by kanban_db so a cross-board hint can be attached in the dispatch handler.
+_UNKNOWN_TASK_ID_CHARS = set(
+    "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-"
+)
+
+
+def _task_ids_from_unknown_task_message(message: str) -> list[str]:
+    """Extract task ids from a ``unknown task …`` ValueError message.
+
+    Handles both singular (``unknown task t_abc``) and plural
+    (``unknown task(s): t_abc, t_def``) forms. Returns ids in order, deduped.
+    """
+    ids: list[str] = []
+    seen: set[str] = set()
+    for token in message.replace(",", " ").split():
+        if token.startswith("t_") and all(c in _UNKNOWN_TASK_ID_CHARS for c in token):
+            if token not in seen:
+                seen.add(token)
+                ids.append(token)
+    return ids
+
+
 def _cmd_complete(args: argparse.Namespace) -> int:
     """Mark one or more tasks done. Supports a single id or a list."""
     ids = list(args.task_ids or [])
@@ -1903,6 +2005,9 @@ def _cmd_complete(args: argparse.Namespace) -> int:
             ):
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
+                hint = _cross_board_hint(conn, [tid])
+                if hint:
+                    print(hint, file=sys.stderr)
             else:
                 print(f"Completed {tid}")
     return 0 if not failed else 1
@@ -1954,7 +2059,10 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 expected_run_id=_worker_run_id_for(tid),
             ):
                 failed.append(tid)
-                print(f"cannot block {tid}", file=sys.stderr)
+                print(f"cannot block {tid} (unknown id or not in running/ready)", file=sys.stderr)
+                hint = _cross_board_hint(conn, [tid])
+                if hint:
+                    print(hint, file=sys.stderr)
             else:
                 # Report where the task actually landed — dependency blocks go
                 # to todo, and a tripped unblock-loop breaker routes to triage.
@@ -2090,7 +2198,10 @@ def _cmd_archive(args: argparse.Namespace) -> int:
         for tid in ids:
             if not kb.archive_task(conn, tid):
                 failed.append(tid)
-                print(f"cannot archive {tid}", file=sys.stderr)
+                print(f"cannot archive {tid} (unknown id or already archived)", file=sys.stderr)
+                hint = _cross_board_hint(conn, [tid])
+                if hint:
+                    print(hint, file=sys.stderr)
             else:
                 print(f"Archived {tid}")
     return 0 if not failed else 1

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -513,6 +513,32 @@ def board_exists(board: Optional[str] = None) -> bool:
     return (d / "board.json").exists() or (d / "kanban.db").exists()
 
 
+def _board_db_path_for_slug(slug: str) -> Path:
+    """Resolve the ``kanban.db`` path for an already-normalized board slug.
+
+    Pure path math — does NOT consult ``HERMES_KANBAN_DB``, so callers that
+    must reach a *different* board even when the dispatcher has pinned the
+    active DB (e.g. the cross-board hint scan) bypass the env override here
+    and pass the result to :func:`connect` as an explicit ``db_path``.
+    """
+    if slug == DEFAULT_BOARD:
+        return kanban_home() / "kanban.db"
+    return board_dir(slug) / "kanban.db"
+
+
+def board_db_path(board: str) -> Path:
+    """Return the path to ``kanban.db`` for ``board``, ignoring env pins.
+
+    Unlike :func:`kanban_db_path`, this never consults
+    ``HERMES_KANBAN_DB``. Use it when you deliberately need to inspect a
+    specific board's DB from a context whose env is pinned to another
+    (e.g. a dispatcher worker scanning sibling boards for the owning
+    board of a task id). ``board`` is required — there is no
+    active-board fallback.
+    """
+    return _board_db_path_for_slug(_normalize_board_slug(board) or DEFAULT_BOARD)
+
+
 def kanban_db_path(board: Optional[str] = None) -> Path:
     """Return the path to the ``kanban.db`` for ``board``.
 
@@ -533,9 +559,7 @@ def kanban_db_path(board: Optional[str] = None) -> Path:
     slug = _normalize_board_slug(board)
     if slug is None:
         slug = get_current_board()
-    if slug == DEFAULT_BOARD:
-        return kanban_home() / "kanban.db"
-    return board_dir(slug) / "kanban.db"
+    return _board_db_path_for_slug(slug)
 
 
 def workspaces_root(board: Optional[str] = None) -> Path:

--- a/tests/hermes_cli/test_kanban_cross_board_error.py
+++ b/tests/hermes_cli/test_kanban_cross_board_error.py
@@ -167,6 +167,35 @@ def test_cross_board_hint_names_owning_board(kanban_home, monkeypatch):
     assert "hermes kanban boards switch alpha" in hint
 
 
+def test_cross_board_hint_with_db_pinned_to_active(kanban_home, monkeypatch):
+    """The hint must still find the owning board when the dispatcher has
+    pinned ``HERMES_KANBAN_DB`` to the active board (#65128).
+
+    Dispatcher-spawned workers always carry this pin (see
+    ``kanban_db.py`` worker env handoff). A naive scan that reconnects via
+    ``connect(board=other)`` honours the pin, reopens the active board's
+    DB, and never finds the task — so the scan must bypass the env
+    override with an explicit ``db_path``.
+    """
+    kb.create_board("default")
+    kb.create_board("alpha")
+    # Create the task on "alpha" BEFORE the DB pin is set, otherwise
+    # ``connect(board="alpha")`` inside _task_on_board would itself be
+    # hijacked by the pin and write the task to the default board.
+    tid = _task_on_board("alpha")
+
+    # Pin the active ("default") board's DB exactly as the dispatcher does.
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(kb.kanban_db_path(board="default")))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+
+    with kb.connect(board="default") as conn:
+        hint = kc._cross_board_hint(conn, [tid])
+
+    assert hint is not None
+    assert "board 'alpha'" in hint
+    assert "hermes kanban boards switch alpha" in hint
+
+
 def test_task_ids_parsed_from_unknown_task_message():
     assert kc._task_ids_from_unknown_task_message("unknown task t_abc123") == [
         "t_abc123"

--- a/tests/hermes_cli/test_kanban_cross_board_error.py
+++ b/tests/hermes_cli/test_kanban_cross_board_error.py
@@ -1,0 +1,182 @@
+"""Tests for the cross-board failure hint in kanban CLI verbs (#65101).
+
+When a kanban verb fails because the task id lives on a *different* board, the
+bare ``unknown task {id}`` (or ``cannot <verb> {id}``) line is misleading: the
+id is real, it's just on the wrong board. The dispatch layer and the per-verb
+``False`` branches now attach an actionable hint naming the owning board and
+the exact ``boards switch`` command.
+
+These tests pin that hint for the real failure paths (the ``unknown task``
+exception raised when a verb touches a task before its state check, and the
+``cannot <verb>`` line when a verb's task op returns ``False``), and confirm no
+hint is shown when the failure is a genuine wrong-state case.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home():
+    """Init the kanban DB under the hermetic HERMES_HOME that conftest sets."""
+    kb.init_db()
+
+
+def _task_on_board(board: str, *, title: str = "remote task") -> str:
+    """Create a task on ``board`` and return its id."""
+    with kb.connect(board=board) as conn:
+        return kb.create_task(conn, title=title, initial_status="running")
+
+
+# ---------------------------------------------------------------------------
+# Real failure path: "unknown task" exception (verb touches the task before
+# its state check — e.g. block with a reason calls add_comment first).
+# ---------------------------------------------------------------------------
+
+
+def test_block_unknown_task_on_other_board_suggests_switch(kanban_home, monkeypatch):
+    """Blocking (with a reason) a task on another board raises 'unknown task'
+    from add_comment; the dispatch layer attaches the owning-board hint."""
+    kb.create_board("default")
+    kb.create_board("cqgambit")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "cqgambit")
+
+    tid = _task_on_board("default")
+
+    out = kc.run_slash(f"block {tid} stuck --kind needs_input")
+
+    assert "unknown task" in out
+    assert f"'{tid}' is on board 'default'" in out
+    assert "hermes kanban boards switch default" in out
+
+
+def test_archive_unknown_task_on_other_board_suggests_switch(kanban_home, monkeypatch):
+    """Archiving a task on another board attaches the owning-board hint."""
+    kb.create_board("default")
+    kb.create_board("other")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "other")
+
+    tid = _task_on_board("default")
+
+    out = kc.run_slash(f"archive {tid}")
+
+    assert f"'{tid}' is on board 'default'" in out
+    assert "hermes kanban boards switch default" in out
+
+
+def test_complete_unknown_task_on_other_board_suggests_switch(kanban_home, monkeypatch):
+    """Completing a task on another board attaches the owning-board hint."""
+    kb.create_board("default")
+    kb.create_board("work")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "work")
+
+    tid = _task_on_board("default")
+
+    out = kc.run_slash(f"complete {tid}")
+
+    assert f"'{tid}' is on board 'default'" in out
+    assert "hermes kanban boards switch default" in out
+
+
+def test_unknown_task_on_current_board_has_no_switch_hint(kanban_home, monkeypatch):
+    """When the task genuinely doesn't exist (not on any board) we must NOT
+    suggest switching boards — that would chase the operator to boards where
+    the task still isn't."""
+    kb.create_board("default")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+
+    out = kc.run_slash("block t_does_not_exist why --kind needs_input")
+
+    assert "unknown task" in out
+    assert "boards switch" not in out
+    assert "is on board" not in out
+
+
+# ---------------------------------------------------------------------------
+# Per-verb "cannot <verb>" path: the task op returns False (no reason, so
+# add_comment isn't called and the verb reaches its own failure print).
+# ---------------------------------------------------------------------------
+
+
+def test_block_returns_false_on_other_board_suggests_switch(kanban_home, monkeypatch):
+    """block without a reason reaches block_task→False and prints
+    'cannot block' plus the cross-board hint."""
+    kb.create_board("default")
+    kb.create_board("cqgambit")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "cqgambit")
+
+    tid = _task_on_board("default")
+
+    out = kc.run_slash(f"block {tid} --kind needs_input")
+
+    assert "cannot block" in out
+    assert "hermes kanban boards switch default" in out
+
+
+def test_wrong_state_failure_has_no_board_hint(kanban_home, monkeypatch):
+    """A task present on the *current* board but in the wrong state must not
+    suggest switching boards — the failure is a state problem, not a
+    wrong-board problem."""
+    kb.create_board("default")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+
+    # Transition a task to 'done', then block it: 'done' isn't in the
+    # running/ready set block accepts → wrong-state failure, no board hint.
+    with kb.connect(board="default") as conn:
+        tid = kb.create_task(conn, title="finished", initial_status="running")
+        kb.complete_task(conn, tid)
+
+    out = kc.run_slash(f"block {tid} --kind needs_input")
+
+    assert "cannot block" in out
+    assert "is on board" not in out
+    assert "boards switch" not in out
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_cross_board_hint_returns_none_when_task_on_current_board(
+    kanban_home, monkeypatch
+):
+    kb.create_board("default")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+
+    with kb.connect(board="default") as conn:
+        tid = kb.create_task(conn, title="here", initial_status="running")
+        assert kc._cross_board_hint(conn, [tid]) is None
+
+
+def test_cross_board_hint_names_owning_board(kanban_home, monkeypatch):
+    kb.create_board("default")
+    kb.create_board("alpha")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+
+    tid = _task_on_board("alpha")
+    with kb.connect(board="default") as conn:
+        hint = kc._cross_board_hint(conn, [tid])
+
+    assert hint is not None
+    assert "board 'alpha'" in hint
+    assert "hermes kanban boards switch alpha" in hint
+
+
+def test_task_ids_parsed_from_unknown_task_message():
+    assert kc._task_ids_from_unknown_task_message("unknown task t_abc123") == [
+        "t_abc123"
+    ]
+    assert kc._task_ids_from_unknown_task_message("unknown task(s): t_abc, t_def") == [
+        "t_abc",
+        "t_def",
+    ]
+    # dedupes
+    msg = "unknown task(s): t_abc, t_abc, t_def"
+    assert kc._task_ids_from_unknown_task_message(msg) == ["t_abc", "t_def"]
+    # non-task tokens ignored
+    assert kc._task_ids_from_unknown_task_message("unknown task not-an-id") == []


### PR DESCRIPTION
## What does this PR do?

When a kanban verb (`block` / `archive` / `complete`) fails because the task id is **real but lives on a different board**, the operator gets an opaque error and no idea a `boards switch` would fix it. The id is known and the card is in a valid state — it is simply on the wrong board. Per #65101, this caused an operator to retry the same failing command 8 times.

Today the operator sees one of two equally-unhelpful messages depending on the verb path:

- `kanban: unknown task t_4dff09c7` — raised *before* the verb's state check (e.g. `block <id> <reason>` calls `add_comment` first, which throws on the missing id), surfaced through `kanban_command`'s shared `except (ValueError, RuntimeError)` branch.
- `cannot block t_4dff09c7` — printed when the verb's task op itself returns `False` (e.g. `block <id>` with no reason reaches `block_task` → `False`).

Neither names the current board, neither mentions that the task exists elsewhere, and neither suggests `hermes kanban boards switch <slug>`.

This PR attaches a one-line hint to both failure shapes:

```
cannot block t_4dff09c7 (unknown id or not in running/ready)
  → 't_4dff09c7' is on board 'default', not on the active board 'cqgambit'. Switch with: hermes kanban boards switch default
```

The hint is shown **only when the id is actually found on another board**. When the task is on the active board (a genuine wrong-state failure) or absent from all boards, no hint is shown — so we never chase the operator to a board where the task still isn't.

The cross-board scan reuses the existing `list_boards` + `connect(board=...)` pattern; a `get_task` check on the active connection gates the scan so the common wrong-state path stays cheap.

## Related Issue

Fixes #65101

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban.py`
  - New `_locate_task_on_other_board()` / `_cross_board_hint()`: scan other boards for a task id, return a switch hint (or `None`). Reuses `list_boards` + `connect(board=...)`.
  - New `_task_ids_from_unknown_task_message()`: recover `t_<hex>` ids from the `unknown task …` / `unknown task(s): …` error strings so the hint can fire in the shared exception branch.
  - `kanban_command` shared `except (ValueError, RuntimeError)`: when the message is `unknown task …`, parse the id(s) and attach the cross-board hint. This covers every verb that touches a task before its own state check (block-with-reason via `add_comment`, etc.).
  - `_cmd_block` / `_cmd_archive` / `_cmd_complete` `False` branches: attach the hint after the existing `cannot <verb> {id}` line. Also clarified the inline parenthetical for `block`/`archive` (previously bare) to match `complete`'s style.

## How to Test

`pytest tests/hermes_cli/test_kanban_cross_board_error.py -q` — 9 tests, all passing. Covers:

1. `block`/`archive`/`complete` of a task on another board → hint with owning board + switch command.
2. `block` with no reason reaching `block_task` → `False` → `cannot block` + hint.
3. Wrong-state failure (task on active board, e.g. blocking a `done` task) → **no** hint.
4. Genuinely unknown id (not on any board) → **no** switch hint.
5. Unit tests for `_cross_board_hint` and the message parser (singular, plural, dedup, non-id tokens ignored).

Manual repro (the exact scenario from the issue):

```
hermes kanban boards switch cqgambit          # active board is cqgambit
hermes kanban block t_4dff09c7 "test" --kind needs_input   # card is on `default`
# Before:  kanban: unknown task t_4dff09c7
# After:   kanban: unknown task t_4dff09c7
#          → 't_4dff09c7' is on board 'default', not on the active board 'cqgambit'. Switch with: hermes kanban boards switch default
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've run the new test file and all tests pass
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] N/A — no config keys, tool schemas, or architecture changes