### PR TITLE
feat(web): add MarkItDown as a local web extract provider (#65179)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1354,6 +1354,28 @@ def _run_post_setup(post_setup_key: str):
         _print_info("    No API key required. DuckDuckGo enforces server-side rate limits.")
         _print_info("    Pair with an extract provider if you also need web_extract.")
 
+    elif post_setup_key == "markitdown":
+        try:
+            __import__("markitdown")
+            _print_success("    markitdown is already installed")
+        except ImportError:
+            _print_info("    Installing markitdown (Microsoft's HTML-to-markdown library)...")
+            try:
+                result = _pip_install(["-U", "markitdown", "--quiet"], timeout=300)
+                if result.returncode == 0:
+                    _print_success("    markitdown installed")
+                else:
+                    _print_warning("    markitdown install failed:")
+                    _print_info(f"      {(result.stderr or '').strip()[:300]}")
+                    _print_info("    Run manually: uv pip install -U markitdown")
+                    return
+            except subprocess.TimeoutExpired:
+                _print_warning("    markitdown install timed out (>5min)")
+                _print_info("    Run manually: uv pip install -U markitdown")
+                return
+        _print_info("    No API key required. Converts HTML pages to markdown locally.")
+        _print_info("    Pair with a search provider (brave-free, ddgs, searxng) for web_search.")
+
     elif post_setup_key == "spotify":
         # Run the full `hermes auth spotify` flow — if the user has no
         # client_id yet, this drops them into the interactive wizard

--- a/plugins/web/markitdown/__init__.py
+++ b/plugins/web/markitdown/__init__.py
@@ -1,0 +1,15 @@
+"""MarkItDown extract plugin — bundled, auto-loaded.
+
+Extract-only — uses Microsoft's MarkItDown library to convert HTML pages
+to clean markdown locally. No API key, no cloud dependency. Pair with any
+search provider (brave-free, ddgs, searxng, etc.) for web_search.
+"""
+
+from __future__ import annotations
+
+from plugins.web.markitdown.provider import MarkItDownExtractProvider
+
+
+def register(ctx) -> None:
+    """Register the MarkItDown provider with the plugin context."""
+    ctx.register_web_search_provider(MarkItDownExtractProvider())

--- a/plugins/web/markitdown/plugin.yaml
+++ b/plugins/web/markitdown/plugin.yaml
@@ -1,0 +1,5 @@
+name: web-markitdown
+version: 1.0.0
+description: "MarkItDown — self-hosted, local web page to markdown conversion via Microsoft's MarkItDown library. No API key needed. Requires the markitdown Python package."
+author: NousResearch
+kind: backend

--- a/plugins/web/markitdown/provider.py
+++ b/plugins/web/markitdown/provider.py
@@ -1,0 +1,161 @@
+"""MarkItDown extract provider — plugin form.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. Uses
+Microsoft's MarkItDown library to locally convert HTML pages to clean
+markdown. No API key, no cloud dependency — purely self-hosted.
+
+Extract-only — ``supports_search()`` returns False. Pair with any search
+provider (brave-free, ddgs, searxng, etc.) for ``web_search``.
+
+Config keys this provider responds to::
+
+    web:
+      extract_backend: "markitdown"  # explicit per-capability
+      backend: "markitdown"          # shared fallback
+
+No env vars required. Ensure the ``markitdown`` Python package is installed:
+
+    pip install markitdown
+
+or via the bundled lazy-install mechanism (``hermes tools`` will prompt).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+# Timeout per-URL fetch (seconds).
+_FETCH_TIMEOUT = 30
+
+
+def _markitdown_package_available() -> bool:
+    """Return True when the ``markitdown`` package is importable.
+
+    Cheap — Python caches the import after the first call. No network I/O.
+    """
+    try:
+        import markitdown  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+class MarkItDownExtractProvider(WebSearchProvider):
+    """Extract web page content to markdown via Microsoft's MarkItDown.
+
+    Fetches each URL with httpx, converts the HTML response to markdown
+    using the local ``markitdown`` library, and returns the result.
+    """
+
+    @property
+    def name(self) -> str:
+        return "markitdown"
+
+    @property
+    def display_name(self) -> str:
+        return "MarkItDown"
+
+    def is_available(self) -> bool:
+        """Return True when the ``markitdown`` package is importable."""
+        return _markitdown_package_available()
+
+    def supports_search(self) -> bool:
+        return False
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Fetch URLs and convert to markdown using MarkItDown.
+
+        Args:
+            urls: List of URL strings to extract content from.
+            **kwargs: Forward-compat extras (``format``, etc.) — ignored.
+
+        Returns:
+            List of result dicts, one per URL, in the same order::
+
+                [
+                    {
+                        "url": str,
+                        "title": str,
+                        "content": str,       # markdown output
+                        "raw_content": str,   # same as content
+                        "metadata": dict,
+                        "error": str,         # only on per-URL failure
+                    },
+                    ...
+                ]
+        """
+        from markitdown import MarkItDown
+
+        md = MarkItDown()
+        results: List[Dict[str, Any]] = []
+
+        for url in urls:
+            result: Dict[str, Any] = {"url": url, "title": "", "content": "", "raw_content": "", "metadata": {}}
+            try:
+                # Fetch the URL with httpx.
+                resp = httpx.get(url, timeout=_FETCH_TIMEOUT, follow_redirects=True)
+                resp.raise_for_status()
+
+                # Convert the response content to markdown.
+                converted = md.convert(io.BytesIO(resp.content))
+
+                title = converted.title or ""
+                text_content = converted.text_content or ""
+
+                result["title"] = title
+                result["content"] = text_content
+                result["raw_content"] = text_content
+
+                logger.info(
+                    "MarkItDown extracted %s (%d chars) from %s",
+                    title[:60] if title else "(no title)",
+                    len(text_content),
+                    url,
+                )
+
+            except httpx.TimeoutException as exc:
+                msg = f"Timeout fetching {url}: {exc}"
+                logger.warning("MarkItDown %s", msg)
+                result["error"] = msg
+
+            except httpx.HTTPStatusError as exc:
+                msg = f"HTTP {exc.response.status_code} fetching {url}"
+                logger.warning("MarkItDown %s", msg)
+                result["error"] = msg
+
+            except httpx.RequestError as exc:
+                msg = f"Request failed for {url}: {exc}"
+                logger.warning("MarkItDown %s", msg)
+                result["error"] = msg
+
+            except Exception as exc:  # noqa: BLE001
+                msg = f"MarkItDown conversion failed for {url}: {exc}"
+                logger.warning("%s", msg)
+                result["error"] = msg
+
+            results.append(result)
+
+        return results
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "MarkItDown",
+            "badge": "free · self-hosted",
+            "tag": (
+                "Local HTML-to-markdown via Microsoft's MarkItDown library. "
+                "No API key needed. Extract-only — pair with any search provider."
+            ),
+            "env_vars": [],
+            "post_setup": "markitdown",
+        }

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -169,7 +169,7 @@ def _load_web_config() -> dict:
 # WebSearchProvider. Keep the two sets aligned by hand: if xai ever ships as
 # a registered provider, drop it here so the registry path takes over.
 _LEGACY_WEB_BACKENDS = frozenset(
-    {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}
+    {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai", "markitdown"}
 )
 
 
@@ -247,6 +247,7 @@ def _get_backend() -> str:
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
+        ("markitdown", _markitdown_package_importable()),
     )
     for backend, available in backend_candidates:
         if available:
