### PR TITLE
fix(desktop): stop reasoning text flashing on every stream delta

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type SmoothOptions, TextMessagePartProvider, useMessagePartText } from '@assistant-ui/react'
+import { TextMessagePartProvider, useMessagePartText } from '@assistant-ui/react'
 import {
   parseMarkdownIntoBlocks,
   type StreamdownTextComponents,
@@ -342,7 +342,6 @@ interface MarkdownTextSurfaceProps {
   containerClassName?: string
   containerProps?: ComponentProps<'div'>
   defer?: boolean
-  smooth?: boolean | SmoothOptions
 }
 
 // Headings shrink to chat scale rather than the prose default (h1≈xl). Kept
@@ -391,7 +390,7 @@ function HugeTextFallback({ containerClassName, text }: { containerClassName?: s
   )
 }
 
-function MarkdownTextSurface({ containerClassName, containerProps, defer, smooth }: MarkdownTextSurfaceProps) {
+function MarkdownTextSurface({ containerClassName, containerProps, defer }: MarkdownTextSurfaceProps) {
   const { status, text } = useMessagePartText()
   const isStreaming = status.type === 'running'
 
@@ -531,15 +530,8 @@ function MarkdownTextSurface({ containerClassName, containerProps, defer, smooth
       parseMarkdownIntoBlocksFn={parseMarkdownIntoBlocksCached}
       plugins={plugins}
       preprocess={preprocessWithTailRepair}
-      smooth={smooth}
     />
   )
-}
-
-const SMOOTH_OPTIONS: SmoothOptions = {
-  drainMs: 500,
-  maxCharsPerFrame: 30,
-  minCommitMs: 33
 }
 
 interface MarkdownTextContentProps extends MarkdownTextSurfaceProps {
@@ -548,12 +540,15 @@ interface MarkdownTextContentProps extends MarkdownTextSurfaceProps {
 }
 
 export function MarkdownTextContent({ isRunning, text, ...surfaceProps }: MarkdownTextContentProps) {
-  // Same path as the assistant answer. A reasoning-only smoothing wrapper used
-  // to sit here but stalled its char-reveal at empty (the part stays running
-  // the whole message), blanking the Thinking widget.
+  // No `smooth` on purpose — same as the assistant answer. `TextMessagePartProvider`
+  // mints a fresh part object on every `text` change, and useSmooth resets its
+  // reveal to empty whenever the part identity changes, so a smoothed reasoning
+  // stream re-types from the first character on every delta (the flash). Token-
+  // streaming reasoners (R1/Qwen/GLM/Claude thinking) hit it hardest; GPT-5's
+  // coarse summary updates too rarely to notice. Plain append matches the answer.
   return (
     <TextMessagePartProvider isRunning={isRunning} text={text}>
-      <MarkdownTextSurface defer smooth={SMOOTH_OPTIONS} {...surfaceProps} />
+      <MarkdownTextSurface defer {...surfaceProps} />
     </TextMessagePartProvider>
   )
 }


### PR DESCRIPTION
## Summary

The "Thinking" (reasoning) block re-typed from the first character on every streaming delta — `h / hell / hello wo / hello world`, flashing the whole message. This kills that.

## Root cause

Reasoning renders through `MarkdownTextContent`, which wraps the text in `TextMessagePartProvider` and enabled a smooth typewriter reveal (`smooth={SMOOTH_OPTIONS}`). Two library internals collide:

- `TextMessagePartProvider` **mints a fresh part object every time `text` changes** (memoized on `[status, text]`).
- `useSmooth` resets its reveal to empty whenever the part identity changes:

  ```js
  if (part !== prevPart || !text.startsWith(displayedText)) {
    setDisplayedText(state.status.type === "running" ? "" : text) // → ""
  }
  ```

The reasoning part is `running` for the whole message, so every delta → new part identity → reveal resets to empty → re-types from char 0. It's structural, not model-specific.

**Why GPT-5.5 looked fine:** it doesn't stream raw chain-of-thought — the Responses API returns a coarse reasoning *summary* in a handful of updates, too infrequent for the reset to be visible. Token-streaming reasoners (DeepSeek-R1, Qwen/QwQ, GLM, Kimi, Anthropic extended thinking) emit a `reasoning.delta` per token and flash hard.

## Fix

Drop `smooth` on the reasoning path so it plain-appends, exactly like the assistant answer already does (the answer never used smooth, which is why it never flashed). Also removes the now-dead `smooth` prop plumbing and `SMOOTH_OPTIONS` constant.

## Test plan

- [ ] Stream a response from a token-streaming reasoner (e.g. DeepSeek-R1 / Qwen thinking / Claude extended thinking) and confirm the Thinking block appends smoothly with no re-typing/flash.
- [ ] Confirm GPT-5.x reasoning still renders identically.
- [ ] Confirm the assistant answer text is unchanged.

Typecheck + lint + prettier clean on the desktop app.