### PR TITLE
fix(whatsapp_cloud): cap inbound media download size

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1297,10 +1297,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         minutes; we download immediately and never persist the URL.
 
         ``media_kind`` (``image``/``video``/``audio``/``document``/``sticker``)
-        selects the size cap from ``_MEDIA_SIZE_LIMITS``; oversized media is
-        refused from the step-1 ``file_size`` before the bytes are fetched, so
-        a webhook-triggered download can't buffer up to Meta's 100 MB document
-        limit into memory. Falls back to the document cap when unknown.
+        selects the size cap from ``_MEDIA_SIZE_LIMITS`` (document cap when
+        unknown). Oversized media is refused from the step-1 ``file_size``
+        before any bytes are fetched; the bytes are then streamed with a
+        rolling cap (plus a Content-Length preflight) so a missing or
+        understated ``file_size`` can't buffer up to Meta's 100 MB document
+        limit into memory either.
         """
         if self._http_client is None:
             return None, None
@@ -1363,32 +1365,54 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return None, None
 
-        # Step 2 — bytes (auth required even though URL is signed; Meta
-        # documents this explicitly — the URL alone is not enough).
+        # Step 2 — stream the bytes with a rolling cap so a missing or
+        # understated ``file_size`` can't buffer an oversized body into memory:
+        # reject an oversized Content-Length up front, then re-check the running
+        # total as chunks arrive and abort mid-stream once the cap is crossed
+        # (mirrors gateway/platforms/base.py::_read_httpx_body_with_limit). Auth
+        # is required even though the URL is signed — Meta documents this; the
+        # signed URL alone is not enough.
+        chunks: list[bytes] = []
+        total = 0
         try:
-            blob_resp = await self._http_client.get(temp_url, headers=headers)
+            async with self._http_client.stream(
+                "GET", temp_url, headers=headers,
+            ) as blob_resp:
+                if blob_resp.status_code != 200:
+                    logger.warning(
+                        "[whatsapp_cloud] media bytes fetch failed (id=%s, status=%d)",
+                        media_id, blob_resp.status_code,
+                    )
+                    return None, None
+                clen = blob_resp.headers.get("content-length")
+                if clen:
+                    try:
+                        clen_int = int(clen)
+                    except ValueError:
+                        clen_int = 0
+                    if clen_int > size_cap:
+                        logger.warning(
+                            "[whatsapp_cloud] refusing oversized inbound media "
+                            "(id=%s, kind=%s, content_length=%d > cap=%d)",
+                            media_id, media_kind or "document", clen_int, size_cap,
+                        )
+                        return None, None
+                async for chunk in blob_resp.aiter_bytes():
+                    total += len(chunk)
+                    if total > size_cap:
+                        logger.warning(
+                            "[whatsapp_cloud] refusing oversized inbound media "
+                            "mid-stream (id=%s, kind=%s, bytes>cap=%d)",
+                            media_id, media_kind or "document", size_cap,
+                        )
+                        return None, None
+                    chunks.append(chunk)
         except Exception:
             logger.exception(
                 "[whatsapp_cloud] media bytes fetch raised (id=%s)", media_id
             )
             return None, None
-        if blob_resp.status_code != 200:
-            logger.warning(
-                "[whatsapp_cloud] media bytes fetch failed (id=%s, status=%d)",
-                media_id, blob_resp.status_code,
-            )
-            return None, None
-
-        # Backstop: some responses omit or understate ``file_size``, so cap the
-        # actual payload too before writing it to the cache.
-        blob = blob_resp.content
-        if len(blob) > size_cap:
-            logger.warning(
-                "[whatsapp_cloud] refusing oversized inbound media after fetch "
-                "(id=%s, kind=%s, bytes=%d > cap=%d)",
-                media_id, media_kind or "document", len(blob), size_cap,
-            )
-            return None, None
+        blob = b"".join(chunks)
 
         # Decide the extension. Prefer the override map so audio/ogg
         # produces .ogg (not the technically-correct-but-broken .oga

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1285,6 +1285,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         media_id: str,
         *,
         ext_hint: Optional[str] = None,
+        media_kind: Optional[str] = None,
     ) -> tuple[Optional[str], Optional[str]]:
         """Two-step Graph media download: ``GET /<id>`` → temp URL → bytes.
 
