### PR TITLE
fix(gateway): rebind selected session credentials

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3323,6 +3323,41 @@ import weakref as _weakref
 _gateway_runner_ref: _weakref.ref = lambda: None
 
 
+def _credential_rebind_failure(code: str, error: str) -> dict[str, Any]:
+    """Build a secret-free failure response for the public rebind API."""
+    return {"ok": False, "code": code, "error": error}
+
+
+async def rebind_gateway_session_credentials(
+    *,
+    session_id: str,
+    provider: str,
+    credential_id: str,
+) -> dict[str, Any]:
+    """Rebind one live Gateway session to a selected pooled credential.
+
+    This module-level facade is intentionally narrow so plugins do not need a
+    private ``GatewayRunner`` reference. The runner performs all ownership and
+    idle-session checks; no credential material is returned to the caller.
+    """
+    runner = _gateway_runner_ref()
+    shutdown_event = getattr(runner, "_shutdown_event", None) if runner else None
+    if (
+        runner is None
+        or not getattr(runner, "_running", False)
+        or (shutdown_event is not None and shutdown_event.is_set())
+    ):
+        return _credential_rebind_failure(
+            "gateway_unavailable",
+            "No live Gateway runner is available in this process.",
+        )
+    return await runner.rebind_session_credentials(
+        session_id=session_id,
+        provider=provider,
+        credential_id=credential_id,
+    )
+
+
 def _normalize_empty_agent_response(
     agent_result: dict,
     response: str,
@@ -22462,6 +22497,243 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "Rehydrated persisted /model override for session=%s: model=%s provider=%s",
             session_key, override.get("model"), provider or "",
         )
