### PR TITLE
fix(gateway): take over scoped token lock on replace

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2851,9 +2851,16 @@ class BasePlatformAdapter(ABC):
         from gateway.status import acquire_scoped_lock
         self._platform_lock_scope = scope
         self._platform_lock_identity = identity
-        acquired, existing = acquire_scoped_lock(
-            scope, identity, metadata={'platform': self.platform.value}
+        runner = getattr(self, "gateway_runner", None)
+        replace_owner = bool(
+            getattr(runner, "_replace_existing_platform_locks", False)
         )
+        lock_kwargs = {'metadata': {'platform': self.platform.value}}
+        if replace_owner:
+            # Preserve the historical call shape for normal starts; several
+            # external adapters wrap this helper and do not accept new kwargs.
+            lock_kwargs['replace_owner'] = True
+        acquired, existing = acquire_scoped_lock(scope, identity, **lock_kwargs)
         if acquired:
             return True
         owner_pid = existing.get('pid') if isinstance(existing, dict) else None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3067,6 +3067,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _loop_heartbeat_task: Optional["asyncio.Task"] = None
     _gateway_started_at: float = 0.0
     _shutdown_watchdog_done: Optional["threading.Event"] = None
+    _replace_existing_platform_locks: bool = False
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -7648,8 +7649,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     logger.warning("No adapter available for %s", _pval)
                 continue
-            
+
             # Set up message + fatal error handlers
+            adapter.gateway_runner = self
             adapter.set_message_handler(self._handle_message)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
@@ -8623,6 +8625,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         del self._failed_platforms[platform]
                         continue
 
+                    adapter.gateway_runner = self
                     adapter.set_message_handler(self._handle_message)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
@@ -9493,6 +9496,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         platform: Platform,
     ) -> None:
         """Install the profile-scoped handlers shared by startup and reconnect."""
