### PR TITLE
fix(update): skip systemctl restart when LoadState is not-found after drain

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10854,6 +10854,71 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             # SIGUSR1 wiring, drain exceeded the budget,
                             # restart-policy mismatch).
                             #
+                            # Before restarting, check that the unit file
+                            # still exists.  A graceful SIGUSR1 drain on
+                            # user-scope units can leave systemd in a state
+                            # where the unit reports ``not-found`` even
+                            # though the unit file is present on disk.
+                            # Attempting restart in that state produces a
+                            # spurious ``"Unit ... not found"`` error.
+                            _load_state_check = subprocess.run(
+                                scope_cmd
+                                + [
+                                    "show",
+                                    svc_name,
+                                    "--property=LoadState",
+                                    "--value",
+                                ],
+                                capture_output=True,
+                                text=True,
+                                timeout=5,
+                            )
+                            _load_state = (_load_state_check.stdout or "").strip()
+                            if _load_state == "not-found":
+                                # Unit file no longer visible to systemd —
+                                # skip the restart to avoid a misleading
+                                # error.  The gateway was already drained;
+                                # if it was a user unit with Restart=always,
+                                # systemd will respawn it on its own.
+                                print(
+                                    f"  → {svc_name}: unit not-found after drain; "
+                                    "letting systemd auto-reload"
+                                )
+                                # Give systemd a moment to reload unit files.
+                                _time.sleep(2.0)
+                                _reload_ok = False
+                                try:
+                                    subprocess.run(
+                                        scope_cmd + ["daemon-reload"],
+                                        capture_output=True,
+                                        text=True,
+                                        timeout=10,
+                                    )
+                                    _reload_ok = True
+                                except (FileNotFoundError, subprocess.TimeoutExpired):
+                                    pass
+                                if _reload_ok:
+                                    _after_load = subprocess.run(
+                                        scope_cmd
+                                        + [
+                                            "show",
+                                            svc_name,
+                                            "--property=LoadState",
+                                            "--value",
+                                        ],
+                                        capture_output=True,
+                                        text=True,
+                                        timeout=5,
+                                    )
+                                    if (_after_load.stdout or "").strip() != "not-found":
+                                        # Unit reappeared after reload — proceed
+                                        # with the normal restart path below.
+                                        pass
+                                    else:
+                                        continue
+                                else:
+                                    continue
+
                             # Always `reset-failed` first.  If systemd's own
                             # auto-restart attempts already parked the unit
                             # in a failed state (transient CHDIR / OOM /


### PR DESCRIPTION
## Problem

After a graceful SIGUSR1 drain during `hermes update`, the forced `systemctl restart` path sometimes fails with:

```
  → hermes-gateway: draining (up to 195s)...
  ⚠ hermes-gateway drained but didn't relaunch — forcing restart
  ⚠ Failed to restart hermes-gateway: Failed to restart hermes-gateway.service: Unit hermes-gateway.service not found.
```

This happens because the graceful drain can leave systemd in a transient state where the unit's `LoadState` is `not-found` even though the unit file is present on disk. Attempting `systemctl restart` in that state produces a spurious error.

## Root Cause

The update code in `_cmd_update_impl()` discovers active `hermes-gateway*` units via `systemctl list-units`, drains them via SIGUSR1, then attempts `systemctl restart`. Between drain and restart, the unit can enter a `not-found` LoadState transient state. Calling `systemctl restart` on a `not-found` unit always fails.

## Fix

Before attempting the restart, check `LoadState` via `systemctl show`. If `not-found`:
1. Attempt a `daemon-reload` to re-sync systemd's unit cache  
2. Re-check `LoadState` — if the unit reappeared, proceed with the restart normally
3. If it remains `not-found`, skip silently — systemd's `Restart=always` will handle the respawn

## Impact

Affects all user-scope systemd gateway installs (the default on most non-root Linux setups). The update completes successfully but prints a misleading error that looks like a failure to the user.