### PR TITLE
fix(tools): accept JSONC in the .json write gate (comments, trailing commas)

### DIFF
--- a/tests/tools/test_write_file_syntax_gate.py
+++ b/tests/tools/test_write_file_syntax_gate.py
@@ -125,3 +125,87 @@ class TestFailClosedSyntaxGate:
         res = ops.write_file(str(target), content)
         assert res.error is None, res.error
         assert target.read_text() == content
+
+
+class TestJsoncAcceptedByGate:
+    """JSONC — comments + trailing commas — is the documented convention of
+    tsconfig.json, VS Code settings.json / launch.json, devcontainer.json,
+    and friends. Like multi-document / tagged YAML above, that's a content
+    convention of the file's consumer, not corruption: the gate must not
+    refuse it. Real corruption in a JSONC file must still be refused."""
+
+    TSCONFIG = (
+        "{\n"
+        "  // Which files to compile\n"
+        '  "include": ["src"],\n'
+        '  "compilerOptions": {\n'
+        "    /* emit settings */\n"
+        '    "target": "ES2022",\n'
+        '    "strict": true,\n'
+        '    "noEmit": true,\n'
+        "  }\n"
+        "}\n"
+    )
+
+    def test_commented_tsconfig_written_exactly(self, ops, tmp_path: Path):
+        target = tmp_path / "tsconfig.json"
+        res = ops.write_file(str(target), self.TSCONFIG)
+        assert res.error is None, res.error
+        assert target.read_text() == self.TSCONFIG, (
+            "JSONC must land on disk byte-for-byte — comments included"
+        )
+
+    def test_patch_replace_on_commented_tsconfig_succeeds(self, ops, tmp_path: Path):
+        """Editing one key of an existing commented tsconfig.json must work —
+        patch_replace writes back through write_file, so a strict-JSON gate
+        would refuse the edit even though the edit itself is valid."""
+        target = tmp_path / "tsconfig.json"
+        target.write_text(self.TSCONFIG)
+        res = ops.patch_replace(str(target), '"strict": true', '"strict": false')
+        assert res.error is None, res.error
+        after = target.read_text()
+        assert '"strict": false' in after
+        assert "// Which files to compile" in after, "comments must survive the patch"
+
+    def test_comment_markers_inside_strings_are_not_comments(self, ops, tmp_path: Path):
+        """`//` in a URL and `/*` in a glob are string content, not comment
+        openers — the JSONC scan must be string-aware."""
+        target = tmp_path / "config.json"
+        content = (
+            "{\n"
+            '  "url": "https://example.com//path",\n'
+            '  "glob": "src/**/*.ts",\n'
+            "}\n"
+        )
+        res = ops.write_file(str(target), content)
+        assert res.error is None, res.error
+        assert target.read_text() == content
+
+    def test_commas_and_brackets_inside_strings_survive(self, ops, tmp_path: Path):
+        target = tmp_path / "data.json"
+        content = '{\n  "sep": ",]",\n  "x": 1,\n}\n'
+        res = ops.write_file(str(target), content)
+        assert res.error is None, res.error
+        assert target.read_text() == content
+
+    def test_truncated_jsonc_still_refused(self, ops, tmp_path: Path):
+        """Comments don't grant amnesty: a truncated file is corruption and
+        must still be refused with nothing written."""
+        target = tmp_path / "tsconfig.json"
+        res = ops.write_file(str(target), '{\n  // comment\n  "include": ["src"\n')
+        assert res.error is not None
+        assert not target.exists()
+
+    def test_unterminated_block_comment_refused(self, ops, tmp_path: Path):
+        target = tmp_path / "config.json"
+        res = ops.write_file(str(target), '{"a": 1} /* never closed')
+        assert res.error is not None
+        assert not target.exists()
+
+    def test_json5_isms_still_refused(self, ops, tmp_path: Path):
+        """Only the JSONC superset is accepted — JSON5 (single quotes,
+        unquoted keys) keeps failing the gate."""
+        target = tmp_path / "config.json"
+        res = ops.write_file(str(target), "{a: 'single'}\n")
+        assert res.error is not None
+        assert not target.exists()

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -599,13 +599,114 @@ def _looks_like_linter_unusable(base_cmd: str, output: str) -> bool:
     return any(p in lower for p in patterns)
 
 
