### PR TITLE
fix(telegram): keep slash-command sender user_id under observe mode (#65085)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7442,9 +7442,13 @@ class TelegramAdapter(BasePlatformAdapter):
         observe_prompt = self._telegram_group_observe_channel_prompt()
         channel_prompt = f"{event.channel_prompt}\n\n{observe_prompt}" if event.channel_prompt else observe_prompt
         if event.message_type == MessageType.COMMAND:
+            # Slash commands carry admin gating via the sender's user_id. The
+            # shared/anonymized observe source (user_id=None) must NOT replace
+            # it — that would make policy_for_source() treat every group command
+            # as non-admin and silently block operators listed in
+            # group_allow_admin_from (#65085). Only align the channel prompt.
             return dataclasses.replace(
                 event,
-                source=shared_source,
                 channel_prompt=channel_prompt,
             )
         return dataclasses.replace(
@@ -7925,7 +7929,6 @@ class TelegramAdapter(BasePlatformAdapter):
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-            profile=event.source.profile,
         )
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7929,6 +7929,7 @@ class TelegramAdapter(BasePlatformAdapter):
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            profile=event.source.profile,
         )
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -343,7 +343,9 @@ def test_observed_group_context_preserves_slash_command_text_for_dispatch():
 
     assert attributed.text == "/new@hermes_bot"
     assert attributed.get_command() == "new"
-    assert attributed.source.user_id is None
+    # #65085: slash commands must keep their sender user_id so admin gating
+    # (group_allow_admin_from) is not broken by the shared observe source.
+    assert attributed.source.user_id == "111"
     assert "observed Telegram group context" in attributed.channel_prompt
 
 
@@ -1343,5 +1345,41 @@ def test_unmentioned_unsupported_document_observed_and_cached(monkeypatch):
         cache_doc.assert_called_once()
         _, message, _ = store.messages[0]
         assert "program.exe" in message["content"]
+
+    asyncio.run(_run())
+
+
+def test_observe_attribution_preserves_command_user_id_for_admin_gating():
+    """#65085: slash commands in an observe-enabled group must keep their
+    sender user_id so group_allow_admin_from admins are not demoted to
+    non-admin (which would block admin-only commands)."""
+
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=True,
+        )
+        adapter._session_store = _FakeSessionStore()
+        # Admin user listed in group_allow_admin_from.
+        text = "/stop"
+        msg = _group_message(
+            text,
+            from_user_id=222,
+            from_user_name="Bob Example",
+        )
+        event = adapter._build_message_event(msg, MessageType.COMMAND, update_id=1004)
+        event.channel_prompt = "Existing topic prompt"
+
+        event = adapter._apply_telegram_group_observe_attribution(event)
+
+        # CRITICAL: the command still carries the sender's user_id so
+        # gateway.slash_access.policy_for_source() recognizes them as admin.
+        assert event.source.user_id == "222"
+        assert event.source.user_name == "Bob Example"
+        # Observe prompt is still attached for attribution context.
+        assert "observed Telegram group context" in event.channel_prompt
+        assert "Existing topic prompt" in event.channel_prompt
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary

Commit-path bug in the Telegram adapter's observe-mode attribution. When
``observe_unmentioned_group_messages: true`` is set,
``_apply_telegram_group_observe_attribution()`` rewrote **every** group message's
``source`` with the shared/anonymized observe source (``user_id=None``) to collapse
observed chatter into one session. Correct for TEXT, but it also fired for
``MessageType.COMMAND`` — so the rewritten source reached
``gateway.slash_access.policy_for_source()`` with ``user_id=None``. ``is_admin(None)``
is ``False``, which demoted operators listed in ``group_allow_admin_from`` to
non-admin and **silently blocked every admin-only command** (``/stop``, ``/compress``,
…) in observe-enabled groups.

## Changes

- ``plugins/platforms/telegram/adapter.py`` (``_apply_telegram_group_observe_attribution``)
  - For ``MessageType.COMMAND``: no longer replace ``event.source`` with the shared
    observe source. Only attach the observe ``channel_prompt`` and keep the sender's
    ``user_id``/``user_name`` so admin gating survives.
  - TEXT attribution behavior is unchanged (still collapses to the shared source).
- ``tests/gateway/test_telegram_group_gating.py``
  - Fixed the pre-existing ``test_observed_group_context_preserves_slash_command_text_for_dispatch``
    assertion that wrongly expected ``source.user_id is None`` for commands (it was
    encoding the bug, not a contract).
  - Added ``test_observe_attribution_preserves_command_user_id_for_admin_gating``
    asserting a COMMAND in an observe-enabled group keeps ``user_id``/``user_name``
    while still receiving the observe channel prompt.

## Why only the COMMAND branch

The shared source's whole purpose is to fold unmentioned group chatter into one
session for *context* — that only matters for observed TEXT. Slash commands are
explicit, directed requests that carry access control via the sender id; stripping
it breaks ``group_allow_admin_from`` with no attribution benefit.

## How to Test

```
pytest tests/gateway/test_telegram_group_gating.py -q
# 52 passed
```

## Checklist

- [x] Scoped to the single COMMAND branch in ``_apply_telegram_group_observe_attribution``
- [x] Tests updated + new regression test added (52 passed)
- [x] Cross-platform: pure Python, no platform-specific code
- [x] No hardcoded paths

## Risk & Impact

**Low.** The fix only stops the observe attribution from overwriting the command
sender's ``user_id``; observed-TEXT history collapsing is untouched, and the observe
prompt is still attached to commands. Admin gating in observe-enabled groups is
restored to the intended behavior.

Type: Bug fix
Closes: #65085