### PR TITLE
fix(web): implement extract() for the ddgs backend

### DIFF
--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import concurrent.futures as _cf
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from agent.web_search_provider import WebSearchProvider
 
@@ -26,6 +26,35 @@ logger = logging.getLogger(__name__)
 # the (single, shared) agent loop indefinitely and block every platform
 # (#36776). Enforce a hard cap here via a worker thread.
 _SEARCH_TIMEOUT_SECS = 30
+
+# Per-URL wall-clock cap for a single ddgs extract() call. Same rationale as
+# _SEARCH_TIMEOUT_SECS above — DDGS(timeout=...) only bounds the individual
+# HTTP request, not any retry/redirect chasing ddgs does internally.
+_EXTRACT_TIMEOUT_SECS = 30
+
+# Map our tool-facing ``format`` values to ddgs's ``DDGS.extract(fmt=...)``
+# values. ddgs supports "text_markdown" (default), "text_plain", "text_rich",
+# "text" (raw HTML), and "content" (raw bytes) — we only expose the two that
+# make sense for an LLM-facing extract tool.
+_FORMAT_MAP = {
+    "markdown": "text_markdown",
+    "text_markdown": "text_markdown",
+    "text": "text_plain",
+    "text_plain": "text_plain",
+    "html": "text",
+}
+
+
+def _run_ddgs_extract(url: str, fmt: str) -> dict[str, Any]:
+    """Run the blocking ddgs extract call for a single URL.
+
+    Module-level (not a closure) so tests can patch it directly without
+    spawning a real worker thread, mirroring ``_run_ddgs_search`` above.
+    """
+    from ddgs import DDGS  # type: ignore
+
+    with DDGS(timeout=10) as client:
+        return client.extract(url, fmt=fmt)
 
 
 def _run_ddgs_search(query: str, safe_limit: int) -> list[dict[str, Any]]:
@@ -89,7 +118,7 @@ class DDGSWebSearchProvider(WebSearchProvider):
         return True
 
     def supports_extract(self) -> bool:
