### PR TITLE
feat: per-message model/provider attribution

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -944,6 +944,8 @@ class CLICommandsMixin:
                     tool_calls=msg.get("tool_calls"),
                     tool_call_id=msg.get("tool_call_id"),
                     reasoning=msg.get("reasoning"),
+                    model=msg.get("model"),
+                    provider=msg.get("provider"),
                 )
             except Exception:
                 pass  # Best-effort copy

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -817,7 +817,9 @@ CREATE TABLE IF NOT EXISTS messages (
     platform_message_id TEXT,
     observed INTEGER DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1,
-    compacted INTEGER NOT NULL DEFAULT 0
+    compacted INTEGER NOT NULL DEFAULT 0,
+    model TEXT,
+    provider TEXT
 );
 
 CREATE TABLE IF NOT EXISTS session_model_usage (
@@ -3806,6 +3808,8 @@ class SessionDB:
         observed: bool = False,
         effect_disposition: Optional[str] = None,
         timestamp: Any = None,
+        model: Optional[str] = None,
+        provider: Optional[str] = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -3818,6 +3822,12 @@ class SessionDB:
         independent of the SQLite autoincrement primary key and is used by
         platform-specific flows like yuanbao's recall guard to redact a
         message by its platform-side identifier.
+
+        ``model``/``provider`` record which model/provider was actually
+        active when this row was written (e.g. the model that produced an
+        assistant reply, or was live when a user prompt was submitted).
+        Historical rows written before this column existed are NULL —
+        callers must not backfill them.
         """
         # Serialize structured fields to JSON before entering the write txn
         reasoning_details_json = (
@@ -3857,8 +3867,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active, model, provider)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -3878,6 +3888,8 @@ class SessionDB:
                     platform_message_id,
                     1 if observed else 0,
                     1,
+                    model,
+                    provider,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -3950,8 +3962,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, active, model, provider)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -3971,6 +3983,8 @@ class SessionDB:
                     platform_msg_id,
                     1 if msg.get("observed") else 0,
                     1,
+                    msg.get("model"),
+                    msg.get("provider"),
                 ),
             )
             inserted += 1
@@ -4457,7 +4471,8 @@ class SessionDB:
             rows = self._conn.execute(
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, effect_disposition, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
-                "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp "
+                "codex_reasoning_items, codex_message_items, platform_message_id, observed, timestamp, "
+                "model, provider "
                 f"FROM messages WHERE session_id IN ({placeholders})"
                 # Order by AUTOINCREMENT id (true insertion order), NOT timestamp:
                 # append_message stamps rows with time.time(), which is not
@@ -4500,6 +4515,13 @@ class SessionDB:
                 msg["message_id"] = row["platform_message_id"]
             if row["observed"]:
                 msg["observed"] = True
+            # Attribution metadata: which model/provider was active when this
+            # row was written. Pure metadata, not part of role/content — never
+            # backfilled for rows written before this column existed.
+            if row["model"]:
+                msg["model"] = row["model"]
+            if row["provider"]:
+                msg["provider"] = row["provider"]
             # Restore reasoning fields on assistant messages so providers
             # that replay reasoning (OpenRouter, OpenAI, Nous) receive
             # coherent multi-turn reasoning context.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1976,6 +1976,8 @@ class AIAgent:
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
                     timestamp=_row_timestamp,
+                    model=getattr(self, "model", "") or None,
+                    provider=getattr(self, "provider", "") or None,
                 )
                 msg[_DB_PERSISTED_MARKER] = True
             # The intrinsic markers are now the sole source of truth. Reset the

--- a/tests/run_agent/test_message_model_attribution.py
+++ b/tests/run_agent/test_message_model_attribution.py
@@ -1,0 +1,104 @@
+"""Per-message model/provider attribution write-path tests.
+
+Verifies ``AIAgent._flush_messages_to_session_db`` stamps each written
+message row with the model/provider that was ACTUALLY active at write
+time (read fresh via getattr, never cached) — so a mid-conversation
+``/model`` switch (an in-place ``agent.switch_model`` on the same
+session/thread) leaves earlier rows attributed to the old model while
+later rows pick up the new one.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+SESSION_ID = "test-model-attribution"
+
+
+def _make_agent(session_db, session_id=SESSION_ID, model="claude-sonnet-5", provider="anthropic"):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model=model,
+            provider=provider,
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._ensure_db_session()
+    return agent
+
+
+class TestMessageModelAttributionWritePath:
+    def test_flush_stamps_current_model_and_provider(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            try:
+                agent = _make_agent(db, model="claude-sonnet-5", provider="anthropic")
+                turn = [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi"},
+                ]
+                agent._flush_messages_to_session_db(turn, [])
+
+                rows = db.get_messages(SESSION_ID)
+                assert [r["model"] for r in rows] == ["claude-sonnet-5", "claude-sonnet-5"]
+                assert [r["provider"] for r in rows] == ["anthropic", "anthropic"]
+            finally:
+                db.close()
+
+    def test_mid_conversation_model_switch_keeps_old_rows_on_old_model(self):
+        """Mirrors an in-place ``agent.switch_model(...)`` call: the same
+        agent/session continues, only ``agent.model``/``agent.provider``
+        change. Rows flushed before the switch must keep the old
+        attribution; rows flushed after must carry the new one.
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            try:
+                agent = _make_agent(db, model="claude-sonnet-5", provider="anthropic")
+
+                first_turn = [
+                    {"role": "user", "content": "first prompt"},
+                    {"role": "assistant", "content": "first reply"},
+                ]
+                agent._flush_messages_to_session_db(first_turn, [])
+
+                # Simulate the runtime effect of a /model switch — switch_model()
+                # ultimately mutates these two attributes in place on the same
+                # live agent/session; no new session is created.
+                agent.model = "grok-4"
+                agent.provider = "xai"
+
+                history = [dict(m) for m in first_turn]
+                second_turn = history + [
+                    {"role": "user", "content": "second prompt"},
+                    {"role": "assistant", "content": "second reply"},
+                ]
+                agent._flush_messages_to_session_db(second_turn, history)
+
+                rows = db.get_messages(SESSION_ID)
+                assert [r["content"] for r in rows] == [
+                    "first prompt", "first reply", "second prompt", "second reply",
+                ]
+                assert [r["model"] for r in rows] == [
+                    "claude-sonnet-5", "claude-sonnet-5", "grok-4", "grok-4",
+                ]
+                assert [r["provider"] for r in rows] == [
+                    "anthropic", "anthropic", "xai", "xai",
+                ]
+                # Same session/thread throughout — the switch never forked a
+                # new session id.
+                assert {r["session_id"] for r in rows} == {SESSION_ID}
+            finally:
+                db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -885,6 +885,80 @@ class TestMessageStorage:
         assert active == 1
         assert len(db.get_messages_as_conversation("s1")) == 1
 
+    def test_append_message_stores_model_and_provider(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(
+            "s1", role="user", content="Hello",
+            model="claude-sonnet-5", provider="anthropic",
+        )
+        db.append_message(
+            "s1", role="assistant", content="Hi there!",
+            model="claude-sonnet-5", provider="anthropic",
+        )
+
+        messages = db.get_messages("s1")
+        assert messages[0]["model"] == "claude-sonnet-5"
+        assert messages[0]["provider"] == "anthropic"
+        assert messages[1]["model"] == "claude-sonnet-5"
+        assert messages[1]["provider"] == "anthropic"
+
+        conv = db.get_messages_as_conversation("s1")
+        assert conv[0]["model"] == "claude-sonnet-5"
+        assert conv[0]["provider"] == "anthropic"
+        assert conv[1]["model"] == "claude-sonnet-5"
+        assert conv[1]["provider"] == "anthropic"
+
+    def test_append_message_without_model_leaves_column_null(self, db):
+        """Historical-shaped writes (no model/provider passed) stay NULL —
+        never backfilled, never defaulted to an empty string."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="Hello")
+
+        messages = db.get_messages("s1")
+        assert messages[0]["model"] is None
+        assert messages[0]["provider"] is None
+
+        conv = db.get_messages_as_conversation("s1")
+        assert "model" not in conv[0]
+        assert "provider" not in conv[0]
+
+    def test_model_switch_mid_conversation_keeps_old_rows_attributed(self, db):
+        """A message written after a mid-conversation model switch carries the
+        NEW model; earlier rows in the same session keep the OLD model."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(
+            "s1", role="user", content="first prompt",
+            model="claude-sonnet-5", provider="anthropic",
+        )
+        db.append_message(
+            "s1", role="assistant", content="first reply",
+            model="claude-sonnet-5", provider="anthropic",
+        )
+        # Simulate an in-place /model switch (agent.switch_model) — the next
+        # turn's rows are written with the new model, the session/thread and
+        # earlier rows are untouched.
+        db.append_message(
+            "s1", role="user", content="second prompt",
+            model="grok-4", provider="xai",
+        )
+        db.append_message(
+            "s1", role="assistant", content="second reply",
+            model="grok-4", provider="xai",
+        )
+
+        messages = db.get_messages("s1")
+        assert len(messages) == 4
+        assert [m["model"] for m in messages] == [
+            "claude-sonnet-5", "claude-sonnet-5", "grok-4", "grok-4",
+        ]
+        assert [m["provider"] for m in messages] == [
+            "anthropic", "anthropic", "xai", "xai",
+        ]
+        # All four rows stayed in the SAME session (one thread) — no new
+        # session was created by the switch.
+        session_ids = {m["session_id"] for m in messages}
+        assert session_ids == {"s1"}
+
     def test_append_message_active_one_when_column_has_no_default(self, tmp_path):
         """Legacy DBs may have active added without a working INSERT default."""
         db_path = tmp_path / "legacy_state.db"
@@ -3727,6 +3801,65 @@ class TestSchemaInit:
         db2.close()
 
         assert cols1 == cols2
+
+    def test_reconciliation_adds_model_provider_columns(self, tmp_path):
+        """A legacy messages table without model/provider gets both columns
+        added automatically via _reconcile_columns — no manual ALTER TABLE
+        migration block is needed for this addition.
+        """
+        import sqlite3
+
+        db_path = tmp_path / "pre_attribution.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version (version) VALUES (1);
+
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL
+            );
+
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                timestamp REAL NOT NULL
+            );
+        """)
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            ("s1", "cli", 1000.0),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, ?, ?, ?)",
+            ("s1", "assistant", "hello", 1001.0),
+        )
+        conn.commit()
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)").fetchall()}
+        assert "model" not in cols
+        assert "provider" not in cols
+        conn.close()
+
+        migrated_db = SessionDB(db_path=db_path)
+        msg_cols = {
+            r[1]
+            for r in migrated_db._conn.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        assert "model" in msg_cols
+        assert "provider" in msg_cols
+
+        # Pre-existing row is NULL, not backfilled.
+        row = migrated_db._conn.execute(
+            "SELECT model, provider FROM messages WHERE session_id = ?", ("s1",)
+        ).fetchone()
+        assert row[0] is None
+        assert row[1] is None
+        migrated_db.close()
 
     def test_schema_sql_is_source_of_truth(self, db):
         """Every column in SCHEMA_SQL exists in the live database.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -976,6 +976,36 @@ def test_history_to_messages_still_drops_empty_assistant_without_reasoning():
     ]
 
 
+def test_history_to_messages_includes_model_and_provider_when_present():
+    history = [
+        {"role": "user", "content": "first prompt", "model": "claude-sonnet-5", "provider": "anthropic"},
+        {"role": "assistant", "content": "first reply", "model": "claude-sonnet-5", "provider": "anthropic"},
+        {"role": "user", "content": "second prompt", "model": "grok-4", "provider": "xai"},
+        {"role": "assistant", "content": "second reply", "model": "grok-4", "provider": "xai"},
+    ]
+
+    assert server._history_to_messages(history) == [
+        {"role": "user", "text": "first prompt", "model": "claude-sonnet-5", "provider": "anthropic"},
+        {"role": "assistant", "text": "first reply", "model": "claude-sonnet-5", "provider": "anthropic"},
+        {"role": "user", "text": "second prompt", "model": "grok-4", "provider": "xai"},
+        {"role": "assistant", "text": "second reply", "model": "grok-4", "provider": "xai"},
+    ]
+
+
+def test_history_to_messages_omits_model_when_absent():
+    # Historical rows written before the model/provider columns existed carry
+    # no such keys -- the resume payload must not fabricate them.
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+
+    assert server._history_to_messages(history) == [
+        {"role": "user", "text": "hi"},
+        {"role": "assistant", "text": "hello"},
+    ]
+
+
 def test_history_to_messages_renders_multimodal_content():
     # bb/gui preserves image URLs in the resume payload so the desktop
     # renderer's extractEmbeddedImages can pull them back out and display
@@ -1182,6 +1212,64 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
     assert captured["service_tier_override"] == "priority"
     runtime_sid = resp["result"]["session_id"]
     assert server._sessions[runtime_sid]["model_override"] == captured["model_override"]
+
+
+def test_session_resume_messages_carry_model_and_provider(monkeypatch):
+    """The session.resume history payload must tag each message with the
+    model/provider that was active when it was written, for parity with the
+    REST /api/sessions/{id}/messages shape."""
+    # Clear any live session left behind by a prior test using the same
+    # "stored-session" id — otherwise this resume hits the already-live
+    # reuse path (_reuse_live_payload) instead of building fresh, and that
+    # path expects fields (e.g. history_lock) this test's fake session
+    # dict doesn't set.
+    server._sessions.clear()
+    captured = {}
+
+    class FakeDB:
+        def get_session(self, target):
+            return {"id": target, "model": "grok-4"}
+
+        def reopen_session(self, target):
+            pass
+
+        def get_messages_as_conversation(self, target, include_ancestors=False):
+            return [
+                {"role": "user", "content": "old prompt", "model": "claude-sonnet-5", "provider": "anthropic"},
+                {"role": "assistant", "content": "old reply", "model": "claude-sonnet-5", "provider": "anthropic"},
+                {"role": "user", "content": "new prompt", "model": "grok-4", "provider": "xai"},
+                {"role": "assistant", "content": "new reply", "model": "grok-4", "provider": "xai"},
+            ]
+
+    def fake_make_agent(sid, key, session_id=None, session_db=None, **kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(model="grok-4", provider="xai")
+
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(
+        server, "_session_info", lambda agent, *a: {"model": agent.model, "provider": agent.provider}
+    )
+
+    def fake_init_session(sid, key, agent, history, cols=80, **_kwargs):
+        server._sessions[sid] = {"agent": agent, "session_key": key}
+
+    monkeypatch.setattr(server, "_init_session", fake_init_session)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.resume", "params": {"session_id": "stored-session", "eager_build": True}}
+    )
+
+    messages = resp["result"]["messages"]
+    assert [m.get("model") for m in messages] == [
+        "claude-sonnet-5", "claude-sonnet-5", "grok-4", "grok-4",
+    ]
+    assert [m.get("provider") for m in messages] == [
+        "anthropic", "anthropic", "xai", "xai",
+    ]
 
 
 def test_session_resume_profile_uses_profile_db_cwd(monkeypatch, tmp_path):
@@ -5089,6 +5177,56 @@ def test_prompt_submit_history_version_mismatch_surfaces_warning(monkeypatch):
             "not saved" in payload["warning"].lower()
             or "changed" in payload["warning"].lower()
         )
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_prompt_submit_message_complete_carries_model_and_provider(monkeypatch):
+    """The live message.complete event must tag the just-completed reply with
+    the model/provider that actually produced it, so a connected client
+    doesn't need a session.resume round-trip to render the tag."""
+
+    class _Agent:
+        model = "grok-4"
+        provider = "xai"
+
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            return {
+                "final_response": "agent reply",
+                "messages": [{"role": "assistant", "content": "agent reply"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None, **kw):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    emits: list[tuple] = []
+    try:
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+        monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+        monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+        monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
+
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hi"},
+            }
+        )
+        assert resp.get("result"), f"got error: {resp.get('error')}"
+
+        complete_calls = [a for a in emits if a[0] == "message.complete"]
+        assert len(complete_calls) == 1
+        _, _, payload = complete_calls[0]
+        assert payload["model"] == "grok-4"
+        assert payload["provider"] == "xai"
     finally:
         server._sessions.pop("sid", None)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1796,7 +1796,13 @@ def _persist_branch_seed(session: dict) -> None:
             return
         try:
             for msg in seed:
-                db.append_message(session_id=key, role=msg.get("role", "user"), content=msg.get("content"))
+                db.append_message(
+                    session_id=key,
+                    role=msg.get("role", "user"),
+                    content=msg.get("content"),
+                    model=msg.get("model"),
+                    provider=msg.get("provider"),
+                )
             session["_branch_seed_persisted"] = True
         except Exception:
             logger.debug("branch seed persist failed", exc_info=True)
@@ -2475,14 +2481,18 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
         agent = session.get("agent")
         db = getattr(agent, "_session_db", None) if agent is not None else None
         if db is not None:
-            db.append_message(session_id=session_key, role="user", content=marker)
+            db.append_message(
+                session_id=session_key, role="user", content=marker,
+                model=model, provider=provider,
+            )
             return
 
         _ensure_session_db_row(session)
         with _session_db(session) as scoped_db:
             if scoped_db is not None:
                 scoped_db.append_message(
-                    session_id=session_key, role="user", content=marker
+                    session_id=session_key, role="user", content=marker,
+                    model=model, provider=provider,
                 )
     except Exception:
         logger.debug("failed to persist model switch marker", exc_info=True)
@@ -5010,6 +5020,13 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
             for key in reasoning_keys:
                 if key in m and m.get(key) is not None:
                     msg[key] = m.get(key)
+        # Per-message model/provider attribution: which model was active
+        # when this row was written. Absent on rows written before this
+        # metadata existed — clients fall back to the session-level model.
+        if m.get("model"):
+            msg["model"] = m.get("model")
+        if m.get("provider"):
+            msg["provider"] = m.get("provider")
         messages.append(msg)
 
     return messages
@@ -8121,6 +8138,8 @@ def _(rid, params: dict) -> dict:
                 session_id=new_key,
                 role=msg.get("role", "user"),
                 content=msg.get("content"),
+                model=msg.get("model"),
+                provider=msg.get("provider"),
             )
         db.set_session_title(new_key, title)
     except Exception as e:
@@ -9212,6 +9231,12 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 status = "complete"
 
             payload = {"text": raw, "usage": _get_usage(agent), "status": status}
+            # Attribute the just-completed reply to the model/provider that
+            # actually produced it, so a client watching live doesn't need a
+            # session.resume round-trip to see the tag (mirrors the model/
+            # provider columns persisted on the message row).
+            payload["model"] = getattr(agent, "model", "") or ""
+            payload["provider"] = getattr(agent, "provider", "") or ""
             if last_reasoning:
                 payload["reasoning"] = last_reasoning
             if status_note:


### PR DESCRIPTION
## What changed

Adds `model`/`provider` columns to the `messages` table, stamped at write
time with whichever model/provider the agent was actually running for that
turn — not backfilled for historical rows (NULL is correct/expected there).

This closes a real gap: mid-conversation `/model` switching already existed
(`agent.switch_model()` mutates the live agent in place, same session/thread,
no new session created) but nothing recorded *which model produced which
message*. A client rendering a long thread that switched models several
times had no way to show "this reply came from Sonnet, that one from Grok."

## Where

- `hermes_state.py` — schema (`CREATE TABLE messages` + auto-reconciled
  columns, no manual `ALTER TABLE` needed) and the `append_message()` /
  `append_messages()` write paths.
- `run_agent.py` — `AIAgent._flush_messages_to_session_db` stamps
  `self.model`/`self.provider` fresh at flush time (never cached), so rows
  written before a mid-conversation switch keep the old model and rows
  written after correctly pick up the new one.
- `hermes_cli/cli_commands_mixin.py` — preserves `model`/`provider` through
  a best-effort message copy path.
- `tui_gateway/server.py` — branch-seed persist, the `/model` switch marker,
  and the live `prompt.submit` completion payload all now carry
  `model`/`provider`; the REST `/api/sessions/{id}/messages` endpoint gets
  the field for free since `get_messages()` already does `SELECT *` +
  `dict(row)`.

## Tests

- `tests/run_agent/test_message_model_attribution.py` — write-path test
  proving a message written after a mid-conversation model switch carries
  the new model while earlier rows in the same session keep the old one
  (same `session_id` throughout — no fork).
- `tests/test_tui_gateway_server.py` — `session.resume` history payload
  parity with the REST shape. (Also fixed a pre-existing test-isolation bug
  this new test exposed: a shared fake session id with a prior test bled
  into the live-session-reuse path and required clearing `server._sessions`
  first.)

Full existing suites for `hermes_state.py`, `run_agent`, and
`tui_gateway/server.py` pass unmodified. Two unrelated failures I found
while running broader `-k model` / `test_api_server.py` sweeps
(`test_model_picker_view_accepts_role_allowlist` under test-order pollution,
plus several `TestSessionKeyHeader`/`TestModelRoutesParsing` fixture errors)
reproduce identically on unmodified `main` — confirmed pre-existing, not
caused by this diff.

## Non-goals / constraints respected

- No backfill of historical rows.
- No new `HERMES_*` env vars.
- No prompt-cache or role-alternation disruption — pure additive metadata
  on existing rows/dicts, never a synthetic message.