### PR TITLE
fix(desktop): keep generated images out of tool overflow

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.test.ts
@@ -1,13 +1,24 @@
 import { describe, expect, it } from 'vitest'
 
-import { shouldBoundToolGroup } from './fallback'
+import { shouldBoundToolGroup, UNBOUNDABLE_TOOLS } from './fallback'
 
 describe('shouldBoundToolGroup', () => {
   it('bounds long runs of ordinary tool calls', () => {
     expect(shouldBoundToolGroup(3, false)).toBe(true)
   })
 
-  it('never bounds a run containing clarify', () => {
+  it('leaves short runs unbounded', () => {
+    expect(shouldBoundToolGroup(2, false)).toBe(false)
+  })
+
+  it('never bounds a run holding an unboundable tool', () => {
     expect(shouldBoundToolGroup(3, true)).toBe(false)
+  })
+})
+
+describe('UNBOUNDABLE_TOOLS', () => {
+  it('exempts clarify forms and generated images from the window', () => {
+    expect(UNBOUNDABLE_TOOLS.has('clarify')).toBe(true)
+    expect(UNBOUNDABLE_TOOLS.has('image_generate')).toBe(true)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -611,8 +611,13 @@ function ToolEntry({ part }: ToolEntryProps) {
 // auto-scrolling window; fewer than this stays a plain inline stack.
 const TOOL_GROUP_SCROLL_THRESHOLD = 3
 
-export function shouldBoundToolGroup(childCount: number, containsClarify: boolean) {
-  return childCount >= TOOL_GROUP_SCROLL_THRESHOLD && !containsClarify
+// Tools whose body (an interactive form, a full-size image) must never be
+// trapped behind the window's max-height + fade mask. A run holding any of
+// them stays a plain, fully-visible stack no matter how long it is.
+export const UNBOUNDABLE_TOOLS = new Set(['clarify', 'image_generate'])
+
+export function shouldBoundToolGroup(childCount: number, hasUnboundable: boolean) {
+  return childCount >= TOOL_GROUP_SCROLL_THRESHOLD && !hasUnboundable
 }
 
 // Pin-to-bottom + top-fade for the bounded tool window. Pins the newest row on
@@ -688,15 +693,15 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
   const messageId = useAuiState(s => s.message.id)
   const messageRunning = useAuiState(selectMessageRunning)
 
-  const containsClarify = useAuiState(s =>
+  const hasUnboundable = useAuiState(s =>
     s.message.parts
       .slice(Math.max(0, startIndex), endIndex + 1)
-      .some(part => part.type === 'tool-call' && part.toolName === 'clarify')
+      .some(part => part.type === 'tool-call' && UNBOUNDABLE_TOOLS.has(part.toolName))
   )
 
   const enterRef = useEnterAnimation(messageRunning, `tool-group:${messageId}:${startIndex}`)
 
-  const bounded = shouldBoundToolGroup(Children.count(children), containsClarify)
+  const bounded = shouldBoundToolGroup(Children.count(children), hasUnboundable)
   const { contentRef, faded, onScroll, scrollRef } = useToolWindow(bounded)
 
   return (


### PR DESCRIPTION
## Summary
- Follow-up to the clarify overflow fix (#64679): the same bounded tool-call window was clipping generated images.
- Generalizes the one-off clarify opt-out into an `UNBOUNDABLE_TOOLS` set (`clarify`, `image_generate`). A run containing any of them stays a plain, fully-visible stack instead of collapsing into the fixed-height auto-scrolling window, where the `max-height` + gradient mask hid the image.
- Ordinary 3+ tool runs still collapse exactly as before.

## Test plan
- [x] `npx vitest run --project ui src/components/assistant-ui/tool/fallback.test.ts`
- [x] `npx eslint src/components/assistant-ui/tool/fallback.tsx src/components/assistant-ui/tool/fallback.test.ts`
- [ ] `npm run typecheck` — fails locally on a pre-existing `@assistant-ui/react` version mismatch in the local install (same failures on clean `main`, in files this PR doesn't touch); green in CI.