### PR TITLE
Jai/conv

### DIFF
--- a/agent/portal_tags.py
+++ b/agent/portal_tags.py
@@ -55,10 +55,32 @@ def hermes_client_tag() -> str:
     return f"client=hermes-client-v{_hermes_version()}"
 
 
-def nous_portal_tags() -> List[str]:
+def conversation_tag(session_id: str) -> str:
+    """Return the ``conversation=...`` tag for a Hermes session/conversation.
+
+    Format: ``conversation=<session_id>``. ``session_id`` is the canonical
+    Hermes conversation identifier (``AIAgent.session_id``) — the same value
+    used for ``~/.hermes/sessions/`` storage, session logs, and lineage.
+
+    Unlike the product/client tags this is high-cardinality (one value per
+    conversation), so it is only appended when a session id is actually
+    available — never as part of the always-on base tag set.
+    """
+    return f"conversation={session_id}"
+
+
+def nous_portal_tags(session_id: str | None = None) -> List[str]:
     """Return the canonical list of Nous Portal product tags.
 
     Always returns a fresh list so callers can mutate it freely
     (e.g. ``merged_extra.setdefault("tags", []).extend(nous_portal_tags())``).
+
+    When ``session_id`` is provided, a ``conversation=<session_id>`` tag is
+    appended so Portal usage can be attributed to a specific Hermes
+    conversation. Callers without a session id (e.g. the auxiliary client's
+    always-on base tags) omit it and get the canonical two-tag set.
     """
-    return ["product=hermes-agent", hermes_client_tag()]
+    tags = ["product=hermes-agent", hermes_client_tag()]
+    if session_id:
+        tags.append(conversation_tag(session_id))
+    return tags

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -13,7 +13,7 @@ class NousProfile(ProviderProfile):
     def build_extra_body(
         self, *, session_id: str | None = None, **context
     ) -> dict[str, Any]:
-        body: dict[str, Any] = {"tags": nous_portal_tags()}
+        body: dict[str, Any] = {"tags": nous_portal_tags(session_id=session_id)}
         provider_preferences = context.get("provider_preferences")
         if provider_preferences:
             body["provider"] = provider_preferences

--- a/tests/agent/test_portal_tags.py
+++ b/tests/agent/test_portal_tags.py
@@ -42,6 +42,33 @@ def test_nous_portal_tags_returns_fresh_list():
     assert "client=test-mutation" not in b
 
 
+def test_conversation_tag_format():
+    """The conversation tag carries the session id verbatim."""
+    from agent.portal_tags import conversation_tag
+
+    assert conversation_tag("abc-123") == "conversation=abc-123"
+
+
+def test_nous_portal_tags_appends_conversation_when_session_id_given():
+    """A session id adds a third, high-cardinality conversation tag."""
+    from agent.portal_tags import conversation_tag, nous_portal_tags
+
+    tags = nous_portal_tags(session_id="sess-42")
+    assert "product=hermes-agent" in tags
+    assert conversation_tag("sess-42") in tags
+    assert len(tags) == 3
+
+
+def test_nous_portal_tags_omits_conversation_without_session_id():
+    """Base tag set stays at two tags when no session id is available."""
+    from agent.portal_tags import nous_portal_tags
+
+    for empty in (None, ""):
+        tags = nous_portal_tags(session_id=empty)
+        assert len(tags) == 2
+        assert not any(t.startswith("conversation=") for t in tags)
+
+
 def test_auxiliary_client_nous_extra_body_uses_helper():
     """auxiliary_client.NOUS_EXTRA_BODY must match the canonical helper output."""
     from agent.auxiliary_client import NOUS_EXTRA_BODY

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -425,6 +425,12 @@ class TestNousProfile:
             "provider": preferences,
         }
 
