### PR TITLE
feat(gateway): config-driven per-chat channel_context injection

### DIFF
--- a/gateway/channel_context.py
+++ b/gateway/channel_context.py
@@ -1,0 +1,436 @@
+"""Config-driven per-chat context for inbound gateway messages.
+
+The public config accepts either an inline mapping or a path to a JSON
+mapping.  File-backed maps are designed for external orchestrators that update
+chat bindings while the gateway is running, so unchanged files stay parsed in
+an in-process cache while every observed file state is validated independently.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from gateway.session import SessionSource
+
+
+logger = logging.getLogger(__name__)
+
+CONFIGURED_CHANNEL_CONTEXT_HEADER = "[Configured chat context]"
+MAX_CHANNEL_CONTEXT_FILE_BYTES = 1024 * 1024
+MAX_CHANNEL_CONTEXT_ENTRIES = 4096
+MAX_CHANNEL_CONTEXT_KEY_BYTES = 512
+MAX_CHANNEL_CONTEXT_VALUE_BYTES = 2 * 1024
+_MAX_CACHED_FILES = 32
+_MAX_WARNING_KEYS = 128
+
+
+@dataclass(frozen=True)
+class _FileSignature:
+    """Metadata that changes for rewrites and atomic file replacements."""
+
+    device: int
+    inode: int
+    size: int
+    mtime_ns: int
+    ctime_ns: int
+
+    @classmethod
+    def from_stat(cls, result: os.stat_result) -> "_FileSignature":
+        return cls(
+            device=int(result.st_dev),
+            inode=int(result.st_ino),
+            size=int(result.st_size),
+            mtime_ns=int(
+                getattr(result, "st_mtime_ns", int(result.st_mtime * 1_000_000_000))
+            ),
+            ctime_ns=int(
+                getattr(result, "st_ctime_ns", int(result.st_ctime * 1_000_000_000))
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class _CachedFileMap:
+    signature: _FileSignature
+    contexts: dict[str, str]
+
+
+def canonical_channel_context_key(source: "SessionSource") -> str:
+    """Return the platform-qualified key used by ``channel_context_map``.
+
+    ``SessionSource.chat_id`` intentionally remains the adapter's raw ID.  The
+    platform namespace prevents the same raw ID on two platforms from sharing
+    context.  Colons inside a native chat ID are preserved verbatim.
+    """
+
+    platform = str(getattr(source.platform, "value", source.platform) or "").strip()
+    chat_id = str(source.chat_id or "")
+    if not platform or not chat_id:
+        return ""
+    return f"{platform}:{chat_id}"
+
+
+def merge_channel_context(
+    adapter_context: Optional[str],
+    configured_context: Optional[str],
+) -> str:
+    """Combine adapter and configured context without mutating the event."""
+
+    blocks: list[str] = []
+    if adapter_context:
+        blocks.append(adapter_context)
+    if configured_context:
+        blocks.append(
+            f"{CONFIGURED_CHANNEL_CONTEXT_HEADER}\n{configured_context}"
+        )
+    return "\n\n".join(blocks)
+
+
+class ChannelContextResolver:
+    """Resolve bounded per-chat context from inline or file-backed config."""
+
+    def __init__(self, *, max_cached_files: int = _MAX_CACHED_FILES) -> None:
+        self._max_cached_files = max(1, int(max_cached_files))
+        self._file_cache: OrderedDict[Path, _CachedFileMap] = OrderedDict()
+        self._warning_keys: OrderedDict[tuple[Any, ...], None] = OrderedDict()
+        self._lock = threading.RLock()
+
+    def clear(self) -> None:
+        """Clear process-local caches (primarily useful for isolated tests)."""
+
+        with self._lock:
+            self._file_cache.clear()
+            self._warning_keys.clear()
+
+    def context_for(
+        self,
+        source: "SessionSource",
+        config_value: Any,
+        *,
+        config_home: Path,
+    ) -> Optional[str]:
+        """Return configured context for ``source``, or ``None`` when absent."""
+
+        lookup_key = canonical_channel_context_key(source)
+        if not lookup_key:
+            return None
+
+        if isinstance(config_value, Mapping):
+            return self._inline_context(config_value, lookup_key)
+        elif isinstance(config_value, str):
+            configured_path = config_value.strip()
+            if not configured_path:
+                return None
+            try:
+                path = Path(configured_path).expanduser()
+                if not path.is_absolute():
+                    path = Path(config_home) / path
+                path = Path(os.path.abspath(path))
+            except (OSError, RuntimeError, ValueError):
+                self._warn_once(
+                    ("invalid-path", type(configured_path).__name__),
+                    "Ignoring invalid gateway.channel_context_map path",
+                )
+                return None
+            contexts = self._load_file(path)
+        elif config_value in (None, ""):
+            return None
+        else:
+            self._warn_once(
+                ("invalid-config-type", type(config_value).__name__),
+                "Ignoring gateway.channel_context_map with unsupported type %s",
+                type(config_value).__name__,
+            )
+            return None
+
+        return contexts.get(lookup_key)
+
+    def _inline_context(
+        self,
+        raw: Mapping[Any, Any],
+        lookup_key: str,
+    ) -> Optional[str]:
+        """Validate only the requested inline entry to keep lookup O(1)."""
+
+        if len(raw) > MAX_CHANNEL_CONTEXT_ENTRIES:
+            self._warn_once(
+                ("too-many-entries", "inline config", len(raw)),
+                "Ignoring inline config for gateway.channel_context_map: "
+                "%d entries exceeds limit %d",
+                len(raw),
+                MAX_CHANNEL_CONTEXT_ENTRIES,
+            )
+            return None
+        if lookup_key not in raw:
+            return None
+
+        value = raw[lookup_key]
+        if not isinstance(value, str):
+            self._warn_once(
+                ("inline-entry-type", type(value).__name__),
+                "Ignoring non-string gateway.channel_context_map context from inline config",
+            )
+            return None
+        if not value.strip():
+            self._warn_once(
+                ("inline-entry-blank",),
+                "Ignoring blank gateway.channel_context_map context from inline config",
+            )
+            return None
+        try:
+            key_bytes = len(lookup_key.encode("utf-8"))
+            value_bytes = len(value.encode("utf-8"))
+        except UnicodeEncodeError:
+            self._warn_once(
+                ("inline-entry-encoding",),
+                "Ignoring non-UTF-8 gateway.channel_context_map entry from inline config",
+            )
+            return None
+        if (
+            key_bytes > MAX_CHANNEL_CONTEXT_KEY_BYTES
+            or value_bytes > MAX_CHANNEL_CONTEXT_VALUE_BYTES
+        ):
+            self._warn_once(
+                ("inline-entry-oversized", key_bytes, value_bytes),
+                "Ignoring oversized gateway.channel_context_map entry from inline config",
+            )
+            return None
+        return value
+
+    def _normalize_mapping(
+        self,
+        raw: Mapping[Any, Any],
+        *,
+        label: str,
+    ) -> dict[str, str]:
+        if len(raw) > MAX_CHANNEL_CONTEXT_ENTRIES:
+            self._warn_once(
+                ("too-many-entries", label, len(raw)),
+                "Ignoring %s for gateway.channel_context_map: %d entries exceeds limit %d",
+                label,
+                len(raw),
+                MAX_CHANNEL_CONTEXT_ENTRIES,
+            )
+            return {}
+
+        contexts: dict[str, str] = {}
+        invalid_type = 0
+        invalid_key = 0
+        oversized = 0
+        blank = 0
+
+        for key, value in raw.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                invalid_type += 1
+                continue
+            platform, separator, chat_id = key.partition(":")
+            if (
+                not separator
+                or not platform
+                or not chat_id
+                or key != key.strip()
+                or any(character.isspace() for character in platform)
+            ):
+                invalid_key += 1
+                continue
+            if not value.strip():
+                blank += 1
+                continue
+            try:
+                key_bytes = len(key.encode("utf-8"))
+                value_bytes = len(value.encode("utf-8"))
+            except UnicodeEncodeError:
+                invalid_type += 1
+                continue
+            if (
+                key_bytes > MAX_CHANNEL_CONTEXT_KEY_BYTES
+                or value_bytes > MAX_CHANNEL_CONTEXT_VALUE_BYTES
+            ):
+                oversized += 1
+                continue
+            contexts[key] = value
+
+        rejected = invalid_type + invalid_key + oversized + blank
+        if rejected:
+            # Do not log keys or values: both may contain sensitive identifiers
+            # or operator-provided instructions.
+            self._warn_once(
+                (
+                    "invalid-entries",
+                    label,
+                    len(raw),
+                    invalid_type,
+                    invalid_key,
+                    oversized,
+                    blank,
+                ),
+                "Ignored %d invalid gateway.channel_context_map entries from %s "
+                "(type=%d, key=%d, oversized=%d, blank=%d)",
+                rejected,
+                label,
+                invalid_type,
+                invalid_key,
+                oversized,
+                blank,
+            )
+        return contexts
+
+    def _load_file(self, path: Path) -> dict[str, str]:
+        # Retry once if an external writer changes the file between stat/open.
+        # Writers should still use a sibling temp file + os.replace() so readers
+        # never observe partially-written JSON.
+        for _attempt in range(2):
+            try:
+                path_stat = path.stat()
+            except (OSError, ValueError) as exc:
+                self._drop_cached_path(path)
+                self._warn_once(
+                    ("file-stat", str(path), type(exc).__name__),
+                    "Could not read gateway.channel_context_map file %s (%s)",
+                    path,
+                    type(exc).__name__,
+                )
+                return {}
+
+            signature = _FileSignature.from_stat(path_stat)
+            cached = self._get_cached(path, signature)
+            if cached is not None:
+                return cached
+
+            if not stat.S_ISREG(path_stat.st_mode):
+                self._cache(path, signature, {})
+                self._warn_once(
+                    ("not-regular", str(path), signature),
+                    "Ignoring non-regular gateway.channel_context_map file %s",
+                    path,
+                )
+                return {}
+            if signature.size > MAX_CHANNEL_CONTEXT_FILE_BYTES:
+                self._cache(path, signature, {})
+                self._warn_once(
+                    ("file-too-large", str(path), signature),
+                    "Ignoring gateway.channel_context_map file %s: %d bytes exceeds limit %d",
+                    path,
+                    signature.size,
+                    MAX_CHANNEL_CONTEXT_FILE_BYTES,
+                )
+                return {}
+
+            try:
+                with path.open("rb") as handle:
+                    opened_stat = os.fstat(handle.fileno())
+                    opened_signature = _FileSignature.from_stat(opened_stat)
+                    if opened_signature != signature:
+                        continue
+                    payload = handle.read(MAX_CHANNEL_CONTEXT_FILE_BYTES + 1)
+            except (OSError, ValueError) as exc:
+                self._drop_cached_path(path)
+                self._warn_once(
+                    ("file-open", str(path), type(exc).__name__),
+                    "Could not read gateway.channel_context_map file %s (%s)",
+                    path,
+                    type(exc).__name__,
+                )
+                return {}
+
+            if len(payload) > MAX_CHANNEL_CONTEXT_FILE_BYTES:
+                self._cache(path, opened_signature, {})
+                self._warn_once(
+                    ("file-read-too-large", str(path), opened_signature),
+                    "Ignoring gateway.channel_context_map file %s: content exceeds limit %d",
+                    path,
+                    MAX_CHANNEL_CONTEXT_FILE_BYTES,
+                )
+                return {}
+
+            try:
+                after_signature = _FileSignature.from_stat(path.stat())
+            except (OSError, ValueError):
+                self._drop_cached_path(path)
+                return {}
+            if after_signature != opened_signature:
+                continue
+
+            try:
+                data = json.loads(payload)
+            except (UnicodeError, ValueError, RecursionError) as exc:
+                self._cache(path, opened_signature, {})
+                self._warn_once(
+                    ("invalid-json", str(path), opened_signature),
+                    "Ignoring invalid gateway.channel_context_map JSON in %s (%s)",
+                    path,
+                    type(exc).__name__,
+                )
+                return {}
+            if not isinstance(data, dict):
+                self._cache(path, opened_signature, {})
+                self._warn_once(
+                    ("non-mapping-json", str(path), opened_signature),
+                    "Ignoring gateway.channel_context_map file %s: JSON root must be an object",
+                    path,
+                )
+                return {}
+
+            contexts = self._normalize_mapping(data, label=f"file {path}")
+            self._cache(path, opened_signature, contexts)
+            return contexts
+
+        self._drop_cached_path(path)
+        self._warn_once(
+            ("file-changing", str(path)),
+            "Ignoring gateway.channel_context_map file %s while it is changing",
+            path,
+        )
+        return {}
+
+    def _get_cached(
+        self,
+        path: Path,
+        signature: _FileSignature,
+    ) -> Optional[dict[str, str]]:
+        with self._lock:
+            cached = self._file_cache.get(path)
+            if cached is None or cached.signature != signature:
+                return None
+            self._file_cache.move_to_end(path)
+            return cached.contexts
+
+    def _cache(
+        self,
+        path: Path,
+        signature: _FileSignature,
+        contexts: dict[str, str],
+    ) -> None:
+        with self._lock:
+            self._file_cache[path] = _CachedFileMap(signature, dict(contexts))
+            self._file_cache.move_to_end(path)
+            while len(self._file_cache) > self._max_cached_files:
+                self._file_cache.popitem(last=False)
+
+    def _drop_cached_path(self, path: Path) -> None:
+        with self._lock:
+            self._file_cache.pop(path, None)
+
+    def _warn_once(
+        self,
+        key: tuple[Any, ...],
+        message: str,
+        *args: Any,
+    ) -> None:
+        with self._lock:
+            if key in self._warning_keys:
+                self._warning_keys.move_to_end(key)
+                return
+            self._warning_keys[key] = None
+            while len(self._warning_keys) > _MAX_WARNING_KEYS:
+                self._warning_keys.popitem(last=False)
+        logger.warning(message, *args)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1744,6 +1744,10 @@ os.environ["HERMES_EXEC_ASK"] = "1"
 # see gateway/cwd_placeholder.py for the three-case contract (local vs docker
 # mount-off vs docker mount-on).  MESSAGING_CWD is a backward-compat fallback.
 from gateway.cwd_placeholder import CWD_PLACEHOLDERS, resolve_placeholder_terminal_cwd
+from gateway.channel_context import (
+    ChannelContextResolver,
+    merge_channel_context,
+)
 
 _configured_cwd = os.environ.get("TERMINAL_CWD", "")
 if not _configured_cwd or _configured_cwd in CWD_PLACEHOLDERS:
@@ -2420,6 +2424,21 @@ def _load_gateway_runtime_config() -> dict:
 
     expanded = _expand_env_vars(cfg)
     return expanded if isinstance(expanded, dict) else {}
+
+
+_channel_context_resolver = ChannelContextResolver()
+
+
+def _load_configured_channel_context(source: SessionSource) -> Optional[str]:
+    """Resolve profile-scoped configured context for one inbound chat."""
+
+    cfg = _load_gateway_runtime_config()
+    config_value = cfg_get(cfg, "gateway", "channel_context_map", default=None)
+    return _channel_context_resolver.context_for(
+        source,
+        config_value,
+        config_home=_gateway_config_home(),
+    )
 
 
 def _resolve_gateway_model(config: dict | None = None) -> str:
@@ -10552,11 +10571,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if _is_shared_multi_user and source.user_name:
             message_text = f"[{source.user_name}] {message_text}"
 
-        # Prepend channel context from history backfill (if any).  This
-        # happens after sender-prefix so the prefix only applies to the
-        # trigger message, not the backfill block.
-        if getattr(event, "channel_context", None):
-            message_text = f"{event.channel_context}\n\n[New message]\n{message_text}"
+        # Prepend adapter/backfill context followed by deterministic context
+        # configured for this platform-qualified chat.  Keep the merge local:
+        # mutating event.channel_context would duplicate configured context if
+        # the same event is prepared again after a retry or queue transition.
+        channel_context = merge_channel_context(
+            getattr(event, "channel_context", None),
+            _load_configured_channel_context(source),
+        )
+        if channel_context:
+            message_text = f"{channel_context}\n\n[New message]\n{message_text}"
 
         # Declare at outer scope so the audio-file-paths handling block below
         # remains safe when ``event.media_urls`` is empty (no inner block runs).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2898,6 +2898,12 @@ DEFAULT_CONFIG = {
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
+        # Deterministic context attached to inbound messages from specific
+        # chats. Accepts either an inline {"platform:chat_id": "context"}
+        # mapping or a JSON file path. Relative paths are resolved from the
+        # active profile's HERMES_HOME; file changes are picked up at runtime.
+        "channel_context_map": "",
+
         # Seconds the gateway waits for a single messaging platform to finish
         # connecting during startup (and on reconnect). Discord in particular
         # can blow past the old fixed 30s when an account has many slash

--- a/tests/gateway/test_channel_context_map.py
+++ b/tests/gateway/test_channel_context_map.py
@@ -1,0 +1,396 @@
+"""Behavior tests for config-driven per-chat inbound context."""
+
+import json
+import logging
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.channel_context import (
+    CONFIGURED_CHANNEL_CONTEXT_HEADER,
+    MAX_CHANNEL_CONTEXT_ENTRIES,
+    MAX_CHANNEL_CONTEXT_FILE_BYTES,
+    MAX_CHANNEL_CONTEXT_VALUE_BYTES,
+    ChannelContextResolver,
+    canonical_channel_context_key,
+    merge_channel_context,
+)
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False):
+        return None
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, text, **kwargs):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _adapter(platform: Platform) -> _StubAdapter:
+    return _StubAdapter(PlatformConfig(enabled=True, token="test"), platform)
+
+
+def _source(platform: Platform = Platform.TELEGRAM, chat_id: str = "123") -> SessionSource:
+    return SessionSource(platform=platform, chat_id=chat_id, chat_type="dm")
+
+
+def _runner(*, multiplex_profiles: bool = False) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        group_sessions_per_user=False,
+        multiplex_profiles=multiplex_profiles,
+    )
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+    return runner
+
+
+@pytest.fixture(autouse=True)
+def _isolated_runtime_resolver(monkeypatch):
+    """Prevent resolver state from leaking between tests in this file."""
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_channel_context_resolver",
+        ChannelContextResolver(),
+    )
+
+
+def _write_runtime_config(home: Path, yaml_body: str) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(yaml_body, encoding="utf-8")
+
+
+def test_adapter_source_uses_raw_chat_id_but_lookup_key_is_platform_qualified():
+    source = _adapter(Platform.TELEGRAM).build_source(123456, chat_type="group")
+
+    assert source.chat_id == "123456"
+    assert canonical_channel_context_key(source) == "telegram:123456"
+
+
+def test_platform_qualified_keys_isolate_identical_raw_chat_ids(tmp_path):
+    resolver = ChannelContextResolver()
+    config = {
+        "telegram:42": "Telegram workspace",
+        "discord:42": "Discord workspace",
+    }
+
+    assert resolver.context_for(
+        _source(Platform.TELEGRAM, "42"), config, config_home=tmp_path
+    ) == "Telegram workspace"
+    assert resolver.context_for(
+        _source(Platform.DISCORD, "42"), config, config_home=tmp_path
+    ) == "Discord workspace"
+    assert resolver.context_for(
+        _source(Platform.SLACK, "42"), config, config_home=tmp_path
+    ) is None
+
+
+def test_canonical_key_preserves_native_colons():
+    source = _source(Platform.MATRIX, "!room-id:example.org")
+
+    assert canonical_channel_context_key(source) == "matrix:!room-id:example.org"
+
+
+def test_merge_marks_configured_context_after_adapter_context():
+    merged = merge_channel_context("[Recent messages]\nAlice: earlier", "Workspace A")
+
+    assert merged == (
+        "[Recent messages]\nAlice: earlier\n\n"
+        f"{CONFIGURED_CHANNEL_CONTEXT_HEADER}\nWorkspace A"
+    )
+
+
+def test_inline_mapping_rejects_invalid_entries_without_logging_secrets(
+    tmp_path,
+    caplog,
+):
+    resolver = ChannelContextResolver()
+    secret_chat_id = "telegram:998877665544332211"
+    secret_context = "do-not-log-this-context"
+    config = {
+        secret_chat_id: secret_context + ("x" * MAX_CHANNEL_CONTEXT_VALUE_BYTES),
+        123: "non-string key",
+        "telegram:numeric-value": 123,
+        "missing-platform-prefix": "invalid key",
+        "telegram:blank": "   ",
+        "telegram:valid": "safe",
+    }
+    caplog.set_level(logging.WARNING, logger="gateway.channel_context")
+
+    assert resolver.context_for(
+        _source(chat_id="valid"), config, config_home=tmp_path
+    ) == "safe"
+    assert resolver.context_for(
+        _source(chat_id="998877665544332211"), config, config_home=tmp_path
+    ) is None
+    assert secret_chat_id not in caplog.text
+    assert secret_context not in caplog.text
+
+
+def test_inline_mapping_over_entry_limit_fails_closed(tmp_path):
+    resolver = ChannelContextResolver()
+    config = {
+        f"telegram:{index}": "context"
+        for index in range(MAX_CHANNEL_CONTEXT_ENTRIES + 1)
+    }
+
+    assert resolver.context_for(
+        _source(chat_id="0"), config, config_home=tmp_path
+    ) is None
+
+
+def test_unchanged_file_is_parsed_only_once(tmp_path):
+    resolver = ChannelContextResolver()
+    map_file = tmp_path / "chat-context.json"
+    map_file.write_text(json.dumps({"telegram:42": "first"}), encoding="utf-8")
+
+    with patch("gateway.channel_context.json.loads", wraps=json.loads) as loads:
+        assert resolver.context_for(
+            _source(chat_id="42"), str(map_file), config_home=tmp_path
+        ) == "first"
+        assert resolver.context_for(
+            _source(chat_id="42"), str(map_file), config_home=tmp_path
+        ) == "first"
+
+    assert loads.call_count == 1
+
+
+def test_atomic_replace_invalidates_same_mtime_and_size(tmp_path):
+    resolver = ChannelContextResolver()
+    map_file = tmp_path / "chat-context.json"
+    replacement = tmp_path / "chat-context.next"
+    first = json.dumps({"telegram:42": "one"})
+    second = json.dumps({"telegram:42": "two"})
+    assert len(first.encode()) == len(second.encode())
+    map_file.write_text(first, encoding="utf-8")
+
+    assert resolver.context_for(
+        _source(chat_id="42"), str(map_file), config_home=tmp_path
+    ) == "one"
+
+    original_stat = map_file.stat()
+    replacement.write_text(second, encoding="utf-8")
+    os.utime(
+        replacement,
+        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+    )
+    os.replace(replacement, map_file)
+
+    assert resolver.context_for(
+        _source(chat_id="42"), str(map_file), config_home=tmp_path
+    ) == "two"
+
+
+def test_switching_paths_with_same_mtime_does_not_reuse_other_file(tmp_path):
+    resolver = ChannelContextResolver()
+    first_file = tmp_path / "first.json"
+    second_file = tmp_path / "second.json"
+    first_file.write_text(json.dumps({"telegram:42": "one"}), encoding="utf-8")
+    second_file.write_text(json.dumps({"telegram:42": "two"}), encoding="utf-8")
+    first_stat = first_file.stat()
+    os.utime(second_file, ns=(first_stat.st_atime_ns, first_stat.st_mtime_ns))
+
+    assert resolver.context_for(
+        _source(chat_id="42"), str(first_file), config_home=tmp_path
+    ) == "one"
+    assert resolver.context_for(
+        _source(chat_id="42"), str(second_file), config_home=tmp_path
+    ) == "two"
+
+
+def test_file_cache_evicts_least_recently_used_path(tmp_path):
+    resolver = ChannelContextResolver(max_cached_files=1)
+    first_file = tmp_path / "first.json"
+    second_file = tmp_path / "second.json"
+    first_file.write_text(json.dumps({"telegram:42": "one"}), encoding="utf-8")
+    second_file.write_text(json.dumps({"telegram:42": "two"}), encoding="utf-8")
+
+    assert resolver.context_for(
+        _source(chat_id="42"), str(first_file), config_home=tmp_path
+    ) == "one"
+    assert resolver.context_for(
+        _source(chat_id="42"), str(second_file), config_home=tmp_path
+    ) == "two"
+
+    with patch("gateway.channel_context.json.loads", wraps=json.loads) as loads:
+        assert resolver.context_for(
+            _source(chat_id="42"), str(first_file), config_home=tmp_path
+        ) == "one"
+
+    assert loads.call_count == 1
+
+
+def test_missing_or_invalid_file_does_not_reuse_cached_context(tmp_path):
+    resolver = ChannelContextResolver()
+    map_file = tmp_path / "chat-context.json"
+    map_file.write_text(json.dumps({"telegram:42": "stale"}), encoding="utf-8")
+
+    assert resolver.context_for(
+        _source(chat_id="42"), str(map_file), config_home=tmp_path
+    ) == "stale"
+
+    map_file.unlink()
+    assert resolver.context_for(
+        _source(chat_id="42"), str(map_file), config_home=tmp_path
+    ) is None
+
+    map_file.write_text("{partial", encoding="utf-8")
+    assert resolver.context_for(
+        _source(chat_id="42"), str(map_file), config_home=tmp_path
+    ) is None
+
+    map_file.write_text(json.dumps({"telegram:42": "fresh"}), encoding="utf-8")
+    assert resolver.context_for(
+        _source(chat_id="42"), str(map_file), config_home=tmp_path
+    ) == "fresh"
+
+
+def test_oversized_file_fails_closed(tmp_path):
+    resolver = ChannelContextResolver()
+    map_file = tmp_path / "chat-context.json"
+    map_file.write_bytes(b"x" * (MAX_CHANNEL_CONTEXT_FILE_BYTES + 1))
+
+    assert resolver.context_for(
+        _source(chat_id="42"), str(map_file), config_home=tmp_path
+    ) is None
+
+
+def test_invalid_file_path_fails_closed(tmp_path):
+    resolver = ChannelContextResolver()
+
+    assert resolver.context_for(
+        _source(chat_id="42"), "chat\x00context.json", config_home=tmp_path
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"[" * 1200 + b"]" * 1200,
+        b'{"telegram:42": ' + (b"9" * 5000) + b"}",
+    ],
+    ids=["excessive-nesting", "integer-digit-limit"],
+)
+def test_json_parser_limits_fail_closed(tmp_path, payload):
+    resolver = ChannelContextResolver()
+    map_file = tmp_path / "chat-context.json"
+    map_file.write_bytes(payload)
+
+    assert resolver.context_for(
+        _source(chat_id="42"), str(map_file), config_home=tmp_path
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_inline_runtime_config_injects_without_mutating_event(
+    tmp_path,
+    monkeypatch,
+):
+    home = tmp_path / "default-profile"
+    _write_runtime_config(
+        home,
+        """gateway:
+  channel_context_map:
+    "telegram:123456": "Bound to workspace A."
+""",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+
+    source = _adapter(Platform.TELEGRAM).build_source(
+        "123456",
+        chat_type="group",
+        user_name="Alice",
+    )
+    event = MessageEvent(
+        text="status",
+        source=source,
+        channel_context="[Recent messages]\nBob: earlier",
+    )
+    runner = _runner()
+
+    first = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+    second = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    expected = (
+        "[Recent messages]\nBob: earlier\n\n"
+        f"{CONFIGURED_CHANNEL_CONTEXT_HEADER}\nBound to workspace A.\n\n"
+        "[New message]\n[Alice] status"
+    )
+    assert first == expected
+    assert second == expected
+    assert event.channel_context == "[Recent messages]\nBob: earlier"
+
+
+@pytest.mark.asyncio
+async def test_file_runtime_config_resolves_relative_to_routed_profile(
+    tmp_path,
+    monkeypatch,
+):
+    default_home = tmp_path / "default"
+    secondary_home = tmp_path / "profiles" / "secondary"
+    _write_runtime_config(
+        default_home,
+        """gateway:
+  channel_context_map:
+    "telegram:42": "Wrong profile"
+""",
+    )
+    _write_runtime_config(
+        secondary_home,
+        """gateway:
+  channel_context_map: maps/chat-context.json
+""",
+    )
+    map_dir = secondary_home / "maps"
+    map_dir.mkdir()
+    (map_dir / "chat-context.json").write_text(
+        json.dumps({"telegram:42": "Secondary profile workspace"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.setattr(gateway_run, "_hermes_home", default_home)
+
+    source = _adapter(Platform.TELEGRAM).build_source("42")
+    source.profile = "secondary"
+    runner = _runner(multiplex_profiles=True)
+    monkeypatch.setattr(
+        runner,
+        "_resolve_profile_home_for_source",
+        lambda _source: secondary_home,
+    )
+
+    result = await runner._prepare_profile_scoped_inbound_message_text(
+        event=MessageEvent(text="hello", source=source),
+        source=source,
+        history=[],
+        session_key="agent:secondary:telegram:dm:42",
+    )
+
+    assert result == (
+        f"{CONFIGURED_CHANNEL_CONTEXT_HEADER}\nSecondary profile workspace\n\n"
+        "[New message]\nhello"
+    )

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1685,6 +1685,60 @@ For separate natural mid-turn assistant updates without progressive token editin
 The master `streaming.enabled` switch is `false` by default — nothing streams until you flip it. Once enabled, streaming is decided **per platform**: Telegram ships with `display.platforms.telegram.streaming: true` (streams) and Discord with `display.platforms.discord.streaming: false` (does not). So after enabling streaming, Telegram streams out of the box and Discord stays on whole-message replies until you change its toggle. You can adjust these per-platform switches from the dashboard's **Channels** toggles or directly in `~/.hermes/config.yaml`.
 :::
 
+## Per-chat Inbound Context
+
+Attach deterministic operator-managed context to messages from a specific chat:
+
+```yaml
+gateway:
+  channel_context_map:
+    "telegram:-1002285219667": "This chat is bound to the release workspace."
+    "discord:123456789012345678": "Use the customer-support runbook for this channel."
+```
+
+Keys always use the exact `<platform>:<chat_id>` form. The platform prefix is
+required even when chat IDs appear globally unique; Hermes does not fall back to
+unqualified IDs because the same raw ID can exist on multiple platforms. Native
+colons inside a chat ID are preserved, for example
+`matrix:!room-id:example.org`.
+
+For maps maintained by another process, point the setting at a JSON file:
+
+```yaml
+gateway:
+  channel_context_map: chat-context.json
+```
+
+Relative paths resolve from the active profile's `HERMES_HOME`; `~` and
+`${ENV_VAR}` references are supported. The JSON root must be an object with the
+same string-to-string entries as the inline form:
+
+```json
+{
+  "telegram:-1002285219667": "This chat is bound to the release workspace.",
+  "discord:123456789012345678": "Use the customer-support runbook for this channel."
+}
+```
+
+Hermes checks file metadata on each inbound message and re-parses only when the
+file changes, so updates do not require a gateway restart. External writers
+should write a sibling temporary file and atomically replace the configured
+file (for example with `os.replace`) so the gateway never observes partial
+JSON. If the file is missing, malformed, changing during the read, or outside
+the limits below, no configured context is injected for that message; stale
+cached bindings are not reused.
+
+- Maximum JSON file size: 1 MiB
+- Maximum entries: 4096
+- Maximum UTF-8 key size: 512 bytes
+- Maximum UTF-8 context size per entry: 2 KiB
+
+Configured text is marked as `[Configured chat context]` in the inbound model
+message. If an adapter also supplied history/backfill context, adapter context
+comes first and configured context follows it. Treat this map like the rest of
+`config.yaml`: its contents are local operator-controlled instructions sent to
+the model, not untrusted chat metadata.
+
 ## Group Chat Session Isolation
 
 Limit how many chat sessions can actively be open across CLI, TUI/dashboard,


### PR DESCRIPTION
## Problem

The inbound pipeline already accepts adapter-provided `event.channel_context`, but operators cannot attach deterministic context to a specific chat through configuration. Dynamic orchestrators therefore have to patch `gateway/run.py` and re-apply that patch after every update.

This keeps the inline/file config shape proposed by @liuhao1024 in #43728 and provides a current-`main` implementation that incorporates the review feedback there around canonical keys, cache identity, runtime config resolution, and integration coverage.

## Solution

Add `gateway.channel_context_map` with inline and JSON-file forms:

```yaml
gateway:
  channel_context_map:
    "telegram:-1002285219667": "This chat is bound to the release workspace."
```

```yaml
gateway:
  channel_context_map: chat-context.json
```

- Keys use one canonical `<platform>:<chat_id>` form, preserving native colons and never falling back to an unqualified ID.
- Relative paths resolve from the active profile's `HERMES_HOME`; `~` and `${ENV_VAR}` are supported through the existing runtime config path.
- Adapter/backfill context remains first. Configured context is appended under `[Configured chat context]` without mutating the inbound event.
- File-backed maps are checked on each inbound message and parsed only when their path/signature changes. Cache identity includes path, device, inode, size, mtime, and ctime, with bounded LRU state.
- Missing, malformed, oversized, non-regular, or concurrently changing files fail closed for that message; stale bindings are not reused. The docs specify atomic replacement for external writers.
- Validation limits files to 1 MiB, 4096 entries, 512-byte UTF-8 keys, and 2 KiB UTF-8 context values. Warning deduplication is also bounded and does not log map keys or values.

## Testing

- Added direct resolver coverage for canonical keys, inline/file config, profile isolation, cache invalidation, atomic replacement, TOCTOU changes, size/type limits, parser/path failures, and bounded caches.
- Added runtime integration coverage for merge order, event immutability, profile-scoped config loading, and existing sender/context behavior.
- `scripts/run_tests.sh tests/gateway/test_channel_context_map.py tests/gateway/test_session.py tests/gateway/test_shared_group_sender_prefix.py tests/gateway/test_context_ref_expansion_runtime.py tests/gateway/relay/test_channel_context_consume.py -q` — 145 passed.
- Ruff and `git diff --check` pass.

Closes #43650
