### PR TITLE
fix(custom-profile): omit reasoning_effort="none" for remote endpoints

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -68,6 +68,32 @@ def _is_local_endpoint(base_url: str) -> bool:
     return False
 
 
+def _read_reasoning_disable_method(ctx: dict) -> str:
+    """Return how to disable reasoning for the current custom provider.
+
+    Reads ``custom_providers[<name>].reasoning_disable`` from config.
+    Returns one of ``"auto"`` (default), ``"none"``, or ``"omit"``.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly()
+        providers = cfg.get("custom_providers") or []
+        # Find the matching provider by base_url
+        for p in providers:
+            if not isinstance(p, dict):
+                continue
+            p_url = (p.get("base_url") or "").strip()
+            ctx_url = (ctx.get("base_url") or "").strip()
+            if p_url and ctx_url and p_url.rstrip("/") == ctx_url.rstrip("/"):
+                val = (p.get("reasoning_disable") or "").strip().lower()
+                if val in {"none", "omit"}:
+                    return val
+                return "auto"
+    except Exception:
+        pass
+    return "auto"
+
+
 class CustomProfile(ProviderProfile):
     """Custom/Ollama local provider — think=false and num_ctx support."""
 
@@ -120,12 +146,26 @@ class CustomProfile(ProviderProfile):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
-                # Only send reasoning_effort="none" + think=False to LOCAL
-                # endpoints (Ollama, local vLLM/llama.cpp). Remote endpoints
-                # reject "none" as invalid — omit entirely so server default applies.
-                if _is_local:
+                # How to signal reasoning-off to the endpoint.
+                #
+                #   "auto" (default) → locality heuristic: send to local,
+                #     omit for remote (Ollama needs it; ofox/ARK reject it)
+                #   "none" → always send reasoning_effort="none" + think=False
+                #     (for remote endpoints that accept it)
+                #   "omit" → never send the disable fields
+                #     (for endpoints that reject "none", let server default apply)
+                #
+                # Read from the per-provider config key ``reasoning_disable``
+                # in ``custom_providers``. Falls back to "auto".
+                _method = _read_reasoning_disable_method(ctx)
+                if _method == "none":
                     top_level["reasoning_effort"] = "none"
                     extra_body["think"] = False
+                elif _method == "auto":
+                    if _is_local:
+                        top_level["reasoning_effort"] = "none"
+                        extra_body["think"] = False
+                # "omit": send neither — server default applies
             elif _effort:
                 top_level["reasoning_effort"] = _effort
 

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -4,18 +4,68 @@ Covers any endpoint registered as provider="custom", including local
 Ollama instances and OpenAI-compatible reasoning endpoints (GLM-5.2 on
 Volcengine ARK, vLLM, llama.cpp). Key quirks:
   - ollama_num_ctx → extra_body.options.num_ctx (local context window)
-  - reasoning_config disabled → top-level reasoning_effort="none"
+  - reasoning_config disabled + local endpoint → top-level reasoning_effort="none"
     (Ollama /v1/chat/completions ignores think=False — ollama#14820)
     + extra_body.think = False for /api/chat and proxies
+    Remote endpoints get neither (they reject "none" as invalid).
   - reasoning_config enabled + effort → top-level reasoning_effort
     (the native OpenAI-compatible format GLM/ARK expect; unset omits it
     so the endpoint's server default applies)
 """
 
+import ipaddress
 from typing import Any
+from urllib.parse import urlparse
 
 from providers import register_provider
 from providers.base import ProviderProfile
+
+
+def _is_local_endpoint(base_url: str) -> bool:
+    """Return True if base_url points to a local/private/LAN endpoint.
+
+    Checks for loopback (v4 + v6), private LAN ranges, and .local domains.
+    Avoids false positives from remote URLs that happen to contain substrings
+    like 'localhost' (e.g. https://localhost.example.com).
+    """
+    if not base_url:
+        return False
+    base_url = base_url.strip()
+    if not base_url:
+        return False
+
+    # Parse URL properly instead of substring matching
+    if not (base_url.startswith("http://") or base_url.startswith("https://")):
+        base_url = f"http://{base_url}"
+    try:
+        parsed = urlparse(base_url)
+        host = parsed.hostname or ""
+    except Exception:
+        return False
+
+    if not host:
+        return False
+
+    host_lower = host.lower()
+
+    # Exact hostname matches for loopback/loopback aliases
+    if host_lower in {"localhost", "ip6-localhost", "ip6-loopback", "0.0.0.0", "::", "::1"}:
+        return True
+
+    # .local mDNS domains (Bonjour/AVAHI — always local LAN)
+    if host_lower.endswith(".local") or host_lower.endswith(".localhost"):
+        return True
+
+    # IP address check: loopback or private/LAN range
+    try:
+        ip = ipaddress.ip_address(host)
+        if ip.is_loopback or ip.is_private or ip.is_link_local:
+            return True
+    except ValueError:
+        # Not an IP, hostname checked above
+        pass
+
+    return False
 
 
 class CustomProfile(ProviderProfile):
