### PR TITLE
fix(desktop): panel layout toggle bugs — terminal reveal, side collapse in column-root layouts, zone-menu restore

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/index.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/index.tsx
@@ -71,7 +71,7 @@ export function LayoutTreeRoot({ children }: { children?: ReactNode }) {
           display: none;
         }
       `}</style>
-      <TreeNode node={tree} root />
+      <TreeNode node={tree} root rootRow={tree.type === 'split' && tree.orientation === 'row'} />
       <NarrowOverlays />
       <TreeEditBar />
       <ZoneEditor />

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-node.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-node.tsx
@@ -5,6 +5,9 @@ import { TreeSplit } from './tree-split'
 
 /** Dispatch a layout node to its renderer — the split/group recursion point.
  *  `root` marks the tree's top split (side collapse applies only there).
+ *  `rootRow` marks the row split that owns the side columns — usually the root
+ *  itself, but in a column-root layout (Terminal deck, Quad) it's the row
+ *  child holding sessions/workspace/files. Side collapse (⌘B/⌘J) applies here.
  *  `parentAxis` is the containing split's orientation — a group collapses
  *  ALONG that axis, so it picks the minimized form (row → vertical rail,
  *  column → horizontal header). `railSide` is which half of that row the
@@ -13,15 +16,17 @@ export function TreeNode({
   node,
   parentAxis,
   railSide,
-  root
+  root,
+  rootRow
 }: {
   node: LayoutNode
   parentAxis?: 'column' | 'row'
   railSide?: 'left' | 'right'
   root?: boolean
+  rootRow?: boolean
 }) {
   return node.type === 'split' ? (
-    <TreeSplit node={node} root={root} />
+    <TreeSplit node={node} root={root} rootRow={rootRow} />
   ) : (
     <TreeGroup node={node} parentAxis={parentAxis} railSide={railSide} />
   )

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -66,7 +66,7 @@ function useSubtreeOverrides(paneIds: readonly string[]): TrackContext['override
   return useSyncExternalStore(cb => $paneStates.listen(cb), snapshot, snapshot)
 }
 
-export function TreeSplit({ node, root }: { node: SplitNode; root?: boolean }) {
+export function TreeSplit({ node, root, rootRow }: { node: SplitNode; root?: boolean; rootRow?: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const panes = useContributions('panes')
   const hiddenPanes = useStore($hiddenTreePanes)
@@ -79,6 +79,21 @@ export function TreeSplit({ node, root }: { node: SplitNode; root?: boolean }) {
   const collapsedSides = useStore($collapsedTreeSides)
   const horizontal = node.orientation === 'row'
   const axis = node.orientation
+
+  // When the root is a column (Terminal deck, Quad), the root ROW — the one
+  // the side-collapse system operates on — is a row child containing main.
+  // Propagate `rootRow` to that child so its `semanticSides` fires.
+  const childRootRow = (child: LayoutNode): boolean => {
+    if (!root || horizontal) {
+      return false
+    }
+
+    if (child.type !== 'split' || child.orientation !== 'row') {
+      return false
+    }
+
+    return allPaneIds(child).some(id => paneChrome(paneFor(id)).placement === 'main')
+  }
 
   // A pane leaves the grid when its contribution isn't registered (yet) — a
   // runtime plugin's pane collapses until the plugin loads, then appears; no
@@ -353,7 +368,9 @@ export function TreeSplit({ node, root }: { node: SplitNode; root?: boolean }) {
   // ⌘B owns the sessions column and ⌘J the other side columns — by pane
   // placement, NOT position, so a ⌘\ flip moves the columns without
   // rewiring the toggles (main parity). In edit mode sides stay visible.
-  const semanticSides = root && horizontal && collapsedSides.size > 0 && !editMode
+  // `rootRow` covers both a row root (Default, Focus) and a row nested inside
+  // a column root (Terminal deck, Quad) — wherever the side columns live.
+  const semanticSides = rootRow && horizontal && collapsedSides.size > 0 && !editMode
 
   const sideGone = (i: number) => {
     if (!semanticSides) {
@@ -463,7 +480,12 @@ export function TreeSplit({ node, root }: { node: SplitNode; root?: boolean }) {
               />
             )}
             {!narrowCollapsed && (
-              <TreeNode node={child} parentAxis={axis} railSide={horizontal ? railSideFor(i) : undefined} />
+              <TreeNode
+                node={child}
+                parentAxis={axis}
+                railSide={horizontal ? railSideFor(i) : undefined}
+                rootRow={rootRow || childRootRow(child)}
+              />
             )}
           </div>
         )

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -35,7 +35,8 @@ import {
   setGroupHeaderHidden as setGroupHeaderHiddenOp,
   setGroupMinimized,
   setSplitWeights as setSplitWeightsOp,
-  splitGroupZone as splitGroupZoneOp
+  splitGroupZone as splitGroupZoneOp,
+  type SplitNode
 } from './model'
 import { rootChildSide } from './renderer/track-model'
 
@@ -357,18 +358,52 @@ export function removeTreePane(paneId: string) {
   }
 }
 
+/** The layout's root ROW — the split that contains main + the side columns.
+ *  Usually the root itself (Default, Focus); in a column-root layout (Terminal
+ *  deck, Quad) it's the row child that holds sessions/workspace/files. Returns
+ *  null when the tree has no row split with side-eligible panes. */
+function rootRow(): SplitNode | null {
+  const tree = $layoutTree.get()
+
+  if (!tree || tree.type !== 'split') {
+    return null
+  }
+
+  if (tree.orientation === 'row') {
+    return tree
+  }
+
+  // Column root: find the row child that contains the main pane — that's the
+  // row the side-collapse system operates on (sessions left, files right).
+  const panes = registry.getArea('panes')
+
+  const hasMain = (node: LayoutNode): boolean => {
+    if (node.type === 'group') {
+      return node.panes.some(id =>
+        (panes.find(p => p.id === id)?.data as { placement?: string } | undefined)?.placement === 'main'
+      )
+    }
+
+    return node.children.some(hasMain)
+  }
+
+  return tree.children.find(child => child.type === 'split' && child.orientation === 'row' && hasMain(child)) as
+    | SplitNode
+    | undefined ?? null
+}
+
 /** Which root-row side a pane currently lives in, or null when it's nested
  *  with main (dragged into the middle) — where a side collapse can't hide it.
  *  Lets side-bound closers (files/sessions) fall back to dismissal. */
 export function paneRootSide(paneId: string): null | TreeSide {
-  const tree = $layoutTree.get()
+  const row = rootRow()
 
-  if (tree?.type !== 'split' || tree.orientation !== 'row') {
+  if (!row) {
     return null
   }
 
   const panes = registry.getArea('panes')
-  const child = tree.children.find(c => allPaneIds(c).includes(paneId))
+  const child = row.children.find(c => allPaneIds(c).includes(paneId))
 
   return child ? rootChildSide(child, id => panes.find(p => p.id === id)) : null
 }
@@ -453,15 +488,15 @@ export function setTreeSideCollapsed(side: TreeSide, collapsed: boolean) {
  * reuses `rootChildSide`, so it tracks a ⌘\ flip / drag like the toggles do.
  */
 export function layoutHasRootSide(side: TreeSide): boolean {
-  const tree = $layoutTree.get()
+  const row = rootRow()
 
-  if (tree?.type !== 'split' || tree.orientation !== 'row') {
+  if (!row) {
     return false
   }
 
   const panes = registry.getArea('panes')
 
-  return tree.children.some(child => rootChildSide(child, id => panes.find(p => p.id === id)) === side)
+  return row.children.some(child => rootChildSide(child, id => panes.find(p => p.id === id)) === side)
 }
 
 /**
@@ -515,13 +550,13 @@ export function bindTreeSideVisibility(
  *  panes) wherever it sits, ⌘J ⇔ the other side columns. Null for the main
  *  column (never side-collapsed). */
 export function treeSideOfPane(paneId: string): TreeSide | null {
-  const tree = $layoutTree.get()
+  const row = rootRow()
 
-  if (!tree || tree.type !== 'split' || tree.orientation !== 'row') {
+  if (!row) {
     return null
   }
 
-  const child = tree.children.find(node => allPaneIds(node).includes(paneId))
+  const child = row.children.find(node => allPaneIds(node).includes(paneId))
 
   if (!child) {
     return null
@@ -1056,6 +1091,18 @@ export function restoreTreePane(paneId: string) {
 
   if (open) {
     open()
+
+    // The opener may be a no-op — the store was already true (zone minimized
+    // via the zone menu, not the toggle). nanostores don't fire listeners on
+    // a same-value .set(), so the bindPaneCollapse listener never runs and
+    // the zone stays minimized. Un-minimize directly when that happens.
+    const group = paneGroup(paneId)
+
+    if (group?.minimized) {
+      toggleTreeGroupMinimized(group.id, false)
+    }
+
+    revealTreePane(paneId)
 
     return
   }

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -574,8 +574,26 @@ export function revealTreePane(paneId: string) {
   const tree = $layoutTree.get()
   const group = tree ? findGroupOfPane(tree, paneId) : null
 
-  if (tree && group && group.active !== paneId) {
-    commit(setActivePaneOp(tree, group.id, paneId))
+  if (tree && group) {
+    // A minimized zone must be restored — "reveal" means show the pane, not
+    // just front its tab behind a collapsed rail. Without this, a tool panel
+    // (terminal/logs) in a shared zone stays minimized after its toggle opens
+    // it: setPaneCollapsed's shared-zone branch calls revealTreePane instead
+    // of toggleTreeGroupMinimized, so the zone never un-minimizes and the
+    // pane appears to "close but not open" on ctrl-` / tab click.
+    let next = tree
+
+    if (group.minimized) {
+      next = setGroupMinimized(next, group.id, false)
+    }
+
+    if (group.active !== paneId) {
+      next = setActivePaneOp(next, group.id, paneId)
+    }
+
+    if (next !== tree) {
+      commit(next)
+    }
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes three regressions in the desktop app's panel layout system, all stemming from the new tree-based layout model.

