### PR TITLE
fix(web): expose custom model reasoning modes

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6590,6 +6590,96 @@ _EMPTY_MODEL_INFO: dict = {
 }
 
 
+def _custom_provider_model_capabilities(
+    cfg: Dict[str, Any], provider: str, model: str
+) -> Dict[str, Any]:
+    """Resolve per-model capability metadata from a named custom provider."""
+    provider_key = str(provider or "").strip()
+    if provider_key.lower().startswith("custom:"):
+        provider_key = provider_key.split(":", 1)[1]
+    provider_key = provider_key.lower()
+    if not provider_key or not model:
+        return {}
+
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+        from hermes_cli.providers import custom_provider_slug
+
+        providers = get_compatible_custom_providers(cfg)
+    except Exception:
+        return {}
+
+    for entry in providers:
+        display_name = str(entry.get("name") or "").strip()
+        # Match the canonical slug form used by runtime resolution
+        # (custom_provider_slug): a display name with spaces ("Inkling
+        # Local") normalises to ``custom:inkling-local``, so after the
+        # ``custom:`` prefix is stripped the provider key is
+        # ``inkling-local``.  The raw display name ("inkling local") would
+        # never match that, so include the slug-derived form explicitly.
+        slug_name = custom_provider_slug(display_name)
+        if slug_name.startswith("custom:"):
+            slug_name = slug_name.split(":", 1)[1]
+        names = {
+            display_name.lower(),
+            slug_name.lower(),
+            str(entry.get("provider_key") or "").strip().lower(),
+        }
+        if provider_key not in names:
+            continue
+
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            return {}
+        metadata = models.get(model)
+        if not isinstance(metadata, dict):
+            model_lower = model.lower()
+            metadata = next(
+                (
+                    value
+                    for model_id, value in models.items()
+                    if str(model_id).lower() == model_lower and isinstance(value, dict)
+                ),
+                None,
+            )
+        if not isinstance(metadata, dict):
+            return {}
+
+        efforts = metadata.get("reasoning_efforts")
+        if not isinstance(efforts, list):
+            efforts = []
+        efforts = [
+            str(effort).strip().lower()
+            for effort in efforts
+            if isinstance(effort, str) and effort.strip()
+        ]
+
+        context_window = metadata.get("context_length")
+        max_output_tokens = metadata.get("max_output_tokens")
+        return {
+            "supports_tools": bool(metadata.get("supports_tools", False)),
+            "supports_vision": bool(metadata.get("supports_vision", False)),
+            "supports_reasoning": bool(
+                metadata.get("supports_reasoning", False) or efforts
+            ),
+            "reasoning_efforts": efforts,
+            "context_window": (
+                int(context_window)
+                if isinstance(context_window, (int, float)) and context_window > 0
+                else 0
+            ),
+            "max_output_tokens": (
+                int(max_output_tokens)
+                if isinstance(max_output_tokens, (int, float))
+                and max_output_tokens > 0
+                else 0
+            ),
+            "model_family": str(metadata.get("model_family") or ""),
+        }
+
+    return {}
+
+
 @app.get("/api/model/info")
 def get_model_info(profile: Optional[str] = None):
     """Return resolved model metadata for the currently configured model.
@@ -6638,22 +6728,25 @@ def get_model_info(profile: Optional[str] = None):
         # Effective is what the agent actually uses
         effective_ctx = config_ctx_int if config_ctx_int > 0 else auto_ctx
 
-        # Try to get model capabilities from models.dev
-        caps = {}
-        try:
-            from agent.models_dev import get_model_capabilities
-            mc = get_model_capabilities(provider=provider, model=model_name)
-            if mc is not None:
-                caps = {
-                    "supports_tools": mc.supports_tools,
-                    "supports_vision": mc.supports_vision,
-                    "supports_reasoning": mc.supports_reasoning,
-                    "context_window": mc.context_window,
-                    "max_output_tokens": mc.max_output_tokens,
-                    "model_family": mc.model_family,
-                }
-        except Exception:
-            pass
+        # Named custom providers carry their own per-model metadata. Prefer it
+        # because models.dev cannot resolve private provider slugs such as
+        # ``custom:vllm-cwb101``.
+        caps = _custom_provider_model_capabilities(cfg, provider, model_name)
+        if not caps:
+            try:
+                from agent.models_dev import get_model_capabilities
+                mc = get_model_capabilities(provider=provider, model=model_name)
+                if mc is not None:
+                    caps = {
+                        "supports_tools": mc.supports_tools,
+                        "supports_vision": mc.supports_vision,
+                        "supports_reasoning": mc.supports_reasoning,
+                        "context_window": mc.context_window,
+                        "max_output_tokens": mc.max_output_tokens,
+                        "model_family": mc.model_family,
+                    }
+            except Exception:
+                pass
 
         return {
             "model": model_name,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -7564,6 +7564,98 @@ class TestModelInfoEndpoint:
         assert caps["max_output_tokens"] == 32000
         assert caps["model_family"] == "claude-opus"
 
+    def test_model_info_custom_provider_capabilities(self, monkeypatch):
+        """Named custom providers expose their configured model capabilities."""
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": {
+                "default": "inkling",
+                "provider": "custom:vllm-cwb101",
+            },
+            "custom_providers": [{
+                "name": "vllm-cwb101",
+                "base_url": "http://127.0.0.1:18080/v1",
+                "models": {
+                    "inkling": {
+                        "context_length": 1048576,
+                        "max_output_tokens": 65536,
+                        "supports_tools": True,
+                        "supports_vision": True,
+                        "supports_reasoning": True,
+                        "reasoning_efforts": [
+                            "none", "low", "medium", "high", "xhigh"
+                        ],
+                    }
+                },
+            }],
+        })
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=1048576), \
+             patch("agent.models_dev.get_model_capabilities") as models_dev_caps:
+            resp = self.client.get("/api/model/info")
+
+        caps = resp.json()["capabilities"]
+        assert caps == {
+            "supports_tools": True,
+            "supports_vision": True,
+            "supports_reasoning": True,
+            "reasoning_efforts": ["none", "low", "medium", "high", "xhigh"],
+            "context_window": 1048576,
+            "max_output_tokens": 65536,
+            "model_family": "",
+        }
+        models_dev_caps.assert_not_called()
+
+    def test_model_info_custom_provider_legacy_display_name_with_spaces(self, monkeypatch):
+        """Legacy custom-provider display names with spaces (e.g. "Inkling
+        Local") are canonicalised by ``custom_provider_slug()`` to
+        ``custom:inkling-local``.  When ``model.provider`` carries that
+        slug, the capability resolver must still match the entry — the raw
+        display name ("inkling local") would not.  Regression test for the
+        sweeper-reported gap."""
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": {
+                "default": "inkling",
+                "provider": "custom:inkling-local",
+            },
+            "custom_providers": [{
+                "name": "Inkling Local",
+                "base_url": "http://127.0.0.1:18080/v1",
+                "models": {
+                    "inkling": {
+                        "context_length": 1048576,
+                        "max_output_tokens": 65536,
+                        "supports_tools": True,
+                        "supports_vision": False,
+                        "supports_reasoning": True,
+                        "reasoning_efforts": [
+                            "none", "low", "medium", "high", "xhigh"
+                        ],
+                    }
+                },
+            }],
+        })
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=1048576), \
+             patch("agent.models_dev.get_model_capabilities") as models_dev_caps:
+            resp = self.client.get("/api/model/info")
+
+        assert resp.status_code == 200
+        caps = resp.json()["capabilities"]
+        assert caps == {
+            "supports_tools": True,
+            "supports_vision": False,
+            "supports_reasoning": True,
+            "reasoning_efforts": ["none", "low", "medium", "high", "xhigh"],
+            "context_window": 1048576,
+            "max_output_tokens": 65536,
+            "model_family": "",
+        }
+        models_dev_caps.assert_not_called()
+
     def test_model_info_graceful_on_metadata_error(self, monkeypatch):
         """Endpoint should return zeros on import/resolution errors, not 500."""
         import hermes_cli.web_server as ws

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -127,6 +127,7 @@ export function ChatSidebar({
   // (currently unused) ModelInfoCard surfaces, so the dashboard exposes a
   // control to *set* the level, not just a read-only "Reasoning" badge.
   const [supportsReasoning, setSupportsReasoning] = useState(false);
+  const [reasoningEfforts, setReasoningEfforts] = useState<string[] | undefined>();
   // Bumped on model change/save so ReasoningPicker re-reads the saved effort
   // (config is profile-scoped the same way the model badge is).
   const [modelRefreshKey, setModelRefreshKey] = useState(0);
@@ -145,6 +146,11 @@ export function ChatSidebar({
       .then((r) => {
         if (r?.model) setEffectiveModel(String(r.model));
         setSupportsReasoning(!!r?.capabilities?.supports_reasoning);
+        setReasoningEfforts(
+          Array.isArray(r?.capabilities?.reasoning_efforts)
+            ? r.capabilities.reasoning_efforts
+            : undefined,
+        );
         // Bump so ReasoningPicker re-reads the saved effort for the new model.
         setModelRefreshKey((k) => k + 1);
       })
@@ -359,6 +365,7 @@ export function ChatSidebar({
             currentModel={modelName}
             profile={profile}
             refreshKey={modelRefreshKey}
+            supportedEfforts={reasoningEfforts}
             onChanged={(effort) =>
               setModelNotice(
                 `Reasoning effort set to ${effort}. Run /new or refresh the page to apply it to this chat.`,

--- a/web/src/components/ReasoningPicker.tsx
+++ b/web/src/components/ReasoningPicker.tsx
@@ -21,12 +21,12 @@
 
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { Brain } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { api } from "@/lib/api";
 import {
-  EFFORT_OPTIONS,
   normalizeEffort,
+  optionsForSupportedEfforts,
   VALID_EFFORTS,
 } from "@/lib/reasoning-effort";
 
@@ -38,6 +38,8 @@ interface ReasoningPickerProps {
   profile?: string;
   /** Bumped after the model picker saves, to re-read config in lockstep. */
   refreshKey?: number;
+  /** Optional model-specific effort allow-list from provider metadata. */
+  supportedEfforts?: string[];
   /** Called after a successful change so the sidebar can show an "apply on
    *  /new or reload" notice, matching the model-switch UX. */
   onChanged?: (effort: string) => void;
@@ -47,12 +49,17 @@ export function ReasoningPicker({
   currentModel,
   profile,
   refreshKey = 0,
+  supportedEfforts,
   onChanged,
 }: ReasoningPickerProps) {
   const [effort, setEffort] = useState("medium");
   const [loaded, setLoaded] = useState(false);
   const [saving, setSaving] = useState(false);
   const lastFetchKeyRef = useRef("");
+  const effortOptions = useMemo(
+    () => optionsForSupportedEfforts(supportedEfforts),
+    [supportedEfforts],
+  );
 
   useEffect(() => {
     const fetchKey = `${profile ?? ""}:${currentModel}:${refreshKey}`;
@@ -114,7 +121,7 @@ export function ReasoningPicker({
         onValueChange={onSelect}
         value={effort}
       >
-        {EFFORT_OPTIONS.map((opt) => (
+        {effortOptions.map((opt) => (
           <SelectOption key={opt.value} value={opt.value}>
             {opt.label}
           </SelectOption>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2290,6 +2290,7 @@ export interface ModelInfoResponse {
     supports_tools?: boolean;
     supports_vision?: boolean;
     supports_reasoning?: boolean;
+    reasoning_efforts?: string[];
     context_window?: number;
     max_output_tokens?: number;
     model_family?: string;

--- a/web/src/lib/reasoning-effort.test.ts
+++ b/web/src/lib/reasoning-effort.test.ts
@@ -3,6 +3,7 @@ import {
   EFFORT_OPTIONS,
   VALID_EFFORTS,
   normalizeEffort,
+  optionsForSupportedEfforts,
 } from "./reasoning-effort";
 
 describe("normalizeEffort", () => {
@@ -43,5 +44,22 @@ describe("EFFORT_OPTIONS", () => {
     for (const level of ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]) {
       expect(values.has(level)).toBe(true);
     }
+  });
+});
+
+describe("optionsForSupportedEfforts", () => {
+  it("keeps the generic menu when a model declares no restrictions", () => {
+    expect(optionsForSupportedEfforts()).toEqual(EFFORT_OPTIONS);
+  });
+
+  it("shows only Inkling's declared levels and maps max to xhigh", () => {
+    expect(
+      optionsForSupportedEfforts(["none", "low", "medium", "high", "max"])
+        .map((option) => option.value),
+    ).toEqual(["none", "low", "medium", "high", "xhigh"]);
+  });
+
+  it("keeps the generic menu when every declared level is unknown", () => {
+    expect(optionsForSupportedEfforts(["turbo"])).toEqual(EFFORT_OPTIONS);
   });
 });

--- a/web/src/lib/reasoning-effort.ts
+++ b/web/src/lib/reasoning-effort.ts
@@ -29,6 +29,22 @@ export const VALID_EFFORTS: ReadonlySet<string> = new Set(
   EFFORT_OPTIONS.map((o) => o.value),
 );
 
+/** Restrict the generic Hermes effort menu to a model's declared levels.
+ *  `max` is accepted as an API alias for Hermes' `xhigh` UI value. */
+export function optionsForSupportedEfforts(
+  supported?: ReadonlyArray<string>,
+): ReadonlyArray<EffortOption> {
+  if (!supported?.length) return EFFORT_OPTIONS;
+  const allowed = new Set(
+    supported.map((raw) => {
+      const value = String(raw ?? "").trim().toLowerCase();
+      return value === "max" ? "xhigh" : value;
+    }),
+  );
+  const filtered = EFFORT_OPTIONS.filter((option) => allowed.has(option.value));
+  return filtered.length ? filtered : EFFORT_OPTIONS;
+}
+
 /** Normalize a raw `agent.reasoning_effort` config value to a selectable
  *  option. Empty/unknown → `medium` (Hermes' default when unset). */
 export function normalizeEffort(raw: unknown): string {


### PR DESCRIPTION
## What does this PR do?

Named custom providers already carry per-model capability metadata in `config.yaml`, but `GET /api/model/info` only queried models.dev. Private provider slugs such as `custom:vllm-cwb101` therefore returned no capabilities, so the dashboard hid its Reasoning picker even when the configured model supported reasoning.

This PR makes the dashboard endpoint prefer the matching custom-provider model metadata, exposes its `reasoning_efforts`, and filters the picker to the declared levels. Missing or invalid effort metadata keeps the existing generic picker behavior.

For Inkling, a provider can now declare:

```yaml
models:
  inkling:
    supports_reasoning: true
    reasoning_efforts: [none, low, medium, high, xhigh]
```

Scope is intentionally limited to dashboard capability discovery and option rendering. It does not change request transport or reasoning payloads; current `main` already maps thinking-off to `reasoning_effort: none` for custom providers.

Existing-PR review:

- #31140 uses the same config-backed capability pattern but changes broader runtime, vision, and context behavior and is currently conflicting.
- #63160 normalizes boolean thinking-off values in the dashboard; it does not discover custom-provider capabilities.
- #59678 gates enabled effort values in the custom transport; it does not populate the dashboard picker.
- No existing Inkling PR or issue matched this capability-discovery gap.

## Related Issue

No matching issue was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Resolve named custom-provider model capabilities in `hermes_cli/web_server.py` before falling back to models.dev.
- Return a model-specific `reasoning_efforts` allow-list from `/api/model/info`.
- Filter the dashboard Reasoning picker to supported efforts, including `max` → `xhigh` alias handling and a safe generic fallback.
- Add backend and frontend regression coverage.

## How to Test

1. Configure a named custom provider model with `supports_reasoning: true` and `reasoning_efforts: [none, low, medium, high, xhigh]`.
2. Select that model in the dashboard and confirm the Reasoning picker appears with only Off, Low, Medium, High, and Extra High.
3. Remove `reasoning_efforts` and confirm the existing generic menu remains available.

Automated verification on macOS 26.5.2, Python 3.11.15, Node 24.2.0:

- `pytest -q tests/hermes_cli/test_web_server.py` — 390 passed.
- `npm --prefix web test` — 83 passed.
- Changed-file ESLint — 0 errors (one pre-existing Fast Refresh warning).
- `npm --prefix web run typecheck` — passed.
- `npm --prefix web run build` — passed.
- After rebasing onto current `main`: 8 endpoint tests and 9 reasoning-effort tests passed; type-check and production build passed again.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted backend and complete WebUI suites are listed above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing config schema is added
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python/TypeScript config handling, no platform-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The production dashboard build completed successfully. Backend coverage asserts the exact Inkling capability response; frontend coverage asserts the filtered effort list and fail-open behavior.
