### PR TITLE
feat(tui): add dormant Kanban activity spine

### DIFF
--- a/docs/plans/2026-07-14-kanban-tui-execution-spine.md
+++ b/docs/plans/2026-07-14-kanban-tui-execution-spine.md
@@ -1,0 +1,904 @@
+# Kanban TUI Execution Spine Implementation Plan
+
+> **For Hermes:** Use `subagent-driven-development` to implement this plan task-by-task, with an independent reviewer after the implementation pass.
+
+**Goal:** Add a native, visually restrained Kanban activity surface to the Hermes TUI that shows durable worker/task progress as a vertical execution spine without injecting status messages into the conversation transcript.
+
+**Architecture:** Extract a shared, read-only Kanban activity projection from the existing database layer, expose it through a TUI JSON-RPC method, and render it in a composer-adjacent Ink component. The resting surface is one compact summary line; focusing it reveals a vertical task/dependency spine. Reuse existing TUI tree, timing, theme, focus, and polling patterns rather than building a second rendering system.
+
+**Tech Stack:** Python, SQLite, Hermes JSON-RPC gateway, TypeScript, React 19, Ink 6, Nanostores, Vitest, Pytest.
+
+### 2026-07-14 execution hold and official-doc alignment
+
+The first implementation pass intentionally stops short of mounting or polling this surface in live TUI sessions. Backend projection/RPC behavior and dormant, fixture-driven Ink components may be built and tested, but `appLayout.tsx`, live session hooks, keyboard routing, transcript state, and notification/subscription behavior remain unchanged until a separate visual approval pass.
+
+This matches the current Nous documentation and product boundaries:
+
+- The TUI is chrome around the same Python runtime and uses its local `tui_gateway`; it should not call the dashboard HTTP API or create a second chat surface.
+- Ambient TUI activity is hidden by default, so a future Kanban dock should be explicitly scoped and visually calm rather than reviving a noisy generic activity feed.
+- `/agents` is a current-session `delegate_task` audit/control surface. Kanban is a durable, multi-profile, multi-board work queue, so its visualization should remain distinct and read-only.
+- Boards are hard isolation boundaries backed by separate databases. The projection must resolve and group boards explicitly, while the resting line may omit board chrome for the common single-board case.
+- Kanban workers use `kanban_*` tools and the shared `kanban_db` layer; the TUI is a human observability consumer, not a worker-control or message-delivery path.
+
+The activation work in Tasks 8–9 is therefore deferred, not silently completed. The dormant slice must prove truthfulness, bounded data, deterministic topology, narrow-terminal rendering, and zero transcript/session mutation before live wiring is reconsidered.
+
+---
+
+## Copy/paste kickoff prompt
+
+```text
+Implement the native Hermes Kanban TUI Execution Spine described in:
+
+/Users/henrymiell/.hermes/hermes-agent/docs/plans/2026-07-14-kanban-tui-execution-spine.md
+
+Repository:
+/Users/henrymiell/.hermes/hermes-agent
+
+Verified planning baseline:
+- base branch: main
+- baseline commit at planning time: df5700ebe317ff9f2d9ea4677513e012eb68b6f4
+- main checkout currently contains unrelated dirty Supermemory edits:
+  - plugins/memory/supermemory/__init__.py
+  - tests/plugins/memory/test_supermemory_provider.py
+
+Do not edit, stash, reset, restore, commit, or otherwise disturb the dirty main checkout. Create a clean worktree from current origin/main, for example:
+
+/Users/henrymiell/.hermes/worktrees/kanban-tui-execution-spine
+branch: feat/kanban-tui-execution-spine
+
+First verify the plan against current source because line numbers and APIs may have moved. Then implement the plan with TDD and small local commits.
+
+Product requirement:
+Create a native TUI activity dock that remains outside transcript/message history. In its resting state it occupies one calm line near the composer. When focused, it expands into a vertical execution spine using actual Kanban tasks, dependencies, worker state, heartbeat freshness, blockers, and completion state. It must never fabricate percentage completion or workflow phases.
+
+Visual direction:
+- distinctive Hermes execution spine, not a Claude Agent View clone
+- vertical filled/unfilled rail: ● completed, ◉ active, ○ upcoming, ! blocked/needs input, × failed
+- branch child tasks sideways using restrained box-drawing characters
+- no card wall, giant rounded container, status-pill soup, rainbow colors, or permanent shortcut footer
+- no continuous distracting animation; a subtle active-node pulse is acceptable and must respect static/reduced-motion behavior
+- one accent color; amber only for attention; red only for actual failure
+- hide the dock when there is no relevant activity
+- narrow-terminal behavior must remain useful and must not crush the composer
+
+Critical constraints:
+1. This is a display-only observability surface. Do not synthesize MessageEvent objects, call adapter.handle_message(), append Msg rows, wake an agent, resume a session, or inject completion content into a transcript.
+2. Do not enable Kanban auto-subscription or change notification routing.
+3. Do not call the dashboard HTTP API from the TUI and do not duplicate its SQL. Put shared read-only activity projection logic in hermes_cli/kanban_db.py and use it from both consumers where appropriate.
+4. Do not add termination, mutation, approval, push, merge, or deployment controls.
+5. Do not show raw prompts, environment variables, command lines, secrets, full logs, or private worker context.
+6. Do not create a general TUI plugin framework. Kanban is bundled; implement the native surface first and generalize only if a second real activity provider exists.
+7. Do not add a new database or broad schema migration unless direct inspection proves existing task/task_run/task_event/task_link data cannot satisfy the accepted V1.
+8. No push, PR, merge, deployment, branch deletion, or modification of the dirty main checkout.
+
+Required implementation sequence:
+1. Establish clean worktree and baseline tests.
+2. Build pure activity model and deterministic vertical-rail fixtures/tests.
+3. Build the static Ink dock and visually verify wide/narrow states before backend wiring.
+4. Extract a shared read-only Kanban activity projection.
+5. Add a TUI `kanban.activity` JSON-RPC method.
+6. Add adaptive polling/store logic with cleanup and no idle flicker.
+7. Integrate the resting dock and focused execution spine near the composer.
+8. Add keyboard/focus behavior without stealing normal text navigation.
+9. Verify multi-board, branching, stale, blocked, failed, completed, empty, and narrow-terminal states.
+10. Run targeted Python and full TUI checks, then perform an independent review.
+
+Definition of done:
+- the dock reflects real Kanban state while work progresses
+- the vertical rail is visually stable and truthful
+- existing subagent/todo/status UI continues to work
+- no activity update enters transcript history
+- polling is bounded and cleaned up
+- all required tests pass
+- wide and narrow Ghostty screenshots are supplied for visual review
+
+Final handoff must include:
+- absolute worktree path
+- branch and base commit
+- exact changed files
+- git status
+- test commands and real outputs
+- screenshots for wide, narrow, blocked, and branching states
+- unresolved risks or design compromises
+- confirmation that no push/merge/deploy occurred
+```
+
+---
+
+## 1. Verified current state
+
+### Existing infrastructure to reuse
+
+- `plugins/kanban/dashboard/plugin_api.py`
+  - `GET /workers/active`
+  - `GET /runs/{run_id}`
+  - `GET /runs/{run_id}/inspect`
+  - bounded task log and diagnostics endpoints elsewhere in the same module
+- `hermes_cli/kanban_db.py`
+  - board enumeration
+  - tasks, runs, events, links, heartbeat, and diagnostics persistence
+- `tui_gateway/server.py`
+  - typed JSON-RPC method registry
+  - existing `delegation.status` read-only status method
+- `ui-tui/src/components/thinking.tsx`
+  - `SubagentAccordion`
+  - tree stems, expandable sections, elapsed-time treatment, restrained status tones
+- `ui-tui/src/lib/subagentTree.ts`
+  - tree construction and duration formatting utilities
+- `ui-tui/src/components/agentsOverlay.tsx`
+  - focus, cursor, expansion, scrolling, and periodic live refresh patterns
+- `ui-tui/src/components/appLayout.tsx`
+  - composer-adjacent rendering location
+  - current coarse `N background tasks running` line at lines approximately 337–341
+- `ui-tui/src/app/useMainApp.ts`
+  - existing local JSON-RPC polling pattern with change-aware store updates
+
+### What does not exist
+
+There is no current `KanbanActivity`, `kanban.activity`, Kanban execution rail, TUI worker dock, or Kanban-to-TUI activity store.
+
+A closed upstream issue, `NousResearch/hermes-agent#37109`, proposed an active-worker panel for the **web dashboard**, not the TUI. It was closed without an implementation branch or PR. `origin/bb/desktop-kanban` concerns the desktop contribution shell, not this feature.
+
+### Dirty-checkout warning
+
+The planning checkout is `main` and currently has unrelated modifications:
+
+```text
+M plugins/memory/supermemory/__init__.py
+M tests/plugins/memory/test_supermemory_provider.py
+```
+
+Implementation must happen in a clean worktree. The plan file itself will initially be untracked in the main checkout, so the implementer should read it from this absolute path or copy it into the clean worktree before beginning.
+
+---
+
+## 2. Product contract
+
+### Resting state
+
+The persistent surface must use at most one line when unfocused:
+
+```text
+KANBAN  3 active   ●━●━◉─○   adaptive cycle · verifying
+```
+
+If width is constrained, progressively collapse detail:
+
+```text
+KANBAN  3 active   ◉ verifying
+```
+
+Then:
+
+```text
+KANBAN  3 active
+```
+
+Never wrap the composer because of this dock.
+
+### Focused state
+
+```text
+KANBAN / adaptive-cycle-core                         08:14
+
+●  architecture audit                               done
+┃
+◉  implementation                                   running
+├── ● models                                        done
+├── ◉ persistence                                   running
+└── ○ independent review                            waiting
+│
+○  completion
+```
+
+This is illustrative; labels must come from real task titles/status, not a fabricated universal phase taxonomy.
+
+### Visual grammar
+
+| Glyph | Meaning |
+|---|---|
+| `●` | Completed task/node |
+| `◉` | Running/current task/node |
+| `○` | Queued, ready, scheduled, or dependency-gated future node |
+| `!` | Blocked or requires human input |
+| `×` | Failed run |
+| `┃` | Completed connection |
+| `│` | Pending/current connection |
+| `├──` / `└──` | Parallel/dependent child task |
+
+Task position communicates workflow progress. Color/animation communicates health. Do not overload one signal with both meanings.
+
+### Truthfulness rules
+
+- Never show a percentage unless backed by a real `current/total` value.
+- Prefer actual task links and statuses over inferred stages.
+- For a root task without children, show its lifecycle and worker health without inventing missing phases.
+- Use `block_reason` verbatim only after safe truncation/redaction; do not expose worker context.
+- Use run summary only after completion.
+- If no meaningful headline exists, show `Working`, not a guessed activity.
+- Stale heartbeat is health information, not proof that the task failed.
+
+### Visibility rules
+
+- Hidden when there is no active, blocked-attention, or recently completed work.
+- Resting mode shows the highest-attention root task plus aggregate counts.
+- Focused mode may show multiple boards, grouped by board.
+- Completed tasks may linger briefly in local UI state, then disappear; do not persist presentation-only linger state to Kanban.
+- The panel must not steal focus when a task changes state.
+
+---
+
+## 3. Non-goals
+
+- Replacing the web Kanban dashboard
+- Building a generic dashboard/plugin framework for TUI components
+- Attaching the user to a worker conversation
+- Sending messages to workers from this panel
+- Mutating task status
+- Terminating or reclaiming workers
+- Showing full worker logs in the resting/focused dock
+- Model-generated progress summaries in V1
+- Continuous tool-call streaming from every Kanban worker in V1
+- Cross-session completion delivery
+- Enabling Kanban notification subscriptions
+- Redesigning `delegate_task` subagent UI
+- Adding fake `review` or other statuses not present in the actual board schema
+
+---
+
+## 4. Implementation plan
+
+### Task 1: Establish isolated workspace and baseline
+
+**Objective:** Prove the feature starts from a clean, reproducible checkout and existing tests pass.
+
+**Files:** None.
+
+**Steps:**
+
+1. From the main repository, create a clean worktree from current `origin/main`:
+
+   ```bash
+   git worktree add -b feat/kanban-tui-execution-spine \
+     /Users/henrymiell/.hermes/worktrees/kanban-tui-execution-spine \
+     origin/main
+   ```
+
+2. Copy this plan into the worktree without modifying the dirty main checkout:
+
+   ```bash
+   mkdir -p /Users/henrymiell/.hermes/worktrees/kanban-tui-execution-spine/docs/plans
+   cp /Users/henrymiell/.hermes/hermes-agent/docs/plans/2026-07-14-kanban-tui-execution-spine.md \
+      /Users/henrymiell/.hermes/worktrees/kanban-tui-execution-spine/docs/plans/
+   ```
+
+3. Record:
+
+   ```bash
+   git status --short --branch
+   git rev-parse HEAD
+   ```
+
+4. Run baseline TUI checks:
+
+   ```bash
+   npm --prefix ui-tui run check
+   ```
+
+5. Run baseline Kanban dashboard tests:
+
+   ```bash
+   python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q
+   ```
+
+6. If baseline failures exist, record them before changing code. Do not silently repair unrelated failures.
+
+**Done when:** Clean branch/worktree exists and baseline results are recorded.
+
+---
+
+### Task 2: Define the pure activity projection contract
+
+**Objective:** Create a serializable, read-only activity model that both gateway and TUI can reason about deterministically.
+
+**Files:**
+
+- Modify: `hermes_cli/kanban_db.py`
+- Create: `tests/hermes_cli/test_kanban_activity_projection.py`
+
+**Design:**
+
+Add a focused helper, name subject to current conventions, equivalent to:
+
+```python
+def get_activity_snapshot(*, board: str) -> dict:
+    """Return a bounded, read-only activity projection for one Kanban board."""
+```
+
+The snapshot should include only bounded presentation-safe fields:
+
+```python
+{
+    "board": "default",
+    "checked_at": 1721000000,
+    "roots": [
+        {
+            "task_id": "t_...",
+            "title": "...",
+            "status": "running",
+            "assignee": "localimplementer",
+            "block_reason": None,
+            "parents": [],
+            "children": [...],
+            "run": {
+                "run_id": 12,
+                "profile": "localimplementer",
+                "started_at": 1720999000,
+                "ended_at": None,
+                "outcome": None,
+                "last_heartbeat_at": 1720999990,
+                "max_runtime_seconds": 7200,
+            },
+        }
+    ],
+}
+```
+
+Do not include:
+
+- prompt/body text
+- comments
+- environment variables
+- raw command line
+- full logs
+- credentials or configuration
+
+**Required tests:**
+
+1. Empty board returns a stable empty snapshot.
+2. Active run appears with task/profile/timing data.
+3. Root/child dependencies are nested deterministically.
+4. Multiple roots preserve deterministic ordering.
+5. Blocked task includes bounded reason and no private body.
+6. Completed/failed outcomes serialize correctly.
+7. Cycles or malformed links fail safely without recursive explosion.
+8. Snapshot query does not mutate board/task/run state.
+
+**Verification:**
+
+```bash
+python -m pytest tests/hermes_cli/test_kanban_activity_projection.py -q
+```
+
+**Done when:** The pure snapshot contract passes without dashboard or TUI dependencies.
+
+---
+
+### Task 3: Reuse the shared projection in the dashboard backend
+
+**Objective:** Remove worker-list SQL duplication and preserve the existing API contract.
+
+**Files:**
+
+- Modify: `plugins/kanban/dashboard/plugin_api.py`
+- Modify: `tests/plugins/test_kanban_dashboard_plugin.py`
+
+**Steps:**
+
+1. Add a failing regression test for `GET /workers/active` using an active `task_runs` fixture.
+2. Refactor the endpoint to consume the shared `kanban_db` helper or a narrower shared worker helper extracted alongside it.
+3. Preserve current response fields and ordering exactly unless a breaking change is explicitly justified.
+4. Do not add dashboard UI work in this task.
+
+**Verification:**
+
+```bash
+python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q
+```
+
+**Done when:** Existing API behavior is preserved and active-worker SQL has one source of truth.
+
+---
+
+### Task 4: Add the TUI gateway activity method
+
+**Objective:** Expose Kanban activity through the existing local JSON-RPC transport without HTTP or chat-message delivery.
+
+**Files:**
+
+- Modify: `tui_gateway/server.py`
+- Create or modify the focused TUI-gateway test file matching current test organization
+
+**Method:**
+
+```text
+kanban.activity
+```
+
+**Request:**
+
+```json
+{
+  "boards": ["default", "formly"]
+}
+```
+
+If `boards` is omitted, return activity for all non-archived boards that currently contain relevant tasks. Board ordering must be deterministic.
+
+**Response:**
+
+```json
+{
+  "boards": [...],
+  "active_count": 3,
+  "attention_count": 1,
+  "checked_at": 1721000000
+}
+```
+
+**Requirements:**
+
+- Read-only.
+- No session lookup required.
+- No `MessageEvent` creation.
+- No notification queue interaction.
+- No `adapter.handle_message()`.
+- No auto-subscription.
+- A broken/missing board should not crash the TUI; return a bounded per-board error or skip with diagnostics.
+- Do not inspect every PID or load logs on each poll.
+
+**Required tests:**
+
+1. Empty response.
+2. Multi-board aggregation.
+3. Active and blocked counts.
+4. Malformed board fails safely.
+5. Method does not alter session history or notification queues.
+
+**Verification:**
+
+```bash
+python -m pytest <focused-tui-gateway-test-file> -q
+```
+
+**Done when:** The method returns deterministic snapshots with no delivery side effects.
+
+---
+
+### Task 5: Build pure TUI rail-model helpers
+
+**Objective:** Convert gateway snapshots into stable, truthful execution-spine rows independently of React rendering.
+
+**Files:**
+
+- Create: `ui-tui/src/lib/kanbanActivity.ts`
+- Create: `ui-tui/src/__tests__/kanbanActivity.test.ts`
+- Modify: `ui-tui/src/gatewayTypes.ts`
+
+**Pure helpers should cover:**
+
+- normalization from snake_case gateway payloads
+- deterministic root/task ordering
+- glyph choice
+- tone choice
+- heartbeat freshness classification
+- focused/collapsed labels
+- width-based truncation
+- branch compression
+- aggregate counts
+
+**Required states:**
+
+- queued/ready/scheduled
+- running
+- blocked/needs attention
+- completed
+- failed/stopped outcome
+- stale heartbeat
+- missing worker/run metadata
+- malformed/cyclic child data
+
+**Tests:**
+
+- glyph and tone are deterministic
+- completed path uses `┃`; upcoming/current path uses `│`
+- no fake percentage appears
+- branch compression engages beyond the visible limit
+- narrow labels do not wrap
+- attention takes precedence over ordinary active work
+- task order does not jump when only heartbeat timestamps change
+
+**Verification:**
+
+```bash
+npm --prefix ui-tui test -- --run src/__tests__/kanbanActivity.test.ts
+```
+
+**Done when:** Fixtures generate stable rail rows without rendering or network code.
+
+---
+
+### Task 6: Build and visually approve a static Ink execution spine
+
+**Objective:** Lock the visual treatment before connecting live polling.
+
+**Files:**
+
+- Create: `ui-tui/src/components/kanbanActivity.tsx`
+- Create: `ui-tui/src/__tests__/kanbanActivityRender.test.tsx`
+- Reuse: `ui-tui/src/theme.ts`
+- Reuse carefully: `ui-tui/src/lib/subagentTree.ts`, `ui-tui/src/components/thinking.tsx`
+
+**Components:**
+
+```tsx
+<KanbanActivityDock />
+<KanbanExecutionSpine />
+<KanbanActivityRow />
+```
+
+Avoid duplicating large portions of `SubagentAccordion`. Extract a small shared primitive only when it genuinely serves both components.
+
+**Fixture states to render:**
+
+1. One active task, no children.
+2. Parent with three parallel children.
+3. Dependency pipeline with completed/current/upcoming nodes.
+4. Blocked task requiring attention.
+5. Stale worker.
+6. Failed run.
+7. Multiple boards.
+8. Empty state.
+9. Narrow terminal.
+10. Many children compressed into a summary.
+
+**Visual acceptance:**
+
+- Resting dock uses one line.
+- Focused spine has no mandatory surrounding box.
+- One accent color dominates.
+- Amber/red are semantic only.
+- Labels align without turning into columns of metadata.
+- Branches remain legible.
+- No raw IDs in resting mode.
+- No permanent shortcut footer.
+- Narrow terminal retains task count/state and does not wrap composer content.
+- Static mode is fully understandable without animation.
+
+**Verification:**
+
+```bash
+npm --prefix ui-tui test -- --run src/__tests__/kanbanActivityRender.test.tsx
+npm --prefix ui-tui run typecheck
+```
+
+Also run the deterministic fixture in Ghostty and capture wide/narrow screenshots before proceeding.
+
+**Stop condition:** If the rail looks like a dense log, card stack, or arbitrary tree dump, revise the visual model before backend integration.
+
+---
+
+### Task 7: Add activity store and adaptive polling
+
+**Objective:** Keep the dock current without expensive work, idle flicker, or transcript updates.
+
+**Files:**
+
+- Create: `ui-tui/src/app/kanbanActivityStore.ts`
+- Create: `ui-tui/src/app/useKanbanActivity.ts`
+- Create: `ui-tui/src/__tests__/kanbanActivityStore.test.ts`
+- Modify: `ui-tui/src/app/useMainApp.ts` or the narrowest appropriate app composition hook
+
+**Requirements:**
+
+- Fetch `kanban.activity` immediately on mount.
+- Poll more frequently only while active/attention work exists.
+- Back off while idle.
+- Stop timers on unmount/session teardown.
+- Do not patch global state when the semantic snapshot has not changed.
+- Keep presentation-only completion linger local to the store.
+- Network/gateway errors should degrade to last-known state plus a quiet stale indicator, not crash the TUI.
+- Polling is local RPC and must not trigger model calls.
+
+**Tests:**
+
+- initial fetch
+- active and idle cadence selection
+- timer cleanup
+- unchanged snapshot does not notify subscribers
+- completion linger expires locally
+- RPC failure preserves last-known state
+- no transcript store access/import
+
+**Verification:**
+
+```bash
+npm --prefix ui-tui test -- --run src/__tests__/kanbanActivityStore.test.ts
+```
+
+**Done when:** Live data updates without unnecessary whole-TUI rerenders.
+
+---
+
+### Task 8: Integrate dock and keyboard focus near the composer
+
+**Objective:** Place the activity surface inside the TUI chat chrome without placing it in transcript history.
+
+**Files:**
+
+- Modify: `ui-tui/src/components/appLayout.tsx`
+- Modify: `ui-tui/src/app/interfaces.ts`
+- Modify: `ui-tui/src/app/uiStore.ts` or add a dedicated activity-focus store
+- Modify the existing keyboard-routing module selected after inspection
+- Add focused integration tests under `ui-tui/src/__tests__/`
+
+**Placement:**
+
+Render the dock in `ComposerPane`, near the existing background-task indicator and queued-message area, before the input itself. It must remain outside `historyItems`, `Msg`, `appendMessage`, and transcript virtualization.
+
+Replace or subsume the coarse:
+
+```text
+N background tasks running
+```
+
+only if doing so does not remove useful non-Kanban background-process visibility. Kanban and terminal background processes are different domains; do not mislabel one as the other.
+
+**Focus behavior:**
+
+- The resting dock must not intercept typing.
+- When input is empty and the cursor is in its neutral position, a non-conflicting action may focus the dock.
+- Inspect existing arrow-key and overlay bindings before selecting the final shortcut.
+- Focused mode supports task selection and expansion.
+- `Esc` always returns cleanly to the composer.
+- State changes never steal focus.
+- Do not append shortcut hints to transcript or permanent chrome.
+
+**Integration tests:**
+
+1. Empty activity renders nothing.
+2. Active activity renders above composer.
+3. Rendering does not add a `Msg` or history item.
+4. Updating activity does not change transcript length.
+5. Focus/escape round trip.
+6. Normal arrow navigation remains intact when dock is not focused.
+7. Narrow composer width remains stable.
+8. Existing queued messages, status rule, overlays, and background-process indicator still render.
+
+**Verification:**
+
+```bash
+npm --prefix ui-tui run check
+```
+
+**Done when:** The dock behaves like TUI chrome, not conversation content.
+
+---
+
+### Task 9: Add restrained activity animation and accessibility fallback
+
+**Objective:** Communicate liveness without visual noise.
+
+**Files:**
+
+- Modify: `ui-tui/src/components/kanbanActivity.tsx`
+- Modify: relevant tests
+
+**Rules:**
+
+- Default understanding must not depend on animation.
+- At most the active node may pulse or alternate subtly.
+- Completed, blocked, failed, and stale nodes remain static.
+- Do not animate every worker.
+- Reuse existing indicator timing primitives where appropriate.
+- If Hermes lacks an explicit reduced-motion setting, provide a static mode tied to the closest existing accessibility/config mechanism or leave animation out of V1 rather than inventing a broad settings system.
+
+**Verification:**
+
+- fake-timer test proves animation timer cleanup
+- static fixture remains legible
+- no idle animation loop when no active node exists
+
+**Done when:** Motion adds liveness without becoming a spinner wall.
+
+---
+
+### Task 10: End-to-end verification with isolated Kanban fixtures
+
+**Objective:** Prove the feature against real local Kanban state, not only mocked React props.
+
+**Files:**
+
+- Add a focused integration fixture/test in the existing TUI-gateway or Kanban test location
+- Do not use the user’s live board database
+
+**Scenarios:**
+
+1. Empty board: dock absent.
+2. One running worker: active node visible.
+3. Parent done, implementer running, reviewer dependency-gated: vertical branch is correct.
+4. Blocked task: amber attention state with bounded reason.
+5. Heartbeat becomes stale: health changes without moving task position.
+6. Run completes: node fills, result lingers locally, then collapses.
+7. Failed run: red failure node.
+8. Multiple boards: deterministic grouping.
+9. Gateway unavailable: last-known state degrades quietly.
+10. No conversation/session history mutation in any scenario.
+
+**Required commands:**
+
+```bash
+python -m pytest tests/hermes_cli/test_kanban_activity_projection.py -q
+python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q
+python -m pytest <focused-tui-gateway-test-file> -q
+npm --prefix ui-tui run check
+```
+
+Run any broader repository tests required by files touched.
+
+**Manual visual verification:**
+
+Capture Ghostty screenshots for:
+
+- wide terminal, branching task
+- narrow terminal
+- blocked/attention state
+- multiple active boards
+
+Check for:
+
+- no flicker while idle
+- no composer rewrap
+- no focus theft
+- no transcript lines produced by updates
+- stable node placement
+- readable hierarchy without a border/card wall
+
+---
+
+### Task 11: Independent review and final handoff
+
+**Objective:** Verify specification compliance, code quality, and contamination safety independently.
+
+**Reviewer checklist:**
+
+- [ ] No existing feature was unnecessarily reimplemented.
+- [ ] Existing subagent/tree/theme/focus primitives are reused appropriately.
+- [ ] Shared Kanban SQL/projection has one source of truth.
+- [ ] TUI does not call dashboard HTTP endpoints.
+- [ ] No synthetic message, agent wake, auto-subscription, or transcript mutation path exists.
+- [ ] No private prompts, body text, raw env, cmdline, or unbounded logs are exposed.
+- [ ] No fake percentage or invented workflow phase appears.
+- [ ] Multi-board and malformed graph handling are bounded.
+- [ ] Polling cleans up and avoids unchanged global-state writes.
+- [ ] Narrow-terminal and empty-state behavior are acceptable.
+- [ ] Visual result is an execution spine, not a Claude Agent View clone.
+- [ ] Tests contain explicit contamination regression coverage.
+- [ ] Dirty main-checkout Supermemory files were untouched.
+
+**Final handoff format:**
+
+```text
+Worktree:
+Branch:
+Base commit:
+Current git status:
+
+Changed files:
+- ...
+
+Behavior delivered:
+- ...
+
+Verification:
+- command: ...
+  result: ...
+
+Visual evidence:
+- wide screenshot: ...
+- narrow screenshot: ...
+- blocked screenshot: ...
+- branching screenshot: ...
+
+Safety confirmation:
+- no transcript injection
+- no notification/subscription changes
+- no push/merge/deploy
+- dirty main checkout untouched
+
+Open risks / follow-up candidates:
+- ...
+```
+
+Do not push, merge, open a PR, deploy, delete the worktree, or modify remote state without fresh explicit approval.
+
+---
+
+## 5. Acceptance criteria
+
+### Functional
+
+- [ ] TUI shows a one-line Kanban summary only when relevant work exists.
+- [ ] Focus reveals a vertical execution spine based on real tasks/links/statuses.
+- [ ] Active, queued, blocked, completed, failed, and stale states are distinct.
+- [ ] Multi-board activity is grouped deterministically.
+- [ ] Branches compress gracefully when numerous.
+- [ ] Polling updates the view as Kanban changes.
+- [ ] Gateway or board failure degrades safely.
+
+### Visual
+
+- [ ] Resting state consumes one line.
+- [ ] No permanent giant box or card wall.
+- [ ] No rainbow status treatment.
+- [ ] Rail remains legible without motion.
+- [ ] Narrow terminal does not break composer geometry.
+- [ ] Focused graph remains spatially stable.
+- [ ] Attention is clear without focus stealing.
+
+### Isolation and safety
+
+- [ ] No activity update enters transcript/history state.
+- [ ] No synthetic user or system message is generated.
+- [ ] No agent is woken or resumed.
+- [ ] No Kanban subscription is created or enabled.
+- [ ] No raw prompt/body/env/cmdline/full log is displayed.
+- [ ] No mutation controls are introduced.
+- [ ] Existing dirty files remain untouched.
+
+### Quality
+
+- [ ] Pure projection/model logic has deterministic tests.
+- [ ] TUI component has wide/narrow/state rendering tests.
+- [ ] Polling cleanup and unchanged-state behavior are tested.
+- [ ] Existing dashboard worker API tests remain green.
+- [ ] Full `ui-tui` check passes.
+- [ ] Independent reviewer approves or records bounded required fixes.
+
+---
+
+## 6. Risks and mitigations
+
+### Risk: The vertical spine implies false sequential progress
+
+**Mitigation:** Render actual dependency/task topology. For single tasks, show lifecycle/health only. Never invent phases or percentages.
+
+### Risk: A global board view recreates cross-session contamination
+
+**Mitigation:** The activity surface is read-only UI chrome. It does not attach results to a session, send messages, or enter context. Group by board and make the global scope explicit.
+
+### Risk: Polling causes flicker or CPU churn
+
+**Mitigation:** Adaptive cadence, change-aware store updates, no PID/log inspection on every poll, timer cleanup tests.
+
+### Risk: Height consumption makes chat worse
+
+**Mitigation:** One-line resting state, focused expansion only, branch compression, narrow-terminal collapse.
+
+### Risk: Raw operational data leaks secrets
+
+**Mitigation:** Projection allowlist. Exclude task bodies, prompts, comments, environment, command lines, and full logs by construction.
+
+### Risk: Over-generalizing into a plugin framework delays value
+
+**Mitigation:** Native bundled Kanban implementation first. Extract a generic activity-source interface only after a second real consumer exists.
+
+### Risk: Existing subagent UI is copied wholesale and becomes a second maintenance burden
+
+**Mitigation:** Reuse small primitives and formatting helpers, but keep Kanban domain modeling separate from delegation-domain modeling.
+
+---
+
+## 7. Future work explicitly deferred
+
+Only consider after V1 is visually approved and stable:
+
+- structured `phase`, `current`, and `total` fields on `kanban_heartbeat`
+- sanitized per-tool activity headlines for Kanban workers
+- optional model-written stale activity summaries
+- full-screen Kanban activity overlay
+- dashboard execution-spine parity
+- generic TUI `activity_source` plugin contract
+- explicit, session-safe worker attachment after routing identity is redesigned
+
+These are not required for the first implementation.