+        adapter.gateway_runner = self
         adapter.set_message_handler(self._make_profile_message_handler(profile_name))
         adapter.set_fatal_error_handler(
             self._make_profile_fatal_error_handler(profile_name, platform)
@@ -22595,6 +22599,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             logging.getLogger().setLevel(_stderr_level)
 
     runner = GatewayRunner(config)
+    # Scoped token locks can reveal a live sibling that the profile-local PID
+    # file missed. Only explicit --replace starts may take over that owner, and
+    # only during initial adapter connection (never on a later reconnect).
+    runner._replace_existing_platform_locks = replace
     
     # Track whether an unexpected signal initiated the shutdown. When an
     # unexpected SIGTERM kills the gateway, we exit non-zero so service
@@ -22806,7 +22814,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         logger.debug("MCP tool discovery failed: %s", e)
 
     # Start the gateway
-    success = await runner.start()
+    try:
+        success = await runner.start()
+    finally:
+        runner._replace_existing_platform_locks = False
     if not success:
         return False
     if runner.should_exit_cleanly:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -215,6 +215,35 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
     return _get_lock_dir() / f"{scope}-{_scope_hash(identity)}.lock"
 
 
+def _acquire_scoped_coordination_lock(lock_path: Path):
+    """Serialize ownership-file reclamation without locking that file itself.
+
+    The coordination file is stable across ownership handoffs, so the guarded
+    code can safely unlink and recreate ``lock_path`` without opening a TOCTOU
+    window for another starter.  A contender fails fast and retries through
+    the platform reconnect path rather than blocking behind a long takeover.
+    """
+    coordination_path = lock_path.with_name(f"{lock_path.name}.guard")
+    try:
+        handle = open(coordination_path, "a+", encoding="utf-8")
+    except OSError:
+        return None
+    if not _try_acquire_file_lock(handle):
+        handle.close()
+        return None
+    return handle
+
+
+def _release_scoped_coordination_lock(handle) -> None:
+    if handle is None:
+        return
+    _release_file_lock(handle)
+    try:
+        handle.close()
+    except OSError:
+        pass
+
+
 def _get_process_start_time(pid: int) -> Optional[int]:
     """Return a stable per-process start-time fingerprint, or None.
 
@@ -1062,7 +1091,134 @@ def remove_pid_file() -> None:
         pass
 
 
-def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, Any]] = None) -> tuple[bool, Optional[dict[str, Any]]]:
+def _scoped_lock_owner_exited(existing: dict[str, Any], timeout: float) -> bool:
+    """Wait for the recorded owner to exit without trusting a recycled PID."""
+    try:
+        owner_pid = int(existing["pid"])
+    except (KeyError, TypeError, ValueError):
+        return True
+
+    recorded_start = existing.get("start_time")
+    deadline = time.monotonic() + max(0.0, timeout)
+    while time.monotonic() < deadline:
+        if not _pid_exists(owner_pid):
+            return True
+        current_start = _get_process_start_time(owner_pid)
+        if (
+            recorded_start is not None
+            and current_start is not None
+            and current_start != recorded_start
+        ):
+            return True
+        time.sleep(0.1)
+    if not _pid_exists(owner_pid):
+        return True
+    current_start = _get_process_start_time(owner_pid)
+    return bool(
+        recorded_start is not None
+        and current_start is not None
+        and current_start != recorded_start
+    )
+
+
+def _get_live_process_hermes_home(pid: int) -> Optional[Path]:
+    """Read a live gateway's home without trusting the shared lock record."""
+    try:
+        import psutil  # type: ignore
+
+        raw_home = psutil.Process(pid).environ().get("HERMES_HOME", "").strip()
+        if raw_home:
+            return Path(raw_home)
+        return _get_platform_default_hermes_home()
+    except Exception:
+        return None
+
+
+def _take_over_scoped_lock_owner(existing: dict[str, Any]) -> bool:
+    """Stop a verified gateway that owns a scoped lock for ``--replace``.
+
+    The lock record provides the PID that the profile-local PID file may have
+    missed.  Treat it as kill authority only after validating liveness, process
+    start time, and the live gateway command line.
+    """
+    try:
+        owner_pid = int(existing["pid"])
+    except (KeyError, TypeError, ValueError):
+        return False
+
+    if owner_pid == os.getpid() or not _pid_exists(owner_pid):
+        return False
+
+    recorded_start = existing.get("start_time")
+    current_start = _get_process_start_time(owner_pid)
+    if (
+        recorded_start is not None
+        and current_start is not None
+        and current_start != recorded_start
+    ):
+        return False
+    if not _looks_like_gateway_process(owner_pid):
+        return False
+
+    recorded_home_raw = existing.get("hermes_home")
+    recorded_home = (
+        Path(recorded_home_raw)
+        if isinstance(recorded_home_raw, str) and recorded_home_raw
+        else None
+    )
+    live_home = _get_live_process_hermes_home(owner_pid)
+    if live_home is not None and recorded_home is not None:
+        if live_home.resolve() != recorded_home.resolve():
+            return False
+    # Prefer the live process environment. If it is unreadable, only a home
+    # recorded by the owner itself is sufficient fallback authority. Guessing
+    # the replacer's home for an older record could put the takeover marker in
+    # the wrong profile and turn a planned stop into a supervisor flap.
+    owner_home = live_home or recorded_home
+    if owner_home is None:
+        return False
+    if live_home is None:
+        owner_cmdline = _read_process_cmdline(owner_pid)
+        if not owner_cmdline or not _command_line_belongs_to_profile(
+            owner_cmdline, owner_home
+        ):
+            return False
+    try:
+        logger.info(
+            "Replacing scoped lock owner gateway (PID %d) for --replace.",
+            owner_pid,
+        )
+        write_takeover_marker(owner_pid, target_hermes_home=owner_home)
+        terminate_pid(owner_pid, force=False)
+        if not _scoped_lock_owner_exited(existing, timeout=10.0):
+            logger.warning(
+                "Scoped lock owner gateway (PID %d) did not exit after SIGTERM; "
+                "forcing termination.",
+                owner_pid,
+            )
+            terminate_pid(owner_pid, force=True)
+            if not _scoped_lock_owner_exited(existing, timeout=5.0):
+                logger.error(
+                    "Scoped lock owner gateway (PID %d) survived force termination.",
+                    owner_pid,
+                )
+                return False
+        return True
+    except ProcessLookupError:
+        return True
+    except (PermissionError, OSError):
+        return False
+    finally:
+        clear_takeover_marker(hermes_home=owner_home)
+
+
+def acquire_scoped_lock(
+    scope: str,
+    identity: str,
+    metadata: Optional[dict[str, Any]] = None,
+    *,
+    replace_owner: bool = False,
+) -> tuple[bool, Optional[dict[str, Any]]]:
     """Acquire a machine-local lock keyed by scope + identity.
 
     Used to prevent multiple local gateways from using the same external identity
@@ -1070,8 +1226,33 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
     """
     lock_path = _get_scope_lock_path(scope, identity)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
+    coordination_handle = _acquire_scoped_coordination_lock(lock_path)
+    if coordination_handle is None:
+        return False, _read_json_file(lock_path)
+    try:
+        return _acquire_scoped_lock_coordinated(
+            lock_path,
+            scope,
+            identity,
+            metadata,
+            replace_owner=replace_owner,
+        )
+    finally:
+        _release_scoped_coordination_lock(coordination_handle)
+
+
+def _acquire_scoped_lock_coordinated(
+    lock_path: Path,
+    scope: str,
+    identity: str,
+    metadata: Optional[dict[str, Any]],
+    *,
+    replace_owner: bool,
+) -> tuple[bool, Optional[dict[str, Any]]]:
+    """Acquire ``lock_path`` while its stable coordination lock is held."""
     record = {
         **_build_pid_record(),
+        "hermes_home": str(_get_process_hermes_home()),
         "scope": scope,
         "identity_hash": _scope_hash(identity),
         "metadata": metadata or {},
@@ -1162,7 +1343,20 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
             except OSError:
                 pass
         else:
-            return False, existing
+            if not replace_owner or not _take_over_scoped_lock_owner(existing):
+                return False, existing
+            # The old process is gone. Remove only the record we validated;
+            # another replacer may already have claimed the path.
+            current = _read_json_file(lock_path)
+            if current is not None and (
+                current.get("pid") != existing.get("pid")
+                or current.get("start_time") != existing.get("start_time")
+            ):
+                return False, current
+            try:
+                lock_path.unlink(missing_ok=True)
+            except OSError:
+                return False, _read_json_file(lock_path)
 
     try:
         fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
@@ -1183,17 +1377,23 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
 def release_scoped_lock(scope: str, identity: str) -> None:
     """Release a previously-acquired scope lock when owned by this process."""
     lock_path = _get_scope_lock_path(scope, identity)
-    existing = _read_json_file(lock_path)
-    if not existing:
-        return
-    if existing.get("pid") != os.getpid():
-        return
-    if existing.get("start_time") != _get_process_start_time(os.getpid()):
+    coordination_handle = _acquire_scoped_coordination_lock(lock_path)
+    if coordination_handle is None:
         return
     try:
-        lock_path.unlink(missing_ok=True)
-    except OSError:
-        pass
+        existing = _read_json_file(lock_path)
+        if not existing:
+            return
+        if existing.get("pid") != os.getpid():
+            return
+        if existing.get("start_time") != _get_process_start_time(os.getpid()):
+            return
+        try:
+            lock_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+    finally:
+        _release_scoped_coordination_lock(coordination_handle)
 
 
 def release_all_scoped_locks(
@@ -1218,26 +1418,32 @@ def release_all_scoped_locks(
     removed = 0
     if lock_dir.exists():
         for lock_file in lock_dir.glob("*.lock"):
-            if owner_pid is not None:
-                record = _read_json_file(lock_file)
-                if not isinstance(record, dict):
-                    continue
-                try:
-                    record_pid = int(record.get("pid"))
-                except (TypeError, ValueError):
-                    continue
-                if record_pid != owner_pid:
-                    continue
-                if (
-                    owner_start_time is not None
-                    and record.get("start_time") != owner_start_time
-                ):
-                    continue
+            coordination_handle = _acquire_scoped_coordination_lock(lock_file)
+            if coordination_handle is None:
+                continue
             try:
-                lock_file.unlink(missing_ok=True)
-                removed += 1
-            except OSError:
-                pass
+                if owner_pid is not None:
+                    record = _read_json_file(lock_file)
+                    if not isinstance(record, dict):
+                        continue
+                    try:
+                        record_pid = int(record.get("pid"))
+                    except (TypeError, ValueError):
+                        continue
+                    if record_pid != owner_pid:
+                        continue
+                    if (
+                        owner_start_time is not None
+                        and record.get("start_time") != owner_start_time
+                    ):
+                        continue
+                try:
+                    lock_file.unlink(missing_ok=True)
+                    removed += 1
+                except OSError:
+                    pass
+            finally:
+                _release_scoped_coordination_lock(coordination_handle)
     return removed
 
 
@@ -1266,9 +1472,9 @@ _PLANNED_STOP_MARKER_FILENAME = ".gateway-planned-stop.json"
 _PLANNED_STOP_MARKER_TTL_S = 60
 
 
-def _get_takeover_marker_path() -> Path:
+def _get_takeover_marker_path(hermes_home: Optional[Path] = None) -> Path:
     """Return the path to the --replace takeover marker file."""
-    home = _get_process_hermes_home()
+    home = hermes_home or _get_process_hermes_home()
     return home / _TAKEOVER_MARKER_FILENAME
 
 
@@ -1328,9 +1534,15 @@ def _consume_pid_marker_for_self(
     # absent as "same home" so old markers and single-profile setups are
     # unaffected. Leave a mismatched marker in place so the correct
     # profile can still consume it.
+    process_home = str(_get_process_hermes_home())
     replacer_home = record.get("replacer_hermes_home")
-    if replacer_home is not None and replacer_home != str(_get_process_hermes_home()):
-        return False
+    target_home = record.get("target_hermes_home")
+    if replacer_home is not None and replacer_home != process_home:
+        # A deliberate scoped-lock takeover writes the marker into the target
+        # profile's home and names that home explicitly. Older markers lack
+        # this field and retain the cross-profile rejection from #29092.
+        if target_home != process_home:
+            return False
 
     our_pid = os.getpid()
     our_start_time = _get_process_start_time(our_pid)
@@ -1361,7 +1573,11 @@ def _consume_pid_marker_for_self(
     return matches
 
 
-def write_takeover_marker(target_pid: int) -> bool:
+def write_takeover_marker(
+    target_pid: int,
+    *,
+    target_hermes_home: Optional[Path] = None,
+) -> bool:
     """Record that ``target_pid`` is being replaced by the current process.
 
     Captures the target's ``start_time`` so that PID reuse after the
@@ -1379,9 +1595,12 @@ def write_takeover_marker(target_pid: int) -> bool:
             "target_start_time": target_start_time,
             "replacer_pid": os.getpid(),
             "replacer_hermes_home": str(_get_process_hermes_home()),
+            "target_hermes_home": (
+                str(target_hermes_home) if target_hermes_home else None
+            ),
             "written_at": _utc_now_iso(),
         }
-        _write_json_file(_get_takeover_marker_path(), record)
+        _write_json_file(_get_takeover_marker_path(target_hermes_home), record)
         return True
     except (OSError, PermissionError):
         return False
@@ -1406,10 +1625,10 @@ def consume_takeover_marker_for_self() -> bool:
     )
 
 
-def clear_takeover_marker() -> None:
+def clear_takeover_marker(*, hermes_home: Optional[Path] = None) -> None:
     """Remove the takeover marker unconditionally. Safe to call repeatedly."""
     try:
-        _get_takeover_marker_path().unlink(missing_ok=True)
+        _get_takeover_marker_path(hermes_home).unlink(missing_ok=True)
     except OSError:
         pass
 

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -256,6 +256,7 @@ class TestSecondaryProfileFatalRecovery:
         assert len(tasks) == 1
         await tasks[0]
         assert runner._profile_adapters["reviewer"][Platform.DISCORD] is replacement
+        assert replacement.gateway_runner is runner
         assert scoped_homes
         assert all(path == Path("/profiles/reviewer") for path in scoped_homes)
 

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -220,6 +220,7 @@ class TestPlatformReconnectWatcher:
 
         assert Platform.TELEGRAM not in runner._failed_platforms
         assert Platform.TELEGRAM in runner.adapters
+        assert succeed_adapter.gateway_runner is runner
 
     @pytest.mark.asyncio
     async def test_reconnect_passes_is_reconnect_true(self):

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -127,8 +127,11 @@ async def test_runner_records_connected_platform_state_on_success(monkeypatch, t
         sessions_dir=tmp_path / "sessions",
     )
     runner = GatewayRunner(config)
+    adapter = _SuccessfulAdapter()
 
-    monkeypatch.setattr(runner, "_create_adapter", lambda platform, platform_config: _SuccessfulAdapter())
+    monkeypatch.setattr(
+        runner, "_create_adapter", lambda platform, platform_config: adapter
+    )
     monkeypatch.setattr(runner.hooks, "discover_and_load", lambda: None)
     monkeypatch.setattr(runner.hooks, "emit", AsyncMock())
 
@@ -140,6 +143,7 @@ async def test_runner_records_connected_platform_state_on_success(monkeypatch, t
     assert state["platforms"]["discord"]["state"] == "connected"
     assert state["platforms"]["discord"]["error_code"] is None
     assert state["platforms"]["discord"]["error_message"] is None
+    assert adapter.gateway_runner is runner
 
 
 @pytest.mark.asyncio
@@ -174,6 +178,49 @@ async def test_start_gateway_verbosity_imports_redacting_formatter(monkeypatch, 
     ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=1)
 
     assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_limits_lock_takeover_to_initial_replace(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    observed = []
+    instances = []
+
+    class _IntentRunner:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit_cleanly = True
+            self.exit_reason = None
+            self.exit_code = None
+            self.adapters = {}
+            instances.append(self)
+
+        async def start(self):
+            observed.append(self._replace_existing_platform_locks)
+            return True
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr(
+        "hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path
+    )
+    monkeypatch.setattr(
+        "hermes_logging._add_rotating_handler", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr("gateway.run.GatewayRunner", _IntentRunner)
+
+    from gateway.run import start_gateway
+
+    assert await start_gateway(
+        config=GatewayConfig(), replace=True, verbosity=None
+    ) is True
+    assert observed == [True]
+    assert instances[0]._replace_existing_platform_locks is False
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_stale_platform_lock_retryable.py
+++ b/tests/gateway/test_stale_platform_lock_retryable.py
@@ -17,6 +17,7 @@ Contract asserted here
 acquisition fails, regardless of the reason.
 """
 
+from types import SimpleNamespace
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
@@ -63,11 +64,28 @@ def test_stale_lock_failure_is_retryable(adapter):
     with patch(
         "gateway.status.acquire_scoped_lock",
         return_value=(False, {"pid": 99999, "start_time": "2026-01-01T00:00:00Z"}),
-    ), patch.object(adapter, "_write_runtime_status_safe"):
+    ) as acquire, patch.object(adapter, "_write_runtime_status_safe"):
         result = adapter._acquire_platform_lock(
             "telegram-bot-token", "test-token", "Telegram bot token"
         )
 
     assert result is False
+    assert "replace_owner" not in acquire.call_args.kwargs
     assert adapter._fatal_error_retryable is True
     assert adapter._fatal_error_code == "telegram-bot-token_lock"
+
+
+def test_platform_lock_forwards_explicit_replace_intent(adapter):
+    """Only an initial --replace connection may take over a live owner."""
+    adapter.gateway_runner = SimpleNamespace(_replace_existing_platform_locks=True)
+
+    with patch(
+        "gateway.status.acquire_scoped_lock",
+        return_value=(True, None),
+    ) as acquire:
+        result = adapter._acquire_platform_lock(
+            "telegram-bot-token", "test-token", "Telegram bot token"
+        )
+
+    assert result is True
+    assert acquire.call_args.kwargs["replace_owner"] is True

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -916,6 +916,214 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_explicit_replace_takes_over_verified_gateway_owner(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "replacer"))
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        owner_home = tmp_path / "owner"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "hermes_home": str(owner_home),
+        }))
+
+        alive = {99999: True}
+        signals = []
+        marker_homes = []
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: alive.get(pid, True))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+        monkeypatch.setattr(
+            status, "_get_live_process_hermes_home", lambda pid: owner_home
+        )
+        monkeypatch.setattr(
+            status,
+            "write_takeover_marker",
+            lambda pid, *, target_hermes_home=None: marker_homes.append(
+                target_hermes_home
+            ) or True,
+        )
+        monkeypatch.setattr(status, "clear_takeover_marker", lambda **kwargs: None)
+
+        def terminate(pid, *, force=False):
+            signals.append((pid, force))
+            alive[pid] = False
+
+        monkeypatch.setattr(status, "terminate_pid", terminate)
+
+        acquired, existing = status.acquire_scoped_lock(
+            "telegram-bot-token",
+            "secret",
+            metadata={"platform": "telegram"},
+            replace_owner=True,
+        )
+
+        assert acquired is True
+        assert existing is None
+        assert signals == [(99999, False)]
+        assert marker_homes == [owner_home]
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+
+    def test_scoped_takeover_does_not_unlink_a_racing_owner(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        original = {
+            "pid": 111,
+            "start_time": 222,
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+        }
+        replacement = {**original, "pid": 333, "start_time": 444}
+        lock_path.write_text(json.dumps(original))
+
+        def takeover(_existing):
+            lock_path.write_text(json.dumps(replacement))
+            return True
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 222)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+        monkeypatch.setattr(status, "_take_over_scoped_lock_owner", takeover)
+
+        acquired, existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", replace_owner=True
+        )
+
+        assert acquired is False
+        assert existing == replacement
+        assert json.loads(lock_path.read_text()) == replacement
+
+    def test_scoped_takeover_serializes_between_recheck_and_unlink(
+        self, tmp_path, monkeypatch
+    ):
+        """A contender cannot reclaim the dead owner in the unlink window."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        original = {
+            "pid": 111,
+            "start_time": 222,
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+        }
+        lock_path.write_text(json.dumps(original))
+
+        alive = {111: True}
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: alive.get(pid, True))
+        monkeypatch.setattr(
+            status,
+            "_get_process_start_time",
+            lambda pid: 222 if pid == 111 else 333,
+        )
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+
+        def takeover(_existing):
+            alive[111] = False
+            return True
+
+        monkeypatch.setattr(status, "_take_over_scoped_lock_owner", takeover)
+
+        real_unlink = Path.unlink
+        contender_results = []
+        interleaved = False
+
+        def unlink_with_contender(path, *args, **kwargs):
+            nonlocal interleaved
+            if path == lock_path and not interleaved:
+                interleaved = True
+                contender_results.append(
+                    status.acquire_scoped_lock("telegram-bot-token", "secret")
+                )
+            return real_unlink(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", unlink_with_contender)
+
+        acquired, existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", replace_owner=True
+        )
+
+        assert acquired is True
+        assert existing is None
+        assert contender_results == [(False, original)]
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+
+    def test_explicit_replace_does_not_kill_unverified_pid(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: False)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+        monkeypatch.setattr(
+            status,
+            "terminate_pid",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("unverified PID must not be terminated")
+            ),
+        )
+
+        acquired, existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", replace_owner=True
+        )
+
+        assert acquired is False
+        assert existing["pid"] == 99999
+
+    def test_explicit_replace_does_not_guess_home_for_legacy_owner(
+        self, tmp_path, monkeypatch
+    ):
+        """An old record plus unreadable live env is not kill authority."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "replacer"))
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+        monkeypatch.setattr(status, "_get_live_process_hermes_home", lambda pid: None)
+        monkeypatch.setattr(
+            status,
+            "terminate_pid",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("owner with unknown home must not be terminated")
+            ),
+        )
+
+        acquired, existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", replace_owner=True
+        )
+
+        assert acquired is False
+        assert existing["pid"] == 99999
+        assert json.loads(lock_path.read_text())["pid"] == 99999
+
     def test_acquire_scoped_lock_recovers_empty_lock_file(self, tmp_path, monkeypatch):
         """Empty lock file (0 bytes) left by a crashed process should be treated as stale."""
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
@@ -1070,6 +1278,26 @@ class TestTakeoverMarker:
         assert result is True
         # Marker must be unlinked after consumption
         assert not (tmp_path / ".gateway-takeover.json").exists()
