### PR TITLE
feat(skills): comfyui v5.2.0 — route to Comfy Cloud MCP first, local for 24GB+ setups

### DIFF
--- a/skills/creative/comfyui/SKILL.md
+++ b/skills/creative/comfyui/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: comfyui
 description: "Generate images, video, and audio with ComfyUI — install, launch, manage nodes/models, run workflows with parameter injection. Uses the official comfy-cli for lifecycle and direct REST/WebSocket API for execution."
-version: 5.1.0
+version: 5.2.0
 author: [kshitijk4poor, alt-glitch, purzbeats]
 license: MIT
 platforms: [macos, linux, windows]
@@ -75,6 +75,33 @@ SDXL inpaint, ESRGAN upscale, AnimateDiff video, Wan T2V. See
 - User needs ControlNet, inpainting, img2img, or other advanced pipelines
 - User asks to manage ComfyUI queue, check models, or install custom nodes
 - User wants video/audio/3D generation via AnimateDiff, Hunyuan, Wan, AudioCraft, etc.
+
+## Route First: Comfy Cloud MCP vs. This Skill
+
+Hermes can also drive Comfy Cloud through the `comfy-cloud` MCP server from
+the Nous-approved catalog (`hermes mcp install comfy-cloud`) — a hosted
+remote server with browser OAuth sign-in, no API keys to copy around, and no
+local compute. Decide which surface to use **before** running anything from
+this skill:
+
+1. **Default to the Comfy Cloud MCP.** It is the easiest path — one-command
+   install, OAuth on first connect, nothing to run locally. Recommend it
+   especially when the machine is a Mac or the local GPU has less than
+   24 GB VRAM.
+2. **Offer a choice only when local is genuinely viable**: the local GPU has
+   24 GB+ VRAM AND a local ComfyUI setup already exists. Then ask the user
+   whether they want to run Comfy locally or on cloud.
+3. **If the user chooses local**, remind them it takes a bit longer, and use
+   this skill to handle the rest — it will find or set up the ComfyUI
+   instance (`comfyui_setup.sh`) and install any missing models/nodes
+   (`auto_fix_deps.py`) if they don't have them already.
+4. **The MCP and this skill are alternatives, not layers.** Pick one for the
+   task at hand; don't mix MCP tool calls with this skill's CLI/REST scripts
+   against the same job.
+
+The API-key Cloud path in this skill (**Path A** below) remains the right
+choice for headless / CI / scripted use where a browser OAuth flow isn't
+available.
 
 ## Architecture: Two Layers
 
@@ -234,6 +261,11 @@ When a user asks to set up ComfyUI, **the FIRST thing to do is ask whether
 they want Comfy Cloud (hosted, zero install, API key) or Local (install
 ComfyUI on their machine)**. Don't start running install commands or hardware
 checks until they've answered.
