### PR TITLE
fix: raise lazy dependency security floors

### DIFF
--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -220,8 +220,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "tool.dashboard": (
         "fastapi==0.133.1",
         "uvicorn[standard]==0.41.0",
-        "starlette==1.0.1",  # CVE-2026-48710 (BadHost) — keep lazy-install in sync with pyproject [web]
-        "python-multipart==0.0.27",  # FastAPI UploadFile/Form for streaming uploads (NS-501)
+        "starlette==1.3.1",  # GHSA-82w8-qh3p-5jfq — keep lazy-install in sync with pyproject [web]
+        "python-multipart==0.0.31",  # GHSA-5rvq-cxj2-64vf and upload parser hardening
     ),
     # Vision image-resize recovery (Pillow). Pillow is now a CORE dependency
     # (pyproject `dependencies`), so this entry is a belt-and-suspenders fallback
@@ -236,7 +236,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # installs so computer_use never dead-ends on `No module named 'mcp'`.
     "tool.computer_use": (
         "mcp==1.26.0",
-        "starlette==1.0.1",  # CVE-2026-48710 — keep in sync with pyproject [computer-use]
+        "starlette==1.3.1",  # GHSA-82w8-qh3p-5jfq — keep in sync with pyproject [computer-use]
     ),
     # HF Agent Trace Viewer upload (hermes trace upload / /upload-trace).
     "tool.trace_upload": ("huggingface-hub==1.2.3",),


### PR DESCRIPTION
## Summary

Raise the dashboard/computer-use lazy-install floors to:

- `starlette==1.3.1` for GHSA-82w8-qh3p-5jfq
- `python-multipart==0.0.31` for GHSA-5rvq-cxj2-64vf and parser hardening

This fixes the lazy-install side of a packaging-pin mismatch discovered during a dependency-security refresh: lazy dependency pins must track the corresponding `pyproject.toml` extras or a later lazy install can downgrade an already-secure environment.

## Scope

This PR intentionally contains only `tools/lazy_deps.py`. The corresponding package metadata/lockfile floor update is not included in this branch.

## Verification

- `git diff --check` passes.
- Commit scope is one file: `tools/lazy_deps.py`.
- The repository’s pin-consistency test requires the corresponding `pyproject.toml` floors to match before the combined security update is green.

## Risk

Until package metadata is raised to the same versions, this isolated change exposes the existing pin mismatch rather than completing the full dependency-floor migration. It prevents the lazy-install definitions from retaining known-vulnerable floors once the package metadata update lands.
