### PR TITLE
fix: don't send reasoning_effort to APIs that don't support it (#65233)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -453,15 +453,26 @@ class ChatCompletionsTransport(ProviderTransport):
         # Reasoning. LM Studio is handled above via top-level reasoning_effort,
         # so skip emitting extra_body.reasoning for it.
         if params.get("supports_reasoning", False) and not params.get("is_lmstudio", False):
-            if is_github_models:
+            # When reasoning is explicitly disabled, omit the reasoning field
+            # entirely so the API doesn't receive a parameter it may not
+            # support or that a disabled config would send as "enabled: True"
+            # with a default effort (which defeats the user's intent).
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    pass  # skip reasoning entirely
+                elif is_github_models:
+                    gh_reasoning = params.get("github_reasoning_extra")
+                    if gh_reasoning is not None:
+                        extra_body["reasoning"] = gh_reasoning
+                else:
+                    _effort = reasoning_config.get("effort", "medium") or "medium"
+                    extra_body["reasoning"] = {"enabled": True, "effort": _effort}
+            elif is_github_models:
                 gh_reasoning = params.get("github_reasoning_extra")
                 if gh_reasoning is not None:
                     extra_body["reasoning"] = gh_reasoning
             else:
-                _effort = "medium"
-                if reasoning_config and isinstance(reasoning_config, dict):
-                    _effort = reasoning_config.get("effort", "medium") or "medium"
-                extra_body["reasoning"] = {"enabled": True, "effort": _effort}
+                extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
 
         if provider_name == "gemini":
             raw_thinking_config = _build_gemini_thinking_config(model, reasoning_config)

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -23,6 +23,7 @@ class CustomProfile(ProviderProfile):
         self,
         *,
         reasoning_config: dict | None = None,
+        supports_reasoning: bool = False,
         ollama_num_ctx: int | None = None,
         **ctx: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -38,6 +39,13 @@ class CustomProfile(ProviderProfile):
         # Reasoning / thinking control for custom OpenAI-compatible endpoints
         # (GLM-5.2 on Volcengine ARK, vLLM, Ollama, llama.cpp, …).
         #
+        # Only emit reasoning parameters when the API is known to support them.
+        # Custom endpoints can be any OpenAI-compatible API — sending
+        # ``reasoning_effort`` or ``think`` to an endpoint that doesn't
+        # understand them causes HTTP 400. Gate on the ``supports_reasoning``
+        # flag resolved upstream from base_url / provider metadata.
+        #
+        # When supported:
         #   - disabled  → extra_body.think = False (Ollama's thinking-off flag)
         #   - enabled + effort set → TOP-LEVEL reasoning_effort string, the
         #     format GLM-5.2/ARK and other OpenAI-compatible reasoning APIs
@@ -49,7 +57,7 @@ class CustomProfile(ProviderProfile):
         # Ollama-only flag and thinking is already server-default-on for these
         # backends, so forcing it risks a 400 on GLM/vLLM endpoints that don't
         # recognize it. Mirrors the DeepSeek/Zai profile precedent.
-        if reasoning_config and isinstance(reasoning_config, dict):
+        if supports_reasoning and reasoning_config and isinstance(reasoning_config, dict):
             _effort = (reasoning_config.get("effort") or "").strip().lower()
             _enabled = reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:


### PR DESCRIPTION
CustomProfile was sending reasoning_effort to all APIs unconditionally, causing HTTP 400 on generic OpenAI-compatible endpoints.\n\n- Added `supports_reasoning` gate to CustomProfile's `build_api_kwargs_extras()`\n- Fixed legacy path in chat_completions.py to skip reasoning when `enabled: False`\n\nCloses #65233