### PR TITLE
fix(dashboard): surface backend outages globally

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -72,6 +72,7 @@ import { ProfileProvider } from "@/contexts/ProfileProvider";
 import { useProfileScope } from "@/contexts/useProfileScope";
 import { ProfileSwitcher } from "@/components/ProfileSwitcher";
 import { ProfileScopeBanner } from "@/components/ProfileScopeBanner";
+import { DashboardOfflineBanner } from "@/components/DashboardOfflineBanner";
 import { useSystemActions } from "@/contexts/useSystemActions";
 import type { SystemAction } from "@/contexts/system-actions-context";
 // Route pages are lazy-loaded so the initial dashboard shell does not pay for
@@ -755,6 +756,7 @@ export default function App() {
                 isDocsRoute && "min-h-0 flex-1",
               )}
             >
+              <DashboardOfflineBanner />
               <PluginSlot name="pre-main" />
               <div
                 className={cn(

--- a/web/src/components/DashboardOfflineBanner.tsx
+++ b/web/src/components/DashboardOfflineBanner.tsx
@@ -1,0 +1,33 @@
+import { WifiOff } from "lucide-react";
+import { useSyncExternalStore } from "react";
+
+import { useI18n } from "@/i18n";
+import {
+  getDashboardReachability,
+  subscribeDashboardReachability,
+} from "@/lib/dashboard-reachability";
+
+export function DashboardOfflineBanner() {
+  const { t } = useI18n();
+  const reachability = useSyncExternalStore(
+    subscribeDashboardReachability,
+    getDashboardReachability,
+    getDashboardReachability,
+  );
+
+  if (reachability === "reachable") return null;
+
+  return (
+    <div
+      className="flex shrink-0 items-center gap-2 border-b border-warning/50 bg-warning/10 px-4 py-2 text-sm text-warning"
+      role="status"
+      aria-live="polite"
+    >
+      <WifiOff className="h-4 w-4 shrink-0" />
+      <span>
+        <strong>{t.app.dashboardOffline ?? "Dashboard backend is unreachable."}</strong>{" "}
+        {t.app.dashboardRetrying ?? "Retrying automatically…"}
+      </span>
+    </div>
+  );
+}

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -97,6 +97,8 @@ export const en: Translations = {
     currentProfileOption: "this dashboard ({name})",
     managingProfileBanner:
       "Managing profile \u201c{name}\u201d \u2014 config, keys, skills, MCPs, model, and new chats apply to that profile.",
+    dashboardOffline: "Dashboard backend is unreachable.",
+    dashboardRetrying: "Retrying automatically…",
   },
 
   status: {

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -115,6 +115,8 @@ export interface Translations {
     managingProfile?: string;
     currentProfileOption?: string;
     managingProfileBanner?: string;
+    dashboardOffline?: string;
+    dashboardRetrying?: string;
   };
 
   // ── Status page ──

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,7 +1,18 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { api, fetchJSON } from "./api";
+import {
+  DASHBOARD_UNREACHABLE_CODE,
+  api,
+  fetchJSON,
+  isDashboardUnreachableError,
+} from "./api";
+import {
+  getDashboardReachability,
+  markDashboardReachable,
+  markDashboardUnreachable,
+  subscribeDashboardReachability,
+} from "./dashboard-reachability";
 
 const reloadMocks = vi.hoisted(() => ({
   attemptDashboardTokenReloadOnce: vi.fn(() => false),
@@ -33,6 +44,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  markDashboardReachable();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -115,6 +127,72 @@ describe("api.getModelOptions", () => {
       "/api/model/options?profile=default&refresh=1&include_unconfigured=1",
       expect.objectContaining({ credentials: "include" }),
     );
+  });
+});
+
+describe("fetchJSON reachability", () => {
+  it("turns network failures into a structured dashboard error", async () => {
+    vi.stubGlobal("window", { location: { origin: "http://localhost:3000" } });
+    const cause = new TypeError("Failed to fetch");
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockRejectedValue(cause));
+    const listener = vi.fn(() => {
+      throw new Error("observer failed");
+    });
+    const unsubscribe = subscribeDashboardReachability(listener);
+
+    try {
+      const request = fetchJSON("/api/status");
+      await expect(request).rejects.toMatchObject({
+        baseUrl: "http://localhost:3000",
+        code: DASHBOARD_UNREACHABLE_CODE,
+        name: "DashboardUnreachableError",
+      });
+      await expect(request).rejects.toSatisfy(isDashboardUnreachableError);
+      await expect(request).rejects.toHaveProperty("cause", cause);
+      expect(getDashboardReachability()).toBe("unreachable");
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      await expect(fetchJSON("/api/status")).rejects.toSatisfy(
+        isDashboardUnreachableError,
+      );
+      expect(listener).toHaveBeenCalledTimes(1);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("clears the outage state when the backend returns any HTTP response", async () => {
+    vi.stubGlobal("window", {});
+    markDashboardUnreachable();
+    const fetchMock = vi.fn<typeof fetch>(
+      async () => new Response("temporarily unavailable", { status: 503 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const listener = vi.fn();
+    const unsubscribe = subscribeDashboardReachability(listener);
+
+    try {
+      const request = fetchJSON("/api/status");
+      await expect(request).rejects.toThrow("503: temporarily unavailable");
+      await expect(request).rejects.not.toSatisfy(isDashboardUnreachableError);
+      expect(getDashboardReachability()).toBe("reachable");
+      expect(listener).toHaveBeenCalledTimes(1);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("preserves aborted requests without changing reachability", async () => {
+    vi.stubGlobal("window", {});
+    const controller = new AbortController();
+    controller.abort();
+    const abortError = new DOMException("This operation was aborted", "AbortError");
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockRejectedValue(abortError));
+
+    await expect(
+      fetchJSON("/api/status", { signal: controller.signal }),
+    ).rejects.toBe(abortError);
+    expect(getDashboardReachability()).toBe("reachable");
   });
 });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,15 @@
 import { buildHermesWebSocketUrl } from "@hermes/shared";
+import {
+  DashboardUnreachableError,
+  markDashboardReachable,
+  markDashboardUnreachable,
+} from "@/lib/dashboard-reachability";
+
+export {
+  DASHBOARD_UNREACHABLE_CODE,
+  DashboardUnreachableError,
+  isDashboardUnreachableError,
+} from "@/lib/dashboard-reachability";
 
 // The dashboard can be served either at the root of its host (e.g.
 // https://kanban.tilos.com/) or under a URL prefix when reverse-proxied
@@ -111,15 +122,26 @@ export async function fetchJSON<T>(
   if (token) {
     setSessionHeader(headers, token);
   }
-  const res = await fetch(`${BASE}${url}`, {
-    ...init,
-    headers,
-    // ``credentials: 'include'`` so the cookie-auth path (gated mode) works
-    // for any fetch routed through here. Loopback mode is unaffected — the
-    // server doesn't read cookies and the legacy session-token header is
-    // already attached above.
-    credentials: init?.credentials ?? "include",
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${BASE}${url}`, {
+      ...init,
+      headers,
+      // ``credentials: 'include'`` so the cookie-auth path (gated mode) works
+      // for any fetch routed through here. Loopback mode is unaffected — the
+      // server doesn't read cookies and the legacy session-token header is
+      // already attached above.
+      credentials: init?.credentials ?? "include",
+    });
+  } catch (error) {
+    if (init?.signal?.aborted || isAbortError(error)) throw error;
+    markDashboardUnreachable();
+    throw new DashboardUnreachableError(getDashboardBaseUrl(), { cause: error });
+  }
+
+  // Any HTTP response proves the backend is reachable. Status/auth/body
+  // failures below retain their existing handling and are not outages.
+  markDashboardReachable();
   if (res.status === 401) {
     // Phase 6: the gated middleware emits a structured envelope so the
     // SPA can full-page-navigate to /login on session expiry. Parse it,
@@ -180,6 +202,19 @@ export async function fetchJSON<T>(
     throw new Error(`${res.status}: ${text}`);
   }
   return res.json();
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { name?: unknown }).name === "AbortError"
+  );
+}
+
+function getDashboardBaseUrl(): string {
+  const origin = typeof window === "undefined" ? "" : window.location?.origin;
+  return origin ? `${origin}${BASE}` : BASE || "/";
 }
 
 /** Encode a plugin registry key for URL paths (preserves `/` segment separators). */

--- a/web/src/lib/dashboard-reachability.ts
+++ b/web/src/lib/dashboard-reachability.ts
@@ -1,0 +1,63 @@
+export const DASHBOARD_UNREACHABLE_CODE = "DASHBOARD_UNREACHABLE" as const;
+
+export class DashboardUnreachableError extends Error {
+  readonly code = DASHBOARD_UNREACHABLE_CODE;
+  readonly baseUrl: string;
+
+  constructor(baseUrl: string, options?: { cause?: unknown }) {
+    const cause = options?.cause;
+    const detail = cause instanceof Error && cause.message ? `: ${cause.message}` : "";
+    super(`Dashboard backend is unreachable at ${baseUrl}${detail}`, options);
+    this.name = "DashboardUnreachableError";
+    this.baseUrl = baseUrl;
+  }
+}
+
+export function isDashboardUnreachableError(
+  error: unknown,
+): error is DashboardUnreachableError {
+  return (
+    error instanceof DashboardUnreachableError ||
+    (typeof error === "object" &&
+      error !== null &&
+      (error as { code?: unknown }).code === DASHBOARD_UNREACHABLE_CODE)
+  );
+}
+
+export type DashboardReachability = "reachable" | "unreachable";
+
+type ReachabilityListener = () => void;
+
+let reachability: DashboardReachability = "reachable";
+const listeners = new Set<ReachabilityListener>();
+
+export function getDashboardReachability(): DashboardReachability {
+  return reachability;
+}
+
+export function subscribeDashboardReachability(
+  listener: ReachabilityListener,
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function markDashboardReachable(): void {
+  setDashboardReachability("reachable");
+}
+
+export function markDashboardUnreachable(): void {
+  setDashboardReachability("unreachable");
+}
+
+function setDashboardReachability(next: DashboardReachability): void {
+  if (next === reachability) return;
+  reachability = next;
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch {
+      // Reachability observers must never alter the request that reported it.
+    }
+  }
+}

--- a/web/src/plugins/sdk.d.ts
+++ b/web/src/plugins/sdk.d.ts
@@ -45,7 +45,9 @@ import type { ComponentType } from "react";
  * JSON ``fetch`` for dashboard ``/api/...`` endpoints. Handles auth in both
  * modes (loopback session-token header / gated cookie), throws
  * ``Error("<status>: <body>")`` on non-2xx, and triggers the global
- * 401 → /login redirect in gated mode. Use for all JSON plugin endpoints.
+ * 401 → /login redirect in gated mode. Transport failures reject with an
+ * error whose ``code`` is ``DASHBOARD_UNREACHABLE``. Use for all JSON plugin
+ * endpoints.
  */
 export type FetchJSON = <T = unknown>(
   url: string,


### PR DESCRIPTION
Network failures in the dashboard's shared JSON transport now become structured errors and drive a non-destructive global offline banner that clears automatically when the backend responds.

## What does this PR do?

`fetchJSON` now distinguishes transport failures from HTTP errors, publishes app-wide reachability state, and gives every dashboard page a consistent offline signal without changing its local error handling or unmounting its UI.

## Related Issue

## Shared root cause

- `web/src/lib/api.ts` previously propagated the browser's opaque fetch rejection without a domain code or shared state transition. Callers then swallowed or generalized that rejection, so the app shell could not render one consistent outage state.
- React error boundaries cannot consume these asynchronous promise rejections, and a fallback that replaces descendants would also disrupt the persistent chat subtree. Publishing reachability at the existing `fetchJSON` chokepoint handles every JSON consumer while keeping routes, widgets, polling, and chat mounted.
- Any received HTTP response now marks the backend reachable before existing 401/non-2xx handling runs; only transport rejection marks it unreachable, and aborted requests remain unchanged.

## How this fixes each issue

- #53719: transport rejection now throws `DashboardUnreachableError` with the stable `DASHBOARD_UNREACHABLE` code, backend base URL, and original cause, while normal HTTP errors retain their existing status/body error.
- #53721: a small external reachability store drives one app-shell `DashboardOfflineBanner`; the existing 10-second sidebar status poll becomes the recovery probe, so the banner disappears after any backend response even when the initiating widget swallowed its error.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added the structured transport error and transition-only reachability store in `web/src/lib/dashboard-reachability.ts`.
- Wrapped the shared fetch await in `web/src/lib/api.ts`, preserving abort, auth, HTTP-status, and JSON behavior.
- Added a translated, accessible offline banner above the routed main content without changing desktop sidebar geometry or unmounting the persistent chat host.
- Documented the additive plugin-SDK error contract and added regression coverage for structured failures, duplicate transitions, observer isolation, HTTP recovery, and aborts.

## How to Test

1. Run `npm run --prefix web check` (passes: typecheck plus 75 tests across 11 files).
2. Run `npm run --prefix web build` (passes; only the existing bundle-size advisory is emitted).
3. Start the dashboard, open any data-backed page, stop the backend, and confirm the global offline banner appears. Restart the backend and confirm the existing status poll removes the banner after it receives a response.
4. Run `python scripts/check-windows-footguns.py --diff origin/main` (passes; no Python files changed).

The mandated broad `pytest tests/ -q -x --timeout=60` run reached tests and stopped on the unrelated existing `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback` assertion; this branch changes no Python or ACP files. Changed-file ESLint is green for every touched module except the pre-existing `react-hooks/set-state-in-effect` violation at `web/src/App.tsx:915`, which is unchanged from `origin/main`.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the unrelated existing ACP failure is documented above
- [x] I've added tests for my changes
- [x] I've tested on macOS on darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation — plugin SDK contract comment updated; broader docs N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No screenshot captured; the production dashboard build and state-transition tests pass as listed above.

---
_This coordinated PR bundles a fix that spans several issues. Happy to split it back into focused per-issue PRs if you'd prefer to review them separately._

Refs #53719
Refs #53721

<!-- autocontrib:worker-id=pr-spanning-823e1c78 kind=pr-open -->