-        return False
+        return True
 
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
         """Execute a DuckDuckGo search and return normalized results.
@@ -146,11 +175,73 @@ class DDGSWebSearchProvider(WebSearchProvider):
         logger.info("DDGS search '%s': %d results (limit %d)", query, len(web_results), limit)
         return {"success": True, "data": {"web": web_results}}
 
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Extract content from one or more URLs via ``DDGS().extract()``.
+
+        ``ddgs`` fetches and readability-parses each URL directly (no
+        rendering — plain HTTP GET + HTML parsing), so it works for static
+        and server-rendered pages but returns only page-shell content for
+        JS-rendered SPAs. Each URL is fetched in its own worker thread with
+        a hard wall-clock cap (mirrors ``search()``'s ``#36776`` fix) so one
+        slow/hanging fetch can't block the shared agent loop; per-URL
+        failures become result entries with an ``error`` field rather than
+        aborting the whole batch.
+        """
+        try:
+            import ddgs  # type: ignore  # noqa: F401 — availability probe
+        except ImportError:
+            return [
+                {
+                    "url": u, "title": "", "content": "",
+                    "error": "ddgs package is not installed — run `pip install ddgs`",
+                }
+                for u in urls
+            ]
+
+        fmt = _FORMAT_MAP.get((kwargs.get("format") or "markdown").lower(), "text_markdown")
+        documents: List[Dict[str, Any]] = []
+        for url in urls:
+            pool = _cf.ThreadPoolExecutor(max_workers=1)
+            try:
+                future = pool.submit(_run_ddgs_extract, url, fmt)
+                try:
+                    result = future.result(timeout=_EXTRACT_TIMEOUT_SECS)
+                    content = result.get("content", "") if isinstance(result, dict) else ""
+                    documents.append(
+                        {
+                            "url": url,
+                            "title": "",
+                            "content": content,
+                            "raw_content": content,
+                            "metadata": {"sourceURL": url},
+                        }
+                    )
+                except _cf.TimeoutError:
+                    logger.warning(
+                        "DDGS extract timed out after %ds for URL: %r",
+                        _EXTRACT_TIMEOUT_SECS, url,
+                    )
+                    documents.append(
+                        {
+                            "url": url, "title": "", "content": "",
+                            "error": f"DuckDuckGo extract timed out after {_EXTRACT_TIMEOUT_SECS}s",
+                        }
+                    )
+            except Exception as exc:  # noqa: BLE001 — ddgs raises its own exceptions
+                logger.warning("DDGS extract error for %s: %s", url, exc)
+                documents.append(
+                    {"url": url, "title": "", "content": "", "error": f"DuckDuckGo extract failed: {exc}"}
+                )
+            finally:
+                # Same rationale as search(): don't join a hung worker.
+                pool.shutdown(wait=False, cancel_futures=True)
+        return documents
+
     def get_setup_schema(self) -> Dict[str, Any]:
         return {
             "name": "DuckDuckGo (ddgs)",
-            "badge": "free · no key · search only",
-            "tag": "Search via the ddgs Python package — no API key (pair with any extract provider)",
+            "badge": "free · no key",
+            "tag": "Search + basic extract via the ddgs Python package — no API key. Extract is HTTP-fetch + readability parsing (no JS rendering), so it won't work on client-rendered SPAs; pair with a browser-based fallback for those.",
             "env_vars": [],
             # Trigger `_run_post_setup("ddgs")` after the user picks this row
             # so the ddgs Python package gets pip-installed on first selection.

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -4,8 +4,9 @@ Covers:
 - DDGSWebSearchProvider.is_available() — reflects package importability
 - DDGSWebSearchProvider.search() — happy path, missing package, runtime error
 - Result normalization (title, url, description, position)
+- DDGSWebSearchProvider.extract() — happy path, missing package, timeout, errors
 - _is_backend_available("ddgs") / _get_backend() integration
-- web_extract returns a search-only error when ddgs is active
+- web_extract dispatches to ddgs when configured (ddgs now supports_extract())
 """
 from __future__ import annotations
 
@@ -18,13 +19,25 @@ import pytest
 from tests.tools.conftest import register_all_web_providers
 
 
-def _install_fake_ddgs(monkeypatch, *, text_results=None, text_raises=None, text_sleep=None):
+def _install_fake_ddgs(
+    monkeypatch, *, text_results=None, text_raises=None, text_sleep=None,
+    extract_result=None, extract_raises=None, extract_sleep=None,
+    extract_fn=None,
+):
     """Install a stub ``ddgs`` module in sys.modules for the duration of a test.
 
     ``text_results``: iterable of dicts to yield from DDGS().text(...).
     ``text_raises``: if set, DDGS().text raises this exception instead.
     ``text_sleep``: if set, DDGS().text blocks for this many seconds before
         yielding — simulates a hung/slow search for the timeout test.
+    ``extract_result``: dict returned from DDGS().extract(...) (defaults to
+        ``{"url": <url>, "content": "<content>"}``).
+    ``extract_raises``: if set, DDGS().extract raises this exception instead.
+    ``extract_sleep``: if set, DDGS().extract blocks for this many seconds
+        before returning — simulates a hung/slow fetch for the timeout test.
+    ``extract_fn``: if set, a ``(url, fmt) -> dict`` callable that fully
+        controls DDGS().extract(...) — takes priority over the other
+        extract_* kwargs. Use when different URLs need different behavior.
     """
     import time as _time
 
@@ -46,8 +59,18 @@ def _install_fake_ddgs(monkeypatch, *, text_results=None, text_raises=None, text
                 raise text_raises
             for hit in (text_results or []):
                 yield hit
+        def extract(self, url, fmt="text_markdown"):
+            if extract_fn is not None:
+                return extract_fn(url, fmt)
+            if extract_sleep is not None:
+                _time.sleep(extract_sleep)
+            if extract_raises is not None:
+                raise extract_raises
+            if extract_result is not None:
+                return extract_result
+            return {"url": url, "content": "<content>"}
 
-    fake.DDGS = _FakeDDGS
+    fake.DDGS = _FakeDDGS  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "ddgs", fake)
     return fake
 
@@ -267,11 +290,142 @@ class TestDDGSBackendWiring:
 
 
 # ---------------------------------------------------------------------------
-# ddgs is search-only: web_extract returns a clear error
+# DDGSWebSearchProvider.extract() unit tests
 # ---------------------------------------------------------------------------
 
 
-class TestDDGSSearchOnlyErrors:
+class TestDDGSProviderExtract:
+    def test_supports_extract_is_true(self):
+        from plugins.web.ddgs.provider import DDGSWebSearchProvider
+        assert DDGSWebSearchProvider().supports_extract() is True
+
+    def test_happy_path_returns_content(self, monkeypatch):
+        _install_fake_ddgs(monkeypatch, extract_result={"url": "https://a.example.com", "content": "# Hello"})
+        from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
+        docs = DDGSWebSearchProvider().extract(["https://a.example.com"])
+
+        assert len(docs) == 1
+        assert docs[0]["url"] == "https://a.example.com"
+        assert docs[0]["content"] == "# Hello"
+        assert docs[0]["raw_content"] == "# Hello"
+        assert "error" not in docs[0]
+
+    def test_multiple_urls_each_extracted(self, monkeypatch):
+        _install_fake_ddgs(monkeypatch)
+        from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
+        docs = DDGSWebSearchProvider().extract(
+            ["https://a.example.com", "https://b.example.com"]
+        )
+
+        assert len(docs) == 2
+        assert {d["url"] for d in docs} == {"https://a.example.com", "https://b.example.com"}
+
+    def test_format_kwarg_maps_to_ddgs_fmt(self, monkeypatch):
+        _install_fake_ddgs(monkeypatch)
+        monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
+        import plugins.web.ddgs.provider as _prov
+
+        captured = {}
+        orig = _prov._run_ddgs_extract
+
+        def _spy(url, fmt):
+            captured["fmt"] = fmt
+            return orig(url, fmt)
+
+        monkeypatch.setattr(_prov, "_run_ddgs_extract", _spy)
+        _prov.DDGSWebSearchProvider().extract(["https://a.example.com"], format="html")
+        assert captured["fmt"] == "text"
+
+    def test_missing_package_returns_error_per_url(self, monkeypatch):
+        monkeypatch.delitem(sys.modules, "ddgs", raising=False)
+        monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
+        import builtins
+        orig_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name == "ddgs":
+                raise ImportError("blocked for test")
+            return orig_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", blocked_import)
+        from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
+        docs = DDGSWebSearchProvider().extract(["https://a.example.com", "https://b.example.com"])
+        assert len(docs) == 2
+        assert all("ddgs" in d["error"].lower() for d in docs)
+        assert all(d["content"] == "" for d in docs)
+
+    def test_runtime_error_returns_error_entry(self, monkeypatch):
+        _install_fake_ddgs(monkeypatch, extract_raises=RuntimeError("HTTP 404"))
+        from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
+        docs = DDGSWebSearchProvider().extract(["https://a.example.com"])
+        assert len(docs) == 1
+        assert docs[0]["content"] == ""
+        assert "404" in docs[0]["error"] or "failed" in docs[0]["error"].lower()
+
+    def test_one_bad_url_does_not_abort_the_batch(self, monkeypatch):
+        """A failing URL must not prevent other URLs in the same batch from
+        being extracted — each URL is fetched independently."""
+        calls = {"n": 0}
+
+        def _extract_fn(url, fmt):
+            calls["n"] += 1
+            if url == "https://bad.example.com":
+                raise RuntimeError("boom")
+            return {"url": url, "content": "ok"}
+
+        _install_fake_ddgs(monkeypatch, extract_fn=_extract_fn)
+        monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
+        from plugins.web.ddgs.provider import DDGSWebSearchProvider
+
+        docs = DDGSWebSearchProvider().extract(
+            ["https://bad.example.com", "https://good.example.com"]
+        )
+        by_url = {d["url"]: d for d in docs}
+        assert by_url["https://bad.example.com"]["error"]
+        assert by_url["https://good.example.com"]["content"] == "ok"
+        assert calls["n"] == 2
+
+    def test_hung_extract_times_out_and_returns_error_entry(self, monkeypatch):
+        """Mirrors #36776's search timeout fix: a hung ddgs.extract() call
+        must be bounded and must not hang the shared agent loop."""
+        import threading
+        import time
+
+        _install_fake_ddgs(monkeypatch)
+        monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
+        import plugins.web.ddgs.provider as _prov
+
+        release = threading.Event()
+
+        def _blocking_extract(url, fmt):
+            release.wait(timeout=10)
+            return {"url": url, "content": "too late"}
+
+        monkeypatch.setattr(_prov, "_run_ddgs_extract", _blocking_extract, raising=True)
+        monkeypatch.setattr(_prov, "_EXTRACT_TIMEOUT_SECS", 0.3, raising=True)
+
+        try:
+            start = time.monotonic()
+            docs = _prov.DDGSWebSearchProvider().extract(["https://hangs.example.com"])
+            elapsed = time.monotonic() - start
+
+            assert len(docs) == 1
+            assert "timed out" in docs[0]["error"].lower()
+            assert elapsed < 3.0, f"extract did not return promptly ({elapsed:.1f}s)"
+        finally:
+            release.set()
+
+
+# ---------------------------------------------------------------------------
+# web_extract dispatches to ddgs when configured (ddgs supports_extract())
+# ---------------------------------------------------------------------------
+
+
+class TestDDGSWebExtractDispatch:
     _register_providers = staticmethod(register_all_web_providers)
 
     @pytest.fixture(autouse=True)
@@ -281,13 +435,17 @@ class TestDDGSSearchOnlyErrors:
         from agent.web_search_registry import _reset_for_tests
         _reset_for_tests()
 
-    def test_web_extract_returns_search_only_error(self, monkeypatch):
+    def test_web_extract_dispatches_to_ddgs_and_returns_content(self, monkeypatch):
         import asyncio
         from tools import web_tools
+
+        _install_fake_ddgs(monkeypatch, extract_result={"url": "https://example.com", "content": "# Hi"})
+        monkeypatch.delitem(sys.modules, "plugins.web.ddgs.provider", raising=False)
 
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "ddgs"})
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+
         async def _allow_ssrf(_url: str) -> bool:
             return True
 
@@ -298,6 +456,5 @@ class TestDDGSSearchOnlyErrors:
             web_tools.web_extract_tool(["https://example.com"])
         )
         result = json.loads(result_str)
-        assert result["success"] is False
-        assert "search-only" in result["error"].lower()
-        assert "duckduckgo" in result["error"].lower() or "ddgs" in result["error"].lower()
+        assert "results" in result
+        assert result["results"][0]["content"] == "# Hi"


### PR DESCRIPTION
## Problem

The `ddgs` web backend is registered as search-only (`supports_extract() -> False`), so `web_extract` always fails with:

> DuckDuckGo (ddgs) is a search-only backend and cannot extract URL content. Set web.extract_backend to firecrawl, tavily, exa, or parallel.

But the `ddgs` package itself ships a working `extract()` (also exposed as `ddgs extract` on the CLI) that fetches a URL and returns clean markdown/text via readability parsing — confirmed manually:

```
$ ddgs extract -u "https://example.com/some-post" -f text_markdown
# ... clean markdown output ...
```

So the plugin was leaving a real, no-API-key capability on the table and forcing users who prefer ddgs (no key, no vendor lock-in) into paid extract backends or full browser automation for pages that a plain HTTP fetch would have handled fine.

## Fix

- `DDGSWebSearchProvider.supports_extract()` -> `True`
- Added `DDGSWebSearchProvider.extract(urls, **kwargs)` backed by `DDGS().extract(url, fmt=...)`
  - Per-URL fetch in its own worker thread with a hard wall-clock cap (`_EXTRACT_TIMEOUT_SECS`), mirroring the existing `search()` timeout guard from #36776 — a hung fetch must not block the shared agent loop.
  - Per-URL failures (missing package, timeout, ddgs exceptions) become result entries with an `error` field instead of aborting the whole batch, matching the tavily/exa provider contract.
  - `format="markdown"/"html"/"text"` maps to ddgs's `fmt="text_markdown"/"text"/"text_plain"`.
- Updated `get_setup_schema()` copy to reflect the new capability and document the known limitation below.

## Known limitation

`ddgs` does a plain HTTP GET + HTML parse — no JS rendering. Client-rendered SPAs will only yield page-shell content (nav/loading skeleton). That's inherent to the approach, not a regression; users who need JS rendering should still reach for a browser-based extraction path or a rendering-capable backend (firecrawl/parallel/etc). Documented in the provider's `get_setup_schema()` tag.

## Testing

Extended `tests/tools/test_web_providers_ddgs.py`:
- `supports_extract()` now True
- happy path, multi-URL batch, format→fmt mapping
- missing package / runtime error / timeout -> per-URL error entries (batch doesn't abort on one bad URL)
- replaced the now-stale "search-only error" dispatch test with one asserting `web_extract_tool` successfully dispatches to and returns content from ddgs

```
$ pytest tests/tools/test_web_providers_ddgs.py tests/integration/test_web_tools.py -q
27 passed in 0.92s
```

Also manually verified against the real `ddgs` package (not just the test stub) via `ddgs extract -u <url> -f text_markdown` against both a static/server-rendered page (clean full extraction) and a client-rendered SPA (confirmed page-shell-only, as expected/documented).