### PR TITLE
fix: classify stale-call circuit breaker as failover not retry

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -840,12 +840,34 @@ def classify_api_error(
             )
         return _result(FailoverReason.timeout, retryable=True)
 
-    # ── 7. Transport / timeout heuristics ───────────────────────────
+    # ── 7b. Stale-call circuit breaker → failover immediately ──────
+    # _check_stale_giveup() in agent/chat_completion_helpers.py raises a
+    # RuntimeError when the provider has been unresponsive for N
+    # consecutive stale attempts (default 5).  The error is NOT a transport
+    # timeout — the circuit breaker fires *before* any network call to avoid
+    # an indefinite stall.  Without this classification the RuntimeError
+    # falls through to FailoverReason.unknown (retryable=True), which burns
+    # all max_retries against the same dead provider (each retry hitting the
+    # circuit breaker instantly with zero network overhead) before fallback
+    # is attempted.  Classify as non-retryable + should_fallback so the
+    # retry loop activates the next fallback provider on the first hit.
+    if (
+        error_type == "RuntimeError"
+        and "consecutive stale attempts" in error_msg
+        and "aborting this call" in error_msg
+    ):
+        return _result(
+            FailoverReason.timeout,
+            retryable=False,
+            should_fallback=True,
+        )
+
+    # ── 8. Transport / timeout heuristics ───────────────────────────
 
     if error_type in _TRANSPORT_ERROR_TYPES or isinstance(error, (TimeoutError, ConnectionError, OSError)):
         return _result(FailoverReason.timeout, retryable=True)
 
-    # ── 8. Fallback: unknown ────────────────────────────────────────
+    # ── 9. Fallback: unknown ────────────────────────────────────────
 
     return _result(FailoverReason.unknown, retryable=True)
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -2067,3 +2067,26 @@ class Test408RequestTimeout:
         assert result.retryable is True
         assert result.should_compress is False
 
+    def test_stale_breaker_runtime_error_triggers_fallback_not_retry(self):
+        # The cross-turn stale-call circuit breaker (_check_stale_giveup in
+        # chat_completion_helpers.py) raises a RuntimeError when the provider
+        # has been unresponsive for N consecutive stale attempts.  This must
+        # be classified as non-retryable + should_fallback so the retry loop
+        # activates the fallback provider immediately instead of burning all
+        # max_retries against the same dead provider (each retry hitting the
+        # circuit breaker instantly with zero network overhead).
+        e = RuntimeError(
+            "Provider has been unresponsive (no response received) for "
+            "6 consecutive stale attempts — aborting this call to "
+            "avoid an indefinite stall. Switch models or start a new "
+            "session, then retry."
+        )
+        result = classify_api_error(
+            e, provider="openrouter", model="anthropic/claude-fable-5",
+            approx_tokens=126327, context_length=200000, num_messages=274,
+        )
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+        assert result.should_compress is False
+


### PR DESCRIPTION
## Summary

The cross-turn stale-call circuit breaker (`_check_stale_giveup` in `agent/chat_completion_helpers.py`) raises a `RuntimeError` when the provider has been unresponsive for N consecutive stale attempts (default 5). This RuntimeError was classified as `FailoverReason.unknown` (`retryable=True, should_fallback=False`), causing the retry loop to burn all `max_retries` against the same dead provider — each retry hitting the circuit breaker instantly with zero network overhead — before fallback was attempted.

**User-visible symptom:**

```
⚠️  API call failed (attempt 1/3): RuntimeError
   📝 Error: Provider has been unresponsive (no response received) for 6 consecutive stale attempts — aborting this call...
⏳ Retrying in 2.3s (attempt 1/3)...
⚠️  API call failed (attempt 2/3): RuntimeError
   📝 Error: Provider has been unresponsive (no response received) for 6 consecutive stale attempts — aborting this call...
⏳ Retrying in 5.1s (attempt 2/3)...
⚠️  API call failed (attempt 3/3): RuntimeError
   📝 Error: Provider has been unresponsive (no response received) for 6 consecutive stale attempts — aborting this call...
⚠️ Max retries (3) exhausted — trying fallback...
```

Three retries × backoff delays = ~17s wasted per occurrence, then fallback.

## Fix

Add a classification rule (section 7b in `classify_api_error`) that recognizes the stale-breaker RuntimeError by its signature phrases (`"consecutive stale attempts"` + `"aborting this call"`) and classifies it as `FailoverReason.timeout` with `retryable=False, should_fallback=True`. This makes the retry loop:

1. Skip all retries (non-retryable)
2. Enter the `is_client_error` path immediately (first error, not third)
3. Call `_try_activate_fallback()` which activates the fallback provider
4. Fallback activation resets the stale streak (existing behavior at `chat_completion_helpers.py:1664`)

**Before:** 3 retries × backoff = ~17s wasted, then fallback
**After:** 0 retries, immediate fallback, stale streak reset

## Verification

- `test_stale_breaker_runtime_error_triggers_fallback_not_retry` — asserts the new classification using the exact error message from user session logs
- All 194 existing error classifier tests pass (193 + 1 new)
