### PR TITLE
fix(dashboard): redraw TUI after fresh session

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -367,6 +367,25 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.rpc).not.toHaveBeenCalled()
   })
 
+  it('routes the /reset catalog alias through the local fresh-session lifecycle', () => {
+    const ctx = buildCtx({
+      local: {
+        catalog: {
+          canon: {
+            '/new': '/new',
+            '/reset': '/new'
+          }
+        }
+      }
+    })
+
+    createSlashHandler(ctx)('/reset')
+    getOverlayState().confirm?.onConfirm()
+
+    expect(ctx.session.newSession).toHaveBeenCalledWith('new session started', undefined)
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
   it('keeps visible scrollback when branching a TUI session', async () => {
     patchUiState({ sid: 'sid-parent' })
     const rpc = vi.fn(() => Promise.resolve({ session_id: 'sid-branch', title: 'branch title' }))

--- a/ui-tui/src/__tests__/useSessionLifecycle.test.ts
+++ b/ui-tui/src/__tests__/useSessionLifecycle.test.ts
@@ -11,8 +11,23 @@ import {
   hydrateLiveSessionInflight,
   liveSessionInflightMessages,
   scheduleResumeScrollToBottom,
+  signalFreshSessionBoundary,
   writeActiveSessionFile
 } from '../app/useSessionLifecycle.js'
+
+describe('fresh session boundary', () => {
+  it('signals only when a live session is replaced by a different session', () => {
+    const onFreshSessionStarted = vi.fn()
+
+    expect(signalFreshSessionBoundary('old-session', 'new-session', onFreshSessionStarted)).toBe(true)
+    expect(signalFreshSessionBoundary(null, 'first-session', onFreshSessionStarted)).toBe(false)
+    expect(signalFreshSessionBoundary('same-session', 'same-session', onFreshSessionStarted)).toBe(false)
+    expect(signalFreshSessionBoundary('old-session', null, onFreshSessionStarted)).toBe(false)
+    expect(signalFreshSessionBoundary('old-session', 'new-session')).toBe(false)
+    expect(onFreshSessionStarted).toHaveBeenCalledOnce()
+    expect(onFreshSessionStarted).toHaveBeenCalledWith('new-session')
+  })
+})
 
 describe('writeActiveSessionFile', () => {
   let dir = ''

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -1,8 +1,16 @@
-import { type ScrollBoxHandle, useApp, useHasSelection, useSelection, useStdout, useTerminalTitle } from '@hermes/ink'
+import {
+  forceRedraw,
+  type ScrollBoxHandle,
+  useApp,
+  useHasSelection,
+  useSelection,
+  useStdout,
+  useTerminalTitle
+} from '@hermes/ink'
 import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { STARTUP_RESUME_ID } from '../config/env.js'
+import { DASHBOARD_TUI_MODE, STARTUP_RESUME_ID } from '../config/env.js'
 import { MAX_HISTORY, WHEEL_SCROLL_STEP } from '../config/limits.js'
 import { RESIZE_COALESCE_MS } from '../config/timing.js'
 import { hasLeadGap, prevRenderedMsg } from '../domain/blockLayout.js'
@@ -184,6 +192,7 @@ export function useMainApp(gw: GatewayClient) {
   const [voiceProcessing, setVoiceProcessing] = useState(false)
   const [voiceRecordKey, setVoiceRecordKey] = useState<ParsedVoiceRecordKey>(DEFAULT_VOICE_RECORD_KEY)
   const [sessionStartedAt, setSessionStartedAt] = useState(() => Date.now())
+  const [dashboardFreshSessionId, setDashboardFreshSessionId] = useState<null | string>(null)
   const [turnStartedAt, setTurnStartedAt] = useState<null | number>(null)
   const [lastTurnEndedAt, setLastTurnEndedAt] = useState<null | number>(null)
   // Bumped by the gateway `reaction` event (core-detected affection).
@@ -496,6 +505,7 @@ export function useMainApp(gw: GatewayClient) {
     colsRef,
     composerActions,
     gw,
+    onFreshSessionStarted: DASHBOARD_TUI_MODE ? setDashboardFreshSessionId : undefined,
     panel,
     rpc,
     scrollRef,
@@ -507,6 +517,12 @@ export function useMainApp(gw: GatewayClient) {
     setVoiceRecording,
     sys
   })
+
+  useEffect(() => {
+    if (dashboardFreshSessionId) {
+      forceRedraw(stdout ?? process.stdout)
+    }
+  }, [dashboardFreshSessionId, stdout])
 
   useEffect(() => {
     if (ui.busy) {

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -68,6 +68,20 @@ export const hydrateLiveSessionInflight = (inflight?: null | SessionInflightTurn
   turnController.hydrateStreamingText(assistant)
 }
 
+export const signalFreshSessionBoundary = (
+  previousSid: null | string,
+  nextSid: null | string,
+  onFreshSessionStarted?: (sessionId: string) => void
+) => {
+  if (!previousSid || !nextSid || previousSid === nextSid || !onFreshSessionStarted) {
+    return false
+  }
+
+  onFreshSessionStarted(nextSid)
+
+  return true
+}
+
 export const scheduleResumeScrollToBottom = (
   scrollRef: RefObject<null | ScrollBoxHandle>,
   delays: readonly number[] = [0, 80, 240]
@@ -115,6 +129,7 @@ export interface UseSessionLifecycleOptions {
   colsRef: { current: number }
   composerActions: ComposerActions
   gw: GatewayClient
+  onFreshSessionStarted?: (sessionId: string) => void
   panel: (title: string, sections: PanelSection[]) => void
   rpc: GatewayRpc
   scrollRef: RefObject<null | ScrollBoxHandle>
@@ -132,6 +147,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     colsRef,
     composerActions,
     gw,
+    onFreshSessionStarted,
     panel,
     rpc,
     scrollRef,
@@ -204,8 +220,10 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
         return null
       }
 
+      const previousSid = getUiState().sid
+
       if (!keepCurrent) {
-        await closeSession(getUiState().sid)
+        await closeSession(previousSid)
       }
 
       const r = await rpc<SessionCreateResponse>('session.create', { cols: colsRef.current })
@@ -270,9 +288,11 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
           })
       }
 
+      signalFreshSessionBoundary(previousSid, r.session_id, onFreshSessionStarted)
+
       return r.session_id
     },
-    [closeSession, colsRef, panel, resetSession, rpc, setHistoryItems, setSessionStartedAt, sys]
+    [closeSession, colsRef, onFreshSessionStarted, panel, resetSession, rpc, setHistoryItems, setSessionStartedAt, sys]
   )
 
   const newSession = useCallback(


### PR DESCRIPTION
## What does this PR do?

Redraws the embedded dashboard TUI after a confirmed fresh-session transition so `/new`, `/clear`, and the `/reset` alias do not leave stale cells from the previous transcript on the xterm.js screen.

The redraw is requested only after `session.create` succeeds and React commits the new session state. This avoids parsing raw browser keystrokes, respects the destructive-action confirmation flow, does not race fresh PTY output with a fixed timer, and does not redraw initial startup.

This follows up on #59932 and implements the backend-confirmed signal path requested by its automated review. Credit to @webtecnica for identifying the missing dashboard terminal clear boundary.

## Related Issue

Fixes #59344

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/app/useSessionLifecycle.ts`: signal a fresh-session boundary only when a live session is successfully replaced by a different session.
- `ui-tui/src/app/useMainApp.ts`: force a dashboard-only full Ink redraw from a post-commit effect.
- `ui-tui/src/__tests__/useSessionLifecycle.test.ts`: cover replacement, initial startup, same-session, missing-next-session, and no-listener behavior.
- `ui-tui/src/__tests__/createSlashHandler.test.ts`: verify the `/reset` catalog alias reaches the local fresh-session lifecycle instead of falling through to the backend.

## How to Test

1. Start `hermes dashboard`, open Chat, enter several messages, then run `/new` and confirm it.
2. Verify the new session starts on a clean visible terminal frame without stale characters from the prior transcript. Repeat with `/clear` and `/reset`.
3. Run `npm --workspace ui-tui test -- src/__tests__/useSessionLifecycle.test.ts src/__tests__/createSlashHandler.test.ts`, `npm --workspace ui-tui run typecheck`, `npm --workspace ui-tui run lint`, and `npm --workspace ui-tui run build`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Node.js 22.22.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused local validation:

- `useSessionLifecycle.test.ts` + `createSlashHandler.test.ts`: 75 tests passed
- TUI TypeScript typecheck: passed
- Focused TUI ESLint: passed
- TUI production build: passed

The full Python suite is not applicable to this TypeScript-only TUI change and is left to GitHub CI.