### PR TITLE
feat(skills): add opt-in routed loading

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1704,7 +1704,11 @@ def init_agent(
         skills_config = _agent_cfg.get("skills", {})
         agent._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 10))
     except Exception:
-        pass
+        skills_config = {}
+
+    from agent.skill_preprocessing import resolve_skill_loading_mode
+
+    agent.skills_loading_mode = resolve_skill_loading_mode(skills_config)
 
     # Tool-use enforcement config: "auto" (default — matches hardcoded
     # model list), true (always), false (never), or list of substrings.

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -26,6 +26,7 @@ from agent.skill_utils import (
     get_disabled_skill_names,
     iter_skill_index_files,
     parse_frontmatter,
+    skill_conditions_match,
     skill_matches_environment,
     skill_matches_platform,
     skill_matches_platform_list,
@@ -1323,7 +1324,7 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-_SKILLS_SNAPSHOT_VERSION = 1
+_SKILLS_SNAPSHOT_VERSION = 2
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1415,7 +1416,7 @@ def _build_snapshot_entry(
     parts = rel_path.parts
     if len(parts) >= 2:
         skill_name = parts[-2]
-        category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
+        category = "/".join(parts[:-2]) if len(parts) > 2 else "general"
     else:
         category = "general"
         skill_name = skill_file.parent.name
@@ -1469,30 +1470,8 @@ def _skill_should_show(
     available_tools: "set[str] | None",
     available_toolsets: "set[str] | None",
 ) -> bool:
-    """Return False if the skill's conditional activation rules exclude it."""
-    if available_tools is None and available_toolsets is None:
-        return True  # No filtering info — show everything (backward compat)
-
-    at = available_tools or set()
-    ats = available_toolsets or set()
-
-    # fallback_for: hide when the primary tool/toolset IS available
-    for ts in conditions.get("fallback_for_toolsets", []):
-        if ts in ats:
-            return False
-    for t in conditions.get("fallback_for_tools", []):
-        if t in at:
-            return False
-
-    # requires: hide when a required tool/toolset is NOT available
-    for ts in conditions.get("requires_toolsets", []):
-        if ts not in ats:
-            return False
-    for t in conditions.get("requires_tools", []):
-        if t not in at:
-            return False
-
-    return True
+    """Compatibility wrapper for shared skill-condition filtering."""
+    return skill_conditions_match(conditions, available_tools, available_toolsets)
 
 
 def _current_session_platform_hint() -> str:
@@ -1515,6 +1494,7 @@ def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
+    loading_mode: str = "eager",
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -1532,9 +1512,9 @@ def build_skills_system_prompt(
 
     ``compact_categories`` (e.g. from the coding posture — see
     agent/coding_context.py) demotes whole categories to a names-only line in
-    the rendered index. Nothing is ever hidden: every skill name stays
-    visible and loadable via ``skill_view`` / ``skills_list``; only the
-    descriptions are dropped, and a footer note explains the demotion.
+    the eager index. ``loading_mode='routed'`` renders only top-level category
+    counts; deterministic trigger matching and ``skills_list(category=...)`` /
+    ``skill_view(name=...)`` provide the on-demand loading path.
     """
     skills_dir = get_skills_dir()
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
@@ -1555,6 +1535,7 @@ def build_skills_system_prompt(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        loading_mode,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1567,6 +1548,7 @@ def build_skills_system_prompt(
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
+    seen_skill_names: set[str] = set()
 
     if snapshot is not None:
         # Fast path: use pre-parsed metadata from disk
@@ -1579,6 +1561,9 @@ def build_skills_system_prompt(
             platforms = entry.get("platforms") or []
             if not skill_matches_platform_list(platforms):
                 continue
+            if frontmatter_name in seen_skill_names:
+                continue
+            seen_skill_names.add(frontmatter_name)
             if frontmatter_name in disabled or skill_name in disabled:
                 continue
             if not _skill_should_show(
@@ -1604,7 +1589,11 @@ def build_skills_system_prompt(
             if not is_compatible:
                 continue
             skill_name = entry["skill_name"]
-            if entry["frontmatter_name"] in disabled or skill_name in disabled:
+            frontmatter_name = entry["frontmatter_name"]
+            if frontmatter_name in seen_skill_names:
+                continue
+            seen_skill_names.add(frontmatter_name)
+            if frontmatter_name in disabled or skill_name in disabled:
                 continue
             if not _skill_should_show(
                 extract_skill_conditions(frontmatter),
@@ -1613,7 +1602,7 @@ def build_skills_system_prompt(
             ):
                 continue
             skills_by_category.setdefault(entry["category"], []).append(
-                (entry["frontmatter_name"], entry["description"])
+                (frontmatter_name, entry["description"])
             )
 
         # Read category-level DESCRIPTION.md files
@@ -1641,11 +1630,6 @@ def build_skills_system_prompt(
     # Scan external dirs directly (no snapshot caching — they're read-only
     # and typically small).  Local skills already in skills_by_category take
     # precedence: we track seen names and skip duplicates from external dirs.
-    seen_skill_names: set[str] = set()
-    for cat_skills in skills_by_category.values():
-        for name, _desc in cat_skills:
-            seen_skill_names.add(name)
-
     for ext_dir in external_dirs:
         if not ext_dir.exists():
             continue
@@ -1688,6 +1672,8 @@ def build_skills_system_prompt(
             except Exception as e:
                 logger.debug("Could not read external skill description %s: %s", desc_file, e)
 
+    category_index_only = loading_mode == "routed"
+
     # Posture-driven category demotion (e.g. non-coding skills while pairing
     # on code). Demoted categories stay in the index as a single names-only
     # line — descriptions are dropped to cut noise, but every skill name
@@ -1699,11 +1685,19 @@ def build_skills_system_prompt(
     # their parent.
     demoted = frozenset(
         cat for cat in skills_by_category
-        if cat.split("/", 1)[0] in (compact_categories or frozenset())
+        if not category_index_only
+        and cat.split("/", 1)[0] in (compact_categories or frozenset())
     )
 
     hidden_note = ""
-    if demoted:
+    if category_index_only:
+        hidden_note = (
+            "\n(Routed skill-loading mode: only categories are shown in the "
+            "system prompt. Call skills_list(category='<category>') to inspect "
+            "a relevant category, then skill_view(name) to load the chosen "
+            "skill.)"
+        )
+    elif demoted:
         hidden_note = (
             "\n(Categories marked [names only] are outside the current coding "
             "context, so their descriptions are omitted — the skills work "
@@ -1714,9 +1708,29 @@ def build_skills_system_prompt(
         result = ""
     else:
         index_lines = []
-        for category in sorted(skills_by_category.keys()):
+        routed_categories: dict[str, set[str]] = {}
+        if category_index_only:
+            for category, skills in skills_by_category.items():
+                top_level = category.split("/", 1)[0]
+                routed_categories.setdefault(top_level, set()).update(
+                    name for name, _ in skills
+                )
+
+        categories_to_render = (
+            sorted(routed_categories) if category_index_only
+            else sorted(skills_by_category)
+        )
+        for category in categories_to_render:
             # Deduplicate and sort skills within each category
             seen = set()
+            if category_index_only:
+                count = len(routed_categories[category])
+                cat_desc = category_descriptions.get(category, "")
+                suffix = f" — {cat_desc}" if cat_desc else ""
+                index_lines.append(
+                    f"  {category}: {count} skill{'s' if count != 1 else ''}{suffix}"
+                )
+                continue
             if category in demoted:
                 names = sorted({name for name, _ in skills_by_category[category]})
                 index_lines.append(f"  {category} [names only]: {', '.join(names)}")
@@ -1726,7 +1740,9 @@ def build_skills_system_prompt(
                 index_lines.append(f"  {category}: {cat_desc}")
             else:
                 index_lines.append(f"  {category}:")
-            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
+            for name, desc in sorted(
+                skills_by_category[category], key=lambda x: x[0]
+            ):
                 if name in seen:
                     continue
                 seen.add(name)
@@ -1735,11 +1751,29 @@ def build_skills_system_prompt(
                 else:
                     index_lines.append(f"    - {name}")
 
+        routed_guidance = (
+            (
+                "The active skill-loading mode is `routed`: matching frontmatter triggers "
+                "are loaded automatically before the turn reaches the model. If no skill "
+                "was loaded and a category below could match the task, call "
+                "skills_list(category='<category>'), then load the best match with "
+                "skill_view(name). Do not conclude that no skill applies from the category "
+                "index alone.\n"
+            )
+            if category_index_only
+            else (
+                "Before replying, scan the skills below. If a skill matches or is even "
+                "partially relevant to your task, you MUST load it with skill_view(name) "
+                "and follow its instructions.\n"
+            )
+        )
+        index_tag = (
+            "available_skill_categories" if category_index_only else "available_skills"
+        )
         result = (
             "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
+            + routed_guidance
+            + "Err on the side of loading — it is always better to have context you don't need "
             "than to miss critical steps, pitfalls, or established workflows. "
             "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
             "and proven workflows that outperform general-purpose approaches. Load the skill "
@@ -1757,11 +1791,12 @@ def build_skills_system_prompt(
             "If a skill you loaded was missing steps, had wrong commands, or needed "
             "pitfalls you discovered, update it before finishing.\n"
             "\n"
-            "<available_skills>\n"
-            + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            + f"<{index_tag}>\n"
+            + "\n".join(index_lines)
+            + "\n"
+            + f"</{index_tag}>\n"
+            + "\n"
+            + "Only proceed without loading a skill if genuinely none are relevant to the task."
             + hidden_note
         )
 

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -27,6 +27,7 @@ _skill_commands_platform: Optional[str] = None
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
 _SKILL_TRIGGER_WORD = re.compile(r"^\w[\w\s-]*\w$|^\w$")
+_SKILL_TRIGGER_PLACEHOLDER = re.compile(r"\[[^\[\]\s]+\]")
 
 # ---------------------------------------------------------------------------
 # Skill-scaffolding markers and the canonical extractor.
@@ -219,9 +220,23 @@ def _extract_skill_triggers(frontmatter: Dict[str, Any]) -> list[str]:
 
 @lru_cache(maxsize=2048)
 def _compile_skill_trigger_pattern(trigger: str) -> re.Pattern[str]:
-    """Build a boundary-aware regex for a skill trigger phrase."""
+    """Build a boundary-aware regex for a skill trigger phrase.
+
+    Bracketed tokens such as ``[URL]`` and ``[owner/repo]`` are placeholders
+    for exactly one non-whitespace argument. Everything else is matched
+    literally, with declaration whitespace allowed to expand in user input.
+    """
     normalized = re.sub(r"\s+", " ", trigger.strip())
-    body = r"\s+".join(re.escape(part) for part in normalized.split(" "))
+    body_parts: list[str] = []
+    cursor = 0
+    for match in _SKILL_TRIGGER_PLACEHOLDER.finditer(normalized):
+        literal = normalized[cursor:match.start()]
+        body_parts.append(r"\s+".join(re.escape(part) for part in literal.split(" ")))
+        body_parts.append(r"\S+")
+        cursor = match.end()
+    literal = normalized[cursor:]
+    body_parts.append(r"\s+".join(re.escape(part) for part in literal.split(" ")))
+    body = "".join(body_parts)
     if _SKILL_TRIGGER_WORD.fullmatch(normalized):
         pattern = rf"\b{body}\b"
     else:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -25,6 +26,7 @@ _skill_commands_platform: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
+_SKILL_TRIGGER_WORD = re.compile(r"^\w[\w\s-]*\w$|^\w$")
 
 # ---------------------------------------------------------------------------
 # Skill-scaffolding markers and the canonical extractor.
@@ -184,6 +186,136 @@ def _resolve_skill_commands_platform() -> Optional[str]:
     except Exception:
         resolved_platform = os.getenv("HERMES_PLATFORM")
     return resolved_platform or None
+
+
+def _extract_skill_triggers(frontmatter: Dict[str, Any]) -> list[str]:
+    """Return normalized auto-trigger phrases declared in skill frontmatter."""
+    metadata = frontmatter.get("metadata")
+    hermes_meta = metadata.get("hermes") if isinstance(metadata, dict) else None
+    raw_triggers = None
+    if isinstance(hermes_meta, dict):
+        raw_triggers = hermes_meta.get("triggers")
+    if raw_triggers is None:
+        raw_triggers = frontmatter.get("triggers")
+
+    if raw_triggers is None:
+        return []
+    if not isinstance(raw_triggers, list):
+        raw_triggers = [raw_triggers]
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in raw_triggers:
+        trigger = re.sub(r"\s+", " ", str(value or "").strip())
+        if not trigger:
+            continue
+        dedupe_key = trigger.casefold()
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        normalized.append(trigger)
+    return normalized
+
+
+@lru_cache(maxsize=2048)
+def _compile_skill_trigger_pattern(trigger: str) -> re.Pattern[str]:
+    """Build a boundary-aware regex for a skill trigger phrase."""
+    normalized = re.sub(r"\s+", " ", trigger.strip())
+    body = r"\s+".join(re.escape(part) for part in normalized.split(" "))
+    if _SKILL_TRIGGER_WORD.fullmatch(normalized):
+        pattern = rf"\b{body}\b"
+    else:
+        pattern = rf"(?<!\w){body}(?!\w)"
+    return re.compile(pattern, re.IGNORECASE)
+
+
+def find_triggered_skill_command(
+    user_message: str,
+    *,
+    available_tools: set[str] | None = None,
+    available_toolsets: set[str] | None = None,
+) -> tuple[str, Dict[str, Any], str] | None:
+    """Return the best matching skill command for a plain user message."""
+    if not isinstance(user_message, str):
+        return None
+
+    text = user_message.strip()
+    if (
+        not text
+        or text.startswith("/")
+        or text.startswith(_SKILL_INVOCATION_PREFIX)
+    ):
+        return None
+
+    from agent.skill_utils import skill_conditions_match
+
+    best_rank: tuple[int, int, str, str] | None = None
+    best_payload: tuple[str, Dict[str, Any], str] | None = None
+    for cmd_key, skill_info in get_skill_commands().items():
+        if not skill_conditions_match(
+            skill_info.get("conditions") or {},
+            available_tools,
+            available_toolsets,
+        ):
+            continue
+        for raw_trigger in skill_info.get("triggers") or []:
+            trigger = str(raw_trigger)
+            if not _compile_skill_trigger_pattern(trigger).search(text):
+                continue
+            rank = (
+                len(trigger),
+                len(str(skill_info.get("name") or "")),
+                cmd_key,
+                trigger,
+            )
+            if best_rank is None or rank > best_rank:
+                best_rank = rank
+                best_payload = (cmd_key, skill_info, trigger)
+
+    return best_payload
+
+
+def expand_triggered_skill_message(
+    user_message: Any,
+    *,
+    loading_mode: str,
+    task_id: str | None = None,
+    available_tools: set[str] | None = None,
+    available_toolsets: set[str] | None = None,
+) -> tuple[Any, Any | None, Dict[str, Any] | None]:
+    """Expand one deterministic trigger match for routed skill loading.
+
+    Returns ``(model_message, original_message, activation)``. The original
+    message is non-``None`` only when expansion succeeded so callers can keep
+    durable transcripts free of injected skill scaffolding.
+    """
+    if loading_mode != "routed" or not isinstance(user_message, str):
+        return user_message, None, None
+
+    matched = find_triggered_skill_command(
+        user_message,
+        available_tools=available_tools,
+        available_toolsets=available_toolsets,
+    )
+    if not matched:
+        return user_message, None, None
+
+    cmd_key, skill_info, trigger = matched
+    expanded = build_skill_invocation_message(
+        cmd_key,
+        user_instruction=user_message,
+        task_id=task_id,
+        runtime_note=f'Auto-activated from skill trigger "{trigger}".',
+    )
+    if not expanded:
+        return user_message, None, None
+
+    activation = {
+        "command": cmd_key,
+        "name": skill_info.get("name") or cmd_key.lstrip("/"),
+        "trigger": trigger,
+    }
+    return expanded, user_message, activation
 
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:
     """Load a skill by name/path and return (loaded_payload, skill_dir, display_name)."""
@@ -378,7 +510,11 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+        from agent.skill_utils import (
+            extract_skill_conditions,
+            get_external_skills_dirs,
+            iter_skill_index_files,
+        )
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
@@ -410,6 +546,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     if name in disabled:
                         continue
                     description = frontmatter.get('description', '')
+                    triggers = _extract_skill_triggers(frontmatter)
                     if not description:
                         for line in body.strip().split('\n'):
                             line = line.strip()
@@ -455,6 +592,8 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),
                         "skill_dir": str(skill_md.parent),
+                        "triggers": triggers,
+                        "conditions": extract_skill_conditions(frontmatter),
                     }
                 except Exception:
                     continue

--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -9,6 +9,9 @@ from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
 
 logger = logging.getLogger(__name__)
 
+SKILL_LOADING_MODES = ("eager", "routed")
+DEFAULT_SKILL_LOADING_MODE = "eager"
+
 # Matches ${HERMES_SKILL_DIR} / ${HERMES_SESSION_ID} tokens in SKILL.md.
 # Tokens that don't resolve (e.g. ${HERMES_SESSION_ID} with no session) are
 # left as-is so the user can debug them.
@@ -34,6 +37,30 @@ def load_skills_config() -> dict:
     except Exception:
         logger.debug("Could not read skills config", exc_info=True)
     return {}
+
+
+def resolve_skill_loading_mode(skills_config: dict | None = None) -> str:
+    """Return the validated, session-stable skill loading mode.
+
+    ``eager`` preserves the complete startup index. ``routed`` keeps only a
+    category index in the system prompt and enables deterministic trigger
+    activation before the user turn reaches the model.
+    """
+    config = load_skills_config() if skills_config is None else skills_config
+    if not isinstance(config, dict):
+        return DEFAULT_SKILL_LOADING_MODE
+
+    raw_mode = config.get("loading", DEFAULT_SKILL_LOADING_MODE)
+    mode = str(raw_mode or DEFAULT_SKILL_LOADING_MODE).strip().lower()
+    if mode in SKILL_LOADING_MODES:
+        return mode
+
+    logger.warning(
+        "Unknown skills.loading value %r; using %s",
+        raw_mode,
+        DEFAULT_SKILL_LOADING_MODE,
+    )
+    return DEFAULT_SKILL_LOADING_MODE
 
 
 def substitute_template_vars(

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -630,6 +630,33 @@ def extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, List]:
     }
 
 
+def skill_conditions_match(
+    conditions: Dict[str, List],
+    available_tools: set[str] | None,
+    available_toolsets: set[str] | None,
+) -> bool:
+    """Return whether a skill's conditional activation rules are satisfied."""
+    if available_tools is None and available_toolsets is None:
+        return True
+
+    tools = available_tools or set()
+    toolsets = available_toolsets or set()
+
+    for toolset in conditions.get("fallback_for_toolsets", []):
+        if toolset in toolsets:
+            return False
+    for tool in conditions.get("fallback_for_tools", []):
+        if tool in tools:
+            return False
+    for toolset in conditions.get("requires_toolsets", []):
+        if toolset not in toolsets:
+            return False
+    for tool in conditions.get("requires_tools", []):
+        if tool not in tools:
+            return False
+    return True
+
+
 # ── Skill config extraction ───────────────────────────────────────────────
 
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -319,6 +319,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
+            loading_mode=getattr(agent, "skills_loading_mode", "eager"),
         )
     else:
         skills_prompt = ""

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -760,6 +760,13 @@ streaming:
 # also create new skills after completing complex tasks.
 #
 skills:
+  # Startup discovery mode:
+  #   eager  — include every skill name and description in the system prompt
+  #   routed — include top-level category counts only; exact frontmatter
+  #            triggers auto-load skills before the turn reaches the model
+  # Takes effect for new agent sessions. Default: eager.
+  loading: eager
+
   # Nudge the agent to create skills after complex tasks.
   # Every N tool-calling iterations, remind the model to consider saving a skill.
   # Set to 0 to disable.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2523,6 +2523,9 @@ DEFAULT_CONFIG = {
     # Each path is expanded (~, ${VAR}) and resolved.  Read-only — skill creation
     # always goes to ~/.hermes/skills/.
     "skills": {
+        # "eager" lists every skill at startup. "routed" keeps a compact
+        # category index and auto-loads deterministic frontmatter triggers.
+        "loading": "eager",
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
@@ -6004,6 +6007,24 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 "warning",
                 f"Root-level key '{key}' looks misplaced — should it be under 'model:' or inside a 'custom_providers' entry?",
                 f"Move '{key}' under the appropriate section",
+            ))
+
+    # ── skills.loading: eager | routed ───────────────────────────────────
+    skills_cfg = config.get("skills")
+    if skills_cfg is not None and not isinstance(skills_cfg, dict):
+        issues.append(ConfigIssue(
+            "error",
+            f"skills should be a dict, got {type(skills_cfg).__name__}",
+            "Change to:\n  skills:\n    loading: eager",
+        ))
+    elif isinstance(skills_cfg, dict):
+        loading_mode = skills_cfg.get("loading", "eager")
+        normalized_loading_mode = str(loading_mode or "eager").strip().lower()
+        if normalized_loading_mode not in {"eager", "routed"}:
+            issues.append(ConfigIssue(
+                "error",
+                f"skills.loading must be 'eager' or 'routed', got {loading_mode!r}",
+                "Use 'eager' for the full startup index or 'routed' for category-first discovery and trigger activation",
             ))
 
     return issues

--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -18,8 +18,10 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-# The skills index is wrapped in this tag pair inside the stable tier.
-_SKILLS_BLOCK_RE = re.compile(r"<available_skills>.*?</available_skills>", re.DOTALL)
+# Eager and routed skill indexes use distinct tag pairs inside the stable tier.
+_SKILLS_BLOCK_RE = re.compile(
+    r"<(available_skills|available_skill_categories)>.*?</\1>", re.DOTALL
+)
 
 # A rendered skill entry inside <available_skills> is ``    - name: desc`` (or
 # ``    - name`` when the skill has no description). Category headers use two
@@ -251,8 +253,8 @@ def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
     context = parts.get("context", "")
     volatile = parts.get("volatile", "")
 
-    # Skills index — the <available_skills> block (the largest single block
-    # when many skills are installed). Measured inside the stable tier.
+    # Skills index — either the eager <available_skills> block or the routed
+    # <available_skill_categories> block. Measured inside the stable tier.
     skills_match = _SKILLS_BLOCK_RE.search(stable)
     skills_index = skills_match.group(0) if skills_match else ""
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -6825,6 +6825,23 @@ class AIAgent:
         from agent.subagent_lifecycle import bind_subagent_parent
         from agent.skill_commands import expand_triggered_skill_message
 
+        # Hidden /moa turns carry the real user prompt inside an encoded
+        # transport marker. Normalize that transport before routed trigger
+        # matching, then pass the decoded config through so the conversation
+        # loop does not decode the already-expanded skill scaffolding again.
+        if moa_config is None:
+            try:
+                from hermes_cli.moa_config import decode_moa_turn
+
+                decoded_message, decoded_moa_config = decode_moa_turn(user_message)
+                if decoded_moa_config is not None:
+                    user_message = decoded_message
+                    moa_config = decoded_moa_config
+                    if persist_user_message is None:
+                        persist_user_message = decoded_message
+            except Exception:
+                pass
+
         available_tools = set(getattr(self, "valid_tool_names", set()) or set())
         available_toolsets = {
             toolset

--- a/run_agent.py
+++ b/run_agent.py
@@ -6823,6 +6823,32 @@ class AIAgent:
             set_conversation_context,
         )
         from agent.subagent_lifecycle import bind_subagent_parent
+        from agent.skill_commands import expand_triggered_skill_message
+
+        available_tools = set(getattr(self, "valid_tool_names", set()) or set())
+        available_toolsets = {
+            toolset
+            for toolset in (
+                get_toolset_for_tool(tool_name) for tool_name in available_tools
+            )
+            if toolset
+        }
+        routed_message, original_message, activation = expand_triggered_skill_message(
+            user_message,
+            loading_mode=getattr(self, "skills_loading_mode", "eager"),
+            task_id=task_id or getattr(self, "session_id", None),
+            available_tools=available_tools,
+            available_toolsets=available_toolsets,
+        )
+        if original_message is not None:
+            user_message = routed_message
+            if persist_user_message is None:
+                persist_user_message = original_message
+            logger.info(
+                "Auto-loaded skill %s from trigger %r",
+                activation.get("name") if activation else "",
+                activation.get("trigger") if activation else "",
+            )
 
         # Publish the conversation id for ambient Nous Portal tagging. Every
         # LLM call made inside this turn — main loop, compression, vision,

--- a/scripts/benchmark_routed_skills.py
+++ b/scripts/benchmark_routed_skills.py
@@ -1,0 +1,185 @@
+"""Benchmark eager versus routed skill loading on deterministic catalogs.
+
+Generates isolated SKILL.md catalogs, then exercises the production prompt
+builder and trigger matcher. Makes no model, network, or user-profile calls.
+
+Usage:
+    .venv/bin/python scripts/benchmark_routed_skills.py
+    .venv/bin/python scripts/benchmark_routed_skills.py --iterations 500
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from typing import Callable
+
+_DESCRIPTION = (
+    "Deterministic benchmark skill for measuring catalog prompt size and routed "
+    "trigger lookup without depending on a user's private skill library."
+)
+
+
+def _measure(action: Callable[[], object], iterations: int) -> list[float]:
+    timings = []
+    for _ in range(iterations):
+        started = time.perf_counter_ns()
+        action()
+        timings.append((time.perf_counter_ns() - started) / 1_000_000)
+    return timings
+
+
+def _median(values: list[float]) -> float:
+    return statistics.median(values)
+
+
+def _write_catalog(
+    skills_root: Path,
+    skill_count: int,
+    category_count: int,
+    trigger_fraction: float,
+) -> int:
+    shutil.rmtree(skills_root, ignore_errors=True)
+    skills_root.mkdir(parents=True)
+    trigger_count = min(skill_count, max(1, round(skill_count * trigger_fraction)))
+
+    for index in range(skill_count):
+        top = f"category-{index % category_count:02d}"
+        category = f"{top}/nested-{index % 3:02d}" if index % 4 == 0 else top
+        name = f"skill-{index:04d}"
+        skill_dir = skills_root / category / name
+        skill_dir.mkdir(parents=True)
+        trigger = (
+            f"triggers:\n  - route synthetic skill {index:04d}\n"
+            if index < trigger_count
+            else ""
+        )
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            f"name: {name}\n"
+            f"description: {_DESCRIPTION}\n"
+            f"{trigger}"
+            "---\n\n"
+            f"# {name}\n\nRun the deterministic benchmark procedure.\n",
+            encoding="utf-8",
+        )
+
+    return trigger_count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skills", nargs="+", type=int, default=[73, 267, 500])
+    parser.add_argument("--categories", type=int, default=12)
+    parser.add_argument(
+        "--trigger-fractions", nargs="+", type=float, default=[0.03, 0.85]
+    )
+    parser.add_argument("--iterations", type=int, default=200)
+    parser.add_argument("--cold-iterations", type=int, default=5)
+    args = parser.parse_args()
+
+    if any(count < 1 for count in args.skills):
+        parser.error("--skills values must be positive")
+    if args.categories < 1:
+        parser.error("--categories must be positive")
+    if any(not 0 < fraction <= 1 for fraction in args.trigger_fractions):
+        parser.error("--trigger-fractions values must be in (0, 1]")
+    if args.iterations < 2 or args.cold_iterations < 1:
+        parser.error("--iterations must be at least 2; cold iterations must be positive")
+
+    with tempfile.TemporaryDirectory(prefix="hermes-routed-benchmark-") as temp:
+        hermes_home = Path(temp)
+        skills_root = hermes_home / "skills"
+        os.environ["HERMES_HOME"] = str(hermes_home)
+
+        # Import only after selecting an isolated profile. This keeps module-level
+        # paths away from the user's real HERMES_HOME.
+        import agent.skill_commands as skill_commands
+        import tools.skills_tool as skills_tool
+        from agent.prompt_builder import (
+            build_skills_system_prompt,
+            clear_skills_system_prompt_cache,
+        )
+
+        skills_tool.SKILLS_DIR = skills_root
+        print(
+            "skills triggers eager_B routed_B reduction "
+            "cold_eager_ms cold_routed_ms scan_ms first_miss_ms warm_miss_ms quality"
+        )
+
+        for skill_count in args.skills:
+            for trigger_fraction in args.trigger_fractions:
+                trigger_count = _write_catalog(
+                    skills_root,
+                    skill_count,
+                    min(args.categories, skill_count),
+                    trigger_fraction,
+                )
+                skill_commands._skill_commands = {}
+                skill_commands._skill_commands_platform = None
+                skill_commands._compile_skill_trigger_pattern.cache_clear()
+                clear_skills_system_prompt_cache(clear_snapshot=True)
+
+                prompts = {}
+                cold = {}
+                for mode in ("eager", "routed"):
+                    cold_times = []
+                    for _ in range(args.cold_iterations):
+                        clear_skills_system_prompt_cache(clear_snapshot=True)
+                        started = time.perf_counter_ns()
+                        prompts[mode] = build_skills_system_prompt(loading_mode=mode)
+                        cold_times.append(
+                            (time.perf_counter_ns() - started) / 1_000_000
+                        )
+                    cold[mode] = _median(cold_times)
+
+                scan_ms = _median(
+                    _measure(skill_commands.scan_skill_commands, args.cold_iterations)
+                )
+                skill_commands.scan_skill_commands()
+                hit = "Please route synthetic skill 0000 for this request."
+                miss = "This ordinary request has no deterministic route."
+
+                skill_commands._compile_skill_trigger_pattern.cache_clear()
+                first_miss_ms = _measure(
+                    lambda: skill_commands.find_triggered_skill_command(miss), 1
+                )[0]
+                skill_commands.find_triggered_skill_command(miss)  # warm regex cache
+                warm_miss_ms = _median(
+                    _measure(
+                        lambda: skill_commands.find_triggered_skill_command(miss),
+                        args.iterations,
+                    )
+                )
+
+                exact = skill_commands.find_triggered_skill_command(hit)
+                casefolded = skill_commands.find_triggered_skill_command(
+                    "ROUTE SYNTHETIC SKILL 0000 now."
+                )
+                boundary = skill_commands.find_triggered_skill_command(
+                    "Please reroute synthetic skill 0000."
+                )
+                ordinary = skill_commands.find_triggered_skill_command(miss)
+                passed = sum(
+                    (exact is not None, casefolded is not None, boundary is None, ordinary is None)
+                )
+
+                eager_bytes = len(prompts["eager"].encode("utf-8"))
+                routed_bytes = len(prompts["routed"].encode("utf-8"))
+                reduction = 100 * (eager_bytes - routed_bytes) / eager_bytes
+                print(
+                    f"{skill_count:>6} {trigger_count:>8} "
+                    f"{eager_bytes:>7} {routed_bytes:>8} {reduction:>8.2f}% "
+                    f"{cold['eager']:>13.3f} {cold['routed']:>14.3f} "
+                    f"{scan_ms:>7.3f} {first_miss_ms:>13.3f} "
+                    f"{warm_miss_ms:>12.3f} {passed:>5}/4"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib
+import json
 import logging
 import sys
 
@@ -463,6 +464,124 @@ class TestBuildSkillsSystemPrompt:
         assert "social-media [names only]" in result
         # Disclosure note explains the demotion and how to load.
         assert "skill_view" in result
+
+    def test_eager_mode_preserves_large_skill_catalog(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        for idx in range(45):
+            category = "devops" if idx % 2 else "creative"
+            d = skills_root / category / f"skill-{idx:02d}"
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                "---\n"
+                f"name: skill-{idx:02d}\n"
+                f"description: Detailed description {idx:02d}\n"
+                "---\n"
+            )
+
+        result = build_skills_system_prompt()
+
+        assert "<available_skills>" in result
+        assert "skill-00" in result
+        assert "Detailed description 00" in result
+
+    def test_routed_mode_uses_top_level_category_index_only(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        for category, name in (
+            ("creative", "diagram"),
+            ("social-media/twitter", "thread-writer"),
+            ("social-media/linkedin", "post-writer"),
+        ):
+            d = skills_root / category / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: Detailed {name}\n---\n"
+            )
+        root_skill = skills_root / "root-helper"
+        root_skill.mkdir(parents=True)
+        (root_skill / "SKILL.md").write_text(
+            "---\nname: root-helper\ndescription: Root-level helper\n---\n"
+        )
+
+        result = build_skills_system_prompt(loading_mode="routed")
+
+        assert "Routed skill-loading mode" in result
+        assert "skills_list(category='<category>')" in result
+        assert "<available_skill_categories>" in result
+        assert "  creative: 1 skill" in result
+        assert "  general: 1 skill" in result
+        assert "  social-media: 2 skills" in result
+        assert "  root-helper:" not in result
+        assert "social-media/twitter" not in result
+        assert "thread-writer" not in result
+        assert "Detailed thread-writer" not in result
+
+        eager = build_skills_system_prompt(loading_mode="eager")
+        assert "thread-writer" in eager
+        assert "Detailed thread-writer" in eager
+
+    def test_routed_mode_stays_within_prompt_budget(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        for idx in range(250):
+            category = f"category-{idx % 25:02d}"
+            name = f"skill-{idx:03d}"
+            d = skills_root / category / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: Detailed workflow for {name}\n---\n"
+            )
+
+        eager = build_skills_system_prompt(loading_mode="eager")
+        routed = build_skills_system_prompt(loading_mode="routed")
+
+        assert len(routed.encode("utf-8")) < 6 * 1024
+        assert len(routed) * 4 < len(eager)
+        assert "skill-000" not in routed
+        assert "Detailed workflow" not in routed
+
+    def test_legacy_snapshot_is_rejected_and_regenerated(self, monkeypatch, tmp_path):
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "root-helper"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: root-helper\ndescription: Root helper\n---\n"
+        )
+
+        first = build_skills_system_prompt(loading_mode="routed")
+        assert "  general: 1 skill" in first
+
+        snapshot_path = tmp_path / ".skills_prompt_snapshot.json"
+        snapshot = json.loads(snapshot_path.read_text())
+        snapshot["version"] = 1
+        snapshot["skills"][0]["category"] = "stale-category"
+        snapshot_path.write_text(json.dumps(snapshot))
+        clear_skills_system_prompt_cache()
+
+        rebuilt = build_skills_system_prompt(loading_mode="routed")
+
+        assert "  general: 1 skill" in rebuilt
+        assert "stale-category" not in rebuilt
+        assert json.loads(snapshot_path.read_text())["version"] == 2
+
+    def test_duplicate_skill_names_are_counted_once_globally(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for category in ("alpha", "omega"):
+            skill_dir = tmp_path / "skills" / category / "duplicate"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: shared-name\ndescription: Shared skill\n---\n"
+            )
+
+        routed = build_skills_system_prompt(loading_mode="routed")
+
+        assert "  alpha: 1 skill" in routed
+        assert "omega" not in routed
 
     def test_compact_categories_demote_nested_and_miss_cache_separately(
         self, monkeypatch, tmp_path
@@ -1723,5 +1842,3 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -179,6 +179,28 @@ class TestScanSkillCommands:
         assert matched[0] == "/fx-watch"
         assert matched[2] == "EUR/USD"
 
+    def test_longest_overlapping_trigger_wins(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "market-watch",
+                frontmatter_extra="triggers: [market]\n",
+            )
+            _make_skill(
+                tmp_path,
+                "market-analysis",
+                frontmatter_extra="triggers: [market analysis]\n",
+            )
+            scan_skill_commands()
+
+            matched = find_triggered_skill_command(
+                "Please run a market analysis for today."
+            )
+
+        assert matched is not None
+        assert matched[0] == "/market-analysis"
+        assert matched[2] == "market analysis"
+
     @pytest.mark.parametrize(
         ("trigger", "message"),
         [

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -10,6 +10,8 @@ import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
+    expand_triggered_skill_message,
+    find_triggered_skill_command,
     resolve_skill_command_key,
     scan_skill_commands,
 )
@@ -112,6 +114,154 @@ class TestScanSkillCommands:
             result = scan_skill_commands()
         assert "/enabled-skill" in result
         assert "/disabled-skill" not in result
+
+    def test_reads_frontmatter_triggers(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "market-watch",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    triggers: [market, EUR/USD, market]\n"
+                ),
+            )
+            result = scan_skill_commands()
+
+        assert result["/market-watch"]["triggers"] == ["market", "EUR/USD"]
+
+    def test_reads_top_level_frontmatter_triggers(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "weather-watch",
+                frontmatter_extra="triggers: [weather forecast]\n",
+            )
+            result = scan_skill_commands()
+
+        assert result["/weather-watch"]["triggers"] == ["weather forecast"]
+
+    def test_finds_triggered_skill_by_word_boundary(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "market-watch",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    triggers: [market]\n"
+                ),
+            )
+            scan_skill_commands()
+            matched = find_triggered_skill_command("What is the market doing today?")
+            not_matched = find_triggered_skill_command("This supermarket is busy.")
+
+        assert matched is not None
+        assert matched[0] == "/market-watch"
+        assert matched[2] == "market"
+        assert not_matched is None
+
+    def test_finds_triggered_skill_with_punctuation_phrase(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "fx-watch",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    triggers: [EUR/USD]\n"
+                ),
+            )
+            scan_skill_commands()
+            matched = find_triggered_skill_command("What is happening with EUR/USD today?")
+
+        assert matched is not None
+        assert matched[0] == "/fx-watch"
+        assert matched[2] == "EUR/USD"
+
+    def test_trigger_respects_required_tool_conditions(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "terminal-watch",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    triggers: [inspect runtime]\n"
+                    "    requires_tools: [terminal]\n"
+                ),
+            )
+            scan_skill_commands()
+            unavailable = find_triggered_skill_command(
+                "Please inspect runtime state.", available_tools=set()
+            )
+            available = find_triggered_skill_command(
+                "Please inspect runtime state.", available_tools={"terminal"}
+            )
+
+        assert unavailable is None
+        assert available is not None
+        assert available[0] == "/terminal-watch"
+
+    def test_trigger_respects_fallback_toolset_conditions(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "browser-fallback",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    triggers: [browse fallback]\n"
+                    "    fallback_for_toolsets: [browser]\n"
+                ),
+            )
+            scan_skill_commands()
+            primary_available = find_triggered_skill_command(
+                "Use the browse fallback.", available_toolsets={"browser"}
+            )
+            fallback_needed = find_triggered_skill_command(
+                "Use the browse fallback.", available_toolsets=set()
+            )
+
+        assert primary_available is None
+        assert fallback_needed is not None
+        assert fallback_needed[0] == "/browser-fallback"
+
+    def test_does_not_rematch_loaded_skill_scaffolding(self):
+        assert find_triggered_skill_command(
+            "[IMPORTANT: The user has invoked the market-watch skill.] market"
+        ) is None
+
+    def test_expands_trigger_only_in_routed_mode(self):
+        match = ("/market-watch", {"name": "market-watch"}, "market")
+        with (
+            patch("agent.skill_commands.find_triggered_skill_command", return_value=match),
+            patch(
+                "agent.skill_commands.build_skill_invocation_message",
+                return_value="[expanded skill payload]",
+            ) as build,
+        ):
+            eager = expand_triggered_skill_message(
+                "What is the market doing?", loading_mode="eager", task_id="t-1"
+            )
+            routed = expand_triggered_skill_message(
+                "What is the market doing?", loading_mode="routed", task_id="t-1"
+            )
+
+        assert eager == ("What is the market doing?", None, None)
+        assert routed[0] == "[expanded skill payload]"
+        assert routed[1] == "What is the market doing?"
+        assert routed[2] == {
+            "command": "/market-watch",
+            "name": "market-watch",
+            "trigger": "market",
+        }
+        build.assert_called_once_with(
+            "/market-watch",
+            user_instruction="What is the market doing?",
+            task_id="t-1",
+            runtime_note='Auto-activated from skill trigger "market".',
+        )
 
     def test_finds_skills_in_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -179,6 +179,51 @@ class TestScanSkillCommands:
         assert matched[0] == "/fx-watch"
         assert matched[2] == "EUR/USD"
 
+    @pytest.mark.parametrize(
+        ("trigger", "message"),
+        [
+            ("pentest [URL]", "Please pentest https://example.test/login"),
+            (
+                "test [URL] for vulnerabilities",
+                "Test https://example.test for vulnerabilities before release",
+            ),
+            (
+                "investigate [owner/repo]",
+                "Investigate NousResearch/hermes-agent for suspicious commits",
+            ),
+        ],
+    )
+    def test_finds_triggered_skill_with_single_argument_placeholder(
+        self, tmp_path, trigger, message
+    ):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "security-review",
+                frontmatter_extra=f'triggers: ["{trigger}"]\n',
+            )
+            scan_skill_commands()
+            matched = find_triggered_skill_command(message)
+
+        assert matched is not None
+        assert matched[0] == "/security-review"
+        assert matched[2] == trigger
+
+    def test_trigger_placeholder_does_not_span_multiple_arguments(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "repository-review",
+                frontmatter_extra='triggers: ["investigate [owner/repo] history"]\n',
+            )
+            scan_skill_commands()
+
+            matched = find_triggered_skill_command(
+                "Investigate NousResearch hermes-agent history"
+            )
+
+        assert matched is None
+
     def test_trigger_respects_required_tool_conditions(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(

--- a/tests/agent/test_skill_loading_mode.py
+++ b/tests/agent/test_skill_loading_mode.py
@@ -1,0 +1,19 @@
+import logging
+
+from agent.skill_preprocessing import resolve_skill_loading_mode
+
+
+def test_skill_loading_mode_defaults_to_eager():
+    assert resolve_skill_loading_mode({}) == "eager"
+
+
+def test_skill_loading_mode_accepts_routed_case_insensitively():
+    assert resolve_skill_loading_mode({"loading": " Routed "}) == "routed"
+
+
+def test_unknown_skill_loading_mode_falls_back_and_warns(caplog):
+    with caplog.at_level(logging.WARNING):
+        mode = resolve_skill_loading_mode({"loading": "semantic"})
+
+    assert mode == "eager"
+    assert "Unknown skills.loading value" in caplog.text

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -24,6 +24,7 @@ def _make_agent(**overrides):
         platform="",
         pass_session_id=False,
         session_id="",
+        skills_loading_mode="eager",
     )
     base.update(overrides)
     return SimpleNamespace(**base)
@@ -60,6 +61,23 @@ class TestContextFileCwd:
     def test_configured_dir_when_terminal_cwd_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert _captured_context_cwd(_make_agent()) == tmp_path
+
+
+def test_skill_loading_mode_is_forwarded_to_prompt_builder():
+    agent = _make_agent(
+        valid_tool_names=["skill_view", "skills_list"],
+        skills_loading_mode="routed",
+    )
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+        patch("run_agent.build_skills_system_prompt", return_value="") as skills_prompt,
+    ):
+        build_system_prompt_parts(agent)
+
+    assert skills_prompt.call_args.kwargs["loading_mode"] == "routed"
 
 
 def _stable_prompt(agent):

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -25,6 +25,7 @@ def _make_agent(**overrides):
         pass_session_id=False,
         session_id="",
         skills_loading_mode="eager",
+        _emit_status=lambda _message: None,
     )
     base.update(overrides)
     return SimpleNamespace(**base)

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -10,6 +10,23 @@ from hermes_cli.config import (
 )
 
 
+class TestSkillsLoadingValidation:
+    def test_accepts_supported_modes(self):
+        for mode in ("eager", "routed", " Routed "):
+            issues = validate_config_structure({"skills": {"loading": mode}})
+            assert not [issue for issue in issues if "skills.loading" in issue.message]
+
+    def test_rejects_unknown_mode(self):
+        issues = validate_config_structure({"skills": {"loading": "semantic"}})
+        errors = [issue for issue in issues if issue.severity == "error"]
+        assert any("skills.loading" in issue.message for issue in errors)
+
+    def test_rejects_non_mapping_skills_section(self):
+        issues = validate_config_structure({"skills": ["routed"]})
+        errors = [issue for issue in issues if issue.severity == "error"]
+        assert any("skills should be a dict" in issue.message for issue in errors)
+
+
 class TestCustomProvidersValidation:
     """custom_providers must be a YAML list, not a dict."""
 

--- a/tests/hermes_cli/test_prompt_size.py
+++ b/tests/hermes_cli/test_prompt_size.py
@@ -137,6 +137,17 @@ def test_skills_index_reflects_installed_skills(isolated_home):
     assert data["skills_index"]["bytes"] > 0
 
 
+def test_routed_category_index_is_measured(isolated_home):
+    from hermes_cli.config import save_config
+
+    _seed_skill(isolated_home, "hello", "a demo skill for size testing")
+    save_config({"skills": {"loading": "routed"}})
+
+    data = compute_prompt_breakdown("cli")
+
+    assert data["skills_index"]["bytes"] > 0
+
+
 def test_memory_and_profile_are_attributed(isolated_home):
     """Memory and user-profile blocks are measured separately."""
     _seed_memory(
@@ -269,6 +280,17 @@ def test_render_includes_per_component_tables(isolated_home):
     out = render_breakdown(data)
     assert "Toolsets by size" in out
     assert "Skills by size" in out
+
+
+def test_skills_block_regex_matches_routed_category_block():
+    text = (
+        "preamble\n<available_skill_categories>\n"
+        "  devops: 3 skills\n</available_skill_categories>\ntail"
+    )
+    m = _SKILLS_BLOCK_RE.search(text)
+    assert m is not None
+    assert m.group(0).startswith("<available_skill_categories>")
+    assert m.group(0).endswith("</available_skill_categories>")
 
 
 def test_render_breakdown_is_plain_text(isolated_home):

--- a/tests/run_agent/test_routed_skill_loading.py
+++ b/tests/run_agent/test_routed_skill_loading.py
@@ -1,0 +1,85 @@
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def test_common_conversation_entrypoint_routes_and_persists_original_message():
+    agent = object.__new__(AIAgent)
+    setattr(agent, "skills_loading_mode", "routed")
+    setattr(agent, "session_id", "session-1")
+    setattr(agent, "valid_tool_names", {"skills_list", "terminal"})
+    routed = (
+        "[expanded skill payload]",
+        "What is the market doing?",
+        {"name": "market-watch", "trigger": "market"},
+    )
+
+    with (
+        patch(
+            "run_agent.get_toolset_for_tool",
+            side_effect=lambda name: {
+                "skills_list": "skills",
+                "terminal": "terminal",
+            }.get(name),
+        ),
+        patch(
+            "agent.skill_commands.expand_triggered_skill_message", return_value=routed
+        ) as expand,
+        patch(
+            "agent.conversation_loop.run_conversation",
+            return_value={"final_response": "done"},
+        ) as conversation,
+    ):
+        result = AIAgent.run_conversation(
+            agent,
+            "What is the market doing?",
+            task_id="task-1",
+        )
+
+    assert result == {"final_response": "done"}
+    expand.assert_called_once_with(
+        "What is the market doing?",
+        loading_mode="routed",
+        task_id="task-1",
+        available_tools={"skills_list", "terminal"},
+        available_toolsets={"skills", "terminal"},
+    )
+    args = conversation.call_args.args
+    assert args[1] == "[expanded skill payload]"
+    assert args[4] == "task-1"
+    assert args[6] == "What is the market doing?"
+
+
+def test_common_entrypoint_preserves_explicit_persistence_override():
+    agent = object.__new__(AIAgent)
+    setattr(agent, "skills_loading_mode", "routed")
+    setattr(agent, "session_id", "session-2")
+    routed = (
+        "[expanded skill payload]",
+        "[voice prefix] original",
+        {"name": "voice-helper", "trigger": "original"},
+    )
+
+    with (
+        patch(
+            "agent.skill_commands.expand_triggered_skill_message", return_value=routed
+        ) as expand,
+        patch(
+            "agent.conversation_loop.run_conversation",
+            return_value={"final_response": "done"},
+        ) as conversation,
+    ):
+        AIAgent.run_conversation(
+            agent,
+            "[voice prefix] original",
+            persist_user_message="original",
+        )
+
+    expand.assert_called_once_with(
+        "[voice prefix] original",
+        loading_mode="routed",
+        task_id="session-2",
+        available_tools=set(),
+        available_toolsets=set(),
+    )
+    assert conversation.call_args.args[6] == "original"

--- a/tests/run_agent/test_routed_skill_loading.py
+++ b/tests/run_agent/test_routed_skill_loading.py
@@ -1,6 +1,28 @@
+from pathlib import Path
 from unittest.mock import patch
 
+import agent.skill_commands as skill_commands_module
+from agent.skill_commands import scan_skill_commands
+from hermes_cli.moa_config import build_moa_turn_prompt
 from run_agent import AIAgent
+
+
+def _make_triggered_skill(skills_dir: Path) -> None:
+    skill_dir = skills_dir / "market-watch"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: market-watch
+description: Inspect current market conditions.
+triggers: [market conditions]
+---
+
+# Market Watch
+
+Inspect the requested market conditions.
+""",
+        encoding="utf-8",
+    )
 
 
 def test_common_conversation_entrypoint_routes_and_persists_original_message():