+
+    def test_scoped_takeover_marker_can_target_another_profile(
+        self, tmp_path, monkeypatch
+    ):
+        replacer_home = tmp_path / "replacer"
+        target_home = tmp_path / "target"
+        replacer_home.mkdir()
+        target_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(replacer_home))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 100)
+
+        ok = status.write_takeover_marker(
+            target_pid=os.getpid(), target_hermes_home=target_home
+        )
+        assert ok is True
+        assert (target_home / ".gateway-takeover.json").exists()
+
+        monkeypatch.setenv("HERMES_HOME", str(target_home))
+        assert status.consume_takeover_marker_for_self() is True
+        assert not (target_home / ".gateway-takeover.json").exists()
 
     def test_consume_returns_false_for_different_pid(self, tmp_path, monkeypatch):
         """A marker naming a DIFFERENT process must not be consumed as ours."""


### PR DESCRIPTION
## Summary

Fixes #65176.

When an explicit `--replace` startup encounters a platform token lock held by a gateway from another profile, it now:

- verifies the owner PID, start time, gateway command, and `HERMES_HOME`
- terminates the verified owner and safely reacquires the lock
- serializes stale reclamation and ownership handoff with a stable OS-level guard

Takeover is limited to initial `--replace` startup. Normal starts and later reconnects retain the existing retryable conflict behavior.

## Tests

- 111 focused gateway status and startup tests passed
- 415 shared platform-adapter tests passed
- Windows footgun check passed