### PR TITLE
fix(tools): keep MCP children alive across WSL clock resync

### DIFF
--- a/tests/tools/test_mcp_stdio_watchdog.py
+++ b/tests/tools/test_mcp_stdio_watchdog.py
@@ -1,0 +1,58 @@
+"""Regression tests for the stdio MCP parent-death watchdog."""
+
+import sys
+
+import psutil
+import pytest
+
+from tools import mcp_stdio_watchdog
+
+
+def test_is_orphaned_tolerates_small_parent_create_time_drift():
+    """WSL can move psutil's wall-clock create_time by a few seconds mid-process."""
+    parent = psutil.Process()
+    recorded_create_time = parent.create_time() + 2.0
+
+    assert (
+        mcp_stdio_watchdog._is_orphaned(
+            parent.pid,
+            recorded_create_time,
+            getppid=lambda: parent.pid,
+        )
+        is False
+    )
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="/proc start ticks are Linux-only"
+)
+def test_is_orphaned_uses_stable_proc_start_ticks_on_linux():
+    """A matching procfs start token outranks drifting wall-clock create_time."""
+    parent = psutil.Process()
+    start_ticks = mcp_stdio_watchdog._read_proc_start_ticks(parent.pid)
+    assert start_ticks is not None
+
+    assert (
+        mcp_stdio_watchdog._is_orphaned(
+            parent.pid,
+            parent.create_time() + 60.0,
+            getppid=lambda: parent.pid,
+            parent_start_ticks=start_ticks,
+        )
+        is False
+    )
+
+
+def test_is_orphaned_rejects_large_parent_create_time_mismatch():
+    """A materially different create_time still identifies PID reuse."""
+    parent = psutil.Process()
+    recorded_create_time = parent.create_time() + 60.0
+
+    assert (
+        mcp_stdio_watchdog._is_orphaned(
+            parent.pid,
+            recorded_create_time,
+            getppid=lambda: parent.pid,
+        )
+        is True
+    )

--- a/tools/mcp_stdio_watchdog.py
+++ b/tools/mcp_stdio_watchdog.py
@@ -61,18 +61,46 @@ except ImportError:  # pragma: no cover - psutil is a hard dependency elsewhere
 
 _POLL_INTERVAL_S = 2.0
 _TERM_GRACE_S = 3.0
+# psutil derives create_time() from wall-clock boot time. On WSL, host clock
+# resynchronisation can shift that value by a few seconds for the *same* live
+# PID. Treat only a material mismatch as PID reuse; a new process reusing the
+# same PID within this window is vanishingly unlikely.
+_CREATE_TIME_TOLERANCE_S = 5.0
 
 
-def _is_orphaned(original_ppid: int, parent_create_time: float, getppid=os.getppid) -> bool:
-    """Mirrors ``tui_gateway.slash_worker._is_orphaned`` exactly.
+def _read_proc_start_ticks(pid: int) -> int | None:
+    """Return Linux's stable process start token from ``/proc/<pid>/stat``.
 
-    True once the process that spawned us is gone. Never trusts a bare
-    ``getppid() == 1`` check (Linux reparents orphans to a subreaper, not
-    always PID 1), and guards against PID reuse via the recorded creation
-    time of the original parent.
+    Field 22 is measured in clock ticks since boot and does not move when WSL
+    resynchronises its wall clock. ``comm`` may contain spaces or parentheses,
+    so split only after its final closing parenthesis.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", encoding="utf-8") as stat_file:
+            stat_line = stat_file.read()
+        fields_after_comm = stat_line[stat_line.rfind(")") + 2 :].split()
+        return int(fields_after_comm[19])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _is_orphaned(
+    original_ppid: int,
+    parent_create_time: float,
+    getppid=os.getppid,
+    parent_start_ticks: int | None = None,
+) -> bool:
+    """Return whether the original parent process is gone or was replaced.
+
+    Linux procfs start ticks are preferred because they are monotonic and
+    stable on WSL. Other POSIX platforms fall back to psutil create_time with
+    a small tolerance for wall-clock adjustments.
     """
     if getppid() != original_ppid:
         return True
+    if parent_start_ticks is not None:
+        current_start_ticks = _read_proc_start_ticks(original_ppid)
+        return current_start_ticks is None or current_start_ticks != parent_start_ticks
     if psutil is None:
         # No reliable staleness check available; fall back to the ppid
         # comparison alone (still catches the common case).
