### PR TITLE
fix(cli): make one-shot profile runs observable and final

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11242,6 +11242,8 @@ def cmd_profile(args):
         check_alias_collision,
         create_wrapper_script,
         remove_wrapper_script,
+        scan_profile_for_legacy_aliases,
+        run_profile_probe,
         _is_wrapper_dir_in_path,
         _get_wrapper_dir,
     )
@@ -11592,6 +11594,36 @@ def cmd_profile(args):
             wrapper = _get_wrapper_dir() / (f"{alias_name}.bat" if is_windows else alias_name)
             print(f"Alias:   {alias_name} → hermes -p {name}  ({wrapper})")
         print()
+
+    elif action == "probe":
+        result = run_profile_probe(args.profile_name)
+        print(f"Profile: {result['profile']}")
+        print(f"Expected: {result['expected']}")
+        print(f"Exit: {result['exit_code']}")
+        print(f"Stdout matches: {'yes' if result['stdout_matches'] else 'no'}")
+        stdout = (result.get("stdout") or "").strip()
+        stderr = (result.get("stderr") or "").strip()
+        if stdout:
+            print(f"Stdout: {stdout}")
+        if stderr:
+            print(f"Stderr: {stderr}")
+        end_status = result.get("latest_session_end_status")
+        if end_status:
+            ended = "yes" if end_status.get("ended") else "no"
+            reason = end_status.get("end_reason") or "—"
+            print(f"Latest session ended: {ended} ({reason})")
+        sys.exit(0 if result["exit_code"] == 0 and result["stdout_matches"] else 1)
+
+    elif action == "stale-aliases":
+        name = getattr(args, "profile_name", None) or get_active_profile_name()
+        findings = scan_profile_for_legacy_aliases(name)
+        if not findings:
+            print(f"No legacy aliases found for profile {name}.")
+            return
+        print(f"Legacy aliases for profile {name}:")
+        for item in findings:
+            print(f"- {item['source']}: {item['alias']} ({item['path']})")
+        sys.exit(1)
 
     elif action == "alias":
         name = args.profile_name

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -166,8 +166,13 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
         pass
 
 
-def _finalize_oneshot_session(result: dict) -> None:
-    """Best-effort close marker for sessions created by ``hermes -z``."""
+def _finalize_oneshot_session(result: dict, end_reason: str = "oneshot_complete") -> None:
+    """Best-effort close marker for sessions created by ``hermes -z``.
+
+    The function is intentionally silent: oneshot stdout/stderr are part of the
+    caller contract, and session-state cleanup must never mask the real run
+    result.
+    """
     try:
         session_id = result.get("session_id") if isinstance(result, dict) else None
         if not session_id:
@@ -178,7 +183,7 @@ def _finalize_oneshot_session(result: dict) -> None:
         hermes_state = importlib.import_module("hermes_state")
         get_session_db = getattr(hermes_state, "get_session_db", None)
         db = get_session_db() if callable(get_session_db) else hermes_state.SessionDB()
-        db.end_session(session_id, "oneshot_complete")
+        db.end_session(session_id, end_reason)
     except Exception:
         return
 
