### PR TITLE
fix(skills): normalize official skill bundle paths to POSIX on Windows

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1836,6 +1836,83 @@ class TestOptionalSkillSourceMetadata:
         assert meta.path == "optional-skills/finance/3-statement-model"
 
 
+    def test_fetch_identifier_uses_posix_separators(self, tmp_path):
+        # Regression for #64878: on Windows, str(WindowsPath) yields backslash
+        # separators in the bundle identifier, which breaks do_install's
+        # `identifier.split("/")` category auto-detection and installs official
+        # skills to a flat path instead of their canonical category path.
+        optional_root = tmp_path / "optional-skills"
+        skill_dir = optional_root / "finance" / "excel-author"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: excel-author\ndescription: test\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+
+        src = OptionalSkillSource()
+        src._optional_dir = optional_root
+
+        bundle = src.fetch("official/finance/excel-author")
+
+        assert bundle is not None
+        assert "\\" not in bundle.identifier
+        assert bundle.identifier == "official/finance/excel-author"
+        # The category auto-detection in do_install relies on this shape.
+        assert bundle.identifier.split("/")[1:-1] == ["finance"]
+
+
+class TestOptionalSkillSourceInstallPath:
+    def test_official_skill_installs_at_category_path(self, tmp_path):
+        # End-to-end regression for #64878: an "official/<category>/<name>"
+        # install must land at skills/<category>/<name>/ with its content, not
+        # at a flat skills/<name>/ path. On Windows the backslash identifier
+        # skipped category detection, producing a metadata-only "ghost" whose
+        # content lived at the wrong path (invisible to the canonical lookup).
+        import tools.skills_hub as hub
+        from hermes_cli.skills_hub import do_install
+
+        optional_root = tmp_path / "optional-skills"
+        skill_dir = optional_root / "finance" / "excel-author"
+        (skill_dir / "scripts").mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: excel-author\ndescription: test\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+        (skill_dir / "scripts" / "recalc.py").write_text(
+            "print('hi')\n", encoding="utf-8"
+        )
+
+        official_source = OptionalSkillSource()
+        official_source._optional_dir = optional_root
+
+        skills_dir = tmp_path / "skills"
+        hub_dir = skills_dir / ".hub"
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "HUB_DIR", hub_dir), \
+             patch.object(hub, "LOCK_FILE", hub_dir / "lock.json"), \
+             patch.object(hub, "QUARANTINE_DIR", hub_dir / "quarantine"), \
+             patch.object(hub, "AUDIT_LOG", hub_dir / "audit.log"), \
+             patch.object(hub, "TAPS_FILE", hub_dir / "taps.json"), \
+             patch.object(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache"), \
+             patch.object(hub, "create_source_router", return_value=[official_source]):
+            do_install(
+                "official/finance/excel-author",
+                skip_confirm=True,
+                force=True,
+                invalidate_cache=False,
+            )
+
+            entry = hub.HubLockFile().get_installed("excel-author")
+
+        assert entry is not None
+        assert entry["install_path"] == "finance/excel-author"
+        install_dir = skills_dir / "finance" / "excel-author"
+        assert (install_dir / "SKILL.md").exists()
+        assert (install_dir / "scripts" / "recalc.py").exists()
+        # No stray flat copy at skills/excel-author/.
+        assert not (skills_dir / "excel-author").exists()
+
+
 class TestOptionalSkillSourceBinaryAssets:
     def test_fetch_preserves_binary_assets(self, tmp_path):
         optional_root = tmp_path / "optional-skills"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3228,7 +3228,10 @@ class OptionalSkillSource(SkillSource):
                 and "__pycache__" not in f.parts
                 and f.suffix != ".pyc"
             ):
-                rel_path = str(f.relative_to(skill_dir))
+                # POSIX separators so bundle keys (and the lock file's recorded
+                # file list) are consistent on Windows; str(WindowsPath) would
+                # emit backslashes like "scripts\\recalc.py" (#64878).
+                rel_path = f.relative_to(skill_dir).as_posix()
                 try:
                     files[rel_path] = f.read_bytes()
                 except OSError:
@@ -3240,11 +3243,18 @@ class OptionalSkillSource(SkillSource):
         # Determine category from directory structure
         name = skill_dir.name
 
+        # Use POSIX separators in the identifier so the "official/<category>/<name>"
+        # shape survives on Windows. str(WindowsPath) yields backslashes, which
+        # breaks do_install's `identifier.split("/")` category auto-detection and
+        # installs the skill to a flat path instead of its canonical category
+        # path. _scan_all() already normalizes with as_posix() for the same reason.
+        rel_identifier = skill_dir.relative_to(self._optional_dir).as_posix()
+
         return SkillBundle(
             name=name,
             files=files,
             source="official",
-            identifier=f"official/{skill_dir.relative_to(self._optional_dir)}",
+            identifier=f"official/{rel_identifier}",
             trust_level="builtin",
         )
 


### PR DESCRIPTION
## What does this PR do?

On Windows, `hermes skills install official/<category>/<name>` prints a success report but the skill ends up as a metadata-only entry: the files are installed to the wrong location, so the canonical category path looks empty and users have to run `skills repair-official --restore` to recover the content.

The cause is in `OptionalSkillSource.fetch()`. It builds the bundle's `identifier` and its file-key map with `str(Path)`, which produces backslash separators on Windows (for example `official/finance\excel-author`). `do_install` then derives the install category by splitting that identifier on `/`. With backslashes the split yields only two segments instead of three, so category detection never fires and the skill installs flat under `skills/<name>/` instead of `skills/<category>/<name>/`. `restore_official_optional_skill` looks for the canonical category path, finds nothing there, and treats the content as missing.

The fix normalizes both paths with `Path.as_posix()`, which is what `_scan_all()` already does a few lines below in the same class. On Linux and macOS `str(Path)` already returns POSIX separators, so this is a no-op on those platforms and only changes Windows behavior.

## Related Issue

Fixes #64878

This addresses Bug 1 in that report (the install code path). Bug 2 in the same issue is about the docs website catalog, which lives outside this repo and is not touched here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skills_hub.py`: in `OptionalSkillSource.fetch()`, build the bundle file keys and the `identifier` with `Path.as_posix()` instead of `str(Path)`.
- `tests/tools/test_skills_hub.py`: add a unit test asserting the fetched identifier uses `/` separators, and an end-to-end test that installs an official category skill and checks it lands at `skills/finance/excel-author/` with its content (and no stray flat copy).

## How to Test

1. On Windows, point an `OptionalSkillSource` at a fixture skill under `optional-skills/finance/excel-author/` (a `SKILL.md` plus `scripts/recalc.py`) and run `do_install("official/finance/excel-author", skip_confirm=True, force=True)` against a temp `HERMES_HOME`.
2. Before the fix: the scan logs `Source: official/finance\excel-author`, the lock records `install_path = excel-author`, and the files land in `skills/excel-author/` while `skills/finance/excel-author/` is empty.
3. After the fix: the lock records `install_path = finance/excel-author` and the files are under `skills/finance/excel-author/`.
4. Automated: `pytest tests/tools/test_skills_hub.py tests/tools/test_skills_sync.py tests/hermes_cli/test_skills_install_flags.py tests/hermes_cli/test_skills_hub.py -q`. The two new tests pass; reverting the one-line fix makes both fail with the backslash identifier.

Note: four tests in these files already fail on Windows both before and after this change (CRLF handling in a fixture, and a `str(Path)` assertion in an unrelated `test_skills_sync` test). They are pre-existing and untouched by this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the skills-related suites listed above; did not run the full suite. See the note about 4 pre-existing Windows failures. -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
