### PR TITLE
feat: add MCP server scope filtering (parent vs delegation)

### DIFF
--- a/tests/fixtures/mcp_echo_server.py
+++ b/tests/fixtures/mcp_echo_server.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Minimal MCP server that exposes a single 'echo' tool.
+
+Used by integration tests to verify MCP server connection and scoping
+without depending on external packages (npx/uvx).
+
+Spawn via stdio: python3 mcp_echo_server.py
+"""
+import asyncio
+import json
+import sys
+
+from mcp.server import Server, NotificationOptions
+from mcp.server.models import InitializationOptions, ServerCapabilities
+from mcp.server.stdio import stdio_server
+from mcp.types import Tool, TextContent, ToolsCapability
+
+
+def _make_echo_tool() -> Tool:
+    return Tool(
+        name="echo",
+        description="Echo back the provided message",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "The message to echo back",
+                },
+            },
+            "required": ["message"],
+        },
+    )
+
+
+async def _serve() -> None:
+    server = Server("mcp-echo-test")
+
+    @server.list_tools()
+    async def list_tools() -> list[Tool]:
+        return [_make_echo_tool()]
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+        if name == "echo":
+            msg = arguments.get("message", "")
+            return [TextContent(type="text", text=f"ECHO: {msg}")]
+        raise ValueError(f"Unknown tool: {name}")
+
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            InitializationOptions(
+                server_name="mcp-echo-test",
+                server_version="1.0.0",
+                capabilities=ServerCapabilities(
+                    tools=ToolsCapability(listChanged=True),
+                ),
+            ),
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(_serve())

--- a/tests/tools/test_mcp_scope_integration.py
+++ b/tests/tools/test_mcp_scope_integration.py
@@ -1,0 +1,122 @@
+"""Integration tests for MCP scope filtering (delegation-only servers).
+
+These tests spawn the echo test MCP server as a real stdio subprocess and
+verify that:
+1. ``discover_mcp_tools()`` (parent path) skips ``scope: delegation`` servers
+2. ``_load_mcp_config(scope_filter=\"delegation\")`` returns only those servers
+3. Sub-agents connect delegation-scoped servers via ``register_mcp_servers()``
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def echo_server_path():
+    """Absolute path to the test echo MCP server."""
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(
+        os.path.dirname(this_dir), "fixtures", "mcp_echo_server.py"
+    )
+
+
+@pytest.fixture()
+def scoped_config(echo_server_path):
+    """Return a config dict with one shared and one delegation-scoped server."""
+    return {
+        "mcp_servers": {
+            "shared_echo": {
+                "command": sys.executable,
+                "args": [echo_server_path],
+            },
+            "sub_echo": {
+                "command": sys.executable,
+                "args": [echo_server_path],
+                "scope": "delegation",
+            },
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1: discover_mcp_tools skips delegation-scoped servers
+# ---------------------------------------------------------------------------
+
+def test_discover_mcp_tools_skips_delegation_scope(scoped_config):
+    """Parent agent discover_mcp_tools should not connect scope:delegation."""
+    from tools.mcp_tool import discover_mcp_tools, _MCP_AVAILABLE
+
+    if not _MCP_AVAILABLE:
+        pytest.skip("MCP SDK not available")
+
+    # We can't fully mock discover_mcp_tools because it uses the real
+    # event loop orchestration. Instead, verify that _load_mcp_config
+    # correctly filters, which is what discover_mcp_tools feeds into
+    # register_mcp_servers.
+    with patch("hermes_cli.config.load_config", return_value=scoped_config):
+        from tools.mcp_tool import _load_mcp_config
+
+        # Parent view: no delegation-scoped servers
+        parent_servers = _load_mcp_config(scope_filter="parent")
+        assert "shared_echo" in parent_servers
+        assert "sub_echo" not in parent_servers
+        assert len(parent_servers) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 2: delegation scope returns only scoped servers
+# ---------------------------------------------------------------------------
+
+def test_delegation_config_returns_only_scoped(scoped_config):
+    """_load_mcp_config(scope_filter='delegation') returns only scoped."""
+    from tools.mcp_tool import _MCP_AVAILABLE
+
+    if not _MCP_AVAILABLE:
+        pytest.skip("MCP SDK not available")
+
+    with patch("hermes_cli.config.load_config", return_value=scoped_config):
+        from tools.mcp_tool import _load_mcp_config
+
+        deleg_servers = _load_mcp_config(scope_filter="delegation")
+        assert "sub_echo" in deleg_servers
+        assert "shared_echo" not in deleg_servers
+        assert len(deleg_servers) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 3: registering delegation-scoped server via register_mcp_servers
+# ---------------------------------------------------------------------------
+
+def test_register_delegation_scoped_server(scoped_config, echo_server_path):
+    """register_mcp_servers can connect delegation-scoped servers."""
+    from tools.mcp_tool import register_mcp_servers, _MCP_AVAILABLE
+
+    if not _MCP_AVAILABLE:
+        pytest.skip("MCP SDK not available")
+
+    # Load only delegation-scoped servers
+    with patch("hermes_cli.config.load_config", return_value=scoped_config):
+        from tools.mcp_tool import _load_mcp_config
+
+        deleg_servers = _load_mcp_config(scope_filter="delegation")
+
+    assert "sub_echo" in deleg_servers
+
+    # Connect the server
+    tool_names = register_mcp_servers(deleg_servers)
+
+    # Should have registered the echo tool from the test server.
+    # MCP tool naming: mcp__<server>__<tool> (double-underscore separator).
+    assert "mcp__sub_echo__echo" in tool_names, (
+        f"Expected mcp__sub_echo__echo in registered tools, got: {tool_names}"
+    )
+
+    # Verify the tool is callable via the MCP handler
+    from tools.mcp_tool import _servers
+
+    server = _servers.get("sub_echo")
+    assert server is not None, "Server 'sub_echo' not found in _servers"
+    assert server.session is not None, "Server 'sub_echo' has no active session"

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -122,6 +122,87 @@ class TestLoadMCPConfig:
             assert result == {}
 
 
+class TestLoadMCPConfigScope:
+    """Tests for scope-based MCP server filtering (parent vs delegation)."""
+
+    @staticmethod
+    def _servers():
+        return {
+            "shared": {
+                "command": "echo",
+                "args": ["shared"],
+            },
+            "sub_only": {
+                "command": "echo",
+                "args": ["sub"],
+                "scope": "delegation",
+            },
+            "parent_only": {
+                "command": "echo",
+                "args": ["parent"],
+                "scope": "parent",
+            },
+            "explicit_all": {
+                "command": "echo",
+                "args": ["all"],
+                "scope": "all",
+            },
+        }
+
+    def test_scope_default_all_included_in_parent(self):
+        """Servers without 'scope' field default to 'all' — included for parent."""
+        with patch("hermes_cli.config.load_config",
+                   return_value={"mcp_servers": self._servers()}):
+            from tools.mcp_tool import _load_mcp_config
+            result = _load_mcp_config(scope_filter="parent")
+            assert "shared" in result
+            assert "explicit_all" in result
+            assert "parent_only" in result
+            assert "sub_only" not in result
+
+    def test_scope_delegation_only_for_subagents(self):
+        """scope_filter='delegation' returns only delegation-scoped servers."""
+        with patch("hermes_cli.config.load_config",
+                   return_value={"mcp_servers": self._servers()}):
+            from tools.mcp_tool import _load_mcp_config
+            result = _load_mcp_config(scope_filter="delegation")
+            assert "sub_only" in result
+            assert "shared" not in result
+            assert "parent_only" not in result
+            assert "explicit_all" not in result
+
+    def test_scope_none_returns_all(self):
+        """scope_filter=None (default, backward compat) returns all servers."""
+        with patch("hermes_cli.config.load_config",
+                   return_value={"mcp_servers": self._servers()}):
+            from tools.mcp_tool import _load_mcp_config
+            result = _load_mcp_config(scope_filter=None)
+            assert len(result) == 4
+            assert "shared" in result
+            assert "sub_only" in result
+            assert "parent_only" in result
+
+    def test_scope_invalid_value_treated_as_all(self):
+        """Unknown scope values default to 'all' behavior."""
+        servers = {
+            "weird_scope": {"command": "echo", "scope": "nonsense"},
+        }
+        with patch("hermes_cli.config.load_config",
+                   return_value={"mcp_servers": servers}):
+            from tools.mcp_tool import _load_mcp_config
+            result_parent = _load_mcp_config(scope_filter="parent")
+            result_deleg = _load_mcp_config(scope_filter="delegation")
+            assert "weird_scope" in result_parent   # treated as "all"
+            assert "weird_scope" not in result_deleg  # not "delegation"
+
+    def test_scope_empty_config_returns_empty(self):
+        """Empty config returns empty regardless of scope_filter."""
+        with patch("hermes_cli.config.load_config", return_value={}):
+            from tools.mcp_tool import _load_mcp_config
+            assert _load_mcp_config(scope_filter="parent") == {}
+            assert _load_mcp_config(scope_filter="delegation") == {}
+
+
 class TestMCPStatus:
     def test_status_distinguishes_configured_connecting_failed_and_disabled(
         self, monkeypatch

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1321,20 +1321,52 @@ def _build_child_agent(
     # These were intentionally skipped by the parent agent's startup; we
     # connect them now so the sub-agent can use them as first-class tools.
     try:
-        from tools.mcp_tool import _load_mcp_config, register_mcp_servers
+        from tools.mcp_tool import (
+            _load_mcp_config,
+            register_mcp_servers,
+            _servers as _mcp_servers,
+            _lock as _mcp_lock,
+        )
 
         delegation_servers = _load_mcp_config(scope_filter="delegation")
         if delegation_servers:
-            connected = register_mcp_servers(delegation_servers)
-            if connected:
-                # Add mcp-<server> toolsets for the child so its tool
-                # resolution includes these newly-connected servers.
+            register_mcp_servers(delegation_servers)
+            # Only add mcp-<server> toolsets for servers that actually
+            # connected.  register_mcp_servers returns ALL tool names from
+            # ALL servers — testing its return value for truthiness is a
+            # false positive when OTHER servers are connected.  Check each
+            # delegation server's presence in the global _servers dict
+            # instead.
+            with _mcp_lock:
                 for srv_name in delegation_servers:
                     ts_name = f"mcp-{srv_name}"
-                    if ts_name not in child_toolsets:
-                        child_toolsets.append(ts_name)
+                    if srv_name in _mcp_servers:
+                        if ts_name not in child_toolsets:
+                            child_toolsets.append(ts_name)
+                    else:
+                        logger.warning(
+                            "Sub-agent MCP delegation: server '%s' failed "
+                            "to connect — tools will not be available",
+                            srv_name,
+                        )
+            # Verify at least one delegation server connected.  If none
+            # did, it may indicate a transport issue (HTTP server not
+            # running, auth failure, timeout) that should be surfaced
+            # rather than silently degrading.
+            connected_count = sum(
+                1 for srv_name in delegation_servers
+                if srv_name in _mcp_servers
+            )
+            if connected_count == 0:
+                logger.warning(
+                    "Sub-agent MCP delegation: %d server(s) configured "
+                    "but NONE connected — is the MCP server running?",
+                    len(delegation_servers),
+                )
     except Exception:
-        logger.debug("Sub-agent MCP delegation connect failed", exc_info=True)
+        logger.warning(
+            "Sub-agent MCP delegation connect failed", exc_info=True
+        )
 
     child = AIAgent(
         base_url=effective_base_url,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1317,6 +1317,25 @@ def _build_child_agent(
     if isinstance(child_max_tokens, int):
         child_optional_kwargs["max_tokens"] = child_max_tokens
 
+    # Connect MCP servers scoped to delegation only (scope: delegation).
+    # These were intentionally skipped by the parent agent's startup; we
+    # connect them now so the sub-agent can use them as first-class tools.
+    try:
+        from tools.mcp_tool import _load_mcp_config, register_mcp_servers
+
+        delegation_servers = _load_mcp_config(scope_filter="delegation")
+        if delegation_servers:
+            connected = register_mcp_servers(delegation_servers)
+            if connected:
+                # Add mcp-<server> toolsets for the child so its tool
+                # resolution includes these newly-connected servers.
+                for srv_name in delegation_servers:
+                    ts_name = f"mcp-{srv_name}"
+                    if ts_name not in child_toolsets:
+                        child_toolsets.append(ts_name)
+    except Exception:
+        logger.debug("Sub-agent MCP delegation connect failed", exc_info=True)
+
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3906,7 +3906,33 @@ def _filter_suspicious_mcp_servers(servers: Dict[str, dict]) -> Dict[str, dict]:
     return safe_servers
 
 
-def _load_mcp_config() -> Dict[str, dict]:
+VALID_MCP_SCOPES = frozenset({"all", "parent", "delegation"})
+
+
+def _scope_matches(cfg: dict, scope_filter: str | None) -> bool:
+    """Check whether a server config matches the given scope filter.
+
+    ``scope_filter=None`` (default, backward compat): include all servers.
+    ``scope_filter=\"parent\"``: include servers whose scope is ``all``
+    (default), ``parent``, or unset.
+    ``scope_filter=\"delegation\"``: include only servers with
+    ``scope: delegation``.
+    Unknown scope values are treated as ``all`` for forward compat.
+    """
+    if scope_filter is None:
+        return True
+    server_scope = cfg.get("scope", "all")
+    # Treat unknown scope values as "all" (forward compat; new scope values
+    # added in future Hermes versions won't break older installs).
+    if server_scope not in VALID_MCP_SCOPES:
+        server_scope = "all"
+    if scope_filter == "delegation":
+        return server_scope == "delegation"
+    # scope_filter="parent": include "all" (including unset/unknown) and "parent"
+    return server_scope != "delegation"
+
+
+def _load_mcp_config(scope_filter: str | None = None) -> Dict[str, dict]:
     """Read ``mcp_servers`` from the Hermes config file.
 
     Returns a dict of ``{server_name: server_config}`` or empty dict.
@@ -3916,6 +3942,12 @@ def _load_mcp_config() -> Dict[str, dict]:
 
     ``${ENV_VAR}`` placeholders in string values are resolved from
     ``os.environ`` (which includes ``~/.hermes/.env`` loaded at startup).
+
+    Args:
+        scope_filter: If ``None`` (default), returns all configured servers
+            (backward-compatible).  ``\"parent\"`` excludes servers with
+            ``scope: delegation``.  ``\"delegation\"`` returns only servers
+            with ``scope: delegation``.
     """
     try:
         from hermes_cli.config import load_config
@@ -3935,6 +3967,8 @@ def _load_mcp_config() -> Dict[str, dict]:
             pass
         safe_servers: Dict[str, dict] = {}
         for name, cfg in _filter_suspicious_mcp_servers(servers).items():
+            if not _scope_matches(cfg, scope_filter):
+                continue
             interpolated = _interpolate_env_vars(cfg)
             if isinstance(interpolated, dict):
                 safe_servers[name] = interpolated
@@ -5215,7 +5249,7 @@ def discover_mcp_tools() -> List[str]:
         logger.debug("MCP SDK not available -- skipping MCP tool discovery")
         return []
 
-    servers = _load_mcp_config()
+    servers = _load_mcp_config(scope_filter="parent")
     if not servers:
         logger.debug("No MCP servers configured")
         return []


### PR DESCRIPTION
## What

Adds MCP server scope filtering so that task-specific MCP servers don't need to be connected by the parent agent at startup. The motivation is to minimize context bloat in the parent agent's tool schema and allow sub-agents to have separate MCP tool sets based on their focus or task set — the parent doesn't need to carry 100+ tools for every possible sub-agent task.

Adds a `scope` field to `mcp_servers` config entries with three values:

| scope | Parent startup | Sub-agent spawn |
|-------|---------------|-----------------|
| `all` (default) | Connects | Inherits from parent |
| `parent` | Connects | Not available to sub-agents |
| `delegation` | Skipped entirely | Connected during `_build_child_agent()` |

## Why

Currently all MCP servers connect at parent startup regardless of whether the parent needs them. For servers that are only relevant to specific sub-agent tasks, this means:

1. The parent logs warnings every time these servers are unreachable
2. 100+ task-specific tools clutter the parent's tool schema on every API call
3. The parent has no way to distinguish "this server is irrelevant to me" from "this server is genuinely broken"

This has been the #1 friction point when using Hermes with multiple MCP servers for different sub-agent tasks.

## How

**`tools/mcp_tool.py`:**
- `_scope_matches()` — new helper, checks server scope against caller's filter
- `_load_mcp_config(scope_filter)` — accepts `None` (backward compat), `"parent"`, or `"delegation"`; filters servers accordingly
- `discover_mcp_tools()` — passes `scope_filter="parent"` to skip delegation-only servers

**`tools/delegate_tool.py`:**
- `_build_child_agent()` — calls `_load_mcp_config(scope_filter="delegation")`, connects those servers via `register_mcp_servers()`, and verifies they actually connected by checking `_servers` before adding toolset names to the child's enabled toolsets

## Backward compatibility

- Configs without `scope` field → defaults to `"all"` → no behavioral change
- Configs without `mcp_servers` at all → returns `{}` → no-op
- Unknown scope values → treated as `"all"` for forward compat
- `scope_filter=None` (legacy path) → returns all servers unchanged

## What was learned during E2E testing

During testing with a real HTTP SSE MCP server (comfyui-mcp, 113 tools), we discovered a false-positive toolset injection bug in the initial implementation:

`register_mcp_servers()` returns ALL tool names from ALL servers. The initial code tested this return value for truthiness to decide whether to add delegation toolset names. Since other MCP servers always have tools, this was always truthy — even when the delegation server failed to connect. The child would see `mcp-comfyui` in its enabled toolsets with zero registered tools.

Fixed by checking each delegation server's presence in the global `_servers` dict directly, and promoting the exception handler from `logger.debug` to `logger.warning`.

## Test plan

**Automated:**
- 5 unit tests for `_scope_matches` / `_load_mcp_config` filtering
- 3 integration tests with real stdio MCP echo server

**Manual E2E:**
- [artokun/comfyui-mcp](https://github.com/artokun/comfyui-mcp) (HTTP SSE, 113 tools) configured with `scope: delegation`
- Sub-agent spawned, confirmed all 113 `mcp__comfyui__*` tools available
- Called `get_system_stats` successfully, returned real GPU/VRAM data
- Repeated with server DOWN — confirmed tools absent and warning logged

## Platforms tested

- WSL2 (Linux) — HTTP SSE MCP transport + stdio MCP transport
- Windows host — ComfyUI + MCP bridge running natively

## Caveats

*Disclaimer: I'm not a professional coder. This fix was generated by Muninn (Hermes Agent) via root cause analysis of MCP connection lifecycle and verified through automated tests + manual E2E with real MCP servers running across WSL and Windows.*