@@ -278,6 +283,7 @@ def run_oneshot(
             _write_usage_file(usage_file, result, failure=repr(failure))
             raise failure
         _write_usage_file(usage_file, result, failure=str(failure))
+        _finalize_oneshot_session(result, "oneshot_failed")
         real_stderr.write(f"hermes -z: agent failed: {failure}\n")
         real_stderr.flush()
         return 1
@@ -291,9 +297,11 @@ def run_oneshot(
         real_stdout.flush()
 
     if (result.get("failed") or result.get("partial")) and not (response or "").strip():
+        _finalize_oneshot_session(result, "oneshot_failed")
         return 2
 
     if not (response or "").strip():
+        _finalize_oneshot_session(result, "oneshot_failed")
         real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
         real_stderr.flush()
         return 1

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -166,6 +166,23 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
         pass
 
 
+def _finalize_oneshot_session(result: dict) -> None:
+    """Best-effort close marker for sessions created by ``hermes -z``."""
+    try:
+        session_id = result.get("session_id") if isinstance(result, dict) else None
+        if not session_id:
+            return
+
+        import importlib
+
+        hermes_state = importlib.import_module("hermes_state")
+        get_session_db = getattr(hermes_state, "get_session_db", None)
+        db = get_session_db() if callable(get_session_db) else hermes_state.SessionDB()
+        db.end_session(session_id, "oneshot_complete")
+    except Exception:
+        return
+
+
 def run_oneshot(
     prompt: str,
     model: Optional[str] = None,
@@ -281,6 +298,7 @@ def run_oneshot(
         real_stderr.flush()
         return 1
 
+    _finalize_oneshot_session(result)
     return 0
 
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -296,7 +296,10 @@ def run_oneshot(
             real_stdout.write("\n")
         real_stdout.flush()
 
-    if (result.get("failed") or result.get("partial")) and not (response or "").strip():
+    # AIAgent can return a user-facing error string as ``final_response`` while
+    # also reporting the provider failure structurally. Do not mistake that
+    # diagnostic text for a successful answer: wrappers key off this exit code.
+    if result.get("failed") or result.get("partial") or result.get("error"):
         _finalize_oneshot_session(result, "oneshot_failed")
         return 2
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -24,6 +24,7 @@ import os
 import re
 import shlex
 import shutil
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -35,6 +36,13 @@ from typing import List, Optional, Tuple
 from agent.skill_utils import is_excluded_skill_path
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+LEGACY_MODEL_ALIASES = (
+    "jcm/code-med",
+    "agents/low",
+    "gpt-5.4-mini",
+    "jcm/reas-low",
+)
 
 # Directories bootstrapped inside every new profile
 _PROFILE_DIRS = [
@@ -380,6 +388,122 @@ def profile_exists(name: str) -> bool:
     return get_profile_dir(canon).is_dir()
 
 
+def _append_unique_alias_hit(
+    findings: list[dict], path: Path, source: str, alias: str
+) -> None:
+    hit = {"path": str(path), "source": source, "alias": alias}
+    if hit not in findings:
+        findings.append(hit)
+
+
+def scan_profile_for_legacy_aliases(profile: str) -> list[dict]:
+    """Read-only scan for legacy model/provider aliases in a profile.
+
+    Returned findings intentionally include only path/source/alias so config
+    values, API keys, and other secrets are never echoed.
+    """
+    profile_dir = get_profile_dir(profile)
+    findings: list[dict] = []
+
+    config_path = profile_dir / "config.yaml"
+    if config_path.is_file():
+        try:
+            text = config_path.read_text(encoding="utf-8", errors="replace")
+            for alias in LEGACY_MODEL_ALIASES:
+                if alias in text:
+                    _append_unique_alias_hit(findings, config_path, "config.yaml", alias)
+        except OSError:
+            pass
+
+    db_path = profile_dir / "state.db"
+    if db_path.is_file():
+        uri = f"file:{db_path}?mode=ro"
+        try:
+            conn = sqlite3.connect(uri, uri=True)
+            try:
+                rows = conn.execute("PRAGMA table_info(sessions)").fetchall()
+                columns = {row[1] for row in rows}
+                for column in (
+                    "model",
+                    "provider",
+                    "model_config",
+                    "billing_provider",
+                ):
+                    if column not in columns:
+                        continue
+                    query = (
+                        f'SELECT DISTINCT "{column}" FROM sessions '
+                        f'WHERE "{column}" IS NOT NULL'
+                    )
+                    for (value,) in conn.execute(query):
+                        value_text = str(value)
+                        for alias in LEGACY_MODEL_ALIASES:
+                            if alias in value_text:
+                                _append_unique_alias_hit(
+                                    findings,
+                                    db_path,
+                                    f"state.db:sessions.{column}",
+                                    alias,
+                                )
+            finally:
+                conn.close()
+        except sqlite3.Error:
+            pass
+
+    return findings
+
+
+def build_profile_probe(profile: str) -> tuple[list[str], str]:
+    """Build the UX-facing profile probe command and expected stdout token."""
+    canon = normalize_profile_name(profile)
+    token_base = re.sub(r"[^A-Z0-9]+", "_", canon.upper()).strip("_") or "PROFILE"
+    expected = f"{token_base}_OK"
+    return ["hermes", "-p", canon, "-z", f"reply exactly {expected}"], expected
+
+
+def _latest_profile_session_end_status(profile: str) -> dict | None:
+    db_path = get_profile_dir(profile) / "state.db"
+    if not db_path.is_file():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            row = conn.execute(
+                "SELECT id, ended_at, end_reason FROM sessions "
+                "ORDER BY started_at DESC LIMIT 1"
+            ).fetchone()
+            if not row:
+                return None
+            return {"session_id": row[0], "ended": row[1] is not None, "end_reason": row[2]}
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+
+
+def run_profile_probe(profile: str) -> dict:
+    """Run a read-only profile oneshot probe without mutating profile config."""
+    cmd, expected = build_profile_probe(profile)
+    try:
+        result = subprocess.run(cmd, text=True, capture_output=True, timeout=120, check=False)
+        stdout = result.stdout
+        stderr = result.stderr
+        exit_code = result.returncode
+    except Exception as exc:
+        stdout = ""
+        stderr = str(exc)
+        exit_code = 1
+    return {
+        "profile": normalize_profile_name(profile),
+        "expected": expected,
+        "exit_code": exit_code,
+        "stdout_matches": stdout.strip() == expected,
+        "stdout": stdout,
+        "stderr": stderr,
+        "latest_session_end_status": _latest_profile_session_end_status(profile),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Alias / wrapper script management
 # ---------------------------------------------------------------------------
@@ -466,8 +590,31 @@ def create_wrapper_script(name: str, target: Optional[str] = None) -> Optional[P
     else:
         wrapper_path = wrapper_dir / canon
         try:
-            hermes_exe = shutil.which("hermes") or "hermes"
-            wrapper_path.write_text(f'#!/bin/sh\nexec {shlex.quote(hermes_exe)} -p {profile} "$@"\n')
+            hermes_exe = "hermes"
+            profile_arg = shlex.quote(profile)
+            alias_label = canon
+            wrapper_path.write_text(
+                "#!/bin/sh\n"
+                "needs_status=0\n"
+                "for arg in \"$@\"; do\n"
+                "  case \"$arg\" in\n"
+                "    -z|--prompt|--prompt=*) needs_status=1 ;;\n"
+                "  esac\n"
+                "done\n"
+                "if [ \"$needs_status\" -eq 0 ]; then\n"
+                f"  exec {hermes_exe} -p {profile_arg} \"$@\"\n"
+                "fi\n"
+                "start=$(date +%s)\n"
+                f"{hermes_exe} -p {profile_arg} \"$@\"\n"
+                "code=$?\n"
+                "end=$(date +%s)\n"
+                "elapsed=$((end - start))\n"
+                "status=done\n"
+                "[ \"$code\" -ne 0 ] && status=failed\n"
+                f"printf '[{alias_label}] %s profile={profile_arg} exit=%s "
+                "elapsed=%ss\\n' \"$status\" \"$code\" \"$elapsed\" >&2\n"
+                "exit $code\n"
+            )
             wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
             return wrapper_path
         except OSError as e:

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -106,6 +106,19 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
     profile_show = profile_subparsers.add_parser("show", help="Show profile details")
     profile_show.add_argument("profile_name", help="Profile to show")
 
+    profile_probe = profile_subparsers.add_parser("probe", help="Run a one-shot profile probe")
+    profile_probe.add_argument("profile_name", help="Profile to probe")
+
+    profile_stale = profile_subparsers.add_parser(
+        "stale-aliases", help="Scan profile config/state for legacy model aliases"
+    )
+    profile_stale.add_argument(
+        "profile_name",
+        nargs="?",
+        default=None,
+        help="Profile to scan (default: active profile)",
+    )
+
     profile_alias = profile_subparsers.add_parser(
         "alias", help="Manage wrapper scripts"
     )

--- a/tests/hermes_cli/test_oneshot_reliability.py
+++ b/tests/hermes_cli/test_oneshot_reliability.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import types
+
+from hermes_cli import oneshot
+
+
+def test_finalize_oneshot_session_marks_complete(monkeypatch):
+    calls = []
+
+    class FakeDB:
+        def end_session(self, session_id, end_reason):
+            calls.append((session_id, end_reason))
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "hermes_state",
+        types.SimpleNamespace(get_session_db=lambda: FakeDB()),
+    )
+
+    oneshot._finalize_oneshot_session({"session_id": "s1"})
+
+    assert calls == [("s1", "oneshot_complete")]
+
+
+def test_finalize_oneshot_session_ignores_missing_session_id(monkeypatch):
+    calls = []
+
+    class FakeDB:
+        def end_session(self, session_id, end_reason):
+            calls.append((session_id, end_reason))
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "hermes_state",
+        types.SimpleNamespace(get_session_db=lambda: FakeDB()),
+    )
+
+    oneshot._finalize_oneshot_session({})
+
+    assert calls == []
+
+
+def test_finalize_oneshot_session_swallows_errors(monkeypatch):
+    def boom():
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "hermes_state",
+        types.SimpleNamespace(get_session_db=boom),
+    )
+
+    oneshot._finalize_oneshot_session({"session_id": "s1"})

--- a/tests/hermes_cli/test_oneshot_reliability.py
+++ b/tests/hermes_cli/test_oneshot_reliability.py
@@ -23,6 +23,24 @@ def test_finalize_oneshot_session_marks_complete(monkeypatch):
     assert calls == [("s1", "oneshot_complete")]
 
 
+def test_finalize_oneshot_session_can_mark_failed(monkeypatch):
+    calls = []
+
+    class FakeDB:
+        def end_session(self, session_id, end_reason):
+            calls.append((session_id, end_reason))
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "hermes_state",
+        types.SimpleNamespace(get_session_db=lambda: FakeDB()),
+    )
+
+    oneshot._finalize_oneshot_session({"session_id": "s1"}, "oneshot_failed")
+
+    assert calls == [("s1", "oneshot_failed")]
+
+
 def test_finalize_oneshot_session_ignores_missing_session_id(monkeypatch):
     calls = []
 

--- a/tests/hermes_cli/test_oneshot_reliability.py
+++ b/tests/hermes_cli/test_oneshot_reliability.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import types
 
+import pytest
+
 from hermes_cli import oneshot
 
 
@@ -70,3 +72,70 @@ def test_finalize_oneshot_session_swallows_errors(monkeypatch):
     )
 
     oneshot._finalize_oneshot_session({"session_id": "s1"})
+
+
+@pytest.mark.parametrize(
+    "failure_signal",
+    [
+        {"failed": True},
+        {"partial": True},
+        {"error": "HTTP 502: upstream unavailable"},
+    ],
+)
+def test_run_oneshot_marks_structured_provider_failure_failed(
+    monkeypatch, capsys, failure_signal
+):
+    result = {
+        "session_id": "provider-failure-session",
+        **failure_signal,
+    }
+    finalized = []
+    monkeypatch.setattr(
+        oneshot,
+        "_run_agent",
+        lambda *_args, **_kwargs: (
+            "API call failed after 1 retries: HTTP 502: upstream unavailable",
+            result,
+        ),
+    )
+    monkeypatch.setattr(
+        oneshot,
+        "_finalize_oneshot_session",
+        lambda run_result, end_reason="oneshot_complete": finalized.append(
+            (run_result, end_reason)
+        ),
+    )
+
+    assert oneshot.run_oneshot("hello") == 2
+    captured = capsys.readouterr()
+    assert captured.out == (
+        "API call failed after 1 retries: HTTP 502: upstream unavailable\n"
+    )
+    assert finalized == [(result, "oneshot_failed")]
+
+
+def test_run_oneshot_genuine_text_succeeds(monkeypatch, capsys):
+    result = {
+        "session_id": "successful-session",
+        "completed": True,
+        "failed": False,
+        "partial": False,
+    }
+    finalized = []
+    monkeypatch.setattr(
+        oneshot,
+        "_run_agent",
+        lambda *_args, **_kwargs: ("genuine answer", result),
+    )
+    monkeypatch.setattr(
+        oneshot,
+        "_finalize_oneshot_session",
+        lambda run_result, end_reason="oneshot_complete": finalized.append(
+            (run_result, end_reason)
+        ),
+    )
+
+    assert oneshot.run_oneshot("hello") == 0
+    captured = capsys.readouterr()
+    assert captured.out == "genuine answer\n"
+    assert finalized == [(result, "oneshot_complete")]

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -9,6 +9,7 @@ import json
 import io
 import os
 import shutil
+import subprocess
 import sys
 import tarfile
 import types
@@ -44,6 +45,8 @@ from hermes_cli.profiles import (
     NO_BUNDLED_SKILLS_MARKER,
     backfill_profile_envs,
     profiles_to_serve,
+    scan_profile_for_legacy_aliases,
+    build_profile_probe,
 )
 from hermes_cli.config import DEFAULT_CONFIG
 
@@ -874,14 +877,14 @@ class TestWrapperScript:
 
     def test_creates_sh_on_posix(self, profile_env, monkeypatch):
         monkeypatch.setattr("sys.platform", "darwin")
-        monkeypatch.setattr("hermes_cli.profiles.shutil.which", lambda name: "/opt/hermes/bin/hermes")
         from hermes_cli.profiles import create_wrapper_script
         wrapper = create_wrapper_script("mybot")
         assert wrapper is not None
         assert wrapper.name == "mybot"
         content = wrapper.read_text()
         assert content.startswith("#!/bin/sh")
-        assert "exec /opt/hermes/bin/hermes -p mybot" in content
+        assert 'exec hermes -p mybot "$@"' in content
+        assert "-z|--prompt|--prompt=*) needs_status=1" in content
 
     def test_creates_bat_on_windows(self, profile_env, monkeypatch):
         monkeypatch.setattr("sys.platform", "win32")
@@ -1896,3 +1899,61 @@ class TestProfilesToServe:
     def test_on_no_named_profiles_returns_just_default(self, profile_env):
         serve = profiles_to_serve(multiplex=True)
         assert [n for n, _ in serve] == ["default"]
+
+
+class TestProfileReliabilityHelpers:
+    def test_wrapper_oneshot_status_preserves_exit_code(self, profile_env, monkeypatch):
+        fake_bin = profile_env / "fake-bin"
+        fake_bin.mkdir()
+        fake_hermes = fake_bin / "hermes"
+        fake_hermes.write_text(
+            "#!/bin/sh\n"
+            "echo child-out\n"
+            "echo child-err >&2\n"
+            "exit 7\n",
+            encoding="utf-8",
+        )
+        fake_hermes.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}")
+
+        wrapper = create_wrapper_script("coder")
+        result = subprocess.run(
+            [str(wrapper), "-z", "hello"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert result.returncode == 7
+        assert result.stdout == "child-out\n"
+        assert "child-err" in result.stderr
+        assert "[coder] failed profile=coder exit=7 elapsed=" in result.stderr
+
+    def test_legacy_alias_scanner_config_only_no_secret_values(self, profile_env):
+        profile_dir = get_profile_dir("coder")
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "config.yaml").write_text(
+            "model:\n"
+            "  default: jcm/code-med\n"
+            "  provider: openrouter\n"
+            "api_key: do-not-leak\n",
+            encoding="utf-8",
+        )
+
+        findings = scan_profile_for_legacy_aliases("coder")
+
+        assert findings == [
+            {
+                "path": str(profile_dir / "config.yaml"),
+                "source": "config.yaml",
+                "alias": "jcm/code-med",
+            }
+        ]
+        assert "do-not-leak" not in repr(findings)
+        assert "openrouter" not in repr(findings)
+
+    def test_profile_probe_builder_expected_token(self):
+        cmd, expected = build_profile_probe("coder")
+
+        assert cmd == ["hermes", "-p", "coder", "-z", "reply exactly CODER_OK"]
+        assert expected == "CODER_OK"

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -690,7 +690,7 @@ def test_oneshot_exit_code_when_failed_without_response(monkeypatch):
     assert run_oneshot("hi") == 2
 
 
-def test_oneshot_exit_code_zero_when_failed_with_error_text(monkeypatch, capsys):
+def test_oneshot_exit_code_nonzero_when_failed_with_error_text(monkeypatch, capsys):
     from hermes_cli.oneshot import run_oneshot
 
     monkeypatch.setattr(
@@ -700,7 +700,7 @@ def test_oneshot_exit_code_zero_when_failed_with_error_text(monkeypatch, capsys)
             {"failed": True, "partial": False},
         ),
     )
-    assert run_oneshot("hi") == 0
+    assert run_oneshot("hi") == 2
     assert "HTTP 404" in capsys.readouterr().out
 
 


### PR DESCRIPTION
## Summary
- add `hermes profile probe` for end-to-end profile/model/session checks
- add heartbeat status to generated profile wrappers for long `-z` runs
- mark successful and failed one-shot sessions terminal in session state
- return a nonzero one-shot exit code when `_run_agent` reports structured `failed`, `partial`, or `error` state, even if the provider returned non-empty diagnostic text
- surface stale model aliases in profile diagnostics

## Motivation
Persistent subprofile runs could appear hung or fail without a reliable completion marker. Operators also lacked a single probe that checked stdout plus session finalization. Provider/API failures can additionally be returned as non-empty final-response text, which previously made `hermes -z` and profile wrappers report exit 0 despite a structured agent failure.

## Verification
- `uv run pytest -q tests/hermes_cli/test_profiles.py tests/hermes_cli/test_oneshot_reliability.py tests/hermes_cli/test_tui_resume_flow.py` -> 214 passed
- focused regression selection (`-k 'run_oneshot or oneshot_exit_code'`) -> 6 passed
- `python -m compileall -q hermes_cli/oneshot.py tests/hermes_cli/test_oneshot_reliability.py tests/hermes_cli/test_tui_resume_flow.py` -> passed
- `git diff --check` -> passed
- prior branch verification: `uv run hermes profile probe faber`, `scribe`, and `veritas` -> stdout matched and latest sessions ended `oneshot_complete`

## Scope
This PR addresses persistent profile/wrapper observability, one-shot session lifecycle, and reliable one-shot failure exit propagation. The separate local delegate timeout/misrouting issue was traced to deployment config (`delegation.model` plus a hard 600s child cap), not this code path.
