### PR TITLE
fix(verification): recognize virtualenv interpreter paths

### DIFF
--- a/agent/verification_evidence.py
+++ b/agent/verification_evidence.py
@@ -27,6 +27,7 @@ _MAX_EVIDENCE_AGE_DAYS = 30
 _MAX_EVENTS_PER_SESSION_ROOT = 100
 _MAX_TOTAL_UNREFERENCED_EVENTS = 10_000
 _AD_HOC_SCRIPT_NAME_PREFIXES = ("hermes-verify-", "hermes-ad-hoc-")
+_AD_HOC_INTERPRETERS = {"python", "python3", "node", "bash", "sh", "ruby", "perl"}
 _VERIFY_SCHEMA_VERSION = 1
 _SHELL_SPLIT_RE = re.compile(r"\s*(?:&&|\|\||;)\s*")
 
@@ -279,6 +280,13 @@ def _is_temp_script_path(token: str, root: str | Path | None) -> bool:
     )
 
 
+def _is_ad_hoc_interpreter(command: str) -> bool:
+    name = re.split(r"[/\\]", command)[-1].lower()
+    if name.endswith(".exe"):
+        name = name[:-4]
+    return name in _AD_HOC_INTERPRETERS
+
+
 def _ad_hoc_script_args(tokens: list[str], root: str | Path | None) -> Optional[list[str]]:
     candidate_tokens = _strip_command_prefix(tokens)
     if not candidate_tokens:
@@ -286,7 +294,7 @@ def _ad_hoc_script_args(tokens: list[str], root: str | Path | None) -> Optional[
     command = candidate_tokens[0]
     if _is_temp_script_path(command, root):
         return candidate_tokens[1:]
-    if command in {"python", "python3", "node", "bash", "sh", "ruby", "perl"}:
+    if _is_ad_hoc_interpreter(command):
         for idx, token in enumerate(candidate_tokens[1:], start=1):
             if token == "--":
                 continue

--- a/tests/agent/test_verification_evidence.py
+++ b/tests/agent/test_verification_evidence.py
@@ -193,6 +193,51 @@ def test_temp_script_records_ad_hoc_evidence_without_canonical_suite(tmp_path, m
     assert evidence.status == "passed"
 
 
+def test_temp_script_accepts_absolute_virtualenv_interpreter(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    script = Path(tempfile.gettempdir()) / f"hermes-verify-{tmp_path.name}.py"
+    script.write_text("print('ok')\n", encoding="utf-8")
+    interpreter = tmp_path / ".venv" / "bin" / "python3"
+    try:
+        evidence = classify_verification_command(
+            f"{interpreter} {script}",
+            cwd=tmp_path,
+            session_id="s1",
+            exit_code=0,
+            output="ok",
+        )
+    finally:
+        script.unlink(missing_ok=True)
+
+    assert evidence is not None
+    assert evidence.canonical_command == "ad-hoc verification script"
+    assert evidence.kind == "ad_hoc"
+    assert evidence.scope == "targeted"
+    assert evidence.status == "passed"
+
+
+def test_temp_script_accepts_windows_virtualenv_interpreter(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    script = Path(tempfile.gettempdir()) / f"hermes-verify-{tmp_path.name}.py"
+    script.write_text("print('ok')\n", encoding="utf-8")
+    interpreter = r"C:\repo\.venv\Scripts\python.exe"
+    try:
+        evidence = classify_verification_command(
+            f"'{interpreter}' {script}",
+            cwd=tmp_path,
+            session_id="s1",
+            exit_code=0,
+            output="ok",
+        )
+    finally:
+        script.unlink(missing_ok=True)
+
+    assert evidence is not None
+    assert evidence.canonical_command == "ad-hoc verification script"
+
+
 def test_unprefixed_temp_script_is_not_ad_hoc_evidence(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
     (tmp_path / "package.json").write_text("{}", encoding="utf-8")


### PR DESCRIPTION
## Summary

- recognize supported ad-hoc verification interpreters by executable basename rather than requiring a literal command token
- accept absolute virtualenv paths such as `/path/.venv/bin/python3`
- handle Windows virtualenv executables such as `C:\repo\.venv\Scripts\python.exe`
- keep the existing temp-path, filename-prefix, and no-canonical-suite safety gates unchanged

## Root cause

`_ad_hoc_script_args()` compared the first command token directly with `python`, `python3`, etc. A successful command such as:

```bash
/path/to/.venv/bin/python /tmp/hermes-verify-abc.py
```

therefore ran successfully but produced no verification evidence, leaving verify-on-stop at `unverified`.

## Tests

- regression test observed failing before the fix for POSIX virtualenv paths
- regression test observed failing before the fix for Windows virtualenv paths
- `TMPDIR=/tmp/hermes-pytest python3 -m pytest tests/agent/test_verification_evidence.py tests/agent/test_verification_stop.py tests/agent/test_verification_stop_caching.py tests/run_agent/test_verification_continuation_budget.py -q` → 76 passed
- `uvx ruff check agent/verification_evidence.py tests/agent/test_verification_evidence.py`
- `python3 -m py_compile agent/verification_evidence.py tests/agent/test_verification_evidence.py`
- `git diff --check`

> On macOS, the unmodified suite's file-tool integration test needs `TMPDIR=/tmp/hermes-pytest`; the default pytest temp root resolves under `/private/var`, which the sensitive-path guard intentionally rejects.