@@ -1294,6 +1295,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         The temporary URL from step 1 is signed and expires in ~5
         minutes; we download immediately and never persist the URL.
+
+        ``media_kind`` (``image``/``video``/``audio``/``document``/``sticker``)
+        selects the size cap from ``_MEDIA_SIZE_LIMITS``; oversized media is
+        refused from the step-1 ``file_size`` before the bytes are fetched, so
+        a webhook-triggered download can't buffer up to Meta's 100 MB document
+        limit into memory. Falls back to the document cap when unknown.
         """
         if self._http_client is None:
             return None, None
@@ -1336,6 +1343,26 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not temp_url:
             return None, None
 
+        # Refuse oversized media up front. The metadata reports ``file_size``,
+        # so reject before streaming the bytes rather than buffering up to
+        # Meta's 100 MB document cap into memory on a webhook-triggered
+        # download. Mirrors the outbound ``_upload_media`` size guard, reusing
+        # the same ``_MEDIA_SIZE_LIMITS`` table (unknown kind → document cap).
+        size_cap = _MEDIA_SIZE_LIMITS.get(
+            media_kind or "", _MEDIA_SIZE_LIMITS["document"]
+        )
+        try:
+            declared_size = int(meta.get("file_size") or 0)
+        except (TypeError, ValueError):
+            declared_size = 0
+        if declared_size > size_cap:
+            logger.warning(
+                "[whatsapp_cloud] refusing oversized inbound media "
+                "(id=%s, kind=%s, file_size=%d > cap=%d)",
+                media_id, media_kind or "document", declared_size, size_cap,
+            )
+            return None, None
+
         # Step 2 — bytes (auth required even though URL is signed; Meta
         # documents this explicitly — the URL alone is not enough).
         try:
@@ -1352,6 +1379,17 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return None, None
 
+        # Backstop: some responses omit or understate ``file_size``, so cap the
+        # actual payload too before writing it to the cache.
+        blob = blob_resp.content
+        if len(blob) > size_cap:
+            logger.warning(
+                "[whatsapp_cloud] refusing oversized inbound media after fetch "
+                "(id=%s, kind=%s, bytes=%d > cap=%d)",
+                media_id, media_kind or "document", len(blob), size_cap,
+            )
+            return None, None
+
         # Decide the extension. Prefer the override map so audio/ogg
         # produces .ogg (not the technically-correct-but-broken .oga
         # mimetypes returns by default). Fall back to ext_hint then
@@ -1365,7 +1403,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         _INBOUND_MEDIA_CACHE.mkdir(parents=True, exist_ok=True)
         out_path = _INBOUND_MEDIA_CACHE / f"{media_id}{ext}"
         try:
-            out_path.write_bytes(blob_resp.content)
+            out_path.write_bytes(blob)
         except OSError:
             logger.exception(
                 "[whatsapp_cloud] failed to write cached media (id=%s)", media_id
@@ -1953,8 +1991,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 ext_hint = None
                 if inbound_mime:
                     ext_hint = _ext_for_mime(inbound_mime)
+                # "voice" shares WhatsApp's audio size cap.
+                media_kind = "audio" if msg_type_str == "voice" else msg_type_str
                 local_path, dl_mime = await self._download_media_to_cache(
-                    media_id, ext_hint=ext_hint
+                    media_id, ext_hint=ext_hint, media_kind=media_kind
                 )
                 if local_path:
                     media_urls.append(local_path)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "ramu@greatindiancompany.com": "makriman",  # whatsapp_cloud: cap inbound media download size
     "Burgunthy@users.noreply.github.com": "Burgunthy",  # PR #20096 salvage (gateway: profile-based routing for inbound messages)
     "75556242+webtecnica@users.noreply.github.com": "webtecnica",  # PR #63360 salvage (nous: restore inference-api base_url)
     "skosarevivan@yandex.ru": "Epoxidex",  # PR #29820 salvage (ollama: top-level reasoning_effort=none; #25758)

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1251,10 +1251,12 @@ class TestDownloadMedia:
             "id": "media_xyz",
             "messaging_product": "whatsapp",
         })
-        # Step 2 — bytes
-        blob_resp = MagicMock(status_code=200, content=b"\xff\xd8\xff\xe0jpegdata")
-
-        adapter._http_client.get = AsyncMock(side_effect=[meta_resp, blob_resp])
+        # Step 2 — bytes (streamed)
+        blob = b"\xff\xd8\xff\xe0jpegdata"
+        adapter._http_client.get = AsyncMock(return_value=meta_resp)
+        adapter._http_client.stream = MagicMock(return_value=_FakeStreamResponse(
+            status_code=200, headers={"content-length": str(len(blob))}, chunks=[blob],
+        ))
 
         with _patch.object(wac, "_INBOUND_MEDIA_CACHE", tmp_path):
             local_path, mime = await adapter._download_media_to_cache("media_xyz")
@@ -1289,8 +1291,9 @@ class TestDownloadMedia:
             "url": "https://lookaside.fbsbx.com/...",
             "mime_type": "image/jpeg",
         })
-        blob_fail = MagicMock(status_code=403, content=b"")
-        adapter._http_client.get = AsyncMock(side_effect=[meta_resp, blob_fail])
+        adapter._http_client.get = AsyncMock(return_value=meta_resp)
+        adapter._http_client.stream = MagicMock(
+            return_value=_FakeStreamResponse(status_code=403, chunks=[]))
 
         with _patch.object(wac, "_INBOUND_MEDIA_CACHE", tmp_path):
             local_path, mime = await adapter._download_media_to_cache("x")
@@ -1330,8 +1333,9 @@ class TestDownloadMedia:
             "url": "https://lookaside.fbsbx.com/test",
             "mime_type": mime,
         })
-        blob_resp = MagicMock(status_code=200, content=b"x")
-        adapter._http_client.get = AsyncMock(side_effect=[meta_resp, blob_resp])
+        adapter._http_client.get = AsyncMock(return_value=meta_resp)
+        adapter._http_client.stream = MagicMock(return_value=_FakeStreamResponse(
+            status_code=200, headers={"content-length": "1"}, chunks=[b"x"]))
 
         with _patch.object(wac, "_INBOUND_MEDIA_CACHE", tmp_path):
             local_path, _ = await adapter._download_media_to_cache("media_x")
@@ -1363,9 +1367,11 @@ class TestInboundMediaDispatch:
             "url": "https://lookaside.fbsbx.com/whatsapp/m/abc",
             "mime_type": "image/jpeg",
         })
-        blob_resp = MagicMock(status_code=200, content=b"\xff\xd8\xff\xe0fake_jpeg")
+        blob = b"\xff\xd8\xff\xe0fake_jpeg"
         adapter._http_client = MagicMock()
-        adapter._http_client.get = AsyncMock(side_effect=[meta_resp, blob_resp])
+        adapter._http_client.get = AsyncMock(return_value=meta_resp)
+        adapter._http_client.stream = MagicMock(return_value=_FakeStreamResponse(
+            status_code=200, headers={"content-length": str(len(blob))}, chunks=[blob]))
 
         # Build an inbound image webhook payload
         payload = {
@@ -1433,9 +1439,11 @@ class TestInboundMediaDispatch:
             "url": "https://lookaside.fbsbx.com/whatsapp/m/doc",
             "mime_type": "text/plain",
         })
-        blob_resp = MagicMock(status_code=200, content=text_content)
         adapter._http_client = MagicMock()
-        adapter._http_client.get = AsyncMock(side_effect=[meta_resp, blob_resp])
+        adapter._http_client.get = AsyncMock(return_value=meta_resp)
+        adapter._http_client.stream = MagicMock(return_value=_FakeStreamResponse(
+            status_code=200, headers={"content-length": str(len(text_content))},
+            chunks=[text_content]))
 
         payload = {
             "object": "whatsapp_business_account",
@@ -2529,19 +2537,47 @@ class TestReplyContextResolution:
 # Inbound media size cap (_download_media_to_cache)
 # ---------------------------------------------------------------------------
 
-def test_inbound_media_size_cap_rejects_oversized():
-    """Media whose reported file_size exceeds the per-kind cap is refused from
-    the step-1 metadata alone — the bytes are never fetched."""
-    adapter = _make_adapter()
+class _FakeStreamResponse:
+    """Minimal async-context-manager stand-in for httpx's streaming response."""
 
