### PR TITLE
feat(telegram): reset topic name on /new

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2918,6 +2918,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Topic renames are serialized so a slow placeholder from /new cannot
         # finish after (and overwrite) the generated or explicit title.
         self._telegram_topic_rename_locks: Dict[tuple[str, str], asyncio.Lock] = {}
+        self._telegram_topic_rename_lock_users: Dict[tuple[str, str], int] = {}
         self._shutdown_event = asyncio.Event()
         self._exit_cleanly = False
         self._exit_with_failure = False
@@ -13959,10 +13960,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if rename_lock is None:
             rename_lock = asyncio.Lock()
             self._telegram_topic_rename_locks[topic_key] = rename_lock
-        async with rename_lock:
-            await self._rename_telegram_topic_for_session_title_locked(
-                source, session_id, title
-            )
+        self._telegram_topic_rename_lock_users[topic_key] = (
+            self._telegram_topic_rename_lock_users.get(topic_key, 0) + 1
+        )
+        try:
+            async with rename_lock:
+                await self._rename_telegram_topic_for_session_title_locked(
+                    source, session_id, title
+                )
+        finally:
+            remaining_users = self._telegram_topic_rename_lock_users[topic_key] - 1
+            if remaining_users:
+                self._telegram_topic_rename_lock_users[topic_key] = remaining_users
+            else:
+                self._telegram_topic_rename_lock_users.pop(topic_key, None)
+                if self._telegram_topic_rename_locks.get(topic_key) is rename_lock:
+                    self._telegram_topic_rename_locks.pop(topic_key, None)
 
     async def _rename_telegram_topic_for_session_title_locked(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2915,6 +2915,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self.delivery_router = DeliveryRouter(self.config)
         self._running = False
         self._gateway_loop: Optional[asyncio.AbstractEventLoop] = None
+        # Topic renames are serialized so a slow placeholder from /new cannot
+        # finish after (and overwrite) the generated or explicit title.
+        self._telegram_topic_rename_locks: Dict[tuple[str, str], asyncio.Lock] = {}
         self._shutdown_event = asyncio.Event()
         self._exit_cleanly = False
         self._exit_with_failure = False
@@ -13949,6 +13952,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> None:
         """Best-effort rename of a Telegram DM topic when Hermes auto-titles a session."""
         if not await asyncio.to_thread(self._is_telegram_topic_lane, source) or not source.chat_id or not source.thread_id:
+            return
+
+        topic_key = (str(source.chat_id), str(source.thread_id))
+        rename_lock = self._telegram_topic_rename_locks.get(topic_key)
+        if rename_lock is None:
+            rename_lock = asyncio.Lock()
+            self._telegram_topic_rename_locks[topic_key] = rename_lock
+        async with rename_lock:
+            await self._rename_telegram_topic_for_session_title_locked(
+                source, session_id, title
+            )
+
+    async def _rename_telegram_topic_for_session_title_locked(
+        self,
+        source: SessionSource,
+        session_id: str,
+        title: str,
+    ) -> None:
+        """Apply one topic rename while holding that topic's ordering lock."""
+        if not source.chat_id or not source.thread_id:
             return
 
         # Operator can fully disable per-topic auto-rename via

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -310,10 +310,10 @@ class GatewaySlashCommandsMixin:
             except Exception:
                 logger.debug("Failed to rebind Telegram topic after /new", exc_info=True)
 
-            # Reused topics otherwise keep advertising the old conversation
-            # until auto-title completes after the first exchange. Rename now
-            # to a neutral placeholder (or the explicit /new <title>) and let
-            # the normal auto-title callback replace it later.
+            # Reused topics otherwise keep advertising the old conversation.
+            # Rename now to a neutral placeholder for bare /new, or to the
+            # persisted explicit /new <title>. Only the untitled placeholder
+            # is later replaced by the normal auto-title callback.
             schedule_rename = getattr(
                 self, "_schedule_telegram_topic_title_rename", None
             )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -269,6 +269,12 @@ class GatewaySlashCommandsMixin:
             new_entry = await self.async_session_store.get_or_create_session(source, force_new=True)
             header = await asyncio.to_thread(self._telegram_topic_new_header, source) or t("gateway.reset.header_new")
 
+        # Keep the visible Telegram topic honest while the replacement session
+        # is still untitled. This is deliberately not persisted as the session
+        # title: the first real exchange should still run the auto-title
+        # pipeline and replace the placeholder with a descriptive name.
+        _telegram_topic_title = "New Session"
+
         # Set session title if provided with /new <title>
         _title_arg = event.get_command_args().strip()
         _title_note = ""
@@ -283,6 +289,7 @@ class GatewaySlashCommandsMixin:
                 try:
                     await self._session_db.set_session_title(new_entry.session_id, sanitized)
                     header = t("gateway.reset.header_titled", title=sanitized)
+                    _telegram_topic_title = sanitized
                 except ValueError as e:
                     _title_note = t("gateway.reset.title_error_untitled", error=str(e))
                 except Exception:
@@ -302,6 +309,27 @@ class GatewaySlashCommandsMixin:
                 await asyncio.to_thread(self._record_telegram_topic_binding, source, new_entry)
             except Exception:
                 logger.debug("Failed to rebind Telegram topic after /new", exc_info=True)
+
+            # Reused topics otherwise keep advertising the old conversation
+            # until auto-title completes after the first exchange. Rename now
+            # to a neutral placeholder (or the explicit /new <title>) and let
+            # the normal auto-title callback replace it later.
+            schedule_rename = getattr(
+                self, "_schedule_telegram_topic_title_rename", None
+            )
+            if callable(schedule_rename):
+                try:
+                    await asyncio.to_thread(
+                        schedule_rename,
+                        source,
+                        new_entry.session_id,
+                        _telegram_topic_title,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Failed to rename Telegram topic after /new",
+                        exc_info=True,
+                    )
 
         # Fire plugin on_session_reset hook (new session guaranteed to exist)
         try:

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -360,6 +360,7 @@ async def test_new_inside_telegram_topic_resets_current_topic_with_parallel_tip(
 
     runner = _make_runner()
     runner._telegram_topic_mode_enabled = lambda source: True
+    runner._schedule_telegram_topic_title_rename = MagicMock()
     topic_source = _make_source(thread_id="17585")
     topic_key = build_session_key(topic_source)
     old_entry = SessionEntry(
@@ -394,6 +395,13 @@ async def test_new_inside_telegram_topic_resets_current_topic_with_parallel_tip(
     assert "parallel work" in result
     assert "All Messages" in result
     runner.session_store.reset_session.assert_called_once_with(topic_key)
+    runner._schedule_telegram_topic_title_rename.assert_called_once()
+    scheduled_source, session_id, title = (
+        runner._schedule_telegram_topic_title_rename.call_args.args
+    )
+    assert scheduled_source.thread_id == "17585"
+    assert session_id == "new-topic-session"
+    assert title == "New Session"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -124,6 +124,7 @@ def _make_runner(session_db=None):
     runner._session_model_overrides = {}
     runner._pending_model_notes = {}
     runner._telegram_topic_rename_locks = {}
+    runner._telegram_topic_rename_lock_users = {}
     # Gateway holds the async facade; the slash handlers await it.
     if session_db is not None:
         from hermes_state import AsyncSessionDB
@@ -975,6 +976,7 @@ async def test_topic_renames_are_serialized_so_newest_title_wins(tmp_path):
     await asyncio.gather(placeholder, generated)
 
     assert applied_titles == ["New Session", "Generated Topic Title"]
+    assert topic_key not in runner._telegram_topic_rename_locks
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -123,6 +123,7 @@ def _make_runner(session_db=None):
     runner._busy_ack_ts = {}
     runner._session_model_overrides = {}
     runner._pending_model_notes = {}
+    runner._telegram_topic_rename_locks = {}
     # Gateway holds the async facade; the slash handlers await it.
     if session_db is not None:
         from hermes_state import AsyncSessionDB
@@ -919,6 +920,61 @@ async def test_auto_generated_title_renames_bound_telegram_topic(tmp_path):
         thread_id="42",
         name="Build Telegram Topic UX",
     )
+
+
+@pytest.mark.asyncio
+async def test_topic_renames_are_serialized_so_newest_title_wins(tmp_path):
+    """A delayed placeholder rename must not overwrite the generated title."""
+    import asyncio
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    applied_titles = []
+
+    async def _slow_rename(*, chat_id, thread_id, name):
+        if name == "New Session":
+            first_started.set()
+            await release_first.wait()
+        applied_titles.append(name)
+
+    setattr(
+        runner.adapters[Platform.TELEGRAM],
+        "rename_dm_topic",
+        AsyncMock(side_effect=_slow_rename),
+    )
+    source = _make_source(thread_id="42")
+
+    placeholder = asyncio.create_task(
+        runner._rename_telegram_topic_for_session_title(
+            source, "sess-topic", "New Session"
+        )
+    )
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+    topic_key = (str(source.chat_id), str(source.thread_id))
+    assert runner._telegram_topic_rename_locks[topic_key].locked()
+
+    generated = asyncio.create_task(
+        runner._rename_telegram_topic_for_session_title(
+            source, "sess-topic", "Generated Topic Title"
+        )
+    )
+    release_first.set()
+    await asyncio.gather(placeholder, generated)
+
+    assert applied_titles == ["New Session", "Generated Topic Title"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -15,13 +15,14 @@ from gateway.session import SessionSource
 
 
 def _make_event(text="/title", platform=Platform.TELEGRAM,
-                user_id="12345", chat_id="67890"):
+                user_id="12345", chat_id="67890", thread_id=None):
     """Build a MessageEvent for testing."""
     source = SessionSource(
         platform=platform,
         user_id=user_id,
         chat_id=chat_id,
         user_name="testuser",
+        thread_id=thread_id,
     )
     return MessageEvent(text=text, source=source)
 
@@ -282,6 +283,7 @@ class TestResetCommandWithTitle:
             user_id="12345",
             chat_id="67890",
             user_name="testuser",
+            thread_id="17585",
         )
         session_key = build_session_key(source)
         new_session_entry = SessionEntry(
@@ -305,13 +307,20 @@ class TestResetCommandWithTitle:
         runner._agent_cache_lock = None
         runner._is_user_authorized = lambda _source: True
         runner._format_session_info = lambda: ""
+        runner._telegram_topic_mode_enabled = lambda source: True
+        runner._record_telegram_topic_binding = MagicMock()
+        runner._schedule_telegram_topic_title_rename = MagicMock()
 
-        event = _make_event(text="/new Custom Name")
+        event = _make_event(text="/new Custom Name", thread_id="17585")
         result = await runner._handle_reset_command(event)
 
         runner.session_store.reset_session.assert_called_once()
         runner._session_db.set_session_title.assert_called_once_with(
             "sess-new", "Custom Name"
+        )
+        assert runner._schedule_telegram_topic_title_rename.call_args.args[1:] == (
+            "sess-new",
+            "Custom Name",
         )
         # Header reflects the applied title
         assert "Custom Name" in str(result)

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -801,7 +801,9 @@ When this flag is on, Hermes still generates an internal session title (used by 
 
 ### `/new` inside a topic
 
-Resets the current topic's session (new session ID, fresh history) without touching other topics. Hermes replies with a reminder that for parallel work, creating another topic (via **All Messages**) is usually what you want.
+Resets the current topic's session (new session ID, fresh history) without touching other topics. The visible Telegram topic is renamed to **New Session** immediately so it no longer advertises the previous conversation; after the first new exchange, the normal auto-title pipeline replaces that placeholder with a descriptive title. If you use `/new <title>`, Hermes applies that explicit title instead. Topic renames remain best-effort and honor `extra.disable_topic_auto_rename`.
+
+Hermes also replies with a reminder that for parallel work, creating another topic (via **All Messages**) is usually what you want.
 
 ### Restoring a previous session
 


### PR DESCRIPTION
## What does this PR do?

Makes Telegram forum-topic resets visible immediately. After bare `/new` (or `/reset`), Hermes renames the reused topic to **New Session** without persisting that placeholder as the session title, so the normal first-exchange auto-title can replace it. `/new <title>` uses the explicit title immediately instead.

The change reuses the existing centralized Telegram topic-rename scheduler, so `disable_topic_auto_rename`, operator-declared topics, binding checks, and non-Telegram/non-topic isolation keep their existing behavior.

## Related Issue

No linked issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: serialize renames per Telegram topic so a delayed placeholder or stale rename cannot overwrite a newer generated/explicit title.
- `gateway/slash_commands.py`: schedule a best-effort topic rename after rebinding the replacement session.
- `tests/gateway/test_telegram_topic_mode.py`: verify bare `/new` schedules the `New Session` placeholder and that concurrent title updates remain ordered.
- `tests/gateway/test_title_command.py`: verify `/new <title>` uses the explicit title.
- `website/docs/user-guide/messaging/telegram.md`: document reset-time naming and later auto-title replacement.

## How to Test

1. In a Telegram forum topic, send `/new`; confirm the topic immediately becomes `New Session`.
2. Send a normal message; confirm the generated session title replaces the placeholder.
3. Send `/new Custom Name`; confirm the topic immediately becomes `Custom Name`.

Automated verification:

- `scripts/run_tests.sh tests/gateway/test_telegram_topic_mode.py tests/gateway/test_title_command.py tests/gateway/test_35994_reset_button_deadlock.py -v --tb=short` — **65 passed**
- `uvx ruff@0.15.10 check gateway/run.py gateway/slash_commands.py tests/gateway/test_telegram_topic_mode.py tests/gateway/test_title_command.py` — **passed**
- `git diff --check` — **passed**
- A broader `scripts/run_tests.sh tests/gateway/ --tb=short` run was attempted. Feature-related tests passed, but the unrelated suite hit existing macOS `/tmp` vs `/private/tmp` assertions and then the runner's file-descriptor limit at 20 workers (`OSError: [Errno 24] Too many open files`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` update: N/A — no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A — no architecture or workflow change
- [x] I've considered cross-platform impact: the behavior is isolated to Telegram topic lanes
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

Not applicable; behavior is covered by gateway tests.
