### PR TITLE
feat(kanban): enforce global worker concurrency cap

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -856,6 +856,33 @@ class GatewayKanbanWatchersMixin:
                 else:
                     logger.info(f"kanban dispatcher: max_in_progress={max_in_progress}")
 
+        # Aggregate cap across every active board. Unlike max_in_progress,
+        # this is enforced under a machine-global dispatch lock so two boards
+        # cannot consume the same remaining slot.
+        raw_global_max = kanban_cfg.get("global_max_in_progress", None)
+        global_max_in_progress = None
+        if raw_global_max is not None:
+            try:
+                global_max_in_progress = int(raw_global_max)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "kanban dispatcher: invalid kanban.global_max_in_progress=%r; ignoring",
+                    raw_global_max,
+                )
+                global_max_in_progress = None
+            else:
+                if global_max_in_progress < 1:
+                    logger.warning(
+                        "kanban dispatcher: kanban.global_max_in_progress=%r is below 1; ignoring",
+                        raw_global_max,
+                    )
+                    global_max_in_progress = None
+                else:
+                    logger.info(
+                        "kanban dispatcher: global_max_in_progress=%d",
+                        global_max_in_progress,
+                    )
+
         raw_failure_limit = kanban_cfg.get("failure_limit", _kb.DEFAULT_FAILURE_LIMIT)
         try:
             failure_limit = int(raw_failure_limit)
@@ -902,7 +929,7 @@ class GatewayKanbanWatchersMixin:
 
         # Read kanban.max_in_progress_per_profile — per-profile concurrency
         # cap (#21582). When set, no single profile gets more than N
-        # workers running at once, even if the global max_in_progress
+        # workers running at once, even if the board-local max_in_progress
         # would allow it. Prevents one profile's local model / API quota
         # / browser pool from being overwhelmed by a fan-out.
         raw_per_profile = kanban_cfg.get("max_in_progress_per_profile", None)
@@ -1018,6 +1045,7 @@ class GatewayKanbanWatchersMixin:
                     board=slug,
                     max_spawn=max_spawn,
                     max_in_progress=max_in_progress,
+                    global_max_in_progress=global_max_in_progress,
                     failure_limit=failure_limit,
                     stale_timeout_seconds=stale_timeout_seconds,
                     default_assignee=default_assignee,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2287,8 +2287,9 @@ def _cmd_tail(args: argparse.Namespace) -> int:
 
 def _cmd_dispatch(args: argparse.Namespace) -> int:
     # Honour kanban.default_assignee as the fallback for unassigned ready
-    # tasks (#27145), kanban.max_in_progress as the global concurrency cap
-    # (#33488), kanban.max_in_progress_per_profile as the per-profile
+    # tasks (#27145), kanban.max_in_progress as the board-local cap (#33488),
+    # kanban.global_max_in_progress as the aggregate cross-board cap,
+    # kanban.max_in_progress_per_profile as the per-profile
     # cap (#21582), and kanban.max_spawn as the per-tick spawn limit
     # (#28805). Same semantics as the gateway dispatch path so behavior
     # matches whether the user runs the CLI directly or relies on the
@@ -2312,6 +2313,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             _kanban_cfg.get("max_in_progress_per_profile")
         )
         max_in_progress = _coerce_positive_int(_kanban_cfg.get("max_in_progress"))
+        global_max_in_progress = _coerce_positive_int(
+            _kanban_cfg.get("global_max_in_progress")
+        )
         # CLI --max overrides config kanban.max_spawn when both are present;
         # CLI is the more explicit signal so it wins.
         cli_max = getattr(args, "max", None)
@@ -2322,6 +2326,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         default_assignee = None
         max_in_progress_per_profile = None
         max_in_progress = None