-    meta_resp = MagicMock(status_code=200)
-    meta_resp.json = MagicMock(return_value={
-        "url": "https://lookaside.example/media",
-        "mime_type": "image/jpeg",
-        "file_size": 60 * 1024 * 1024,  # 60 MB; image cap is 5 MB
-    })
+    def __init__(self, *, status_code=200, headers=None, chunks=()):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._chunks = chunks  # iterable; may be a lazy generator
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+def _media_client(meta, stream_resp=None):
+    """Mock httpx client: async ``.get()`` for step-1 metadata, sync
+    ``.stream()`` returning an async-CM for the step-2 byte download."""
     client = MagicMock()
-    client.get = AsyncMock(return_value=meta_resp)
+    client.get = AsyncMock(return_value=meta)
+    client.stream = MagicMock(return_value=stream_resp)
+    return client
+
+
+def _meta(**extra):
+    m = MagicMock(status_code=200)
+    payload = {"url": "https://lookaside.example/media", "mime_type": "image/jpeg"}
+    payload.update(extra)
+    m.json = MagicMock(return_value=payload)
+    return m
+
+
+def test_inbound_media_size_cap_rejects_from_metadata_before_streaming():
+    """A file whose reported file_size exceeds the per-kind cap is refused from
+    the step-1 metadata alone — the byte stream is never opened."""
+    adapter = _make_adapter()
+    client = _media_client(_meta(file_size=60 * 1024 * 1024))  # 60 MB; image cap 5 MB
     adapter._http_client = client
 
     path, mime = asyncio.run(
@@ -2549,56 +2585,67 @@ def test_inbound_media_size_cap_rejects_oversized():
     )
 
     assert path is None and mime is None