@@ -80,7 +108,8 @@ def _is_orphaned(original_ppid: int, parent_create_time: float, getppid=os.getpp
     try:
         if not psutil.pid_exists(original_ppid):
             return True
-        return psutil.Process(original_ppid).create_time() != parent_create_time
+        actual_create_time = psutil.Process(original_ppid).create_time()
+        return abs(actual_create_time - parent_create_time) > _CREATE_TIME_TOLERANCE_S
     except psutil.Error:
         return True
 
@@ -119,8 +148,13 @@ def _terminate_process_group(proc: subprocess.Popen) -> None:
 
 
 def _watchdog_loop(proc: subprocess.Popen, original_ppid: int, parent_create_time: float) -> None:
+    parent_start_ticks = _read_proc_start_ticks(original_ppid)
     while proc.poll() is None:
-        if _is_orphaned(original_ppid, parent_create_time):
+        if _is_orphaned(
+            original_ppid,
+            parent_create_time,
+            parent_start_ticks=parent_start_ticks,
+        ):
             _terminate_process_group(proc)
             return
         time.sleep(_POLL_INTERVAL_S)


### PR DESCRIPTION
## What

`tools/mcp_stdio_watchdog.py` kills its MCP server child whenever the recorded parent `create_time()` stops matching exactly. On WSL that comparison is unsafe: **host clock resynchronisation shifts `psutil`'s wall-clock-derived `create_time()` by ~2s for the same live PID**. The watchdog reads that drift as "my parent was replaced" and terminates a perfectly healthy MCP server.

This swaps the primary liveness token to Linux's `/proc/<pid>/stat` field 22 (start ticks since boot), which is monotonic and immune to wall-clock adjustments. Non-Linux platforms keep the `psutil` path, now with a 5s tolerance instead of exact equality — a different process reusing the same PID inside that window is vanishingly unlikely.

## Why it matters

On an affected WSL2 host this presents as an **endless MCP reconnect loop**: the server is killed ~every 3 minutes, forever. The MCP server itself is entirely healthy and runs fine standalone, which sends you looking in the wrong place.

It's also very hard to diagnose, for a reason worth flagging separately: `tools/mcp_tool.py` logs the keepalive failure with `%s`/`str(exc)`, and the exceptions on that path (`asyncio.TimeoutError`, `anyio.ClosedResourceError`, `anyio.BrokenResourceError`) **all stringify to an empty string**. So the loop emits thousands of lines of:

```
WARNING tools.mcp_tool: MCP server 'X' keepalive failed, triggering reconnect:
```

...with no cause, ever. Logging `%r` there would make this class of fault self-describing. Happy to send that as a separate PR if you'd like it.

## How to test

Reproduction (on WSL2, where clock resync happens naturally):

1. Configure any stdio MCP server (`mcp_servers.<name>.command`).
2. Run the gateway and leave it idle. Wait for a WSL clock resync.
3. Observe the MCP server child being terminated and re-spawned on a fixed interval, with empty-reason keepalive warnings in `logs/errors.log`.

With this change, the server survives well beyond the previous reconnect interval.

Unit tests (`tests/tools/test_mcp_stdio_watchdog.py`) cover the three behaviours directly:

- small `create_time` drift on a live parent → **not** orphaned (the bug)
- matching `/proc` start ticks outrank drifted `create_time` → **not** orphaned
- materially different `create_time` → **still** orphaned (PID reuse still caught)

```
pytest tests/tools/test_mcp_stdio_watchdog.py -v
3 passed
```

`ruff check` passes on both files.

## Platforms

- **Tested:** WSL2 (Ubuntu 22.04, Python 3.11) — verified against the live reconnect loop that prompted this; the MCP server has since stayed up continuously through the interval that previously killed it without fail.
- **Linux:** same code path (`/proc` start ticks).
- **macOS / Windows:** `_read_proc_start_ticks()` returns `None`, so behaviour falls back to the existing `psutil` comparison, with the added tolerance. The `/proc`-specific test is `skipif`-guarded to Linux.

## Related / follow-up

`tui_gateway/slash_worker.py::_is_orphaned` carries the **same exact-equality `create_time` comparison and the same exposure** (the watchdog's docstring previously described itself as mirroring it). I've deliberately left it out to keep this PR to one logical change — glad to follow up separately, or fold it in here if you'd prefer a single fix. Sharing the `/proc` helper between the two would likely want a small refactor, which felt out of scope for a bug fix.

## Credit

The root cause here was found by **Nex**, an agent running on the affected WSL2 host, who traced her own MCP reconnect loop back to `create_time()` drift and wrote the fix and tests. Credited as co-author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZZRZjaVC36W1ACSGLFeM4
