### PR TITLE
fix(tui): interrupt in-flight TTS playback when starting voice recording

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13523,6 +13523,18 @@ def _(rid, params: dict) -> dict:
                 global _voice_event_sid
                 _voice_event_sid = params.get("session_id") or _voice_event_sid
 
+            # Interrupt any in-flight TTS playback before opening the mic —
+            # mirrors cli.py's Ctrl+B handler (classic CLI). Without this the
+            # TUI's record key starts listening but leaves TTS audio playing
+            # in the background, since nothing else in this path ever calls
+            # stop_playback() (parity fix — TUI previously had no interrupt).
+            try:
+                from tools.voice_mode import stop_playback
+
+                stop_playback()
+            except Exception:
+                pass
+
             from hermes_cli.voice import start_continuous
 
             # Shape-safe lookups: malformed ``voice:`` YAML (bool/scalar/list)


### PR DESCRIPTION
## Summary

The classic CLI (`cli.py`) calls `stop_playback()` before opening the mic on its Ctrl+B / record-key handler, so pressing the key while Hermes is speaking cuts off TTS and immediately starts listening. The TUI's `voice.record` RPC handler (`tui_gateway/server.py`) never had this call — pressing the record key while TTS was playing would start recording but leave the audio playing in the background, with no way to interrupt it short of exiting the session.

This adds the same `stop_playback()` call to the TUI's `voice.record` 'start' action, restoring parity with the classic CLI's interrupt behavior.

## Root cause

- `hermes_cli/voice.py::speak_text` plays TTS audio via a subprocess tracked in `tools/voice_mode.py`'s `_active_playback`.
- `tools/voice_mode.py::stop_playback()` terminates that subprocess.
- `cli.py`'s Ctrl+B handler already calls `stop_playback()` before starting a new recording (see `cli.py` around the voice key binding).
- `tui_gateway/server.py`'s `voice.record` method (used by the Ink TUI, the default interface) never referenced `stop_playback` or `tools.voice_mode` at all — confirmed via `grep -rn stop_playback tui_gateway/server.py` returning zero matches before this patch.

## Fix

Added a `stop_playback()` call (best-effort, wrapped in try/except like the neighboring `stop_continuous` cleanup path) at the top of the `voice.record` 'start' action, before `start_continuous()` is invoked.

## Test plan

- `scripts/run_tests.sh tests/test_tui_gateway_server.py` — 323/323 passed, no regressions.
- Manual mock verification: patched `stop_playback` and `start_continuous`, dispatched `voice.record` with `action=start`, confirmed both are called and the RPC still returns `{status: recording}`.
- Manually verified end-to-end in a live TUI session: TTS now stops immediately when the voice record key is pressed mid-playback.