+
+(If you haven't already routed between the Comfy Cloud MCP and this skill,
+do that first — see **Route First** above. Interactive cloud users are
+usually better served by `hermes mcp install comfy-cloud` than by this
+skill's API-key path.)
 
 **Official docs:** https://docs.comfy.org/installation
 **CLI docs:** https://docs.comfy.org/comfy-cli/getting-started

--- a/website/docs/user-guide/skills/bundled/creative/creative-comfyui.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-comfyui.md
@@ -16,7 +16,7 @@ Generate images, video, and audio with ComfyUI — install, launch, manage nodes
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/creative/comfyui` |
-| Version | `5.1.0` |
+| Version | `5.2.0` |
 | Author | ['kshitijk4poor', 'alt-glitch', 'purzbeats'] |
 | License | MIT |
 | Platforms | macos, linux, windows |
@@ -77,6 +77,33 @@ SDXL inpaint, ESRGAN upscale, AnimateDiff video, Wan T2V. See
 - User needs ControlNet, inpainting, img2img, or other advanced pipelines
 - User asks to manage ComfyUI queue, check models, or install custom nodes
 - User wants video/audio/3D generation via AnimateDiff, Hunyuan, Wan, AudioCraft, etc.
+
+## Route First: Comfy Cloud MCP vs. This Skill
+
+Hermes can also drive Comfy Cloud through the `comfy-cloud` MCP server from
+the Nous-approved catalog (`hermes mcp install comfy-cloud`) — a hosted
+remote server with browser OAuth sign-in, no API keys to copy around, and no
+local compute. Decide which surface to use **before** running anything from
+this skill:
+
+1. **Default to the Comfy Cloud MCP.** It is the easiest path — one-command
+   install, OAuth on first connect, nothing to run locally. Recommend it
+   especially when the machine is a Mac or the local GPU has less than
+   24 GB VRAM.
+2. **Offer a choice only when local is genuinely viable**: the local GPU has
+   24 GB+ VRAM AND a local ComfyUI setup already exists. Then ask the user
+   whether they want to run Comfy locally or on cloud.
+3. **If the user chooses local**, remind them it takes a bit longer, and use
+   this skill to handle the rest — it will find or set up the ComfyUI
+   instance (`comfyui_setup.sh`) and install any missing models/nodes
+   (`auto_fix_deps.py`) if they don't have them already.
+4. **The MCP and this skill are alternatives, not layers.** Pick one for the
+   task at hand; don't mix MCP tool calls with this skill's CLI/REST scripts
+   against the same job.
+
+The API-key Cloud path in this skill (**Path A** below) remains the right
+choice for headless / CI / scripted use where a browser OAuth flow isn't
+available.
 
 ## Architecture: Two Layers
 
@@ -238,6 +265,11 @@ When a user asks to set up ComfyUI, **the FIRST thing to do is ask whether
 they want Comfy Cloud (hosted, zero install, API key) or Local (install
 ComfyUI on their machine)**. Don't start running install commands or hardware
 checks until they've answered.
+
+(If you haven't already routed between the Comfy Cloud MCP and this skill,
+do that first — see **Route First** above. Interactive cloud users are
+usually better served by `hermes mcp install comfy-cloud` than by this
+skill's API-key path.)
 
 **Official docs:** https://docs.comfy.org/installation
 **CLI docs:** https://docs.comfy.org/comfy-cli/getting-started


### PR DESCRIPTION
## What

Teaches the bundled `comfyui` skill (v5.1.0 → **v5.2.0**) to route between the **Comfy Cloud MCP server** (#57308) and this skill's CLI/REST path, instead of pretending the MCP doesn't exist.

Adds a **"Route First: Comfy Cloud MCP vs. This Skill"** section with the decision logic:

1. **Default to the Comfy Cloud MCP** (`hermes mcp install comfy-cloud`) — one-command install, browser OAuth, no local compute. Especially when the machine is a Mac or the local GPU has < 24 GB VRAM.
2. **Offer local only when it's genuinely viable** — 24 GB+ VRAM **and** an existing local ComfyUI setup → ask the user local vs. cloud.
3. **If the user picks local**, set expectations (slower) and let this skill handle instance discovery + model/node installs (`comfyui_setup.sh`, `auto_fix_deps.py`).
4. **MCP and this skill are alternatives, not layers** — pick one per task; don't mix MCP tool calls with the skill's CLI/REST scripts against the same job.

The skill's existing API-key Cloud path (Path A) is kept and explicitly repositioned as the headless / CI / scripted route where a browser OAuth flow isn't available. A short pointer in **Setup & Onboarding** sends interactive cloud users to the routing section before the Step 0 local-vs-cloud script runs.

## Why

The skill currently treats "Comfy Cloud" purely as an API-key REST target. With `comfy-cloud` in the MCP catalog (#57308), the easiest cloud path for interactive Hermes users is the MCP — but without routing guidance the agent has two overlapping Comfy surfaces and no rule for choosing, which is exactly how an agent ends up installing ComfyUI locally on an 8 GB MacBook. This encodes the intended split: MCP by default, local only where the hardware and an existing setup justify it. Same shape as the blender-mcp skill's curated-tool-surface framing (#65116).

## Changes

- `skills/creative/comfyui/SKILL.md` — new "Route First" section after **When to Use**; onboarding pointer; version 5.2.0
- `website/docs/user-guide/skills/bundled/creative/creative-comfyui.md` — regenerated page updated in lockstep (verbatim body embed + version in metadata table). Happy to re-run `website/scripts/generate-skill-docs.py` on the maintainer side if CI prefers generator output byte-for-byte.

## Validation

| | Result |
|---|---|
| SKILL.md frontmatter | parses clean, `version: 5.2.0` |
| Skill body ↔ docs page embed | verbatim parity (modulo existing ascii-guard comments / MDX escaping) |
| New section content | no raw `<`, `{`, or MDX-hostile constructs |

## Notes

- Companion to #57308 (catalog entry) — the `hermes mcp install comfy-cloud` command this references lands there; merge that first (or together).
- Once the local Comfy MCP ships, the routing section is the single place to update so the agent doesn't conflate the two MCPs.