--- a/docs/plans/2026-07-14-kanban-tui-visualization-findings.md
+++ b/docs/plans/2026-07-14-kanban-tui-visualization-findings.md
@@ -69,6 +69,37 @@ Raw IDs, prompts, bodies, comments, commands, environment, full logs, and worker
 - Consider an event/change-sequence transport after bounded polling proves useful. Do not start with cross-process notification subscriptions or transcript delivery.
 - Add a full-screen read-only graph/inspector only if users need more than the composer-adjacent spine; do not turn the resting dock into a tiny dashboard.
 
+## Visual review decisions (2026-07-15, accepted)
+
+The Fable design review was accepted in full. These are now binding visual decisions:
+
+1. **Segmented row paint.** The rail/connector prefix is always muted, the title renders in
+   the default foreground, `— owner` is dim, and only the glyph and the `· state` word carry
+   the lifecycle tone. No row is ever painted edge-to-edge in one color.
+2. **One light rail.** The heavy `┃` rail is retired; topology uses `│` exclusively and never
+   encodes lifecycle. Ancestor continuation segments (`│   ` vs `    `) keep branch lines
+   attached to their parent at depth 2+, and the last visible child keeps `├──` when an
+   omitted-siblings summary row follows.
+3. **State survives truncation.** Labels drop the blocked-reason detail first, then the
+   owner, then title characters; the state word is removed only when fewer than 8 cells
+   remain for the title. `— unassigned` is never rendered.
+4. **Accent means live.** Only fresh-heartbeat running work (and the active dock lamp) uses
+   accent. `ready` / `review queued` are neutral (default foreground); `scheduled`,
+   `triage`, and `archived` stay muted.
+5. **Board headers are identity, not activity.** Bare board name in bold default foreground
+   (no `Kanban ·` repetition); an unavailable board appends `· unavailable` in the warn tone.
+   Name and suffix share one width budget so the row can never wrap, and at widths too
+   narrow for both, the error signal survives and the name is dropped.
+6. **Dock ladder.** Wide: `Kanban · N need attention · N active · <headline> <state>`, with
+   the headline ranked failed > blocked > stale > running > recent-terminal; if fewer than
+   12 cells remain for the headline the dock falls back to counts. Narrow (<28 cols) speaks
+   glyph shorthand with no separate lamp prefix, painted as segments — `K` neutral, `!N`
+   warn, `◉N` accent, `●N` success; tiny (<14 cols) drops the `K`. Zero-count badges are
+   never shown: completed-only recent activity reads `K ●N`, never `◉0`.
+7. **Title identity is inviolable.** Task titles render in the default foreground with no
+   dim and no tint on every row, including muted-tone rows; only the glyph and state word
+   carry lifecycle color.
+
 ## Activation gate
 
 Live mounting should wait until all of these are demonstrated against isolated fixtures:
@@ -113,5 +144,9 @@ Those deferred items are the activation phase, not missing invisible wiring. The
 └── ○ Independent review — implementer · ready
 │ ! Visual approval — implementer · blocked: Needs human visual choice
 
