### PR TITLE
feat(web): add runtime search provider fallbacks

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -378,6 +378,21 @@ class TestBackendSelection:
              patch("tools.web_tools._is_tool_gateway_ready", return_value=True):
             assert _get_backend() == "firecrawl"
 
+    def test_capability_fallback_backends_normalize_and_deduplicate_plugin_names(self):
+        """Fallback config accepts plugin names without a core allowlist."""
+        from tools.web_tools import _get_capability_fallback_backends
+
+        with patch(
+            "tools.web_tools._load_web_config",
+            return_value={
+                "search_fallback_backends": " DDGS, custom-search,ddgs, ,CUSTOM-search "
+            },
+        ):
+            assert _get_capability_fallback_backends("search") == [
+                "ddgs",
+                "custom-search",
+            ]
+
 
 class TestParallelClientConfig:
     """Test suite for Parallel client initialization."""
@@ -525,6 +540,88 @@ class TestWebSearchErrorHandling:
         assert "exception_type" not in result
         assert "exception_chain" not in result
         assert "traceback" not in result
+
+    def test_search_runtime_fallback_uses_configured_provider_after_primary_failure(self):
+        import tools.web_tools
+
+        primary_provider = MagicMock()
+        primary_provider.name = "tavily"
+        primary_provider.supports_search.return_value = True
+        primary_provider.search.return_value = {
+            "success": False,
+            "error": "quota exhausted",
+        }
+
+        fallback_provider = MagicMock()
+        fallback_provider.name = "ddgs"
+        fallback_provider.supports_search.return_value = True
+        fallback_provider.is_available.return_value = True
+        fallback_provider.search.return_value = {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": "Fallback result",
+                        "url": "https://example.com",
+                        "description": "ok",
+                    }
+                ]
+            },
+        }
+
+        providers = {"tavily": primary_provider, "ddgs": fallback_provider}
+        with patch("tools.web_tools._get_search_backend", return_value="tavily"), \
+             patch("tools.web_tools._get_capability_fallback_backends", return_value=["ddgs"]), \
+             patch("agent.web_search_registry.get_provider", side_effect=providers.get), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("test query", limit=3))
+
+        assert result["success"] is True
+        assert result["metadata"] == {
+            "fallback_from": "tavily",
+            "fallback_backend": "ddgs",
+        }
+        primary_provider.search.assert_called_once_with("test query", 3)
+        fallback_provider.search.assert_called_once_with("test query", 3)
+
+    def test_search_runtime_fallback_recovers_from_primary_exception(self):
+        import tools.web_tools
+
+        primary_provider = MagicMock()
+        primary_provider.name = "tavily"
+        primary_provider.supports_search.return_value = True
+        primary_provider.search.side_effect = RuntimeError("temporary outage")
+
+        fallback_provider = MagicMock()
+        fallback_provider.name = "ddgs"
+        fallback_provider.supports_search.return_value = True
+        fallback_provider.is_available.return_value = True
+        fallback_provider.search.return_value = {
+            "success": True,
+            "data": {"web": []},
+        }
+
+        providers = {"tavily": primary_provider, "ddgs": fallback_provider}
+        with patch("tools.web_tools._get_search_backend", return_value="tavily"), \
+             patch("tools.web_tools._get_capability_fallback_backends", return_value=["ddgs"]), \
+             patch("agent.web_search_registry.get_provider", side_effect=providers.get), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("test query", limit=3))
+
+        assert result == {
+            "success": True,
+            "data": {"web": []},
+            "metadata": {
+                "fallback_from": "tavily",
+                "fallback_backend": "ddgs",
+            },
+        }
+        primary_provider.search.assert_called_once_with("test query", 3)
+        fallback_provider.search.assert_called_once_with("test query", 3)
 
 
 class TestCheckWebApiKey:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -308,6 +308,39 @@ def _get_capability_backend(capability: str) -> str:
     return _get_backend()
 
 
