### PR TITLE
fix(agent): send session-scope headers to custom Codex-compatible providers (#65094)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1389,6 +1389,18 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             )
         )
         is_xai_responses = agent.provider in {"xai", "xai-oauth"} or agent._base_url_hostname == "api.x.ai"
+        # A custom OpenAI-compatible /v1 provider (e.g. a Codex-protocol
+        # pooler) reaches this codex_responses wire format without matching
+        # any of the three named backends above. It still benefits from the
+        # session_id / x-client-request-id cache-scope headers the Codex
+        # backend gets — those are plain HTTP headers (safe for any HTTP
+        # provider to receive, unlike Codex's body-level extra_headers
+        # rejection) — but is otherwise untouched (issuer classification,
+        # max_output_tokens handling) since this is scoped to the one gap
+        # reported: missing session headers (#65094).
+        is_custom_responses_backend = (
+            not is_codex_backend and not is_github_responses and not is_xai_responses
+        )
         _msgs_for_codex = agent._prepare_messages_for_non_vision_model(api_messages)
 
         # Native server-side compaction (gpt-5.6 on direct OpenAI API /
@@ -1448,6 +1460,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
+            is_custom_responses_backend=is_custom_responses_backend,
             github_reasoning_extra=agent._github_models_reasoning_extra_body() if is_github_responses else None,
             replay_encrypted_reasoning=bool(
                 getattr(agent, "_codex_reasoning_replay_enabled", True)

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -247,6 +247,10 @@ class ResponsesApiTransport(ProviderTransport):
             is_github_responses: bool — Copilot/GitHub models backend
             is_codex_backend: bool — chatgpt.com/backend-api/codex
             is_xai_responses: bool — xAI/Grok backend
+            is_custom_responses_backend: bool — any other /v1 provider using
+                this wire format (e.g. a Codex-protocol pooler); gets the
+                same session-scope headers as ``is_codex_backend`` but is
+                otherwise unaffected (#65094)
             github_reasoning_extra: dict | None — Copilot reasoning params
         """
         from agent.codex_responses_adapter import (
@@ -268,6 +272,7 @@ class ResponsesApiTransport(ProviderTransport):
         is_github_responses = params.get("is_github_responses") is True
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
+        is_custom_responses_backend = params.get("is_custom_responses_backend") is True
         replay_encrypted_reasoning = bool(
             params.get("replay_encrypted_reasoning", True)
         )
@@ -466,7 +471,7 @@ class ResponsesApiTransport(ProviderTransport):
         else:
             kwargs.pop("timeout", None)
 
-        if is_codex_backend:
+        if is_codex_backend or is_custom_responses_backend:
             # The Codex backend rejects body-level ``extra_headers`` with
             # HTTP 400, but the OpenAI SDK's ``extra_headers`` kwarg maps
             # to actual HTTP request headers (not body fields).  ``session_id``
@@ -474,6 +479,8 @@ class ResponsesApiTransport(ProviderTransport):
             # the #57012 contract — while ``x-client-request-id`` mirrors the
             # body's effective ``prompt_cache_key`` so header and body always
             # agree on the same routing bucket instead of diverging (#78941).
+            # Also applied for custom /v1 providers on this wire format
+            # (`is_custom_responses_backend`, #65094).
             final_cache_key = kwargs.get("prompt_cache_key") or _bounded_prompt_cache_key(_cache_scope)
             if session_id or final_cache_key:
                 existing_extra_headers = kwargs.get("extra_headers")

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -331,6 +331,58 @@ class TestCodexBuildKwargs:
 
 
 
+
+    def test_custom_responses_backend_sets_cache_routing_headers(self, transport):
+        """A custom OpenAI-compatible /v1 provider using this wire format
+        (e.g. a Codex-protocol pooler) gets the same session-scope headers
+        as the real Codex backend — the gap reported in #65094."""
+        messages = [{"role": "user", "content": "Hi"}]
+
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            session_id="conv-custom-1",
+            is_codex_backend=False,
+            is_custom_responses_backend=True,
+        )
+
+        headers = kw.get("extra_headers", {})
+        assert headers.get("session_id") == "conv-custom-1"
+        # On modern main, x-client-request-id mirrors the body prompt_cache_key
+        # (content-addressed), not the raw session_id (#78941).
+        assert headers.get("x-client-request-id") == kw["prompt_cache_key"]
+
+    def test_custom_responses_backend_still_gets_max_output_tokens(self, transport):
+        """Unlike the real Codex backend, a custom provider keeps
+        max_output_tokens — only the session headers gap is fixed, not the
+        Codex-specific max_tokens exemption (#65094 scope)."""
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            max_tokens=4096,
+            is_codex_backend=False,
+            is_custom_responses_backend=True,
+        )
+        assert kw.get("max_output_tokens") == 4096
+
+    def test_plain_non_codex_responses_still_gets_no_extra_headers(self, transport):
+        """A request with neither is_codex_backend nor
+        is_custom_responses_backend set (e.g. xAI/GitHub, handled by their
+        own flags) does not pick up the session-scope headers."""
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            session_id="conv-1",
+            is_codex_backend=False,
+            is_custom_responses_backend=False,
+        )
+        assert "extra_headers" not in kw
+
     def test_xai_injects_native_web_search_when_client_web_search_present(self, transport, monkeypatch):
         """When the active/configured search backend is xAI, swap client
         ``web_search`` for Grok's native built-in so server-side search

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -39,6 +39,9 @@ def _patch_agent_bootstrap(monkeypatch):
     monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
 
 
+_PLACEHOLDER_TOKEN = "-".join(["not", "a", "real", "credential"])
+
+
 def _build_agent(monkeypatch):
     _patch_agent_bootstrap(monkeypatch)
 
@@ -331,6 +334,85 @@ def test_build_api_kwargs_mantle_sets_extended_prompt_cache_retention(monkeypatc
 
 
 
+
+
+def test_build_api_kwargs_custom_responses_backend_gets_session_headers(monkeypatch):
+    """#65094: a custom OpenAI-compatible /v1 provider that opts into the
+    codex_responses wire format (e.g. a Codex-protocol pooler) must still
+    get the cache-scope routing headers, even though it isn't the Codex
+    backend, GitHub Copilot, or xAI.
+
+    Regression coverage for a real reviewer gap: the transport-level test
+    (tests/agent/transports/test_codex_transport.py's
+    test_custom_responses_backend_sets_cache_routing_headers) exercises
+    ResponsesApiTransport.build_kwargs() directly with hand-built flags —
+    it can't catch a break in the production classification/forwarding
+    path at agent/chat_completion_helpers.py that computes
+    is_custom_responses_backend and decides whether to pass session_id
+    through at all. This test drives the real agent._build_api_kwargs()
+    entry point end-to-end instead.
+    """
+    _patch_agent_bootstrap(monkeypatch)
+
+    agent = run_agent.AIAgent(
+        model="my-custom-model",
+        provider="custom",
+        api_mode="codex_responses",
+        base_url="https://my-codex-pooler.example.internal/v1",
+        api_key=_PLACEHOLDER_TOKEN,
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent.session_id = "session-abc123"
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+    headers = kwargs.get("extra_headers") or {}
+    assert headers.get("session_id") == "session-abc123", (
+        "A custom /v1 provider using codex_responses must receive the "
+        "session_id cache-scope header — see #65094."
+    )
+    # x-client-request-id mirrors the body prompt_cache_key (content-addressed),
+    # not the raw session_id (#78941).
+    assert headers.get("x-client-request-id") == kwargs.get("prompt_cache_key"), (
+        "A custom /v1 provider using codex_responses must receive the "
+        "x-client-request-id cache-scope header — see #65094."
+    )
+    assert headers.get("x-client-request-id"), "x-client-request-id must be set"
+
+
+def test_build_api_kwargs_custom_responses_backend_no_headers_without_session_id(monkeypatch):
+    """Sanity check: no session_id set → session_id header is not injected
+    (proves the session_id assertion above isn't trivially true for every
+    request). x-client-request-id may still be present when a content-addressed
+    prompt_cache_key exists (#78941)."""
+    _patch_agent_bootstrap(monkeypatch)
+
+    agent = run_agent.AIAgent(
+        model="my-custom-model",
+        provider="custom",
+        api_mode="codex_responses",
+        base_url="https://my-codex-pooler.example.internal/v1",
+        api_key=_PLACEHOLDER_TOKEN,
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent.session_id = None
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+    extra_headers = kwargs.get("extra_headers") or {}
+    assert "session_id" not in extra_headers
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`_is_openai_codex_backend`-style detection in `agent/chat_completion_helpers.py`
(`is_codex_backend`) only matches `agent.provider == "openai-codex"` or the
literal `chatgpt.com/backend-api/codex` URL. A custom OpenAI-compatible
`/v1` provider using the same `codex_responses` wire format (e.g. a Codex
Pooler) reaches the Responses transport but is classified as
`is_codex_backend = False`, so it never receives the `session_id` /
`x-client-request-id` HTTP headers used for prompt-cache-scope routing —
the session-header injection in `agent/transports/codex.py` is gated on
that same flag.

## Changes

- `agent/chat_completion_helpers.py`: added `is_custom_responses_backend`
  — true for any `codex_responses`-mode request that isn't already
  classified as xAI or GitHub Responses — and pass it through to
  `build_kwargs`.
- `agent/transports/codex.py`: extended only the session-header injection
  gate (`if is_codex_backend or is_custom_responses_backend:`) to include
  the new flag. Deliberately scoped narrow: the Codex-specific
  `max_output_tokens` exemption (`not is_codex_backend`, line ~366) and
  the issuer classification used for encrypted-reasoning replay safety
  (`_classify_responses_issuer`) are untouched — those aren't part of the
  reported gap and changing them would be a bigger, riskier surface than
  the missing headers.
- `tests/agent/transports/test_codex_transport.py`: added coverage
  mirroring the existing `is_codex_backend` header tests —
  `is_custom_responses_backend` gets the session headers, still gets
  `max_output_tokens` (unlike the real Codex backend), and a request with
  neither flag set still gets no extra headers.

## Validation

| Command | Result |
|---|---|
| `pytest tests/agent/transports/test_codex_transport.py -q` | 78 passed |
| Fail-before (stashed both source files) | new `is_custom_responses_backend` tests fail as expected |
| Pass-after (restored) | 78 passed |
| `pytest tests/agent/transports/ tests/agent/test_codex_responses_adapter.py tests/agent/test_codex_ttfb_watchdog.py tests/run_agent/test_codex_xai_oauth_recovery.py tests/run_agent/test_codex_no_tools_nonetype.py -q` | 470 passed |
| `ruff check` on touched files | All checks passed |

Closes #65094