-! K · !1 · A2
+K !1 ◉2
 ```
+
+(Fixture updated 2026-07-15 for the accepted narrow-dock grammar; the spine rows read the
+same in plain text — the accepted changes redistribute color across segments rather than
+changing the row text.)

--- a/docs/plans/2026-07-14-kanban-tui-visualization-findings.md
+++ b/docs/plans/2026-07-14-kanban-tui-visualization-findings.md
@@ -1,0 +1,117 @@
+# Kanban TUI Visualization Findings
+
+Date: 2026-07-14
+
+## Scope decision
+
+This pass builds and verifies the read-only activity projection, local TUI RPC, pure rail model, and fixture-rendered Ink surface. It deliberately does **not** mount the dock, start polling from a live TUI session, change keyboard routing, or write anything into transcript/history state.
+
+## Official Nous documentation consulted
+
+- [Kanban reference](https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban)
+- [Kanban tutorial](https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban-tutorial)
+- [TUI guide](https://hermes-agent.nousresearch.com/docs/user-guide/tui)
+- [Subagent delegation](https://hermes-agent.nousresearch.com/docs/user-guide/features/delegation)
+- [Slash-command reference](https://hermes-agent.nousresearch.com/docs/reference/slash-commands)
+
+## Boundaries confirmed by the docs
+
+1. Kanban is a durable, multi-profile, multi-board queue; `delegate_task` is a current-session fork/join mechanism. The Kanban dock must not be folded into `/agents` or imply that board workers belong to the current transcript.
+2. Human, model-tool, CLI, and dashboard surfaces share the `kanban_db` layer. The TUI should consume a shared read projection through its local JSON-RPC gateway, not call the dashboard HTTP API.
+3. Boards are separate databases and hard isolation boundaries. Multi-board grouping must be explicit and deterministic.
+4. The TUI owns screen chrome while Python owns state and agent/runtime behavior. The activity spine belongs outside message history.
+5. Current TUI ambient activity is hidden by default. A permanently noisy activity wall would fight the product's existing defaults.
+6. Worker visibility endpoints can expose operational details such as PID and log path, but those are unnecessary and too sensitive/noisy for the composer-adjacent dock.
+7. `/kanban` can mutate or inspect the board mid-run, but this V1 dock should remain read-only. Existing slash commands and the dashboard remain the control surfaces.
+
+## Strong visual model
+
+### Resting line: answer one question
+
+> What durable work needs my attention right now?
+
+Use one calm line, hidden when irrelevant. Prioritize blocked/failed/stale work over ordinary running work. Progressively collapse title and rail before allowing wrap.
+
+### Focused spine: separate three signals
+
+- **Topology:** indentation and `├──` / `└──` show dependency structure.
+- **Lifecycle:** `●`, `◉`, `○`, `!`, `×` show task/run state.
+- **Health:** restrained semantic color and a stale label show heartbeat condition.
+
+Keeping these signals separate prevents the rail from pretending that every graph is a linear checklist.
+
+### Information hierarchy
+
+1. attention state and task title
+2. dependency position
+3. assignee/profile
+4. elapsed or heartbeat freshness
+5. board label only when multiple boards are relevant
+
+Raw IDs, prompts, bodies, comments, commands, environment, full logs, and worker context do not belong in this surface.
+
+## Improvements beyond a basic status line
+
+### V1-worthy
+
+- Show why a task is waiting: dependency-gated versus merely ready.
+- Preserve node positions when heartbeat timestamps change; movement should mean topology/status changed.
+- Compress large sibling sets into a truthful `+N more` row rather than a scrolling log.
+- Treat stale heartbeat as degraded health, not failure.
+- Keep blocked reason bounded and presentation-safe.
+- Make single-board mode visually lighter; only group/label boards when there is more than one.
+- Keep all understanding available in static mode; no animation required.
+
+### High-value follow-up after visual approval
+
+- Add a safe `attempt_count` and latest terminal outcome so retries/crash recovery are visible without exposing run logs. Retry history is a first-class Kanban concept in the official tutorial.
+- Add structured heartbeat fields (`phase`, `current`, `total`) only when produced by the worker contract. Never infer percentages from prose.
+- Consider an event/change-sequence transport after bounded polling proves useful. Do not start with cross-process notification subscriptions or transcript delivery.
+- Add a full-screen read-only graph/inspector only if users need more than the composer-adjacent spine; do not turn the resting dock into a tiny dashboard.
+
+## Activation gate
+
+Live mounting should wait until all of these are demonstrated against isolated fixtures:
+
+- backend projection is bounded, deterministic, and read-only
+- malformed links cannot recurse indefinitely
+- multi-board failures degrade per board
+- no session lookup, message event, notification queue, or subscription side effect
+- wide, narrow, blocked, stale, failed, branching, and empty render states are visually approved
+- polling cleanup and unchanged-snapshot behavior are tested
+- integration proves transcript/history length is unchanged
+
+Until then, the implementation remains dormant and test-only by design.
+
+## Current implementation pass
+
+Delivered in the isolated worktree:
+
+- shared read-only activity projection with recent-completion visibility, graph bounding, cycle handling, forced secret redaction, and presentation-field allowlisting
+- DB-pin isolation that rejects cross-board relabeling instead of returning the pinned board's data under another slug
+- independently bounded seed, recursive-scan, display, and per-child parent-edge budgets; every overflow sets `truncated` and renders `+ more activity not shown`
+- preserved multi-parent truthfulness, including references to parents outside a truncated presentation slice
+- dashboard `/workers/active` reuse of a shared database helper without changing its response contract
+- local `kanban.activity` JSON-RPC aggregation with canonical multi-board deduplication, explicit overflow diagnostics, and no session/delivery side effects
+- typed payloads, pure normalization/presentation helpers, and static Ink dock/spine components
+- focused wide, narrow, branching, blocked, failed, stale, multi-board, empty, and dormant-integration tests
+
+Deliberately deferred:
+
+- live TUI mounting or composer integration
+- polling/store lifecycle
+- keyboard focus and task selection
+- animation
+- live-session screenshots
+
+Those deferred items are the activation phase, not missing invisible wiring. The standalone fixture render for this pass produced:
+
+```text
+│ ◉ Adaptive cycle core — implementer · running
+├── ● Models — implementer · completed
+├── ◉ Persistence — implementer · running
+└── ○ Independent review — implementer · ready
+│ ! Visual approval — implementer · blocked: Needs human visual choice
+
+! K · !1 · A2
+```

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -137,6 +137,15 @@ KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 KANBAN_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
 
+# The activity projection is polled by local UI surfaces.  Keep both database
+# work and serialized output bounded even when a board has accumulated a large
+# history or malformed dependency graph.
+ACTIVITY_MAX_TASKS = 200
+ACTIVITY_MAX_GRAPH_SCAN = ACTIVITY_MAX_TASKS * 4
+ACTIVITY_MAX_PARENTS_PER_TASK = 16
+ACTIVITY_BLOCK_REASON_MAX_CHARS = 240
+ACTIVITY_RECENT_COMPLETION_SECONDS = 300
+
 
 def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None:
     """Fire a kanban lifecycle plugin hook, fully best-effort.
@@ -366,6 +375,11 @@ def _normalize_board_slug(slug: Optional[str]) -> Optional[str]:
             f"alphanumerics / hyphens / underscores, not starting with '-' or '_'"
         )
     return s
+
+
+def normalize_board_slug(slug: Optional[str]) -> Optional[str]:
+    """Public, side-effect-free board slug canonicalizer."""
+    return _normalize_board_slug(slug)
 
 
 def kanban_home() -> Path:
@@ -2772,6 +2786,342 @@ def list_tasks(
         query += f" LIMIT {int(limit)}"
     rows = conn.execute(query, params).fetchall()
     return [Task.from_row(r) for r in rows]
+
+
+def _bounded_activity_text(value: Any, limit: int) -> Optional[str]:
+    """Return a single-line, length-bounded presentation string."""
+    if value is None:
+        return None
+    text = " ".join(str(value).split())
+    if not text:
+        return None
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _activity_block_reason(payload: Any) -> Optional[str]:
+    """Extract only the documented reason field from a task-event payload."""
+    if not payload:
+        return None
+    try:
+        decoded = json.loads(payload)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    reason = _bounded_activity_text(decoded.get("reason"), ACTIVITY_BLOCK_REASON_MAX_CHARS)
+    if reason is None:
+        return None
+    try:
+        from agent.redact import redact_sensitive_text
+
+        reason = redact_sensitive_text(reason, force=True)
+    except Exception:
+        # This projection is presentation-safe by construction. If the shared
+        # redactor cannot load, fail closed rather than exposing arbitrary task
+        # text in a composer-adjacent surface.
+        return "Details unavailable"
+    return _bounded_activity_text(reason, ACTIVITY_BLOCK_REASON_MAX_CHARS)
+
+
+def activity_board_scope() -> Optional[str]:
+    """Return the sole board allowed by a process-level DB pin, if any."""
+    if not os.environ.get("HERMES_KANBAN_DB", "").strip():
+        return None
+    try:
+        return _normalize_board_slug(os.environ.get("HERMES_KANBAN_BOARD")) or DEFAULT_BOARD
+    except ValueError:
+        return DEFAULT_BOARD
+
+
+def _activity_db_path(board: str) -> Path:
+    """Resolve an activity board without letting a DB pin alias another slug."""
+    slug = _normalize_board_slug(board)
+    if not slug:
+        raise ValueError("board slug is required")
+    pinned = activity_board_scope()
+    if pinned is not None:
+        if slug != pinned:
+            raise PermissionError(f"board {slug!r} is outside pinned activity scope")
+        return Path(os.environ["HERMES_KANBAN_DB"]).expanduser()
+    return kanban_db_path(board=slug)
+
+
+def _open_activity_reader(board: str) -> sqlite3.Connection:
+    """Open an existing board database in SQLite read-only mode.
+
+    Unlike :func:`connect`, this never initializes or migrates a database.  A
+    presentation poll therefore cannot create a missing board or write schema,
+    WAL, task, run, event, or subscription state.
+    """
+    slug = _normalize_board_slug(board)
+    if not slug:
+        raise ValueError("board slug is required")
+    path = _activity_db_path(slug).resolve()
+    conn = sqlite3.connect(path.as_uri() + "?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    return conn
+
+
+def get_activity_snapshot(*, board: str) -> dict:
+    """Return a bounded, deterministic, read-only activity projection.
+
+    The projection is deliberately an allowlist: task body/result/comments,
+    run summaries/metadata/errors, process ids, claims, command lines, logs,
+    and environment data never enter the returned structure.  Malformed links
+    are ignored; cyclic components are rooted deterministically and every task
+    is emitted at most once, preventing recursive or exponential expansion.
+    """
+    slug = _normalize_board_slug(board)
+    if not slug:
+        raise ValueError("board slug is required")
+    checked_at = int(time.time())
+    conn = _open_activity_reader(slug)
+    try:
+        connected_rows = conn.execute(
+            """
+            WITH RECURSIVE
+            seed(id) AS (
+                SELECT t.id
+                  FROM tasks t
+                 WHERE t.status IN ('running', 'blocked')
+                    OR EXISTS (
+                        SELECT 1
+                          FROM task_runs recent
+                         WHERE recent.task_id = t.id
+                           AND recent.ended_at IS NOT NULL
+                           AND recent.ended_at >= ?
+                    )
+                 ORDER BY t.created_at ASC, t.id ASC
+                 LIMIT ?
+            ),
+            connected(id) AS (
+                SELECT id FROM seed
+                UNION
+                SELECT links.parent_id
+                  FROM task_links links
+                  JOIN connected current ON links.child_id = current.id
+                UNION
+                SELECT links.child_id
+                  FROM task_links links
+                  JOIN connected current ON links.parent_id = current.id
+                LIMIT ?
+            )
+            SELECT id FROM connected
+            """,
+            (
+                checked_at - ACTIVITY_RECENT_COMPLETION_SECONDS,
+                ACTIVITY_MAX_TASKS + 1,
+                ACTIVITY_MAX_GRAPH_SCAN + 1,
+            ),
+        ).fetchall()
+        scan_truncated = len(connected_rows) > ACTIVITY_MAX_GRAPH_SCAN
+        connected_ids = [row["id"] for row in connected_rows[:ACTIVITY_MAX_GRAPH_SCAN]]
+        if not connected_ids:
+            return {"board": slug, "checked_at": checked_at, "roots": []}
+
+        connected_placeholders = ",".join("?" for _ in connected_ids)
+        task_rows = conn.execute(
+            f"""
+            SELECT id, title, status, assignee, created_at
+              FROM tasks
+             WHERE id IN ({connected_placeholders})
+               AND status != 'archived'
+             ORDER BY created_at ASC, id ASC
+             LIMIT ?
+            """,
+            [*connected_ids, ACTIVITY_MAX_TASKS + 1],
+        ).fetchall()
+        truncated = scan_truncated or len(task_rows) > ACTIVITY_MAX_TASKS
+        task_rows = task_rows[:ACTIVITY_MAX_TASKS]
+        if not task_rows:
+            snapshot = {"board": slug, "checked_at": checked_at, "roots": []}
+            if truncated:
+                snapshot["truncated"] = True
+            return snapshot
+
+        task_ids = [row["id"] for row in task_rows]
+        id_set = set(task_ids)
+        placeholders = ",".join("?" for _ in task_ids)
+
+        link_rows = conn.execute(
+            f"""
+            SELECT parent_id, child_id, parent_rank
+              FROM (
+                    SELECT parent_id, child_id,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY child_id ORDER BY parent_id ASC
+                           ) AS parent_rank
+                      FROM task_links
+                     WHERE child_id IN ({placeholders})
+              )
+             WHERE parent_rank <= ?
+             ORDER BY child_id ASC, parent_rank ASC
+            """,
+            [*task_ids, ACTIVITY_MAX_PARENTS_PER_TASK + 1],
+        ).fetchall()
+        if any(row["parent_rank"] > ACTIVITY_MAX_PARENTS_PER_TASK for row in link_rows):
+            truncated = True
+            link_rows = [
+                row
+                for row in link_rows
+                if row["parent_rank"] <= ACTIVITY_MAX_PARENTS_PER_TASK
+            ]
+
+        run_rows = conn.execute(
+            f"""
+            SELECT r.id, r.task_id, r.profile, r.started_at, r.ended_at,
+                   r.outcome, r.last_heartbeat_at, r.max_runtime_seconds
+              FROM task_runs r
+             WHERE r.task_id IN ({placeholders})
+               AND r.id = (
+                   SELECT latest.id
+                     FROM task_runs latest
+                    WHERE latest.task_id = r.task_id
+                    ORDER BY latest.started_at DESC, latest.id DESC
+                    LIMIT 1
+               )
+            """,
+            task_ids,
+        ).fetchall()
+
+        reason_rows = conn.execute(
+            f"""
+            SELECT e.task_id, e.payload
+              FROM task_events e
+             WHERE e.task_id IN ({placeholders})
+               AND e.kind IN ('blocked', 'dependency_wait', 'block_loop_detected')
+               AND e.id = (
+                   SELECT latest.id
+                     FROM task_events latest
+                    WHERE latest.task_id = e.task_id
+                      AND latest.kind IN ('blocked', 'dependency_wait', 'block_loop_detected')
+                    ORDER BY latest.id DESC
+                    LIMIT 1
+               )
+            """,
+            task_ids,
+        ).fetchall()
+    finally:
+        conn.close()
+
+    task_by_id = {row["id"]: row for row in task_rows}
+    run_by_task = {row["task_id"]: row for row in run_rows}
+    reason_by_task = {
+        row["task_id"]: _activity_block_reason(row["payload"])
+        for row in reason_rows
+    }
+    parents: dict[str, list[str]] = {task_id: [] for task_id in task_ids}
+    children: dict[str, list[str]] = {task_id: [] for task_id in task_ids}
+    for link in link_rows:
+        parent_id = link["parent_id"]
+        child_id = link["child_id"]
+        if child_id not in id_set:
+            continue
+        parents[child_id].append(parent_id)
+        if parent_id in id_set:
+            children[parent_id].append(child_id)
+
+    order = {task_id: index for index, task_id in enumerate(task_ids)}
+    fallback_order = len(order)
+    for values in parents.values():
+        values.sort(key=lambda task_id: (order.get(task_id, fallback_order), task_id))
+    for values in children.values():
+        values.sort(key=order.__getitem__)
+
+    emitted: set[str] = set()
+
+    def build_node(task_id: str) -> dict:
+        emitted.add(task_id)
+        task = task_by_id[task_id]
+        run = run_by_task.get(task_id)
+        node = {
+            "task_id": task_id,
+            "title": _bounded_activity_text(task["title"], 500) or "Untitled task",
+            "status": task["status"],
+            "assignee": _bounded_activity_text(task["assignee"], 128),
+            "block_reason": reason_by_task.get(task_id),
+            "parents": list(parents[task_id]),
+            "children": [],
+            "run": None,
+        }
+        if run is not None:
+            node["run"] = {
+                "run_id": int(run["id"]),
+                "profile": _bounded_activity_text(run["profile"], 128),
+                "started_at": run["started_at"],
+                "ended_at": run["ended_at"],
+                "outcome": _bounded_activity_text(run["outcome"], 64),
+                "last_heartbeat_at": run["last_heartbeat_at"],
+                "max_runtime_seconds": run["max_runtime_seconds"],
+            }
+        for child_id in children[task_id]:
+            if child_id not in emitted:
+                node["children"].append(build_node(child_id))
+        return node
+
+    root_ids = [task_id for task_id in task_ids if not parents[task_id]]
+    roots = [build_node(task_id) for task_id in root_ids if task_id not in emitted]
+    # Cycles and nodes whose ancestors fell outside a truncated presentation
+    # have no selected natural root. Emit each remaining component once; the
+    # explicit parent ids keep the missing edge visible to the renderer.
+    roots.extend(build_node(task_id) for task_id in task_ids if task_id not in emitted)
+    snapshot = {"board": slug, "checked_at": checked_at, "roots": roots}
+    if truncated:
+        snapshot["truncated"] = True
+    return snapshot
+
+
+def list_active_worker_rows(conn: sqlite3.Connection) -> list[dict]:
+    """Return the dashboard's established active-worker row contract.
+
+    This intentionally remains narrower than :func:`get_activity_snapshot`:
+    the dashboard endpoint has a pre-existing process/claim-oriented contract
+    that would be distorted by deriving it from the presentation projection.
+    Keeping its SQL here still gives all backend consumers one source of truth.
+    """
+    rows = conn.execute(
+        """
+        SELECT
+            r.id          AS run_id,
+            r.task_id,
+            t.title       AS task_title,
+            t.status      AS task_status,
+            t.assignee    AS task_assignee,
+            r.profile,
+            r.worker_pid,
+            r.started_at,
+            r.claim_lock,
+            r.claim_expires,
+            r.last_heartbeat_at,
+            r.max_runtime_seconds
+        FROM task_runs r
+        JOIN tasks t ON t.id = r.task_id
+        WHERE r.ended_at IS NULL
+          AND r.worker_pid IS NOT NULL
+          AND t.status = 'running'
+        ORDER BY r.started_at ASC
+        """
+    ).fetchall()
+    return [
+        {
+            "run_id": row["run_id"],
+            "task_id": row["task_id"],
+            "task_title": row["task_title"],
+            "task_status": row["task_status"],
+            "task_assignee": row["task_assignee"],
+            "profile": row["profile"],
+            "worker_pid": row["worker_pid"],
+            "started_at": row["started_at"],
+            "claim_lock": row["claim_lock"],
+            "claim_expires": row["claim_expires"],
+            "last_heartbeat_at": row["last_heartbeat_at"],
+            "max_runtime_seconds": row["max_runtime_seconds"],
+        }
+        for row in rows
+    ]
 
 
 def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) -> bool:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1381,46 +1381,7 @@ def list_active_workers(
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        rows = conn.execute(
-            """
-            SELECT
-                r.id          AS run_id,
-                r.task_id,
-                t.title       AS task_title,
-                t.status      AS task_status,
-                t.assignee    AS task_assignee,
-                r.profile,
-                r.worker_pid,
-                r.started_at,
-                r.claim_lock,
-                r.claim_expires,
-                r.last_heartbeat_at,
-                r.max_runtime_seconds
-            FROM task_runs r
-            JOIN tasks t ON t.id = r.task_id
-            WHERE r.ended_at IS NULL
-              AND r.worker_pid IS NOT NULL
-              AND t.status = 'running'
-            ORDER BY r.started_at ASC
-            """,
-        ).fetchall()
-        workers = [
-            {
-                "run_id": row["run_id"],
-                "task_id": row["task_id"],
-                "task_title": row["task_title"],
-                "task_status": row["task_status"],
-                "task_assignee": row["task_assignee"],
-                "profile": row["profile"],
-                "worker_pid": row["worker_pid"],
-                "started_at": row["started_at"],
-                "claim_lock": row["claim_lock"],
-                "claim_expires": row["claim_expires"],
-                "last_heartbeat_at": row["last_heartbeat_at"],
-                "max_runtime_seconds": row["max_runtime_seconds"],
-            }
-            for row in rows
-        ]
+        workers = kanban_db.list_active_worker_rows(conn)
         return {"workers": workers, "count": len(workers), "checked_at": int(time.time())}
     finally:
         conn.close()

--- a/tests/hermes_cli/test_kanban_activity_projection.py
+++ b/tests/hermes_cli/test_kanban_activity_projection.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def isolated_board(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    kb.init_db()
+    return db_path
+
+
+def _run(conn, task_id, *, ended_at=None, outcome=None, heartbeat=None):
+    cur = conn.execute(
+        "INSERT INTO task_runs(task_id,profile,status,started_at,ended_at,outcome,last_heartbeat_at,max_runtime_seconds) VALUES (?,'implementer',?,?,?,?,?,3600)",
+        (task_id, "completed" if ended_at is not None else "running", int(time.time()) - 30, ended_at, outcome, heartbeat),
+    )
+    return int(cur.lastrowid)
+
+
+def _flatten(roots):
+    seen, stack = [], list(roots)
+    while stack:
+        node = stack.pop(); seen.append(node); stack.extend(node["children"])
+    return seen
+
+
+def test_empty_snapshot_is_stable_and_read_only(isolated_board):
+    before = isolated_board.read_bytes()
+    assert kb.get_activity_snapshot(board="default")["roots"] == []
+    assert before == isolated_board.read_bytes()
+
+
+def test_pinned_database_cannot_be_relabelled_as_another_board(isolated_board):
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="Default private task", assignee="worker")
+        conn.execute("UPDATE tasks SET status='running' WHERE id=?", (task_id,)); _run(conn, task_id, heartbeat=int(time.time())); conn.commit()
+    with pytest.raises(PermissionError):
+        kb.get_activity_snapshot(board="alpha")
+    assert kb.get_activity_snapshot(board="default")["roots"][0]["title"] == "Default private task"
+
+
+def test_projection_is_allowlisted_and_redacts_block_reason(isolated_board):
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="Parent", assignee="architect")
+        child = kb.create_task(conn, title="Child", assignee="implementer", parents=[parent])
+        conn.execute("UPDATE tasks SET status='done' WHERE id=?", (parent,)); conn.execute("UPDATE tasks SET status='blocked' WHERE id=?", (child,))
+        parent_run = _run(conn, parent, ended_at=now, outcome="completed", heartbeat=now - 20); child_run = _run(conn, child, heartbeat=now - 5)
+        conn.execute("INSERT INTO task_events(task_id,kind,payload,created_at) VALUES (?,'blocked',?,?)", (child, json.dumps({"reason": "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz"}), now)); conn.commit()
+    root = kb.get_activity_snapshot(board="default")["roots"][0]; node = root["children"][0]
+    assert root["run"]["run_id"] == parent_run and node["run"]["run_id"] == child_run
+    assert "sk-abcdefghijklmnopqrstuvwxyz" not in node["block_reason"]
+    assert "body" not in node and "worker_pid" not in node["run"] and "error" not in node["run"]
+
+
+def test_old_completed_and_backlog_only_work_are_hidden(isolated_board):
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        recent = kb.create_task(conn, title="Recent", assignee="worker"); old = kb.create_task(conn, title="Old", assignee="worker")
+        conn.execute("UPDATE tasks SET status='done' WHERE id IN (?,?)", (recent, old)); _run(conn, recent, ended_at=now - 5, outcome="completed"); _run(conn, old, ended_at=now - kb.ACTIVITY_RECENT_COMPLETION_SECONDS - 10, outcome="completed"); conn.commit()
+    ids = [node["task_id"] for node in kb.get_activity_snapshot(board="default")["roots"]]
+    assert recent in ids and old not in ids
+    with kb.connect_closing() as conn:
+        conn.execute("UPDATE task_runs SET ended_at=? WHERE task_id=?", (now - 1000, recent))
+        for status in ("triage", "todo", "scheduled", "ready", "review"):
+            task_id = kb.create_task(conn, title=status, assignee="worker"); conn.execute("UPDATE tasks SET status=? WHERE id=?", (status, task_id))
+        conn.commit()
+    assert kb.get_activity_snapshot(board="default")["roots"] == []
+
+
+def test_connected_statuses_and_multi_parent_edges_are_retained(isolated_board):
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        a = kb.create_task(conn, title="Parent A", assignee="worker"); b = kb.create_task(conn, title="Parent B", assignee="worker")
+        shared = kb.create_task(conn, title="Shared", assignee="reviewer", parents=[a, b]); scheduled = kb.create_task(conn, title="Scheduled", assignee="worker", parents=[shared])
+        conn.execute("UPDATE tasks SET status='running' WHERE id=?", (a,)); conn.execute("UPDATE tasks SET status='review' WHERE id=?", (shared,)); conn.execute("UPDATE tasks SET status='scheduled' WHERE id=?", (scheduled,)); _run(conn, a, heartbeat=now); conn.commit()
+    nodes = _flatten(kb.get_activity_snapshot(board="default")["roots"]); node = next(n for n in nodes if n["task_id"] == shared)
+    assert set(node["parents"]) == {a, b} and node["status"] == "review" and node["children"][0]["status"] == "scheduled"
+
+
+def test_recursive_graph_expansion_is_capped_and_keeps_external_parent(isolated_board):
+    with kb.connect_closing() as conn:
+        ids = [kb.create_task(conn, title=f"Node {i}", assignee="worker") for i in range(kb.ACTIVITY_MAX_TASKS + 30)]
+        conn.execute("UPDATE tasks SET status='running' WHERE id=?", (ids[0],)); _run(conn, ids[0], heartbeat=int(time.time()))
+        conn.executemany("INSERT INTO task_links(parent_id,child_id) VALUES (?,?)", zip(ids, ids[1:]))
+        omitted = kb.create_task(conn, title="Omitted parent", assignee="worker"); conn.execute("INSERT INTO task_links(parent_id,child_id) VALUES (?,?)", (omitted, ids[0])); conn.commit()
+    snap = kb.get_activity_snapshot(board="default"); nodes = _flatten(snap["roots"])
+    assert len(nodes) <= kb.ACTIVITY_MAX_TASKS and snap["truncated"] is True
+    assert omitted in next(n for n in nodes if n["task_id"] == ids[0])["parents"]
+
+
+def test_parent_edge_cap_is_per_child(isolated_board):
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        a = kb.create_task(conn, title="Child A", assignee="worker"); z = kb.create_task(conn, title="Child Z", assignee="worker")
+        conn.execute("UPDATE tasks SET status='running' WHERE id IN (?,?)", (a, z)); _run(conn, a, heartbeat=now); _run(conn, z, heartbeat=now)
+        parents = [kb.create_task(conn, title=f"Parent {i}", assignee="worker") for i in range(kb.ACTIVITY_MAX_PARENTS_PER_TASK + 4)]; later = kb.create_task(conn, title="Later", assignee="worker")
+        conn.executemany("INSERT INTO task_links(parent_id,child_id) VALUES (?,?)", [(p, a) for p in parents] + [(later, z)]); conn.commit()
+    snap = kb.get_activity_snapshot(board="default"); nodes = _flatten(snap["roots"])
+    assert len(next(n for n in nodes if n["task_id"] == a)["parents"]) == kb.ACTIVITY_MAX_PARENTS_PER_TASK
+    assert next(n for n in nodes if n["task_id"] == z)["parents"] == [later] and snap["truncated"] is True
+
+
+def test_graph_scan_cap_sets_truncation(isolated_board):
+    count = kb.ACTIVITY_MAX_GRAPH_SCAN + 5; ids = [f"bulk-{i:04d}" for i in range(count)]; now = int(time.time())
+    with kb.connect_closing() as conn:
+        conn.executemany("INSERT INTO tasks(id,title,assignee,status,created_at) VALUES (?,?,'worker',?,?)", [(x, x, "running" if i == 0 else "todo", now + i) for i, x in enumerate(ids)])
+        _run(conn, ids[0], heartbeat=now); conn.executemany("INSERT INTO task_links(parent_id,child_id) VALUES (?,?)", zip(ids, ids[1:])); conn.commit()
+    snap = kb.get_activity_snapshot(board="default")
+    assert snap["truncated"] is True and len(_flatten(snap["roots"])) <= kb.ACTIVITY_MAX_TASKS
+
+
+def test_cycles_fail_boundedly_without_duplicates(isolated_board):
+    with kb.connect_closing() as conn:
+        a = kb.create_task(conn, title="A", assignee="worker"); b = kb.create_task(conn, title="B", assignee="worker")
+        conn.execute("UPDATE tasks SET status='running' WHERE id=?", (a,)); _run(conn, a, heartbeat=int(time.time())); conn.execute("INSERT INTO task_links VALUES (?,?)", (a, b)); conn.execute("INSERT INTO task_links VALUES (?,?)", (b, a)); conn.commit()
+    seen = [n["task_id"] for n in _flatten(kb.get_activity_snapshot(board="default")["roots"])]
+    assert sorted(seen) == sorted([a, b]) and len(seen) == len(set(seen))
+
+
+def test_missing_board_does_not_get_created(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"; monkeypatch.setenv("HERMES_HOME", str(home)); monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    target = home / "kanban" / "boards" / "missing" / "kanban.db"
+    with pytest.raises(Exception): kb.get_activity_snapshot(board="missing")
+    assert not target.exists()

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2484,3 +2484,33 @@ def test_dashboard_parent_notice_and_child_results_use_detail_links():
     assert "t.link_counts" not in detail
     assert "Child Results" in detail
     assert "props.data.child_results" in detail
+
+
+def test_active_workers_endpoint_uses_shared_database_projection(client, monkeypatch):
+    expected = {
+        "run_id": 7,
+        "task_id": "task-shared",
+        "task_title": "Shared read helper",
+        "task_status": "running",
+        "task_assignee": "worker",
+        "profile": "worker",
+        "worker_pid": 4242,
+        "started_at": 100,
+        "claim_lock": "claim",
+        "claim_expires": 200,
+        "last_heartbeat_at": 150,
+        "max_runtime_seconds": 3600,
+    }
+    calls = []
+
+    def shared_rows(conn):
+        calls.append(conn)
+        return [expected]
+
+    monkeypatch.setattr(kb, "list_active_worker_rows", shared_rows)
+    response = client.get("/api/plugins/kanban/workers/active")
+
+    assert response.status_code == 200
+    assert response.json()["workers"] == [expected]
+    assert response.json()["count"] == 1
+    assert len(calls) == 1

--- a/tests/tui_gateway/test_kanban_activity.py
+++ b/tests/tui_gateway/test_kanban_activity.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import copy
+from hermes_cli import kanban_db
+import tui_gateway.server as srv
+
+
+def _call(params): return srv._methods["kanban.activity"](1, params)["result"]
+def _task(task_id, status, *, outcome=None, children=None):
+    return {"task_id": task_id, "title": task_id, "status": status, "assignee": "worker", "block_reason": None, "parents": [], "children": children or [], "run": None if status not in {"running", "done"} else {"run_id": 1, "profile": "worker", "started_at": 10, "ended_at": 20 if status == "done" else None, "outcome": outcome, "last_heartbeat_at": 15, "max_runtime_seconds": 3600}}
+
+
+def test_empty_implicit_response_omits_uninitialized_board(monkeypatch, tmp_path):
+    missing = tmp_path / "missing.db"; monkeypatch.setattr(kanban_db, "activity_board_scope", lambda: None); monkeypatch.setattr(kanban_db, "list_boards", lambda include_archived=False: [{"slug": "default"}]); monkeypatch.setattr(kanban_db, "kanban_db_path", lambda board=None: missing)
+    result = _call({}); assert result["boards"] == []; assert result["active_count"] == result["attention_count"] == 0; assert not missing.exists()
+
+
+def test_implicit_pinned_scope_reads_only_pinned_board(monkeypatch, tmp_path):
+    pinned = tmp_path / "alpha.db"; pinned.touch(); monkeypatch.setattr(kanban_db, "activity_board_scope", lambda: "alpha"); monkeypatch.setattr(kanban_db, "kanban_db_path", lambda board=None: pinned); seen = []
+    monkeypatch.setattr(kanban_db, "get_activity_snapshot", lambda board: seen.append(board) or {"board": board, "checked_at": 10, "roots": []}); _call({}); assert seen == ["alpha"]
+
+
+def test_multi_board_canonicalization_and_overflow(monkeypatch):
+    snapshots = {"alpha": {"board": "alpha", "checked_at": 10, "roots": [_task("running", "running", children=[_task("blocked", "blocked")])]}, "zeta": {"board": "zeta", "checked_at": 10, "roots": [_task("failed", "done", outcome="stopped")]}}
+    monkeypatch.setattr(kanban_db, "get_activity_snapshot", lambda board: copy.deepcopy(snapshots.get(board, {"board": board, "checked_at": 10, "roots": []})))
+    result = _call({"boards": ["zeta", "ALPHA", "alpha"]}); assert [b["board"] for b in result["boards"]] == ["alpha", "zeta"]; assert result["active_count"] == 1 and result["attention_count"] == 2
+    overflow = _call({"boards": [f"board-{i}" for i in range(srv._KANBAN_ACTIVITY_MAX_BOARDS + 3)]}); assert len(overflow["boards"]) == srv._KANBAN_ACTIVITY_MAX_BOARDS; assert overflow["diagnostics"] == [f"board-limit:{srv._KANBAN_ACTIVITY_MAX_BOARDS}"]
+
+
+def test_private_backend_error_is_bounded(monkeypatch):
+    def unavailable(*, board): raise RuntimeError("private path or database detail")
+    monkeypatch.setattr(kanban_db, "get_activity_snapshot", unavailable); result = _call({"boards": ["broken"]}); assert result["boards"][0]["error"] == "board unavailable"; assert "private path" not in repr(result)
+
+
+def test_rpc_does_not_touch_session_or_delivery_state(monkeypatch):
+    sessions, pending = dict(srv._sessions), dict(srv._pending); monkeypatch.setattr(kanban_db, "get_activity_snapshot", lambda board: {"board": board, "checked_at": 10, "roots": [_task("running", "running")]})
+    assert _call({"boards": ["default"]})["active_count"] == 1; assert srv._sessions == sessions and srv._pending == pending

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8205,6 +8205,125 @@ def _(rid, params: dict) -> dict:
 # translators between JSON-RPC and the Python API.
 
 
+_KANBAN_ACTIVITY_MAX_BOARDS = 32
+_KANBAN_FAILURE_OUTCOMES = frozenset(
+    {"crashed", "timed_out", "spawn_failed", "gave_up", "failed", "stopped"}
+)
+
+
+def _kanban_activity_counts(snapshots: list[dict]) -> tuple[int, int]:
+    """Count active/attention tasks without assuming a well-formed tree."""
+    active = 0
+    attention = 0
+    stack = [
+        (str(snapshot.get("board") or ""), root)
+        for snapshot in reversed(snapshots)
+        for root in snapshot.get("roots", [])
+    ]
+    seen: set[tuple[str, str]] = set()
+    while stack:
+        board, node = stack.pop()
+        if not isinstance(node, dict):
+            continue
+        key = (board, str(node.get("task_id") or ""))
+        if key in seen:
+            continue
+        seen.add(key)
+        status = node.get("status")
+        raw_run = node.get("run")
+        run: dict = raw_run if isinstance(raw_run, dict) else {}
+        if status == "running":
+            active += 1
+        if status == "blocked" or run.get("outcome") in _KANBAN_FAILURE_OUTCOMES:
+            attention += 1
+        children = node.get("children")
+        if isinstance(children, list):
+            stack.extend((board, child) for child in reversed(children))
+    return active, attention
+
+
+@method("kanban.activity")
+def _(rid, params: dict) -> dict:
+    """Read bounded Kanban activity without touching chat/session delivery."""
+    from hermes_cli import kanban_db
+
+    requested = params.get("boards")
+    explicit = requested is not None
+    diagnostics: list[str] = []
+    if explicit:
+        if not isinstance(requested, list) or any(
+            not isinstance(board, str) for board in requested
+        ):
+            return _err(rid, 4000, "boards must be a list of board slugs")
+        canonical: set[str] = set()
+        for board in requested:
+            candidate = board.strip()
+            if not candidate:
+                continue
+            try:
+                candidate = kanban_db.normalize_board_slug(candidate) or ""
+            except ValueError:
+                # Preserve invalid input long enough to return its bounded error.
+                candidate = candidate[:64]
+            if candidate:
+                canonical.add(candidate)
+        board_names = sorted(canonical)
+        if len(board_names) > _KANBAN_ACTIVITY_MAX_BOARDS:
+            diagnostics.append(f"board-limit:{_KANBAN_ACTIVITY_MAX_BOARDS}")
+            board_names = board_names[:_KANBAN_ACTIVITY_MAX_BOARDS]
+    else:
+        pinned = kanban_db.activity_board_scope()
+        if pinned is not None:
+            board_names = [pinned]
+        else:
+            board_names = [
+                str(metadata["slug"])
+                for metadata in kanban_db.list_boards(include_archived=False)
+            ]
+            if len(board_names) > _KANBAN_ACTIVITY_MAX_BOARDS:
+                diagnostics.append(f"board-limit:{_KANBAN_ACTIVITY_MAX_BOARDS}")
+                board_names = board_names[:_KANBAN_ACTIVITY_MAX_BOARDS]
+
+    snapshots: list[dict] = []
+    for board in board_names:
+        # The default board is a logical back-compat board even before its DB
+        # exists. Ambient polling must not turn that fresh-install state into a
+        # permanent "board unavailable" warning or initialize the DB as a side
+        # effect. Explicit requests still receive a bounded error below.
+        if not explicit and not kanban_db.kanban_db_path(board=board).exists():
+            continue
+        try:
+            snapshot = kanban_db.get_activity_snapshot(board=board)
+        except ValueError:
+            snapshot = {
+                "board": board[:64],
+                "checked_at": int(time.time()),
+                "roots": [],
+                "error": "invalid board slug",
+            }
+        except Exception as exc:
+            logger.debug("kanban activity read failed for %r: %s", board, exc)
+            snapshot = {
+                "board": board[:64],
+                "checked_at": int(time.time()),
+                "roots": [],
+                "error": "board unavailable",
+            }
+        if explicit or snapshot.get("roots") or snapshot.get("error"):
+            snapshots.append(snapshot)
+
+    active_count, attention_count = _kanban_activity_counts(snapshots)
+    result = {
+        "boards": snapshots,
+        "active_count": active_count,
+        "attention_count": attention_count,
+        "checked_at": int(time.time()),
+    }
+    if diagnostics:
+        result["diagnostics"] = diagnostics
+    return _ok(rid, result)
+
+
 @method("delegation.status")
 def _(rid, params: dict) -> dict:
     from tools.delegate_tool import (

--- a/ui-tui/src/__tests__/kanbanActivity.test.ts
+++ b/ui-tui/src/__tests__/kanbanActivity.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import type { KanbanActivityResponse, KanbanActivityTask } from '../gatewayTypes.js'
+import { activityPresentation, aggregateKanbanActivity, buildKanbanActivityRows, collapsedActivityLabel, normalizeKanbanActivity, truncateActivityLabel } from '../lib/kanbanActivity.js'
+
+const NOW = 1_721_000_000
+const task = (overrides: Partial<KanbanActivityTask> = {}): KanbanActivityTask => ({ assignee: 'implementer', block_reason: null, children: [], parents: [], status: 'running', task_id: 'task-a', title: 'Implement the execution spine', run: { ended_at: null, last_heartbeat_at: NOW - 10, max_runtime_seconds: 3600, outcome: null, profile: 'implementer', run_id: 12, started_at: NOW - 100 }, ...overrides })
+const payload = (roots: KanbanActivityTask[]): KanbanActivityResponse => ({ active_count: 0, attention_count: 0, boards: [{ board: 'default', checked_at: NOW, roots }], checked_at: NOW })
+
+describe('kanban activity model', () => {
+  it('preserves backend order across status changes', () => {
+    const roots = [task({ task_id: 'b' }), task({ task_id: 'a' })]
+    const before = normalizeKanbanActivity(payload(roots), NOW).boards[0]!.roots.map(root => root.id)
+    roots[0]!.status = 'done'; roots[1]!.status = 'blocked'
+    expect(normalizeKanbanActivity(payload(roots), NOW).boards[0]!.roots.map(root => root.id)).toEqual(before)
+  })
+  it('handles every backend status and scopes heartbeat health to running', () => {
+    for (const [status, label] of [['review', 'review queued'], ['scheduled', 'scheduled'], ['ready', 'ready']] as const) {
+      const node = normalizeKanbanActivity(payload([task({ run: null, status })]), NOW).boards[0]!.roots[0]!
+      expect(node.status).toBe(status); expect(activityPresentation(node, NOW).stateLabel).toBe(label)
+    }
+
+    const done = normalizeKanbanActivity(payload([task({ run: null, status: 'done' })]), NOW).boards[0]!.roots[0]!
+    expect(activityPresentation(done, NOW)).toMatchObject({ glyph: '●', stateLabel: 'completed' })
+    const missing = normalizeKanbanActivity(payload([task({ run: null, status: 'running' })]), NOW).boards[0]!.roots[0]!
+    expect(activityPresentation(missing, NOW)).toMatchObject({ glyph: '!', stateLabel: 'heartbeat unavailable' })
+  })
+  it('prioritizes current attention and ignores stale terminal history', () => {
+    const old = task({ run: { ...task().run!, ended_at: NOW - 1000, outcome: 'failed' }, status: 'done', task_id: 'old' })
+    const model = normalizeKanbanActivity(payload([old, task({ task_id: 'active', title: 'Current work' }), task({ block_reason: 'review', status: 'blocked', task_id: 'blocked', title: 'Needs Henry' })]), NOW)
+    expect(aggregateKanbanActivity(model, NOW)).toMatchObject({ active: 1, attention: 1, completed: 0 }); expect(collapsedActivityLabel(model, 100, NOW)).toContain('Needs Henry')
+  })
+  it('shows every parent without duplicating task counts', () => {
+    const shared = task({ parents: ['parent-a', 'parent-b'], task_id: 'shared', title: 'Shared child' })
+    const model = normalizeKanbanActivity(payload([task({ children: [shared], task_id: 'parent-a', title: 'Parent A' }), task({ task_id: 'parent-b', title: 'Parent B' })]), NOW)
+    const rows = buildKanbanActivityRows(model, { now: NOW }); expect(rows.some(row => row.kind === 'summary' && row.label === '↳ also linked from Parent B')).toBe(true); expect(aggregateKanbanActivity(model, NOW).total).toBe(3)
+  })
+  it('surfaces graph truncation', () => {
+    const wire = payload([task()]); wire.boards[0]!.truncated = true
+    expect(buildKanbanActivityRows(normalizeKanbanActivity(wire, NOW), { now: NOW }).some(row => row.kind === 'summary' && row.label === '+ more activity not shown')).toBe(true)
+  })
+  it('compresses branches and bounds cycles', () => {
+    const children = Array.from({ length: 7 }, (_, i) => task({ task_id: `child-${i}` })); const rows = buildKanbanActivityRows(normalizeKanbanActivity(payload([task({ children, task_id: 'root' })]), NOW), { maxChildren: 3, now: NOW }); expect(rows.some(row => row.kind === 'summary' && row.label === '+4 more tasks')).toBe(true)
+    const cyclic = task({ task_id: 'cycle' }); cyclic.children = [cyclic]; const model = normalizeKanbanActivity(payload([cyclic]), NOW); expect(model.diagnostics).toContain('cycle:cycle'); expect(model.boards[0]!.roots[0]!.children).toEqual([])
+  })
+  it('never fabricates progress and truncates without wrapping', () => {
+    const rows = buildKanbanActivityRows(normalizeKanbanActivity(payload([task()]), NOW), { now: NOW }); expect(rows.map(row => row.kind === 'task' ? row.label : '').join(' ')).not.toMatch(/%|percent|phase/i); expect(truncateActivityLabel('Implement a very long execution spine', 12)).toBe('Implement a…')
+  })
+})

--- a/ui-tui/src/__tests__/kanbanActivity.test.ts
+++ b/ui-tui/src/__tests__/kanbanActivity.test.ts
@@ -1,11 +1,14 @@
+import { stringWidth } from '@hermes/ink'
 import { describe, expect, it } from 'vitest'
 
 import type { KanbanActivityResponse, KanbanActivityTask } from '../gatewayTypes.js'
-import { activityPresentation, aggregateKanbanActivity, buildKanbanActivityRows, collapsedActivityLabel, normalizeKanbanActivity, truncateActivityLabel } from '../lib/kanbanActivity.js'
+import { activityPresentation, aggregateKanbanActivity, buildKanbanActivityRows, collapsedActivityLabel, collapsedActivitySegments, composeActivityLabel, normalizeKanbanActivity, truncateActivityLabel } from '../lib/kanbanActivity.js'
 
 const NOW = 1_721_000_000
 const task = (overrides: Partial<KanbanActivityTask> = {}): KanbanActivityTask => ({ assignee: 'implementer', block_reason: null, children: [], parents: [], status: 'running', task_id: 'task-a', title: 'Implement the execution spine', run: { ended_at: null, last_heartbeat_at: NOW - 10, max_runtime_seconds: 3600, outcome: null, profile: 'implementer', run_id: 12, started_at: NOW - 100 }, ...overrides })
 const payload = (roots: KanbanActivityTask[]): KanbanActivityResponse => ({ active_count: 0, attention_count: 0, boards: [{ board: 'default', checked_at: NOW, roots }], checked_at: NOW })
+const firstRoot = (t: KanbanActivityTask) => normalizeKanbanActivity(payload([t]), NOW).boards[0]!.roots[0]!
+const taskRows = (model: ReturnType<typeof normalizeKanbanActivity>, options: Parameters<typeof buildKanbanActivityRows>[1] = {}) => buildKanbanActivityRows(model, { now: NOW, ...options }).filter(row => row.kind === 'task')
 
 describe('kanban activity model', () => {
   it('preserves backend order across status changes', () => {
@@ -16,14 +19,20 @@ describe('kanban activity model', () => {
   })
   it('handles every backend status and scopes heartbeat health to running', () => {
     for (const [status, label] of [['review', 'review queued'], ['scheduled', 'scheduled'], ['ready', 'ready']] as const) {
-      const node = normalizeKanbanActivity(payload([task({ run: null, status })]), NOW).boards[0]!.roots[0]!
+      const node = firstRoot(task({ run: null, status }))
       expect(node.status).toBe(status); expect(activityPresentation(node, NOW).stateLabel).toBe(label)
     }
 
-    const done = normalizeKanbanActivity(payload([task({ run: null, status: 'done' })]), NOW).boards[0]!.roots[0]!
+    const done = firstRoot(task({ run: null, status: 'done' }))
     expect(activityPresentation(done, NOW)).toMatchObject({ glyph: '●', stateLabel: 'completed' })
-    const missing = normalizeKanbanActivity(payload([task({ run: null, status: 'running' })]), NOW).boards[0]!.roots[0]!
+    const missing = firstRoot(task({ run: null, status: 'running' }))
     expect(activityPresentation(missing, NOW)).toMatchObject({ glyph: '!', stateLabel: 'heartbeat unavailable' })
+  })
+  it('reserves accent for live work and keeps queued states neutral', () => {
+    expect(activityPresentation(firstRoot(task()), NOW).tone).toBe('accent')
+    expect(activityPresentation(firstRoot(task({ run: null, status: 'ready' })), NOW).tone).toBe('neutral')
+    expect(activityPresentation(firstRoot(task({ run: null, status: 'review' })), NOW).tone).toBe('neutral')
+    expect(activityPresentation(firstRoot(task({ run: null, status: 'scheduled' })), NOW).tone).toBe('muted')
   })
   it('prioritizes current attention and ignores stale terminal history', () => {
     const old = task({ run: { ...task().run!, ended_at: NOW - 1000, outcome: 'failed' }, status: 'done', task_id: 'old' })
@@ -37,7 +46,7 @@ describe('kanban activity model', () => {
   })
   it('surfaces graph truncation', () => {
     const wire = payload([task()]); wire.boards[0]!.truncated = true
-    expect(buildKanbanActivityRows(normalizeKanbanActivity(wire, NOW), { now: NOW }).some(row => row.kind === 'summary' && row.label === '+ more activity not shown')).toBe(true)
+    expect(buildKanbanActivityRows(normalizeKanbanActivity(wire, NOW), { now: NOW }).some(row => row.kind === 'summary' && row.label === '+ more activity not shown' && row.prefix === '└── ')).toBe(true)
   })
   it('compresses branches and bounds cycles', () => {
     const children = Array.from({ length: 7 }, (_, i) => task({ task_id: `child-${i}` })); const rows = buildKanbanActivityRows(normalizeKanbanActivity(payload([task({ children, task_id: 'root' })]), NOW), { maxChildren: 3, now: NOW }); expect(rows.some(row => row.kind === 'summary' && row.label === '+4 more tasks')).toBe(true)
@@ -45,5 +54,170 @@ describe('kanban activity model', () => {
   })
   it('never fabricates progress and truncates without wrapping', () => {
     const rows = buildKanbanActivityRows(normalizeKanbanActivity(payload([task()]), NOW), { now: NOW }); expect(rows.map(row => row.kind === 'task' ? row.label : '').join(' ')).not.toMatch(/%|percent|phase/i); expect(truncateActivityLabel('Implement a very long execution spine', 12)).toBe('Implement a…')
+  })
+})
+
+describe('segmented labels and truncation priority', () => {
+  const blocked = () => firstRoot(task({ assignee: 'implementer', block_reason: 'Needs Henry visual choice', run: null, status: 'blocked', task_id: 'visual', title: 'Visual approval' }))
+
+  it('keeps the full blocked reason when it fits', () => {
+    expect(composeActivityLabel(blocked(), 80, NOW)).toEqual({ owner: 'implementer', state: 'blocked: Needs Henry visual choice', title: 'Visual approval' })
+  })
+  it('trims the blocked reason before anything else', () => {
+    expect(composeActivityLabel(blocked(), 50, NOW)).toEqual({ owner: 'implementer', state: 'blocked', title: 'Visual approval' })
+  })
+  it('drops the owner before the state', () => {
+    expect(composeActivityLabel(blocked(), 30, NOW)).toEqual({ owner: null, state: 'blocked', title: 'Visual approval' })
+  })
+  it('truncates the title while the state survives', () => {
+    expect(composeActivityLabel(blocked(), 20, NOW)).toEqual({ owner: null, state: 'blocked', title: 'Visual ap…' })
+  })
+  it('drops the state word only as a last resort', () => {
+    expect(composeActivityLabel(blocked(), 12, NOW)).toEqual({ owner: null, state: null, title: 'Visual appr…' })
+  })
+  it('never renders an unassigned placeholder', () => {
+    const node = firstRoot(task({ assignee: null, run: null, status: 'ready' }))
+    expect(composeActivityLabel(node, 80, NOW).owner).toBeNull()
+  })
+})
+
+describe('topology prefixes', () => {
+  it('renders ancestor continuation rails at depth 2', () => {
+    const grandchildren = [task({ task_id: 'g1', title: 'Grandchild 1' }), task({ run: null, status: 'ready', task_id: 'g2', title: 'Grandchild 2' })]
+    const roots = [task({ children: [task({ children: grandchildren, task_id: 'a', title: 'Child A' }), task({ run: null, status: 'ready', task_id: 'b', title: 'Child B' })], task_id: 'root', title: 'Ship feature' })]
+    expect(taskRows(normalizeKanbanActivity(payload(roots), NOW)).map(row => row.prefix)).toEqual(['│ ', '├── ', '│   ├── ', '│   └── ', '└── '])
+  })
+  it('uses blank continuation under a last child', () => {
+    const roots = [task({ children: [task({ children: [task({ task_id: 'g' })], task_id: 'a' })], task_id: 'root' })]
+    expect(taskRows(normalizeKanbanActivity(payload(roots), NOW)).map(row => row.prefix)).toEqual(['│ ', '└── ', '    └── '])
+  })
+  it('keeps a branch connector on the last visible child when siblings are omitted', () => {
+    const children = Array.from({ length: 3 }, (_, i) => task({ task_id: `child-${i}` }))
+    const rows = buildKanbanActivityRows(normalizeKanbanActivity(payload([task({ children, task_id: 'root' })]), NOW), { maxChildren: 2, now: NOW })
+    const prefixes = rows.filter(row => row.kind !== 'board').map(row => row.prefix)
+    expect(prefixes).toEqual(['│ ', '├── ', '├── ', '└── '])
+    expect(rows.at(-1)).toMatchObject({ kind: 'summary', label: '+1 more tasks' })
+  })
+  it('closes the linked-parent row when nothing follows it', () => {
+    const shared = task({ parents: ['parent-a', 'parent-b'], task_id: 'shared', title: 'Shared child' })
+    const model = normalizeKanbanActivity(payload([task({ children: [shared], task_id: 'parent-a', title: 'Parent A' }), task({ task_id: 'parent-b', title: 'Parent B' })]), NOW)
+    const linked = buildKanbanActivityRows(model, { now: NOW }).find(row => row.kind === 'summary')!
+    expect(linked.prefix).toBe('    └── ')
+  })
+  it('keeps a branch connector on the linked-parent row when children follow', () => {
+    const shared = task({ children: [task({ task_id: 'nested' })], parents: ['parent-a', 'parent-b'], task_id: 'shared', title: 'Shared child' })
+    const model = normalizeKanbanActivity(payload([task({ children: [shared], task_id: 'parent-a', title: 'Parent A' }), task({ task_id: 'parent-b', title: 'Parent B' })]), NOW)
+    const linked = buildKanbanActivityRows(model, { now: NOW }).find(row => row.kind === 'summary')!
+    expect(linked.prefix).toBe('    ├── ')
+  })
+  it('budgets labels from the exact prefix width', () => {
+    const long = 'A deliberately very long task title that cannot fit in a narrow spine'
+    const roots = [task({ children: [task({ task_id: 'child', title: long })], task_id: 'root', title: long })]
+
+    for (const row of taskRows(normalizeKanbanActivity(payload(roots), NOW), { width: 30 })) {
+      expect(stringWidth(`${row.prefix}${row.glyph} ${row.label}`)).toBeLessThanOrEqual(30)
+    }
+  })
+})
+
+describe('board rows', () => {
+  const erroredWire = () => { const wire = payload([task()]); wire.boards[0]!.error = 'db locked';
+
+ return wire }
+
+  const boardRow = (width: number) => buildKanbanActivityRows(normalizeKanbanActivity(erroredWire(), NOW), { now: NOW, width })[0]!
+
+  it('labels boards by bare name and flags per-board errors', () => {
+    expect(boardRow(120)).toMatchObject({ error: true, kind: 'board', label: 'default', suffix: ' · unavailable' })
+  })
+  it('never repeats the Kanban brand inside board headers', () => {
+    const wire: KanbanActivityResponse = { active_count: 0, attention_count: 0, boards: [{ board: 'alpha', checked_at: NOW, roots: [task({ task_id: 'a' })] }, { board: 'zeta', checked_at: NOW, roots: [task({ task_id: 'z' })] }], checked_at: NOW }
+    const boards = buildKanbanActivityRows(normalizeKanbanActivity(wire, NOW), { now: NOW }).filter(row => row.kind === 'board')
+    expect(boards.map(row => row.label)).toEqual(['alpha', 'zeta'])
+    expect(boards.map(row => row.suffix)).toEqual([null, null])
+  })
+  it('budgets the name and error suffix together at every width', () => {
+    expect(boardRow(20)).toMatchObject({ label: 'defau…', suffix: ' · unavailable' })
+
+    for (const width of [1, 2, 4, 8, 12, 16, 20, 40]) {
+      const row = boardRow(width)
+
+      expect(row.kind).toBe('board')
+
+      if (row.kind === 'board') {
+        expect(stringWidth(`${row.label}${row.suffix ?? ''}`)).toBeLessThanOrEqual(width)
+      }
+    }
+  })
+  it('keeps the error signal over identity at extreme widths', () => {
+    expect(boardRow(1)).toMatchObject({ label: '', suffix: '…' })
+    expect(boardRow(12)).toMatchObject({ label: '', suffix: 'unavailable' })
+    expect(boardRow(8)).toMatchObject({ label: '', suffix: 'unavail…' })
+  })
+})
+
+describe('resting dock ladder', () => {
+  const attentionModel = () => normalizeKanbanActivity(payload([task({ block_reason: 'review', run: null, status: 'blocked', task_id: 'blocked', title: 'Needs Henry' }), task({ task_id: 'active', title: 'Current work' })]), NOW)
+
+  it('uses plural copy and appends the headline state at wide widths', () => {
+    expect(collapsedActivityLabel(attentionModel(), 100, NOW)).toBe('Kanban · 1 need attention · 1 active · Needs Henry blocked')
+  })
+  it('ranks failed above blocked above stale for the headline', () => {
+    const stale = task({ run: { ...task().run!, last_heartbeat_at: NOW - 1000 }, task_id: 'stale', title: 'Long job' })
+    const failed = task({ run: { ...task().run!, ended_at: NOW, outcome: 'failed' }, status: 'done', task_id: 'failed', title: 'Tests' })
+    const model = normalizeKanbanActivity(payload([stale, failed]), NOW)
+    expect(collapsedActivityLabel(model, 100, NOW)).toContain('Tests failed')
+  })
+  it('falls back to counts instead of a headline fragment', () => {
+    const blockedTasks = Array.from({ length: 3 }, (_, i) => task({ block_reason: 'review', run: null, status: 'blocked', task_id: `blocked-${i}`, title: `Blocked task ${i}` }))
+    const model = normalizeKanbanActivity(payload([...blockedTasks, task({ task_id: 'active' })]), NOW)
+    expect(collapsedActivityLabel(model, 50, NOW)).toBe('Kanban · 3 need attention · 1 active')
+    expect(collapsedActivityLabel(model, 60, NOW).startsWith('Kanban · 3 need attention · 1 active · Blocked')).toBe(true)
+  })
+  it('never shows a zero-count badge and reports completed-only activity truthfully', () => {
+    const completedOnly = normalizeKanbanActivity(payload([task({ run: { ...task().run!, ended_at: NOW - 10, outcome: 'completed' }, status: 'done' })]), NOW)
+    expect(collapsedActivityLabel(completedOnly, 20, NOW)).toBe('K ●1')
+    expect(collapsedActivityLabel(completedOnly, 13, NOW)).toBe('●1')
+    expect(collapsedActivityLabel(completedOnly, 40, NOW)).toBe('Kanban · 1 completed')
+    expect(collapsedActivityLabel(completedOnly, 80, NOW)).toBe('Kanban · 1 completed · Implement the execution spine')
+
+    const attentionOnly = normalizeKanbanActivity(payload([task({ block_reason: 'review', run: null, status: 'blocked', task_id: 'blocked' })]), NOW)
+    expect(collapsedActivityLabel(attentionOnly, 20, NOW)).toBe('K !1')
+    expect(collapsedActivityLabel(attentionOnly, 13, NOW)).toBe('!1')
+  })
+  it('exposes narrow shorthand as tone-tagged segments', () => {
+    expect(collapsedActivitySegments(attentionModel(), 18, NOW)).toEqual([
+      { text: 'K', tone: 'neutral' },
+      { text: ' !1', tone: 'warning' },
+      { text: ' ◉1', tone: 'accent' }
+    ])
+    expect(collapsedActivitySegments(attentionModel(), 13, NOW)).toEqual([
+      { text: '!1', tone: 'warning' },
+      { text: '◉1', tone: 'accent' }
+    ])
+    const completedOnly = normalizeKanbanActivity(payload([task({ run: { ...task().run!, ended_at: NOW - 10, outcome: 'completed' }, status: 'done' })]), NOW)
+    expect(collapsedActivitySegments(completedOnly, 18, NOW)).toEqual([
+      { text: 'K', tone: 'neutral' },
+      { text: ' ●1', tone: 'success' }
+    ])
+    expect(collapsedActivitySegments(attentionModel(), 40, NOW)).toEqual([
+      { text: 'Kanban · ', tone: 'neutral' },
+      { text: '1', tone: 'warning' },
+      { text: ' need attention · ', tone: 'neutral' },
+      { text: '1', tone: 'accent' },
+      { text: ' active', tone: 'neutral' }
+    ])
+    expect(collapsedActivitySegments(completedOnly, 40, NOW)).toEqual([
+      { text: 'Kanban · ', tone: 'neutral' },
+      { text: '1', tone: 'success' },
+      { text: ' completed', tone: 'neutral' }
+    ])
+  })
+  it('speaks glyph shorthand at narrow widths without duplicate bangs', () => {
+    expect(collapsedActivityLabel(attentionModel(), 20, NOW)).toBe('K !1 ◉1')
+    expect(collapsedActivityLabel(attentionModel(), 13, NOW)).toBe('!1◉1')
+    const calm = normalizeKanbanActivity(payload([task()]), NOW)
+    expect(collapsedActivityLabel(calm, 20, NOW)).toBe('K ◉1')
+    expect(collapsedActivityLabel(calm, 13, NOW)).toBe('◉1')
   })
 })

--- a/ui-tui/src/__tests__/kanbanActivityDormant.test.ts
+++ b/ui-tui/src/__tests__/kanbanActivityDormant.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+const srcRoot = fileURLToPath(new URL('../', import.meta.url))
+const read = (relative: string) => readFileSync(new URL(relative, `file://${srcRoot}/`), 'utf8')
+describe('dormant Kanban activity slice', () => {
+  it('is not mounted, polled, or imported by live composition', () => {
+    for (const path of ['app/useMainApp.ts', 'components/appLayout.tsx', 'app/interfaces.ts']) {expect(read(path)).not.toMatch(/kanbanActivity|KanbanActivity|kanban\.activity/)}
+  })
+  it('does not import gateway, transcript, message, or session stores', () => {
+    expect([read('lib/kanbanActivity.ts'), read('components/kanbanActivity.tsx')].join('\n')).not.toMatch(/gatewayClient|historyItems|appendMessage|messageStore|sessionStore|uiStore/)
+  })
+})

