### PR TITLE
fix(security): detect env dumps behind sudo / a full path so their opaque secrets are masked

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -691,19 +691,34 @@ def redact_sensitive_text(
 # fixtures, ``postgresql://{user}`` f-string templates). See issue #43025.
 _ENV_DUMP_COMMANDS = frozenset({"env", "printenv", "set", "export", "declare"})
 
+# Wrapper commands that commonly precede a real command without changing what
+# it prints. ``sudo env`` / ``command env`` / ``/usr/bin/env`` still dump the
+# environment, so the env-dump classification must see through them — otherwise
+# the ENV-assignment redaction pass is skipped and an opaque-named secret
+# (a VAR whose name isn't a known-secret word and whose value has no vendor
+# prefix) leaks verbatim from the dump.
+_ENV_DUMP_WRAPPERS = frozenset(
+    {"sudo", "command", "nice", "nohup", "stdbuf", "time", "doas", "setsid"}
+)
+
 
 def is_env_dump_command(command: str | None) -> bool:
     """Return True if ``command`` dumps environment variables to stdout.
 
     Detects ``env`` / ``printenv`` / ``set`` / ``export`` / ``declare`` as the
-    first token of any segment in a pipeline or sequence (``;`` / ``&&`` /
-    ``||`` / ``|``). Conservative: a parse failure or anything unrecognized
-    returns False (callers then fall back to the safer code_file=True path,
-    which still masks prefix-shaped keys).
+    effective command of any segment in a pipeline or sequence (``;`` / ``&&``
+    / ``||`` / ``|``). The command is matched by its basename so a full path
+    (``/usr/bin/env``) counts, and a leading wrapper such as ``sudo`` /
+    ``command`` (with its own ``-flags`` and ``VAR=val`` assignments) is
+    skipped so ``sudo env`` / ``sudo -E printenv`` are recognised. Conservative:
+    a parse failure or anything unrecognized returns False (callers then fall
+    back to the safer code_file=True path, which still masks prefix-shaped
+    keys).
     """
     if not command or not isinstance(command, str):
         return False
-    # Split on shell separators, then inspect the first token of each segment.
+    # Split on shell separators, then inspect the effective command of each
+    # segment.
     segments = re.split(r"[|;&]+", command)
     for seg in segments:
         seg = seg.strip()
@@ -713,7 +728,19 @@ def is_env_dump_command(command: str | None) -> bool:
             tokens = shlex.split(seg)
         except ValueError:
             tokens = seg.split()
-        if tokens and tokens[0] in _ENV_DUMP_COMMANDS:
+        # Skip leading wrapper commands plus the flags / assignments that
+        # belong to them, then match the real command's basename.
+        idx = 0
+        while idx < len(tokens):
+            if os.path.basename(tokens[idx]) in _ENV_DUMP_WRAPPERS:
+                idx += 1
+                while idx < len(tokens) and (
+                    tokens[idx].startswith("-") or "=" in tokens[idx]
+                ):
+                    idx += 1
+                continue
+            break
+        if idx < len(tokens) and os.path.basename(tokens[idx]) in _ENV_DUMP_COMMANDS:
             return True
     return False
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -893,6 +893,34 @@ class TestTerminalOutputRedaction:
         assert not is_env_dump_command("")
         assert not is_env_dump_command(None)
 
+    def test_is_env_dump_command_sees_through_sudo_and_full_paths(self):
+        """`sudo env` / `/usr/bin/env` / `command env` still dump the whole
+        environment, so they must be classified as env dumps — otherwise the
+        ENV pass is skipped and an opaque-named secret leaks from the dump."""
+        from agent.redact import is_env_dump_command
+        assert is_env_dump_command("sudo env")
+        assert is_env_dump_command("sudo printenv")
+        assert is_env_dump_command("sudo -E env")
+        assert is_env_dump_command("sudo -EH printenv")
+        assert is_env_dump_command("/usr/bin/env")
+        assert is_env_dump_command("/usr/bin/printenv")
+        assert is_env_dump_command("command env")
+        assert is_env_dump_command("cat /tmp/x && sudo env")
+        assert is_env_dump_command("sudo /usr/bin/env | grep API")
+        # A real program that merely lives at a path ending in a different
+        # basename is NOT an env dump.
+        assert not is_env_dump_command("sudo python app.py")
+        assert not is_env_dump_command("/usr/local/bin/myenvtool")
+
+    def test_sudo_env_masks_opaque_token(self):
+        """End-to-end: the opaque-named secret in a `sudo env` dump is masked,
+        matching bare `env` — the leak this fix closes."""
+        from agent.redact import redact_terminal_output
+        out = "DEPLOY_SESSION_SECRET=a9Xk2Lp7Qz4Rt8Vw1Nb6Mc3\nPATH=/usr/bin"
+        red = redact_terminal_output(out, "sudo env", force=True)
+        assert "a9Xk2Lp7Qz4Rt8Vw1Nb6Mc3" not in red
+        assert "PATH=/usr/bin" in red
+
     def test_env_dump_masks_opaque_token(self):
         from agent.redact import redact_terminal_output
         out = "MY_SERVICE_TOKEN=abc123randomopaquetokenvalue999\nHOME=/home/u"


### PR DESCRIPTION
## What does this PR do?

`redact_terminal_output` picks its redaction mode from `is_env_dump_command`: an environment dump (`env` / `printenv` / `set` / `export` / `declare`) uses `code_file=False` so the ENV-assignment pass masks **opaque tokens** — env vars whose name is not a known-secret word and whose value carries no vendor prefix, which nothing else catches. Any other command uses `code_file=True` and skips that pass.

`is_env_dump_command` only matched the **bare first token**, so common ways to run the very same dump were classified as "not a dump" and took the `code_file=True` path, leaking their opaque-named secrets verbatim into terminal output the model reads (and into the session DB, gateway delivery, and logs):

- `sudo env` / `sudo -E printenv` — first token is `sudo`
- `/usr/bin/env` / `/usr/bin/printenv` — first token is a full path
- `command env` — the `command` builtin

`sudo` in particular is routine for an agent inspecting a privileged environment, so a custom secret such as `DEPLOY_SESSION_SECRET=…` in `sudo env` output reached the model unmasked, while bare `env` masked it.

## Root cause

```python
if tokens and tokens[0] in _ENV_DUMP_COMMANDS:
    return True
```

Exact match on `tokens[0]` misses a full-path invocation and any wrapper (`sudo`, `command`, …) in front of the dump command.

## Fix

Match the command by **basename** (so a full path counts) and **skip a leading wrapper** (`sudo` / `command` / `nice` / `nohup` / `stdbuf` / `time` / `doas` / `setsid`) plus its own `-flags` and `VAR=val` assignments before matching. A wrapped command that resolves to something else is still not a dump, so the safe `code_file=True` default is unchanged for non-dumps (no new false positives on legitimate source/config output).

This extends the env-dump redaction added in #43025 / #54149. It is complementary to the open #61352 (which masks *known* Hermes secret var *names* regardless of mode): this PR fixes the env-dump *detection* so **any** opaque-named var in a wrapped dump is masked, including secrets whose names aren't in any known set.

## Related Issue

Fixes # — extends #43025 (`Security: redact_secrets config not preventing API key exposure in terminal`) and its fix #54149.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `agent/redact.py` — `is_env_dump_command` now basename-matches the effective command and skips leading wrapper commands (new `_ENV_DUMP_WRAPPERS` set) together with their flags/assignments.
- `tests/agent/test_redact.py` — two regression tests added to `TestTerminalOutputRedaction`.

## How to Test

1. `pytest tests/agent/test_redact.py -q` → 151 passed (149 pre-existing + 2 new). Existing env-dump / code-file / passthrough tests are unchanged.
2. New coverage:
   - `test_is_env_dump_command_sees_through_sudo_and_full_paths`: `sudo env`, `sudo -E env`, `sudo -EH printenv`, `/usr/bin/env`, `/usr/bin/printenv`, `command env`, and pipeline/sequence forms (`cat /tmp/x && sudo env`, `sudo /usr/bin/env | grep API`) are detected; a wrapped non-dump (`sudo python app.py`, `/usr/local/bin/myenvtool`) is not.
   - `test_sudo_env_masks_opaque_token`: end-to-end, an opaque-named secret (`DEPLOY_SESSION_SECRET=…`) in a `sudo env` dump is masked, while a benign `PATH=/usr/bin` line survives.
3. Confirmed both new tests fail on the pre-fix source (the wrapped/full-path forms are undetected and the secret leaks) and pass with the fix.
4. `pytest tests/tools/test_kanban_redaction.py tests/gateway/test_pii_redaction.py tests/hermes_cli/test_redact_config_bridge.py -q` → 28 passed (no regression in the wider redaction surfaces).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring on `is_env_dump_command`) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `os.path.basename` + shlex; no OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

### Security

This closes a credential-leak gap in terminal-output redaction: environment dumps run behind `sudo` or a full path were not classified as dumps, so opaque-named secrets in their output were not masked. The fix reuses the existing ENV-assignment redaction pass; it only widens detection and never weakens it (unknown/non-dump commands keep the safe `code_file=True` default).

## Screenshots / Logs

Before (current `main`):

```
cmd='env'          env_dump_detected=True   secret_leaked=False
cmd='sudo env'     env_dump_detected=False  secret_leaked=True
cmd='/usr/bin/env' env_dump_detected=False  secret_leaked=True
cmd='command env'  env_dump_detected=False  secret_leaked=True
```

After (this branch): all of the above report `env_dump_detected=True` and `secret_leaked=False`.