### PR TITLE
feat(cli): promote Fireworks AI to #2 in the hermes model provider list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1052,6 +1052,7 @@ class ProviderEntry(NamedTuple):
 
 CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nous",           "Nous Portal",              "Nous Portal (Everything your agent needs, 300+ models with bundled tool use)"),
+    ProviderEntry("fireworks",      "Fireworks AI",             "Fireworks AI (OpenAI-compatible direct model API)"),
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (Pay-per-use API aggregator)"),
     ProviderEntry("moa",            "Mixture of Agents",        "Mixture of Agents (named presets; aggregator acts after reference models)"),
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)"),
@@ -1081,7 +1082,6 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("ollama-cloud",   "Ollama Cloud",             "Ollama Cloud (Cloud-hosted open models, ollama.com)"),
     ProviderEntry("arcee",          "Arcee AI",                 "Arcee AI (Trinity models, direct API)"),
     ProviderEntry("gmi",            "GMI Cloud",                "GMI Cloud (Multi-model direct API)"),
-    ProviderEntry("fireworks",      "Fireworks AI",             "Fireworks AI (OpenAI-compatible direct model API)"),
     ProviderEntry("kilocode",       "Kilo Code",                "Kilo Code (Kilo Gateway API)"),
     ProviderEntry("opencode-zen",   "OpenCode Zen",             "OpenCode Zen (Curated models, pay-as-you-go)"),
     ProviderEntry("opencode-go",    "OpenCode Go",              "OpenCode Go (Open models subscription)"),


### PR DESCRIPTION
## Summary
Fireworks AI is now the #2 provider in the `hermes model` picker, directly below Nous Portal and ahead of OpenRouter.

## Changes
- `hermes_cli/models.py`: moved the `fireworks` entry in `CANONICAL_PROVIDERS` from its old slot (after GMI Cloud) to position 2; old entry removed, no duplicate slug.

Since `CANONICAL_PROVIDERS` is the single source of truth, the reorder propagates automatically to `hermes model`, the setup wizard, Telegram `/model`, `--provider` choices, and the desktop provider catalog.

## Validation
| Check | Result |
|---|---|
| Live import order | `['nous', 'fireworks', 'openrouter', 'moa', ...]`, `fireworks` count = 1 |
| `group_providers()` picker rows | fireworks passes through as single row at position 2 |
| Targeted tests (catalog parity, order contract, inventory, provider parity) | 81/81 passed |

## Infographic

![provider-picker-reorder](https://v3b.fal.media/files/b/0aa26565/a58eKQn_qKTLFtsFownSg_JWP0kX6W.png)