-    # Only the metadata GET happened; the byte download was skipped.
-    assert client.get.await_count == 1
+    client.stream.assert_not_called()
+
+
+def test_inbound_media_size_cap_rejects_oversized_content_length():
+    """An oversized Content-Length is refused before any body chunks are read."""
+    adapter = _make_adapter()
+    stream = _FakeStreamResponse(
+        headers={"content-length": str(60 * 1024 * 1024)},
+        chunks=[b"should-not-be-read"],
+    )
+    adapter._http_client = _media_client(_meta(), stream)  # no file_size in metadata
+
+    path, mime = asyncio.run(
+        adapter._download_media_to_cache("MEDIA123", media_kind="image")
+    )
+
+    assert path is None and mime is None
 
 
 def test_inbound_media_size_cap_allows_within_limit(tmp_path, monkeypatch):
-    """Media within the cap is downloaded (metadata + bytes) as normal."""
+    """Media within the cap streams to the cache normally."""
     from gateway.platforms import whatsapp_cloud as wac
     monkeypatch.setattr(wac, "_INBOUND_MEDIA_CACHE", tmp_path)
     adapter = _make_adapter()
-
-    meta_resp = MagicMock(status_code=200)
-    meta_resp.json = MagicMock(return_value={
-        "url": "https://lookaside.example/media",
-        "mime_type": "image/jpeg",
-        "file_size": 1234,
-    })
-    blob_resp = MagicMock(status_code=200, content=b"x" * 1234)
-    client = MagicMock()
-    client.get = AsyncMock(side_effect=[meta_resp, blob_resp])
-    adapter._http_client = client
+    stream = _FakeStreamResponse(
+        headers={"content-length": "2048"},
+        chunks=[b"x" * 1024, b"y" * 1024],
+    )
+    adapter._http_client = _media_client(_meta(file_size=2048), stream)
 
     path, mime = asyncio.run(
         adapter._download_media_to_cache("MEDIA123", media_kind="image")
     )
 
     assert path is not None and mime == "image/jpeg"
