### PR TITLE
fix(desktop): rebase simple-git paths from repo-root to cwd-relative

### DIFF
--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { resolveRenamePath } from './git-review-ops'
+import { rebasePath, resolveRenamePath } from './git-review-ops'
 
 test('resolveRenamePath: plain path is unchanged', () => {
   assert.equal(resolveRenamePath('src/a.ts'), 'src/a.ts')
@@ -18,4 +18,27 @@ test('resolveRenamePath: brace rename resolves to the new path', () => {
 
 test('resolveRenamePath: brace rename collapsing a segment', () => {
   assert.equal(resolveRenamePath('src/{lib => }/file.ts'), 'src/file.ts')
+})
+
+// rebasePath maps repo-root-relative paths (what simple-git returns) to
+// cwd-relative paths (what the renderer expects). When the session cwd is a
+// subdirectory of the repo root, un-rebased paths would cause wrong-file
+// diffs and stage/unstage failures.
+
+test('rebasePath: nested cwd strips the common prefix', () => {
+  assert.equal(rebasePath('/repo', '/repo/apps', 'apps/foo.ts'), 'foo.ts')
+})
+
+test('rebasePath: deeply nested cwd strips all common segments', () => {
+  assert.equal(rebasePath('/repo', '/repo/apps/desktop', 'apps/desktop/src/a.ts'), 'src/a.ts')
+})
+
+test('rebasePath: cwd === root is a no-op (no subdirectory)', () => {
+  assert.equal(rebasePath('/repo', '/repo', 'src/a.ts'), 'src/a.ts')
+})
+
+test('rebasePath: falsy inputs pass through unchanged', () => {
+  assert.equal(rebasePath(null, '/repo', 'src/a.ts'), 'src/a.ts')
+  assert.equal(rebasePath('/repo', null, 'src/a.ts'), 'src/a.ts')
+  assert.equal(rebasePath('/repo', '/repo', ''), '')
 })

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -46,6 +46,27 @@ function gitFor(cwd, gitBin) {
   return simpleGit({ baseDir: cwd, binary: gitBin || 'git', maxConcurrentProcesses: 4, trimmed: false })
 }
 
+// simple-git returns paths relative to the git repo root, but the renderer
+// expects them relative to the requested cwd (which may be a subdirectory of
+// the repo). Resolve the repo root once per call, then re-base each path.
+// gitBin is threaded (not discarded) so Windows PortableGit — resolved in the
+// main process and deliberately NOT on PATH — is used for the toplevel probe.
+async function repoRoot(cwd, gitBin) {
+  try {
+    return (await gitFor(cwd, gitBin).revparse(['--show-toplevel'])).trim()
+  } catch {
+    return cwd
+  }
+}
+
+function rebasePath(root, cwd, repoRelativePath) {
+  if (!root || !cwd || !repoRelativePath) {
+    return repoRelativePath
+  }
+
+  return path.relative(cwd, path.join(root, repoRelativePath))
+}
+
 // simple-git reports renames as `old => new` (and `dir/{old => new}/f`); resolve
 // to the NEW path so the row addresses the real file for diff/stage.
 function resolveRenamePath(raw) {
@@ -239,9 +260,10 @@ async function reviewList(repoPath, scope, baseRef, gitBin) {
 
       const range = scope === 'branch' ? `${base}...HEAD` : base
       const summary = await git.diffSummary([range])
+      const root = await repoRoot(cwd, gitBin)
 
       const files = summary.files.map(file => ({
-        path: resolveRenamePath(file.file),
+        path: rebasePath(root, cwd, resolveRenamePath(file.file)),
         added: 'insertions' in file ? file.insertions : 0,
         removed: 'deletions' in file ? file.deletions : 0,
         status: 'M',
@@ -252,9 +274,11 @@ async function reviewList(repoPath, scope, baseRef, gitBin) {
       if (scope === 'lastTurn') {
         const status = await git.status()
 
-        for (const path of status.not_added) {
-          if (!files.some(f => f.path === path)) {
-            files.push({ path, added: 0, removed: 0, status: '?', staged: false })
+        for (const entry of status.not_added) {
+          const rp = rebasePath(root, cwd, entry)
+
+          if (!files.some(f => f.path === rp)) {
+            files.push({ path: rp, added: 0, removed: 0, status: '?', staged: false })
           }
         }
       }
@@ -274,11 +298,14 @@ async function reviewList(repoPath, scope, baseRef, gitBin) {
 
     const stagedCounts = countsByPath(staged)
     const unstagedCounts = countsByPath(unstaged)
+    const root = await repoRoot(cwd, gitBin)
 
     const files = status.files.map(file => {
-      const filePath = resolveRenamePath(file.path)
-      const sc = stagedCounts.get(filePath) || { added: 0, removed: 0 }
-      const uc = unstagedCounts.get(filePath) || { added: 0, removed: 0 }
+      const filePath = rebasePath(root, cwd, resolveRenamePath(file.path))
+      // countsByPath keys are root-relative (from simple-git's diffSummary),
+      // so look up with the original (pre-rebase) path.
+      const sc = stagedCounts.get(resolveRenamePath(file.path)) || { added: 0, removed: 0 }
+      const uc = unstagedCounts.get(resolveRenamePath(file.path)) || { added: 0, removed: 0 }
 
       return {
         path: filePath,
@@ -677,6 +704,7 @@ async function repoStatus(repoPath, gitBin) {
 export {
   branchBase,
   fileDiffVsHead,
+  rebasePath,
   repoStatus,
   resolveRenamePath,
   reviewCommit,


### PR DESCRIPTION
## What does this PR do?

Fixes a cross-platform bug where the desktop review pane shows file paths incorrectly when the active session's cwd is a subdirectory of the git repo root. `simple-git` returns repo-root-relative paths, but the renderer expects cwd-relative paths. This mismatch caused "No diff to show", wrong-file diffs, and silent failures in stage/unstage/revert.

This is a **salvage** of #60157 by @tuancookiez-hub. The original PR targeted `git-review-ops.cjs`, which was migrated to `.ts` in `39d09453`; the submitted file was no longer the live implementation. This PR ports the same rebasing logic to the current `git-review-ops.ts` module and addresses both issues raised in the sweeper review:

1. **Ported to `.ts`** — all changes applied to `apps/desktop/electron/git-review-ops.ts`.
2. **`gitBin` threaded** — `repoRoot(cwd, gitBin)` uses the resolved binary instead of discarding it (`gitFor(cwd, null)` → `gitFor(cwd, gitBin)`), so Windows PortableGit (resolved by the main process, deliberately not on PATH) is used for the `--show-toplevel` probe.

## Related Issue

Fixes #60157

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/git-review-ops.ts`:
  - Add `repoRoot(cwd, gitBin)` helper that returns `git rev-parse --show-toplevel` (falls back to `cwd` if not in a repo). Threads `gitBin` so Windows PortableGit is used.
  - Add `rebasePath(root, cwd, repoRelativePath)` helper that maps a repo-root-relative path to a cwd-relative path.
  - In `reviewList`:
    - **branch / lastTurn scope**: rebase `summary.files[].file` from `git.diffSummary(range)`.
    - **lastTurn untracked**: rebase `status.not_added[]` entries.
    - **default (uncommitted) scope**: rebase `status.files[].path` for the returned `filePath`, while using the original root-relative path as the lookup key for `stagedCounts`/`unstagedCounts` (since `countsByPath` is built from `simple-git` diffSummary results which are also root-relative).
  - Export `rebasePath` for testing.
- `apps/desktop/electron/git-review-ops.test.ts`:
  - Add tests for `rebasePath`: nested cwd strips common prefix, deeply nested cwd, repo-root no-op, and falsy-input passthrough.

No changes to `reviewDiff`, `fileDiffVsHead`, `reviewStage`, `reviewUnstage`, or `reviewRevert` — those receive cwd-relative paths from the renderer and pass them straight to `simple-git` (which uses `baseDir=cwd`), so they were already correct.

## How to Test

1. `cd apps/desktop && npx vitest run electron/git-review-ops.test.ts` — all 8 tests pass.
2. `npx eslint electron/git-review-ops.ts electron/git-review-ops.test.ts` — clean.
3. `npx tsc -p . --noEmit` — no errors in changed files.

**Reproduction (any platform, in a monorepo or any repo where cwd can be a subdirectory):**
1. Create a git repo: `mkdir /tmp/rebase-test && cd /tmp/rebase-test && git init && touch README.md && git add . && git commit -m initial`
2. Make the repo a "monorepo": `mkdir apps && touch apps/foo.ts && git add apps/foo.ts`
3. From the desktop app, open a session with cwd set to `/tmp/rebase-test/apps`
4. Open the review pane (Ctrl+G)
5. **Before:** file appears as `foo.ts` — looks correct, but `Open Changes` shows the diff for `apps/foo.ts` from repo root, not the cwd-relative path. Stage targets `apps/foo.ts` from cwd, which resolves to `/tmp/rebase-test/apps/apps/foo.ts` (wrong path).
6. **After:** file appears as `foo.ts` (correctly cwd-relative). `Open Changes` shows the real diff. Stage targets `apps/foo.ts` correctly.

**Sanity check for non-subdirectory case:**
1. Open any normal repo (cwd = repo root) — no change in behavior, rebase is a no-op.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (desktop TS only, no Python changes)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (NixOS)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — gitBin threading fixes the Windows PortableGit path
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A