### PR TITLE
fix(desktop): declare macOS calendar and reminder permissions

### DIFF
--- a/apps/desktop/electron/entitlements.mac.plist
+++ b/apps/desktop/electron/entitlements.mac.plist
@@ -12,5 +12,7 @@
   <true/>
   <key>com.apple.security.device.camera</key>
   <true/>
+  <key>com.apple.security.personal-information.calendars</key>
+  <true/>
 </dict>
 </plist>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -214,7 +214,11 @@
         "CFBundleName": "Hermes",
         "NSAudioCaptureUsageDescription": "Hermes uses audio capture for voice conversations.",
         "NSCameraUsageDescription": "Hermes uses the camera when a plugin or feature you enable requests it.",
-        "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations."
+        "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations.",
+        "NSCalendarsUsageDescription": "Hermes needs access to Calendar to provide requested meeting and scheduling support.",
+        "NSCalendarsFullAccessUsageDescription": "Hermes needs full access to Calendar to read and manage events when explicitly requested.",
+        "NSRemindersUsageDescription": "Hermes needs access to Reminders to provide requested personal-assistant and scheduling support.",
+        "NSRemindersFullAccessUsageDescription": "Hermes needs full access to Reminders to read and manage reminders when explicitly requested."
       },
       "gatekeeperAssess": false,
       "hardenedRuntime": true,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -235,7 +235,11 @@
         "CFBundleName": "Hermes",
         "NSAudioCaptureUsageDescription": "Hermes uses audio capture for voice conversations.",
         "NSCameraUsageDescription": "Hermes uses the camera when a plugin or feature you enable requests it.",
-        "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations."
+        "NSMicrophoneUsageDescription": "Hermes uses the microphone for voice input and voice conversations.",
+        "NSCalendarsUsageDescription": "Hermes needs access to Calendar to provide requested meeting and scheduling support.",
+        "NSCalendarsFullAccessUsageDescription": "Hermes needs full access to Calendar to read and manage events when explicitly requested.",
+        "NSRemindersUsageDescription": "Hermes needs access to Reminders to provide requested personal-assistant and scheduling support.",
+        "NSRemindersFullAccessUsageDescription": "Hermes needs full access to Reminders to read and manage reminders when explicitly requested."
       },
       "gatekeeperAssess": false,
       "hardenedRuntime": true,


### PR DESCRIPTION
## Summary

- declare Calendar and Reminders usage descriptions in the macOS Electron build configuration
- add the Calendar signing entitlement required by the hardened Hermes runtime
- ensure rebuilt Desktop bundles retain both layers of the EventKit permission configuration

## Problem

Hermes Desktop can invoke Calendar and Reminders tooling as the responsible macOS application. The generated app bundle currently lacks the corresponding usage-description keys, so macOS may refuse to present or honor the required TCC consent.

The usage strings alone are not sufficient for Calendar access from the hardened runtime. macOS TCC logs report that `kTCCServiceCalendar` requires `com.apple.security.personal-information.calendars`; without that entitlement, Calendar access remains unavailable even when the bundle contains the usage descriptions.

Editing the generated `Info.plist` or re-signing an installed bundle is only a temporary repair. Desktop rebuilds regenerate the plist from `apps/desktop/package.json` and apply signing entitlements from `apps/desktop/electron/entitlements.mac.plist`. This change fixes both canonical build inputs.

## Verification

Revalidated on 2026-08-17 after rebasing onto current `main` (`dc2e9dde9a6e`):

- `npm ci` — passed; 1,210 packages installed. The current upstream dependency audit reports 6 high-severity vulnerabilities, unrelated to this two-file diff.
- `CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack` — passed
- verified the generated `Hermes.app/Contents/Info.plist` contains non-empty values for:
  - `NSCalendarsUsageDescription`
  - `NSCalendarsFullAccessUsageDescription`
  - `NSRemindersUsageDescription`
  - `NSRemindersFullAccessUsageDescription`
- `plutil -lint apps/desktop/electron/entitlements.mac.plist` — passed
- verified the source entitlement plist preserves the existing JIT, library-validation, microphone, and camera entitlements and adds `com.apple.security.personal-information.calendars = true`
- `git diff --check` — passed
- the equivalent repaired local Desktop bundle passed the complete post-update privacy preflight with `PASS=12 WARN=0 FAIL=0`; Calendar enumeration, upcoming-event access, the Calendar fallback bridge, and EventKit Reminders access all succeeded without resetting existing consent

The contributor build intentionally disabled signing auto-discovery. `codesign --verify --deep --strict` therefore does not pass for that unsigned package, so final Developer ID-signed entitlement validation remains release/CI-side.
