### PR TITLE
feat(kanban): enforce bounded orchestration policy

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2844,6 +2844,21 @@ def run_slash(rest: str) -> str:
     if not tokens or tokens[0] in {"help", "--help", "-h", "?"}:
         return _SLASH_KANBAN_HELP
 
+    # Program roots grant bounded delegation authority and are broker-only.
+    # Every interactive and gateway /kanban path enters through run_slash;
+    # reject before argparse dispatch so no future handler refactor can expose
+    # this mutation surface outside trusted direct OS argv.
+    command_tokens = [token for token in tokens if not token.startswith("--board=")]
+    if command_tokens[:2] == ["program", "create"] or (
+        len(command_tokens) >= 4
+        and command_tokens[0] == "--board"
+        and command_tokens[2:4] == ["program", "create"]
+    ):
+        return (
+            "⚠ /kanban program create is restricted to the trusted direct "
+            "OS argv CLI"
+        )
+
     # Single argparse tree rooted at "/kanban".  build_parser() expects a
     # subparsers action to attach to, so build a throwaway one and pull
     # the kanban_parser back out — then drive it directly so usage/error

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -368,6 +368,27 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "to skip the brief running-to-blocked transition.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
+    # Trusted argv-only control plane for bounded orchestration roots.  This is
+    # intentionally separate from both ordinary create and the model tool.
+    p_program = sub.add_parser("program", help="Manage bounded orchestration programs")
+    program_sub = p_program.add_subparsers(dest="program_action", required=True)
+    p_program_create = program_sub.add_parser("create", help="Create a bounded policy root")
+    p_program_create.add_argument("--title", required=True)
+    p_program_create.add_argument("--body", default=None)
+    p_program_create.add_argument("--assignee", required=True)
+    p_program_create.add_argument("--allowed-assignee", action="append", required=True)
+    p_program_create.add_argument("--orchestrator", action="append", required=True)
+    p_program_create.add_argument("--max-depth", type=int, required=True)
+    p_program_create.add_argument("--max-tasks", type=int, required=True)
+    p_program_create.add_argument("--max-concurrency", type=int, required=True)
+    p_program_create.add_argument("--max-runtime-seconds", type=int, required=True)
+    p_program_create.add_argument("--max-wall-clock-seconds", type=int, required=True)
+    p_program_create.add_argument("--goal-max-turns", type=int, required=True)
+    p_program_create.add_argument("--tenant", default=None)
+    p_program_create.add_argument("--project", default=None)
+    p_program_create.add_argument("--idempotency-key", default=None)
+    p_program_create.add_argument("--json", action="store_true")
+
     # --- swarm ---
     p_swarm = sub.add_parser(
         "swarm",
@@ -938,6 +959,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         handlers = {
             "init":     _cmd_init,
             "create":   _cmd_create,
+            "program":  _cmd_program_create,
             "swarm":    _cmd_swarm,
             "list":     _cmd_list,
             "ls":       _cmd_list,
@@ -1365,6 +1387,42 @@ def _cmd_create(args: argparse.Namespace) -> int:
             running, message = _check_dispatcher_presence()
             if not running and message:
                 print(f"\n⚠  {message}", file=sys.stderr)
+    return 0
+
+
+def _cmd_program_create(args: argparse.Namespace) -> int:
+    try:
+        policy = kb.OrchestrationPolicy(
+            allowed_assignees=tuple(args.allowed_assignee),
+            orchestrator_assignees=tuple(args.orchestrator),
+            max_depth=args.max_depth,
+            max_tasks=args.max_tasks,
+            max_runtime_seconds=args.max_runtime_seconds,
+            max_concurrency=args.max_concurrency,
+            max_wall_clock_seconds=args.max_wall_clock_seconds,
+            goal_max_turns=args.goal_max_turns,
+        )
+        with kb.connect_closing() as conn:
+            task_id = kb.create_task(
+                conn, title=args.title, body=args.body, assignee=args.assignee,
+                tenant=args.tenant, project_id=args.project,
+                idempotency_key=args.idempotency_key,
+                orchestration_policy=policy, created_by=_profile_author(),
+            )
+            task = kb.get_task(conn, task_id)
+    except ValueError as exc:
+        print(f"kanban program create: {exc}", file=sys.stderr)
+        return 2
+    safe = {
+        "id": task.id,
+        "status": task.status,
+        "orchestration_root_id": task.orchestration_root_id,
+        "policy": json.loads(task.orchestration_policy.to_json()),
+    }
+    if args.json:
+        print(json.dumps(safe, sort_keys=True, separators=(",", ":")))
+    else:
+        print(f"Created program {task.id} ({task.status})")
     return 0
 
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -907,6 +907,11 @@ def kanban_command(args: argparse.Namespace) -> int:
             )
         return 0
 
+    # Reject before board resolution or DB initialization can read, create, or
+    # mutate any persistent state.
+    if action == "program" and not kb.is_mission_control_command_cgroup():
+        return _reject_program_create()
+
     # Board-management commands operate on board metadata and the persisted
     # current-board pointer itself. They must ignore the shared `--board`
     # task-routing override; otherwise `/kanban --board beta boards show`
@@ -1390,7 +1395,18 @@ def _cmd_create(args: argparse.Namespace) -> int:
     return 0
 
 
+def _reject_program_create() -> int:
+    print(
+        "kanban program create: restricted to the trusted Mission Control broker",
+        file=sys.stderr,
+    )
+    return 2
+
+
 def _cmd_program_create(args: argparse.Namespace) -> int:
+    """Create a program root only inside Mission Control's command unit."""
+    if not kb.is_mission_control_command_cgroup():
+        return _reject_program_create()
     try:
         policy = kb.OrchestrationPolicy(
             allowed_assignees=tuple(args.allowed_assignee),
@@ -1675,8 +1691,12 @@ def _cmd_show(args: argparse.Namespace) -> int:
 
 def _cmd_assign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in {"none", "-", "null"} else args.profile
-    with kb.connect_closing() as conn:
-        ok = kb.assign_task(conn, args.task_id, profile)
+    try:
+        with kb.connect_closing() as conn:
+            ok = kb.assign_task(conn, args.task_id, profile)
+    except ValueError as exc:
+        print(f"kanban assign: {exc}", file=sys.stderr)
+        return 2
     if not ok:
         print(f"no such task: {args.task_id}", file=sys.stderr)
         return 1
@@ -1855,8 +1875,12 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
 
 
 def _cmd_link(args: argparse.Namespace) -> int:
-    with kb.connect_closing() as conn:
-        kb.link_tasks(conn, args.parent_id, args.child_id)
+    try:
+        with kb.connect_closing() as conn:
+            kb.link_tasks(conn, args.parent_id, args.child_id)
+    except ValueError as exc:
+        print(f"kanban link: {exc}", file=sys.stderr)
+        return 2
     print(f"Linked {args.parent_id} -> {args.child_id}")
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -836,6 +836,107 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
 # Data classes
 # ---------------------------------------------------------------------------
 
+@dataclass(frozen=True)
+class OrchestrationPolicy:
+    """Immutable, bounded authority for one dynamically expanded program."""
+
+    allowed_assignees: tuple[str, ...]
+    orchestrator_assignees: tuple[str, ...]
+    max_depth: int
+    max_tasks: int
+    max_runtime_seconds: int
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.allowed_assignees, (list, tuple))
+            or not isinstance(self.orchestrator_assignees, (list, tuple))
+            or any(type(item) is not str for item in self.allowed_assignees)
+            or any(type(item) is not str for item in self.orchestrator_assignees)
+            or any(
+                type(value) is not int
+                for value in (
+                    self.max_depth,
+                    self.max_tasks,
+                    self.max_runtime_seconds,
+                )
+            )
+        ):
+            raise ValueError("malformed orchestration policy")
+        assignees = tuple(
+            dict.fromkeys(_canonical_assignee(a) for a in self.allowed_assignees)
+        )
+        orchestrators = tuple(
+            dict.fromkeys(_canonical_assignee(a) for a in self.orchestrator_assignees)
+        )
+        if not assignees or any(not a for a in assignees) or len(assignees) > 64:
+            raise ValueError("allowed_assignees must contain 1 to 64 profile names")
+        if not orchestrators or any(not a for a in orchestrators):
+            raise ValueError("orchestrator_assignees must contain profile names")
+        if not set(orchestrators).issubset(assignees):
+            raise ValueError("orchestrator_assignees must be a subset of allowed_assignees")
+        if not 1 <= self.max_depth <= 32:
+            raise ValueError("max_depth must be between 1 and 32")
+        if not 1 <= self.max_tasks <= 10_000:
+            raise ValueError("max_tasks must be between 1 and 10000")
+        if not 1 <= self.max_runtime_seconds <= 604_800:
+            raise ValueError("max_runtime_seconds must be between 1 and 604800")
+        object.__setattr__(self, "allowed_assignees", assignees)
+        object.__setattr__(self, "orchestrator_assignees", orchestrators)
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "allowed_assignees": list(self.allowed_assignees),
+                "orchestrator_assignees": list(self.orchestrator_assignees),
+                "max_depth": self.max_depth,
+                "max_tasks": self.max_tasks,
+                "max_runtime_seconds": self.max_runtime_seconds,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @classmethod
+    def from_json(cls, value: str) -> "OrchestrationPolicy":
+        try:
+            data = json.loads(value)
+            if not isinstance(data, dict) or set(data) != {
+                "allowed_assignees",
+                "orchestrator_assignees",
+                "max_depth",
+                "max_tasks",
+                "max_runtime_seconds",
+            }:
+                raise ValueError
+            if (
+                not isinstance(data["allowed_assignees"], list)
+                or not isinstance(data["orchestrator_assignees"], list)
+                or any(type(item) is not str for item in data["allowed_assignees"])
+                or any(type(item) is not str for item in data["orchestrator_assignees"])
+                or any(type(data[key]) is not int for key in (
+                    "max_depth", "max_tasks", "max_runtime_seconds"
+                ))
+            ):
+                raise ValueError
+            return cls(
+                allowed_assignees=tuple(data["allowed_assignees"]),
+                orchestrator_assignees=tuple(data["orchestrator_assignees"]),
+                max_depth=data["max_depth"],
+                max_tasks=data["max_tasks"],
+                max_runtime_seconds=data["max_runtime_seconds"],
+            )
+        except (TypeError, ValueError, json.JSONDecodeError, KeyError) as exc:
+            raise ValueError("malformed orchestration policy") from exc
+
+
+@dataclass(frozen=True)
+class CreationAuthority:
+    task_id: str
+    run_id: int
+    claim_lock: str
+    actor_profile: str
+
+
 @dataclass
 class Task:
     """In-memory view of a row from the ``tasks`` table."""
@@ -915,6 +1016,10 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    orchestration_policy: Optional[OrchestrationPolicy] = None
+    orchestration_root_id: Optional[str] = None
+    orchestration_depth: Optional[int] = None
+    orchestration_parent_id: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -998,6 +1103,20 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            orchestration_policy=(
+                OrchestrationPolicy.from_json(row["orchestration_policy"])
+                if "orchestration_policy" in keys and row["orchestration_policy"] else None
+            ),
+            orchestration_root_id=(
+                row["orchestration_root_id"] if "orchestration_root_id" in keys else None
+            ),
+            orchestration_depth=(
+                row["orchestration_depth"] if "orchestration_depth" in keys else None
+            ),
+            orchestration_parent_id=(
+                row["orchestration_parent_id"]
+                if "orchestration_parent_id" in keys else None
             ),
         )
 
@@ -1117,6 +1236,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     tenant               TEXT,
     result               TEXT,
     idempotency_key      TEXT,
+    orchestration_policy TEXT,
+    orchestration_root_id TEXT,
+    orchestration_depth  INTEGER,
+    orchestration_parent_id TEXT,
     -- Unified consecutive-failure counter. Incremented on spawn
     -- failure, timeout, or crash; reset only on successful completion.
     -- The circuit breaker in _record_task_failure trips when this
