### PR TITLE
fix(gateway): avoid kanban board env race

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -57,6 +57,80 @@ def _resolve_auto_decompose_settings(
     return enabled, per_tick
 
 
+def _run_auto_decompose_tick(
+    kb_module: Any,
+    decomp_module: Any,
+    auto_decompose_per_tick: int,
+) -> int:
+    """Auto-decompose triage tasks using explicit per-board routing.
+
+    This helper runs in a background thread.  Passing ``board=`` through the
+    decomposer keeps it isolated from process-global ``os.environ``, which may
+    be read concurrently by dotenv and other agent work (#65225).
+    """
+    try:
+        boards = kb_module.list_boards(include_archived=False)
+    except Exception:
+        boards = [kb_module.read_board_metadata(kb_module.DEFAULT_BOARD)]
+
+    attempted = 0
+    successes = 0
+    for board in boards:
+        slug = board.get("slug") or kb_module.DEFAULT_BOARD
+        if attempted >= auto_decompose_per_tick:
+            break
+        try:
+            triage_ids = decomp_module.list_triage_ids(board=slug)
+        except Exception as exc:
+            logger.debug(
+                "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
+                slug,
+                exc,
+            )
+            triage_ids = []
+        for task_id in triage_ids:
+            if attempted >= auto_decompose_per_tick:
+                break
+            attempted += 1
+            try:
+                outcome = decomp_module.decompose_task(
+                    task_id,
+                    author="auto-decomposer",
+                    board=slug,
+                )
+            except Exception:
+                logger.exception(
+                    "kanban auto-decompose: decompose_task crashed on %s",
+                    task_id,
+                )
+                continue
+            if outcome.ok:
+                successes += 1
+                if outcome.fanout and outcome.child_ids:
+                    logger.info(
+                        "kanban auto-decompose [%s]: %s → %d children",
+                        slug,
+                        task_id,
+                        len(outcome.child_ids),
+                    )
+                else:
+                    logger.info(
+                        "kanban auto-decompose [%s]: %s → single task (no fanout)",
+                        slug,
+                        task_id,
+                    )
+            else:
+                # Expected no-op reasons (for example no auxiliary client)
+                # should not spam logs every dispatcher tick.
+                logger.debug(
+                    "kanban auto-decompose [%s]: %s skipped: %s",
+                    slug,
+                    task_id,
+                    outcome.reason,
+                )
+    return successes
+
+
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
     """Take an exclusive, non-blocking advisory lock for the sole dispatcher.
 
@@ -1143,70 +1217,11 @@ class GatewayKanbanWatchersMixin:
                     "kanban auto-decompose: import failed (%s); skipping", exc,
                 )
                 return 0
-            try:
-                boards = _kb.list_boards(include_archived=False)
-            except Exception:
-                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
-            attempted = 0
-            successes = 0
-            for b in boards:
-                slug = b.get("slug") or _kb.DEFAULT_BOARD
-                if attempted >= auto_decompose_per_tick:
-                    break
-                # Pin this board for the duration of the call — same
-                # pattern as the dashboard specify endpoint. The
-                # decomposer module connects with no board kwarg and
-                # relies on the env var.
-                prev_env = os.environ.get("HERMES_KANBAN_BOARD")
-                try:
-                    os.environ["HERMES_KANBAN_BOARD"] = slug
-                    try:
-                        triage_ids = _decomp.list_triage_ids()
-                    except Exception as exc:
-                        logger.debug(
-                            "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
-                            slug, exc,
-                        )
-                        triage_ids = []
-                    for tid in triage_ids:
-                        if attempted >= auto_decompose_per_tick:
-                            break
-                        attempted += 1
-                        try:
-                            outcome = _decomp.decompose_task(
-                                tid, author="auto-decomposer",
-                            )
-                        except Exception:
-                            logger.exception(
-                                "kanban auto-decompose: decompose_task crashed on %s",
-                                tid,
-                            )
-                            continue
-                        if outcome.ok:
-                            successes += 1
-                            if outcome.fanout and outcome.child_ids:
-                                logger.info(
-                                    "kanban auto-decompose [%s]: %s → %d children",
-                                    slug, tid, len(outcome.child_ids),
-                                )
-                            else:
-                                logger.info(
-                                    "kanban auto-decompose [%s]: %s → single task (no fanout)",
-                                    slug, tid,
-                                )
-                        else:
-                            # Common no-op reasons (no aux client configured) shouldn't
-                            # spam logs every tick. Log at debug.
-                            logger.debug(
-                                "kanban auto-decompose [%s]: %s skipped: %s",
-                                slug, tid, outcome.reason,
-                            )
-                finally:
-                    if prev_env is None:
-                        os.environ.pop("HERMES_KANBAN_BOARD", None)
-                    else:
-                        os.environ["HERMES_KANBAN_BOARD"] = prev_env
-            return successes
+            return _run_auto_decompose_tick(
+                _kb,
+                _decomp,
+                auto_decompose_per_tick,
+            )
 
         logger.info(
             "kanban dispatcher: embedded in gateway (interval=%.1fs)", interval

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -273,6 +273,7 @@ def decompose_task(
     *,
     author: Optional[str] = None,
     timeout: Optional[int] = None,
+    board: Optional[str] = None,
 ) -> DecomposeOutcome:
     """Decompose a triage task into a graph of child tasks.
 
@@ -281,7 +282,7 @@ def decompose_task(
     configured, API error, malformed response, decomposer returned
     fanout=true with empty task list) — those surface via ``ok=False``.
     """
-    with kb.connect_closing() as conn:
+    with kb.connect_closing(board=board) as conn:
         task = kb.get_task(conn, task_id)
     if task is None:
         return DecomposeOutcome(task_id, False, "unknown task id")
@@ -361,7 +362,7 @@ def decompose_task(
             return DecomposeOutcome(
                 task_id, False, "decomposer returned fanout=false with no title/body",
             )
-        with kb.connect_closing() as conn:
+        with kb.connect_closing(board=board) as conn:
             ok = kb.specify_triage_task(
                 conn,
                 task_id,
@@ -430,7 +431,7 @@ def decompose_task(
         })
 
     try:
-        with kb.connect_closing() as conn:
+        with kb.connect_closing(board=board) as conn:
             child_ids = kb.decompose_triage_task(
                 conn,
                 task_id,
@@ -456,9 +457,13 @@ def decompose_task(
     )
 
 
-def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
+def list_triage_ids(
+    *,
+    tenant: Optional[str] = None,
+    board: Optional[str] = None,
+) -> list[str]:
     """Return task ids currently in the triage column."""
-    with kb.connect_closing() as conn:
+    with kb.connect_closing(board=board) as conn:
         rows = kb.list_tasks(
             conn,
             status="triage",

--- a/tests/gateway/test_kanban_auto_decompose_live.py
+++ b/tests/gateway/test_kanban_auto_decompose_live.py
@@ -9,9 +9,15 @@ called every tick, reading the current config.
 
 from __future__ import annotations
 
+import os
+from types import SimpleNamespace
+
 import pytest
 
-from gateway.kanban_watchers import _resolve_auto_decompose_settings
+from gateway.kanban_watchers import (
+    _resolve_auto_decompose_settings,
+    _run_auto_decompose_tick,
+)
 
 
 def test_enabled_by_default_when_key_absent():
@@ -81,3 +87,40 @@ def test_live_toggle_takes_effect_between_calls():
     # User edits config.yaml mid-run.
     state["kanban"]["auto_decompose"] = False
     assert _resolve_auto_decompose_settings(lambda: state)[0] is False
+
+
+def test_auto_decompose_routes_boards_without_mutating_environment(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    original_env = dict(os.environ)
+
+    class FakeKanbanDb:
+        DEFAULT_BOARD = "default"
+
+        @staticmethod
+        def list_boards(*, include_archived):
+            assert include_archived is False
+            return [{"slug": "alpha"}, {"slug": "beta"}]
+
+    calls = []
+
+    class FakeDecomposer:
+        @staticmethod
+        def list_triage_ids(*, board):
+            calls.append(("list", board))
+            return [f"{board}-task"]
+
+        @staticmethod
+        def decompose_task(task_id, *, author, board):
+            calls.append(("decompose", task_id, author, board))
+            return SimpleNamespace(ok=True, fanout=False, child_ids=[], reason="")
+
+    successes = _run_auto_decompose_tick(FakeKanbanDb, FakeDecomposer, 3)
+
+    assert successes == 2
+    assert calls == [
+        ("list", "alpha"),
+        ("decompose", "alpha-task", "auto-decomposer", "alpha"),
+        ("list", "beta"),
+        ("decompose", "beta-task", "auto-decomposer", "beta"),
+    ]
+    assert dict(os.environ) == original_env

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -8,6 +8,7 @@ and the assignee-fallback logic.
 from __future__ import annotations
 
 import json as jsonlib
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -73,6 +74,96 @@ def _patch_list_profiles(names: list[str]):
         patch("hermes_cli.profiles.profile_exists", side_effect=lambda x: x in names),
         patch("hermes_cli.profiles.get_active_profile_name", return_value=names[0] if names else "default"),
     ]
+
+
+def test_explicit_board_routes_without_environment_pin(kanban_home, monkeypatch):
+    kb.create_board("alternate")
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    with kb.connect(board="alternate") as conn:
+        tid = kb.create_task(conn, title="alternate task", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit",
+        "title": "Routed alternate task",
+        "body": "Stay on the explicitly selected board.",
+    })
+    patches = _patch_list_profiles(["orchestrator"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            assert decomp.list_triage_ids(board="alternate") == [tid]
+            outcome = decomp.decompose_task(
+                tid,
+                author="me",
+                board="alternate",
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    assert "HERMES_KANBAN_BOARD" not in os.environ
+    with kb.connect(board="alternate") as conn:
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.title == "Routed alternate task"
+    with kb.connect(board="default") as conn:
+        assert kb.get_task(conn, tid) is None
+
+
+def test_explicit_board_fanout_keeps_root_and_children_isolated(
+    kanban_home, monkeypatch
+):
+    kb.create_board("alternate")
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    with kb.connect(board="alternate") as conn:
+        tid = kb.create_task(conn, title="split alternate task", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "two independent parts",
+        "tasks": [
+            {
+                "title": "First alternate child",
+                "body": "Handle the first part.",
+                "assignee": "engineer",
+                "parents": [],
+            },
+            {
+                "title": "Second alternate child",
+                "body": "Handle the second part.",
+                "assignee": "engineer",
+                "parents": [],
+            },
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(
+                tid,
+                author="me",
+                board="alternate",
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    assert outcome.fanout is True
+    assert outcome.child_ids and len(outcome.child_ids) == 2
+    task_ids = [tid, *outcome.child_ids]
+    with kb.connect(board="alternate") as conn:
+        alternate_tasks = [kb.get_task(conn, task_id) for task_id in task_ids]
+    assert all(task is not None for task in alternate_tasks)
+    with kb.connect(board="default") as conn:
+        default_tasks = [kb.get_task(conn, task_id) for task_id in task_ids]
+    assert default_tasks == [None, None, None]
+    assert "HERMES_KANBAN_BOARD" not in os.environ
 
 
 def test_decompose_with_fanout_creates_children(kanban_home):


### PR DESCRIPTION
## Summary

Fixes #65225.

The background kanban dispatcher no longer mutates `HERMES_KANBAN_BOARD` while auto-decomposing tasks. It now passes the board explicitly through `list_triage_ids`, `decompose_task`, and each database connection, removing the race with concurrent dotenv reads.

The existing CLI behavior remains unchanged when no explicit board is supplied.

## Tests

- 19 focused decomposer and environment-race tests passed
- 199 adjacent kanban gateway and database tests passed
- Windows footgun check passed