### PR TITLE
fix(ci): handle merge race in js-autofix poll loop

### DIFF
--- a/.github/workflows/js-autofix.yml
+++ b/.github/workflows/js-autofix.yml
@@ -207,12 +207,17 @@ jobs:
               exit 0
             fi
 
-            # If main moved, close the PR — the next workflow run re-applies
-            # on the current state.
+            # If main moved, the PR may have already merged (which moves
+            # main) or another commit landed. Re-check state first.
             CURRENT_SHA=$(gh api "repos/${{ github.repository }}/branches/main" --jq '.commit.sha')
             if [ "$CURRENT_SHA" != "$START_SHA" ]; then
+              STATE=$(gh pr view "$PR_NUM" --json state --jq '.state')
+              if [ "$STATE" = "MERGED" ]; then
+                echo "PR #$PR_NUM merged (main moved to $CURRENT_SHA)."
+                exit 0
+              fi
               echo "Main moved ($START_SHA → $CURRENT_SHA). Closing stale PR."
-              gh pr close "$PR_NUM" --delete-branch
+              gh pr close "$PR_NUM" --delete-branch || true
               exit 0
             fi
 


### PR DESCRIPTION
## What does this PR do?

The js-autofix workflow's poll loop has a race condition: when the bot PR
auto-merges, `main` moves (because the merge creates a new commit). The poll
loop detects this as "main moved" and tries to `gh pr close` — but the PR is
already merged, so `gh pr close` fails with:

```
Pull request NousResearch/hermes-agent#65229 can't be closed because it was already merged
```

Fix: when `main` moves, re-check the PR state before closing. If it's already
`MERGED`, exit cleanly. Also make `gh pr close` non-fatal (`|| true`) on all
close paths as a belt-and-suspenders guard against the same race.

## Related Issue

Follow-up to #65186 and #65221. Discovered when the workflow successfully
created + auto-merged PR #65229 but the poll step failed on the merge race.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `.github/workflows/js-autofix.yml`: re-check PR state when `main` moves before closing; make `gh pr close` non-fatal with `|| true`

## How to Test

1. Merge this PR.
2. Trigger the `auto-fix lint issues & formatting` workflow.
3. The bot PR should auto-merge, and the poll step should exit cleanly with "PR #N merged" instead of failing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: CI workflow change, no Python tests affected
- [x] I've added tests for my changes — N/A: GitHub Actions workflow, validated via YAML parse + structure check
- [x] I've tested on my platform: NixOS (workflow YAML validated with `yaml.safe_load`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (workflow internal)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (GitHub Actions only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Failing run after PR #65229 auto-merged:
```
Apply patch  Wait for merge, auto-close on failure or stale  Waiting for PR #65229 to merge...
Apply patch  Wait for merge, auto-close on failure or stale  Main moved (5222d24f3 → 75f45a069). Closing stale PR.
Apply patch  Wait for merge, auto-close on failure or stale  X Pull request NousResearch/hermes-agent#65229 can't be closed because it was already merged
Apply patch  Wait for merge, auto-close on failure or stale  ##[error]Process completed with exit code 1.
```