+def _strip_jsonc_constructs(content: str) -> str:
+    """Reduce JSONC to plain JSON: drop comments and trailing commas.
+
+    Used by ``_lint_json_inproc`` to decide whether a strict-parse failure
+    is real corruption or merely JSONC.  String-aware: ``//`` inside a
+    string value (URLs), ``/*`` inside a glob pattern, and comma/bracket
+    sequences inside strings are left untouched.  Newlines inside dropped
+    comments are preserved so line numbers in a subsequent strict-parse
+    error still point at the right line.  An unterminated block comment is
+    left in place so the strict parse rejects it — a comment that never
+    closes is truncation, not a JSONC convention.
+    """
+    out: list = []
+    i, n = 0, len(content)
+    in_string = False
+    while i < n:
+        ch = content[i]
+        if in_string:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(content[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and content.startswith("//", i):
+            eol = content.find("\n", i)
+            if eol == -1:
+                break  # line comment runs to EOF — valid JSONC, just drop it
+            i = eol  # keep the newline itself (appended on the next pass)
+            continue
+        if ch == "/" and content.startswith("/*", i):
+            end = content.find("*/", i + 2)
+            if end == -1:
+                out.append(content[i:])  # unterminated — let strict parse reject it
+                break
+            out.append("\n" * content.count("\n", i, end + 2))
+            i = end + 2
+            continue
+        out.append(ch)
+        i += 1
+
+    text = "".join(out)
+    out2: list = []
+    i, n = 0, len(text)
+    in_string = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out2.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out2.append(text[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out2.append(ch)
+            i += 1
+            continue
+        if ch == ",":
+            j = i + 1
+            while j < n and text[j] in " \t\r\n":
+                j += 1
+            if j < n and text[j] in "}]":
+                i += 1  # trailing comma — drop from the validation copy
+                continue
+        out2.append(ch)
+        i += 1
+    return "".join(out2)
+
+
 def _lint_json_inproc(content: str) -> tuple[bool, str]:
-    """In-process JSON syntax check.  Returns (ok, error_message)."""
+    """In-process JSON syntax check.  Returns (ok, error_message).
+
+    Accepts the JSONC superset — ``//`` and ``/* */`` comments plus
+    trailing commas — on top of strict JSON.  Plenty of ``.json`` files
+    are JSONC by their consumer's documented convention (``tsconfig.json``,
+    VS Code ``settings.json`` / ``launch.json``, ``devcontainer.json``);
+    comments there are a feature of the format, not a syntax error, and
+    this linter's verdict is used as a fail-closed WRITE gate in
+    ``write_file`` — a false positive here refuses a legitimate write
+    outright (the same reasoning that keeps ``_lint_yaml_inproc`` below
+    syntax-only for multi-document/tagged YAML).  Real corruption
+    (truncated generation, mashed quotes) still fails after the JSONC
+    constructs are stripped, so the gate keeps catching what it was built
+    to catch.
+    """
     import json as _json
     try:
         _json.loads(content)
         return True, ""
     except _json.JSONDecodeError as e:
+        try:
+            _json.loads(_strip_jsonc_constructs(content))
+            return True, ""
+        except Exception:  # noqa: BLE001 — not JSONC either; report the strict error
+            pass
         return False, f"JSONDecodeError: {e.msg} (line {e.lineno}, column {e.colno})"
     except Exception as e:  # noqa: BLE001 — any parse failure is a lint failure
         return False, f"{type(e).__name__}: {e}"


### PR DESCRIPTION
## What does this PR do?

The fail-closed pre-write syntax gate validates `.json` candidates with strict `json.loads`, so **valid JSONC is refused outright**. JSONC — `//` and `/* */` comments plus trailing commas — is the documented convention of `tsconfig.json`, VS Code `settings.json` / `launch.json`, `devcontainer.json`, and similar files. Since `patch_replace` writes back through `write_file`, the agent can neither create a commented `tsconfig.json` nor change a single key in an existing one:

- `write_file("tsconfig.json", <content with comments>)` → `Refusing to write ... candidate content fails .json syntax validation (JSONDecodeError: Expecting property name enclosed in double quotes ...)`, nothing written.
- `patch_replace("tsconfig.json", '"strict": true', '"strict": false')` → same refusal, file untouched. The edit itself is perfectly valid — the pre-existing comments make the whole file fail strict parsing.

The agent then loops "fixing" content that is already correct, or strips the user's comments to force strict JSON — silently destroying documentation in their config files.

This is the same false-positive class already fixed for YAML right after the gate landed: `safe_load` was switched to `yaml.parse` because multi-document streams and application-defined tags are a **consumer's content convention, not corruption**, and a false positive in a fail-closed gate refuses a legitimate write outright. This PR applies the identical reasoning to the JSON side.

**The fix:** `_lint_json_inproc` tries strict `json.loads` first; on failure it re-parses a validation-only copy produced by a string-aware JSONC scrub (drops `//` and `/* */` comments and trailing commas; markers inside strings — URLs, globs — are untouched; newlines inside dropped comments are preserved so error line numbers stay meaningful). The file lands on disk **byte-for-byte as sent, comments included** — the scrub is only used to judge syntax. Real corruption (truncated generation, mashed quotes, unterminated block comments, JSON5-isms like single quotes/unquoted keys) still fails after the scrub and keeps being refused with the original strict error, so the gate keeps catching exactly what it was built to catch.

## Related Issue

Fixes # — no existing issue. Follow-up to the write gate introduced via #60525, sibling of the YAML syntax-only follow-up commit (`6695640c1`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py`
  - New `_strip_jsonc_constructs()` helper: string-aware, single-pass comment removal + trailing-comma removal used only to build the validation copy. Unterminated block comments are deliberately left in place so the strict parse rejects them (a comment that never closes is truncation, not JSONC).
  - `_lint_json_inproc()` now accepts the JSONC superset via strict-parse-first / scrub-and-reparse-fallback, and reports the original strict error when both parses fail.
- `tests/tools/test_write_file_syntax_gate.py`
  - New `TestJsoncAcceptedByGate` class (7 tests) alongside the existing gate tests.

## How to Test

1. Run the gate suite: `pytest tests/tools/test_write_file_syntax_gate.py -q` → 18 passed (11 pre-existing + 7 new).
2. New tests cover both directions:
   - **Accepted (previously refused):** a realistic `tsconfig.json` with `//` line comments, a `/* */` block comment, and a trailing comma is written **byte-for-byte**; `patch_replace` flipping `"strict": true → false` in an existing commented tsconfig succeeds with comments preserved; `//` inside a URL string and `/*` inside a glob string are not treated as comment openers; commas/brackets inside string values survive validation.
   - **Still refused (no regression in the gate's purpose):** truncated JSONC (`{ // comment` + unclosed array) refused with nothing written; an unterminated `/*` block comment refused; JSON5-isms (single quotes, unquoted keys) refused.
3. Manual repro of the original bug (on `main`, before this fix):
   ```python
   from tools.environments.local import LocalEnvironment
   from tools.file_operations import ShellFileOperations
   ops = ShellFileOperations(LocalEnvironment(cwd="<tmp>"), cwd="<tmp>")
   ops.write_file("<tmp>/tsconfig.json", '{\n  // compile scope\n  "include": ["src"],\n}\n')
   # -> error: "Refusing to write ... fails .json syntax validation", file not created
   ```
   With this fix the same call succeeds and the file contains the comment verbatim.
4. Full neighbouring suites (`tests/tools/test_file_operations.py`, `test_file_operations_edge_cases.py`, `test_file_write_safety.py`) show no new failures versus `main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — the new gate behavior is documented on `_lint_json_inproc` / `_strip_jsonc_constructs`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python string scan, no OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no schema change; the gate's refusal contract is unchanged for genuinely invalid content)

## Screenshots / Logs

Before (current `main`):

```
=== write_file: NEW tsconfig.json with comments (valid JSONC) ===
error: Refusing to write '<tmp>/tsconfig.json': candidate content fails .json syntax
validation (JSONDecodeError: Expecting property name enclosed in double quotes
(line 2, column 3)). The file was NOT created or modified. Fix the content and retry.
file exists after write: False

=== patch_replace: edit ONE key in an existing commented tsconfig.json ===
error: Failed to write changes: Refusing to write '<tmp>/proj/tsconfig.json': ...
file still contains '"strict": true' (unmodified): True
```

After (this branch): both operations succeed, the file lands byte-for-byte with comments preserved, and all corruption cases above remain refused.