+    def test_tags_include_conversation_when_session_id(self):
+        from agent.portal_tags import conversation_tag
+        p = get_provider_profile("nous")
+        body = p.build_extra_body(session_id="sess-99")
+        assert conversation_tag("sess-99") in body["tags"]
+
     def test_auth_type(self):
         p = get_provider_profile("nous")
         assert p.auth_type == "oauth_device_code"

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -429,7 +429,7 @@ class TestBuildApiKwargsNousPortal:
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
-        assert extra.get("tags") == nous_portal_tags()
+        assert extra.get("tags") == nous_portal_tags(session_id=agent.session_id)
 
     def test_uses_chat_completions_format(self, monkeypatch):
         agent = _make_agent(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3973,7 +3973,9 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         from agent.portal_tags import nous_portal_tags
 
-        assert kwargs["extra_body"]["tags"] == nous_portal_tags()
+        assert kwargs["extra_body"]["tags"] == nous_portal_tags(
+            session_id=agent.session_id
+        )
         assert kwargs["extra_body"]["provider"] == {
             "only": ["deepseek"],
             "ignore": ["deepinfra"],
@@ -3995,7 +3997,9 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         from agent.portal_tags import nous_portal_tags
 
-        assert kwargs["extra_body"] == {"tags": nous_portal_tags()}
+        assert kwargs["extra_body"] == {
+            "tags": nous_portal_tags(session_id=agent.session_id)
+        }
 
     def test_summary_drops_invalid_provider_sort(self, agent):
         agent.base_url = "https://openrouter.ai/api/v1"


### PR DESCRIPTION
## What does this PR do?

Adds a per-session `conversation=<session_id>` tag to **Nous Portal** inference
requests so Portal-side usage can be attributed to a specific Hermes session.

Every Portal request already carries two product-attribution tags
(`product=hermes-agent`, `client=hermes-client-v<version>`) built centrally in
`agent/portal_tags.py`. The Nous provider profile already receives the agent's
`session_id` but discarded it. This PR threads that id into the tag list as an
**additive, opt-in third tag**, emitted only when a session id is present.

The approach keeps the single-source-of-truth pattern in `agent/portal_tags.py`
(no inlined literals) and is fully backward compatible: `nous_portal_tags()`
with no argument still returns the canonical two-tag list, so auxiliary/base
call sites are unchanged.

## Related Issue

N/A (no tracking issue). Happy to open one if maintainers prefer.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/portal_tags.py`
  - Added `conversation_tag(session_id: str) -> str` returning
    `conversation=<session_id>` (mirrors the existing `hermes_client_tag()`
    factoring; documents that this tag is high-cardinality and opt-in).
  - Extended `nous_portal_tags(session_id: str | None = None)` to append the
    conversation tag **only** when a truthy `session_id` is provided. Default
    behavior (no arg) is unchanged → still
    `["product=hermes-agent", "client=hermes-client-v<version>"]`.
- `plugins/model-providers/nous/__init__.py`
  - `NousProfile.build_extra_body()` now forwards its `session_id` kwarg into
    the tag list (alongside the existing `provider_preferences` handling).
- `tests/agent/test_portal_tags.py`
  - Added: conversation-tag format, presence when a session id is supplied,
    and omission when it is `None`/`""`.
- `tests/providers/test_provider_profiles.py`
  - Added `TestNousProfile.test_tags_include_conversation_when_session_id`.
- `tests/run_agent/test_provider_parity.py`
  - Updated the end-to-end `_build_api_kwargs` Nous parity assertion to expect
    the conversation tag when the agent has a `session_id`.

### Scope / known limitations (intentional)

- The tag rides the **main agent loop only**. Auxiliary/background Portal calls
  (compression, title generation, vision, web-extract, session search, kanban,
  curator, etc.) build tags without a session id and remain untagged, so
  per-conversation cost analytics built on this tag will undercount.
- `session_id` rotates on context compression and `/new`, so a single
  user-facing conversation can emit multiple `conversation=` values. The value
  is the current session segment, not a stable end-to-end conversation id.
- Only the opaque `session_id` (`<timestamp>_<uuid>`) is sent — never the
  gateway session key, which can embed PII (phone numbers / user ids).

## How to Test

1. Point Hermes at the Nous Portal (`hermes model` → provider `nous`, or set
   `model.provider: nous` in `~/.hermes/config.yaml`).

2. Confirm the profile emits the tag when a session id is present:

```bash
python -c "
from providers import get_provider_profile
p = get_provider_profile('nous')
print('no session :', p.build_extra_body())
print('w/ session :', p.build_extra_body(session_id='conv-abc-123'))
"
```

Expected:

```
no session : {'tags': ['product=hermes-agent', 'client=hermes-client-v<ver>']}
w/ session : {'tags': ['product=hermes-agent', 'client=hermes-client-v<ver>', 'conversation=conv-abc-123']}
```

3. Run the targeted tests:

```bash
pytest tests/agent/test_portal_tags.py \
       tests/providers/test_provider_profiles.py \
       tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings in `agent/portal_tags.py` updated; no user-facing docs needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ pytest tests/agent/test_portal_tags.py tests/providers/test_provider_profiles.py \
         tests/run_agent/test_provider_parity.py::TestBuildApiKwargsNousPortal -q
.....................................................................    [100%]
69 passed in 1.14s
```