### PR TITLE
fix(context): preserve history on compression access failures

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import call_llm, _is_connection_error, aux_interrupt_protection
 from agent.context_engine import ContextEngine
+from agent.error_classifier import FailoverReason, classify_api_error
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     get_model_context_length,
@@ -36,11 +37,7 @@ from agent.redact import redact_sensitive_text
 logger = logging.getLogger(__name__)
 
 
-_SUMMARY_ACCESS_OR_QUOTA_ERROR_SUBSTRINGS: tuple[str, ...] = (
-    "invalid api key",
-    "invalid x-api-key",
-    "unauthorized",
-    "authentication",
+_SUMMARY_PERMANENT_QUOTA_MARKERS: tuple[str, ...] = (
     "insufficient_quota",
     "quota exceeded",
     "quota_exceeded",
@@ -54,6 +51,12 @@ _SUMMARY_ACCESS_OR_QUOTA_ERROR_SUBSTRINGS: tuple[str, ...] = (
 def _is_summary_access_or_quota_error(exc: Exception) -> bool:
     """Return True for non-retryable summary auth, permission, or quota errors."""
 
+    classified = classify_api_error(exc)
+    if classified.reason is FailoverReason.rate_limit:
+        return False
+    if classified.reason in {FailoverReason.auth, FailoverReason.auth_permanent}:
+        return True
+
     status = getattr(exc, "status_code", None) or getattr(
         getattr(exc, "response", None), "status_code", None
     )
@@ -61,9 +64,9 @@ def _is_summary_access_or_quota_error(exc: Exception) -> bool:
         return True
 
     err_text = str(exc).lower()
-    if "api key" in err_text and ("invalid" in err_text or "blocked" in err_text):
-        return True
-    return any(marker in err_text for marker in _SUMMARY_ACCESS_OR_QUOTA_ERROR_SUBSTRINGS)
+    if classified.reason is FailoverReason.billing:
+        return any(marker in err_text for marker in _SUMMARY_PERMANENT_QUOTA_MARKERS)
+    return any(marker in err_text for marker in _SUMMARY_PERMANENT_QUOTA_MARKERS)
 
 
 HISTORICAL_TASK_HEADING = "## Historical Task Snapshot"

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -47,6 +47,11 @@ _SUMMARY_PERMANENT_QUOTA_MARKERS: tuple[str, ...] = (
     "out of extra usage",
 )
 
+_SUMMARY_MISSING_CREDENTIAL_MARKERS: tuple[str, ...] = (
+    "no api key was found",
+    "no api key found",
+)
+
 
 def _is_summary_access_or_quota_error(exc: Exception) -> bool:
     """Return True for non-retryable summary auth, permission, or quota errors."""
@@ -57,13 +62,16 @@ def _is_summary_access_or_quota_error(exc: Exception) -> bool:
     if classified.reason in {FailoverReason.auth, FailoverReason.auth_permanent}:
         return True
 
+    err_text = str(exc).lower()
+    if any(marker in err_text for marker in _SUMMARY_MISSING_CREDENTIAL_MARKERS):
+        return True
+
     status = getattr(exc, "status_code", None) or getattr(
         getattr(exc, "response", None), "status_code", None
     )
     if status in {401, 402, 403}:
         return True
 
-    err_text = str(exc).lower()
     if classified.reason is FailoverReason.billing:
         return any(marker in err_text for marker in _SUMMARY_PERMANENT_QUOTA_MARKERS)
     return any(marker in err_text for marker in _SUMMARY_PERMANENT_QUOTA_MARKERS)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -35,6 +35,37 @@ from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
+
+_SUMMARY_ACCESS_OR_QUOTA_ERROR_SUBSTRINGS: tuple[str, ...] = (
+    "invalid api key",
+    "invalid x-api-key",
+    "unauthorized",
+    "authentication",
+    "insufficient_quota",
+    "quota exceeded",
+    "quota_exceeded",
+    "out of funds",
+    "out of credits",
+    "out of credit",
+    "out of extra usage",
+)
+
+
+def _is_summary_access_or_quota_error(exc: Exception) -> bool:
+    """Return True for non-retryable summary auth, permission, or quota errors."""
+
+    status = getattr(exc, "status_code", None) or getattr(
+        getattr(exc, "response", None), "status_code", None
+    )
+    if status in {401, 402, 403}:
+        return True
+
+    err_text = str(exc).lower()
+    if "api key" in err_text and ("invalid" in err_text or "blocked" in err_text):
+        return True
+    return any(marker in err_text for marker in _SUMMARY_ACCESS_OR_QUOTA_ERROR_SUBSTRINGS)
+
+
 HISTORICAL_TASK_HEADING = "## Historical Task Snapshot"
 HISTORICAL_IN_PROGRESS_HEADING = "## Historical In-Progress State"
 HISTORICAL_PENDING_ASKS_HEADING = "## Historical Pending User Asks"
@@ -2314,24 +2345,15 @@ This compaction should PRIORITISE preserving all information related to the focu
             # back to the main model instead of entering a 60-second cooldown.
             # See issue #18458.
             _is_streaming_closed = _is_connection_error(e)
-            # Authentication / permission failures (401/403) are NOT transient
-            # and NOT fixable by retrying the same request: the credential is
-            # invalid/blocked/expired or the endpoint is wrong (e.g. a prod
-            # token sent to a staging inference URL). Flag them so compress()
-            # aborts and preserves the session instead of rotating into a
+            # Authentication, permission, and exhausted-quota failures are NOT
+            # transient or fixable by retrying the same request. Flag them so
+            # compress() preserves the session instead of rotating into a
             # degraded child with a placeholder summary. We still allow the
             # one-shot fallback to the MAIN model below when the failure came
-            # from a distinct auxiliary summary_model (its dedicated creds may
-            # be the only broken thing); only a failure on the main model — or
-            # a fallback that also auth-fails — makes the abort stick.
-            _is_auth_error = (
-                _status in {401, 403}
-                or "invalid api key" in _err_str
-                or "invalid x-api-key" in _err_str
-                or ("api key" in _err_str and ("invalid" in _err_str or "blocked" in _err_str))
-                or "unauthorized" in _err_str
-                or "authentication" in _err_str
-            )
+            # from a distinct auxiliary summary_model; only a failure on the
+            # main model — or a fallback that also access/quota-fails — makes
+            # the abort stick.
+            _is_auth_error = _is_summary_access_or_quota_error(e)
             if _is_auth_error:
                 self._last_summary_auth_failure = True
             if _is_json_decode and not _is_model_not_found and not _is_timeout:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2364,8 +2364,10 @@ This compaction should PRIORITISE preserving all information related to the focu
             # from a distinct auxiliary summary_model; only a failure on the
             # main model — or a fallback that also access/quota-fails — makes
             # the abort stick.
-            _is_auth_error = _is_summary_access_or_quota_error(e)
-            if _is_auth_error:
+            _is_access_or_quota_error = _is_summary_access_or_quota_error(e)
+            if _is_access_or_quota_error:
+                # Keep the established field name for caller compatibility;
+                # it now represents the broader terminal access/quota class.
                 self._last_summary_auth_failure = True
             if _is_json_decode and not _is_model_not_found and not _is_timeout:
                 logger.error(
@@ -3251,16 +3253,14 @@ This compaction should PRIORITISE preserving all information related to the focu
         #           surface a warning.
         # Default is False (historical behavior).
         #
-        # EXCEPTION — auth AND transient network failures always abort. A
-        # 401/403 from the summary call means the credential or endpoint is
-        # broken (invalid/blocked key, or a token pointed at the wrong
-        # inference host). A connection/stream-close error means the network
-        # blipped at the compaction moment (#29559). In BOTH cases rotating into
-        # a child session with a placeholder summary on a broken credential
-        # strands the user on a degraded session for zero benefit — every
-        # subsequent call fails the same way. So when the failure was an auth
-        # error we abort regardless of abort_on_summary_failure, preserving
-        # the conversation unchanged until the credential is fixed.
+        # EXCEPTION — terminal access/quota AND transient network failures
+        # always abort. Missing credentials, 401/402/403 access failures, and
+        # confirmed non-resetting quota exhaustion cannot be repaired by
+        # retrying the same summary request. A connection/stream-close error
+        # means the network blipped at the compaction moment (#29559). In all
+        # of these cases, rotating into a child session with a placeholder
+        # summary degrades the conversation for zero benefit. Preserve it
+        # unchanged until access is restored or connectivity recovers.
         if not summary and (
             self.abort_on_summary_failure
             or self._last_summary_auth_failure
@@ -3273,11 +3273,12 @@ This compaction should PRIORITISE preserving all information related to the focu
             if not self.quiet_mode:
                 if self._last_summary_auth_failure:
                     logger.warning(
-                        "Summary generation failed with an authentication "
-                        "error — aborting compression. %d message(s) preserved "
-                        "unchanged; the session was NOT rotated. Check your "
-                        "provider credential / inference endpoint, then retry "
-                        "with /compress or start fresh with /new.",
+                        "Summary generation failed with a terminal access or "
+                        "quota error — aborting compression. %d message(s) "
+                        "preserved unchanged; the session was NOT rotated. "
+                        "Check the provider credential, permission, quota, or "
+                        "inference endpoint, then retry with /compress or "
+                        "start fresh with /new.",
                         n_skipped,
                     )
                 elif self._last_summary_network_failure:

--- a/agent/manual_compression_feedback.py
+++ b/agent/manual_compression_feedback.py
@@ -4,45 +4,83 @@ from __future__ import annotations
 
 from typing import Any, Sequence
 
+from agent.redact import redact_sensitive_text
+
 
 def summarize_manual_compression(
     before_messages: Sequence[dict[str, Any]],
     after_messages: Sequence[dict[str, Any]],
     before_tokens: int,
     after_tokens: int,
+    *,
+    compression_state: Any = None,
 ) -> dict[str, Any]:
     """Return consistent user-facing feedback for manual compression."""
     before_count = len(before_messages)
     after_count = len(after_messages)
     noop = list(after_messages) == list(before_messages)
+    aborted = (
+        compression_state is not None
+        and getattr(compression_state, "_last_compress_aborted", False) is True
+    )
+    fallback_used = (
+        compression_state is not None
+        and getattr(compression_state, "_last_summary_fallback_used", False) is True
+    )
+    failure_reason = (
+        getattr(compression_state, "_last_summary_error", None)
+        if compression_state is not None
+        else None
+    )
+    if not isinstance(failure_reason, str) or not failure_reason.strip():
+        failure_reason = None
 
-    if noop:
+    if aborted:
+        headline = f"Compression aborted: {before_count} messages preserved"
+    elif fallback_used:
+        headline = (
+            f"Compressed with fallback: {before_count} → {after_count} messages"
+        )
+    elif noop:
         headline = f"No changes from compression: {before_count} messages"
-        if after_tokens == before_tokens:
-            token_line = (
-                f"Approx request size: ~{before_tokens:,} tokens (unchanged)"
-            )
-        else:
-            token_line = (
-                f"Approx request size: ~{before_tokens:,} → "
-                f"~{after_tokens:,} tokens"
-            )
     else:
         headline = f"Compressed: {before_count} → {after_count} messages"
+
+    if noop and after_tokens == before_tokens:
+        token_line = f"Approx request size: ~{before_tokens:,} tokens (unchanged)"
+    else:
         token_line = (
             f"Approx request size: ~{before_tokens:,} → "
             f"~{after_tokens:,} tokens"
         )
 
     note = None
-    if not noop and after_count < before_count and after_tokens > before_tokens:
+    if aborted:
+        note = "Summary generation failed; no messages were removed."
+    elif fallback_used:
+        dropped_count = getattr(
+            compression_state, "_last_summary_dropped_count", None
+        )
+        if not isinstance(dropped_count, int) or isinstance(dropped_count, bool):
+            dropped_count = max(before_count - after_count, 0)
+        note = (
+            "Summary generation failed; Hermes used limited fallback context "
+            f"and removed {dropped_count} message(s)."
+        )
+    elif not noop and after_count < before_count and after_tokens > before_tokens:
         note = (
             "Note: fewer messages can still raise this estimate when "
             "compression rewrites the transcript into denser summaries."
         )
 
+    if failure_reason and (aborted or fallback_used):
+        safe_reason = redact_sensitive_text(failure_reason.strip())
+        note = f"{note} Reason: {safe_reason}"
+
     return {
         "noop": noop,
+        "aborted": aborted,
+        "fallback_used": fallback_used,
         "headline": headline,
         "token_line": token_line,
         "note": note,

--- a/agent/manual_compression_feedback.py
+++ b/agent/manual_compression_feedback.py
@@ -74,7 +74,10 @@ def summarize_manual_compression(
         )
 
     if failure_reason and (aborted or fallback_used):
-        safe_reason = redact_sensitive_text(failure_reason.strip())
+        # This text crosses a user-facing UI boundary.  Never let a disabled
+        # global redaction preference expose credentials embedded in provider
+        # exception text.
+        safe_reason = redact_sensitive_text(failure_reason.strip(), force=True)
         note = f"{note} Reason: {safe_reason}"
 
     return {

--- a/cli.py
+++ b/cli.py
@@ -9641,8 +9641,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     self.conversation_history,
                     approx_tokens,
                     new_tokens,
+                    compression_state=getattr(
+                        self.agent, "context_compressor", None
+                    ),
                 )
-                icon = "🗜️" if summary["noop"] else "✅"
+                if summary.get("aborted") or summary.get("fallback_used"):
+                    icon = "⚠️"
+                else:
+                    icon = "🗜️" if summary["noop"] else "✅"
                 print(f"  {icon} {summary['headline']}")
                 print(f"     {summary['token_line']}")
                 if summary["note"]:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -854,11 +854,19 @@ class TestAuthFailureAborts:
     def test_quota_classifier_accepts_explicit_provider_signals(self, message):
         assert _is_summary_access_or_quota_error(Exception(message)) is True
 
+    def test_missing_provider_api_key_is_terminal_access_failure(self):
+        err = RuntimeError(
+            "Provider 'opencode-zen' is set in config.yaml but no API key was "
+            "found. Set the OPENCODE-ZEN_API_KEY environment variable."
+        )
+        assert _is_summary_access_or_quota_error(err) is True
+
     @pytest.mark.parametrize(
         "message",
         [
             "billing portal is temporarily unavailable",
             "usage limit documentation could not be loaded",
+            "API key documentation was not found",
             "rate limit exceeded; retry later",
             "quota exceeded, please retry after the window resets",
             "request timed out",
@@ -904,6 +912,34 @@ class TestAuthFailureAborts:
         assert c._last_summary_auth_failure is True
         assert c._last_compress_aborted is True
         assert c._last_summary_fallback_used is False
+
+    def test_missing_provider_api_key_preserves_original_messages(self):
+        """A configured auxiliary provider without a visible key preserves context."""
+        err = RuntimeError(
+            "Provider 'opencode-zen' is set in config.yaml but no API key was "
+            "found. Set the OPENCODE-ZEN_API_KEY environment variable, or switch "
+            "to a different provider with hermes model."
+        )
+        with patch(
+            "agent.context_compressor.get_model_context_length", return_value=100000
+        ):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        msgs = self._msgs(12)
+        with patch("agent.context_compressor.call_llm", side_effect=err):
+            result = c.compress(msgs, current_tokens=999999, force=True)
+
+        assert result == msgs
+        assert c._last_summary_error == str(err)
+        assert c._last_summary_auth_failure is True
+        assert c._last_compress_aborted is True
+        assert c._last_summary_fallback_used is False
+        assert c._last_summary_dropped_count == 0
 
     def test_402_quota_with_retry_uses_existing_fallback(self):
         """A reset-window quota remains transient instead of aborting compression."""

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -11,8 +11,16 @@ from agent.context_compressor import (
     SUMMARY_PREFIX,
     COMPRESSED_SUMMARY_METADATA_KEY,
     _summarize_tool_result,
+    _is_summary_access_or_quota_error,
 )
 from hermes_state import SessionDB
+
+
+class StubProviderError(Exception):
+    def __init__(self, message, *, status_code=None, response=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response = response
 
 
 @pytest.fixture()
@@ -825,12 +833,76 @@ class TestAuthFailureAborts:
         ]
 
     def _auth_err(self, status=401):
-        err = Exception(
+        return StubProviderError(
             f"Error code: {status} - "
-            "{'status': 401, 'message': 'Your API key is invalid, blocked or out of funds.'}"
+            "{'status': 401, 'message': 'Your API key is invalid, blocked or out of funds.'}",
+            status_code=status,
         )
-        err.status_code = status
-        return err
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "insufficient_quota",
+            "quota exceeded",
+            "quota_exceeded",
+            "out of funds",
+            "out of credits",
+            "out of credit",
+            "out of extra usage",
+        ],
+    )
+    def test_quota_classifier_accepts_explicit_provider_signals(self, message):
+        assert _is_summary_access_or_quota_error(Exception(message)) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "billing portal is temporarily unavailable",
+            "usage limit documentation could not be loaded",
+            "rate limit exceeded; retry later",
+            "request timed out",
+        ],
+    )
+    def test_quota_classifier_rejects_transient_or_ambiguous_messages(self, message):
+        assert _is_summary_access_or_quota_error(Exception(message)) is False
+
+    @pytest.mark.parametrize("status", [401, 402, 403])
+    def test_access_classifier_accepts_non_retryable_http_statuses(self, status):
+        err = StubProviderError(
+            "provider rejected summary request",
+            status_code=status,
+        )
+        assert _is_summary_access_or_quota_error(err) is True
+
+    def test_classifier_reads_response_status_code(self):
+        err = StubProviderError(
+            "provider rejected summary request",
+            response=MagicMock(status_code=402),
+        )
+        assert _is_summary_access_or_quota_error(err) is True
+
+    def test_400_out_of_extra_usage_aborts_instead_of_dropping_context(self):
+        """Quota exhaustion preserves the original messages for a later retry."""
+        err = StubProviderError(
+            "Error code: 400 - {'error': {'message': 'out of extra usage'}}",
+            status_code=400,
+        )
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        msgs = self._msgs(12)
+        with patch("agent.context_compressor.call_llm", side_effect=err):
+            result = c.compress(msgs, current_tokens=999999, force=True)
+
+        assert result == msgs
+        assert c._last_summary_auth_failure is True
+        assert c._last_compress_aborted is True
+        assert c._last_summary_fallback_used is False
 
     def test_generate_summary_flags_auth_failure(self):
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -860,6 +860,7 @@ class TestAuthFailureAborts:
             "billing portal is temporarily unavailable",
             "usage limit documentation could not be loaded",
             "rate limit exceeded; retry later",
+            "quota exceeded, please retry after the window resets",
             "request timed out",
         ],
     )
@@ -903,6 +904,29 @@ class TestAuthFailureAborts:
         assert c._last_summary_auth_failure is True
         assert c._last_compress_aborted is True
         assert c._last_summary_fallback_used is False
+
+    def test_402_quota_with_retry_uses_existing_fallback(self):
+        """A reset-window quota remains transient instead of aborting compression."""
+        err = StubProviderError(
+            "quota exceeded, please retry after the window resets",
+            status_code=402,
+        )
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        msgs = self._msgs(12)
+        with patch("agent.context_compressor.call_llm", side_effect=err):
+            result = c.compress(msgs, current_tokens=999999, force=True)
+
+        assert result != msgs
+        assert c._last_summary_auth_failure is False
+        assert c._last_compress_aborted is False
+        assert c._last_summary_fallback_used is True
 
     def test_generate_summary_flags_auth_failure(self):
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):

--- a/tests/agent/test_manual_compression_feedback.py
+++ b/tests/agent/test_manual_compression_feedback.py
@@ -1,0 +1,62 @@
+"""Behavioral coverage for manual compression status messages."""
+
+from types import SimpleNamespace
+
+from agent.manual_compression_feedback import summarize_manual_compression
+
+
+def _messages(count: int) -> list[dict[str, str]]:
+    return [
+        {"role": "user" if index % 2 == 0 else "assistant", "content": str(index)}
+        for index in range(count)
+    ]
+
+
+def test_aborted_compression_reports_preserved_messages_and_reason():
+    messages = _messages(12)
+    state = SimpleNamespace(
+        _last_compress_aborted=True,
+        _last_summary_fallback_used=False,
+        _last_summary_error=(
+            "Provider 'opencode-zen' is set in config.yaml but no API key was found."
+        ),
+    )
+
+    feedback = summarize_manual_compression(
+        messages,
+        list(messages),
+        120_000,
+        120_000,
+        compression_state=state,
+    )
+
+    assert feedback["aborted"] is True
+    assert feedback["fallback_used"] is False
+    assert feedback["headline"] == "Compression aborted: 12 messages preserved"
+    assert "no messages were removed" in feedback["note"]
+    assert "no API key was found" in feedback["note"]
+
+
+def test_fallback_compression_reports_dropped_message_count():
+    before = _messages(12)
+    after = before[:2] + before[-2:]
+    state = SimpleNamespace(
+        _last_compress_aborted=False,
+        _last_summary_fallback_used=True,
+        _last_summary_dropped_count=8,
+        _last_summary_error="summary provider returned an invalid response",
+    )
+
+    feedback = summarize_manual_compression(
+        before,
+        after,
+        120_000,
+        40_000,
+        compression_state=state,
+    )
+
+    assert feedback["aborted"] is False
+    assert feedback["fallback_used"] is True
+    assert feedback["headline"] == "Compressed with fallback: 12 → 4 messages"
+    assert "removed 8 message(s)" in feedback["note"]
+    assert "invalid response" in feedback["note"]

--- a/tests/agent/test_manual_compression_feedback.py
+++ b/tests/agent/test_manual_compression_feedback.py
@@ -37,6 +37,28 @@ def test_aborted_compression_reports_preserved_messages_and_reason():
     assert "no API key was found" in feedback["note"]
 
 
+def test_failure_reason_redaction_is_forced_at_ui_boundary(monkeypatch):
+    messages = _messages(12)
+    fake_secret = "sk-proj-" + "X" * 40
+    state = SimpleNamespace(
+        _last_compress_aborted=True,
+        _last_summary_fallback_used=False,
+        _last_summary_error=f"provider rejected OPENAI_API_KEY={fake_secret}",
+    )
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False, raising=False)
+
+    feedback = summarize_manual_compression(
+        messages,
+        list(messages),
+        120_000,
+        120_000,
+        compression_state=state,
+    )
+
+    assert fake_secret not in feedback["note"]
+    assert "OPENAI_API_KEY=" in feedback["note"]
+
+
 def test_fallback_compression_reports_dropped_message_count():
     before = _messages(12)
     after = before[:2] + before[-2:]

--- a/tests/cli/test_manual_compress.py
+++ b/tests/cli/test_manual_compress.py
@@ -38,6 +38,32 @@ def test_manual_compress_reports_noop_without_success_banner(capsys):
     assert "Approx request size: ~100 tokens (unchanged)" in output
 
 
+def test_manual_compress_reports_aborted_summary_without_success_banner(capsys):
+    shell = _make_cli()
+    history = _make_history()
+    shell.conversation_history = history
+    shell.agent = MagicMock()
+    shell.agent.compression_enabled = True
+    shell.agent._cached_system_prompt = ""
+    shell.agent.tools = None
+    shell.agent.session_id = shell.session_id
+    shell.agent.context_compressor._last_compress_aborted = True
+    shell.agent.context_compressor._last_summary_fallback_used = False
+    shell.agent.context_compressor._last_summary_error = (
+        "Provider 'opencode-zen' is set in config.yaml but no API key was found."
+    )
+    shell.agent._compress_context.return_value = (list(history), "")
+
+    with patch("agent.model_metadata.estimate_request_tokens_rough", return_value=100):
+        shell._manual_compress()
+
+    output = capsys.readouterr().out
+    assert "⚠️ Compression aborted: 4 messages preserved" in output
+    assert "no messages were removed" in output
+    assert "no API key was found" in output
+    assert "✅ Compressed:" not in output
+
+
 def test_manual_compress_explains_when_token_estimate_rises(capsys):
     shell = _make_cli()
     history = _make_history()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4155,6 +4155,52 @@ def test_session_compress_uses_compress_helper(monkeypatch):
     emit.assert_any_call("status.update", "sid", {"kind": "status", "text": "ready"})
 
 
+def test_session_compress_reports_aborted_summary_without_success(monkeypatch):
+    compression_state = types.SimpleNamespace(
+        _last_compress_aborted=True,
+        _last_summary_fallback_used=False,
+        _last_summary_error=(
+            "Provider 'opencode-zen' is set in config.yaml but no API key was found."
+        ),
+    )
+    agent = types.SimpleNamespace(
+        context_compressor=compression_state,
+        _cached_system_prompt="",
+        tools=None,
+    )
+    history = [{"role": "user", "content": f"m{i}"} for i in range(6)]
+    server._sessions["sid"] = _session(agent=agent, history=history)
+
+    monkeypatch.setattr(
+        server,
+        "_compress_session_history",
+        lambda session, focus_topic=None, **_kw: (0, {"total": 42}),
+    )
+    monkeypatch.setattr(server, "_session_info", lambda _agent, *a: {"model": "x"})
+
+    try:
+        with patch("tui_gateway.server._emit"):
+            resp = server.handle_request(
+                {
+                    "id": "1",
+                    "method": "session.compress",
+                    "params": {"session_id": "sid"},
+                }
+            )
+
+        result = resp["result"]
+        assert result["status"] == "aborted"
+        assert result["removed"] == 0
+        assert result["summary"]["aborted"] is True
+        assert result["summary"]["headline"] == (
+            "Compression aborted: 6 messages preserved"
+        )
+        assert "no API key was found" in result["summary"]["note"]
+        assert "Compressed:" not in result["summary"]["headline"]
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_session_compress_syncs_session_key_after_rotation(monkeypatch):
     """When AIAgent._compress_context rotates session_id (compression split),
     the gateway session_key must follow so subsequent approval routing,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7976,14 +7976,18 @@ def _(rid, params: dict) -> dict:
             agent = session["agent"]
             _sync_session_key_after_compress(sid, session)
             summary = summarize_manual_compression(
-                before_messages, messages, before_tokens, after_tokens
+                before_messages,
+                messages,
+                before_tokens,
+                after_tokens,
+                compression_state=getattr(agent, "context_compressor", None),
             )
             info = _session_info(agent, session)
             _emit("session.info", sid, info)
             return _ok(
                 rid,
                 {
-                    "status": "compressed",
+                    "status": "aborted" if summary["aborted"] else "compressed",
                     "removed": removed,
                     "before_messages": before_count,
                     "after_messages": after_count,
@@ -12423,7 +12427,11 @@ def _(rid, params: dict) -> dict:
             )
             _sync_session_key_after_compress(sid, session)
             summary = summarize_manual_compression(
-                before_messages, after_messages, before_tokens, after_tokens
+                before_messages,
+                after_messages,
+                before_tokens,
+                after_tokens,
+                compression_state=getattr(_agent, "context_compressor", None),
             )
             _emit("session.info", sid, _session_info(session.get("agent"), session))
             return _ok(
@@ -13196,7 +13204,11 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             )
             _emit("session.info", sid, _session_info(agent, session))
             _fb = summarize_manual_compression(
-                _before_messages, _after_messages, _before_tokens, _after_tokens
+                _before_messages,
+                _after_messages,
+                _before_tokens,
+                _after_tokens,
+                compression_state=getattr(agent, "context_compressor", None),
             )
             _lines = [_fb["headline"], _fb["token_line"]]
             if _fb.get("note"):


### PR DESCRIPTION
## What does this PR do?

Preserves conversation history when context-summary generation fails because the configured compression provider has no usable API key, and makes manual compression report the failure instead of presenting a successful-looking message-count reduction.

This incorporates the two commits from #62422 with Alex López's original authorship intact, then extends that work to the missing-credential failure observed in Discord support thread `1527017669147099218` and to the CLI/TUI feedback surfaces.

The root cause was twofold:

- `ContextCompressor` did not classify the runtime error `no API key was found` as a terminal access failure, so the default failure path inserted static fallback context and removed the middle message window.
- Manual compression feedback only compared message and token counts, so TUI `/compress` reported `Compressed: 209 → 188 messages` without exposing that summary generation had failed.

## Related Issue

- Extends and incorporates #62422.
- Support thread: https://discord.com/channels/1053877538025386074/1527017669147099218

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve all original messages when summary generation reports that the configured provider has no API key.
- Preserve the permanent-quota behavior and transient quota/reset distinction from #62422.
- Add explicit `aborted` and `fallback_used` outcomes to shared manual-compression feedback.
- Report `Compression aborted: N messages preserved` with the redacted failure reason when no history was removed.
- Force-redact provider exception text at that UI boundary even when global redaction is disabled.
- Report `Compressed with fallback` plus the dropped-message count when a generic summary failure still uses the historical fallback path.
- Pass compressor outcome state through classic CLI and all three TUI manual-compression paths; the `session.compress` RPC now returns `status: aborted` for a preserved transcript.
- Add behavioral coverage for the exact provider error, transcript preservation, shared feedback, CLI output, and the TUI RPC response.

## How to Test

1. Configure an auxiliary compression provider but make its API key unavailable to the running Hermes process.
2. Run manual `/compress` on a transcript with a compressible middle window.
3. Verify that every original message remains, no child session is created, and the client reports `Compression aborted: N messages preserved` with the missing-key reason instead of `Compressed: N → M messages`.

Focused local validation on Windows 11:

- Python compilation passed for every changed Python module and test file.
- An isolated direct compressor reproduction classified the exact `opencode-zen` error as terminal, returned the original 12-message transcript, set `_last_compress_aborted=True`, kept `_last_summary_fallback_used=False`, and reported zero dropped messages.
- A direct `session.compress` JSON-RPC reproduction returned `status: aborted` and `Compression aborted: 6 messages preserved`.
- Permanent/transient classifier boundary assertions passed.
- A direct boundary check confirmed fallback state survives compression session rebinding and still reports `Compressed with fallback`.
- Forced-redaction validation confirmed a credential-shaped value cannot escape through the failure reason even when global redaction is disabled.
- `python scripts/check-windows-footguns.py --diff origin/main` passed.
- `git diff --check origin/main...HEAD` passed.

The pytest suite was not run locally under this workstation's test-safety policy; GitHub CI owns pytest coverage for this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11.10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Compression aborted: 12 messages preserved
Summary generation failed; no messages were removed. Reason: Provider 'opencode-zen' is set in config.yaml but no API key was found. Set the OPENCODE-ZEN_API_KEY environment variable.
DIRECT_REPRO_OK

Compression aborted: 6 messages preserved
TUI_RPC_REPRO_OK

✓ No Windows footguns found (8 file(s) scanned).
```