@@ -83,3 +105,36 @@ def test_common_entrypoint_preserves_explicit_persistence_override():
         available_toolsets=set(),
     )
     assert conversation.call_args.args[6] == "original"
+
+
+def test_encoded_moa_turn_is_decoded_before_routed_trigger_expansion(tmp_path):
+    agent = object.__new__(AIAgent)
+    setattr(agent, "skills_loading_mode", "routed")
+    setattr(agent, "session_id", "session-moa")
+    setattr(agent, "valid_tool_names", {"terminal"})
+    user_prompt = "Inspect the market conditions before tomorrow."
+    encoded_prompt = build_moa_turn_prompt(user_prompt)
+    _make_triggered_skill(tmp_path)
+
+    with (
+        patch("tools.skills_tool.SKILLS_DIR", tmp_path),
+        patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+        patch.object(skill_commands_module, "_skill_commands", {}),
+        patch.object(skill_commands_module, "_skill_commands_platform", None),
+        patch(
+            "agent.conversation_loop.run_conversation",
+            return_value={"final_response": "done"},
+        ) as conversation,
+    ):
+        scan_skill_commands()
+        result = AIAgent.run_conversation(agent, encoded_prompt, task_id="task-moa")
+
+    assert result == {"final_response": "done"}
+    args = conversation.call_args.args
+    assert args[1].startswith(
+        '[IMPORTANT: The user has invoked the "market-watch" skill'
+    )
+    assert user_prompt in args[1]
+    assert encoded_prompt not in args[1]
+    assert args[6] == user_prompt
+    assert conversation.call_args.kwargs["moa_config"] is not None

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -350,6 +350,30 @@ class TestSkillsList:
         result = json.loads(raw)
         assert result["count"] == 1
         assert result["skills"][0]["name"] == "skill-a"
