### PR TITLE
fix(models): resolve dash-form model IDs against dotted OpenRouter catalog (#65152)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2100,6 +2100,9 @@ def _find_openrouter_slug(model_name: str) -> Optional[str]:
     - Exact match: ``anthropic/claude-opus-4.6`` → as-is
     - Bare name: ``deepseek-chat`` → ``deepseek/deepseek-chat``
     - Bare name: ``claude-opus-4.6`` → ``anthropic/claude-opus-4.6``
+    - Punctuation-flexible match: ``claude-opus-4-8`` → ``anthropic/claude-opus-4.8``
+      (last-resort alnum-only compare; avoids dash<->dot rewrites that would
+      collapse legitimate word-separator dashes like ``deepseek-chat``.)
     """
     name_lower = model_name.strip().lower()
     if not name_lower:
@@ -2116,6 +2119,20 @@ def _find_openrouter_slug(model_name: str) -> Optional[str]:
             _, model_part = mid.split("/", 1)
             if name_lower == model_part.lower():
                 return mid
+
+    # Last resort: punctuation-insensitive compare on the model part only.
+    # Strips every non-alphanumeric char so a dash-only input like
+    # ``claude-opus-4-8`` matches the dotted ``claude-opus-4.8`` catalog
+    # entry. Word-separator dashes (``deepseek-chat``) remain distinct from
+    # bare-catalog entries because we still require the catalog entry to
+    # carry a provider/ prefix.
+    name_alnum = re.sub(r"[^a-z0-9]", "", name_lower)
+    if name_alnum:
+        for mid in model_ids():
+            if "/" in mid:
+                _, model_part = mid.split("/", 1)
+                if re.sub(r"[^a-z0-9]", "", model_part.lower()) == name_alnum:
+                    return mid
 
     return None
 

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -242,6 +242,40 @@ class TestFindOpenrouterSlug:
         with patch("hermes_cli.models.fetch_openrouter_models", return_value=LIVE_OPENROUTER_MODELS):
             assert _find_openrouter_slug("totally-fake-model-xyz") is None
 
+    def test_dash_matches_dotted_catalog_entry(self):
+        """Anthropic-curated dash IDs (e.g. ``claude-opus-4-6``) should resolve
+        to the dotted OpenRouter catalog entry via alnum-only last-resort
+        matching — closes #65152."""
+        from hermes_cli.models import _find_openrouter_slug
+        catalog = LIVE_OPENROUTER_MODELS + [
+            ("anthropic/claude-opus-4.8", "recommended"),
+        ]
+        with patch("hermes_cli.models.fetch_openrouter_models", return_value=catalog):
+            assert _find_openrouter_slug("claude-opus-4-8") == "anthropic/claude-opus-4.8"
+
+    def test_dash_match_does_not_collapse_word_separator_dashes(self):
+        """Word-separator dashes (``deepseek-chat``) must remain distinct
+        from a hypothetical bare-catalog entry — the alnum compare only runs
+        against the post-/ model part, so a bare catalog hit still requires
+        a provider/ prefix on the catalog side."""
+        from hermes_cli.models import _find_openrouter_slug
+        catalog = [
+            ("deepseek/deepseek-chat", ""),
+            ("deepseek/deepseek-chat-v3", ""),
+        ]
+        with patch("hermes_cli.models.fetch_openrouter_models", return_value=catalog):
+            # Both dash inputs resolve to their dotted catalog entry.
+            assert _find_openrouter_slug("deepseek-chat") == "deepseek/deepseek-chat"
+            assert (
+                _find_openrouter_slug("deepseek-chat-v3")
+                == "deepseek/deepseek-chat-v3"
+            )
+
+    def test_dash_match_still_unknown_when_no_catalog_match(self):
+        from hermes_cli.models import _find_openrouter_slug
+        with patch("hermes_cli.models.fetch_openrouter_models", return_value=LIVE_OPENROUTER_MODELS):
+            assert _find_openrouter_slug("completely-bogus-name-12345") is None
+
 
 class TestDetectProviderForModel:
     def test_anthropic_model_detected(self):


### PR DESCRIPTION
Closes #65152

`_find_openrouter_slug` matches a bare model name against the OpenRouter catalog by exact string comparison on the model part (after `provider/`). The Anthropic curated list (`hermes_cli/models.py` under `"anthropic":`) uses Anthropic's dash convention (`claude-opus-4-8`), while the OpenRouter catalog uses dotted, provider-prefixed slugs (`anthropic/claude-opus-4.8`).

When the active provider is `openrouter` and the resolved model name comes from the Anthropic curated list (e.g. via `/model` switch or auto-escalation), the dash/dot mismatch makes both exact-match passes return `None`, and the caller falls through to sending the raw, unresolved name straight to the OpenRouter API, which rejects it with `HTTP 400: claude-opus-4-8 is not a valid model ID`.

Fix: add a punctuation-insensitive (alnum-only) last-resort matching pass on the post-`/` model part. This maps a dash-only input like `claude-opus-4-8` to the dotted `anthropic/claude-opus-4.8` catalog entry without doing a blanket dash↔dot rewrite that would also collapse legitimate word-separator dashes (e.g. `deepseek-chat` ↔ `deepseek/chat`).

Reproduction on current `main`:

```python
from hermes_cli.models import _find_openrouter_slug
_find_openrouter_slug("claude-opus-4-8")  # -> None before fix, "anthropic/claude-opus-4.8" after
```

Tests:

- `test_dash_matches_dotted_catalog_entry` — regression for the reported case.
- `test_dash_match_does_not_collapse_word_separator_dashes` — confirms word-separator dashes still resolve correctly to their catalog entries.
- `test_dash_match_still_unknown_when_no_catalog_match` — confirms unknown dash inputs still return `None`.
- The pre-existing `test_unknown_returns_none` and `test_bare_name_match` cases continue to pass.

Diff: +14 source / +34 tests, 2 files. Comments document the last-resort rationale and the word-separator constraint.