@@ -37,10 +87,25 @@ class CustomProfile(ProviderProfile):
             options["num_ctx"] = ollama_num_ctx
             extra_body["options"] = options
 
+        # Resolve base URL for local detection
+        _base_url = str(
+            ctx.get("base_url")
+            or getattr(self, "base_url", "")
+            or ""
+        ).strip()
+        # If no base_url is provided (only happens in legacy tests, never production),
+        # default to local behavior to preserve backward compatibility
+        _is_local = True if not _base_url else _is_local_endpoint(_base_url)
+
         # Reasoning / thinking control for custom OpenAI-compatible endpoints
         # (GLM-5.2 on Volcengine ARK, vLLM, Ollama, llama.cpp, …).
         #
-        #   - disabled  → extra_body.think = False (Ollama's thinking-off flag)
+        #   - disabled + LOCAL endpoint → extra_body.think = False + reasoning_effort="none"
+        #     (Ollama's thinking-off flag + top-level field that Ollama /v1/chat/completions
+        #     actually respects; ollama#14820, #25758)
+        #   - disabled + REMOTE endpoint → emit NEITHER. Remote OpenAI-compatible APIs
+        #     (ofox, Volcengine ARK, etc.) reject reasoning_effort="none" as invalid, so we
+        #     omit the field entirely and let the server default apply.
         #   - enabled + effort set → TOP-LEVEL reasoning_effort string, the
         #     format GLM-5.2/ARK and other OpenAI-compatible reasoning APIs
         #     expect (GLM documents "high" and "max"; "max" is its default).
@@ -55,14 +120,12 @@ class CustomProfile(ProviderProfile):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
-                # Ollama's /v1/chat/completions silently ignores
-                # extra_body.think (only /api/chat honours it — ollama#14820)
-                # but respects the top-level reasoning_effort field, so both
-                # are needed to actually stop a thinking-capable model from
-                # reasoning (#25758). Endpoints that recognize neither simply
-                # ignore them.
-                top_level["reasoning_effort"] = "none"
-                extra_body["think"] = False
+                # Only send reasoning_effort="none" + think=False to LOCAL
+                # endpoints (Ollama, local vLLM/llama.cpp). Remote endpoints
+                # reject "none" as invalid — omit entirely so server default applies.
+                if _is_local:
+                    top_level["reasoning_effort"] = "none"
+                    extra_body["think"] = False
             elif _effort:
                 top_level["reasoning_effort"] = _effort
 

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -7,7 +7,9 @@ nothing when reasoning was *enabled*, so a configured ``reasoning_effort``
 was silently dropped for every custom endpoint.
 
 These tests pin the wire-shape contract:
-  - disabled            → extra_body.think = False
+  - disabled + local endpoint  → extra_body.think = False + reasoning_effort="none"
+  - disabled + remote endpoint → nothing emitted (avoids HTTP 400 from APIs
+                                 that reject reasoning_effort="none")
   - enabled + effort    → top-level reasoning_effort (native OpenAI-compat
                           format GLM/ARK expect), passed through verbatim
                           including ``max``/``xhigh``
@@ -48,27 +50,51 @@ class TestCustomReasoningWireShape:
         assert eb == {}
         assert tl == {}
 
-    def test_disabled_sends_think_false(self, custom_profile):
-        """enabled=False → reasoning_effort='none' top-level + think=False.
+    def test_disabled_sends_think_false_for_local(self, custom_profile):
+        """enabled=False + local base_url → reasoning_effort='none' + think=False.
 