+        assert result["category_counts"] == {"devops": 1, "mlops": 1}
+
+    def test_top_level_category_includes_nested_skills(self, tmp_path):
+        _make_skill(tmp_path, "publisher", category="social-media")
+        _make_skill(tmp_path, "thread-writer", category="social-media/twitter")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            data = json.loads(skills_list(category="social-media"))
+
+        assert data["count"] == 2
+        assert {skill["name"] for skill in data["skills"]} == {
+            "publisher",
+            "thread-writer",
+        }
+
+    def test_general_category_filter_finds_root_skills(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "root-skill")
+            raw = skills_list(category="general")
+
+        result = json.loads(raw)
+        assert result["count"] == 1
+        assert result["categories"] == ["general"]
+        assert result["category_counts"] == {"general": 1}
+        assert result["skills"][0]["name"] == "root-skill"
 
     def test_category_filter_finds_symlinked_category(self, tmp_path):
         external_root = tmp_path / "repo"

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -69,6 +69,7 @@ Usage:
 import json
 import logging
 import time
+from collections import Counter
 
 from hermes_constants import get_hermes_home, display_hermes_home
 import os
@@ -751,7 +752,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 if len(description) > MAX_DESCRIPTION_LENGTH:
                     description = description[:MAX_DESCRIPTION_LENGTH - 3] + "..."
 
