### PR TITLE
fix(desktop): show full task titles in status stack

### DIFF
--- a/apps/desktop/src/.gitignore
+++ b/apps/desktop/src/.gitignore
@@ -1,4 +1,0 @@
-# Prevent local transpilation artifacts from shadowing TS/TSX source files.
-# If needed intentionally, force-add with: git add -f <file>
-**/*.js
-**/*.js.map

--- a/apps/desktop/src/.gitignore
+++ b/apps/desktop/src/.gitignore
@@ -1,0 +1,4 @@
+# Prevent local transpilation artifacts from shadowing TS/TSX source files.
+# If needed intentionally, force-add with: git add -f <file>
+**/*.js
+**/*.js.map

--- a/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/status-row.tsx
@@ -122,13 +122,14 @@ export const StatusItemRow = memo(function StatusItemRow({ item, onDismiss, onOp
       >
         <span
           className={cn(
-            'min-w-0 max-w-[18rem] truncate text-[0.73rem] leading-4',
+            'min-w-0 flex-1 whitespace-normal break-words text-[0.73rem] leading-4',
             failed
               ? 'text-destructive/90'
               : item.todoStatus && item.todoStatus !== 'in_progress'
                 ? 'text-muted-foreground/75'
                 : 'text-foreground/92'
           )}
+          title={item.title}
         >
           {item.title}
         </span>


### PR DESCRIPTION
## Summary
- show full task titles in the composer status stack (remove single-line truncation)
- allow wrapping with `whitespace-normal break-words`
- add tooltip fallback via `title={item.title}`

## Files
- `apps/desktop/src/app/chat/composer/status-stack/status-row.tsx`

## Verification
- `npx eslint src/app/chat/composer/status-stack/status-row.tsx` (pass, from local implementation run)
- desktop pack + restart were validated locally during implementation