### Bug 1: Ctrl+` toggles the terminal closed but not open

`revealTreePane()` fronts a pane's tab but never un-minimizes its zone. This was invisible for lone-pane zones (the single-pane branch in `setPaneCollapsed` calls `toggleTreeGroupMinimized` directly), but the `logs` pane has `placement: 'bottom'` — same as `terminal` — so `adoptContributedPanes()` silently adopts it into the terminal's group, making it a **shared zone** (2 panes). In the shared-zone branch, `setPaneCollapsed` routes opens through `revealTreePane` instead of `toggleTreeGroupMinimized`, so the zone stays minimized and the terminal never shows.

**Fix:** `revealTreePane` now un-minimizes the zone before fronting the pane, chaining the un-minimize + activate into a single `commit` so the second op sees the updated tree.

### Bug 2: Ctrl+B / Ctrl+J don't work in the Terminal deck (and Quad) layout

The side-collapse system (`treeSideOfPane`, `paneRootSide`, `layoutHasRootSide`, and the renderer's `semanticSides`) only operated on the ROOT split when it was a `row`. Terminal deck's root is a `column`, so the side columns (sessions/files) nested inside a child row were invisible to the collapse system — pressing Ctrl+B set `$sidebarOpen` to false, but the renderer never applied the collapse.

**Fix:** Extracted a `rootRow()` helper that finds the row containing the main pane (the root itself for row layouts, or the row child of a column root). All three store functions use it. On the renderer side, a `rootRow` prop is propagated through `TreeNode` → `TreeSplit` so `semanticSides` fires on the right split regardless of root orientation.

### Bug 3: Clicking the "logs" tab in a minimized terminal/logs zone needs a double-click (when minimized via the zone menu)

If the zone was minimized via the zone menu (right-click → minimize) instead of the toggle, `$logsOpen` stayed `true`. Clicking the tab called `restoreTreePane('logs')` → opener `$logsOpen.set(true)` — but nanostores don't fire listeners on a no-op `.set()`, so `setPaneCollapsed`/`revealTreePane` never ran and the zone stayed minimized.

**Fix:** `restoreTreePane` now checks if the zone is still minimized after calling the opener, and if so un-minimizes directly + calls `revealTreePane` to front the pane.

## Related Issue

Reported in Discord: Ctrl+` closes terminal but doesn't open it; terminal/logs tabs need double-click; Ctrl+B / Ctrl+J and the "show sidebar" button do nothing (the sidebar part fixed by "reset layout" — the terminal toggle persists).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/store.ts`:
  - `revealTreePane()` now un-minimizes the zone before fronting the pane, chaining un-minimize + activate into a single `commit` (bug 1)
  - New `rootRow()` helper finds the row containing main — the root itself for row layouts, or the row child of a column root (bug 2)
  - `treeSideOfPane()`, `paneRootSide()`, `layoutHasRootSide()` all use `rootRow()` instead of checking `tree.orientation !== 'row'` on the root (bug 2)
  - `restoreTreePane()` now un-minimizes directly + calls `revealTreePane` when the zone is still minimized after the opener runs (bug 3)
- `apps/desktop/src/components/pane-shell/tree/renderer/tree-node.tsx` — added `rootRow` prop, propagated to `TreeSplit` (bug 2)
- `apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx` — `semanticSides` uses `rootRow` instead of `root`; new `childRootRow()` detects the row child containing main in a column root and propagates `rootRow` to it (bug 2)
- `apps/desktop/src/components/pane-shell/tree/renderer/index.tsx` — `LayoutTreeRoot` passes `rootRow` when the root is a row split (bug 2)

## How to Test

1. **Bug 1:** Launch the desktop app (default layout). Press Ctrl+` to collapse the terminal — it should minimize to a rail. Press Ctrl+` again — it should **restore** (previously: stayed collapsed). Click the terminal tab in the rail — single click should restore (previously: needed double-click). Same for the logs pane (toggle via command palette "Toggle logs").
2. **Bug 2:** Switch to the "Terminal deck" layout (command palette or layout picker). Press Ctrl+B — the sessions sidebar should hide. Press again — it should show. Same for Ctrl+J and the right sidebar.
3. **Bug 3:** Right-click the terminal/logs zone header → "Minimize". Click the "logs" tab in the rail — single click should restore it (previously: needed double-click).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run tests: `npx vitest run` (desktop suite) — 1699 passed, 17 pre-existing failures in `markdown-text.test.ts` (unrelated `@assistant-ui/react-streamdown` version mismatch), 0 new failures
- [x] I've tested on my platform: Linux (NixOS, Hyprland)

### Documentation and Housekeeping

- [x] N/A — no docs/config/AGENTS.md changes needed (logic fix in the layout tree store + renderer)