+        global_max_in_progress = None
         max_spawn = getattr(args, "max", None)
     with kb.connect_closing() as conn:
         res = kb.dispatch_once(
@@ -2329,6 +2334,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             dry_run=args.dry_run,
             max_spawn=max_spawn,
             max_in_progress=max_in_progress,
+            global_max_in_progress=global_max_in_progress,
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
@@ -2516,10 +2522,25 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
         except Exception:
             return False
 
+    global_max_in_progress = None
+    try:
+        from hermes_cli.config import load_config
+
+        raw_global_max = (load_config().get("kanban") or {}).get(
+            "global_max_in_progress"
+        )
+        if raw_global_max is not None:
+            parsed_global_max = int(raw_global_max)
+            if parsed_global_max > 0:
+                global_max_in_progress = parsed_global_max
+    except Exception:
+        pass
+
     try:
         kb.run_daemon(
             interval=args.interval,
             max_spawn=args.max,
+            global_max_in_progress=global_max_in_progress,
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
             on_tick=_on_tick,
         )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1551,6 +1551,21 @@ def _maybe_checkpoint_wal(conn: sqlite3.Connection, db_path: Path) -> None:
         _log.debug("kanban WAL checkpoint on %s skipped: %s", key, exc)
 
 
+def _global_dispatch_tick_lock():
+    """Serialize capped dispatch decisions across every kanban board.
+
+    The per-board lock prevents duplicate writers to one database, but cannot
+    make an aggregate capacity check atomic across separate board databases.
+    Callers that enable ``global_max_in_progress`` take this machine-global
+    lock before counting running tasks and spawning. It is deliberately
+    non-blocking, matching :func:`_dispatch_tick_lock`: another dispatcher
+    holding the lock is already making progress, so the losing tick retries
+    at the next interval instead of stalling the gateway.
+    """
+    lock_anchor = kanban_home() / "kanban" / ".global"
+    return _dispatch_tick_lock(lock_anchor)
+
+
 def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
     """Return True for a TLS record header at ``data[offset:]``."""
     if len(data) < offset + 5:
@@ -7770,6 +7785,71 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     return False
 
 
+def _count_running_across_boards(
+    *,
+    current_conn: sqlite3.Connection,
+    current_board: Optional[str],
+) -> Optional[int]:
+    """Count running tasks across active boards, or fail closed with ``None``.
+
+    Missing databases count as empty. If an existing board database cannot be
+    read, the aggregate count is unknown and callers must not interpret that
+    as spare capacity.
+    """
+    current_slug = _normalize_board_slug(current_board) or get_current_board()
+    try:
+        current_path = kanban_db_path(board=current_slug).resolve()
+        boards = list_boards(include_archived=False)
+    except Exception:
+        _log.exception("kanban global cap: could not enumerate active boards")
+        return None
+
+    total = 0
+    seen_paths: set[Path] = set()
+    for metadata in boards:
+        slug = _normalize_board_slug(metadata.get("slug")) or DEFAULT_BOARD
+        path = kanban_db_path(board=slug).resolve()
+        if path in seen_paths:
+            continue
+        seen_paths.add(path)
+        if path == current_path:
+            try:
+                total += int(
+                    current_conn.execute(
+                        "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+                    ).fetchone()[0]
+                )
+            except sqlite3.DatabaseError:
+                _log.exception(
+                    "kanban global cap: could not count running tasks on board %s",
+                    slug,
+                )
+                return None
+            continue
+
+        if not path.exists():
+            continue
+        other_conn = None
+        try:
+            other_conn = connect(board=slug)
+            total += int(
+                other_conn.execute(
+                    "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+                ).fetchone()[0]
+            )
+        except (OSError, sqlite3.DatabaseError):
+            _log.exception(
+                "kanban global cap: could not count running tasks on board %s; "
+                "skipping all new spawns this tick",
+                slug,
+            )
+            return None
+        finally:
+            if other_conn is not None:
+                other_conn.close()
+    return total
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -7778,6 +7858,7 @@ def dispatch_once(
     dry_run: bool = False,
     max_spawn: Optional[int] = None,
     max_in_progress: Optional[int] = None,
+    global_max_in_progress: Optional[int] = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stale_timeout_seconds: int = 0,
     board: Optional[str] = None,
@@ -7799,45 +7880,54 @@ def dispatch_once(
     boards tick in parallel. See :func:`_dispatch_tick_lock` for the
     cross-process / cross-platform mechanics.
     """
-    try:
-        db_path = kanban_db_path(board=board)
-    except Exception:
-        # Path resolution should never fail, but if it somehow does we
-        # must not lose the tick — fall through to an unguarded dispatch
-        # rather than dropping work.
-        return _dispatch_once_locked(
-            conn,
-            spawn_fn=spawn_fn,
-            ttl_seconds=ttl_seconds,
-            dry_run=dry_run,
-            max_spawn=max_spawn,
-            max_in_progress=max_in_progress,
-            failure_limit=failure_limit,
-            stale_timeout_seconds=stale_timeout_seconds,
-            board=board,
-            default_assignee=default_assignee,
-            max_in_progress_per_profile=max_in_progress_per_profile,
-        )
-    with _dispatch_tick_lock(db_path) as held:
-        if not held:
-            return DispatchResult(skipped_locked=True)
-        result = _dispatch_once_locked(
-            conn,
-            spawn_fn=spawn_fn,
-            ttl_seconds=ttl_seconds,
-            dry_run=dry_run,
-            max_spawn=max_spawn,
-            max_in_progress=max_in_progress,
-            failure_limit=failure_limit,
-            stale_timeout_seconds=stale_timeout_seconds,
-            board=board,
-            default_assignee=default_assignee,
-            max_in_progress_per_profile=max_in_progress_per_profile,
-        )
-        # Still under the dispatch lock: opportunistically truncate the WAL
-        # at a coarse interval so it cannot grow unbounded between restarts.
-        _maybe_checkpoint_wal(conn, db_path)
-        return result
+    def _run_board_tick() -> DispatchResult:
+        try:
+            db_path = kanban_db_path(board=board)
+        except Exception:
+            # Path resolution should never fail, but if it somehow does we
+            # must not lose the tick — fall through to an unguarded dispatch.
+            return _dispatch_once_locked(
+                conn,
+                spawn_fn=spawn_fn,
+                ttl_seconds=ttl_seconds,
+                dry_run=dry_run,
+                max_spawn=max_spawn,
+                max_in_progress=max_in_progress,
+                global_max_in_progress=global_max_in_progress,
+                failure_limit=failure_limit,
+                stale_timeout_seconds=stale_timeout_seconds,
+                board=board,
+                default_assignee=default_assignee,
+                max_in_progress_per_profile=max_in_progress_per_profile,
+            )
+        with _dispatch_tick_lock(db_path) as held:
+            if not held:
+                return DispatchResult(skipped_locked=True)
+            result = _dispatch_once_locked(
+                conn,
+                spawn_fn=spawn_fn,
+                ttl_seconds=ttl_seconds,
+                dry_run=dry_run,
+                max_spawn=max_spawn,
+                max_in_progress=max_in_progress,
+                global_max_in_progress=global_max_in_progress,
+                failure_limit=failure_limit,
+                stale_timeout_seconds=stale_timeout_seconds,
+                board=board,
+                default_assignee=default_assignee,
+                max_in_progress_per_profile=max_in_progress_per_profile,
+            )
+            # Still under the dispatch lock: opportunistically truncate the WAL
+            # at a coarse interval so it cannot grow unbounded between restarts.
+            _maybe_checkpoint_wal(conn, db_path)
+            return result
+
+    if isinstance(global_max_in_progress, int) and global_max_in_progress > 0:
+        with _global_dispatch_tick_lock() as held:
+            if not held:
+                return DispatchResult(skipped_locked=True)
+            return _run_board_tick()
+    return _run_board_tick()
 
 
 def _dispatch_once_locked(
@@ -7848,6 +7938,7 @@ def _dispatch_once_locked(
     dry_run: bool = False,
     max_spawn: Optional[int] = None,
     max_in_progress: Optional[int] = None,
+    global_max_in_progress: Optional[int] = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stale_timeout_seconds: int = 0,
     board: Optional[str] = None,
@@ -7911,13 +8002,46 @@ def _dispatch_once_locked(
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
+    # Convert aggregate headroom into an effective board-local cap. The public
+    # wrapper holds the machine-global dispatch lock around this count and the
+    # subsequent spawn, so two boards cannot both consume the same slot.
+    if isinstance(global_max_in_progress, int) and global_max_in_progress > 0:
+        global_running = _count_running_across_boards(
+            current_conn=conn,
+            current_board=board,
+        )
+        if global_running is None or global_running >= global_max_in_progress:
+            return result
+        local_running = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+            ).fetchone()[0]
+        )
+        effective_local_cap = local_running + (
+            global_max_in_progress - global_running
+        )
+        if max_in_progress is None or max_in_progress > effective_local_cap:
+            max_in_progress = effective_local_cap
+
+    # Apply the board-local/global-derived cap to the shared ready + review
+    # dispatch budget before either queue is inspected. ``max_spawn`` is a
+    # concurrency ceiling in this function (existing running workers plus new
+    # spawns), not merely a per-tick count.
+    if max_in_progress is not None:
+        in_progress = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+            ).fetchone()[0]
+        )
+        if in_progress >= max_in_progress:
+            return result
+        if max_spawn is None or max_spawn > max_in_progress:
+            max_spawn = max_in_progress
+
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full
     # rationale; the short version is that a 60-second tick interval with a
-    # per-tick budget of N would grow concurrency by N every tick on a busy
-    # board, since "running" tasks aren't reclaimed by completion alone —
-    # they sit in status='running' until the worker calls
-    # kanban_complete/kanban_block (or the dispatcher TTL-reclaims them).
+    # slow backend must not add max_spawn new workers every minute.
     running_count = 0
     if max_spawn is not None:
         running_count = int(
@@ -7931,20 +8055,6 @@ def _dispatch_once_locked(
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
-    # Honour kanban.max_in_progress: if the board already has enough running
-    # tasks, skip spawning this tick so slow workers (local LLMs,
-    # resource-constrained hosts) can finish what they have before more tasks
-    # pile up and time out.
-    if max_in_progress is not None and ready_rows:
-        in_progress = conn.execute(
-            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
-        ).fetchone()[0]
-        if in_progress >= max_in_progress:
-            return result
-        # Only spawn enough to reach the cap, respecting max_spawn too.
-        remaining = max_in_progress - in_progress
-        if max_spawn is None or max_spawn > remaining:
-            max_spawn = remaining
     spawned = 0
     # Per-profile concurrency cap (#21582): when set, track how many
     # workers each assignee already has in flight, and refuse to spawn
@@ -8088,6 +8198,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
+            spawned += 1
             # Increment per-profile counter even in dry_run so the cap
             # check sees the would-be spawn on subsequent iterations.
             # Without this, dry_run reports every task as spawnable and
@@ -8188,6 +8299,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
+            spawned += 1
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -8701,6 +8813,7 @@ def run_daemon(
     *,
     interval: float = 60.0,
     max_spawn: Optional[int] = None,
+    global_max_in_progress: Optional[int] = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stop_event=None,
     on_tick=None,
@@ -8738,6 +8851,7 @@ def run_daemon(
                 res = dispatch_once(
                     conn,
                     max_spawn=max_spawn,
+                    global_max_in_progress=global_max_in_progress,
                     failure_limit=failure_limit,
                 )
             if on_tick is not None:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1957,10 +1957,27 @@ def dispatch(
     board: Optional[str] = Query(None),
 ):
     board = _resolve_board(board)
+    global_max_in_progress = None
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        kanban_config = config.get("kanban", {}) if isinstance(config, dict) else {}
+        raw_global_max = kanban_config.get("global_max_in_progress")
+        if raw_global_max is not None:
+            parsed_global_max = int(raw_global_max)
+            if parsed_global_max > 0:
+                global_max_in_progress = parsed_global_max
+    except Exception:
+        pass
     conn = _conn(board=board)
     try:
         result = kanban_db.dispatch_once(
-            conn, dry_run=dry_run, max_spawn=max_n, board=board,
+            conn,
+            dry_run=dry_run,
+            max_spawn=max_n,
+            global_max_in_progress=global_max_in_progress,
+            board=board,
         )
         # DispatchResult is a dataclass.
         try:

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -40,6 +40,7 @@ def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, m
     fake_config = {
         "kanban": {
             "max_in_progress": 3,
+            "global_max_in_progress": 4,
             "max_spawn": 5,
             "default_assignee": "default",
             "max_in_progress_per_profile": 2,
@@ -64,6 +65,7 @@ def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, m
     assert captured.get("max_in_progress") == 3, (
         f"CLI must pass kanban.max_in_progress from config; got {captured.get('max_in_progress')!r}"
     )
+    assert captured.get("global_max_in_progress") == 4
     assert captured.get("max_spawn") == 5, (
         f"CLI must pass kanban.max_spawn from config when --max is not provided; got {captured.get('max_spawn')!r}"
     )
@@ -114,6 +116,56 @@ def test_cli_invalid_max_in_progress_silently_disables(isolated_kanban_home, mon
             f"invalid max_in_progress={bad_val!r} should fall through to None, "
             f"got {captured.get('max_in_progress')!r}"
         )
+
+
+def test_cli_invalid_global_max_in_progress_silently_disables(
+    isolated_kanban_home, monkeypatch
+):
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    for bad_val in (0, -1, "abc", "1.5"):
+        fake_config = {"kanban": {"global_max_in_progress": bad_val}}
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: fake_config)
+        captured = {}
+        monkeypatch.setattr(
+            kanban_db,
+            "dispatch_once",
+            lambda conn, **kw: (captured.update(kw), kanban_db.DispatchResult())[1],
+        )
+        args = argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=False)
+        kb_cli._cmd_dispatch(args)
+        assert captured.get("global_max_in_progress") is None
+
+
+def test_forced_daemon_passes_global_cap_from_config(
+    isolated_kanban_home, monkeypatch
+):
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"global_max_in_progress": 2}},
+    )
+    monkeypatch.setattr(kanban_db, "init_db", lambda: None)
+    captured = {}
+    monkeypatch.setattr(
+        kanban_db,
+        "run_daemon",
+        lambda **kwargs: captured.update(kwargs),
+    )
+    args = argparse.Namespace(
+        force=True,
+        interval=60.0,
+        max=None,
+        failure_limit=2,
+        pidfile=None,
+        verbose=False,
+    )
+
+    assert kb_cli._cmd_daemon(args) == 0
+    assert captured["global_max_in_progress"] == 2
 
 
 def test_kanban_swarm_uses_existing_humanizer_skill():

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3674,6 +3674,50 @@ def test_gateway_dispatcher_watcher_env_truthy_uses_config(monkeypatch):
     )
 
 
+def test_gateway_dispatcher_passes_global_cap(kanban_home, monkeypatch):
+    """The embedded gateway path must not bypass the cross-board cap."""
+    import asyncio
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
+                "global_max_in_progress": 2,
+            }
+        },
+    )
+    captured = {}
+
+    def fake_dispatch_once(_conn, **kwargs):
+        captured.update(kwargs)
+        runner._running = False
+        return _kb.DispatchResult()
+
+    async def immediate_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(_kb, "dispatch_once", fake_dispatch_once)
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.sleep", immediate_sleep)
+
+    asyncio.run(
+        asyncio.wait_for(
+            runner._kanban_dispatcher_watcher(),
+            timeout=3.0,
+        )
+    )
+
+    assert captured["global_max_in_progress"] == 2
+
+
 @pytest.mark.parametrize("corrupt_exc", ["sqlite", "guard"])
 def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     monkeypatch, tmp_path, caplog, corrupt_exc

--- a/tests/hermes_cli/test_kanban_global_cap.py
+++ b/tests/hermes_cli/test_kanban_global_cap.py
@@ -1,0 +1,217 @@
+"""Cross-board concurrency tests for ``kanban.global_max_in_progress``."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _profile: True)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db(board="default")
+    kb.create_board("other", name="Other")
+    return home
+
+
+def _mark_running(conn, task_id: str) -> None:
+    now = int(time.time())
+    conn.execute(
+        "UPDATE tasks SET status = 'running', claim_lock = ?, claim_expires = ?, "
+        "worker_pid = ?, started_at = ?, last_heartbeat_at = ? WHERE id = ?",
+        (f"lock-{task_id}", now + 3600, os.getpid(), now, now, task_id),
+    )
+    conn.commit()
+
+
+def _spawn_stub(calls: list[str]):
+    def spawn(task, _workspace_path, board=None):
+        calls.append(f"{board}:{task.id}")
+        return os.getpid()
+
+    return spawn
+
+
+def test_global_cap_counts_running_tasks_on_other_boards(kanban_home):
+    with kb.connect(board="default") as default_conn:
+        running_id = kb.create_task(default_conn, title="already running", assignee="worker")
+        _mark_running(default_conn, running_id)
+
+    calls: list[str] = []
+    with kb.connect(board="other") as other_conn:
+        ready_id = kb.create_task(other_conn, title="must wait", assignee="worker")
+        result = kb.dispatch_once(
+            other_conn,
+            board="other",
+            global_max_in_progress=1,
+            spawn_fn=_spawn_stub(calls),
+        )
+        assert result.spawned == []
+        assert calls == []
+        assert kb.get_task(other_conn, ready_id).status == "ready"
+
+
+def test_global_cap_only_fills_remaining_cross_board_slots(kanban_home):
+    with kb.connect(board="default") as default_conn:
+        running_id = kb.create_task(default_conn, title="already running", assignee="worker")
+        _mark_running(default_conn, running_id)
+
+    calls: list[str] = []
+    with kb.connect(board="other") as other_conn:
+        task_ids = [
+            kb.create_task(other_conn, title=f"ready {n}", assignee="worker")
+            for n in range(3)
+        ]
+        result = kb.dispatch_once(
+            other_conn,
+            board="other",
+            global_max_in_progress=2,
+            spawn_fn=_spawn_stub(calls),
+        )
+        assert len(result.spawned) == 1
+        assert len(calls) == 1
+        statuses = [kb.get_task(other_conn, task_id).status for task_id in task_ids]
+        assert statuses.count("running") == 1
+        assert statuses.count("ready") == 2
+
+
+def test_global_cap_serializes_dispatch_across_boards(kanban_home):
+    calls: list[str] = []
+    with kb.connect(board="other") as other_conn:
+        kb.create_task(other_conn, title="must not race", assignee="worker")
+        with kb._global_dispatch_tick_lock() as held:
+            assert held is True
+            result = kb.dispatch_once(
+                other_conn,
+                board="other",
+                global_max_in_progress=2,
+                spawn_fn=_spawn_stub(calls),
+            )
+
+    assert result.skipped_locked is True
+    assert calls == []
+
+
+def test_global_cap_composes_with_stricter_board_cap(kanban_home):
+    calls: list[str] = []
+    with kb.connect(board="other") as other_conn:
+        first = kb.create_task(other_conn, title="local running", assignee="worker")
+        _mark_running(other_conn, first)
+        kb.create_task(other_conn, title="must wait locally", assignee="worker")
+        result = kb.dispatch_once(
+            other_conn,
+            board="other",
+            max_in_progress=1,
+            global_max_in_progress=4,
+            spawn_fn=_spawn_stub(calls),
+        )
+
+    assert result.spawned == []
+    assert calls == []
+
+
+def test_review_only_dispatch_respects_remaining_global_slot(kanban_home):
+    with kb.connect(board="default") as default_conn:
+        running_id = kb.create_task(
+            default_conn, title="already running", assignee="worker"
+        )
+        _mark_running(default_conn, running_id)
+
+    calls: list[str] = []
+    with kb.connect(board="other") as other_conn:
+        review_ids = [
+            kb.create_task(other_conn, title=f"review {n}", assignee="worker")
+            for n in range(2)
+        ]
+        other_conn.executemany(
+            "UPDATE tasks SET status = 'review' WHERE id = ?",
+            [(task_id,) for task_id in review_ids],
+        )
+        other_conn.commit()
+
+        result = kb.dispatch_once(
+            other_conn,
+            board="other",
+            global_max_in_progress=2,
+            spawn_fn=_spawn_stub(calls),
+        )
+        statuses = [kb.get_task(other_conn, task_id).status for task_id in review_ids]
+
+    assert len(result.spawned) == 1
+    assert len(calls) == 1
+    assert statuses.count("running") == 1
+    assert statuses.count("review") == 1
+
+
+def test_dry_run_reports_only_global_headroom(kanban_home):
+    with kb.connect(board="default") as conn:
+        for index in range(3):
+            kb.create_task(conn, title=f"ready {index}", assignee="worker")
+
+        result = kb.dispatch_once(
+            conn,
+            board="default",
+            dry_run=True,
+            global_max_in_progress=1,
+        )
+        running = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+        ).fetchone()[0]
+
+    assert len(result.spawned) == 1
+    assert running == 0
+
+
+def test_running_count_deduplicates_board_aliases(kanban_home, monkeypatch):
+    with kb.connect(board="default") as conn:
+        running_id = kb.create_task(conn, title="already running", assignee="worker")
+        _mark_running(conn, running_id)
+        shared_path = kb.kanban_db_path(board="default")
+        monkeypatch.setattr(
+            kb,
+            "list_boards",
+            lambda include_archived=False: [
+                {"slug": "default"},
+                {"slug": "alias"},
+            ],
+        )
+        monkeypatch.setattr(kb, "kanban_db_path", lambda board=None: shared_path)
+
+        count = kb._count_running_across_boards(
+            current_conn=conn,
+            current_board="default",
+        )
+
+    assert count == 1
+
+
+def test_run_daemon_passes_global_cap(kanban_home, monkeypatch):
+    import threading
+
+    stop = threading.Event()
+    captured = {}
+
+    def fake_dispatch_once(_conn, **kwargs):
+        captured.update(kwargs)
+        stop.set()
+        return kb.DispatchResult()
+
+    monkeypatch.setattr(kb, "dispatch_once", fake_dispatch_once)
+    kb.run_daemon(
+        interval=0,
+        global_max_in_progress=2,
+        stop_event=stop,
+    )
+
+    assert captured["global_max_in_progress"] == 2

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -764,6 +764,26 @@ def test_dispatch_dry_run(client):
     assert isinstance(body, dict)
 
 
+def test_dispatch_passes_global_cap_from_config(client, monkeypatch):
+    from hermes_cli import kanban_db
+
+    captured = {}
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"global_max_in_progress": 2}},
+    )
+
+    def fake_dispatch_once(_conn, **kwargs):
+        captured.update(kwargs)
+        return kanban_db.DispatchResult()
+
+    monkeypatch.setattr(kanban_db, "dispatch_once", fake_dispatch_once)
+    response = client.post("/api/plugins/kanban/dispatch?dry_run=true&max=4")
+
+    assert response.status_code == 200
+    assert captured["global_max_in_progress"] == 2
+
+
 # ---------------------------------------------------------------------------
 # Triage column (new v1 status)
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -721,7 +721,8 @@ All commands are also available as a slash command in the interactive CLI and in
 
 | Config key | Default | What it does |
 |------------|---------|--------------|
-| `kanban.max_in_progress` | unset (unlimited) | Caps the number of simultaneously running tasks. When the board already has N running, the dispatcher skips spawning more — useful for slow workers (local LLMs, resource-constrained hosts) so they finish what they have before more pile up and time out. Invalid or below-1 values log a warning and behave as unlimited. |
+| `kanban.max_in_progress` | unset (unlimited) | Per-board cap on simultaneously running tasks. When the current board already has N running, the dispatcher skips spawning more. Invalid or below-1 values log a warning and behave as unlimited. |
+| `kanban.global_max_in_progress` | unset (unlimited) | Aggregate cap across all active boards. Gateway, CLI, and dashboard dispatches share a machine-global lock while checking this limit, preventing concurrent board ticks from consuming the same remaining slot. Useful for protecting a shared local model or other constrained backend. |
 | `kanban.max_in_progress_per_profile` | unset (unlimited) | Per-profile variant of `max_in_progress` — caps how many tasks any single assignee profile may run concurrently. Useful when one profile is slow or rate-limited but others should keep flowing. Applies alongside the board-wide `max_in_progress`; both must allow a spawn for it to proceed. |
 | `kanban.auto_promote_children` | `true` | After `decompose_triage_task()` produces children with no parent-blocker dependencies, they're automatically promoted to `ready` so the dispatcher can pick them up. Set to `false` to require manual review — children stay in `todo` until you promote them. |
 | `kanban.default_workdir` | unset | Board-level default working directory applied to new tasks when neither `--workspace` nor the task itself overrides it. Per-task `workspace:` still wins. |
@@ -729,6 +730,7 @@ All commands are also available as a slash command in the interactive CLI and in
 ```yaml
 kanban:
   max_in_progress: 2
+  global_max_in_progress: 3
   auto_promote_children: false
   default_workdir: ~/work/active-project
 ```


### PR DESCRIPTION
## Summary

- add `kanban.global_max_in_progress` as an aggregate concurrency cap across active Kanban boards
- serialize capped dispatch decisions with a machine-global dispatch lock
- share one remaining-capacity budget across ready and review dispatch paths
- propagate the cap through gateway, CLI dispatch, standalone daemon, and dashboard paths
- document the setting and expose it in dashboard status

## Safety and compatibility

- disabled by default; existing behavior is unchanged when unset
- existing board-local `max_in_progress`, per-profile limits, and per-tick `max_spawn` continue to apply
- count failures fail closed rather than treating unknown state as spare capacity
- duplicate board metadata resolving to the same database path is counted once
- dry-run reports the same bounded candidate count without claiming or spawning tasks

## Verification

- `534 passed` across Kanban DB/core/locking/CLI/dashboard suites
- `14 passed` in focused global-cap and CLI propagation tests after rebasing onto current `main`
- Ruff passed on all changed Python files
- `git diff --check` passed
- independent read-only review found no blocking findings