-        Both fields are required: Ollama's /v1/chat/completions silently
+        Both fields are required for Ollama: /v1/chat/completions silently
         ignores extra_body.think (only /api/chat honours it — ollama#14820)
-        but respects top-level reasoning_effort (#25758). think=False stays
-        for proxies and the native /api/chat path.
+        but respects top-level reasoning_effort (#25758).
         """
         eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": False}, model="glm-5.2"
+            reasoning_config={"enabled": False}, model="glm-5.2",
+            base_url="http://localhost:11434/v1",
         )
         assert eb == {"think": False}
         assert tl == {"reasoning_effort": "none"}
 
-    def test_effort_none_sends_think_false(self, custom_profile):
-        """effort='none' is the disable alias → same dual emission."""
+    def test_disabled_omits_for_remote(self, custom_profile):
+        """enabled=False + remote base_url → nothing emitted.
+
+        Remote OpenAI-compatible APIs (ofox, Volcengine ARK, etc.) reject
+        reasoning_effort="none" as invalid.  Omit so the server default applies.
+        """
         eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "none"}, model="glm-5.2"
+            reasoning_config={"enabled": False}, model="doubao-seed-2.1-pro",
+            base_url="https://api.ofox.ai/v1",
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_effort_none_sends_think_false_for_local(self, custom_profile):
+        """effort='none' + local → same dual emission as enabled=False."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"}, model="glm-5.2",
+            base_url="http://127.0.0.1:11434/v1",
         )
         assert eb == {"think": False}
         assert tl == {"reasoning_effort": "none"}
+
+    def test_effort_none_omits_for_remote(self, custom_profile):
+        """effort='none' + remote → nothing emitted."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"},
+            model="doubao-seed-2.1-pro",
+            base_url="https://api.ofox.ai/v1",
+        )
+        assert eb == {}
+        assert tl == {}
 
     @pytest.mark.parametrize(
         "effort", ["minimal", "low", "medium", "high", "xhigh", "max"]

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -130,6 +130,59 @@ class TestCustomReasoningWireShape:
         assert eb.get("think") is not True
 
 
+class TestCustomReasoningDisableConfig:
+    """``reasoning_disable`` config key overrides the locality heuristic."""
+
+    def test_disable_none_forces_on_remote(self, custom_profile, monkeypatch):
+        """reasoning_disable='none' → always send fields, even remote."""
+        import sys
+        _mod = sys.modules["plugins.model_providers.custom"]
+        monkeypatch.setattr(_mod, "_read_reasoning_disable_method", lambda ctx: "none")
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="doubao-seed-2.1-pro",
+            base_url="https://api.ofox.ai/v1",
+        )
+        assert eb == {"think": False}
+        assert tl == {"reasoning_effort": "none"}
+
+    def test_disable_omit_suppresses_on_local(self, custom_profile, monkeypatch):
+        """reasoning_disable='omit' → never send fields, even local."""
+        import sys
+        _mod = sys.modules["plugins.model_providers.custom"]
+        monkeypatch.setattr(_mod, "_read_reasoning_disable_method", lambda ctx: "omit")
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="glm-5.2",
+            base_url="http://localhost:11434/v1",
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_disable_auto_keeps_locality_default(self, custom_profile, monkeypatch):
+        """reasoning_disable='auto' (default) → locality heuristic applies."""
+        import sys
+        _mod = sys.modules["plugins.model_providers.custom"]
+        monkeypatch.setattr(_mod, "_read_reasoning_disable_method", lambda ctx: "auto")
+        # Local → fields emitted
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="glm-5.2",
+            base_url="http://localhost:11434/v1",
+        )
+        assert eb == {"think": False}
+        assert tl == {"reasoning_effort": "none"}
+
+        # Remote → fields omitted
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="doubao-seed-2.1-pro",
+            base_url="https://api.ofox.ai/v1",
+        )
+        assert eb == {}
+        assert tl == {}
+
+
 class TestCustomReasoningWithNumCtx:
     """Ollama num_ctx and reasoning are independent and compose."""
 


### PR DESCRIPTION
Fixes #65233
Related: #59660

## Problem
CustomProfile.build_api_kwargs_extras() unconditionally sent `reasoning_effort="none"` + `think=False` when reasoning was disabled. Remote OpenAI-compatible APIs (ofox, Volcengine ARK, Doubao, etc.) reject `reasoning_effort="none"` as invalid — HTTP 400.

## Fix
Only emit both fields for local endpoints. Remote endpoints get neither — server default applies.

### Local endpoint detection (proper, not substring matching)

1. **`urlparse` for hostname extraction** — avoids false positives like `https://localhost.example.com` being treated as local
2. **Exact hostname matches**: `localhost`, `ip6-localhost`, `ip6-loopback`, `0.0.0.0`, `::`, `::1`
3. **IPv6 loopback support**: `[::1]`, `[::]` recognized
4. **RFC1918 private/LAN ranges**: 192.168.x.x, 10.x.x.x, 172.16-31.x.x via `ipaddress` module
5. **Link-local addresses**: 169.254.x.x
6. **mDNS `.local` domains**: Bonjour/Avahi (Ollama on other Macs, AirDrop)
7. **Fallback**: no `base_url` → default to local (backward compat with legacy tests that don’t pass base_url)

### Wire behavior

| Scenario | Fields emitted |
|---|---|
| disabled + local | `reasoning_effort="none"`, `think=False` |
| disabled + remote | nothing |
| effort="none" + local | `reasoning_effort="none"`, `think=False` |
| effort="none" + remote | nothing |
| effort=low/medium/high/max/xhigh | `reasoning_effort=<effort>` (passed through) |
| enabled, no effort | nothing |

## Testing
- All 13 existing tests pass
- 4 new tests added: remote-local split for both `enabled=False` and `effort="none"` paths
- Valid effort levels (low/medium/high/max/xhigh) still pass through verbatim