+def _get_capability_fallback_backends(capability: str) -> list[str]:
+    """Return ordered runtime fallback providers for a web capability.
+
+    ``web.<capability>_fallback_backends`` takes precedence over the shared
+    ``web.fallback_backends`` setting. Both accept a YAML sequence or a
+    comma-separated string. Names are resolved by the provider registry at
+    dispatch time so plugin-contributed providers work without a core
+    allowlist.
+    """
+    cfg = _load_web_config()
+    raw = cfg.get(f"{capability}_fallback_backends")
+    if raw is None:
+        raw = cfg.get("fallback_backends")
+
+    if isinstance(raw, str):
+        candidates = raw.split(",")
+    elif isinstance(raw, (list, tuple)):
+        candidates = raw
+    else:
+        return []
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in candidates:
+        if not isinstance(item, str):
+            continue
+        name = item.strip().lower()
+        if name and name not in seen:
+            seen.add(name)
+            result.append(name)
+    return result
+
+
 def _is_backend_available(backend: str) -> bool:
     """Return True when the selected backend is currently usable.
 
@@ -716,11 +749,76 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                     ),
                 }
         else:
-            logger.info(
-                "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
-            )
-            response_data = provider.search(query, limit)
+            providers_to_try = [provider]
+            for fallback_name in _get_capability_fallback_backends("search"):
+                fallback_provider = _wsp_get_provider(fallback_name)
+                if fallback_provider is None or fallback_provider.name == provider.name:
+                    continue
+                try:
+                    if (
+                        fallback_provider.supports_search()
+                        and fallback_provider.is_available()
+                    ):
+                        providers_to_try.append(fallback_provider)
+                except Exception as exc:  # noqa: BLE001 — skip broken fallbacks
+                    logger.debug(
+                        "Web fallback provider %r is unavailable: %s",
+                        fallback_name,
+                        exc,
+                    )
+
+            primary_response = None
+            primary_exception = None
+            for index, candidate in enumerate(providers_to_try):
+                logger.info(
+                    "Web search via %s: '%s' (limit: %d)",
+                    candidate.name,
+                    query,
+                    limit,
+                )
+                try:
+                    candidate_response = candidate.search(query, limit)
+                except Exception as exc:  # noqa: BLE001 — provider boundary
+                    if index == 0:
+                        primary_exception = exc
+                    logger.warning(
+                        "Web search via %s raised: %s",
+                        candidate.name,
+                        str(exc)[:200],
+                    )
+                    continue
+
+                if index == 0:
+                    primary_response = candidate_response
+                if not candidate_response.get("success"):
+                    logger.warning(
+                        "Web search via %s returned failure: %s",
+                        candidate.name,
+                        str(candidate_response.get("error", "search failed"))[:200],
+                    )
+                    continue
+
+                response_data = dict(candidate_response)
+                if index > 0:
+                    metadata = dict(response_data.get("metadata") or {})
+                    metadata.update(
+                        {
+                            "fallback_from": provider.name,
+                            "fallback_backend": candidate.name,
+                        }
+                    )
+                    response_data["metadata"] = metadata
+                break
+            else:
+                if primary_response is not None:
+                    response_data = primary_response
+                elif primary_exception is not None:
+                    raise primary_exception
+                else:  # Defensive: providers_to_try always includes the primary.
+                    response_data = {
+                        "success": False,
+                        "error": "No web search provider attempted.",
+                    }
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -249,6 +249,21 @@ web:
 
 With this config, Hermes uses SearXNG for all search queries and Firecrawl for URL extraction — combining free search with high-quality extraction.
 
+#### Add runtime search fallbacks
+
+A configured provider can be available at startup and still fail later because of a quota, rate limit, or outage. Add ordered fallback providers for `web_search`:
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  search_backend: "tavily"
+  search_fallback_backends:
+    - "ddgs"
+    - "brave-free"
+```
+
+Hermes tries these providers only after the primary search returns a failure or raises an error. Successful fallback responses include `metadata.fallback_from` and `metadata.fallback_backend`. Providers must be installed, enabled, support search, and report themselves available. The setting also accepts a comma-separated string.
+
 ---
 
 ### Tavily


### PR DESCRIPTION
## Summary

- add ordered runtime fallback providers for `web_search`
- support both `web.search_fallback_backends` and shared `web.fallback_backends`
- resolve fallback names through the provider registry so plugin providers work without a core allowlist
- annotate successful fallback responses with `metadata.fallback_from` and `metadata.fallback_backend`
- document the configuration and accepted list/comma-separated formats

## Motivation

A provider can pass startup availability checks and still fail at request time because of quota exhaustion, rate limits, plan restrictions, or a temporary outage. Previously, that failure ended the search even when another configured provider was healthy.

The primary backend remains unchanged during normal operation. Fallbacks are attempted only after the primary raises or returns an unsuccessful response.

## Compatibility

- no behavior change when no fallback list is configured
- the original primary failure/exception remains the final result when no fallback succeeds
- unavailable, unsupported, duplicate, or unknown fallback providers are skipped
- provider response objects are copied before fallback metadata is added

## Test plan

```text
150 passed
```

Targeted suites:

- `tests/tools/test_web_tools_config.py`
- `tests/tools/test_web_providers.py`
- `tests/plugins/web/test_web_search_provider_plugins.py`
- `tests/hermes_cli/test_gpt56_registration.py`
- `tests/gateway/test_discord_sync_limit.py`

An independent pre-commit review found no security concerns or blocking logic errors.