@@ -1987,6 +2110,23 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    if "orchestration_policy" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "orchestration_policy", "orchestration_policy TEXT"
+        )
+    if "orchestration_root_id" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "orchestration_root_id", "orchestration_root_id TEXT"
+        )
+    if "orchestration_depth" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "orchestration_depth", "orchestration_depth INTEGER"
+        )
+    if "orchestration_parent_id" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "orchestration_parent_id", "orchestration_parent_id TEXT"
+        )
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2408,6 +2548,9 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    orchestration_policy: Optional[OrchestrationPolicy] = None,
+    current_orchestrator_task_id: Optional[str] = None,
+    creation_authority: Optional[CreationAuthority] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2433,6 +2576,12 @@ def create_task(
     translation skill regardless of the profile's default config).
     """
     assignee = _canonical_assignee(assignee)
+    if orchestration_policy is not None and not isinstance(
+        orchestration_policy, OrchestrationPolicy
+    ):
+        raise ValueError("orchestration_policy must be an OrchestrationPolicy")
+    if orchestration_policy is not None and current_orchestrator_task_id is not None:
+        raise ValueError("a child cannot supply orchestration policy authority")
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
@@ -2448,6 +2597,9 @@ def create_task(
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
+
+    requested_tenant = tenant
+    project_was_requested = bool(project_id is not None and str(project_id).strip())
 
     # Resolve an optional first-class Project link. A project-linked task is
     # anchored to the project's primary repo as a git worktree, so its branch
@@ -2490,7 +2642,11 @@ def create_task(
                 # ``<repo>/.worktrees/<task-id>`` dir keyed on the new task id.
                 project_repo = str(project_obj.primary_path)
 
+    requested_project_id = project_id
+    project_resolution_failed = project_was_requested and project_obj is None
+
     parents = tuple(p for p in parents if p)
+    requested_parents = parents
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
     # (preserving order). Refuse commas inside a single name so we don't
@@ -2537,21 +2693,6 @@ def create_task(
             )
         skills_list = cleaned
 
-    # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
-    if idempotency_key:
-        row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
-            "AND status != 'archived' "
-            "ORDER BY created_at DESC LIMIT 1",
-            (idempotency_key,),
-        ).fetchone()
-        if row:
-            return row["id"]
-
     now = int(time.time())
 
     # Resolve workspace_path from board-level default_workdir when the
@@ -2579,6 +2720,140 @@ def create_task(
         task_id = _new_task_id()
         try:
             with write_txn(conn):
+                policy = orchestration_policy
+                orchestration_root_id = None
+                orchestration_depth = None
+                orchestration_parent_id = None
+                if current_orchestrator_task_id is not None:
+                    authority = get_task(conn, current_orchestrator_task_id)
+                    if authority is None:
+                        raise ValueError("current task has no orchestration authority")
+                    # Dispatcher context is also present for legacy workers.
+                    # A real current task without policy keeps the unrestricted
+                    # pre-policy create behavior; a missing row still fails
+                    # closed (most importantly on an explicitly foreign board).
+                    if authority.orchestration_policy is None:
+                        authority = None
+                    else:
+                        policy = authority.orchestration_policy
+                if current_orchestrator_task_id is not None and authority is not None:
+                    if (
+                        not isinstance(creation_authority, CreationAuthority)
+                        or type(creation_authority.run_id) is not int
+                        or not isinstance(creation_authority.task_id, str)
+                        or not creation_authority.task_id
+                        or not isinstance(creation_authority.claim_lock, str)
+                        or not creation_authority.claim_lock
+                        or not isinstance(creation_authority.actor_profile, str)
+                        or not creation_authority.actor_profile
+                    ):
+                        raise ValueError("missing active orchestration authority")
+                    active = conn.execute(
+                        "SELECT 1 FROM tasks t JOIN task_runs r ON r.id = t.current_run_id "
+                        "WHERE t.id = ? AND t.status = 'running' "
+                        "AND t.current_run_id = ? AND t.claim_lock = ? "
+                        "AND t.assignee = ? AND r.task_id = t.id "
+                        "AND r.profile = ? AND r.status = 'running' "
+                        "AND r.claim_lock = ? AND r.ended_at IS NULL",
+                        (
+                            creation_authority.task_id,
+                            creation_authority.run_id,
+                            creation_authority.claim_lock,
+                            creation_authority.actor_profile,
+                            creation_authority.actor_profile,
+                            creation_authority.claim_lock,
+                        ),
+                    ).fetchone()
+                    if (
+                        creation_authority.task_id != current_orchestrator_task_id
+                        or active is None
+                    ):
+                        raise ValueError("missing or stale active orchestration authority")
+                    if creation_authority.actor_profile not in policy.orchestrator_assignees:
+                        raise ValueError("profile is not allowed to orchestrate")
+                    orchestration_root_id = authority.orchestration_root_id
+                    orchestration_parent_id = authority.id
+                    if not orchestration_root_id or authority.orchestration_depth is None:
+                        raise ValueError("malformed orchestration authority")
+                    if requested_tenant is not None and requested_tenant != authority.tenant:
+                        raise ValueError("tenant does not match orchestration program")
+                    if project_resolution_failed or (
+                        project_was_requested and requested_project_id != authority.project_id
+                    ):
+                        raise ValueError("project does not match orchestration program")
+                    if requested_parents:
+                        parent_rows = conn.execute(
+                            "SELECT id, orchestration_root_id FROM tasks WHERE id IN ("
+                            + ",".join("?" * len(requested_parents)) + ")",
+                            requested_parents,
+                        ).fetchall()
+                        if len(parent_rows) != len(set(requested_parents)) or any(
+                            row["orchestration_root_id"] != orchestration_root_id
+                            for row in parent_rows
+                        ):
+                            raise ValueError("dependency parent is outside orchestration program")
+                    orchestration_depth = authority.orchestration_depth + 1
+                    tenant = authority.tenant
+                    project_id = authority.project_id
+                    parents = requested_parents or (authority.id,)
+                    max_runtime_seconds = policy.max_runtime_seconds
+                elif policy is not None:
+                    if project_resolution_failed:
+                        raise ValueError("project does not match orchestration program")
+                    orchestration_root_id = task_id
+                    orchestration_depth = 0
+                    max_runtime_seconds = policy.max_runtime_seconds
+
+                # Re-check under the write lock so concurrent replay cannot
+                # spend quota twice. A key already owned by another program is
+                # an authority mismatch, never a successful replay.
+                if idempotency_key:
+                    existing = conn.execute(
+                        "SELECT id, assignee, tenant, project_id, orchestration_policy, "
+                        "orchestration_root_id, orchestration_depth, orchestration_parent_id "
+                        "FROM tasks "
+                        "WHERE idempotency_key = ? AND status != 'archived' "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (idempotency_key,),
+                    ).fetchone()
+                    if existing:
+                        if current_orchestrator_task_id is not None and policy is not None:
+                            same_scope = (
+                                existing["orchestration_root_id"] == orchestration_root_id
+                            )
+                        elif orchestration_policy is not None:
+                            same_scope = (
+                                existing["id"] == existing["orchestration_root_id"]
+                                and existing["orchestration_depth"] == 0
+                                and existing["orchestration_parent_id"] is None
+                                and existing["orchestration_policy"] == orchestration_policy.to_json()
+                                and existing["assignee"] == assignee
+                                and existing["tenant"] == tenant
+                                and existing["project_id"] == project_id
+                            )
+                        else:
+                            same_scope = existing["orchestration_root_id"] is None
+                        if not same_scope:
+                            raise ValueError(
+                                "idempotency key belongs to another program"
+                            )
+                        return existing["id"]
+
+                if policy is not None:
+                    if assignee not in policy.allowed_assignees:
+                        raise ValueError("assignee is not allowed by orchestration policy")
+                    if (
+                        orchestration_depth is None
+                        or orchestration_depth > policy.max_depth
+                    ):
+                        raise ValueError("maximum orchestration depth exceeded")
+                    program_size = conn.execute(
+                        "SELECT COUNT(*) FROM tasks WHERE orchestration_root_id = ?",
+                        (orchestration_root_id,),
+                    ).fetchone()[0]
+                    if program_size >= policy.max_tasks:
+                        raise ValueError("maximum orchestration task count exceeded")
+
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -2635,9 +2910,11 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
-                        max_runtime_seconds,
+                        max_runtime_seconds, orchestration_policy,
+                        orchestration_root_id, orchestration_depth,
+                        orchestration_parent_id,
                         skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2655,6 +2932,10 @@ def create_task(
                         tenant,
                         idempotency_key,
                         int(max_runtime_seconds) if max_runtime_seconds is not None else None,
+                        policy.to_json() if policy is not None else None,
+                        orchestration_root_id,
+                        orchestration_depth,
+                        orchestration_parent_id,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
                         1 if goal_mode else 0,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -838,13 +838,23 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
 
 @dataclass(frozen=True)
 class OrchestrationPolicy:
-    """Immutable, bounded authority for one dynamically expanded program."""
+    """Immutable, bounded authority for one dynamically expanded program.
+
+    Version 2 adds execution budgets.  A1 was never released, but persisted
+    development databases may contain its exact five-key JSON document;
+    ``from_json`` deliberately upgrades that shape to conservative bounded
+    defaults.  Every new serialization is an exact, explicitly-versioned v2
+    document so future compatibility cannot emerge from accidental parsing.
+    """
 
     allowed_assignees: tuple[str, ...]
     orchestrator_assignees: tuple[str, ...]
     max_depth: int
     max_tasks: int
     max_runtime_seconds: int
+    max_concurrency: int = 1
+    max_wall_clock_seconds: int = 86_400
+    goal_max_turns: int = 20
 
     def __post_init__(self) -> None:
         if (
@@ -858,6 +868,9 @@ class OrchestrationPolicy:
                     self.max_depth,
                     self.max_tasks,
                     self.max_runtime_seconds,
+                    self.max_concurrency,
+                    self.max_wall_clock_seconds,
+                    self.goal_max_turns,
                 )
             )
         ):
@@ -868,6 +881,10 @@ class OrchestrationPolicy:
         orchestrators = tuple(
             dict.fromkeys(_canonical_assignee(a) for a in self.orchestrator_assignees)
         )
+        if len(assignees) != len(self.allowed_assignees):
+            raise ValueError("allowed_assignees must not contain duplicates")
+        if len(orchestrators) != len(self.orchestrator_assignees):
+            raise ValueError("orchestrator_assignees must not contain duplicates")
         if not assignees or any(not a for a in assignees) or len(assignees) > 64:
             raise ValueError("allowed_assignees must contain 1 to 64 profile names")
         if not orchestrators or any(not a for a in orchestrators):
@@ -880,17 +897,27 @@ class OrchestrationPolicy:
             raise ValueError("max_tasks must be between 1 and 10000")
         if not 1 <= self.max_runtime_seconds <= 604_800:
             raise ValueError("max_runtime_seconds must be between 1 and 604800")
+        if not 1 <= self.max_concurrency <= 32:
+            raise ValueError("max_concurrency must be between 1 and 32")
+        if not 1 <= self.max_wall_clock_seconds <= 86_400:
+            raise ValueError("max_wall_clock_seconds must be between 1 and 86400")
+        if not 1 <= self.goal_max_turns <= 20:
+            raise ValueError("goal_max_turns must be between 1 and 20")
         object.__setattr__(self, "allowed_assignees", assignees)
         object.__setattr__(self, "orchestrator_assignees", orchestrators)
 
     def to_json(self) -> str:
         return json.dumps(
             {
+                "version": 2,
                 "allowed_assignees": list(self.allowed_assignees),
                 "orchestrator_assignees": list(self.orchestrator_assignees),
                 "max_depth": self.max_depth,
                 "max_tasks": self.max_tasks,
                 "max_runtime_seconds": self.max_runtime_seconds,
+                "max_concurrency": self.max_concurrency,
+                "max_wall_clock_seconds": self.max_wall_clock_seconds,
+                "goal_max_turns": self.goal_max_turns,
             },
             sort_keys=True,
             separators=(",", ":"),
@@ -900,13 +927,21 @@ class OrchestrationPolicy:
     def from_json(cls, value: str) -> "OrchestrationPolicy":
         try:
             data = json.loads(value)
-            if not isinstance(data, dict) or set(data) != {
+            a1_keys = {
                 "allowed_assignees",
                 "orchestrator_assignees",
                 "max_depth",
                 "max_tasks",
                 "max_runtime_seconds",
-            }:
+            }
+            v2_keys = a1_keys | {
+                "version", "max_concurrency", "max_wall_clock_seconds",
+                "goal_max_turns",
+            }
+            if not isinstance(data, dict) or set(data) not in (a1_keys, v2_keys):
+                raise ValueError
+            is_a1 = set(data) == a1_keys
+            if not is_a1 and (type(data["version"]) is not int or data["version"] != 2):
                 raise ValueError
             if (
                 not isinstance(data["allowed_assignees"], list)
@@ -916,6 +951,9 @@ class OrchestrationPolicy:
                 or any(type(data[key]) is not int for key in (
                     "max_depth", "max_tasks", "max_runtime_seconds"
                 ))
+                or (not is_a1 and any(type(data[key]) is not int for key in (
+                    "max_concurrency", "max_wall_clock_seconds", "goal_max_turns"
+                )))
             ):
                 raise ValueError
             return cls(
@@ -924,6 +962,9 @@ class OrchestrationPolicy:
                 max_depth=data["max_depth"],
                 max_tasks=data["max_tasks"],
                 max_runtime_seconds=data["max_runtime_seconds"],
+                max_concurrency=1 if is_a1 else data["max_concurrency"],
+                max_wall_clock_seconds=86_400 if is_a1 else data["max_wall_clock_seconds"],
+                goal_max_turns=20 if is_a1 else data["goal_max_turns"],
             )
         except (TypeError, ValueError, json.JSONDecodeError, KeyError) as exc:
             raise ValueError("malformed orchestration policy") from exc
@@ -2797,12 +2838,14 @@ def create_task(
                     project_id = authority.project_id
                     parents = requested_parents or (authority.id,)
                     max_runtime_seconds = policy.max_runtime_seconds
+                    goal_max_turns = policy.goal_max_turns
                 elif policy is not None:
                     if project_resolution_failed:
                         raise ValueError("project does not match orchestration program")
                     orchestration_root_id = task_id
                     orchestration_depth = 0
                     max_runtime_seconds = policy.max_runtime_seconds
+                    goal_max_turns = policy.goal_max_turns
 
                 # Re-check under the write lock so concurrent replay cannot
                 # spend quota twice. A key already owned by another program is
@@ -2826,7 +2869,10 @@ def create_task(
                                 existing["id"] == existing["orchestration_root_id"]
                                 and existing["orchestration_depth"] == 0
                                 and existing["orchestration_parent_id"] is None
-                                and existing["orchestration_policy"] == orchestration_policy.to_json()
+                                and existing["orchestration_policy"] is not None
+                                and OrchestrationPolicy.from_json(
+                                    existing["orchestration_policy"]
+                                ) == orchestration_policy
                                 and existing["assignee"] == assignee
                                 and existing["tenant"] == tenant
                                 and existing["project_id"] == project_id
@@ -2840,6 +2886,25 @@ def create_task(
                         return existing["id"]
 
                 if policy is not None:
+                    root_created_at = conn.execute(
+                        "SELECT created_at FROM tasks WHERE id = ?",
+                        (orchestration_root_id,),
+                    ).fetchone()
+                    # A new root has no row yet, so its immutable creation
+                    # instant is the boundary's own ``now`` value.
+                    created_at = (
+                        int(root_created_at["created_at"])
+                        if root_created_at is not None else now
+                    )
+                    if now > created_at + policy.max_wall_clock_seconds:
+                        raise ValueError("orchestration program deadline exceeded")
+                    if (
+                        orchestration_depth == 0
+                        and assignee not in policy.orchestrator_assignees
+                    ):
+                        raise ValueError(
+                            "root assignee must be allowed to orchestrate"
+                        )
                     if assignee not in policy.allowed_assignees:
                         raise ValueError("assignee is not allowed by orchestration policy")
                     if (
@@ -3667,6 +3732,46 @@ def claim_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        program = conn.execute(
+            "SELECT orchestration_root_id, orchestration_policy FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if program and program["orchestration_policy"]:
+            try:
+                policy = OrchestrationPolicy.from_json(program["orchestration_policy"])
+            except ValueError:
+                policy = None
+            root = conn.execute(
+                "SELECT created_at FROM tasks WHERE id = ?",
+                (program["orchestration_root_id"],),
+            ).fetchone()
+            deadline_reason = (
+                "program_authority_invalid"
+                if policy is None or root is None
+                else "program_deadline"
+            )
+            if (
+                policy is None
+                or root is None
+                or now > int(root["created_at"]) + policy.max_wall_clock_seconds
+            ):
+                parked = conn.execute(
+                    "UPDATE tasks SET status = 'blocked' "
+                    "WHERE id = ? AND status = 'ready'",
+                    (task_id,),
+                )
+                if parked.rowcount == 1:
+                    _append_event(conn, task_id, "blocked", {"reason": deadline_reason})
+                return None
+            active = conn.execute(
+                "SELECT COUNT(*) FROM task_runs r "
+                "JOIN tasks t ON t.id = r.task_id "
+                "WHERE t.orchestration_root_id = ? AND r.status = 'running' "
+                "AND r.ended_at IS NULL AND r.claim_expires >= ?",
+                (program["orchestration_root_id"], now),
+            ).fetchone()[0]
+            if active >= policy.max_concurrency:
+                return None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -6592,13 +6697,12 @@ def enforce_max_runtime(
     *,
     signal_fn=None,
 ) -> list[str]:
-    """Terminate workers whose per-task ``max_runtime_seconds`` has elapsed.
+    """Terminate workers whose task runtime or program wall-clock has elapsed.
 
     Sends SIGTERM, waits a short grace window, then SIGKILL. Emits a
-    ``timed_out`` event and drops the task back to ``ready`` so the next
-    dispatcher tick re-spawns it — unless the spawn-failure circuit
-    breaker has already given up, in which case the task stays blocked
-    where ``_record_spawn_failure`` parked it.
+    ``timed_out`` event. Per-task runtime exhaustion returns the task to
+    ``ready`` for bounded retry; whole-program deadline exhaustion parks it
+    ``blocked`` so an expired program cannot enter a requeue loop.
 
     Runs host-local: only tasks claimed by this host are candidates
     (same reasoning as ``detect_crashed_workers``). ``signal_fn`` is a
@@ -6612,9 +6716,11 @@ def enforce_max_runtime(
     rows = conn.execute(
         "SELECT t.id, t.worker_pid, "
         "       COALESCE(r.started_at, t.started_at) AS active_started_at, "
-        "       t.max_runtime_seconds, t.claim_lock "
+        "       t.max_runtime_seconds, t.claim_lock, t.orchestration_policy, "
+        "       root.created_at AS root_created_at "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
+        "LEFT JOIN tasks root ON root.id = t.orchestration_root_id "
         "WHERE t.status = 'running' AND t.max_runtime_seconds IS NOT NULL "
         "  AND COALESCE(r.started_at, t.started_at) IS NOT NULL "
         "  AND t.worker_pid IS NOT NULL"
@@ -6627,8 +6733,32 @@ def enforce_max_runtime(
         # intentionally records the first time a task ever started, so retries
         # must be measured from the active task_runs row when present.
         elapsed = now - int(row["active_started_at"])
-        if elapsed < int(row["max_runtime_seconds"]):
+        runtime_exceeded = elapsed >= int(row["max_runtime_seconds"])
+        program_deadline_exceeded = False
+        program_elapsed = 0
+        program_limit = 0
+        if row["orchestration_policy"]:
+            try:
+                policy = OrchestrationPolicy.from_json(row["orchestration_policy"])
+                if row["root_created_at"] is None:
+                    program_deadline_exceeded = True
+                else:
+                    program_elapsed = now - int(row["root_created_at"])
+                    program_limit = policy.max_wall_clock_seconds
+                    program_deadline_exceeded = program_elapsed > program_limit
+            except ValueError:
+                # Malformed persisted authority must not leave a worker
+                # running outside enforceable bounds.
+                program_deadline_exceeded = True
+        if not runtime_exceeded and not program_deadline_exceeded:
             continue
+
+        deadline_reason = "program_deadline" if program_deadline_exceeded else "task_runtime"
+        effective_elapsed = program_elapsed if program_deadline_exceeded else elapsed
+        effective_limit = (
+            program_limit if program_deadline_exceeded
+            else int(row["max_runtime_seconds"])
+        )
 
         pid = int(row["worker_pid"])
         tid = row["id"]
@@ -6659,37 +6789,50 @@ def enforce_max_runtime(
                     pass
 
         with write_txn(conn):
+            next_status = "blocked" if program_deadline_exceeded else "ready"
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running' "
                 "  AND worker_pid = ? AND claim_lock IS ?",
-                (tid, pid, row["claim_lock"]),
+                (next_status, tid, pid, row["claim_lock"]),
             )
             if cur.rowcount == 1:
                 payload = {
                     "pid": pid,
-                    "elapsed_seconds": int(elapsed),
-                    "limit_seconds": int(row["max_runtime_seconds"]),
+                    "reason": deadline_reason,
+                    "elapsed_seconds": int(effective_elapsed),
+                    "limit_seconds": int(effective_limit),
                     "sigkill": killed,
                 }
                 run_id = _end_run(
                     conn, tid,
                     outcome="timed_out", status="timed_out",
-                    error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
+                    error=(
+                        f"{deadline_reason}: elapsed {int(effective_elapsed)}s "
+                        f"> limit {int(effective_limit)}s"
+                    ),
                     metadata=payload,
                 )
                 _append_event(
                     conn, tid, "timed_out", payload, run_id=run_id,
                 )
+                if program_deadline_exceeded:
+                    _append_event(
+                        conn,
+                        tid,
+                        "blocked",
+                        {"reason": "program_deadline"},
+                        run_id=run_id,
+                    )
                 timed_out.append(tid)
         # Increment the unified failure counter. Outside the write_txn
         # above because ``_record_task_failure`` opens its own. If the
         # breaker trips, this flips the task ``ready → blocked`` and
         # emits a ``gave_up`` event on top of the ``timed_out`` we
         # already emitted.
-        if cur.rowcount == 1:
+        if cur.rowcount == 1 and not program_deadline_exceeded:
             _record_task_failure(
                 conn, tid,
                 error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1277,6 +1277,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     tenant               TEXT,
     result               TEXT,
     idempotency_key      TEXT,
+    program_create_fingerprint TEXT,
     orchestration_policy TEXT,
     orchestration_root_id TEXT,
     orchestration_depth  INTEGER,
@@ -2031,6 +2032,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     if "idempotency_key" not in cols:
         _add_column_if_missing(
             conn, "tasks", "idempotency_key", "idempotency_key TEXT"
+        )
+    if "program_create_fingerprint" not in cols:
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "program_create_fingerprint",
+            "program_create_fingerprint TEXT",
         )
     # ``idx_tasks_idempotency`` is created unconditionally below alongside
     # the other additive-column indexes — see the block after the
@@ -2847,6 +2855,50 @@ def create_task(
                     max_runtime_seconds = policy.max_runtime_seconds
                     goal_max_turns = policy.goal_max_turns
 
+                program_create_fingerprint = None
+                if policy is not None:
+                    # Versioned, canonical request identity for managed program
+                    # roots and children.  This is intentionally computed from
+                    # effective values after policy/lineage/project inheritance,
+                    # never from raw argv and never logged.
+                    fingerprint_document = {
+                        "version": 1,
+                        "title": title.strip(),
+                        "body": body,
+                        "assignee": assignee,
+                        "created_by": created_by,
+                        "workspace_kind": workspace_kind,
+                        "workspace_path": workspace_path,
+                        "branch_name": branch_name,
+                        "tenant": tenant,
+                        "priority": priority,
+                        "parents": sorted(parents),
+                        "triage": bool(triage),
+                        "max_runtime_seconds": max_runtime_seconds,
+                        "skills": skills_list,
+                        "max_retries": max_retries,
+                        "goal_mode": bool(goal_mode),
+                        "goal_max_turns": goal_max_turns,
+                        "initial_status": initial_status,
+                        "session_id": session_id,
+                        "project_id": project_id,
+                        "policy": json.loads(policy.to_json()),
+                        "orchestration_root_id": (
+                            "self" if orchestration_depth == 0 else orchestration_root_id
+                        ),
+                        "orchestration_depth": orchestration_depth,
+                        "orchestration_parent_id": orchestration_parent_id,
+                    }
+                    canonical_request = json.dumps(
+                        fingerprint_document,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                        ensure_ascii=False,
+                    ).encode("utf-8")
+                    program_create_fingerprint = (
+                        "v1:" + hashlib.sha256(canonical_request).hexdigest()
+                    )
+
                 # Re-check under the write lock so concurrent replay cannot
                 # spend quota twice. A key already owned by another program is
                 # an authority mismatch, never a successful replay.
@@ -2854,12 +2906,17 @@ def create_task(
                     existing = conn.execute(
                         "SELECT id, assignee, tenant, project_id, orchestration_policy, "
                         "orchestration_root_id, orchestration_depth, orchestration_parent_id "
+                        ", program_create_fingerprint "
                         "FROM tasks "
                         "WHERE idempotency_key = ? AND status != 'archived' "
                         "ORDER BY created_at DESC LIMIT 1",
                         (idempotency_key,),
                     ).fetchone()
                     if existing:
+                        if policy is not None and existing["program_create_fingerprint"]:
+                            if existing["program_create_fingerprint"] != program_create_fingerprint:
+                                raise ValueError("idempotency key request does not match")
+                            return existing["id"]
                         if current_orchestrator_task_id is not None and policy is not None:
                             same_scope = (
                                 existing["orchestration_root_id"] == orchestration_root_id
@@ -2896,7 +2953,9 @@ def create_task(
                         int(root_created_at["created_at"])
                         if root_created_at is not None else now
                     )
-                    if now > created_at + policy.max_wall_clock_seconds:
+                    # The expiry instant is closed throughout the lifecycle:
+                    # no mutation or admission is allowed at ``now >= deadline``.
+                    if now >= created_at + policy.max_wall_clock_seconds:
                         raise ValueError("orchestration program deadline exceeded")
                     if (
                         orchestration_depth == 0
@@ -2975,11 +3034,12 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
+                        program_create_fingerprint,
                         max_runtime_seconds, orchestration_policy,
                         orchestration_root_id, orchestration_depth,
                         orchestration_parent_id,
                         skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2996,6 +3056,7 @@ def create_task(
                         project_id,
                         tenant,
                         idempotency_key,
+                        program_create_fingerprint,
                         int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         policy.to_json() if policy is not None else None,
                         orchestration_root_id,
@@ -3716,6 +3777,72 @@ def recompute_ready(
 # Claim / complete / block
 # ---------------------------------------------------------------------------
 
+def _program_deadline(
+    conn: sqlite3.Connection, task_id: str, now: int,
+) -> tuple[Optional[OrchestrationPolicy], Optional[str], bool, str]:
+    """Resolve immutable program authority and its closed expiry boundary."""
+    row = conn.execute(
+        "SELECT orchestration_root_id, orchestration_policy FROM tasks WHERE id=?",
+        (task_id,),
+    ).fetchone()
+    if row is None or not row["orchestration_policy"]:
+        return None, None, False, ""
+    root_id = row["orchestration_root_id"]
+    try:
+        policy = OrchestrationPolicy.from_json(row["orchestration_policy"])
+    except ValueError:
+        return None, root_id, True, "program_authority_invalid"
+    root = conn.execute(
+        "SELECT created_at FROM tasks WHERE id=?", (root_id,),
+    ).fetchone()
+    if root is None:
+        return policy, root_id, True, "program_authority_invalid"
+    expired = now >= int(root["created_at"]) + policy.max_wall_clock_seconds
+    return policy, root_id, expired, "program_deadline" if expired else ""
+
+
+def _block_expired_program_task(
+    conn: sqlite3.Connection, task_id: str, now: int, reason: str,
+) -> bool:
+    """Park expired program work permanently; caller must hold write txn."""
+    row = conn.execute(
+        "SELECT status, current_run_id FROM tasks WHERE id=?", (task_id,),
+    ).fetchone()
+    if row is None or row["status"] in {"done", "archived", "blocked"}:
+        return False
+    cur = conn.execute(
+        "UPDATE tasks SET status='blocked', claim_lock=NULL, claim_expires=NULL, "
+        "worker_pid=NULL, last_heartbeat_at=NULL WHERE id=?",
+        (task_id,),
+    )
+    if row["status"] == "running" and row["current_run_id"] is not None:
+        _end_run(
+            conn, task_id, outcome="timed_out", status="timed_out",
+            error=reason, metadata={"reason": reason},
+        )
+    if cur.rowcount == 1:
+        _append_event(conn, task_id, "blocked", {"reason": reason})
+    return cur.rowcount == 1
+
+
+def _admit_program_run(
+    conn: sqlite3.Connection, task_id: str, now: int,
+) -> bool:
+    """Atomic managed-program admission; caller must hold BEGIN IMMEDIATE."""
+    policy, root_id, expired, reason = _program_deadline(conn, task_id, now)
+    if expired:
+        _block_expired_program_task(conn, task_id, now, reason)
+        return False
+    if policy is None:
+        return True
+    active = conn.execute(
+        "SELECT COUNT(*) FROM task_runs r JOIN tasks t ON t.id=r.task_id "
+        "WHERE t.orchestration_root_id=? AND r.status='running' "
+        "AND r.ended_at IS NULL AND r.claim_expires >= ?",
+        (root_id, now),
+    ).fetchone()[0]
+    return active < policy.max_concurrency
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -3732,46 +3859,8 @@ def claim_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
-        program = conn.execute(
-            "SELECT orchestration_root_id, orchestration_policy FROM tasks WHERE id = ?",
-            (task_id,),
-        ).fetchone()
-        if program and program["orchestration_policy"]:
-            try:
-                policy = OrchestrationPolicy.from_json(program["orchestration_policy"])
-            except ValueError:
-                policy = None
-            root = conn.execute(
-                "SELECT created_at FROM tasks WHERE id = ?",
-                (program["orchestration_root_id"],),
-            ).fetchone()
-            deadline_reason = (
-                "program_authority_invalid"
-                if policy is None or root is None
-                else "program_deadline"
-            )
-            if (
-                policy is None
-                or root is None
-                or now > int(root["created_at"]) + policy.max_wall_clock_seconds
-            ):
-                parked = conn.execute(
-                    "UPDATE tasks SET status = 'blocked' "
-                    "WHERE id = ? AND status = 'ready'",
-                    (task_id,),
-                )
-                if parked.rowcount == 1:
-                    _append_event(conn, task_id, "blocked", {"reason": deadline_reason})
-                return None
-            active = conn.execute(
-                "SELECT COUNT(*) FROM task_runs r "
-                "JOIN tasks t ON t.id = r.task_id "
-                "WHERE t.orchestration_root_id = ? AND r.status = 'running' "
-                "AND r.ended_at IS NULL AND r.claim_expires >= ?",
-                (program["orchestration_root_id"], now),
-            ).fetchone()[0]
-            if active >= policy.max_concurrency:
-                return None
+        if not _admit_program_run(conn, task_id, now):
+            return None
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -3901,6 +3990,8 @@ def claim_review_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        if not _admit_program_run(conn, task_id, now):
+            return None
         cur = conn.execute(
             """
             UPDATE tasks
@@ -3965,9 +4056,14 @@ def heartbeat_claim(
     Workers that know they'll exceed 15 minutes should call this every
     few minutes to keep ownership.
     """
-    expires = int(time.time()) + _resolve_claim_ttl_seconds(ttl_seconds)
+    now = int(time.time())
+    expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     lock = claimer or _claimer_id()
     with write_txn(conn):
+        _policy, _root_id, expired, reason = _program_deadline(conn, task_id, now)
+        if expired:
+            _block_expired_program_task(conn, task_id, now, reason)
+            return False
         cur = conn.execute(
             "UPDATE tasks SET claim_expires = ? "
             "WHERE id = ? AND status = 'running' AND claim_lock = ?",
@@ -4027,6 +4123,19 @@ def release_stale_claims(
     for row in stale:
         lock = row["claim_lock"] or ""
         host_local = lock.startswith(host_prefix)
+        _policy, _root_id, program_expired, deadline_reason = _program_deadline(
+            conn, row["id"], now
+        )
+        if program_expired:
+            _terminate_reclaimed_worker(
+                row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
+            )
+            with write_txn(conn):
+                if _block_expired_program_task(
+                    conn, row["id"], now, deadline_reason
+                ):
+                    reclaimed += 1
+            continue
         hb = row["last_heartbeat_at"]
         # Heartbeat staleness backstop: if we have a heartbeat at all
         # and it's older than the max-stale threshold, the worker is
@@ -6745,7 +6854,7 @@ def enforce_max_runtime(
                 else:
                     program_elapsed = now - int(row["root_created_at"])
                     program_limit = policy.max_wall_clock_seconds
-                    program_deadline_exceeded = program_elapsed > program_limit
+                    program_deadline_exceeded = program_elapsed >= program_limit
             except ValueError:
                 # Malformed persisted authority must not leave a worker
                 # running outside enforceable bounds.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2573,6 +2573,53 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+_CGROUP_READ_LIMIT = 16 * 1024
+_MC_COMMAND_UNIT_RE = re.compile(r"vigo-mc-command-[0-9a-f]{18}\.service")
+
+
+def _read_self_cgroup() -> bytes:
+    """Read procfs with a hard cap; kept separate for test injection."""
+    with open("/proc/self/cgroup", "rb") as stream:
+        data = stream.read(_CGROUP_READ_LIMIT + 1)
+    if len(data) > _CGROUP_READ_LIMIT:
+        raise ValueError("oversized cgroup membership")
+    return data
+
+
+def is_mission_control_command_cgroup() -> bool:
+    """Prove membership in the broker's exact transient systemd unit."""
+    try:
+        raw = _read_self_cgroup()
+        if len(raw) > _CGROUP_READ_LIMIT:
+            return False
+        text = raw.decode("ascii")
+    except (OSError, UnicodeError, ValueError):
+        return False
+    if not text or not text.endswith("\n") or "\r" in text or "\x00" in text:
+        return False
+
+    proof_paths: list[str] = []
+    for line in text.splitlines():
+        match = re.fullmatch(r"([0-9]+):([^:]*):(/[^:]*)", line)
+        if match is None:
+            return False
+        hierarchy, controllers, path = match.groups()
+        if hierarchy == "0" and controllers == "":  # cgroup v2
+            proof_paths.append(path)
+        elif "name=systemd" in controllers.split(","):  # safe cgroup v1 proof
+            proof_paths.append(path)
+
+    if len(proof_paths) != 1:
+        return False
+    expected = re.fullmatch(
+        r"/system\.slice/(vigo-mc-command-[0-9a-f]{18}\.service)", proof_paths[0]
+    )
+    return (
+        expected is not None
+        and _MC_COMMAND_UNIT_RE.fullmatch(expected.group(1)) is not None
+    )
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -2631,6 +2678,10 @@ def create_task(
         raise ValueError("orchestration_policy must be an OrchestrationPolicy")
     if orchestration_policy is not None and current_orchestrator_task_id is not None:
         raise ValueError("a child cannot supply orchestration policy authority")
+    if orchestration_policy is not None and not is_mission_control_command_cgroup():
+        raise ValueError(
+            "program root creation is restricted to the trusted Mission Control broker"
+        )
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
@@ -2916,6 +2967,14 @@ def create_task(
                         if policy is not None and existing["program_create_fingerprint"]:
                             if existing["program_create_fingerprint"] != program_create_fingerprint:
                                 raise ValueError("idempotency key request does not match")
+                            if (
+                                orchestration_policy is not None
+                                and not is_mission_control_command_cgroup()
+                            ):
+                                raise ValueError(
+                                    "program root creation is restricted to the trusted "
+                                    "Mission Control broker"
+                                )
                             return existing["id"]
                         if current_orchestrator_task_id is not None and policy is not None:
                             same_scope = (
@@ -2939,6 +2998,14 @@ def create_task(
                         if not same_scope:
                             raise ValueError(
                                 "idempotency key belongs to another program"
+                            )
+                        if (
+                            orchestration_policy is not None
+                            and not is_mission_control_command_cgroup()
+                        ):
+                            raise ValueError(
+                                "program root creation is restricted to the trusted "
+                                "Mission Control broker"
                             )
                         return existing["id"]
 
@@ -3028,6 +3095,14 @@ def create_task(
                         except Exception:
                             branch_name = None
 
+                if (
+                    orchestration_policy is not None
+                    and not is_mission_control_command_cgroup()
+                ):
+                    raise ValueError(
+                        "program root creation is restricted to the trusted "
+                        "Mission Control broker"
+                    )
                 conn.execute(
                     """
                     INSERT INTO tasks (
@@ -3181,6 +3256,27 @@ def list_tasks(
     return [Task.from_row(r) for r in rows]
 
 
+def _validate_managed_assignee(
+    conn: sqlite3.Connection, task_id: str, profile: Optional[str],
+) -> None:
+    """Validate a managed-task assignment before any lifecycle mutation."""
+    row = conn.execute(
+        "SELECT orchestration_policy FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if row is None or row["orchestration_policy"] is None:
+        return
+    try:
+        policy = OrchestrationPolicy.from_json(row["orchestration_policy"])
+    except ValueError as exc:
+        raise ValueError(
+            "cannot reassign managed task: orchestration policy is invalid"
+        ) from exc
+    if profile not in policy.allowed_assignees:
+        raise ValueError(
+            "managed task assignee must be one of policy.allowed_assignees"
+        )
+
+
 def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) -> bool:
     """Assign or reassign a task.  Returns True on success.
 
@@ -3190,7 +3286,8 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
     profile = _canonical_assignee(profile)
     with write_txn(conn):
         row = conn.execute(
-            "SELECT status, claim_lock, assignee FROM tasks WHERE id = ?", (task_id,)
+            "SELECT status, claim_lock, assignee "
+            "FROM tasks WHERE id = ?", (task_id,)
         ).fetchone()
         if not row:
             return False
@@ -3199,6 +3296,7 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
                 f"cannot reassign {task_id}: currently running (claimed). "
                 "Wait for completion or reclaim the stale lock first."
             )
+        _validate_managed_assignee(conn, task_id, profile)
         if row["assignee"] != profile:
             # The retry guard is scoped to the task/profile combination. A
             # human reassigning the task is an explicit recovery action, so the
@@ -3225,6 +3323,27 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
         missing = _find_missing_parents(conn, [parent_id, child_id])
         if missing:
             raise ValueError(f"unknown task(s): {', '.join(missing)}")
+        scope_rows = conn.execute(
+            "SELECT id, orchestration_policy, orchestration_root_id, tenant, project_id "
+            "FROM tasks WHERE id IN (?, ?)",
+            (parent_id, child_id),
+        ).fetchall()
+        scopes = {row["id"]: row for row in scope_rows}
+        parent_scope = scopes[parent_id]
+        child_scope = scopes[child_id]
+        if (
+            parent_scope["orchestration_policy"] is not None
+            or child_scope["orchestration_policy"] is not None
+        ) and (
+            parent_scope["orchestration_root_id"]
+            != child_scope["orchestration_root_id"]
+            or parent_scope["tenant"] != child_scope["tenant"]
+            or parent_scope["project_id"] != child_scope["project_id"]
+        ):
+            raise ValueError(
+                "managed task links must stay within the same orchestration scope "
+                "(program root, tenant, and project)"
+            )
         if _would_cycle(conn, parent_id, child_id):
             raise ValueError(
                 f"linking {parent_id} -> {child_id} would create a cycle"
@@ -3838,8 +3957,8 @@ def _admit_program_run(
     active = conn.execute(
         "SELECT COUNT(*) FROM task_runs r JOIN tasks t ON t.id=r.task_id "
         "WHERE t.orchestration_root_id=? AND r.status='running' "
-        "AND r.ended_at IS NULL AND r.claim_expires >= ?",
-        (root_id, now),
+        "AND r.ended_at IS NULL",
+        (root_id,),
     ).fetchone()[0]
     return active < policy.max_concurrency
 
@@ -4327,6 +4446,10 @@ def reassign_task(
     Returns True if the reassign landed. ``profile`` may be ``None`` to
     unassign entirely.
     """
+    profile = _canonical_assignee(profile)
+    # Validate before reclaiming/killing a running worker. A forbidden target
+    # must be a side-effect-free rejection, not a partial recovery operation.
+    _validate_managed_assignee(conn, task_id, profile)
     if reclaim_first:
         # Safe to call even if nothing to reclaim.
         reclaim_task(conn, task_id, reason=reason or "reassign")
@@ -6769,6 +6892,10 @@ def heartbeat_worker(
     """
     now = int(time.time())
     with write_txn(conn):
+        _policy, _root_id, expired, reason = _program_deadline(conn, task_id, now)
+        if expired:
+            _block_expired_program_task(conn, task_id, now, reason)
+            return False
         if expected_run_id is None:
             cur = conn.execute(
                 "UPDATE tasks SET last_heartbeat_at = ? "

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -251,6 +251,27 @@ def test_run_slash_assign_reassigns(kanban_home):
     assert "bob" in show
 
 
+def test_run_slash_assign_rejects_managed_task_outside_policy(
+    kanban_home, monkeypatch,
+):
+    monkeypatch.setattr(kb, "is_mission_control_command_cgroup", lambda: True)
+    policy = kb.OrchestrationPolicy(
+        allowed_assignees=("planner", "worker"),
+        orchestrator_assignees=("planner",),
+        max_depth=2,
+        max_tasks=4,
+        max_runtime_seconds=60,
+    )
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(
+            conn, title="managed", assignee="planner", orchestration_policy=policy
+        )
+    out = kc.run_slash(f"assign {tid} outsider")
+    assert "allowed_assignees" in out
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, tid).assignee == "planner"
+
+
 def test_run_slash_link_unlink(kanban_home):
     a = kc.run_slash("create 'a'")
     b = kc.run_slash("create 'b'")

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -490,6 +490,29 @@ async def test_gateway_create_autosubscribes_on_explicit_board(kanban_home):
 
 
 @pytest.mark.asyncio
+async def test_gateway_program_create_uses_fail_closed_slash_path(kanban_home):
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    runner = object.__new__(GatewayRunner)
+    event = SimpleNamespace(
+        text=(
+            "/kanban program create --title root --assignee planner "
+            "--allowed-assignee planner --orchestrator planner --max-depth 1 "
+            "--max-tasks 2 --max-concurrency 1 --max-runtime-seconds 60 "
+            "--max-wall-clock-seconds 300 --goal-max-turns 5"
+        ),
+        source=SimpleNamespace(
+            platform=Platform.TELEGRAM, chat_id="chat1", thread_id=None, user_id="u1"
+        ),
+    )
+    output = await GatewayRunner._handle_kanban_command(runner, event)
+    assert "trusted direct" in output.lower()
+    with kb.connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+@pytest.mark.asyncio
 async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path, monkeypatch):
     """When a completed event carries ``artifacts`` in its payload, the
     notifier uploads each file to the subscribed chat as a native

--- a/tests/hermes_cli/test_kanban_orchestration_policy.py
+++ b/tests/hermes_cli/test_kanban_orchestration_policy.py
@@ -5,6 +5,272 @@ import json
 import pytest
 
 
+def _policy(**overrides):
+    values = {
+        "allowed_assignees": ("planner", "worker"),
+        "orchestrator_assignees": ("planner",),
+        "max_depth": 2,
+        "max_tasks": 8,
+        "max_runtime_seconds": 60,
+        "max_concurrency": 2,
+        "max_wall_clock_seconds": 300,
+        "goal_max_turns": 5,
+    }
+    values.update(overrides)
+    return kb.OrchestrationPolicy(**values)
+
+
+def test_policy_v2_added_fields_are_strict_and_canonical():
+    policy = _policy()
+    encoded = json.loads(policy.to_json())
+    assert encoded == {
+        "version": 2,
+        "allowed_assignees": ["planner", "worker"],
+        "orchestrator_assignees": ["planner"],
+        "max_depth": 2,
+        "max_tasks": 8,
+        "max_runtime_seconds": 60,
+        "max_concurrency": 2,
+        "max_wall_clock_seconds": 300,
+        "goal_max_turns": 5,
+    }
+    assert kb.OrchestrationPolicy.from_json(policy.to_json()) == policy
+
+    for field, bad in (
+        ("max_concurrency", True),
+        ("max_concurrency", 1.0),
+        ("max_concurrency", "1"),
+        ("max_wall_clock_seconds", False),
+        ("goal_max_turns", 2.0),
+    ):
+        payload = dict(encoded)
+        payload[field] = bad
+        with pytest.raises(ValueError, match="malformed orchestration policy"):
+            kb.OrchestrationPolicy.from_json(json.dumps(payload))
+
+    for field, bad in (
+        ("max_concurrency", 0), ("max_concurrency", 33),
+        ("max_wall_clock_seconds", 0), ("max_wall_clock_seconds", 86401),
+        ("goal_max_turns", 0), ("goal_max_turns", 21),
+    ):
+        with pytest.raises(ValueError):
+            _policy(**{field: bad})
+
+
+def test_policy_a1_json_has_deliberate_bounded_upgrade():
+    a1 = json.dumps({
+        "allowed_assignees": ["planner"],
+        "orchestrator_assignees": ["planner"],
+        "max_depth": 1,
+        "max_tasks": 2,
+        "max_runtime_seconds": 3,
+    })
+    upgraded = kb.OrchestrationPolicy.from_json(a1)
+    assert upgraded.max_concurrency == 1
+    assert upgraded.max_wall_clock_seconds == 86400
+    assert upgraded.goal_max_turns == 20
+    assert json.loads(upgraded.to_json())["version"] == 2
+
+
+def test_policy_a1_root_replay_compares_upgraded_policy_semantics(tmp_path):
+    a1 = json.dumps(
+        {
+            "allowed_assignees": ["planner"],
+            "orchestrator_assignees": ["planner"],
+            "max_depth": 1,
+            "max_tasks": 2,
+            "max_runtime_seconds": 3,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    upgraded = kb.OrchestrationPolicy.from_json(a1)
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        root = kb.create_task(
+            conn,
+            title="root",
+            assignee="planner",
+            idempotency_key="a1-root",
+            orchestration_policy=upgraded,
+        )
+        conn.execute("UPDATE tasks SET orchestration_policy = ? WHERE id = ?", (a1, root))
+        replay = kb.create_task(
+            conn,
+            title="root replay",
+            assignee="planner",
+            idempotency_key="a1-root",
+            orchestration_policy=upgraded,
+        )
+        assert replay == root
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
+def test_policy_child_inherits_goal_turn_budget(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        root = kb.create_task(conn, title="root", assignee="planner", orchestration_policy=_policy())
+        authority = _claim_authority(conn, root)
+        child = _bounded_create(
+            conn, authority, title="child", assignee="worker", goal_mode=True,
+            goal_max_turns=20,
+        )
+        assert kb.get_task(conn, child).goal_max_turns == 5
+    finally:
+        conn.close()
+
+
+def test_policy_root_assignee_must_be_an_orchestrator(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        with pytest.raises(ValueError, match="root assignee"):
+            kb.create_task(
+                conn,
+                title="unusable root",
+                assignee="worker",
+                orchestration_policy=_policy(),
+            )
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_program_deadline_rejects_create_and_claim_but_allows_exact_replay(tmp_path, monkeypatch):
+    now = 1_700_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        root = kb.create_task(conn, title="root", assignee="planner", orchestration_policy=_policy(max_wall_clock_seconds=10))
+        authority = _claim_authority(conn, root)
+        child = _bounded_create(conn, authority, title="child", assignee="worker", idempotency_key="child-key")
+        monkeypatch.setattr(kb.time, "time", lambda: now + 11)
+        assert _bounded_create(conn, authority, title="replay", assignee="worker", idempotency_key="child-key") == child
+        before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+        with pytest.raises(ValueError, match="deadline"):
+            _bounded_create(conn, authority, title="late", assignee="worker", idempotency_key="new-key")
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before
+        kb.complete_task(conn, root, result="delegated", expected_run_id=authority.run_id)
+        assert kb.claim_task(conn, child) is None
+        expired_child = kb.get_task(conn, child)
+        assert expired_child is not None
+        assert expired_child.status == "blocked"
+        assert kb.recompute_ready(conn) == 0
+        expired_child = kb.get_task(conn, child)
+        assert expired_child is not None
+        assert expired_child.status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_program_deadline_terminates_running_worker_without_requeue(tmp_path, monkeypatch):
+    now = 1_700_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        root = kb.create_task(
+            conn,
+            title="root",
+            assignee="planner",
+            orchestration_policy=_policy(
+                max_runtime_seconds=3600,
+                max_wall_clock_seconds=10,
+            ),
+        )
+        claimed = kb.claim_task(conn, root, claimer=f"{kb._claimer_id().split(':', 1)[0]}:deadline")
+        assert claimed is not None
+        conn.execute("UPDATE tasks SET worker_pid = ? WHERE id = ?", (999999, root))
+        conn.execute(
+            "UPDATE task_runs SET worker_pid = ? WHERE id = ?",
+            (999999, claimed.current_run_id),
+        )
+        monkeypatch.setattr(kb.time, "time", lambda: now + 11)
+        signals = []
+        assert kb.enforce_max_runtime(
+            conn,
+            signal_fn=lambda pid, sig: signals.append((pid, sig)),
+        ) == [root]
+        assert signals
+        task = kb.get_task(conn, root)
+        assert task is not None
+        assert task.status == "blocked"
+        run = kb.latest_run(conn, root)
+        assert run is not None
+        assert run.status == "timed_out"
+        assert run.outcome == "timed_out"
+        assert kb.recompute_ready(conn) == 0
+        task = kb.get_task(conn, root)
+        assert task is not None
+        assert task.status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_program_max_concurrency_is_atomic_and_ignores_ended_runs(tmp_path):
+    path = tmp_path / "kanban.db"
+    conn = kb.connect(path)
+    try:
+        root = kb.create_task(conn, title="root", assignee="planner", orchestration_policy=_policy(max_concurrency=1))
+        authority = _claim_authority(conn, root)
+        first = _bounded_create(conn, authority, title="first", assignee="worker")
+        second = _bounded_create(conn, authority, title="second", assignee="worker")
+        kb.complete_task(conn, root, result="delegated", expected_run_id=authority.run_id)
+    finally:
+        conn.close()
+
+    barrier = threading.Barrier(2)
+    def claim(task_id):
+        c = kb.connect(path)
+        try:
+            barrier.wait()
+            return kb.claim_task(c, task_id)
+        finally:
+            c.close()
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(claim, (first, second)))
+    assert sum(result is not None for result in results) == 1
+
+    winner = next(result for result in results if result is not None)
+    loser = second if winner.id == first else first
+    conn = kb.connect(path)
+    try:
+        # Expired-but-not-ended runs are stale and must not hold a slot.
+        conn.execute(
+            "UPDATE task_runs SET claim_expires=? WHERE id=?",
+            (int(kb.time.time()) - 1, winner.current_run_id),
+        )
+        assert kb.claim_task(conn, loser) is not None
+        loser_task = kb.get_task(conn, loser)
+        assert kb.complete_task(
+            conn, loser, result="done", expected_run_id=loser_task.current_run_id
+        )
+        # Ended history is likewise free, even while the stale winner row
+        # remains marked running for a later reclamation pass.
+        conn.execute(
+            "UPDATE tasks SET status='ready', current_run_id=NULL, claim_lock=NULL WHERE id=?",
+            (loser,),
+        )
+        assert kb.claim_task(conn, loser) is not None
+    finally:
+        conn.close()
+
+
+def test_legacy_unmanaged_claim_and_create_remain_unbounded(tmp_path, monkeypatch):
+    now = 1_700_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        parent = kb.create_task(conn, title="legacy", assignee="planner")
+        monkeypatch.setattr(kb.time, "time", lambda: now + 100_000)
+        assert kb.claim_task(conn, parent) is not None
+        child = kb.create_task(conn, title="legacy child", assignee="worker", current_orchestrator_task_id=parent)
+        assert kb.get_task(conn, child).orchestration_policy is None
+    finally:
+        conn.close()
+
+
 def _claim_authority(conn, task_id):
     claimed = kb.claim_task(conn, task_id, ttl_seconds=300)
     assert claimed is not None

--- a/tests/hermes_cli/test_kanban_orchestration_policy.py
+++ b/tests/hermes_cli/test_kanban_orchestration_policy.py
@@ -94,7 +94,10 @@ def test_policy_a1_root_replay_compares_upgraded_policy_semantics(tmp_path):
             idempotency_key="a1-root",
             orchestration_policy=upgraded,
         )
-        conn.execute("UPDATE tasks SET orchestration_policy = ? WHERE id = ?", (a1, root))
+        conn.execute(
+            "UPDATE tasks SET orchestration_policy = ?, program_create_fingerprint = NULL WHERE id = ?",
+            (a1, root),
+        )
         replay = kb.create_task(
             conn,
             title="root replay",
@@ -145,8 +148,10 @@ def test_program_deadline_rejects_create_and_claim_but_allows_exact_replay(tmp_p
         root = kb.create_task(conn, title="root", assignee="planner", orchestration_policy=_policy(max_wall_clock_seconds=10))
         authority = _claim_authority(conn, root)
         child = _bounded_create(conn, authority, title="child", assignee="worker", idempotency_key="child-key")
-        monkeypatch.setattr(kb.time, "time", lambda: now + 11)
-        assert _bounded_create(conn, authority, title="replay", assignee="worker", idempotency_key="child-key") == child
+        monkeypatch.setattr(kb.time, "time", lambda: now + 10)
+        assert _bounded_create(conn, authority, title="child", assignee="worker", idempotency_key="child-key") == child
+        with pytest.raises(ValueError, match="idempotency"):
+            _bounded_create(conn, authority, title="changed", assignee="worker", idempotency_key="child-key")
         before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
         with pytest.raises(ValueError, match="deadline"):
             _bounded_create(conn, authority, title="late", assignee="worker", idempotency_key="new-key")
@@ -186,7 +191,7 @@ def test_program_deadline_terminates_running_worker_without_requeue(tmp_path, mo
             "UPDATE task_runs SET worker_pid = ? WHERE id = ?",
             (999999, claimed.current_run_id),
         )
-        monkeypatch.setattr(kb.time, "time", lambda: now + 11)
+        monkeypatch.setattr(kb.time, "time", lambda: now + 10)
         signals = []
         assert kb.enforce_max_runtime(
             conn,
@@ -236,7 +241,6 @@ def test_program_max_concurrency_is_atomic_and_ignores_ended_runs(tmp_path):
     loser = second if winner.id == first else first
     conn = kb.connect(path)
     try:
-        # Expired-but-not-ended runs are stale and must not hold a slot.
         conn.execute(
             "UPDATE task_runs SET claim_expires=? WHERE id=?",
             (int(kb.time.time()) - 1, winner.current_run_id),
@@ -246,8 +250,6 @@ def test_program_max_concurrency_is_atomic_and_ignores_ended_runs(tmp_path):
         assert kb.complete_task(
             conn, loser, result="done", expected_run_id=loser_task.current_run_id
         )
-        # Ended history is likewise free, even while the stale winner row
-        # remains marked running for a later reclamation pass.
         conn.execute(
             "UPDATE tasks SET status='ready', current_run_id=NULL, claim_lock=NULL WHERE id=?",
             (loser,),
@@ -255,6 +257,117 @@ def test_program_max_concurrency_is_atomic_and_ignores_ended_runs(tmp_path):
         assert kb.claim_task(conn, loser) is not None
     finally:
         conn.close()
+
+
+@pytest.mark.parametrize("modes", [("normal", "review"), ("review", "review")])
+def test_program_admission_is_atomic_for_review_and_normal_claims(tmp_path, modes):
+    path = tmp_path / "kanban.db"
+    conn = kb.connect(path)
+    try:
+        root = kb.create_task(conn, title="root", assignee="planner", orchestration_policy=_policy(max_concurrency=1))
+        authority = _claim_authority(conn, root)
+        tasks = [_bounded_create(conn, authority, title=f"task-{i}", assignee="worker") for i in range(2)]
+        kb.complete_task(conn, root, result="delegated", expected_run_id=authority.run_id)
+        for task_id, mode in zip(tasks, modes):
+            if mode == "review":
+                conn.execute("UPDATE tasks SET status='review' WHERE id=?", (task_id,))
+    finally:
+        conn.close()
+
+    barrier = threading.Barrier(2)
+    def claim(item):
+        task_id, mode = item
+        c = kb.connect(path)
+        try:
+            barrier.wait()
+            return (kb.claim_review_task if mode == "review" else kb.claim_task)(c, task_id)
+        finally:
+            c.close()
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(claim, zip(tasks, modes)))
+    assert sum(result is not None for result in results) == 1
+
+
+def test_program_deadline_blocks_heartbeat_and_stale_release_at_boundary(tmp_path, monkeypatch):
+    now = 1_700_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        root = kb.create_task(conn, title="root", assignee="planner", orchestration_policy=_policy(max_wall_clock_seconds=10))
+        claimed = kb.claim_task(conn, root, claimer=f"{kb._claimer_id().split(':', 1)[0]}:deadline")
+        conn.execute("UPDATE tasks SET worker_pid=?, claim_expires=? WHERE id=?", (123, now + 1, root))
+        monkeypatch.setattr(kb.time, "time", lambda: now + 10)
+        assert kb.heartbeat_claim(conn, root, claimer=claimed.claim_lock) is False
+        assert kb.release_stale_claims(conn, signal_fn=lambda *_: None) == 0
+        task = kb.get_task(conn, root)
+        assert task.status == "blocked"
+        assert task.claim_expires is None
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, root).status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_expired_program_stale_claim_is_blocked_not_extended_or_requeued(tmp_path, monkeypatch):
+    now = 1_700_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        root = kb.create_task(conn, title="root", assignee="planner", orchestration_policy=_policy(max_wall_clock_seconds=10))
+        claimed = kb.claim_task(conn, root)
+        conn.execute("UPDATE tasks SET worker_pid=?, claim_expires=? WHERE id=?", (123, now + 1, root))
+        monkeypatch.setattr(kb.time, "time", lambda: now + 10)
+        assert kb.release_stale_claims(conn, signal_fn=lambda *_: None) == 1
+        task = kb.get_task(conn, root)
+        assert task.status == "blocked"
+        assert task.claim_expires is None
+        assert kb.latest_run(conn, root).ended_at is not None
+        assert kb.recompute_ready(conn) == 0
+    finally:
+        conn.close()
+
+
+def test_managed_idempotency_fingerprint_migrates_and_rejects_changed_request(tmp_path):
+    path = tmp_path / "kanban.db"
+    conn = kb.connect(path)
+    conn.execute("ALTER TABLE tasks DROP COLUMN program_create_fingerprint")
+    conn.close()
+    kb.init_db(path)
+    conn = kb.connect(path)
+    try:
+        assert "program_create_fingerprint" in {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+        root = kb.create_task(conn, title="root", body="body", assignee="planner", idempotency_key="root-fp", orchestration_policy=_policy())
+        assert kb.create_task(conn, title="root", body="body", assignee="planner", idempotency_key="root-fp", orchestration_policy=_policy()) == root
+        for changed in ({"title": "other", "body": "body"}, {"title": "root", "body": "other"}, {"title": "root", "body": "body", "priority": 1}):
+            with pytest.raises(ValueError, match="idempotency"):
+                kb.create_task(conn, assignee="planner", idempotency_key="root-fp", orchestration_policy=_policy(), **changed)
+    finally:
+        conn.close()
+
+
+def test_managed_exact_idempotent_replay_is_atomic(tmp_path):
+    path = tmp_path / "kanban.db"
+    kb.init_db(path)
+    barrier = threading.Barrier(2)
+
+    def create():
+        conn = kb.connect(path)
+        try:
+            barrier.wait()
+            return kb.create_task(
+                conn, title="same", body="same", assignee="planner",
+                idempotency_key="same-key", orchestration_policy=_policy(),
+            )
+        finally:
+            conn.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _index: create(), range(2)))
+    assert results[0] == results[1]
+    with kb.connect(path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
 
 
 def test_legacy_unmanaged_claim_and_create_remain_unbounded(tmp_path, monkeypatch):
@@ -348,7 +461,7 @@ def test_policy_root_idempotency_is_scope_aware(tmp_path):
         )
         replay = kb.create_task(
             conn,
-            title="bounded root retry",
+            title="bounded root",
             assignee="planner",
             tenant="tenant-a",
             idempotency_key="root-key",
@@ -368,7 +481,7 @@ def test_policy_root_idempotency_is_scope_aware(tmp_path):
             {"orchestration_policy": policy, "tenant": "tenant-b", "assignee": "planner"},
             {"orchestration_policy": policy, "tenant": "tenant-a", "assignee": "worker"},
         ):
-            with pytest.raises(ValueError, match="idempotency key belongs to another program"):
+            with pytest.raises(ValueError, match="idempotency"):
                 kb.create_task(
                     conn,
                     title="conflicting root retry",
@@ -632,7 +745,7 @@ def test_program_task_cap_is_atomic_and_idempotent_replay_is_free(tmp_path):
         winning_key = "child-a" if results[0].startswith("t_") else "child-b"
         replay = kb.create_task(
             conn,
-            title="ignored replay title",
+            title=winning_key,
             assignee="worker",
             current_orchestrator_task_id=root_id,
             creation_authority=authority,

--- a/tests/hermes_cli/test_kanban_orchestration_policy.py
+++ b/tests/hermes_cli/test_kanban_orchestration_policy.py
@@ -5,6 +5,18 @@ import json
 import pytest
 
 
+VALID_MISSION_CONTROL_CGROUP = (
+    b"0::/system.slice/vigo-mc-command-0123456789abcdef01.service\n"
+)
+REAL_MISSION_CONTROL_CGROUP_PROOF = kb.is_mission_control_command_cgroup
+
+
+@pytest.fixture(autouse=True)
+def allow_managed_roots_in_policy_tests(monkeypatch):
+    """These tests intentionally construct roots; production stays fail-closed."""
+    monkeypatch.setattr(kb, "is_mission_control_command_cgroup", lambda: True)
+
+
 def _policy(**overrides):
     values = {
         "allowed_assignees": ("planner", "worker"),
@@ -245,6 +257,10 @@ def test_program_max_concurrency_is_atomic_and_ignores_ended_runs(tmp_path):
             "UPDATE task_runs SET claim_expires=? WHERE id=?",
             (int(kb.time.time()) - 1, winner.current_run_id),
         )
+        # Lease expiry alone is not a release. The run remains authoritative
+        # until the reclaim/termination path closes it.
+        assert kb.claim_task(conn, loser) is None
+        assert kb.reclaim_task(conn, winner.id, reason="expired test run")
         assert kb.claim_task(conn, loser) is not None
         loser_task = kb.get_task(conn, loser)
         assert kb.complete_task(
@@ -255,6 +271,78 @@ def test_program_max_concurrency_is_atomic_and_ignores_ended_runs(tmp_path):
             (loser,),
         )
         assert kb.claim_task(conn, loser) is not None
+    finally:
+        conn.close()
+
+
+def test_managed_assignment_rejects_profiles_outside_policy(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        root = kb.create_task(
+            conn, title="root", assignee="planner", orchestration_policy=_policy()
+        )
+        with pytest.raises(ValueError, match="allowed_assignees"):
+            kb.assign_task(conn, root, "outsider")
+        with pytest.raises(ValueError, match="allowed_assignees"):
+            kb.assign_task(conn, root, None)
+        assert kb.get_task(conn, root).assignee == "planner"
+        assert kb.assign_task(conn, root, "worker")
+    finally:
+        conn.close()
+
+
+def test_managed_reassign_rejects_before_reclaiming_active_run(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        root = kb.create_task(
+            conn, title="root", assignee="planner", orchestration_policy=_policy()
+        )
+        claimed = kb.claim_task(conn, root)
+        assert claimed is not None
+        with pytest.raises(ValueError, match="allowed_assignees"):
+            kb.reassign_task(conn, root, "outsider", reclaim_first=True)
+        task = kb.get_task(conn, root)
+        assert task.status == "running"
+        assert task.current_run_id == claimed.current_run_id
+        assert kb.latest_run(conn, root).ended_at is None
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("mismatch", ["root", "tenant", "project", "unmanaged"])
+def test_managed_links_must_stay_in_exact_program_scope(tmp_path, mismatch):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        policy = _policy()
+        root = kb.create_task(
+            conn, title="root", assignee="planner", tenant="tenant-a",
+            orchestration_policy=policy,
+        )
+        conn.execute("UPDATE tasks SET project_id='project-a' WHERE id=?", (root,))
+        authority = _claim_authority(conn, root)
+        child = _bounded_create(conn, authority, title="child", assignee="worker")
+        other = kb.create_task(conn, title="other", assignee="planner")
+        if mismatch == "root":
+            other = kb.create_task(
+                conn, title="other root", assignee="planner", tenant="tenant-a",
+                orchestration_policy=policy,
+            )
+            conn.execute("UPDATE tasks SET project_id='project-a' WHERE id=?", (other,))
+        elif mismatch == "tenant":
+            conn.execute(
+                "UPDATE tasks SET orchestration_root_id=?, orchestration_policy=?, "
+                "orchestration_depth=1, tenant='tenant-b', project_id='project-a' WHERE id=?",
+                (root, policy.to_json(), other),
+            )
+        elif mismatch == "project":
+            conn.execute(
+                "UPDATE tasks SET orchestration_root_id=?, orchestration_policy=?, "
+                "orchestration_depth=1, tenant='tenant-a', project_id='project-b' WHERE id=?",
+                (root, policy.to_json(), other),
+            )
+        with pytest.raises(ValueError, match="orchestration scope"):
+            kb.link_tasks(conn, other, child)
+        assert other not in kb.parent_ids(conn, child)
     finally:
         conn.close()
 
@@ -305,6 +393,79 @@ def test_program_deadline_blocks_heartbeat_and_stale_release_at_boundary(tmp_pat
         assert task.claim_expires is None
         assert kb.recompute_ready(conn) == 0
         assert kb.get_task(conn, root).status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_heartbeat_worker_blocks_expired_program_without_heartbeat_mutation(
+    tmp_path, monkeypatch,
+):
+    now = 1_700_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        root = kb.create_task(
+            conn,
+            title="root",
+            assignee="planner",
+            orchestration_policy=_policy(max_wall_clock_seconds=10),
+        )
+        claimed = kb.claim_task(conn, root)
+        assert claimed is not None
+        conn.execute(
+            "UPDATE tasks SET last_heartbeat_at=? WHERE id=?", (now + 3, root)
+        )
+        conn.execute(
+            "UPDATE task_runs SET last_heartbeat_at=? WHERE id=?",
+            (now + 4, claimed.current_run_id),
+        )
+        heartbeat_events_before = conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='heartbeat'",
+            (root,),
+        ).fetchone()[0]
+
+        monkeypatch.setattr(kb.time, "time", lambda: now + 10)
+        assert kb.heartbeat_worker(
+            conn, root, note="too late", expected_run_id=claimed.current_run_id
+        ) is False
+
+        task = kb.get_task(conn, root)
+        assert task.status == "blocked"
+        assert task.last_heartbeat_at is None
+        run = kb.latest_run(conn, root)
+        assert run.status == "timed_out"
+        assert run.last_heartbeat_at == now + 4
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='heartbeat'",
+            (root,),
+        ).fetchone()[0] == heartbeat_events_before
+    finally:
+        conn.close()
+
+
+def test_heartbeat_worker_legacy_task_ignores_program_deadline_check(
+    tmp_path, monkeypatch,
+):
+    now = 1_700_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: now)
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        task_id = kb.create_task(conn, title="legacy", assignee="worker")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None
+        monkeypatch.setattr(kb.time, "time", lambda: now + 100_000)
+
+        assert kb.heartbeat_worker(
+            conn, task_id, expected_run_id=claimed.current_run_id
+        ) is True
+        task = kb.get_task(conn, task_id)
+        assert task.status == "running"
+        assert task.last_heartbeat_at == now + 100_000
+        assert kb.latest_run(conn, task_id).last_heartbeat_at == now + 100_000
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='heartbeat'",
+            (task_id,),
+        ).fetchone()[0] == 1
     finally:
         conn.close()
 
@@ -402,6 +563,100 @@ def _bounded_create(conn, authority, **kwargs):
         creation_authority=authority,
         **kwargs,
     )
+
+
+def test_direct_root_requires_cgroup_and_forged_context_cannot_bypass(
+    tmp_path, monkeypatch,
+):
+    conn = kb.connect(tmp_path / "kanban.db")
+    monkeypatch.setattr(kb, "is_mission_control_command_cgroup", lambda: False)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "forged-root")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "1")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "forged-lock")
+    forged = kb.CreationAuthority(
+        task_id="forged-root",
+        run_id=1,
+        claim_lock="forged-lock",
+        actor_profile="planner",
+    )
+    try:
+        with pytest.raises(ValueError, match="Mission Control"):
+            kb.create_task(
+                conn,
+                title="forged root",
+                assignee="planner",
+                orchestration_policy=_policy(),
+                creation_authority=forged,
+            )
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_exact_cgroup_creates_root_and_child_authority_works_outside_cgroup(
+    tmp_path, monkeypatch,
+):
+    conn = kb.connect(tmp_path / "kanban.db")
+    monkeypatch.setattr(kb, "_read_self_cgroup", lambda: VALID_MISSION_CONTROL_CGROUP)
+    # Exercise the real proof parser, not the module's root-construction fixture.
+    monkeypatch.setattr(
+        kb,
+        "is_mission_control_command_cgroup",
+        REAL_MISSION_CONTROL_CGROUP_PROOF,
+    )
+    try:
+        root = kb.create_task(
+            conn,
+            title="root",
+            assignee="planner",
+            orchestration_policy=_policy(),
+        )
+        authority = _claim_authority(conn, root)
+        monkeypatch.setattr(kb, "is_mission_control_command_cgroup", lambda: False)
+        child = _bounded_create(
+            conn, authority, title="child", assignee="worker"
+        )
+        assert kb.get_task(conn, child).orchestration_root_id == root
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("replay", [False, True])
+def test_root_cgroup_proof_loss_inside_transaction_rejects_without_state(
+    tmp_path, monkeypatch, replay,
+):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        existing = kb.create_task(
+            conn,
+            title="root",
+            assignee="planner",
+            idempotency_key="root-key",
+            orchestration_policy=_policy(),
+        )
+        before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+        proofs = iter((True, False))
+        monkeypatch.setattr(
+            kb, "is_mission_control_command_cgroup", lambda: next(proofs)
+        )
+
+        with pytest.raises(ValueError, match="Mission Control"):
+            kb.create_task(
+                conn,
+                title="root" if replay else "new root",
+                assignee="planner",
+                idempotency_key="root-key" if replay else "new-root-key",
+                orchestration_policy=_policy(),
+            )
+
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before
+        assert kb.get_task(conn, existing) is not None
+        if not replay:
+            assert conn.execute(
+                "SELECT 1 FROM tasks WHERE idempotency_key='new-root-key'"
+            ).fetchone() is None
+    finally:
+        conn.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/hermes_cli/test_kanban_orchestration_policy.py
+++ b/tests/hermes_cli/test_kanban_orchestration_policy.py
@@ -1,0 +1,612 @@
+from hermes_cli import kanban_db as kb
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import json
+import pytest
+
+
+def _claim_authority(conn, task_id):
+    claimed = kb.claim_task(conn, task_id, ttl_seconds=300)
+    assert claimed is not None
+    return kb.CreationAuthority(
+        task_id=claimed.id,
+        run_id=claimed.current_run_id,
+        claim_lock=claimed.claim_lock,
+        actor_profile=claimed.assignee,
+    )
+
+
+def _bounded_create(conn, authority, **kwargs):
+    return kb.create_task(
+        conn,
+        current_orchestrator_task_id=authority.task_id,
+        creation_authority=authority,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"allowed_assignees": ["planner"], "orchestrator_assignees": ["planner"], "max_depth": True, "max_tasks": 2, "max_runtime_seconds": 3},
+        {"allowed_assignees": ["planner"], "orchestrator_assignees": ["planner"], "max_depth": 1.0, "max_tasks": 2, "max_runtime_seconds": 3},
+        {"allowed_assignees": ["planner"], "orchestrator_assignees": ["planner"], "max_depth": "1", "max_tasks": 2, "max_runtime_seconds": 3},
+        {"allowed_assignees": "planner", "orchestrator_assignees": ["planner"], "max_depth": 1, "max_tasks": 2, "max_runtime_seconds": 3},
+        {"allowed_assignees": [True], "orchestrator_assignees": [True], "max_depth": 1, "max_tasks": 2, "max_runtime_seconds": 3},
+        {"allowed_assignees": ["planner"], "orchestrator_assignees": "planner", "max_depth": 1, "max_tasks": 2, "max_runtime_seconds": 3},
+        {"allowed_assignees": ["worker"], "orchestrator_assignees": ["planner"], "max_depth": 1, "max_tasks": 2, "max_runtime_seconds": 3},
+        {"allowed_assignees": ["planner"], "max_depth": 1, "max_tasks": 2, "max_runtime_seconds": 3},
+        {"allowed_assignees": ["planner"], "orchestrator_assignees": ["planner"], "max_depth": 1, "max_tasks": 2, "max_runtime_seconds": 3, "extra": 4},
+    ],
+)
+def test_policy_json_is_strict(payload):
+    with pytest.raises(ValueError, match="malformed orchestration policy"):
+        kb.OrchestrationPolicy.from_json(json.dumps(payload))
+
+
+def test_policy_root_idempotency_is_scope_aware(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        policy = kb.OrchestrationPolicy(
+            allowed_assignees=("planner", "worker"),
+            orchestrator_assignees=("planner",),
+            max_depth=2,
+            max_tasks=4,
+            max_runtime_seconds=60,
+        )
+        legacy = kb.create_task(
+            conn,
+            title="legacy",
+            assignee="worker",
+            idempotency_key="shared-key",
+        )
+        with pytest.raises(ValueError, match="idempotency key belongs to another program"):
+            kb.create_task(
+                conn,
+                title="bounded root",
+                assignee="planner",
+                idempotency_key="shared-key",
+                orchestration_policy=policy,
+            )
+        legacy_task = kb.get_task(conn, legacy)
+        assert legacy_task is not None
+        assert legacy_task.orchestration_policy is None
+
+        root = kb.create_task(
+            conn,
+            title="bounded root",
+            assignee="planner",
+            tenant="tenant-a",
+            idempotency_key="root-key",
+            orchestration_policy=policy,
+        )
+        replay = kb.create_task(
+            conn,
+            title="bounded root retry",
+            assignee="planner",
+            tenant="tenant-a",
+            idempotency_key="root-key",
+            orchestration_policy=policy,
+        )
+        assert replay == root
+
+        wider = kb.OrchestrationPolicy(
+            allowed_assignees=("planner", "worker", "other"),
+            orchestrator_assignees=("planner",),
+            max_depth=2,
+            max_tasks=4,
+            max_runtime_seconds=60,
+        )
+        for changed in (
+            {"orchestration_policy": wider, "tenant": "tenant-a", "assignee": "planner"},
+            {"orchestration_policy": policy, "tenant": "tenant-b", "assignee": "planner"},
+            {"orchestration_policy": policy, "tenant": "tenant-a", "assignee": "worker"},
+        ):
+            with pytest.raises(ValueError, match="idempotency key belongs to another program"):
+                kb.create_task(
+                    conn,
+                    title="conflicting root retry",
+                    idempotency_key="root-key",
+                    **changed,
+                )
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_only_policy_orchestrators_can_fan_out(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        policy = kb.OrchestrationPolicy(
+            allowed_assignees=("planner", "architect", "worker"),
+            orchestrator_assignees=("planner", "architect"),
+            max_depth=3,
+            max_tasks=8,
+            max_runtime_seconds=60,
+        )
+        root = kb.create_task(conn, title="root", assignee="planner", orchestration_policy=policy)
+        root_auth = _claim_authority(conn, root)
+        worker = _bounded_create(conn, root_auth, title="ordinary", assignee="worker")
+        architect = _bounded_create(conn, root_auth, title="approved", assignee="architect")
+        assert kb.complete_task(conn, root, result="delegated", expected_run_id=root_auth.run_id)
+
+        worker_auth = _claim_authority(conn, worker)
+        with pytest.raises(ValueError, match="not allowed to orchestrate"):
+            _bounded_create(conn, worker_auth, title="recursive escape", assignee="worker")
+        assert kb.complete_task(conn, worker, result="done", expected_run_id=worker_auth.run_id)
+
+        architect_auth = _claim_authority(conn, architect)
+        child = _bounded_create(conn, architect_auth, title="approved fanout", assignee="worker")
+        assert kb.get_task(conn, child).orchestration_parent_id == architect
+    finally:
+        conn.close()
+
+
+def test_dependency_fan_in_keeps_current_lineage_parent(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        policy = kb.OrchestrationPolicy(
+            allowed_assignees=("architect", "worker"),
+            orchestrator_assignees=("architect",),
+            max_depth=3,
+            max_tasks=8,
+            max_runtime_seconds=60,
+        )
+        root = kb.create_task(conn, title="root", assignee="architect", orchestration_policy=policy)
+        root_auth = _claim_authority(conn, root)
+        orchestrator = _bounded_create(conn, root_auth, title="next architect", assignee="architect")
+        sibling = _bounded_create(conn, root_auth, title="dependency sibling", assignee="worker")
+        assert kb.complete_task(conn, root, result="delegated", expected_run_id=root_auth.run_id)
+        sibling_auth = _claim_authority(conn, sibling)
+        assert kb.complete_task(conn, sibling, result="done", expected_run_id=sibling_auth.run_id)
+        orchestrator_auth = _claim_authority(conn, orchestrator)
+
+        fan_in = _bounded_create(
+            conn,
+            orchestrator_auth,
+            title="fan in",
+            assignee="worker",
+            parents=[sibling],
+        )
+        task = kb.get_task(conn, fan_in)
+        assert kb.parent_ids(conn, fan_in) == [sibling]
+        assert task.orchestration_parent_id == orchestrator
+        assert task.orchestration_depth == 2
+    finally:
+        conn.close()
+
+
+def test_bounded_project_slug_is_canonical_and_unresolved_fails_closed(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli import projects_db
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with projects_db.connect_closing() as project_conn:
+        project_id = projects_db.create_project(
+            project_conn, name="Real Project", slug="real-project", primary_path=str(repo)
+        )
+
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        policy = kb.OrchestrationPolicy(
+            allowed_assignees=("planner", "worker"),
+            orchestrator_assignees=("planner",),
+            max_depth=2,
+            max_tasks=4,
+            max_runtime_seconds=60,
+        )
+        root = kb.create_task(
+            conn, title="root", assignee="planner", project_id=project_id,
+            orchestration_policy=policy,
+        )
+        authority = _claim_authority(conn, root)
+        child = _bounded_create(
+            conn, authority, title="slug child", assignee="worker", project_id="real-project"
+        )
+        assert kb.get_task(conn, child).project_id == project_id
+        before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+        with pytest.raises(ValueError, match="project does not match"):
+            _bounded_create(
+                conn, authority, title="bad project", assignee="worker", project_id="missing"
+            )
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before
+    finally:
+        conn.close()
+
+
+def test_bounded_child_requires_exact_active_run_authority(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        policy = kb.OrchestrationPolicy(
+            allowed_assignees=("planner", "worker"),
+            orchestrator_assignees=("planner",),
+            max_depth=2,
+            max_tasks=4,
+            max_runtime_seconds=60,
+        )
+        root_id = kb.create_task(
+            conn, title="root", assignee="planner", orchestration_policy=policy
+        )
+        authority = _claim_authority(conn, root_id)
+
+        for forged in (
+            None,
+            kb.CreationAuthority(root_id, authority.run_id + 1, authority.claim_lock, "planner"),
+            kb.CreationAuthority(root_id, authority.run_id, "forged", "planner"),
+            kb.CreationAuthority(root_id, authority.run_id, authority.claim_lock, "worker"),
+        ):
+            before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+            with pytest.raises(ValueError, match="active orchestration authority"):
+                kb.create_task(
+                    conn,
+                    title="must not exist",
+                    assignee="worker",
+                    current_orchestrator_task_id=root_id,
+                    creation_authority=forged,
+                )
+            assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before
+
+        child_id = kb.create_task(
+            conn,
+            title="valid child",
+            assignee="worker",
+            current_orchestrator_task_id=root_id,
+            creation_authority=authority,
+        )
+        assert kb.get_task(conn, child_id) is not None
+
+        conn.execute("UPDATE task_runs SET status = 'done' WHERE id = ?", (authority.run_id,))
+        with pytest.raises(ValueError, match="active orchestration authority"):
+            kb.create_task(
+                conn,
+                title="stale child",
+                assignee="worker",
+                current_orchestrator_task_id=root_id,
+                creation_authority=authority,
+            )
+    finally:
+        conn.close()
+
+
+def test_orchestrator_child_inherits_program_policy_and_scope(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        policy = kb.OrchestrationPolicy(
+            allowed_assignees=("planner", "worker"),
+            orchestrator_assignees=("planner",),
+            max_depth=3,
+            max_tasks=8,
+            max_runtime_seconds=900,
+        )
+        root_id = kb.create_task(
+            conn,
+            title="Program root",
+            assignee="planner",
+            tenant="tenant-a",
+            project_id=None,
+            orchestration_policy=policy,
+        )
+        conn.execute("UPDATE tasks SET project_id = 'project-a' WHERE id = ?", (root_id,))
+        authority = _claim_authority(conn, root_id)
+
+        child_id = _bounded_create(
+            conn,
+            authority,
+            title="Delegated work",
+            assignee="worker",
+        )
+
+        root = kb.get_task(conn, root_id)
+        child = kb.get_task(conn, child_id)
+        assert root.orchestration_root_id == root_id
+        assert root.orchestration_depth == 0
+        assert root.orchestration_policy == policy
+        assert child.orchestration_root_id == root_id
+        assert child.orchestration_depth == 1
+        assert child.orchestration_policy == policy
+        assert child.tenant == root.tenant
+        assert child.project_id == root.project_id
+        assert kb.parent_ids(conn, child_id) == [root_id]
+        assert child.max_runtime_seconds == policy.max_runtime_seconds
+    finally:
+        conn.close()
+
+def test_program_task_cap_is_atomic_and_idempotent_replay_is_free(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path)
+    try:
+        policy = kb.OrchestrationPolicy(
+            allowed_assignees=("planner", "worker"),
+            orchestrator_assignees=("planner",),
+            max_depth=2,
+            max_tasks=2,
+            max_runtime_seconds=60,
+        )
+        root_id = kb.create_task(
+            conn, title="root", assignee="planner", orchestration_policy=policy
+        )
+        authority = _claim_authority(conn, root_id)
+    finally:
+        conn.close()
+
+    barrier = threading.Barrier(2)
+
+    def create_child(key):
+        thread_conn = kb.connect(db_path)
+        try:
+            barrier.wait()
+            try:
+                return kb.create_task(
+                    thread_conn,
+                    title=key,
+                    assignee="worker",
+                    current_orchestrator_task_id=root_id,
+                    creation_authority=authority,
+                    idempotency_key=key,
+                )
+            except ValueError as exc:
+                return str(exc)
+        finally:
+            thread_conn.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(create_child, ("child-a", "child-b")))
+
+    ids = [result for result in results if result.startswith("t_")]
+    errors = [result for result in results if not result.startswith("t_")]
+    assert len(ids) == 1
+    assert errors == ["maximum orchestration task count exceeded"]
+
+    conn = kb.connect(db_path)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 2
+        winning_key = "child-a" if results[0].startswith("t_") else "child-b"
+        replay = kb.create_task(
+            conn,
+            title="ignored replay title",
+            assignee="worker",
+            current_orchestrator_task_id=root_id,
+            creation_authority=authority,
+            idempotency_key=winning_key,
+        )
+        assert replay == ids[0]
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    ("assignee", "root_depth", "message"),
+    [
+        ("intruder", 0, "assignee is not allowed"),
+        ("worker", 1, "maximum orchestration depth"),
+    ],
+)
+def test_orchestrator_rejects_assignee_and_depth_before_insert(
+    tmp_path, assignee, root_depth, message
+):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        policy = kb.OrchestrationPolicy(
+            allowed_assignees=("planner", "worker"),
+            orchestrator_assignees=("planner",),
+            max_depth=1,
+            max_tasks=4,
+            max_runtime_seconds=60,
+        )
+        root_id = kb.create_task(
+            conn, title="root", assignee="planner", orchestration_policy=policy
+        )
+        authority = _claim_authority(conn, root_id)
+        authority_id = root_id
+        if root_depth:
+            authority_id = _bounded_create(
+                conn,
+                authority,
+                title="level one",
+                assignee="planner",
+            )
+            assert kb.complete_task(
+                conn, root_id, result="delegated", expected_run_id=authority.run_id
+            )
+            authority = _claim_authority(conn, authority_id)
+        before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+
+        with pytest.raises(ValueError, match=message):
+            kb.create_task(
+                conn,
+                title="must not exist",
+                assignee=assignee,
+                current_orchestrator_task_id=authority_id,
+                creation_authority=authority,
+            )
+
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before
+    finally:
+        conn.close()
+
+
+def test_child_cannot_widen_or_cross_program_scope(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        policy = kb.OrchestrationPolicy(
+            allowed_assignees=("planner", "worker"),
+            orchestrator_assignees=("planner",),
+            max_depth=2,
+            max_tasks=6,
+            max_runtime_seconds=60,
+        )
+        root_id = kb.create_task(
+            conn,
+            title="root",
+            assignee="planner",
+            tenant="tenant-a",
+            orchestration_policy=policy,
+        )
+        foreign_id = kb.create_task(
+            conn, title="foreign", assignee="worker", idempotency_key="foreign-key"
+        )
+        authority = _claim_authority(conn, root_id)
+
+        with pytest.raises(ValueError, match="tenant does not match"):
+            kb.create_task(
+                conn,
+                title="tenant escape",
+                assignee="worker",
+                tenant="tenant-b",
+                current_orchestrator_task_id=root_id,
+                creation_authority=authority,
+            )
+        with pytest.raises(ValueError, match="outside orchestration program"):
+            kb.create_task(
+                conn,
+                title="foreign parent",
+                assignee="worker",
+                parents=[foreign_id],
+                current_orchestrator_task_id=root_id,
+                creation_authority=authority,
+            )
+        with pytest.raises(ValueError, match="idempotency key belongs to another program"):
+            kb.create_task(
+                conn,
+                title="foreign replay",
+                assignee="worker",
+                idempotency_key="foreign-key",
+                current_orchestrator_task_id=root_id,
+                creation_authority=authority,
+            )
+        wider = kb.OrchestrationPolicy(
+            allowed_assignees=("planner", "worker", "intruder"),
+            orchestrator_assignees=("planner",),
+            max_depth=3,
+            max_tasks=10,
+            max_runtime_seconds=120,
+        )
+        with pytest.raises(ValueError, match="cannot supply orchestration policy"):
+            kb.create_task(
+                conn,
+                title="policy escape",
+                assignee="worker",
+                orchestration_policy=wider,
+                current_orchestrator_task_id=root_id,
+            )
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_legacy_tasks_keep_unrestricted_creation_behavior(tmp_path):
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        parent_id = kb.create_task(conn, title="legacy parent", assignee="old")
+        child_id = kb.create_task(
+            conn,
+            title="legacy child",
+            assignee="any-profile",
+            parents=[parent_id],
+            tenant="independent",
+            max_runtime_seconds=123,
+        )
+        child = kb.get_task(conn, child_id)
+        assert child.orchestration_policy is None
+        assert child.orchestration_root_id is None
+        assert child.orchestration_depth is None
+        assert child.max_runtime_seconds == 123
+        assert child.tenant == "independent"
+    finally:
+        conn.close()
+
+
+def test_kanban_create_derives_authority_from_current_worker_context(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path)
+    try:
+        policy = kb.OrchestrationPolicy(
+            allowed_assignees=("planner", "worker"),
+            orchestrator_assignees=("planner",),
+            max_depth=2,
+            max_tasks=3,
+            max_runtime_seconds=60,
+        )
+        root_id = kb.create_task(
+            conn, title="root", assignee="planner", orchestration_policy=policy
+        )
+        authority = _claim_authority(conn, root_id)
+    finally:
+        conn.close()
+
+    from tools import kanban_tools
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", root_id)
+    monkeypatch.setenv("HERMES_PROFILE", "planner")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(authority.run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", authority.claim_lock)
+    monkeypatch.setattr(
+        kanban_tools, "_connect", lambda **_kwargs: (kb, kb.connect(db_path))
+    )
+    result = json.loads(
+        kanban_tools._handle_create({"title": "child", "assignee": "worker"})
+    )
+    assert "error" not in result
+
+    conn = kb.connect(db_path)
+    try:
+        child = kb.get_task(conn, result["task_id"])
+        assert child.orchestration_root_id == root_id
+        assert child.orchestration_depth == 1
+        assert child.orchestration_policy == policy
+    finally:
+        conn.close()
+
+
+def test_malformed_and_cross_board_authority_fail_closed(tmp_path, monkeypatch):
+    source_path = tmp_path / "source.db"
+    foreign_path = tmp_path / "foreign.db"
+    conn = kb.connect(source_path)
+    try:
+        policy = kb.OrchestrationPolicy(
+            allowed_assignees=("planner", "worker"),
+            orchestrator_assignees=("planner",),
+            max_depth=2,
+            max_tasks=3,
+            max_runtime_seconds=60,
+        )
+        root_id = kb.create_task(
+            conn, title="root", assignee="planner", orchestration_policy=policy
+        )
+        conn.execute(
+            "UPDATE tasks SET orchestration_policy = '{bad json' WHERE id = ?",
+            (root_id,),
+        )
+        with pytest.raises(ValueError, match="malformed orchestration policy"):
+            kb.create_task(
+                conn,
+                title="malformed escape",
+                assignee="worker",
+                current_orchestrator_task_id=root_id,
+            )
+    finally:
+        conn.close()
+
+    from tools import kanban_tools
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", root_id)
+    monkeypatch.setattr(
+        kanban_tools, "_connect", lambda **_kwargs: (kb, kb.connect(foreign_path))
+    )
+    result = json.loads(
+        kanban_tools._handle_create(
+            {"title": "cross-board escape", "assignee": "worker", "board": "foreign"}
+        )
+    )
+    assert "current task has no orchestration authority" in result["error"]
+    conn = kb.connect(foreign_path)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_kanban_program_cli.py
+++ b/tests/hermes_cli/test_kanban_program_cli.py
@@ -1,0 +1,53 @@
+import json
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(kb, "_INITIALIZED_PATHS", set())
+    return home
+
+
+def _argv(extra=""):
+    return (
+        "program create --title 'Ship it' --assignee Planner "
+        "--allowed-assignee planner --allowed-assignee worker "
+        "--orchestrator planner --max-depth 2 --max-tasks 8 "
+        "--max-concurrency 2 --max-runtime-seconds 60 "
+        "--max-wall-clock-seconds 300 --goal-max-turns 5 --json " + extra
+    )
+
+
+def test_program_create_cli_emits_deterministic_safe_json_and_canonical_root(kanban_home):
+    payload = json.loads(kc.run_slash(_argv()))
+    assert set(payload) == {"id", "status", "orchestration_root_id", "policy"}
+    assert payload["id"] == payload["orchestration_root_id"]
+    assert payload["status"] == "ready"
+    assert payload["policy"]["allowed_assignees"] == ["planner", "worker"]
+    assert payload["policy"]["goal_max_turns"] == 5
+    with kb.connect() as conn:
+        tasks = kb.list_tasks(conn)
+    assert len(tasks) == 1
+    assert tasks[0].orchestration_depth == 0
+    assert tasks[0].goal_max_turns == 5
+
+
+@pytest.mark.parametrize("extra", [
+    "--max-concurrency 0",
+    "--orchestrator outsider",
+    "--allowed-assignee planner",
+    "--assignee worker",
+    "--project missing-project",
+])
+def test_program_create_cli_invalid_input_leaves_no_root(kanban_home, extra):
+    output = kc.run_slash(_argv(extra))
+    assert "error" in output.lower() or "must" in output.lower() or "match" in output.lower()
+    with kb.connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0

--- a/tests/hermes_cli/test_kanban_program_cli.py
+++ b/tests/hermes_cli/test_kanban_program_cli.py
@@ -26,7 +26,17 @@ def _argv(extra=""):
     )
 
 
-def test_program_create_cli_emits_deterministic_safe_json_and_canonical_root(kanban_home):
+VALID_CGROUP = b"0::/system.slice/vigo-mc-command-0123456789abcdef01.service\n"
+
+
+@pytest.fixture
+def mission_control_cgroup(monkeypatch):
+    monkeypatch.setattr(kb, "_read_self_cgroup", lambda: VALID_CGROUP)
+
+
+def test_program_create_broker_emits_deterministic_safe_json_and_canonical_root(
+    kanban_home, mission_control_cgroup,
+):
     parser = kc.build_parser(__import__("argparse").ArgumentParser().add_subparsers())
     args = parser.parse_args(shlex.split(_argv()))
     assert kc.kanban_command(args) == 0
@@ -57,7 +67,9 @@ def test_program_create_cli_emits_deterministic_safe_json_and_canonical_root(kan
     "--assignee worker",
     "--project missing-project",
 ])
-def test_program_create_cli_invalid_input_leaves_no_root(kanban_home, extra):
+def test_program_create_cli_invalid_input_leaves_no_root(
+    kanban_home, mission_control_cgroup, extra,
+):
     parser = kc.build_parser(__import__("argparse").ArgumentParser().add_subparsers())
     args = parser.parse_args(shlex.split(_argv(extra)))
     assert kc.kanban_command(args) == 2
@@ -70,6 +82,84 @@ def test_program_create_is_rejected_by_slash_without_creating_row(kanban_home):
     assert "trusted" in output.lower() and "direct" in output.lower()
     with kb.connect() as conn:
         assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+def test_program_create_is_rejected_by_direct_argv_without_creating_row(
+    kanban_home, capsys, monkeypatch,
+):
+    """A terminal-capable model must not turn direct argv into root authority."""
+    parser = kc.build_parser(__import__("argparse").ArgumentParser().add_subparsers())
+    args = parser.parse_args(shlex.split(_argv()))
+    monkeypatch.setattr(kb, "_read_self_cgroup", lambda: b"0::/user.slice/test.service\n")
+    monkeypatch.setattr(kb, "init_db", lambda *a, **k: pytest.fail("DB initialized"))
+    assert kc.kanban_command(args) == 2
+    assert "mission control" in capsys.readouterr().err.lower()
+    with kb.connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+def test_program_create_direct_argv_rejects_forged_namespace_marker(
+    kanban_home, capsys, monkeypatch,
+):
+    parser = kc.build_parser(__import__("argparse").ArgumentParser().add_subparsers())
+    args = parser.parse_args(shlex.split(_argv()))
+    args.trusted = True
+    args.broker = "mission-control"
+    args._trusted_program_create = True
+    monkeypatch.setattr(kb, "_read_self_cgroup", lambda: b"0::/user.slice/test.service\n")
+    assert kc.kanban_command(args) == 2
+    assert "mission control" in capsys.readouterr().err.lower()
+    with kb.connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+@pytest.mark.parametrize("cgroup", [
+    b"0::/system.slice/vigo-mc-command-0123456789abcdef0.service\n",
+    b"0::/system.slice/hermes-mc-command-0123456789abcdef01.service\n",
+    b"0::/system.slice/vigo-mc-command-0123456789ABCDEf01.service\n",
+    b"0::/system.slice/vigo-mc-command-0123456789abcdef01.service.extra\n",
+    b"0::/system.slice/../system.slice/vigo-mc-command-0123456789abcdef01.service\n",
+    VALID_CGROUP + b"1:name=systemd:/system.slice/other.service\n",
+    b"not:a:cgroup:line\n",
+    b"",
+    b"x" * (kb._CGROUP_READ_LIMIT + 1),
+])
+def test_program_create_rejects_non_exact_cgroup(kanban_home, monkeypatch, cgroup):
+    parser = kc.build_parser(__import__("argparse").ArgumentParser().add_subparsers())
+    args = parser.parse_args(shlex.split(_argv()))
+    monkeypatch.setattr(kb, "_read_self_cgroup", lambda: cgroup)
+    assert kc.kanban_command(args) == 2
+    with kb.connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+@pytest.mark.parametrize("error", [PermissionError("denied"), FileNotFoundError()])
+def test_program_create_rejects_unreadable_or_missing_cgroup(
+    kanban_home, monkeypatch, error,
+):
+    parser = kc.build_parser(__import__("argparse").ArgumentParser().add_subparsers())
+    args = parser.parse_args(shlex.split(_argv()))
+
+    def unreadable():
+        raise error
+
+    monkeypatch.setattr(kb, "_read_self_cgroup", unreadable)
+    assert kc.kanban_command(args) == 2
+    with kb.connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+def test_program_create_accepts_exact_v1_systemd_cgroup(
+    kanban_home, monkeypatch,
+):
+    parser = kc.build_parser(__import__("argparse").ArgumentParser().add_subparsers())
+    args = parser.parse_args(shlex.split(_argv()))
+    monkeypatch.setattr(
+        kb, "_read_self_cgroup",
+        lambda: b"7:cpu,cpuacct:/ordinary\n1:name=systemd:/system.slice/"
+        b"vigo-mc-command-fedcba9876543210ab.service\n",
+    )
+    assert kc.kanban_command(args) == 0
 
 
 def test_interactive_kanban_dispatch_uses_fail_closed_slash_path(kanban_home, capsys):

--- a/tests/hermes_cli/test_kanban_program_cli.py
+++ b/tests/hermes_cli/test_kanban_program_cli.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 
 import pytest
 
@@ -26,7 +27,17 @@ def _argv(extra=""):
 
 
 def test_program_create_cli_emits_deterministic_safe_json_and_canonical_root(kanban_home):
-    payload = json.loads(kc.run_slash(_argv()))
+    parser = kc.build_parser(__import__("argparse").ArgumentParser().add_subparsers())
+    args = parser.parse_args(shlex.split(_argv()))
+    assert kc.kanban_command(args) == 0
+    with kb.connect() as conn:
+        task = kb.list_tasks(conn)[0]
+    payload = {
+        "id": task.id,
+        "status": task.status,
+        "orchestration_root_id": task.orchestration_root_id,
+        "policy": json.loads(task.orchestration_policy.to_json()),
+    }
     assert set(payload) == {"id", "status", "orchestration_root_id", "policy"}
     assert payload["id"] == payload["orchestration_root_id"]
     assert payload["status"] == "ready"
@@ -47,7 +58,24 @@ def test_program_create_cli_emits_deterministic_safe_json_and_canonical_root(kan
     "--project missing-project",
 ])
 def test_program_create_cli_invalid_input_leaves_no_root(kanban_home, extra):
-    output = kc.run_slash(_argv(extra))
-    assert "error" in output.lower() or "must" in output.lower() or "match" in output.lower()
+    parser = kc.build_parser(__import__("argparse").ArgumentParser().add_subparsers())
+    args = parser.parse_args(shlex.split(_argv(extra)))
+    assert kc.kanban_command(args) == 2
+    with kb.connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+def test_program_create_is_rejected_by_slash_without_creating_row(kanban_home):
+    output = kc.run_slash(_argv())
+    assert "trusted" in output.lower() and "direct" in output.lower()
+    with kb.connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+def test_interactive_kanban_dispatch_uses_fail_closed_slash_path(kanban_home, capsys):
+    from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+    CLICommandsMixin._handle_kanban_command(object(), "/kanban " + _argv())
+    assert "trusted direct" in capsys.readouterr().out.lower()
     with kb.connect() as conn:
         assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1316,6 +1316,31 @@ def test_link_rejects_cycle(worker_env):
     assert json.loads(out).get("error")
 
 
+def test_link_tool_rejects_managed_to_unmanaged_scope(worker_env, monkeypatch):
+    """The model tool must inherit the DB's managed-program boundary."""
+    from hermes_cli import kanban_db as kb
+    monkeypatch.setattr(kb, "is_mission_control_command_cgroup", lambda: True)
+    policy = kb.OrchestrationPolicy(
+        allowed_assignees=("planner", "worker"),
+        orchestrator_assignees=("planner",),
+        max_depth=2,
+        max_tasks=4,
+        max_runtime_seconds=60,
+    )
+    with kb.connect_closing() as conn:
+        managed = kb.create_task(
+            conn, title="managed", assignee="planner", orchestration_policy=policy
+        )
+        unmanaged = kb.create_task(conn, title="unmanaged", assignee="worker")
+    from tools import kanban_tools as kt
+    out = json.loads(kt._handle_link({
+        "parent_id": unmanaged, "child_id": managed,
+    }))
+    assert "orchestration scope" in out.get("error", "")
+    with kb.connect_closing() as conn:
+        assert unmanaged not in kb.parent_ids(conn, managed)
+
+
 def test_unblock_happy_path(monkeypatch, worker_env):
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     from hermes_cli import kanban_db as kb

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -61,6 +61,19 @@ def test_kanban_tools_visible_with_env_var(monkeypatch, tmp_path):
     assert kanban == expected, f"expected {expected}, got {kanban}"
 
 
+def test_kanban_create_schema_has_no_program_authority_arguments():
+    from tools.kanban_tools import KANBAN_CREATE_SCHEMA
+
+    properties = KANBAN_CREATE_SCHEMA["parameters"]["properties"]
+    assert not {
+        "orchestration_policy", "allowed_assignees", "orchestrator_assignees",
+        "max_depth", "max_tasks", "max_concurrency", "max_wall_clock_seconds",
+    } & set(properties)
+    # Existing per-task goal controls remain part of the legacy schema; the DB
+    # clamps this value when the caller is inside a bounded program.
+    assert "goal_max_turns" in properties
+
+
 def test_kanban_worker_env_overrides_profile_toolset_filter(monkeypatch, tmp_path):
     """Dispatcher-spawned workers must get lifecycle tools even when the
     assignee profile restricts enabled toolsets and does not list kanban.

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -902,6 +902,31 @@ def _handle_create(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            current_orchestrator_task_id = os.environ.get("HERMES_KANBAN_TASK")
+            creation_authority = None
+            if current_orchestrator_task_id:
+                try:
+                    creation_authority = kb.CreationAuthority(
+                        task_id=current_orchestrator_task_id,
+                        run_id=int(os.environ["HERMES_KANBAN_RUN_ID"]),
+                        claim_lock=os.environ["HERMES_KANBAN_CLAIM_LOCK"],
+                        actor_profile=os.environ["HERMES_PROFILE"],
+                    )
+                except (KeyError, TypeError, ValueError):
+                    creation_authority = None
+                if (
+                    creation_authority is None
+                    and not os.environ.get("HERMES_KANBAN_RUN_ID")
+                    and not os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
+                    and board is None
+                    and kb.get_task(conn, current_orchestrator_task_id) is None
+                ):
+                    # Pre-authority worker fixtures and unmanaged callers may
+                    # carry only a stale task id across a HERMES_HOME switch.
+                    # They have no bounded policy to exercise; preserve their
+                    # legacy create behavior. Any dispatcher authority fields
+                    # make this a bounded attempt and therefore fail closed.
+                    current_orchestrator_task_id = None
             # Inherit the spawning worker's own task workspace when the
             # caller didn't specify one (see resolution note above).
             if _inherit_workspace:
@@ -940,6 +965,11 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                # Trusted dispatcher context, deliberately absent from the
+                # model-facing schema/body. The DB resolves all authority from
+                # this task row and fails closed if it belongs to another board.
+                current_orchestrator_task_id=current_orchestrator_task_id,
+                creation_authority=creation_authority,
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)


### PR DESCRIPTION
## Summary

Adds a generic, bounded orchestration-policy tracer slice to the existing Hermes Kanban kernel.

- persists immutable orchestration policy and lineage with additive SQLite columns
- binds child creation to the active task run, claim lock, and server-provided profile context
- separates orchestrator profiles from allowed worker assignees
- enforces inherited tenant/project/runtime/depth/task limits at the DB mutation boundary
- supports same-program dependency fan-in while keeping lineage distinct
- atomically enforces program task quotas and scope-aware idempotency under `BEGIN IMMEDIATE`
- preserves unmanaged legacy task creation behavior
- keeps orchestration authority out of the model-facing `kanban_create` schema

## Security properties

- malformed policy JSON fails closed without coercing booleans, floats, numeric strings, or invalid containers
- stale/forged run, claim-lock, task, or profile authority is rejected before insertion
- child policy widening, foreign dependency parents, cross-board authority, and foreign project scope are rejected
- ordinary allowed workers cannot recursively fan out unless listed in `orchestrator_assignees`
- policy-root, bounded-child, and unmanaged idempotency namespaces cannot resolve into one another

## Tests

RED evidence was captured before each implementation slice, including:

- missing `OrchestrationPolicy`
- missing assignee/depth/quota enforcement
- forged/stale active-run authority
- invalid policy coercions
- dependency/lineage and project-scope failures
- policy-root idempotency resolving an unrelated legacy task

Final local gates:

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_kanban_orchestration_policy.py \
  tests/hermes_cli/test_kanban_swarm.py \
  tests/hermes_cli/test_kanban_db.py \
  tests/hermes_cli/test_kanban_db_init.py \
  tests/tools/test_kanban_tools.py -q

358 passed, 0 failed
```

```text
.venv/bin/ruff check hermes_cli/kanban_db.py tools/kanban_tools.py tests/hermes_cli/test_kanban_orchestration_policy.py
All checks passed

git diff --check
passed
```

Two independent Codex reviews were run. The first identified and caused a fix for policy-root idempotency scope isolation. The second reported no actionable correctness defects.

## Scope

This PR does not modify installed Hermes runtime, profiles, services, gateway configuration, or production. It does not yet expose root-policy creation as a model tool or implement autonomy decision records/command envelopes; those remain later reviewed slices.