-    assert client.get.await_count == 2  # metadata + bytes
+    assert list(tmp_path.iterdir())  # a cache file was written
 
 
-def test_inbound_media_size_cap_backstop_when_file_size_absent(tmp_path, monkeypatch):
-    """With no file_size in the metadata, the post-download backstop still
-    caps the actual payload before it is written to the cache."""
+def test_inbound_media_size_cap_aborts_stream_when_metadata_missing(tmp_path, monkeypatch):
+    """With no file_size and no Content-Length, the rolling cap aborts the
+    stream once the running total crosses the per-kind limit — the whole body
+    is never buffered and no cache file is written."""
     from gateway.platforms import whatsapp_cloud as wac
     monkeypatch.setattr(wac, "_INBOUND_MEDIA_CACHE", tmp_path)
     adapter = _make_adapter()
 
-    meta_resp = MagicMock(status_code=200)
-    meta_resp.json = MagicMock(return_value={
-        "url": "https://lookaside.example/media",
-        "mime_type": "image/jpeg",
-        # file_size deliberately omitted
-    })
-    blob_resp = MagicMock(status_code=200, content=b"x" * (6 * 1024 * 1024))  # 6 MB > 5 MB
-    client = MagicMock()
-    client.get = AsyncMock(side_effect=[meta_resp, blob_resp])
-    adapter._http_client = client
+    consumed = {"chunks": 0}
+
+    def _lazy_chunks():
+        # 8 x 1 MB = 8 MB streamed; image cap is 5 MB → must abort partway.
+        for _ in range(8):
+            consumed["chunks"] += 1
+            yield b"x" * (1024 * 1024)
+
+    stream = _FakeStreamResponse(headers={}, chunks=_lazy_chunks())
+    adapter._http_client = _media_client(_meta(), stream)
 
     path, mime = asyncio.run(
         adapter._download_media_to_cache("MEDIA123", media_kind="image")
     )
 
     assert path is None and mime is None
-    assert client.get.await_count == 2  # fetched, then rejected before write
+    assert not list(tmp_path.glob("MEDIA123*"))  # our media was never cached
+    assert consumed["chunks"] < 8                # aborted before draining the body

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -2523,3 +2523,82 @@ class TestReplyContextResolution:
             rich_sent_store.lookup("15551234567", "wamid.OUT")
             == "here is your answer"
         )