-                category = _get_category_from_path(skill_md)
+                category = _get_category_from_path(skill_md) or "general"
 
                 seen_names.add(name)
                 skills.append({
@@ -824,12 +825,23 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                 ensure_ascii=False,
             )
 
+        category_counts = Counter(
+            s.get("category") or "general"
+            for s in all_skills
+        )
+
         # Filter by category if specified
         if category:
-            all_skills = [s for s in all_skills if s.get("category") == category]
-
-        # Sort by category then name
-        all_skills = _sort_skills(all_skills)
+            category_prefix = f"{category}/"
+            filtered = [
+                skill
+                for skill in all_skills
+                if skill.get("category") == category
+                or str(skill.get("category") or "").startswith(category_prefix)
+            ]
+        else:
+            filtered = all_skills
+        all_skills = _sort_skills(filtered)
 
         # Extract unique categories
         categories = sorted(
@@ -841,6 +853,7 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                 "success": True,
                 "skills": all_skills,
                 "categories": categories,
+                "category_counts": dict(sorted(category_counts.items())),
                 "count": len(all_skills),
                 "hint": "Use skill_view(name) to see full content, tags, and linked files",
             },
@@ -1683,7 +1696,11 @@ if __name__ == "__main__":
 
 SKILLS_LIST_SCHEMA = {
     "name": "skills_list",
-    "description": "List available skills (name + description). Use skill_view(name) to load full content.",
+    "description": (
+        "List available skills by category (name + description). Use category "
+        "to drill into large category-only skill indexes, then skill_view(name) "
+        "to load full content."
+    ),
     "parameters": {
         "type": "object",
         "properties": {

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -139,6 +139,47 @@ Level 2: skill_view(name, path)  → Specific reference file       (varies)
 
 The agent only loads the full skill content when it actually needs it.
 
+### Routed loading for large skill libraries
+
+The default `eager` loading mode includes every available skill name and
+description in the system prompt. This gives the model maximum recall and keeps
+existing installations unchanged.
+
+For large libraries, opt into routed loading in `~/.hermes/config.yaml`:
+
+```yaml
+skills:
+  loading: routed
+```
+
+`routed` mode replaces the full startup catalog with top-level category counts.
+The agent drills into a likely category with `skills_list(category=...)`, then
+loads the selected skill with `skill_view(name)`. Category names match the
+top-level directories under `~/.hermes/skills/`; nested categories roll up to
+their top-level parent.
+
+Skills may also declare deterministic trigger phrases:
+
+```yaml
+---
+name: weather-watch
+description: Check forecasts and weather alerts.
+triggers:
+  - weather forecast
+  - severe weather alert
+---
+```
+
+In routed mode, a case-insensitive, word-boundary match loads the skill before
+the user turn reaches the model. The longest matching trigger wins when phrases
+overlap. Trigger activation runs through the common agent entry point, so it
+applies consistently to the CLI, gateway platforms, and API server. The
+original user message—not the injected skill body—is retained in the durable
+transcript.
+
+For namespaced metadata, `metadata.hermes.triggers` is also accepted. Changes to
+`skills.loading` take effect in new sessions.
+
 ## SKILL.md Format
 
 ```markdown
@@ -147,6 +188,8 @@ name: my-skill
 description: Brief description of what this skill does
 version: 1.0.0
 platforms: [macos, linux]     # Optional — restrict to specific OS platforms
+triggers:                      # Optional — exact phrases used in routed mode
+  - natural language trigger
 metadata:
   hermes:
     tags: [python, automation]

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -167,6 +167,7 @@ description: Check forecasts and weather alerts.
 triggers:
   - weather forecast
   - severe weather alert
+  - inspect weather for [LOCATION]
 ---
 ```
 
@@ -176,6 +177,12 @@ overlap. Trigger activation runs through the common agent entry point, so it
 applies consistently to the CLI, gateway platforms, and API server. The
 original user message—not the injected skill body—is retained in the durable
 transcript.
+
+Triggers are literal phrases except for bracketed placeholders. A placeholder
+such as `[URL]`, `[LOCATION]`, or `[owner/repo]` matches exactly one
+non-whitespace argument. For example, `pentest [URL]` matches
+`pentest https://example.test`, while `investigate [owner/repo]` matches
+`investigate NousResearch/hermes-agent`.
 
 For namespaced metadata, `metadata.hermes.triggers` is also accepted. Changes to
 `skills.loading` take effect in new sessions.
@@ -188,7 +195,7 @@ name: my-skill
 description: Brief description of what this skill does
 version: 1.0.0
 platforms: [macos, linux]     # Optional — restrict to specific OS platforms
-triggers:                      # Optional — exact phrases used in routed mode
+triggers:                      # Optional — literal phrases; [NAME] matches one argument
   - natural language trigger
 metadata:
   hermes:


### PR DESCRIPTION
## Summary

Add an opt-in routed skill-loading mode for large skill libraries while preserving the existing eager behavior as the default.

```yaml
skills:
  loading: routed
```

Routed mode:

- replaces the full startup name/description catalog with compact top-level category counts;
- auto-loads one skill from deterministic frontmatter `triggers`;
- preserves `skills_list(category=...)`, `skill_view(name)`, explicit slash invocation, stacking, and bundles as fallback/explicit discovery;
- routes through `AIAgent.run_conversation`, so CLI, gateway, API, MoA, and direct callers share one normalization path;
- persists the original user message rather than generated skill scaffolding;
- honors platform, environment, tool, and toolset conditions;
- separates eager/routed prompt cache keys and invalidates the old disk snapshot schema.

This reconciles and builds on the category-index work in #55675 and trigger-loading work from #55674.

## Why

Hermes already loads full skill bodies on demand, but the default system prompt still advertises every eligible skill name and description on every model request. That fixed cost scales linearly with large/custom catalogs.

Routed mode keeps every capability reachable while making catalog disclosure proportional to the number of top-level categories.

## Hermes Agent v0.19.0 / Quicksilver compatibility

This branch is rebased onto v0.19.0/current `main`. Quicksilver's advertised ~80% first-token improvement removes blocking orchestration work before model dispatch; routed skill loading addresses a separate cost by reducing the skill catalog transmitted in the system prompt. The two changes are complementary rather than duplicate optimizations.

The v0.19.0 prompt-build cache is compatible with routed loading: eager and routed variants use separate cache keys, and the focused suite covers that boundary. The benchmark percentages below measure prompt-byte reduction, not an additional 70%–94% wall-clock TTFT claim.

## Backward compatibility

- `skills.loading` defaults to `eager`.
- Existing eager prompts retain the full name/description catalog.
- Unknown modes fail config validation and safely resolve to eager at runtime.
- The loading mode is resolved once per agent session; tool schemas and prompt bytes do not mutate mid-conversation.
- Existing explicit slash skills, stacked invocations, bundles, preloads, platform filtering, and disabled-skill behavior remain unchanged.
- Changes take effect on new sessions.

## Routing contract

- Top-level and `metadata.hermes` trigger declarations are supported.
- Matching is case-insensitive and boundary-aware.
- Bracketed placeholders such as `[URL]` and `[owner/repo]` match exactly one non-whitespace argument.
- The longest overlapping trigger wins.
- At most one skill auto-loads per turn.
- Loaded skill scaffolding cannot retrigger itself.
- Hidden MoA turns are decoded before matching.
- The durable transcript retains the decoded/original user request, not the generated skill body.

## Reproducible benchmark

Run:

```bash
python scripts/benchmark_routed_skills.py
```

The script generates deterministic `SKILL.md` catalogs in an isolated temporary `HERMES_HOME` and exercises the production prompt builder and trigger matcher. It makes no model, network, or user-profile calls.

Environment: macOS 26.3.1 arm64, Python 3.11.15. Candidate rebased onto current upstream `main` at `d71033a4077a6dfdcdb42c9e9eeab4c41e4a7012` on July 27, 2026.

| Skills | Triggered skills | Eager prompt | Routed prompt | Reduction | Eager cold build | Routed cold build | First cold miss | Warm miss |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 73 | 2 | 7,577 B | 2,291 B | 69.76% | 6.69 ms | 6.60 ms | 0.09 ms | 0.006 ms |
| 73 | 62 | 7,577 B | 2,291 B | 69.76% | 6.51 ms | 6.54 ms | 1.41 ms | 0.019 ms |
| 267 | 8 | 22,903 B | 2,303 B | 89.94% | 21.78 ms | 20.82 ms | 0.06 ms | 0.024 ms |
| 267 | 227 | 22,903 B | 2,303 B | 89.94% | 22.67 ms | 21.81 ms | 3.97 ms | 0.066 ms |
| 500 | 15 | 41,310 B | 2,303 B | 94.43% | 39.10 ms | 38.55 ms | 0.13 ms | 0.042 ms |
| 500 | 425 | 41,310 B | 2,303 B | 94.43% | 46.80 ms | 40.40 ms | 4.83 ms | 0.118 ms |

Each row passed all four benchmark route checks: exact match, case-insensitive match, word-boundary rejection, and ordinary-message miss.

The benchmark deliberately shows both sides of the tradeoff:

- routed mode reduces transmitted prompt bytes substantially as the catalog grows;
- it does not avoid the cold metadata scan, so cold prompt-build time remains comparable;
- trigger matching stays below 5.5 ms for the first worst-case miss and below 0.13 ms after regex compilation in the 500-skill/425-trigger stress case.

## Verification

Focused feature and adjacent regression suite on the rebased PR branch:

```text
397 passed, 1 skipped, 0 failed
```

Additional local gates:

- `ruff check` passes on all changed Python files;
- `py_compile` passes on all changed production Python files and the benchmark;
- `git diff --check origin/main...HEAD` passes;
- benchmark correctness: 4/4 for all six catalog scenarios;
- direct rebase of the four focused commits onto current `origin/main` succeeds;
- one test-fixture compatibility commit supplies the `_emit_status` method now required by current upstream prompt construction.

The prior repository-wide baseline comparison is intentionally retired after this rebase because upstream advanced substantially. GitHub CI on the updated branch is the authoritative repository-wide result; the focused local suite above covers the routed feature and adjacent prompt/config/tool contracts before push.

## Test coverage

Coverage includes:

- eager default compatibility;
- routed category rendering and prompt budget;
- loading-mode cache separation;
- disk snapshot migration;
- root and nested category fallback;
- duplicate-name precedence;
- top-level and `metadata.hermes` triggers;
- punctuation, whitespace, and word boundaries;
- single-argument placeholders;
- longest-overlap selection;
- tool/toolset requirements and fallbacks;
- recursion protection;
- common-entry-point activation;
- encoded MoA activation;
- original-message persistence and explicit persistence overrides;
- config validation;
- prompt-size reporting.

## Review map

- Configuration/session stability: `agent/skill_preprocessing.py`, `agent/agent_init.py`, `hermes_cli/config.py`
- Prompt/category rendering and cache behavior: `agent/prompt_builder.py`, `agent/system_prompt.py`
- Trigger matching and skill expansion: `agent/skill_commands.py`
- Common turn normalization/transcript preservation: `run_agent.py`
- Category fallback tool: `tools/skills_tool.py`
- Reproducible performance evidence: `scripts/benchmark_routed_skills.py`
- User documentation: `website/docs/user-guide/features/skills.md`