### PR TITLE
fix(telegram): create System topic on auto-threaded first /topic (#65202)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4382,24 +4382,23 @@ class GatewaySlashCommandsMixin:
                     await self._send_telegram_topic_setup_image(source)
                 return t("gateway.topic.topics_user_disallowed")
 
-        # Whether topic mode was already active *before* this /topic call.
+        # ``enable_telegram_topic_mode`` reads the prior state and upserts
+        # the row in ONE atomic transaction and reports whether THIS call
+        # performed the disabled-to-enabled transition ("first activation").
         # This is the correct signal for "first activation", not
         # ``source.thread_id``: when the user sends /topic from the All
         # Messages view, Telegram auto-creates a topic for the command
         # itself, so the command reaches us with a thread_id even on the
         # very first activation. Gating System-topic creation on thread_id
-        # skipped it in that case (#65202).
+        # skipped it in that case (#65202). A separate read-then-write
+        # (checking is_telegram_topic_mode_enabled first, then calling
+        # enable_telegram_topic_mode) left a race: Telegram dispatches each
+        # inbound message as its own background task, so two concurrent
+        # /topic invocations for the same chat could both read "disabled"
+        # before either write landed, and both then call the non-idempotent
+        # System-topic creator (#65216 review).
         try:
-            topic_mode_was_enabled = await self._session_db.is_telegram_topic_mode_enabled(
-                chat_id=str(source.chat_id),
-                user_id=str(source.user_id),
-            )
-        except Exception:
-            logger.debug("Failed to read Telegram topic-mode state", exc_info=True)
-            topic_mode_was_enabled = False
-
-        try:
-            await self._session_db.enable_telegram_topic_mode(
+            first_activation = await self._session_db.enable_telegram_topic_mode(
                 chat_id=str(source.chat_id),
                 user_id=str(source.user_id),
                 has_topics_enabled=capabilities.get("has_topics_enabled"),
@@ -4413,7 +4412,7 @@ class GatewaySlashCommandsMixin:
         # ``_ensure_telegram_system_topic`` creates a fresh "System" topic and
         # is not idempotent, so it must not run on a repeat /topic once mode
         # is already enabled.
-        if not topic_mode_was_enabled:
+        if first_activation:
             await self._ensure_telegram_system_topic(source)
 
         if source.thread_id:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4382,6 +4382,22 @@ class GatewaySlashCommandsMixin:
                     await self._send_telegram_topic_setup_image(source)
                 return t("gateway.topic.topics_user_disallowed")
 
+        # Whether topic mode was already active *before* this /topic call.
+        # This is the correct signal for "first activation", not
+        # ``source.thread_id``: when the user sends /topic from the All
+        # Messages view, Telegram auto-creates a topic for the command
+        # itself, so the command reaches us with a thread_id even on the
+        # very first activation. Gating System-topic creation on thread_id
+        # skipped it in that case (#65202).
+        try:
+            topic_mode_was_enabled = await self._session_db.is_telegram_topic_mode_enabled(
+                chat_id=str(source.chat_id),
+                user_id=str(source.user_id),
+            )
+        except Exception:
+            logger.debug("Failed to read Telegram topic-mode state", exc_info=True)
+            topic_mode_was_enabled = False
+
         try:
             await self._session_db.enable_telegram_topic_mode(
                 chat_id=str(source.chat_id),
@@ -4393,7 +4409,11 @@ class GatewaySlashCommandsMixin:
             logger.exception("Failed to enable Telegram topic mode")
             return t("gateway.topic.enable_failed", error=exc)
 
-        if not source.thread_id:
+        # Create the managed System topic on first activation only.
+        # ``_ensure_telegram_system_topic`` creates a fresh "System" topic and
+        # is not idempotent, so it must not run on a repeat /topic once mode
+        # is already enabled.
+        if not topic_mode_was_enabled:
             await self._ensure_telegram_system_topic(source)
 
         if source.thread_id:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10243,11 +10243,27 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         user_id: str,
         has_topics_enabled: Optional[bool] = None,
         allows_users_to_create_topics: Optional[bool] = None,
-    ) -> None:
+    ) -> bool:
         """Enable Telegram DM topic mode for one private chat/user.
 
         This method intentionally owns the explicit topic migration. Ordinary
         SessionDB startup must not create these side tables.
+
+        Returns whether THIS call performed the disabled-to-enabled
+        transition (i.e., this is the first activation). The prior state is
+        read and the row is upserted inside the same ``_execute_write``
+        transaction (single ``BEGIN IMMEDIATE`` under ``self._lock``), so two
+        concurrent activations for the same chat (Telegram dispatches each
+        inbound message as its own background task — see
+        ``gateway/platforms/base.py``'s per-message task spawn) can never
+        both observe "not yet enabled": whichever caller's transaction
+        commits first sees the prior row as disabled and gets True; the
+        second sees it already enabled (by the first caller's own write, now
+        visible within its own subsequent transaction) and gets False. A
+        caller-side read-then-write across two separate lock acquisitions
+        (the previous shape here) left a real gap for both to observe
+        "disabled" and each trigger the non-idempotent System-topic creator
+        (#65216 review).
         """
         self.apply_telegram_topic_migration()
         now = time.time()
@@ -10257,7 +10273,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 return None
             return 1 if value else 0
 
-        def _do(conn):
+        def _do(conn) -> bool:
+            row = conn.execute(
+                "SELECT enabled FROM telegram_dm_topic_mode WHERE chat_id = ?",
+                (str(chat_id),),
+            ).fetchone()
+            was_enabled = bool(row is not None and row[0])
+
             conn.execute(
                 """
                 INSERT INTO telegram_dm_topic_mode (
@@ -10283,7 +10305,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     now,
                 ),
             )
-        self._execute_write(_do)
+            return not was_enabled
+
+        return self._execute_write(_do)
 
     def disable_telegram_topic_mode(
         self,

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -758,7 +758,82 @@ def test_get_telegram_topic_binding_by_session_returns_binding(tmp_path):
     assert binding["session_id"] == "sess-27166"
 
 
+
 # ---------------------------------------------------------------------------
-# Test for session-split thread_id recovery (issue #27166)
+# Regression: System topic on auto-threaded first /topic (#65202)
 # ---------------------------------------------------------------------------
 
+
+@pytest.mark.asyncio
+async def test_topic_first_activation_creates_system_topic_when_auto_threaded(
+    tmp_path, monkeypatch
+):
+    """Regression for #65202.
+
+    Telegram auto-creates a topic for the `/topic` message when it is sent
+    from the All Messages view, so the command reaches Hermes with a
+    `thread_id` even on the very first activation. The System topic must
+    still be created in that case.
+    """
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    runner = _make_runner(session_db=session_db)
+    runner._ensure_telegram_system_topic = AsyncMock()
+    runner._get_telegram_topic_capabilities = AsyncMock(
+        return_value={
+            "checked": True,
+            "has_topics_enabled": True,
+            "allows_users_to_create_topics": True,
+        }
+    )
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("/topic activation must not enter the agent loop")
+    )
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    # First /topic arrives already inside an auto-created topic (thread_id set).
+    await runner._handle_message(_make_event("/topic", thread_id="17585"))
+
+    runner._ensure_telegram_system_topic.assert_awaited_once()
+    assert session_db.is_telegram_topic_mode_enabled(
+        chat_id="208214988", user_id="208214988"
+    )
+
+
+@pytest.mark.asyncio
+async def test_topic_repeat_activation_does_not_recreate_system_topic(
+    tmp_path, monkeypatch
+):
+    """A second /topic once mode is enabled must not create another System topic.
+
+    `_ensure_telegram_system_topic` is not idempotent (it always creates a
+    fresh `System` forum topic), so it must only fire on first activation.
+    """
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(
+        chat_id="208214988", user_id="208214988"
+    )
+    runner = _make_runner(session_db=session_db)
+    runner._ensure_telegram_system_topic = AsyncMock()
+    runner._get_telegram_topic_capabilities = AsyncMock(
+        return_value={
+            "checked": True,
+            "has_topics_enabled": True,
+            "allows_users_to_create_topics": True,
+        }
+    )
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("/topic status must not enter the agent loop")
+    )
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    await runner._handle_message(_make_event("/topic", thread_id="17585"))
+
+    runner._ensure_telegram_system_topic.assert_not_awaited()

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -4,6 +4,7 @@ Topic mode makes the root Telegram DM a system lobby while user-created
 Telegram topics act as independent Hermes session lanes.
 """
 
+import asyncio
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -462,6 +463,43 @@ async def test_topic_binding_follows_compression_tip_on_read(tmp_path, monkeypat
     )
     assert refreshed is not None
     assert refreshed["session_id"] == "child-session"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_topic_activation_creates_system_topic_exactly_once(tmp_path, monkeypatch):
+    """Regression for the #65216 review: two /topic invocations for the same
+    chat racing concurrently must not both see "not yet enabled" and both
+    invoke the non-idempotent System-topic creator.
+
+    AsyncSessionDB offloads every SessionDB call via `asyncio.to_thread`
+    (see hermes_state.py), so `await` on two concurrent
+    `enable_telegram_topic_mode` calls really does run them on separate
+    OS threads against the same SQLite connection -- this reproduces the
+    real race, not just an interleaving on a single thread.
+    """
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    runner = _make_runner(session_db=session_db)
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("/topic activation must not enter the agent loop")
+    )
+    runner._ensure_telegram_system_topic = AsyncMock()
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    results = await asyncio.gather(
+        runner._handle_message(_make_event("/topic")),
+        runner._handle_message(_make_event("/topic")),
+    )
+
+    assert runner._ensure_telegram_system_topic.call_count == 1, (
+        "Two concurrent /topic activations for the same chat must create "
+        "the System topic exactly once, not once per racing caller."
+    )
+    assert any("enabled" in r for r in results)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Running `/topic` from Telegram's **All Messages** view enables multi-session
topic mode but does not create the managed `System` topic. Telegram
auto-creates a topic for the `/topic` message itself, so the command reaches
Hermes with a `thread_id` even on the very first activation.
`_handle_topic_command` gated System-topic creation on `not source.thread_id`,
so that auto-threaded first activation skipped `_ensure_telegram_system_topic`
entirely. Sending `/topic` through the Bot API *without* a topic works, which
is exactly the `thread_id`-present vs -absent split the reporter observed.

## Changes

- `gateway/slash_commands.py` — in `_handle_topic_command`, read
  `is_telegram_topic_mode_enabled` **before** enabling topic mode and gate
  `_ensure_telegram_system_topic` on whether topic mode was *already* enabled
  (the correct "first activation" signal), instead of on `source.thread_id`.
  The read is wrapped defensively (defaults to "not enabled" on error) and runs
  on the existing async DB facade. Because `_ensure_telegram_system_topic`
  creates a fresh `System` forum topic and is **not** idempotent, gating on
  first-activation also prevents re-creating a duplicate `System` topic on a
  repeat `/topic`.
- `tests/gateway/test_telegram_topic_mode.py` — regression coverage:
  - `test_topic_first_activation_creates_system_topic_when_auto_threaded`:
    first `/topic` arriving with a `thread_id` (auto-created topic) must still
    create the System topic. **Fails on `main`** (System topic never created).
  - `test_topic_repeat_activation_does_not_recreate_system_topic`: a second
    `/topic` once mode is enabled must not create another System topic.

## Validation

| Command | Result |
| --- | --- |
| `pytest .../test_topic_first_activation_creates_system_topic_when_auto_threaded` (on `main`, no fix) | **FAIL** — `_ensure_telegram_system_topic` awaited 0 times |
| `pytest -k "system_topic or recreate_system"` (with fix) | 3 passed |
| `pytest tests/gateway/test_telegram_topic_mode.py` | 47 passed |
| `ruff check gateway/slash_commands.py tests/gateway/test_telegram_topic_mode.py` | All checks passed |

## Behavior preserved

- `/topic` from root when mode disabled → still creates the System topic.
- `/topic` inside an existing topic when mode already enabled → still a no-op
  for System-topic creation (was `not thread_id`, now `already-enabled`; same
  outcome).

Closes #65202