+
+
+# ---------------------------------------------------------------------------
+# Inbound media size cap (_download_media_to_cache)
+# ---------------------------------------------------------------------------
+
+def test_inbound_media_size_cap_rejects_oversized():
+    """Media whose reported file_size exceeds the per-kind cap is refused from
+    the step-1 metadata alone — the bytes are never fetched."""
+    adapter = _make_adapter()
+
+    meta_resp = MagicMock(status_code=200)
+    meta_resp.json = MagicMock(return_value={
+        "url": "https://lookaside.example/media",
+        "mime_type": "image/jpeg",
+        "file_size": 60 * 1024 * 1024,  # 60 MB; image cap is 5 MB
+    })
+    client = MagicMock()
+    client.get = AsyncMock(return_value=meta_resp)
+    adapter._http_client = client
+
+    path, mime = asyncio.run(
+        adapter._download_media_to_cache("MEDIA123", media_kind="image")
+    )
+
+    assert path is None and mime is None
+    # Only the metadata GET happened; the byte download was skipped.
+    assert client.get.await_count == 1
+
+
+def test_inbound_media_size_cap_allows_within_limit(tmp_path, monkeypatch):
+    """Media within the cap is downloaded (metadata + bytes) as normal."""
+    from gateway.platforms import whatsapp_cloud as wac
+    monkeypatch.setattr(wac, "_INBOUND_MEDIA_CACHE", tmp_path)
+    adapter = _make_adapter()
+
+    meta_resp = MagicMock(status_code=200)
+    meta_resp.json = MagicMock(return_value={
+        "url": "https://lookaside.example/media",
+        "mime_type": "image/jpeg",
+        "file_size": 1234,
+    })
+    blob_resp = MagicMock(status_code=200, content=b"x" * 1234)
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=[meta_resp, blob_resp])
+    adapter._http_client = client
+
+    path, mime = asyncio.run(
+        adapter._download_media_to_cache("MEDIA123", media_kind="image")
+    )
+
+    assert path is not None and mime == "image/jpeg"
+    assert client.get.await_count == 2  # metadata + bytes
+
+
+def test_inbound_media_size_cap_backstop_when_file_size_absent(tmp_path, monkeypatch):
+    """With no file_size in the metadata, the post-download backstop still
+    caps the actual payload before it is written to the cache."""
+    from gateway.platforms import whatsapp_cloud as wac
+    monkeypatch.setattr(wac, "_INBOUND_MEDIA_CACHE", tmp_path)
+    adapter = _make_adapter()
+
+    meta_resp = MagicMock(status_code=200)
+    meta_resp.json = MagicMock(return_value={
+        "url": "https://lookaside.example/media",
+        "mime_type": "image/jpeg",
+        # file_size deliberately omitted
+    })
+    blob_resp = MagicMock(status_code=200, content=b"x" * (6 * 1024 * 1024))  # 6 MB > 5 MB
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=[meta_resp, blob_resp])
+    adapter._http_client = client
+
+    path, mime = asyncio.run(
+        adapter._download_media_to_cache("MEDIA123", media_kind="image")
+    )
+
+    assert path is None and mime is None
+    assert client.get.await_count == 2  # fetched, then rejected before write


### PR DESCRIPTION
## What

`_download_media_to_cache` in the WhatsApp Cloud adapter fetches the Graph media metadata (which reports `file_size`) but ignored it, then buffered the entire media blob into memory (`blob_resp.content`) with no size check. Any inbound media message therefore pulls up to Meta's per-type limit — 100 MB for a document — fully into RAM from a webhook-triggered download, which is an OOM risk on memory-constrained hosts.

## Why

The adapter already bounds the two other media surfaces:
- the inbound webhook body (`WEBHOOK_MAX_BODY_BYTES`, 3 MB), and
- outbound uploads (`_MEDIA_SIZE_LIMITS` — "refuse above the limit instead of round-tripping to Graph").

The inbound *download* was the one path left unbounded. This applies the same `_MEDIA_SIZE_LIMITS` table to it:
- reject from the step-1 `file_size` **before** fetching the bytes (no wasted download, no buffering), plus
- a post-download backstop for responses that omit or understate `file_size`.

The caller passes the message's media kind; `voice` shares the `audio` cap. Unknown kinds fall back to the most permissive (document) cap, so nothing that works today starts failing.

## How to test

`pytest tests/gateway/test_whatsapp_cloud.py -q` → 115 passed (3 new):
- `test_inbound_media_size_cap_rejects_oversized` — oversized `file_size` is refused and the byte download is never issued.
- `test_inbound_media_size_cap_allows_within_limit` — within-cap media downloads normally (metadata + bytes).
- `test_inbound_media_size_cap_backstop_when_file_size_absent` — missing `file_size` still capped by the post-download backstop.

`ruff check gateway/platforms/whatsapp_cloud.py` clean. (Ran the affected test file + ruff locally; full suite left to CI.)

## Platforms tested

Linux — fixture-driven unit tests, httpx patched, no live network.