@@ -349,6 +350,8 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    if backend == "markitdown":
+        return _markitdown_package_importable()
     return False
 
 
@@ -366,8 +369,22 @@ def _ddgs_package_importable() -> bool:
     except ImportError:
         return False
 
-# ─── Firecrawl Client ────────────────────────────────────────────────────────
 
+def _markitdown_package_importable() -> bool:
+    """Return True when the ``markitdown`` Python package can be imported.
+
+    Like ddgs, markitdown's availability is driven by package presence
+    rather than an env var. Wrapped in a helper so auto-detect and
+    ``_is_backend_available`` share the same check.
+    """
+    try:
+        import markitdown  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+# ─── Firecrawl Client ────────────────────────────────────────────────────────
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 # After PR #25182, the firecrawl client, lazy SDK proxy, dual-auth config
 # resolution, response normalizers, and check_firecrawl_api_key() all live
@@ -887,7 +904,7 @@ async def web_extract_tool(
                                 f"{provider.display_name} is a search-only "
                                 "backend and cannot extract URL content. "
                                 "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "tavily, exa, parallel, or markitdown."
                             ),
                         },
                         ensure_ascii=False,
@@ -921,7 +938,7 @@ async def web_extract_tool(
                             "error": (
                                 "No web extract provider configured. "
                                 "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "tavily, exa, parallel, or markitdown."
                             ),
                         },
                         ensure_ascii=False,
@@ -1114,6 +1131,8 @@ if __name__ == "__main__":
             print("   Using Brave Search free tier (search only)")
         elif backend == "ddgs":
             print("   Using DuckDuckGo via ddgs package (search only)")
+        elif backend == "markitdown":
+            print("   Using MarkItDown (local HTML-to-markdown, extract only)")
         elif firecrawl_url_available:
             print(f"   Using self-hosted Firecrawl: {(_gev('FIRECRAWL_API_URL') or '').strip().rstrip('/')}")
         elif firecrawl_key_available:
@@ -1123,10 +1142,11 @@ if __name__ == "__main__":
         else:
             print("   Firecrawl backend selected but not configured")
     else:
-        print("❌ No web search backend configured")
+        print("❌ No web search/extract backend configured")
         print(
             "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
-            f"{_firecrawl_backend_help_suffix()}"
+            f"{_firecrawl_backend_help_suffix()}, or install markitdown"
+            " (pip install markitdown) for local extract-only use."
         )
 
     if not web_available:


### PR DESCRIPTION
Adds Microsoft MarkItDown as a local web_fetch provider option. Users can extract web content to markdown locally without external services.\n\n- Creates `plugins/web/markitdown/` plugin (manifest + provider)\n- Wires into `tools/web_tools.py` auto-detect chain\n- Auto-installable via `hermes tools`\n\nCloses #65179