+
+    async def rebind_session_credentials(
+        self,
+        *,
+        session_id: str,
+        provider: str,
+        credential_id: str,
+    ) -> dict[str, Any]:
+        """Refresh credential-backed runtime state for one idle session.
+
+        The selected credential is resolved through the normal provider path,
+        then checked against its stable pool id before any live state changes.
+        Only ephemeral credential fields are replaced; the session record,
+        transcript, model, and provider selection are left untouched.
+        """
+        requested_session_id = str(session_id or "").strip()
+        requested_provider = str(provider or "").strip().lower()
+        requested_credential_id = str(credential_id or "").strip()
+        if (
+            not requested_session_id
+            or not requested_provider
+            or not requested_credential_id
+        ):
+            return _credential_rebind_failure(
+                "invalid_request",
+                "session_id, provider, and credential_id are required.",
+            )
+
+        entry = await self.async_session_store.lookup_by_session_id(
+            requested_session_id
+        )
+        if entry is None:
+            return _credential_rebind_failure(
+                "session_not_found",
+                "The requested Gateway session is not active.",
+            )
+        session_key = str(getattr(entry, "session_key", "") or "")
+        if not session_key:
+            return _credential_rebind_failure(
+                "session_not_found",
+                "The requested Gateway session has no active routing key.",
+            )
+        if session_key in self._running_agents:
+            return _credential_rebind_failure(
+                "session_busy",
+                "The requested Gateway session is currently running a turn.",
+            )
+
+        live_override = self._session_model_overrides.get(session_key)
+        persisted_override = getattr(entry, "model_override", None)
+        override = live_override
+        if override is None and isinstance(persisted_override, dict):
+            override = persisted_override
+        cache = getattr(self, "_agent_cache", None)
+        cache_lock = getattr(self, "_agent_cache_lock", None)
+        if cache_lock is not None and cache is not None:
+            with cache_lock:
+                cached_entry = cache.get(session_key)
+        else:
+            cached_entry = cache.get(session_key) if cache is not None else None
+        cached_agent = (
+            cached_entry[0]
+            if isinstance(cached_entry, tuple) and cached_entry
+            else cached_entry
+        )
+        if cached_agent is _AGENT_PENDING_SENTINEL:
+            return _credential_rebind_failure(
+                "session_busy",
+                "The requested Gateway session is currently creating an agent.",
+            )
+
+        owner_provider = ""
+        owner_base_url = ""
+        target_model = None
+        if override is not None:
+            owner_provider = str(override.get("provider") or "").strip()
+            owner_base_url = str(override.get("base_url") or "").strip()
+            target_model = override.get("model")
+            if not owner_provider:
+                return _credential_rebind_failure(
+                    "session_provider_unknown",
+                    "The session override has no provider identity to verify.",
+                )
+        elif cached_agent is not None:
+            owner_provider = str(getattr(cached_agent, "provider", "") or "").strip()
+            owner_base_url = str(getattr(cached_agent, "base_url", "") or "").strip()
+            target_model = getattr(cached_agent, "model", None)
+            if not owner_provider:
+                return _credential_rebind_failure(
+                    "session_provider_unknown",
+                    "The cached session agent has no provider identity to verify.",
+                )
+        else:
+            return _credential_rebind_failure(
+                "session_runtime_missing",
+                "The session has no provider-bound runtime state to refresh.",
+            )
+
+        try:
+            from agent.credential_pool import credential_pool_matches_provider
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            runtime = await asyncio.to_thread(
+                resolve_runtime_provider,
+                requested=requested_provider,
+                target_model=target_model,
+            )
+        except Exception as exc:
+            logger.debug(
+                "Gateway credential rebind resolution failed for provider=%s (%s)",
+                requested_provider,
+                type(exc).__name__,
+            )
+            return _credential_rebind_failure(
+                "credential_resolution_failed",
+                "The selected provider credential could not be resolved.",
+            )
+
+        runtime_api_key = runtime.get("api_key")
+        pool = runtime.get("credential_pool")
+        current_fn = getattr(pool, "current", None)
+        selected = current_fn() if callable(current_fn) else None
+        selected_id = str(getattr(selected, "id", "") or "")
+        selected_api_key = getattr(selected, "runtime_api_key", "") if selected else ""
+        if not isinstance(runtime_api_key, str) or not runtime_api_key.strip():
+            return _credential_rebind_failure(
+                "runtime_token_missing",
+                "The selected credential did not resolve to a runtime token.",
+            )
+        if pool is None or selected is None:
+            return _credential_rebind_failure(
+                "credential_pool_missing",
+                "The provider resolver did not return a selected credential pool entry.",
+            )
+        if selected_id != requested_credential_id:
+            return _credential_rebind_failure(
+                "credential_mismatch",
+                "The provider resolver selected a different credential.",
+            )
+        if (
+            not isinstance(selected_api_key, str)
+            or not selected_api_key.strip()
+            or selected_api_key != runtime_api_key
+        ):
+            return _credential_rebind_failure(
+                "credential_mismatch",
+                "The resolved runtime token does not match the selected pool entry.",
+            )
+
+        runtime_provider = str(runtime.get("provider") or "").strip()
+        runtime_base_url = str(runtime.get("base_url") or "").strip()
+        resolved_request = str(
+            runtime.get("requested_provider") or requested_provider
+        ).strip()
+        if not credential_pool_matches_provider(
+            pool,
+            resolved_request,
+            base_url=runtime_base_url,
+        ) or not credential_pool_matches_provider(
+            pool,
+            runtime_provider,
+            base_url=runtime_base_url,
+        ):
+            return _credential_rebind_failure(
+                "provider_mismatch",
+                "The resolved credential pool does not belong to the requested provider.",
+            )
+        if owner_provider and not credential_pool_matches_provider(
+            pool,
+            owner_provider,
+            base_url=owner_base_url or runtime_base_url,
+        ):
+            return _credential_rebind_failure(
+                "session_provider_mismatch",
+                "The selected credential does not belong to the session provider.",
+            )
+
+        # Resolution can refresh OAuth material and therefore runs off-loop.
+        # Recheck every live identity observed before that await so an auth
+        # switch cannot overwrite a concurrent /model, /new, or agent rebuild.
+        current_entry = await self.async_session_store.lookup_by_session_id(
+            requested_session_id
+        )
+        if (
+            current_entry is None
+            or str(getattr(current_entry, "session_key", "") or "") != session_key
+            or session_key in self._running_agents
+            or self._session_model_overrides.get(session_key) is not live_override
+            or (
+                live_override is None
+                and override is not None
+                and getattr(current_entry, "model_override", None)
+                is not persisted_override
+            )
+        ):
+            return _credential_rebind_failure(
+                "session_changed",
+                "The Gateway session changed while credentials were resolving.",
+            )
+        if cache_lock is not None and cache is not None:
+            with cache_lock:
+                current_cached_entry = cache.get(session_key)
+        else:
+            current_cached_entry = cache.get(session_key) if cache is not None else None
+        if current_cached_entry is not cached_entry:
+            return _credential_rebind_failure(
+                "session_changed",
+                "The Gateway session agent changed while credentials were resolving.",
+            )
+
+        if override is not None:
+            refreshed_override = dict(override)
+            refreshed_override.update(
+                {
+                    "api_key": runtime_api_key,
+                    "base_url": runtime.get("base_url"),
+                    "api_mode": runtime.get("api_mode"),
+                    "credential_pool": pool,
+                }
+            )
+            self._session_model_overrides[session_key] = refreshed_override
+        self._evict_cached_agent(session_key)
+
+        logger.info(
+            "Rebound Gateway session credentials: session=%s provider=%s credential_id=%s",
+            requested_session_id,
+            requested_provider,
+            requested_credential_id,
+        )
+        return {
+            "ok": True,
+            "code": "rebound",
+            "session_id": requested_session_id,
+            "provider": requested_provider,
+            "credential_id": requested_credential_id,
+            "session_override_refreshed": override is not None,
+        }
 
     def _apply_session_model_override(
         self, session_key: str, model: str, runtime_kwargs: dict

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3550,6 +3550,41 @@ import weakref as _weakref
 _gateway_runner_ref: _weakref.ref = lambda: None
 
 
+def _credential_rebind_failure(code: str, error: str) -> dict[str, Any]:
+    """Build a secret-free failure response for the public rebind API."""
+    return {"ok": False, "code": code, "error": error}
+
+
+async def rebind_gateway_session_credentials(
+    *,
+    session_id: str,
+    provider: str,
+    credential_id: str,
+) -> dict[str, Any]:
+    """Rebind one live Gateway session to a selected pooled credential.
+
+    This module-level facade is intentionally narrow so plugins do not need a
+    private ``GatewayRunner`` reference. The runner performs all ownership and
+    idle-session checks; no credential material is returned to the caller.
+    """
+    runner = _gateway_runner_ref()
+    shutdown_event = getattr(runner, "_shutdown_event", None) if runner else None
+    if (
+        runner is None
+        or not getattr(runner, "_running", False)
+        or (shutdown_event is not None and shutdown_event.is_set())
+    ):
+        return _credential_rebind_failure(
+            "gateway_unavailable",
+            "No live Gateway runner is available in this process.",
+        )
+    return await runner.rebind_session_credentials(
+        session_id=session_id,
+        provider=provider,
+        credential_id=credential_id,
+    )
+
+
 def _normalize_empty_agent_response(
     agent_result: dict,
     response: str,
@@ -24052,6 +24087,243 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "Rehydrated persisted /model override for session=%s: model=%s provider=%s",
             session_key, override.get("model"), provider or "",
         )
+
+    async def rebind_session_credentials(
+        self,
+        *,
+        session_id: str,
+        provider: str,
+        credential_id: str,
+    ) -> dict[str, Any]:
+        """Refresh credential-backed runtime state for one idle session.
+
+        The selected credential is resolved through the normal provider path,
+        then checked against its stable pool id before any live state changes.
+        Only ephemeral credential fields are replaced; the session record,
+        transcript, model, and provider selection are left untouched.
+        """
+        requested_session_id = str(session_id or "").strip()
+        requested_provider = str(provider or "").strip().lower()
+        requested_credential_id = str(credential_id or "").strip()
+        if (
+            not requested_session_id
+            or not requested_provider
+            or not requested_credential_id
+        ):
+            return _credential_rebind_failure(
+                "invalid_request",
+                "session_id, provider, and credential_id are required.",
+            )
+
+        entry = await self.async_session_store.lookup_by_session_id(
+            requested_session_id
+        )
+        if entry is None:
+            return _credential_rebind_failure(
+                "session_not_found",
+                "The requested Gateway session is not active.",
+            )
+        session_key = str(getattr(entry, "session_key", "") or "")
+        if not session_key:
+            return _credential_rebind_failure(
+                "session_not_found",
+                "The requested Gateway session has no active routing key.",
+            )
+        if session_key in self._running_agents:
+            return _credential_rebind_failure(
+                "session_busy",
+                "The requested Gateway session is currently running a turn.",
+            )
+
+        live_override = self._session_model_overrides.get(session_key)
+        persisted_override = getattr(entry, "model_override", None)
+        override = live_override
+        if override is None and isinstance(persisted_override, dict):
+            override = persisted_override
+        cache = getattr(self, "_agent_cache", None)
+        cache_lock = getattr(self, "_agent_cache_lock", None)
+        if cache_lock is not None and cache is not None:
+            with cache_lock:
+                cached_entry = cache.get(session_key)
+        else:
+            cached_entry = cache.get(session_key) if cache is not None else None
+        cached_agent = (
+            cached_entry[0]
+            if isinstance(cached_entry, tuple) and cached_entry
+            else cached_entry
+        )
+        if cached_agent is _AGENT_PENDING_SENTINEL:
+            return _credential_rebind_failure(
+                "session_busy",
+                "The requested Gateway session is currently creating an agent.",
+            )
+
+        owner_provider = ""
+        owner_base_url = ""
+        target_model = None
+        if override is not None:
+            owner_provider = str(override.get("provider") or "").strip()
+            owner_base_url = str(override.get("base_url") or "").strip()
+            target_model = override.get("model")
+            if not owner_provider:
+                return _credential_rebind_failure(
+                    "session_provider_unknown",
+                    "The session override has no provider identity to verify.",
+                )
+        elif cached_agent is not None:
+            owner_provider = str(getattr(cached_agent, "provider", "") or "").strip()
+            owner_base_url = str(getattr(cached_agent, "base_url", "") or "").strip()
+            target_model = getattr(cached_agent, "model", None)
+            if not owner_provider:
+                return _credential_rebind_failure(
+                    "session_provider_unknown",
+                    "The cached session agent has no provider identity to verify.",
+                )
+        else:
+            return _credential_rebind_failure(
+                "session_runtime_missing",
+                "The session has no provider-bound runtime state to refresh.",
+            )
+
+        try:
+            from agent.credential_pool import credential_pool_matches_provider
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            runtime = await asyncio.to_thread(
+                resolve_runtime_provider,
+                requested=requested_provider,
+                target_model=target_model,
+            )
+        except Exception as exc:
+            logger.debug(
+                "Gateway credential rebind resolution failed for provider=%s (%s)",
+                requested_provider,
+                type(exc).__name__,
+            )
+            return _credential_rebind_failure(
+                "credential_resolution_failed",
+                "The selected provider credential could not be resolved.",
+            )
+
+        runtime_api_key = runtime.get("api_key")
+        pool = runtime.get("credential_pool")
+        current_fn = getattr(pool, "current", None)
+        selected = current_fn() if callable(current_fn) else None
+        selected_id = str(getattr(selected, "id", "") or "")
+        selected_api_key = getattr(selected, "runtime_api_key", "") if selected else ""
+        if not isinstance(runtime_api_key, str) or not runtime_api_key.strip():
+            return _credential_rebind_failure(
+                "runtime_token_missing",
+                "The selected credential did not resolve to a runtime token.",
+            )
+        if pool is None or selected is None:
+            return _credential_rebind_failure(
+                "credential_pool_missing",
+                "The provider resolver did not return a selected credential pool entry.",
+            )
+        if selected_id != requested_credential_id:
+            return _credential_rebind_failure(
+                "credential_mismatch",
+                "The provider resolver selected a different credential.",
+            )
+        if (
+            not isinstance(selected_api_key, str)
+            or not selected_api_key.strip()
+            or selected_api_key != runtime_api_key
+        ):
+            return _credential_rebind_failure(
+                "credential_mismatch",
+                "The resolved runtime token does not match the selected pool entry.",
+            )
+
+        runtime_provider = str(runtime.get("provider") or "").strip()
+        runtime_base_url = str(runtime.get("base_url") or "").strip()
+        resolved_request = str(
+            runtime.get("requested_provider") or requested_provider
+        ).strip()
+        if not credential_pool_matches_provider(
+            pool,
+            resolved_request,
+            base_url=runtime_base_url,
+        ) or not credential_pool_matches_provider(
+            pool,
+            runtime_provider,
+            base_url=runtime_base_url,
+        ):
+            return _credential_rebind_failure(
+                "provider_mismatch",
+                "The resolved credential pool does not belong to the requested provider.",
+            )
+        if owner_provider and not credential_pool_matches_provider(
+            pool,
+            owner_provider,
+            base_url=owner_base_url or runtime_base_url,
+        ):
+            return _credential_rebind_failure(
+                "session_provider_mismatch",
+                "The selected credential does not belong to the session provider.",
+            )
+
+        # Resolution can refresh OAuth material and therefore runs off-loop.
+        # Recheck every live identity observed before that await so an auth
+        # switch cannot overwrite a concurrent /model, /new, or agent rebuild.
+        current_entry = await self.async_session_store.lookup_by_session_id(
+            requested_session_id
+        )
+        if (
+            current_entry is None
+            or str(getattr(current_entry, "session_key", "") or "") != session_key
+            or session_key in self._running_agents
+            or self._session_model_overrides.get(session_key) is not live_override
+            or (
+                live_override is None
+                and override is not None
+                and getattr(current_entry, "model_override", None)
+                is not persisted_override
+            )
+        ):
+            return _credential_rebind_failure(
+                "session_changed",
+                "The Gateway session changed while credentials were resolving.",
+            )
+        if cache_lock is not None and cache is not None:
+            with cache_lock:
+                current_cached_entry = cache.get(session_key)
+        else:
+            current_cached_entry = cache.get(session_key) if cache is not None else None
+        if current_cached_entry is not cached_entry:
+            return _credential_rebind_failure(
+                "session_changed",
+                "The Gateway session agent changed while credentials were resolving.",
+            )
+
+        if override is not None:
+            refreshed_override = dict(override)
+            refreshed_override.update(
+                {
+                    "api_key": runtime_api_key,
+                    "base_url": runtime.get("base_url"),
+                    "api_mode": runtime.get("api_mode"),
+                    "credential_pool": pool,
+                }
+            )
+            self._session_model_overrides[session_key] = refreshed_override
+        self._evict_cached_agent(session_key)
+
+        logger.info(
+            "Rebound Gateway session credentials: session=%s provider=%s credential_id=%s",
+            requested_session_id,
+            requested_provider,
+            requested_credential_id,
+        )
+        return {
+            "ok": True,
+            "code": "rebound",
+            "session_id": requested_session_id,
+            "provider": requested_provider,
+            "credential_id": requested_credential_id,
+            "session_override_refreshed": override is not None,
+        }
 
     def _apply_session_model_override(
         self, session_key: str, model: str, runtime_kwargs: dict

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -405,6 +405,27 @@ class PluginContext:
         except Exception:
             return "default"
 
+    async def rebind_gateway_session_credentials(
+        self,
+        *,
+        session_id: str,
+        provider: str,
+        credential_id: str,
+    ) -> dict[str, Any]:
+        """Refresh one idle Gateway session after a credential-pool switch.
+
+        ``credential_id`` must be the selected pool entry's stable id. The
+        Gateway verifies that selection through normal runtime resolution,
+        updates only ephemeral credential fields, and returns no secrets.
+        """
+        from gateway.run import rebind_gateway_session_credentials
+
+        return await rebind_gateway_session_credentials(
+            session_id=session_id,
+            provider=provider,
+            credential_id=credential_id,
+        )
+
     # -- tool registration --------------------------------------------------
 
     def register_tool(

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1387,6 +1387,27 @@ class PluginContext:
                 ),
             )
 
+    async def rebind_gateway_session_credentials(
+        self,
+        *,
+        session_id: str,
+        provider: str,
+        credential_id: str,
+    ) -> dict[str, Any]:
+        """Refresh one idle Gateway session after a credential-pool switch.
+
+        ``credential_id`` must be the selected pool entry's stable id. The
+        Gateway verifies that selection through normal runtime resolution,
+        updates only ephemeral credential fields, and returns no secrets.
+        """
+        from gateway.run import rebind_gateway_session_credentials
+
+        return await rebind_gateway_session_credentials(
+            session_id=session_id,
+            provider=provider,
+            credential_id=credential_id,
+        )
+
     # -- tool registration --------------------------------------------------
 
     @_serialized_replacement

--- a/tests/gateway/test_session_credential_rebind.py
+++ b/tests/gateway/test_session_credential_rebind.py
@@ -1,0 +1,373 @@
+"""Public Gateway credential rebinds are scoped, verified, and ephemeral."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.run import GatewayRunner, rebind_gateway_session_credentials
+
+
+class _Store:
+    def __init__(self, entry):
+        self.entry = entry
+        self.transcript = [{"role": "user", "content": "keep me"}]
+
+    def lookup_by_session_id(self, session_id):
+        if self.entry is not None and self.entry.session_id == session_id:
+            return self.entry
+        return None
+
+    def set_model_override(self, *_args, **_kwargs):
+        raise AssertionError("credential rebind must not persist the override")
+
+
+class _Pool:
+    def __init__(self, provider="openrouter", credential_id="cred-b", token="token-b"):
+        self.provider = provider
+        self._selected = SimpleNamespace(
+            id=credential_id,
+            runtime_api_key=token,
+        )
+
+    def current(self):
+        return self._selected
+
+
+def _runner(*, override_provider="openrouter", with_override=True, with_cache=True):
+    runner = object.__new__(GatewayRunner)
+    entry = SimpleNamespace(
+        session_id="session-1",
+        session_key="route-1",
+        model_override=None,
+    )
+    runner.session_store = _Store(entry)
+    runner._async_session_store = None
+    runner._running_agents = {}
+    runner._session_model_overrides = {}
+    if with_override:
+        runner._session_model_overrides["route-1"] = {
+            "model": "model-a",
+            "provider": override_provider,
+            "api_key": "token-a",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+            "marker": "preserve",
+        }
+    runner._session_model_overrides["route-2"] = {
+        "model": "other-model",
+        "provider": "anthropic",
+        "api_key": "other-token",
+    }
+    runner._agent_cache = {}
+    if with_cache:
+        agent = SimpleNamespace(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            model="model-a",
+        )
+        runner._agent_cache["route-1"] = (agent, "sig", 1, "session-1")
+    runner._agent_cache["route-2"] = (object(), "other-sig")
+    runner._agent_cache_lock = threading.Lock()
+    runner._evict_cached_agent = MagicMock()
+    return runner
+
+
+def _runtime(
+    *,
+    pool=None,
+    token="token-b",
+    provider="openrouter",
+    requested_provider="openrouter",
+):
+    return {
+        "provider": provider,
+        "requested_provider": requested_provider,
+        "api_key": token,
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_mode": "chat_completions",
+        "credential_pool": pool if pool is not None else _Pool(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_rebind_refreshes_only_ephemeral_target_session_state(monkeypatch):
+    runner = _runner()
+    original_override = runner._session_model_overrides["route-1"]
+    other_override = runner._session_model_overrides["route-2"]
+    other_cache = runner._agent_cache["route-2"]
+    transcript = runner.session_store.transcript
+    pool = _Pool()
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: _runtime(pool=pool),
+    )
+
+    result = await runner.rebind_session_credentials(
+        session_id="session-1",
+        provider="openrouter",
+        credential_id="cred-b",
+    )
+
+    assert result == {
+        "ok": True,
+        "code": "rebound",
+        "session_id": "session-1",
+        "provider": "openrouter",
+        "credential_id": "cred-b",
+        "session_override_refreshed": True,
+    }
+    refreshed = runner._session_model_overrides["route-1"]
+    assert refreshed is not original_override
+    assert refreshed == {
+        "model": "model-a",
+        "provider": "openrouter",
+        "api_key": "token-b",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_mode": "chat_completions",
+        "credential_pool": pool,
+        "marker": "preserve",
+    }
+    assert runner._session_model_overrides["route-2"] is other_override
+    assert runner._agent_cache["route-2"] is other_cache
+    assert runner.session_store.transcript is transcript
+    runner._evict_cached_agent.assert_called_once_with("route-1")
+    assert "token-a" not in str(result)
+    assert "token-b" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_rebind_can_invalidate_cached_agent_without_model_override(monkeypatch):
+    runner = _runner(with_override=False)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: _runtime(),
+    )
+
+    result = await runner.rebind_session_credentials(
+        session_id="session-1",
+        provider="openrouter",
+        credential_id="cred-b",
+    )
+
+    assert result["ok"] is True
+    assert result["session_override_refreshed"] is False
+    assert "route-1" not in runner._session_model_overrides
+    runner._evict_cached_agent.assert_called_once_with("route-1")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("runtime", "expected_code"),
+    [
+        (_runtime(pool=_Pool(credential_id="cred-c")), "credential_mismatch"),
+        (_runtime(pool=_Pool(token="different-token")), "credential_mismatch"),
+        (_runtime(token=""), "runtime_token_missing"),
+        ({**_runtime(), "credential_pool": None}, "credential_pool_missing"),
+        (
+            _runtime(pool=_Pool(provider="anthropic")),
+            "provider_mismatch",
+        ),
+    ],
+)
+async def test_rebind_fails_closed_on_resolver_disagreement(
+    monkeypatch, runtime, expected_code
+):
+    runner = _runner()
+    original_override = runner._session_model_overrides["route-1"]
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: runtime,
+    )
+
+    result = await runner.rebind_session_credentials(
+        session_id="session-1",
+        provider="openrouter",
+        credential_id="cred-b",
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == expected_code
+    assert runner._session_model_overrides["route-1"] is original_override
+    runner._evict_cached_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rebind_rejects_credential_from_another_session_provider(monkeypatch):
+    runner = _runner(override_provider="anthropic")
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: _runtime(),
+    )
+
+    result = await runner.rebind_session_credentials(
+        session_id="session-1",
+        provider="openrouter",
+        credential_id="cred-b",
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "session_provider_mismatch"
+    runner._evict_cached_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rebind_refuses_busy_session_before_resolving(monkeypatch):
+    runner = _runner()
+    runner._running_agents["route-1"] = object()
+    resolver = MagicMock(return_value=_runtime())
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        resolver,
+    )
+
+    result = await runner.rebind_session_credentials(
+        session_id="session-1",
+        provider="openrouter",
+        credential_id="cred-b",
+    )
+
+    assert result["code"] == "session_busy"
+    resolver.assert_not_called()
+    runner._evict_cached_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rebind_restores_persisted_override_without_writing_it(monkeypatch):
+    runner = _runner(with_override=False, with_cache=False)
+    runner.session_store.entry.model_override = {
+        "model": "model-a",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: _runtime(),
+    )
+
+    result = await runner.rebind_session_credentials(
+        session_id="session-1",
+        provider="openrouter",
+        credential_id="cred-b",
+    )
+
+    assert result["ok"] is True
+    assert runner._session_model_overrides["route-1"]["api_key"] == "token-b"
+    assert runner.session_store.entry.model_override == {
+        "model": "model-a",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+    runner._evict_cached_agent.assert_called_once_with("route-1")
+
+
+@pytest.mark.asyncio
+async def test_rebind_refuses_session_without_provider_bound_runtime(monkeypatch):
+    runner = _runner(with_override=False, with_cache=False)
+    resolver = MagicMock(return_value=_runtime())
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        resolver,
+    )
+
+    result = await runner.rebind_session_credentials(
+        session_id="session-1",
+        provider="openrouter",
+        credential_id="cred-b",
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "session_runtime_missing"
+    resolver.assert_not_called()
+    runner._evict_cached_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rebind_refuses_session_change_during_resolution(monkeypatch):
+    runner = _runner()
+
+    async def change_session_then_resolve(func, *args, **kwargs):
+        result = func(*args, **kwargs)
+        runner.session_store.entry = SimpleNamespace(
+            session_id="session-1",
+            session_key="route-replaced",
+            model_override=None,
+        )
+        return result
+
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", change_session_then_resolve)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: _runtime(),
+    )
+
+    result = await runner.rebind_session_credentials(
+        session_id="session-1",
+        provider="openrouter",
+        credential_id="cred-b",
+    )
+
+    assert result["code"] == "session_changed"
+    runner._evict_cached_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_public_rebind_reports_missing_gateway_without_secrets(monkeypatch):
+    monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+
+    result = await rebind_gateway_session_credentials(
+        session_id="session-1",
+        provider="openrouter",
+        credential_id="cred-b",
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "gateway_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_public_rebind_rejects_stopped_gateway(monkeypatch):
+    stopped_runner = SimpleNamespace(
+        _running=False,
+        _shutdown_event=SimpleNamespace(is_set=lambda: False),
+        rebind_session_credentials=AsyncMock(),
+    )
+    monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: stopped_runner)
+
+    result = await rebind_gateway_session_credentials(
+        session_id="session-1",
+        provider="openrouter",
+        credential_id="cred-b",
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "gateway_unavailable"
+    stopped_runner.rebind_session_credentials.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_plugin_context_delegates_to_public_gateway_rebind(monkeypatch):
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    facade = AsyncMock(return_value={"ok": True, "code": "rebound"})
+    monkeypatch.setattr("gateway.run.rebind_gateway_session_credentials", facade)
+    context = PluginContext(
+        PluginManifest(name="credential-switcher", source="user"),
+        PluginManager(),
+    )
+
+    result = await context.rebind_gateway_session_credentials(
+        session_id="session-1",
+        provider="openrouter",
+        credential_id="cred-b",
+    )
+
+    assert result == {"ok": True, "code": "rebound"}
+    facade.assert_awaited_once_with(
+        session_id="session-1",
+        provider="openrouter",
+        credential_id="cred-b",
+    )

--- a/tests/gateway/test_session_credential_rebind.py
+++ b/tests/gateway/test_session_credential_rebind.py
@@ -8,7 +8,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from agent.credential_pool import CredentialPool, PooledCredential
+from gateway.config import GatewayConfig, Platform
 from gateway.run import GatewayRunner, rebind_gateway_session_credentials
+from gateway.session import AsyncSessionStore, SessionSource, SessionStore
 
 
 class _Store:
@@ -91,6 +94,114 @@ def _runtime(
         "api_mode": "chat_completions",
         "credential_pool": pool if pool is not None else _Pool(),
     }
+
+
+@pytest.mark.asyncio
+async def test_rebind_crosses_real_persistence_and_next_runtime_resolution(
+    tmp_path, monkeypatch
+):
+    import hermes_state
+
+    hermes_home = tmp_path / "hermes-home"
+    sessions_dir = hermes_home / "sessions"
+    state_db = hermes_home / "state.db"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", state_db)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        user_id="user-1",
+        user_name="tester",
+        chat_type="dm",
+    )
+    store = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    entry = store.get_or_create_session(source)
+    store.set_model_override(
+        entry.session_key,
+        {
+            "model": "model-a",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+        },
+    )
+    store.append_to_transcript(entry.session_id, {"role": "user", "content": "keep me"})
+    store._db.close()
+
+    restarted_store = SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+    restarted_entry = restarted_store.lookup_by_session_id(entry.session_id)
+    assert restarted_entry is not None
+    assert restarted_entry.model_override == {
+        "model": "model-a",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+    transcript_before = restarted_store.load_transcript(entry.session_id)
+
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = restarted_store
+    runner._async_session_store = AsyncSessionStore(restarted_store)
+    runner._running_agents = {}
+    runner._session_model_overrides = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._evict_cached_agent = MagicMock()
+
+    pool = CredentialPool(
+        "openrouter",
+        [
+            PooledCredential(
+                provider="openrouter",
+                id="cred-a",
+                label="A",
+                auth_type="api_key",
+                priority=0,
+                source="manual",
+                access_token="token-a",
+            ),
+            PooledCredential(
+                provider="openrouter",
+                id="cred-b",
+                label="B",
+                auth_type="api_key",
+                priority=1,
+                source="manual",
+                access_token="token-b",
+            ),
+        ],
+    )
+    assert pool.acquire_lease("cred-b") == "cred-b"
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: _runtime(pool=pool, token="token-b"),
+    )
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda _config: "global")
+
+    result = await runner.rebind_session_credentials(
+        session_id=entry.session_id,
+        provider="openrouter",
+        credential_id="cred-b",
+    )
+    model, runtime = runner._resolve_session_agent_runtime(
+        session_key=entry.session_key,
+        user_config={},
+    )
+
+    assert result["ok"] is True
+    assert model == "model-a"
+    assert runtime["api_key"] == "token-b"
+    assert runtime["credential_pool"] is pool
+    assert restarted_store.load_transcript(entry.session_id) == transcript_before
+    assert restarted_store.get_model_override(entry.session_key) == {
+        "model": "model-a",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+
+    restarted_store._db.close()
+    for persisted_file in hermes_home.rglob("*"):
+        if persisted_file.is_file():
+            assert b"token-b" not in persisted_file.read_bytes()
 
 
 @pytest.mark.asyncio

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -821,6 +821,30 @@ def register(ctx):
     ctx.register_command("check", handler=_handle_check, description="Run async check")
 ```
 
+### Rebind a Gateway session after credential selection
+
+A plugin that changes the selected entry in a credential pool can refresh an
+existing Gateway session without clearing its transcript:
+
+```python
+async def rebind_session(ctx, session_id: str, provider: str, credential_id: str):
+    result = await ctx.rebind_gateway_session_credentials(
+        session_id=session_id,
+        provider=provider,
+        credential_id=credential_id,
+    )
+    if not result["ok"]:
+        return f"Credential switch was not applied: {result['error']}"
+    return "Credential switch applied to the current session."
+```
+
+The `credential_id` must be the stable id of the pool entry selected by the
+plugin. The call fails closed if the normal provider resolver selects a
+different entry, the session is busy or changed during resolution, or no live
+Gateway is available. It updates only in-memory credential fields and evicts
+only the target session's cached agent; it does not rewrite the session record,
+transcript, or config, and it never returns raw credential material.
+
 ### Dispatch tools from slash commands
 
 Slash command handlers that need to orchestrate tools (spawn a subagent via `delegate_task`, call `file_edit`, etc.) should use `ctx.dispatch_tool()` instead of reaching into framework internals. The parent-agent context (workspace hints, spinner, model inheritance) is wired up automatically.

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -1143,6 +1143,30 @@ def register(ctx):
     ctx.register_command("check", handler=_handle_check, description="Run async check")
 ```
 
+### Rebind a Gateway session after credential selection
+
+A plugin that changes the selected entry in a credential pool can refresh an
+existing Gateway session without clearing its transcript:
+
+```python
+async def rebind_session(ctx, session_id: str, provider: str, credential_id: str):
+    result = await ctx.rebind_gateway_session_credentials(
+        session_id=session_id,
+        provider=provider,
+        credential_id=credential_id,
+    )
+    if not result["ok"]:
+        return f"Credential switch was not applied: {result['error']}"
+    return "Credential switch applied to the current session."
+```
+
+The `credential_id` must be the stable id of the pool entry selected by the
+plugin. The call fails closed if the normal provider resolver selects a
+different entry, the session is busy or changed during resolution, or no live
+Gateway is available. It updates only in-memory credential fields and evicts
+only the target session's cached agent; it does not rewrite the session record,
+transcript, or config, and it never returns raw credential material.
+
 ### Dispatch tools from slash commands
 
 Slash command handlers that need to orchestrate tools (spawn a subagent via `delegate_task`, call `file_edit`, etc.) should use `ctx.dispatch_tool()` instead of reaching into framework internals. The parent-agent context (workspace hints, spinner, model inheritance) is wired up automatically.


### PR DESCRIPTION
## Summary

- add a public, provider-generic Gateway credential rebind API for plugins
- verify the resolver-selected pool entry by stable credential id, runtime token, and provider ownership before changing live state
- refresh only ephemeral session credential fields and evict only the idle target session's cached agent
- preserve the session record, transcript, model/provider selection, and legacy plugin command handler contract

Fixes #64271.

## Current-main proof

On `8b209e0dd7b8`, a session override populated by `/model` keeps its old `api_key` on `_resolve_session_agent_runtime()`'s fast path after the credential pool selects a different entry. Current main also has no public Gateway or `PluginContext` rebind callback, so a plugin cannot safely refresh that session without reaching into private runner state or clearing the conversation.

## Implementation

`PluginContext.rebind_gateway_session_credentials()` delegates to a narrow module-level Gateway facade. The runner:

1. resolves the durable session id through `AsyncSessionStore` and refuses active turns;
2. resolves the requested provider off the event loop through `resolve_runtime_provider()`;
3. requires the returned pool's current entry id and runtime token to match the request and validates requested, resolved, and session provider ownership with `credential_pool_matches_provider()`;
4. rechecks the session mapping, live override identity, persisted override identity, running slot, and cached-agent identity after the await;
5. copies only `api_key`, `base_url`, `api_mode`, and `credential_pool` into the in-memory override, then evicts only that session's cached agent.

A persisted non-secret `/model` override can be rehydrated into live memory after restart. Cached-agent-only sessions are invalidated without creating an override. Sessions with no provider-bound runtime state fail instead of reporting a no-op success. Failure results and logs do not include runtime tokens.

## Coverage

The sibling-path audit covers live overrides, persisted overrides after restart, cached-agent-only sessions, missing runtime state, busy sessions, session replacement during resolution, selected-id mismatch, selected-token mismatch, missing pool/token, cross-provider mismatch, stopped/missing Gateway runners, other-session isolation, transcript preservation, and plugin-facade delegation.

Hermetic validation through `scripts/run_tests.sh`:

- 434 tests passed across 14 files covering the new regression, plugins, async session storage, model override persistence, credential pools, provider boundaries, provider resolution, and agent pool rotation
- `ruff check .`
- `scripts/check-windows-footguns.py --diff origin/main`
- `git diff --check`
- contribution publish gate and gitleaks passed for the exact commit range

All tests used fake credentials and isolated state; no live Gateway, account, transcript, or model was used.