--- a/ui-tui/src/__tests__/kanbanActivityRender.test.tsx
+++ b/ui-tui/src/__tests__/kanbanActivityRender.test.tsx
@@ -1,0 +1,255 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { KanbanActivityDock, KanbanExecutionSpine } from '../components/kanbanActivity.js'
+import type { KanbanActivityResponse, KanbanActivityTask } from '../gatewayTypes.js'
+import { normalizeKanbanActivity } from '../lib/kanbanActivity.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const NOW = 1_721_000_000
+
+function task(overrides: Partial<KanbanActivityTask> = {}): KanbanActivityTask {
+  return {
+    assignee: 'implementer',
+    block_reason: null,
+    children: [],
+    parents: [],
+    run: {
+      ended_at: null,
+      last_heartbeat_at: NOW - 5,
+      max_runtime_seconds: 3600,
+      outcome: null,
+      profile: 'implementer',
+      run_id: 1,
+      started_at: NOW - 50
+    },
+    status: 'running',
+    task_id: 'task',
+    title: 'Build execution spine',
+    ...overrides
+  }
+}
+
+function activity(boards: { board: string; roots: KanbanActivityTask[] }[]) {
+  const payload: KanbanActivityResponse = {
+    active_count: 0,
+    attention_count: 0,
+    boards: boards.map(board => ({ ...board, checked_at: NOW })),
+    checked_at: NOW
+  }
+
+  return normalizeKanbanActivity(payload, NOW)
+}
+
+function renderFrame(element: React.ReactElement, columns = 80): string {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+  Object.assign(stdout, { columns, isTTY: false, rows: 30 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(element, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return stripAnsi(output)
+    .split('\n')
+    .map(line => line.replace(/\s+$/, ''))
+    .filter(Boolean)
+    .join('\n')
+}
+
+describe('Kanban activity static Ink components', () => {
+  it('renders an active collapsed dock on exactly one line', () => {
+    const frame = renderFrame(
+      <KanbanActivityDock
+        activity={activity([{ board: 'default', roots: [task()] }])}
+        now={NOW}
+        t={DEFAULT_THEME}
+        width={70}
+      />
+    )
+
+    expect(frame.split('\n')).toHaveLength(1)
+    expect(frame).toContain('Kanban')
+    expect(frame).toContain('1 active')
+    expect(frame).toContain('Build execution spine')
+  })
+
+  it('renders branching children with legible connectors', () => {
+    const children = ['Research', 'Implement', 'Review'].map((title, index) =>
+      task({ status: index === 2 ? 'ready' : 'running', task_id: `child-${index}`, title })
+    )
+
+    const frame = renderFrame(
+      <KanbanExecutionSpine
+        activity={activity([{ board: 'default', roots: [task({ children, task_id: 'root', title: 'Ship feature' })] }])}
+        now={NOW}
+        t={DEFAULT_THEME}
+        width={70}
+      />
+    )
+
+    expect(frame).toContain('├──')
+    expect(frame).toContain('└──')
+    expect(frame).toContain('○ Review')
+  })
+
+  it('renders a completed/current/upcoming pipeline with heavy and light rails', () => {
+    const frame = renderFrame(
+      <KanbanExecutionSpine
+        activity={activity([
+          {
+            board: 'release',
+            roots: [
+              task({ status: 'done', task_id: 'plan', title: 'Plan' }),
+              task({ task_id: 'build', title: 'Build' }),
+              task({ status: 'ready', task_id: 'verify', title: 'Verify' })
+            ]
+          }
+        ])}
+        now={NOW}
+        t={DEFAULT_THEME}
+        width={70}
+      />
+    )
+
+    expect(frame).toMatch(/┃ ● Plan/)
+    expect(frame).toMatch(/│ ◉ Build/)
+    expect(frame).toMatch(/│ ○ Verify/)
+  })
+
+  it('renders blocked, stale, and failed states truthfully', () => {
+    const frame = renderFrame(
+      <KanbanExecutionSpine
+        activity={activity([
+          {
+            board: 'default',
+            roots: [
+              task({ block_reason: 'Human review required', status: 'blocked', task_id: 'blocked', title: 'Publish' }),
+              task({ run: { ...task().run!, last_heartbeat_at: NOW - 1000 }, task_id: 'stale', title: 'Long job' }),
+              task({
+                run: { ...task().run!, ended_at: NOW, outcome: 'failed' },
+                status: 'done',
+                task_id: 'failed',
+                title: 'Tests'
+              })
+            ]
+          }
+        ])}
+        now={NOW}
+        staleAfterSeconds={300}
+        t={DEFAULT_THEME}
+        width={80}
+      />
+    )
+
+    expect(frame).toContain('! Publish — implementer · blocked: Human review required')
+    expect(frame).toContain('! Long job — implementer · heartbeat stale')
+    expect(frame).toContain('× Tests — implementer · failed')
+    expect(frame).not.toMatch(/%|phase/i)
+  })
+
+  it('groups multiple boards deterministically and hides empty activity', () => {
+    const multi = renderFrame(
+      <KanbanExecutionSpine
+        activity={activity([
+          { board: 'zeta', roots: [task({ task_id: 'z', title: 'Z task' })] },
+          { board: 'alpha', roots: [task({ task_id: 'a', title: 'A task' })] }
+        ])}
+        now={NOW}
+        t={DEFAULT_THEME}
+        width={60}
+      />
+    )
+
+    expect(multi.indexOf('alpha')).toBeLessThan(multi.indexOf('zeta'))
+    expect(renderFrame(<KanbanExecutionSpine activity={activity([])} now={NOW} t={DEFAULT_THEME} width={60} />)).toBe(
+      ''
+    )
+    expect(renderFrame(<KanbanActivityDock activity={activity([])} now={NOW} t={DEFAULT_THEME} width={60} />)).toBe('')
+  })
+
+  it('hides backlog-only and expired-completion activity', () => {
+    const queued = activity([
+      {
+        board: 'default',
+        roots: [
+          task({ run: null, status: 'triage', task_id: 'triage' }),
+          task({ run: null, status: 'ready', task_id: 'ready' }),
+          task({ run: null, status: 'review', task_id: 'review' }),
+          task({ run: null, status: 'scheduled', task_id: 'scheduled' })
+        ]
+      }
+    ])
+
+    const expired = activity([
+      {
+        board: 'default',
+        roots: [task({ run: { ...task().run!, ended_at: NOW - 1000, outcome: 'completed' }, status: 'done' })]
+      }
+    ])
+
+    expect(renderFrame(<KanbanActivityDock activity={queued} now={NOW} t={DEFAULT_THEME} width={60} />)).toBe('')
+    expect(renderFrame(<KanbanExecutionSpine activity={queued} now={NOW} t={DEFAULT_THEME} width={60} />)).toBe('')
+    expect(renderFrame(<KanbanActivityDock activity={expired} now={NOW} t={DEFAULT_THEME} width={60} />)).toBe('')
+  })
+
+  it('progressively collapses the narrow dock without wrapping', () => {
+    const frame = renderFrame(
+      <KanbanActivityDock
+        activity={activity([
+          {
+            board: 'default',
+            roots: [task(), task({ block_reason: 'Review', status: 'blocked', task_id: 'blocked' })]
+          }
+        ])}
+        now={NOW}
+        t={DEFAULT_THEME}
+        width={18}
+      />,
+      18
+    )
+
+    expect(frame.split('\n')).toHaveLength(1)
+    expect(frame).toContain('!1')
+    expect(frame.length).toBeLessThanOrEqual(18)
+    expect(frame).not.toContain('task-')
+  })
+
+  it('compresses many children into a bounded summary row', () => {
+    const children = Array.from({ length: 9 }, (_, index) =>
+      task({ task_id: `child-${index}`, title: `Child ${index}` })
+    )
+
+    const frame = renderFrame(
+      <KanbanExecutionSpine
+        activity={activity([
+          { board: 'default', roots: [task({ children, task_id: 'root', title: 'Parallel work' })] }
+        ])}
+        maxChildren={3}
+        now={NOW}
+        t={DEFAULT_THEME}
+        width={70}
+      />
+    )
+
+    expect(frame).toContain('+6 more tasks')
+    expect(frame).not.toContain('Child 8')
+  })
+})

--- a/ui-tui/src/__tests__/kanbanActivityRender.test.tsx
+++ b/ui-tui/src/__tests__/kanbanActivityRender.test.tsx
@@ -1,12 +1,12 @@
 import { PassThrough } from 'stream'
 
-import { renderSync } from '@hermes/ink'
+import { renderSync, stringWidth, Text } from '@hermes/ink'
 import React from 'react'
 import { describe, expect, it } from 'vitest'
 
-import { KanbanActivityDock, KanbanExecutionSpine } from '../components/kanbanActivity.js'
+import { KanbanActivityDock, KanbanActivityRow, KanbanExecutionSpine } from '../components/kanbanActivity.js'
 import type { KanbanActivityResponse, KanbanActivityTask } from '../gatewayTypes.js'
-import { normalizeKanbanActivity } from '../lib/kanbanActivity.js'
+import { buildKanbanActivityRows, normalizeKanbanActivity } from '../lib/kanbanActivity.js'
 import { stripAnsi } from '../lib/text.js'
 import { DEFAULT_THEME } from '../theme.js'
 
@@ -34,7 +34,7 @@ function task(overrides: Partial<KanbanActivityTask> = {}): KanbanActivityTask {
   }
 }
 
-function activity(boards: { board: string; roots: KanbanActivityTask[] }[]) {
+function activity(boards: { board: string; error?: string; roots: KanbanActivityTask[] }[]) {
   const payload: KanbanActivityResponse = {
     active_count: 0,
     attention_count: 0,
@@ -45,17 +45,29 @@ function activity(boards: { board: string; roots: KanbanActivityTask[] }[]) {
   return normalizeKanbanActivity(payload, NOW)
 }
 
-function renderFrame(element: React.ReactElement, columns = 80): string {
+// Each stdout.write CALL from @hermes/ink is one complete frame (verified by
+// probing: non-TTY renders write the full frame per render pass, then a bare
+// newline on cleanup). Intercept the write method itself — stream 'data'
+// events may coalesce or split chunks, write-call boundaries cannot.
+function captureFrames(element: React.ReactElement, columns: number): string[] {
   const stdout = new PassThrough()
   const stdin = new PassThrough()
   const stderr = new PassThrough()
-  let output = ''
+  const frames: string[] = []
+  const originalWrite = stdout.write.bind(stdout)
+
+  stdout.write = ((
+    chunk: Buffer | string,
+    encoding?: ((error?: Error | null) => void) | BufferEncoding,
+    callback?: (error?: Error | null) => void
+  ): boolean => {
+    frames.push(chunk.toString())
+
+    return typeof encoding === 'function' ? originalWrite(chunk, encoding) : originalWrite(chunk, encoding, callback)
+  }) as typeof stdout.write
   Object.assign(stdout, { columns, isTTY: false, rows: 30 })
   Object.assign(stdin, { isTTY: false })
   Object.assign(stderr, { isTTY: false })
-  stdout.on('data', chunk => {
-    output += chunk.toString()
-  })
 
   const instance = renderSync(element, {
     patchConsole: false,
@@ -67,11 +79,59 @@ function renderFrame(element: React.ReactElement, columns = 80): string {
   instance.unmount()
   instance.cleanup()
 
-  return stripAnsi(output)
+  return frames
+}
+
+function renderFrame(element: React.ReactElement, columns = 80): string {
+  const lastFrame =
+    captureFrames(element, columns)
+      .map(frame => stripAnsi(frame))
+      .filter(frame => frame.trim().length > 0)
+      .at(-1) ?? ''
+
+  return lastFrame
     .split('\n')
     .map(line => line.replace(/\s+$/, ''))
     .filter(Boolean)
     .join('\n')
+}
+
+interface TextSegment {
+  color: string | undefined
+  dim: boolean
+  text: string
+}
+
+// The non-TTY test renderer strips all color/dim codes from output, so the
+// paint-channel contract is asserted on the element tree instead. These
+// components are hook-free, which makes their memo-wrapped render functions
+// directly callable.
+function renderElement<Props>(component: unknown, props: Props): React.ReactElement {
+  return (component as { type: (componentProps: Props) => React.ReactElement }).type(props)
+}
+
+function collectTextSegments(node: unknown, segments: TextSegment[] = []): TextSegment[] {
+  if (!React.isValidElement(node)) {
+    return segments
+  }
+
+  const props = node.props as { children?: React.ReactNode; color?: string; dim?: boolean }
+
+  if (node.type === Text) {
+    const text = React.Children.toArray(props.children)
+      .filter(child => typeof child === 'string' || typeof child === 'number')
+      .join('')
+
+    segments.push({ color: props.color, dim: Boolean(props.dim), text })
+
+    return segments
+  }
+
+  React.Children.forEach(props.children, child => {
+    collectTextSegments(child, segments)
+  })
+
+  return segments
 }
 
 describe('Kanban activity static Ink components', () => {
@@ -110,7 +170,33 @@ describe('Kanban activity static Ink components', () => {
     expect(frame).toContain('○ Review')
   })
 
-  it('renders a completed/current/upcoming pipeline with heavy and light rails', () => {
+  it('draws ancestor continuation rails at depth 2', () => {
+    const grandchildren = [
+      task({ task_id: 'g1', title: 'Grandchild 1' }),
+      task({ run: null, status: 'ready', task_id: 'g2', title: 'Grandchild 2' })
+    ]
+
+    const roots = [
+      task({
+        children: [
+          task({ children: grandchildren, task_id: 'a', title: 'Child A' }),
+          task({ run: null, status: 'ready', task_id: 'b', title: 'Child B' })
+        ],
+        task_id: 'root',
+        title: 'Ship feature'
+      })
+    ]
+
+    const frame = renderFrame(
+      <KanbanExecutionSpine activity={activity([{ board: 'default', roots }])} now={NOW} t={DEFAULT_THEME} width={70} />
+    )
+
+    expect(frame).toContain('│   ├── ◉ Grandchild 1')
+    expect(frame).toContain('│   └── ○ Grandchild 2')
+    expect(frame).toContain('└── ○ Child B')
+  })
+
+  it('renders a completed/current/upcoming pipeline on one light rail', () => {
     const frame = renderFrame(
       <KanbanExecutionSpine
         activity={activity([
@@ -129,9 +215,10 @@ describe('Kanban activity static Ink components', () => {
       />
     )
 
-    expect(frame).toMatch(/┃ ● Plan/)
+    expect(frame).toMatch(/│ ● Plan/)
     expect(frame).toMatch(/│ ◉ Build/)
     expect(frame).toMatch(/│ ○ Verify/)
+    expect(frame).not.toContain('┃')
   })
 
   it('renders blocked, stale, and failed states truthfully', () => {
@@ -165,6 +252,28 @@ describe('Kanban activity static Ink components', () => {
     expect(frame).not.toMatch(/%|phase/i)
   })
 
+  it('keeps the state label visible when width squeezes the row', () => {
+    const frame = renderFrame(
+      <KanbanExecutionSpine
+        activity={activity([
+          {
+            board: 'default',
+            roots: [
+              task({ block_reason: 'Needs Henry', run: null, status: 'blocked', task_id: 'visual', title: 'Visual approval' })
+            ]
+          }
+        ])}
+        now={NOW}
+        t={DEFAULT_THEME}
+        width={32}
+      />,
+      40
+    )
+
+    expect(frame).toContain('Visual approval · blocked')
+    expect(frame).not.toContain('implementer')
+  })
+
   it('groups multiple boards deterministically and hides empty activity', () => {
     const multi = renderFrame(
       <KanbanExecutionSpine
@@ -179,10 +288,24 @@ describe('Kanban activity static Ink components', () => {
     )
 
     expect(multi.indexOf('alpha')).toBeLessThan(multi.indexOf('zeta'))
+    expect(multi).not.toContain('Kanban ·')
     expect(renderFrame(<KanbanExecutionSpine activity={activity([])} now={NOW} t={DEFAULT_THEME} width={60} />)).toBe(
       ''
     )
     expect(renderFrame(<KanbanActivityDock activity={activity([])} now={NOW} t={DEFAULT_THEME} width={60} />)).toBe('')
+  })
+
+  it('marks an unavailable board in place', () => {
+    const frame = renderFrame(
+      <KanbanExecutionSpine
+        activity={activity([{ board: 'default', error: 'db locked', roots: [task()] }])}
+        now={NOW}
+        t={DEFAULT_THEME}
+        width={60}
+      />
+    )
+
+    expect(frame).toContain('default · unavailable')
   })
 
   it('hides backlog-only and expired-completion activity', () => {
@@ -210,7 +333,7 @@ describe('Kanban activity static Ink components', () => {
     expect(renderFrame(<KanbanActivityDock activity={expired} now={NOW} t={DEFAULT_THEME} width={60} />)).toBe('')
   })
 
-  it('progressively collapses the narrow dock without wrapping', () => {
+  it('speaks glyph shorthand in the narrow dock without a duplicate bang', () => {
     const frame = renderFrame(
       <KanbanActivityDock
         activity={activity([
@@ -226,10 +349,7 @@ describe('Kanban activity static Ink components', () => {
       18
     )
 
-    expect(frame.split('\n')).toHaveLength(1)
-    expect(frame).toContain('!1')
-    expect(frame.length).toBeLessThanOrEqual(18)
-    expect(frame).not.toContain('task-')
+    expect(frame).toBe('K !1 ◉1')
   })
 
   it('compresses many children into a bounded summary row', () => {
@@ -249,7 +369,191 @@ describe('Kanban activity static Ink components', () => {
       />
     )
 
-    expect(frame).toContain('+6 more tasks')
+    expect(frame).toContain('├── ◉ Child 2')
+    expect(frame).toContain('└── +6 more tasks')
     expect(frame).not.toContain('Child 8')
+  })
+
+  it('captures every line of a multi-row frame, including repeated labels', () => {
+    const frame = renderFrame(
+      <KanbanExecutionSpine
+        activity={activity([
+          {
+            board: 'default',
+            roots: [
+              task({
+                children: [task({ task_id: 'c1', title: 'Repeat' }), task({ task_id: 'c2', title: 'Repeat' })],
+                task_id: 'root'
+              })
+            ]
+          }
+        ])}
+        now={NOW}
+        t={DEFAULT_THEME}
+        width={70}
+      />
+    )
+
+    expect(frame).toBe(
+      [
+        '│ ◉ Build execution spine — implementer · running',
+        '├── ◉ Repeat — implementer · running',
+        '└── ◉ Repeat — implementer · running'
+      ].join('\n')
+    )
+  })
+
+  it('bounds the unavailable-board row at extreme widths', () => {
+    const frame = renderFrame(
+      <KanbanExecutionSpine
+        activity={activity([{ board: 'default', error: 'db locked', roots: [task()] }])}
+        now={NOW}
+        t={DEFAULT_THEME}
+        width={12}
+      />,
+      40
+    )
+
+    expect(frame).toContain('unavailable')
+    expect(frame).not.toContain('· unavailable')
+
+    for (const line of frame.split('\n')) {
+      expect(stringWidth(line)).toBeLessThanOrEqual(12)
+    }
+  })
+
+  it('reports completed-only recent activity truthfully in the narrow dock', () => {
+    const frame = renderFrame(
+      <KanbanActivityDock
+        activity={activity([
+          {
+            board: 'default',
+            roots: [task({ run: { ...task().run!, ended_at: NOW - 10, outcome: 'completed' }, status: 'done' })]
+          }
+        ])}
+        now={NOW}
+        t={DEFAULT_THEME}
+        width={18}
+      />,
+      18
+    )
+
+    expect(frame).toBe('K ●1')
+  })
+})
+
+describe('segment paint contract', () => {
+  const themedRows = (roots: KanbanActivityTask[], width = 60) =>
+    buildKanbanActivityRows(activity([{ board: 'default', roots }]), { now: NOW, width })
+
+  it('never dims or tints a task title, even on muted rows', () => {
+    const rows = themedRows([
+      task({ children: [task({ run: null, status: 'scheduled', task_id: 'c1', title: 'Scheduled thing' })], task_id: 'root' })
+    ])
+
+    const muted = rows.find(row => row.kind === 'task' && row.task.id === 'c1')!
+    const segments = collectTextSegments(renderElement(KanbanActivityRow, { row: muted, t: DEFAULT_THEME, width: 60 }))
+    const title = segments.find(segment => segment.text === 'Scheduled thing')
+
+    expect(title).toBeDefined()
+    expect(title!.dim).toBe(false)
+    expect(title!.color).toBeUndefined()
+
+    const state = segments.find(segment => segment.text === ' · scheduled')
+
+    expect(state!.color).toBe(DEFAULT_THEME.color.muted)
+    expect(state!.dim).toBe(false)
+  })
+
+  it('keeps warning color on the state word while the title stays default', () => {
+    const rows = themedRows([
+      task({ block_reason: 'Needs Henry', run: null, status: 'blocked', task_id: 'blocked', title: 'Visual approval' })
+    ])
+
+    const blocked = rows.find(row => row.kind === 'task')!
+    const segments = collectTextSegments(renderElement(KanbanActivityRow, { row: blocked, t: DEFAULT_THEME, width: 60 }))
+
+    expect(segments.find(segment => segment.text === 'Visual approval')!.color).toBeUndefined()
+    expect(segments.find(segment => segment.text.includes('blocked'))!.color).toBe(DEFAULT_THEME.color.warn)
+  })
+
+  it('splits the narrow dock into neutral, warning, and accent segments', () => {
+    const model = activity([
+      { board: 'default', roots: [task(), task({ block_reason: 'Review', status: 'blocked', task_id: 'blocked' })] }
+    ])
+
+    const segments = collectTextSegments(
+      renderElement(KanbanActivityDock, { activity: model, now: NOW, t: DEFAULT_THEME, width: 18 })
+    )
+
+    expect(segments.map(segment => ({ color: segment.color, text: segment.text }))).toEqual([
+      { color: undefined, text: 'K' },
+      { color: DEFAULT_THEME.color.warn, text: ' !1' },
+      { color: DEFAULT_THEME.color.accent, text: ' ◉1' }
+    ])
+  })
+
+  it('colors medium dock lamps and counts without tinting the copy', () => {
+    const model = activity([
+      { board: 'default', roots: [task(), task({ block_reason: 'Review', status: 'blocked', task_id: 'blocked' })] }
+    ])
+
+    const segments = collectTextSegments(
+      renderElement(KanbanActivityDock, { activity: model, now: NOW, t: DEFAULT_THEME, width: 40 })
+    )
+
+    expect(segments.map(segment => ({ color: segment.color, text: segment.text }))).toEqual([
+      { color: DEFAULT_THEME.color.warn, text: '! ' },
+      { color: undefined, text: 'Kanban · ' },
+      { color: DEFAULT_THEME.color.warn, text: '1' },
+      { color: undefined, text: ' need attention · ' },
+      { color: DEFAULT_THEME.color.accent, text: '1' },
+      { color: undefined, text: ' active' }
+    ])
+  })
+
+  it('applies dock ladder breakpoints to the full component width', () => {
+    const model = activity([{ board: 'default', roots: [task({ title: 'Current work' })] }])
+
+    for (const width of [28, 29]) {
+      const frame = renderFrame(
+        <KanbanActivityDock activity={model} now={NOW} t={DEFAULT_THEME} width={width} />,
+        width
+      )
+
+      expect(frame).toContain('Kanban · 1 active')
+      expect(frame).not.toContain('K ◉1')
+    }
+
+    const belowWide = renderFrame(
+      <KanbanActivityDock activity={model} now={NOW} t={DEFAULT_THEME} width={47} />,
+      47
+    )
+
+    expect(belowWide).toBe('◉ Kanban · 1 active')
+
+    for (const width of [48, 49]) {
+      const frame = renderFrame(
+        <KanbanActivityDock activity={model} now={NOW} t={DEFAULT_THEME} width={width} />,
+        width
+      )
+
+      expect(frame).toContain('Kanban · 1 active · Current work')
+    }
+  })
+
+  it('colors the completed-only narrow dock with the success tone', () => {
+    const model = activity([
+      { board: 'default', roots: [task({ run: { ...task().run!, ended_at: NOW - 10, outcome: 'completed' }, status: 'done' })] }
+    ])
+
+    const segments = collectTextSegments(
+      renderElement(KanbanActivityDock, { activity: model, now: NOW, t: DEFAULT_THEME, width: 18 })
+    )
+
+    expect(segments.map(segment => ({ color: segment.color, text: segment.text }))).toEqual([
+      { color: undefined, text: 'K' },
+      { color: DEFAULT_THEME.color.ok, text: ' ●1' }
+    ])
   })
 })

--- a/ui-tui/src/components/kanbanActivity.tsx
+++ b/ui-tui/src/components/kanbanActivity.tsx
@@ -1,0 +1,160 @@
+import { Box, Text } from '@hermes/ink'
+import { memo } from 'react'
+
+import {
+  aggregateKanbanActivity,
+  buildKanbanActivityRows,
+  collapsedActivityLabel,
+  type KanbanActivityModel,
+  type KanbanActivityRowModel
+} from '../lib/kanbanActivity.js'
+import type { Theme } from '../theme.js'
+
+function toneColor(t: Theme, row: KanbanActivityRowModel): string {
+  if (row.kind === 'board') {
+    return t.color.accent
+  }
+
+  if (row.tone === 'error') {
+    return t.color.error
+  }
+
+  if (row.tone === 'warning') {
+    return t.color.warn
+  }
+
+  if (row.tone === 'success') {
+    return t.color.ok
+  }
+
+  if (row.tone === 'accent') {
+    return t.color.accent
+  }
+
+  return t.color.muted
+}
+
+export const KanbanActivityRow = memo(function KanbanActivityRow({
+  row,
+  t,
+  width
+}: {
+  row: KanbanActivityRowModel
+  t: Theme
+  width: number
+}) {
+  if (row.kind === 'board') {
+    return (
+      <Text bold color={toneColor(t, row)} wrap="truncate">
+        Kanban · {row.label}
+      </Text>
+    )
+  }
+
+  if (row.kind === 'summary') {
+    const indent = '  '.repeat(Math.max(0, row.depth - 1))
+
+    return (
+      <Text color={toneColor(t, row)} dim wrap="truncate">
+        {indent}
+        {row.connector} {row.label}
+      </Text>
+    )
+  }
+
+  const color = toneColor(t, row)
+
+  const prefix =
+    row.depth === 0
+      ? `${row.rail} ${row.glyph} `
+      : `${'  '.repeat(Math.max(0, row.depth - 1))}${row.connector} ${row.glyph} `
+
+  return (
+    <Box width={Math.max(1, width)}>
+      <Text color={color} dim={row.tone === 'muted'} wrap="truncate">
+        {prefix}
+        {row.label}
+      </Text>
+    </Box>
+  )
+})
+
+export const KanbanActivityDock = memo(function KanbanActivityDock({
+  activity,
+  now = activity.checkedAt,
+  t,
+  width
+}: {
+  activity: KanbanActivityModel
+  now?: number
+  t: Theme
+  width: number
+}) {
+  const counts = aggregateKanbanActivity(activity, now)
+
+  if (!counts.active && !counts.attention && !counts.completed) {
+    return null
+  }
+
+  const label = collapsedActivityLabel(activity, Math.max(1, width - 2), now)
+  const prefix = counts.attention > 0 ? '! ' : counts.active > 0 ? '◉ ' : counts.completed > 0 ? '● ' : '○ '
+
+  const color =
+    counts.attention > 0
+      ? t.color.warn
+      : counts.active > 0
+        ? t.color.accent
+        : counts.completed > 0
+          ? t.color.ok
+          : t.color.muted
+
+  return (
+    <Box height={1} width={Math.max(1, width)}>
+      <Text color={color} wrap="truncate">
+        {prefix}
+        {label}
+      </Text>
+    </Box>
+  )
+})
+
+export const KanbanExecutionSpine = memo(function KanbanExecutionSpine({
+  activity,
+  maxChildren = 5,
+  now = activity.checkedAt,
+  staleAfterSeconds = 300,
+  t,
+  width
+}: {
+  activity: KanbanActivityModel
+  maxChildren?: number
+  now?: number
+  staleAfterSeconds?: number
+  t: Theme
+  width: number
+}) {
+  const counts = aggregateKanbanActivity(activity, now)
+
+  if (!counts.active && !counts.attention && !counts.completed) {
+    return null
+  }
+
+  const rows = buildKanbanActivityRows(activity, { maxChildren, now, staleAfterSeconds, width })
+
+  if (!rows.length) {
+    return null
+  }
+
+  return (
+    <Box flexDirection="column" width={Math.max(1, width)}>
+      {rows.map((row, index) => (
+        <KanbanActivityRow
+          key={`${row.board}:${row.kind}:${row.kind === 'task' ? row.task.id : index}`}
+          row={row}
+          t={t}
+          width={width}
+        />
+      ))}
+    </Box>
+  )
+})

--- a/ui-tui/src/components/kanbanActivity.tsx
+++ b/ui-tui/src/components/kanbanActivity.tsx
@@ -2,38 +2,43 @@ import { Box, Text } from '@hermes/ink'
 import { memo } from 'react'
 
 import {
+  type ActivityTone,
   aggregateKanbanActivity,
   buildKanbanActivityRows,
-  collapsedActivityLabel,
+  collapsedActivitySegments,
   type KanbanActivityModel,
   type KanbanActivityRowModel
 } from '../lib/kanbanActivity.js'
 import type { Theme } from '../theme.js'
 
-function toneColor(t: Theme, row: KanbanActivityRowModel): string {
-  if (row.kind === 'board') {
-    return t.color.accent
-  }
-
-  if (row.tone === 'error') {
+// Lifecycle tones only. 'neutral' (queued work) renders in the terminal's
+// default foreground so accent stays reserved for live activity.
+function toneColor(t: Theme, tone: ActivityTone): string | undefined {
+  if (tone === 'error') {
     return t.color.error
   }
 
-  if (row.tone === 'warning') {
+  if (tone === 'warning') {
     return t.color.warn
   }
 
-  if (row.tone === 'success') {
+  if (tone === 'success') {
     return t.color.ok
   }
 
-  if (row.tone === 'accent') {
+  if (tone === 'accent') {
     return t.color.accent
   }
 
-  return t.color.muted
+  if (tone === 'muted') {
+    return t.color.muted
+  }
+
+  return undefined
 }
 
+// Each signal paints its own channel: topology prefix muted, glyph and state
+// word in the lifecycle tone, title in the default foreground, owner dim.
 export const KanbanActivityRow = memo(function KanbanActivityRow({
   row,
   t,
@@ -45,36 +50,44 @@ export const KanbanActivityRow = memo(function KanbanActivityRow({
 }) {
   if (row.kind === 'board') {
     return (
-      <Text bold color={toneColor(t, row)} wrap="truncate">
-        Kanban · {row.label}
-      </Text>
+      <Box width={Math.max(1, width)}>
+        {row.label ? (
+          <Text bold wrap="truncate">
+            {row.label}
+          </Text>
+        ) : null}
+        {row.suffix === null ? null : (
+          <Text color={t.color.warn} wrap="truncate">
+            {row.suffix}
+          </Text>
+        )}
+      </Box>
     )
   }
 
   if (row.kind === 'summary') {
-    const indent = '  '.repeat(Math.max(0, row.depth - 1))
-
     return (
-      <Text color={toneColor(t, row)} dim wrap="truncate">
-        {indent}
-        {row.connector} {row.label}
+      <Text color={t.color.muted} dim wrap="truncate">
+        {row.prefix}
+        {row.label}
       </Text>
     )
   }
 
-  const color = toneColor(t, row)
-
-  const prefix =
-    row.depth === 0
-      ? `${row.rail} ${row.glyph} `
-      : `${'  '.repeat(Math.max(0, row.depth - 1))}${row.connector} ${row.glyph} `
+  const tone = toneColor(t, row.tone)
 
   return (
     <Box width={Math.max(1, width)}>
-      <Text color={color} dim={row.tone === 'muted'} wrap="truncate">
-        {prefix}
-        {row.label}
-      </Text>
+      <Text color={t.color.muted}>{row.prefix}</Text>
+      <Text color={tone}>{`${row.glyph} `}</Text>
+      {/* Title identity never changes: no tone, no dim, on every row kind. */}
+      <Text wrap="truncate">{row.parts.title}</Text>
+      {row.parts.owner === null ? null : (
+        <Text color={t.color.muted} dim>{` — ${row.parts.owner}`}</Text>
+      )}
+      {row.parts.state === null ? null : (
+        <Text color={tone}>{` · ${row.parts.state}`}</Text>
+      )}
     </Box>
   )
 })
@@ -96,8 +109,25 @@ export const KanbanActivityDock = memo(function KanbanActivityDock({
     return null
   }
 
-  const label = collapsedActivityLabel(activity, Math.max(1, width - 2), now)
-  const prefix = counts.attention > 0 ? '! ' : counts.active > 0 ? '◉ ' : counts.completed > 0 ? '● ' : '○ '
+  // Below the medium breakpoint the shorthand badges are the lamp: each
+  // segment carries its own tone ('K' neutral, '!N' warn, '◉N'/'●N' toned),
+  // so no separate prefix glyph is rendered.
+  if (width < 28) {
+    const segments = collapsedActivitySegments(activity, Math.max(1, width), now)
+
+    return (
+      <Box height={1} width={Math.max(1, width)}>
+        {segments.map((segment, index) => (
+          <Text color={toneColor(t, segment.tone)} key={`${segment.text}:${index}`} wrap="truncate">
+            {segment.text}
+          </Text>
+        ))}
+      </Box>
+    )
+  }
+
+  const glyph = counts.attention > 0 ? '!' : counts.active > 0 ? '◉' : '●'
+  const segments = collapsedActivitySegments(activity, Math.max(1, width - 2), now, width)
 
   const color =
     counts.attention > 0
@@ -110,10 +140,12 @@ export const KanbanActivityDock = memo(function KanbanActivityDock({
 
   return (
     <Box height={1} width={Math.max(1, width)}>
-      <Text color={color} wrap="truncate">
-        {prefix}
-        {label}
-      </Text>
+      <Text color={color}>{`${glyph} `}</Text>
+      {segments.map((segment, index) => (
+        <Text color={toneColor(t, segment.tone)} key={`${segment.text}:${index}`} wrap="truncate">
+          {segment.text}
+        </Text>
+      ))}
     </Box>
   )
 })

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -534,6 +534,57 @@ export interface RollbackRestoreResponse {
   success?: boolean
 }
 
+// ── Kanban activity ──────────────────────────────────────────────────
+
+export type KanbanTaskStatus =
+  | 'archived'
+  | 'blocked'
+  | 'done'
+  | 'ready'
+  | 'review'
+  | 'running'
+  | 'scheduled'
+  | 'todo'
+  | 'triage'
+export type KanbanRunOutcome = string
+
+export interface KanbanActivityRun {
+  ended_at: null | number
+  last_heartbeat_at: null | number
+  max_runtime_seconds: null | number
+  outcome: KanbanRunOutcome | null
+  profile: null | string
+  run_id: number
+  started_at: null | number
+}
+
+export interface KanbanActivityTask {
+  assignee: null | string
+  block_reason: null | string
+  children: KanbanActivityTask[]
+  parents: string[]
+  run: KanbanActivityRun | null
+  status: KanbanTaskStatus
+  task_id: string
+  title: string
+}
+
+export interface KanbanActivityBoard {
+  board: string
+  checked_at: number
+  error?: string
+  roots: KanbanActivityTask[]
+  truncated?: boolean
+}
+
+export interface KanbanActivityResponse {
+  active_count: number
+  attention_count: number
+  boards: KanbanActivityBoard[]
+  checked_at: number
+  diagnostics?: string[]
+}
+
 // ── Subagent events ──────────────────────────────────────────────────
 
 export interface SubagentEventPayload {
@@ -692,7 +743,13 @@ export type GatewayEvent =
       type: 'clarify.request'
     }
   | {
-      payload: { allow_permanent?: boolean; choices?: string[]; command: string; description: string; smart_denied?: boolean }
+      payload: {
+        allow_permanent?: boolean
+        choices?: string[]
+        command: string
+        description: string
+        smart_denied?: boolean
+      }
       session_id?: string
       type: 'approval.request'
     }

--- a/ui-tui/src/lib/kanbanActivity.ts
+++ b/ui-tui/src/lib/kanbanActivity.ts
@@ -1,0 +1,571 @@
+import { stringWidth } from '@hermes/ink'
+
+import type {
+  KanbanActivityBoard,
+  KanbanActivityResponse,
+  KanbanActivityRun,
+  KanbanActivityTask,
+  KanbanRunOutcome,
+  KanbanTaskStatus
+} from '../gatewayTypes.js'
+
+export type ActivityTone = 'accent' | 'error' | 'muted' | 'success' | 'warning'
+export type HeartbeatFreshness = 'fresh' | 'missing' | 'not-applicable' | 'stale'
+
+export interface ActivityRun {
+  endedAt: null | number
+  lastHeartbeatAt: null | number
+  maxRuntimeSeconds: null | number
+  outcome: KanbanRunOutcome | null
+  profile: null | string
+  runId: null | number
+  startedAt: null | number
+}
+
+export interface ActivityTask {
+  assignee: null | string
+  blockReason: null | string
+  children: ActivityTask[]
+  id: string
+  parents: string[]
+  run: ActivityRun | null
+  status: KanbanTaskStatus
+  title: string
+}
+
+export interface ActivityBoard {
+  checkedAt: number
+  error: null | string
+  name: string
+  roots: ActivityTask[]
+  truncated: boolean
+}
+
+export interface KanbanActivityModel {
+  boards: ActivityBoard[]
+  checkedAt: number
+  diagnostics: string[]
+}
+
+export interface ActivityCounts {
+  active: number
+  attention: number
+  completed: number
+  queued: number
+  total: number
+}
+
+export interface ActivityTaskRow {
+  board: string
+  connector: '' | '├──' | '└──'
+  depth: number
+  glyph: '!' | '×' | '○' | '●' | '◉'
+  kind: 'task'
+  label: string
+  rail: '┃' | '│'
+  stateLabel: string
+  task: ActivityTask
+  tone: ActivityTone
+}
+
+export interface ActivityBoardRow {
+  board: string
+  kind: 'board'
+  label: string
+}
+
+export interface ActivitySummaryRow {
+  board: string
+  connector: '├──' | '└──'
+  depth: number
+  kind: 'summary'
+  label: string
+  tone: 'muted'
+}
+
+export type KanbanActivityRowModel = ActivityBoardRow | ActivitySummaryRow | ActivityTaskRow
+
+const STATUSES = new Set<KanbanTaskStatus>([
+  'archived',
+  'blocked',
+  'done',
+  'ready',
+  'review',
+  'running',
+  'scheduled',
+  'todo',
+  'triage'
+])
+
+const FAILED_OUTCOMES = new Set(['crashed', 'failed', 'gave_up', 'spawn_failed', 'stopped', 'timed_out'])
+const DEFAULT_STALE_SECONDS = 300
+const DEFAULT_COMPLETION_LINGER_SECONDS = 300
+const MAX_DEPTH = 32
+const MAX_TASKS = 1000
+
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : null
+}
+
+function finiteNumber(value: unknown, fallback: null | number = null): null | number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function cleanText(value: unknown, fallback = '', max = 160): string {
+  const cleaned = typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : ''
+
+  return (cleaned || fallback).slice(0, max)
+}
+
+function normalizeRun(value: unknown): ActivityRun | null {
+  const raw = record(value)
+
+  if (!raw) {
+    return null
+  }
+
+  const runId = finiteNumber(raw.run_id)
+
+  return {
+    endedAt: finiteNumber(raw.ended_at),
+    lastHeartbeatAt: finiteNumber(raw.last_heartbeat_at),
+    maxRuntimeSeconds: finiteNumber(raw.max_runtime_seconds),
+    outcome: cleanText(raw.outcome, '', 40) || null,
+    profile: cleanText(raw.profile, '', 80) || null,
+    runId,
+    startedAt: finiteNumber(raw.started_at)
+  }
+}
+
+
+export function normalizeKanbanActivity(payload: unknown, now = Date.now() / 1000): KanbanActivityModel {
+  const raw = record(payload)
+  const diagnostics: string[] = []
+  let visited = 0
+
+  const normalizeTask = (
+    value: unknown,
+    pathIds: ReadonlySet<string>,
+    pathObjects: ReadonlySet<object>,
+    depth: number
+  ): ActivityTask | null => {
+    const rawTask = record(value)
+
+    if (!rawTask) {
+      diagnostics.push('malformed-task')
+
+      return null
+    }
+
+    const id = cleanText(rawTask.task_id, '', 128)
+
+    if (!id) {
+      diagnostics.push('missing-task-id')
+
+      return null
+    }
+
+    if (pathIds.has(id) || pathObjects.has(rawTask)) {
+      diagnostics.push(`cycle:${id}`)
+
+      return null
+    }
+
+    if (depth > MAX_DEPTH || visited >= MAX_TASKS) {
+      diagnostics.push('task-limit')
+
+      return null
+    }
+
+    visited += 1
+    const status = STATUSES.has(rawTask.status as KanbanTaskStatus) ? (rawTask.status as KanbanTaskStatus) : 'todo'
+
+    if (status !== rawTask.status) {
+      diagnostics.push(`invalid-status:${id}`)
+    }
+
+    const nextIds = new Set(pathIds).add(id)
+    const nextObjects = new Set(pathObjects).add(rawTask)
+    const rawChildren = Array.isArray(rawTask.children) ? rawTask.children : []
+
+    if (rawTask.children !== undefined && !Array.isArray(rawTask.children)) {
+      diagnostics.push(`malformed-children:${id}`)
+    }
+
+    const children = rawChildren
+      .map(child => normalizeTask(child, nextIds, nextObjects, depth + 1))
+      .filter((child): child is ActivityTask => child !== null)
+
+    return {
+      assignee: cleanText(rawTask.assignee, '', 80) || null,
+      blockReason: cleanText(rawTask.block_reason, '', 120) || null,
+      children,
+      id,
+      parents: Array.isArray(rawTask.parents)
+        ? rawTask.parents
+            .map(parent => cleanText(parent, '', 128))
+            .filter(Boolean)
+            .sort()
+        : [],
+      run: normalizeRun(rawTask.run),
+      status,
+      title: cleanText(rawTask.title, 'Untitled task', 160)
+    }
+  }
+
+  const boardsSource = Array.isArray(raw?.boards) ? raw.boards : []
+
+  const boards = boardsSource
+    .map((value, index): ActivityBoard | null => {
+      const rawBoard = record(value)
+
+      if (!rawBoard) {
+        diagnostics.push(`malformed-board:${index}`)
+
+        return null
+      }
+
+      const name = cleanText(rawBoard.board, `board-${index}`, 80)
+
+      const roots = (Array.isArray(rawBoard.roots) ? rawBoard.roots : [])
+        .map(root => normalizeTask(root, new Set(), new Set(), 0))
+        .filter((root): root is ActivityTask => root !== null)
+
+      return {
+        checkedAt: finiteNumber(rawBoard.checked_at, now) ?? now,
+        error: cleanText(rawBoard.error, '', 160) || null,
+        name,
+        roots,
+        truncated: rawBoard.truncated === true
+      }
+    })
+    .filter((board): board is ActivityBoard => board !== null)
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  return {
+    boards,
+    checkedAt: finiteNumber(raw?.checked_at, now) ?? now,
+    diagnostics: [
+      ...new Set([
+        ...(Array.isArray(raw?.diagnostics) ? raw.diagnostics.map(item => cleanText(item)).filter(Boolean) : []),
+        ...diagnostics
+      ])
+    ]
+  }
+}
+
+export function heartbeatFreshness(
+  task: ActivityTask,
+  now: number,
+  staleAfterSeconds = DEFAULT_STALE_SECONDS
+): HeartbeatFreshness {
+  if (task.status !== 'running' || (task.run?.endedAt !== null && task.run?.endedAt !== undefined)) {
+    return 'not-applicable'
+  }
+
+  if (!task.run || task.run.lastHeartbeatAt === null) {
+    return 'missing'
+  }
+
+  return now - task.run.lastHeartbeatAt > staleAfterSeconds ? 'stale' : 'fresh'
+}
+
+function isFailed(task: ActivityTask): boolean {
+  return Boolean(task.run?.outcome && FAILED_OUTCOMES.has(task.run.outcome))
+}
+
+export function activityPresentation(
+  task: ActivityTask,
+  now: number,
+  staleAfterSeconds = DEFAULT_STALE_SECONDS
+): Pick<ActivityTaskRow, 'glyph' | 'rail' | 'stateLabel' | 'tone'> {
+  if (isFailed(task)) {
+    return { glyph: '×', rail: '┃', stateLabel: task.run!.outcome!, tone: 'error' }
+  }
+
+  if (task.status === 'blocked') {
+    const reason = task.blockReason ? `blocked: ${task.blockReason}` : 'blocked'
+
+    return { glyph: '!', rail: '│', stateLabel: reason, tone: 'warning' }
+  }
+
+  if (task.status === 'triage') {
+    return { glyph: '○', rail: '│', stateLabel: 'triage', tone: 'muted' }
+  }
+
+  if (task.status === 'running') {
+    const freshness = heartbeatFreshness(task, now, staleAfterSeconds)
+
+    if (freshness === 'stale') {
+      return { glyph: '!', rail: '│', stateLabel: 'heartbeat stale', tone: 'warning' }
+    }
+
+    if (freshness === 'missing') {
+      return { glyph: '!', rail: '│', stateLabel: 'heartbeat unavailable', tone: 'warning' }
+    }
+
+    return { glyph: '◉', rail: '│', stateLabel: 'running', tone: 'accent' }
+  }
+
+  if (task.status === 'review') {
+    return { glyph: '○', rail: '│', stateLabel: 'review queued', tone: 'accent' }
+  }
+
+  if (task.status === 'scheduled') {
+    return { glyph: '○', rail: '│', stateLabel: 'scheduled', tone: 'muted' }
+  }
+
+  if (task.status === 'ready') {
+    return { glyph: '○', rail: '│', stateLabel: 'ready', tone: 'accent' }
+  }
+
+  if (task.status === 'done') {
+    return { glyph: '●', rail: '┃', stateLabel: 'completed', tone: 'success' }
+  }
+
+  if (task.status === 'archived') {
+    return { glyph: '●', rail: '┃', stateLabel: 'archived', tone: 'muted' }
+  }
+
+  return { glyph: '○', rail: '│', stateLabel: task.status, tone: 'muted' }
+}
+
+function isRecentTerminal(task: ActivityTask, now: number, lingerSeconds: number): boolean {
+  const endedAt = task.run?.endedAt
+
+  return endedAt !== null && endedAt !== undefined && now - endedAt >= 0 && now - endedAt <= lingerSeconds
+}
+
+function needsAttention(
+  task: ActivityTask,
+  now: number,
+  staleAfterSeconds: number,
+  completionLingerSeconds: number
+): boolean {
+  if (task.status === 'blocked') {
+    return true
+  }
+
+  const freshness = heartbeatFreshness(task, now, staleAfterSeconds)
+
+  return freshness === 'missing' || freshness === 'stale' || (isFailed(task) && isRecentTerminal(task, now, completionLingerSeconds))
+}
+
+export function aggregateKanbanActivity(
+  model: KanbanActivityModel,
+  now = model.checkedAt,
+  staleAfterSeconds = DEFAULT_STALE_SECONDS,
+  completionLingerSeconds = DEFAULT_COMPLETION_LINGER_SECONDS
+): ActivityCounts {
+  const counts: ActivityCounts = { active: 0, attention: 0, completed: 0, queued: 0, total: 0 }
+
+  const walk = (tasks: readonly ActivityTask[]) => {
+    for (const task of tasks) {
+      counts.total += 1
+
+      if (task.status === 'running' && !isFailed(task)) {
+        counts.active += 1
+      }
+
+      if (needsAttention(task, now, staleAfterSeconds, completionLingerSeconds)) {
+        counts.attention += 1
+      }
+
+      if (
+        (task.status === 'done' || task.status === 'archived') &&
+        !isFailed(task) &&
+        isRecentTerminal(task, now, completionLingerSeconds)
+      ) {
+        counts.completed += 1
+      }
+
+      if (['ready', 'review', 'scheduled', 'todo', 'triage'].includes(task.status)) {
+        counts.queued += 1
+      }
+
+      walk(task.children)
+    }
+  }
+
+  for (const board of model.boards) {
+    if (board.error) {
+      counts.attention += 1
+    }
+
+    walk(board.roots)
+  }
+
+  return counts
+}
+
+export function truncateActivityLabel(value: string, width: number): string {
+  const clean = value.replace(/\s+/g, ' ').trim()
+
+  if (width <= 0) {
+    return ''
+  }
+
+  if (stringWidth(clean) <= width) {
+    return clean
+  }
+
+  if (width === 1) {
+    return '…'
+  }
+
+  const chars = Array.from(clean)
+
+  while (chars.length && stringWidth(chars.join('')) > width - 1) {
+    chars.pop()
+  }
+
+  return `${chars.join('')}…`
+}
+
+export function focusedActivityLabel(
+  task: ActivityTask,
+  width: number,
+  now: number,
+  staleAfterSeconds = DEFAULT_STALE_SECONDS
+): string {
+  const { stateLabel } = activityPresentation(task, now, staleAfterSeconds)
+  const owner = task.assignee ?? task.run?.profile ?? 'unassigned'
+
+  return truncateActivityLabel(`${task.title} — ${owner} · ${stateLabel}`, width)
+}
+
+export function collapsedActivityLabel(model: KanbanActivityModel, width: number, now = model.checkedAt): string {
+  const counts = aggregateKanbanActivity(model, now)
+
+  if (!counts.total && !counts.attention) {
+    return truncateActivityLabel('Kanban · idle', width)
+  }
+
+  const lead = counts.attention
+    ? `${counts.attention} needs attention · ${counts.active} active`
+    : `${counts.active} active`
+
+  const tasks: ActivityTask[] = []
+
+  const collect = (nodes: readonly ActivityTask[]) => {
+    for (const task of nodes) {
+      tasks.push(task)
+      collect(task.children)
+    }
+  }
+
+  model.boards.forEach(board => collect(board.roots))
+
+  const headline =
+    tasks.find(task => needsAttention(task, now, DEFAULT_STALE_SECONDS, DEFAULT_COMPLETION_LINGER_SECONDS)) ??
+    tasks.find(task => task.status === 'running') ??
+    tasks.find(task => isRecentTerminal(task, now, DEFAULT_COMPLETION_LINGER_SECONDS)) ??
+    tasks[0]
+
+  const wide = headline ? `Kanban · ${lead} · ${headline.title}` : `Kanban · ${lead}`
+  const medium = `Kanban · ${lead}`
+  const narrow = counts.attention ? `K · !${counts.attention} · A${counts.active}` : `K · ${counts.active} active`
+  const tiny = counts.attention ? `K !${counts.attention} A${counts.active}` : `K ${counts.active}`
+  const source = width >= 48 ? wide : width >= 28 ? medium : width >= 14 ? narrow : tiny
+
+  return truncateActivityLabel(source, width)
+}
+
+export function branchChildren<T>(children: readonly T[], visibleLimit = 5): { omitted: number; visible: T[] } {
+  const limit = Math.max(0, Math.floor(visibleLimit))
+
+  return { omitted: Math.max(0, children.length - limit), visible: children.slice(0, limit) }
+}
+
+export function buildKanbanActivityRows(
+  model: KanbanActivityModel,
+  options: { maxChildren?: number; now?: number; staleAfterSeconds?: number; width?: number } = {}
+): KanbanActivityRowModel[] {
+  const rows: KanbanActivityRowModel[] = []
+  const now = options.now ?? model.checkedAt
+  const staleAfterSeconds = options.staleAfterSeconds ?? DEFAULT_STALE_SECONDS
+  const maxChildren = options.maxChildren ?? 5
+  const width = options.width ?? 120
+  const showBoards = model.boards.length > 1
+  const taskTitles = new Map<string, string>()
+
+  const indexTasks = (tasks: readonly ActivityTask[]) => {
+    for (const task of tasks) {
+      taskTitles.set(task.id, task.title)
+      indexTasks(task.children)
+    }
+  }
+
+  model.boards.forEach(board => indexTasks(board.roots))
+
+  const walk = (board: string, tasks: readonly ActivityTask[], depth: number, parentId: null | string = null) => {
+    tasks.forEach((task, index) => {
+      const presentation = activityPresentation(task, now, staleAfterSeconds)
+      const connector = depth === 0 ? '' : index === tasks.length - 1 ? '└──' : '├──'
+      const prefixWidth = 2 + (depth > 0 ? depth * 2 + 4 : 0)
+      rows.push({
+        board,
+        connector,
+        depth,
+        ...presentation,
+        kind: 'task',
+        label: focusedActivityLabel(task, Math.max(1, width - prefixWidth), now, staleAfterSeconds),
+        task
+      })
+
+      for (const linkedParent of task.parents.filter(id => id !== parentId)) {
+        rows.push({
+          board,
+          connector: '├──',
+          depth: depth + 1,
+          kind: 'summary',
+          label: `↳ also linked from ${taskTitles.get(linkedParent) ?? linkedParent}`,
+          tone: 'muted'
+        })
+      }
+
+      const { omitted, visible } = branchChildren(task.children, maxChildren)
+      walk(board, visible, depth + 1, task.id)
+
+      if (omitted) {
+        rows.push({
+          board,
+          connector: '└──',
+          depth: depth + 1,
+          kind: 'summary',
+          label: `+${omitted} more tasks`,
+          tone: 'muted'
+        })
+      }
+    })
+  }
+
+  for (const board of model.boards) {
+    if (showBoards || board.error) {
+      rows.push({ board: board.name, kind: 'board', label: board.error ? `${board.name} · unavailable` : board.name })
+    }
+
+    walk(board.name, board.roots, 0)
+
+    if (board.truncated) {
+      rows.push({
+        board: board.name,
+        connector: '└──',
+        depth: 0,
+        kind: 'summary',
+        label: '+ more activity not shown',
+        tone: 'muted'
+      })
+    }
+  }
+
+  return rows
+}
+
+// Compile-time alignment checks for the wire contract. These are intentionally
+// dormant: no gateway request or live TUI import is introduced here.
+export type KanbanActivityWireContract = KanbanActivityResponse
+export type KanbanActivityBoardWireContract = KanbanActivityBoard
+export type KanbanActivityTaskWireContract = KanbanActivityTask
+export type KanbanActivityRunWireContract = KanbanActivityRun

--- a/ui-tui/src/lib/kanbanActivity.ts
+++ b/ui-tui/src/lib/kanbanActivity.ts
@@ -9,7 +9,7 @@ import type {
   KanbanTaskStatus
 } from '../gatewayTypes.js'
 
-export type ActivityTone = 'accent' | 'error' | 'muted' | 'success' | 'warning'
+export type ActivityTone = 'accent' | 'error' | 'muted' | 'neutral' | 'success' | 'warning'
 export type HeartbeatFreshness = 'fresh' | 'missing' | 'not-applicable' | 'stale'
 
 export interface ActivityRun {
@@ -55,31 +55,43 @@ export interface ActivityCounts {
   total: number
 }
 
+// Truncation-aware label segments. `title` renders in the default foreground,
+// `owner` dim, and `state` in the row tone — the segments exist so the
+// component can paint each signal on its own channel.
+export interface ActivityLabelParts {
+  owner: null | string
+  state: null | string
+  title: string
+}
+
 export interface ActivityTaskRow {
   board: string
-  connector: '' | '├──' | '└──'
   depth: number
   glyph: '!' | '×' | '○' | '●' | '◉'
   kind: 'task'
   label: string
-  rail: '┃' | '│'
+  parts: ActivityLabelParts
+  prefix: string
   stateLabel: string
   task: ActivityTask
   tone: ActivityTone
 }
 
+// `label` is the width-budgeted board name (possibly empty at extreme widths)
+// and `suffix` the warn-toned error marker; together they always fit `width`.
 export interface ActivityBoardRow {
   board: string
+  error: boolean
   kind: 'board'
   label: string
+  suffix: null | string
 }
 
 export interface ActivitySummaryRow {
   board: string
-  connector: '├──' | '└──'
-  depth: number
   kind: 'summary'
   label: string
+  prefix: string
   tone: 'muted'
 }
 
@@ -275,60 +287,63 @@ function isFailed(task: ActivityTask): boolean {
   return Boolean(task.run?.outcome && FAILED_OUTCOMES.has(task.run.outcome))
 }
 
+// Lifecycle channel only: glyph + state word + tone. Topology (the rail) is
+// built separately and stays muted, and accent is reserved for live work —
+// queued states (ready/review) render neutral so triage reads at a glance.
 export function activityPresentation(
   task: ActivityTask,
   now: number,
   staleAfterSeconds = DEFAULT_STALE_SECONDS
-): Pick<ActivityTaskRow, 'glyph' | 'rail' | 'stateLabel' | 'tone'> {
+): Pick<ActivityTaskRow, 'glyph' | 'stateLabel' | 'tone'> {
   if (isFailed(task)) {
-    return { glyph: '×', rail: '┃', stateLabel: task.run!.outcome!, tone: 'error' }
+    return { glyph: '×', stateLabel: task.run!.outcome!, tone: 'error' }
   }
 
   if (task.status === 'blocked') {
     const reason = task.blockReason ? `blocked: ${task.blockReason}` : 'blocked'
 
-    return { glyph: '!', rail: '│', stateLabel: reason, tone: 'warning' }
+    return { glyph: '!', stateLabel: reason, tone: 'warning' }
   }
 
   if (task.status === 'triage') {
-    return { glyph: '○', rail: '│', stateLabel: 'triage', tone: 'muted' }
+    return { glyph: '○', stateLabel: 'triage', tone: 'muted' }
   }
 
   if (task.status === 'running') {
     const freshness = heartbeatFreshness(task, now, staleAfterSeconds)
 
     if (freshness === 'stale') {
-      return { glyph: '!', rail: '│', stateLabel: 'heartbeat stale', tone: 'warning' }
+      return { glyph: '!', stateLabel: 'heartbeat stale', tone: 'warning' }
     }
 
     if (freshness === 'missing') {
-      return { glyph: '!', rail: '│', stateLabel: 'heartbeat unavailable', tone: 'warning' }
+      return { glyph: '!', stateLabel: 'heartbeat unavailable', tone: 'warning' }
     }
 
-    return { glyph: '◉', rail: '│', stateLabel: 'running', tone: 'accent' }
+    return { glyph: '◉', stateLabel: 'running', tone: 'accent' }
   }
 
   if (task.status === 'review') {
-    return { glyph: '○', rail: '│', stateLabel: 'review queued', tone: 'accent' }
+    return { glyph: '○', stateLabel: 'review queued', tone: 'neutral' }
   }
 
   if (task.status === 'scheduled') {
-    return { glyph: '○', rail: '│', stateLabel: 'scheduled', tone: 'muted' }
+    return { glyph: '○', stateLabel: 'scheduled', tone: 'muted' }
   }
 
   if (task.status === 'ready') {
-    return { glyph: '○', rail: '│', stateLabel: 'ready', tone: 'accent' }
+    return { glyph: '○', stateLabel: 'ready', tone: 'neutral' }
   }
 
   if (task.status === 'done') {
-    return { glyph: '●', rail: '┃', stateLabel: 'completed', tone: 'success' }
+    return { glyph: '●', stateLabel: 'completed', tone: 'success' }
   }
 
   if (task.status === 'archived') {
-    return { glyph: '●', rail: '┃', stateLabel: 'archived', tone: 'muted' }
+    return { glyph: '●', stateLabel: 'archived', tone: 'muted' }
   }
 
-  return { glyph: '○', rail: '│', stateLabel: task.status, tone: 'muted' }
+  return { glyph: '○', stateLabel: task.status, tone: 'muted' }
 }
 
 function isRecentTerminal(task: ActivityTask, now: number, lingerSeconds: number): boolean {
@@ -423,28 +438,236 @@ export function truncateActivityLabel(value: string, width: number): string {
   return `${chars.join('')}…`
 }
 
+const MIN_TITLE_WIDTH = 8
+
+function shortActivityState(task: ActivityTask, now: number, staleAfterSeconds = DEFAULT_STALE_SECONDS): string {
+  return task.status === 'blocked' ? 'blocked' : activityPresentation(task, now, staleAfterSeconds).stateLabel
+}
+
+export function joinActivityLabelParts(parts: ActivityLabelParts): string {
+  const owner = parts.owner === null ? '' : ` — ${parts.owner}`
+  const state = parts.state === null ? '' : ` · ${parts.state}`
+
+  return `${parts.title}${owner}${state}`
+}
+
+// Truncation drops the least important signal first: blocked-reason detail,
+// then the owner, then title characters. The state word goes last — the glyph
+// and tone still encode it, but the word is the primary carrier.
+export function composeActivityLabel(
+  task: ActivityTask,
+  width: number,
+  now: number,
+  staleAfterSeconds = DEFAULT_STALE_SECONDS
+): ActivityLabelParts {
+  const { stateLabel } = activityPresentation(task, now, staleAfterSeconds)
+  const owner = task.assignee ?? task.run?.profile ?? null
+  const shortState = shortActivityState(task, now, staleAfterSeconds)
+
+  const candidates: ActivityLabelParts[] = [
+    { owner, state: stateLabel, title: task.title },
+    { owner, state: shortState, title: task.title },
+    { owner: null, state: shortState, title: task.title }
+  ]
+
+  for (const candidate of candidates) {
+    if (stringWidth(joinActivityLabelParts(candidate)) <= width) {
+      return candidate
+    }
+  }
+
+  const titleWidth = width - stringWidth(` · ${shortState}`)
+
+  if (titleWidth >= MIN_TITLE_WIDTH) {
+    return { owner: null, state: shortState, title: truncateActivityLabel(task.title, titleWidth) }
+  }
+
+  return { owner: null, state: null, title: truncateActivityLabel(task.title, width) }
+}
+
 export function focusedActivityLabel(
   task: ActivityTask,
   width: number,
   now: number,
   staleAfterSeconds = DEFAULT_STALE_SECONDS
 ): string {
-  const { stateLabel } = activityPresentation(task, now, staleAfterSeconds)
-  const owner = task.assignee ?? task.run?.profile ?? 'unassigned'
-
-  return truncateActivityLabel(`${task.title} — ${owner} · ${stateLabel}`, width)
+  return joinActivityLabelParts(composeActivityLabel(task, width, now, staleAfterSeconds))
 }
 
-export function collapsedActivityLabel(model: KanbanActivityModel, width: number, now = model.checkedAt): string {
+const MIN_HEADLINE_WIDTH = 12
+
+export interface ActivityDockSegment {
+  text: string
+  tone: ActivityTone
+}
+
+function segmentDockCounts(label: string, counts: ActivityCounts): ActivityDockSegment[] {
+  const markers: ActivityDockSegment[] = counts.attention
+    ? [
+        { text: String(counts.attention), tone: 'warning' },
+        { text: String(counts.active), tone: 'accent' }
+      ]
+    : counts.active
+      ? [{ text: String(counts.active), tone: 'accent' }]
+      : [{ text: String(counts.completed), tone: 'success' }]
+
+  const segments: ActivityDockSegment[] = []
+  let cursor = 0
+
+  const push = (text: string, tone: ActivityTone) => {
+    if (!text) {
+      return
+    }
+
+    const previous = segments.at(-1)
+
+    if (previous?.tone === tone) {
+      previous.text += text
+    } else {
+      segments.push({ text, tone })
+    }
+  }
+
+  for (const marker of markers) {
+    const index = label.indexOf(marker.text, cursor)
+
+    if (index < 0) {
+      continue
+    }
+
+    push(label.slice(cursor, index), 'neutral')
+    push(marker.text, marker.tone)
+    cursor = index + marker.text.length
+  }
+
+  push(label.slice(cursor), 'neutral')
+
+  return segments
+}
+
+// Narrow-dock shorthand never shows a zero-count badge: attention and active
+// appear only when present, and completed-only recent activity reports itself
+// as '●N' instead of a false '◉0'.
+function shorthandBadges(counts: ActivityCounts): ActivityDockSegment[] {
+  const badges: ActivityDockSegment[] = []
+
+  if (counts.attention) {
+    badges.push({ text: `!${counts.attention}`, tone: 'warning' })
+  }
+
+  if (counts.active) {
+    badges.push({ text: `◉${counts.active}`, tone: 'accent' })
+  }
+
+  if (!counts.attention && !counts.active && counts.completed) {
+    badges.push({ text: `●${counts.completed}`, tone: 'success' })
+  }
+
+  return badges
+}
+
+// Tone-tagged view of the collapsed dock so the component can paint 'K'
+// neutral, '!N' warning, and '◉N' accent as separate segments below the
+// medium breakpoint. Above it the single label renders in the default
+// foreground behind the dock's lamp glyph.
+export function collapsedActivitySegments(
+  model: KanbanActivityModel,
+  width: number,
+  now = model.checkedAt,
+  layoutWidth = width
+): ActivityDockSegment[] {
+  const counts = aggregateKanbanActivity(model, now)
+
+  if (!counts.total && !counts.attention) {
+    return [{ text: truncateActivityLabel('Kanban · idle', width), tone: 'muted' }]
+  }
+
+  if (layoutWidth >= 28) {
+    return segmentDockCounts(collapsedActivityLabel(model, width, now, layoutWidth), counts)
+  }
+
+  const badges = shorthandBadges(counts)
+
+  const segments: ActivityDockSegment[] =
+    width >= 14
+      ? [{ text: 'K', tone: 'neutral' }, ...badges.map(badge => ({ ...badge, text: ` ${badge.text}` }))]
+      : badges
+
+  const total = segments.reduce((sum, segment) => sum + stringWidth(segment.text), 0)
+
+  if (total > width) {
+    return [{ text: collapsedActivityLabel(model, width, now), tone: badges[0]?.tone ?? 'muted' }]
+  }
+
+  return segments
+}
+
+// The wide-dock headline is the single most attention-worthy task: a fresh
+// failure outranks a block, which outranks a degraded heartbeat, which
+// outranks ordinary running work.
+function headlineTask(tasks: readonly ActivityTask[], now: number): ActivityTask | null {
+  const ranks: ((task: ActivityTask) => boolean)[] = [
+    task => isFailed(task) && isRecentTerminal(task, now, DEFAULT_COMPLETION_LINGER_SECONDS),
+    task => task.status === 'blocked',
+    task => {
+      const freshness = heartbeatFreshness(task, now)
+
+      return freshness === 'missing' || freshness === 'stale'
+    },
+    task => task.status === 'running' && !isFailed(task),
+    task => isRecentTerminal(task, now, DEFAULT_COMPLETION_LINGER_SECONDS)
+  ]
+
+  for (const matches of ranks) {
+    const found = tasks.find(matches)
+
+    if (found) {
+      return found
+    }
+  }
+
+  return tasks[0] ?? null
+}
+
+export function collapsedActivityLabel(
+  model: KanbanActivityModel,
+  width: number,
+  now = model.checkedAt,
+  layoutWidth = width
+): string {
   const counts = aggregateKanbanActivity(model, now)
 
   if (!counts.total && !counts.attention) {
     return truncateActivityLabel('Kanban · idle', width)
   }
 
+  if (layoutWidth < 14) {
+    return truncateActivityLabel(
+      shorthandBadges(counts)
+        .map(badge => badge.text)
+        .join(''),
+      width
+    )
+  }
+
+  if (layoutWidth < 28) {
+    return truncateActivityLabel(
+      ['K', ...shorthandBadges(counts).map(badge => badge.text)].join(' '),
+      width
+    )
+  }
+
   const lead = counts.attention
-    ? `${counts.attention} needs attention · ${counts.active} active`
-    : `${counts.active} active`
+    ? `${counts.attention} need attention · ${counts.active} active`
+    : counts.active
+      ? `${counts.active} active`
+      : `${counts.completed} completed`
+
+  const medium = `Kanban · ${lead}`
+
+  if (layoutWidth < 48) {
+    return truncateActivityLabel(medium, width)
+  }
 
   const tasks: ActivityTask[] = []
 
@@ -457,25 +680,68 @@ export function collapsedActivityLabel(model: KanbanActivityModel, width: number
 
   model.boards.forEach(board => collect(board.roots))
 
-  const headline =
-    tasks.find(task => needsAttention(task, now, DEFAULT_STALE_SECONDS, DEFAULT_COMPLETION_LINGER_SECONDS)) ??
-    tasks.find(task => task.status === 'running') ??
-    tasks.find(task => isRecentTerminal(task, now, DEFAULT_COMPLETION_LINGER_SECONDS)) ??
-    tasks[0]
+  const headline = headlineTask(tasks, now)
 
-  const wide = headline ? `Kanban · ${lead} · ${headline.title}` : `Kanban · ${lead}`
-  const medium = `Kanban · ${lead}`
-  const narrow = counts.attention ? `K · !${counts.attention} · A${counts.active}` : `K · ${counts.active} active`
-  const tiny = counts.attention ? `K !${counts.attention} A${counts.active}` : `K ${counts.active}`
-  const source = width >= 48 ? wide : width >= 28 ? medium : width >= 14 ? narrow : tiny
+  if (!headline) {
+    return truncateActivityLabel(medium, width)
+  }
 
-  return truncateActivityLabel(source, width)
+  const headlineText = needsAttention(headline, now, DEFAULT_STALE_SECONDS, DEFAULT_COMPLETION_LINGER_SECONDS)
+    ? `${headline.title} ${shortActivityState(headline, now)}`
+    : headline.title
+
+  const wide = `${medium} · ${headlineText}`
+
+  if (stringWidth(wide) <= width) {
+    return wide
+  }
+
+  // A headline fragment under ~12 cells reads as noise — fall back to counts.
+  const headlineWidth = width - stringWidth(`${medium} · `)
+
+  if (headlineWidth >= MIN_HEADLINE_WIDTH) {
+    return `${medium} · ${truncateActivityLabel(headlineText, headlineWidth)}`
+  }
+
+  return truncateActivityLabel(medium, width)
 }
 
 export function branchChildren<T>(children: readonly T[], visibleLimit = 5): { omitted: number; visible: T[] } {
   const limit = Math.max(0, Math.floor(visibleLimit))
 
   return { omitted: Math.max(0, children.length - limit), visible: children.slice(0, limit) }
+}
+
+const RAIL_PREFIX = '│ '
+const BRANCH_CONNECTOR = '├── '
+const LAST_CONNECTOR = '└── '
+const CONTINUE_SEGMENT = '│   '
+const GAP_SEGMENT = '    '
+
+// One '│   '/'    ' segment per ancestor level below the root keeps branch
+// lines attached to their parent at depth 2+ ('│   ├── …'). The topology
+// prefix is a single light rail — lifecycle never changes its weight.
+function continuationPrefix(ancestors: readonly boolean[]): string {
+  return ancestors.map(hasMore => (hasMore ? CONTINUE_SEGMENT : GAP_SEGMENT)).join('')
+}
+
+const BOARD_ERROR_SUFFIX = ' · unavailable'
+const MIN_BOARD_NAME_WIDTH = 2
+
+// Name and error suffix share one width budget so the row can never wrap.
+// When the budget cannot hold both, the error signal outranks identity.
+function boardRowPresentation(name: string, error: boolean, width: number): Pick<ActivityBoardRow, 'label' | 'suffix'> {
+  if (!error) {
+    return { label: truncateActivityLabel(name, width), suffix: null }
+  }
+
+  const nameWidth = width - stringWidth(BOARD_ERROR_SUFFIX)
+
+  if (nameWidth >= MIN_BOARD_NAME_WIDTH) {
+    return { label: truncateActivityLabel(name, nameWidth), suffix: BOARD_ERROR_SUFFIX }
+  }
+
+  return { label: '', suffix: truncateActivityLabel('unavailable', width) }
 }
 
 export function buildKanbanActivityRows(
@@ -499,42 +765,56 @@ export function buildKanbanActivityRows(
 
   model.boards.forEach(board => indexTasks(board.roots))
 
-  const walk = (board: string, tasks: readonly ActivityTask[], depth: number, parentId: null | string = null) => {
+  const walk = (
+    board: string,
+    tasks: readonly ActivityTask[],
+    omittedAfter: number,
+    depth: number,
+    parentId: null | string,
+    ancestors: readonly boolean[]
+  ) => {
     tasks.forEach((task, index) => {
+      const moreAfter = index < tasks.length - 1 || omittedAfter > 0
       const presentation = activityPresentation(task, now, staleAfterSeconds)
-      const connector = depth === 0 ? '' : index === tasks.length - 1 ? '└──' : '├──'
-      const prefixWidth = 2 + (depth > 0 ? depth * 2 + 4 : 0)
+
+      const prefix =
+        depth === 0 ? RAIL_PREFIX : `${continuationPrefix(ancestors)}${moreAfter ? BRANCH_CONNECTOR : LAST_CONNECTOR}`
+
+      const labelWidth = Math.max(1, width - stringWidth(`${prefix}${presentation.glyph} `))
+      const parts = composeActivityLabel(task, labelWidth, now, staleAfterSeconds)
       rows.push({
         board,
-        connector,
         depth,
         ...presentation,
         kind: 'task',
-        label: focusedActivityLabel(task, Math.max(1, width - prefixWidth), now, staleAfterSeconds),
+        label: joinActivityLabelParts(parts),
+        parts,
+        prefix,
         task
       })
 
-      for (const linkedParent of task.parents.filter(id => id !== parentId)) {
+      const childAncestors = depth === 0 ? [] : [...ancestors, moreAfter]
+      const { omitted, visible } = branchChildren(task.children, maxChildren)
+      const linkedParents = task.parents.filter(id => id !== parentId)
+      linkedParents.forEach((linkedParent, linkedIndex) => {
+        const followed = linkedIndex < linkedParents.length - 1 || visible.length > 0 || omitted > 0
         rows.push({
           board,
-          connector: '├──',
-          depth: depth + 1,
           kind: 'summary',
           label: `↳ also linked from ${taskTitles.get(linkedParent) ?? linkedParent}`,
+          prefix: `${continuationPrefix(childAncestors)}${followed ? BRANCH_CONNECTOR : LAST_CONNECTOR}`,
           tone: 'muted'
         })
-      }
+      })
 
-      const { omitted, visible } = branchChildren(task.children, maxChildren)
-      walk(board, visible, depth + 1, task.id)
+      walk(board, visible, omitted, depth + 1, task.id, childAncestors)
 
       if (omitted) {
         rows.push({
           board,
-          connector: '└──',
-          depth: depth + 1,
           kind: 'summary',
           label: `+${omitted} more tasks`,
+          prefix: `${continuationPrefix(childAncestors)}${LAST_CONNECTOR}`,
           tone: 'muted'
         })
       }
@@ -543,18 +823,22 @@ export function buildKanbanActivityRows(
 
   for (const board of model.boards) {
     if (showBoards || board.error) {
-      rows.push({ board: board.name, kind: 'board', label: board.error ? `${board.name} · unavailable` : board.name })
+      rows.push({
+        board: board.name,
+        error: Boolean(board.error),
+        kind: 'board',
+        ...boardRowPresentation(board.name, Boolean(board.error), width)
+      })
     }
 
-    walk(board.name, board.roots, 0)
+    walk(board.name, board.roots, 0, 0, null, [])
 
     if (board.truncated) {
       rows.push({
         board: board.name,
-        connector: '└──',
-        depth: 0,
         kind: 'summary',
         label: '+ more activity not shown',
+        prefix: LAST_CONNECTOR,
         tone: 'muted'
       })
     }


### PR DESCRIPTION
## Summary

Adds a dormant, read-only Kanban activity foundation for the Hermes TUI without mounting or activating it in live sessions.

- add a bounded, redacted Kanban activity projection with explicit board isolation and truncation
- expose local `kanban.activity` JSON-RPC through the TUI gateway
- reuse the dashboard's active-worker projection contract
- add pure frontend normalization, topology, truncation, and aggregation helpers
- add static Ink activity dock and execution-spine components
- incorporate reviewed terminal-native visual refinements for nested rails, semantic paint channels, responsive dock states, and multi-board/error presentation
- document the visualization findings and preserve an explicit activation hold

## Safety and scope boundaries

This PR intentionally does **not**:

- mount the activity components in the live TUI
- add polling, stores, subscriptions, or background processes
- modify session, transcript, composer, history, or keyboard behavior
- add task execution controls
- mutate Kanban state from the activity projection

Activity output is allowlisted and redacted; prompts, task bodies, comments, commands, environment values, logs, PIDs, and raw worker errors are not exposed.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_activity_projection.py tests/tui_gateway/test_kanban_activity.py tests/plugins/test_kanban_dashboard_plugin.py -q`
  - 126 passed
- focused frontend activity suites
  - 52 passed
- broad frontend suite excluding unchanged `packages/hermes-ink/src/ink/ink-backpressure.test.ts`
  - 1,169 passed, 4 skipped
- Ink build, TypeScript typecheck, ESLint, Ruff, and `git diff --check` passed

## Known inherited issue

The unfiltered frontend suite still has one existing failure in `packages/hermes-ink/src/ink/ink-backpressure.test.ts` (`forces a write through after the coalesce ceiling`). That file is unchanged by this PR and the focused/broad candidate suites are green when it is excluded.

## Activation hold

The implementation should remain dormant until a separate product/design decision approves live placement, refresh cadence, visibility rules, and interaction behavior.
