### PR TITLE
fix(computer_use): add timeout to cua-driver permissions subprocess.run

### DIFF
--- a/tools/computer_use/permissions.py
+++ b/tools/computer_use/permissions.py
@@ -191,6 +191,7 @@ def request_permissions_grant(driver_cmd: Optional[str] = None) -> int:
                 [binary, "permissions", "grant"],
                 env=_child_env(),
                 stdin=subprocess.DEVNULL,
+                timeout=60,
             ).returncode
         )
     except KeyboardInterrupt:  # pragma: no cover - interactive


### PR DESCRIPTION
## Summary

Add timeout=60 to subprocess.run in the cua-driver permissions grant flow.

## Problem

The subprocess.run call on line 190 of tools/computer_use/permissions.py has no timeout parameter. If the cua-driver binary hangs during the macOS accessibility permissions dialog or crashes, the agent turn blocks indefinitely.

## Fix

Added timeout=60 to the subprocess.run call. The existing except Exception handler on line 200 already catches subprocess.TimeoutExpired, so no additional error handling is needed.

## Testing
- Syntax check passed (py_compile)
- Behavior verified