### PR TITLE
fix(desktop): match sessions by git branch in ctrl-k palette and sidebar search

### DIFF
--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -118,6 +118,7 @@ interface PalettePage {
 }
 
 interface SessionEntry {
+  git_branch?: null | string
   id: string
   preview?: string
   title: string
@@ -212,6 +213,7 @@ const SESSION_ID_RE = /^\d{8}_\d{6}_[a-f0-9]{6}$/
 type SessionRow = Awaited<ReturnType<typeof listAllProfileSessions>>['sessions'][number]
 
 const toSessionEntry = (session: SessionRow): SessionEntry => ({
+  git_branch: session.git_branch ?? null,
   id: session.id,
   preview: session.preview ?? undefined,
   title: sessionTitle(session)
@@ -684,7 +686,7 @@ export function CommandPalette() {
         items: sessions.map(session => ({
           icon: MessageCircle,
           id: `session-${session.id}`,
-          keywords: ['chat', 'session', ...(session.preview ? [session.preview] : [])],
+          keywords: ['chat', 'session', ...(session.preview ? [session.preview] : []), ...(session.git_branch ? [session.git_branch] : [])],
           label: session.title,
           run: go(sessionRoute(session.id))
         }))
@@ -722,7 +724,7 @@ export function CommandPalette() {
         items: archivedSessions.map(session => ({
           icon: Archive,
           id: `archived-${session.id}`,
-          keywords: ['archived', 'chat', 'session', ...(session.preview ? [session.preview] : [])],
+          keywords: ['archived', 'chat', 'session', ...(session.preview ? [session.preview] : []), ...(session.git_branch ? [session.git_branch] : [])],
           label: session.title,
           run: go(`${SETTINGS_ROUTE}?tab=sessions&session=${encodeURIComponent(session.id)}`)
         }))

--- a/apps/desktop/src/lib/session-search.test.ts
+++ b/apps/desktop/src/lib/session-search.test.ts
@@ -52,6 +52,12 @@ describe('sessionMatchesSearch', () => {
     expect(sessionMatchesSearch(session, 'hermes-agent')).toBe(true)
   })
 
+  it('matches sessions by git branch', () => {
+    expect(sessionMatchesSearch(makeSession({ git_branch: 'feat/cool-thing' }), 'feat/cool-thing')).toBe(true)
+    expect(sessionMatchesSearch(makeSession({ git_branch: 'feat/cool-thing' }), 'cool')).toBe(true)
+    expect(sessionMatchesSearch(makeSession({ git_branch: 'main' }), 'main')).toBe(true)
+  })
+
   it('matches sessions by source platform and aliases', () => {
     expect(sessionMatchesSearch(makeSession({ source: 'telegram' }), 'Telegram')).toBe(true)
     expect(sessionMatchesSearch(makeSession({ source: 'whatsapp' }), 'WhatsApp')).toBe(true)

--- a/apps/desktop/src/lib/session-search.ts
+++ b/apps/desktop/src/lib/session-search.ts
@@ -17,6 +17,7 @@ export function sessionMatchesSearch(session: SessionInfo, query: string): boole
     sessionTitle(session),
     session.preview ?? '',
     session.cwd ?? '',
+    session.git_branch ?? '',
     ...sessionSourceSearchTerms(session.source)
   ].some(value => value.toLowerCase().includes(needle))
 }


### PR DESCRIPTION
## What does this PR do?

SessionInfo already carries `git_branch` from the backend, but neither the ctrl-k command palette nor the sidebar search function included it in their matching fields. Typing a branch name matched nothing — now it surfaces all sessions on that branch.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/session-search.ts` — add `session.git_branch` to `sessionMatchesSearch` so sidebar search matches on branch
- `apps/desktop/src/app/command-palette/index.tsx` — thread `git_branch` through `SessionEntry`/`toSessionEntry` and into the `keywords` array for both the sessions and archived sessions groups, so `scoreItem`'s keyword-matching path picks it up
- `apps/desktop/src/lib/session-search.test.ts` — cover full branch name, partial branch name, and `main`

## How to Test

1. Have sessions on different git branches (the backend already captures `git_branch` on session start/resume)
2. Open the ctrl-k command palette (⌘K) and type a branch name — sessions from that branch appear
3. Type a branch name in the sidebar search — sessions on that branch are filtered

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux 7.1.0)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed