### PR TITLE
fix(agent): prevent empty tool_calls arrays after dedup for DeepSeek V4

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2662,7 +2662,10 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                     seen_assistant_call_ids.add(cid)
                 kept_tcs.append(tc)
             if len(kept_tcs) != len(msg.get("tool_calls") or []):
-                msg = {**msg, "tool_calls": kept_tcs}
+                if kept_tcs:
+                    msg = {**msg, "tool_calls": kept_tcs}
+                else:
+                    msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
             cid = (msg.get("tool_call_id") or "").strip()


### PR DESCRIPTION
## Problem
DeepSeek V4 (and other strict OpenAI-compatible providers) reject API requests with HTTP 400 when any message contains `tool_calls: []` (empty array).

The existing `sanitize_api_messages` already strips `tool_calls: []` from assistant messages (lines 2508-2541), but the deduplication block at lines 2652-2666 can **re-introduce** an empty array: if every tool call in an assistant message is identified as a duplicate and removed, `kept_tcs` ends up empty but the code still does `msg = {**msg, "tool_calls": kept_tcs}` which produces `[]`.

This hits long-running sessions where history corruption, retry artifacts, or compression re-emits cause duplicate tool_call_ids.

## Fix
In the dedup block: when `kept_tcs` is empty after removing duplicates, delete the `tool_calls` key from the message dict instead of setting it to `[]`.

## Changed file
- `agent/agent_runtime_helpers.py` — 4 lines added, 1 removed

## Related
- Closes the same root cause as PR #64843 (the other half of the fix — this handles the dedup re-injection path specifically)

## Verification
- Manual: ran `hermes chat` with DeepSeek V4 after a long session with Ctrl+C interruptions — no more 400 errors