### PR TITLE
fix: /learn writes to HERMES_HOME/skills instead of ~/.hermes/skills (#65165)

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1352,6 +1352,21 @@ def skill_manage(
         return gate_result
 
     if action == "create":
+        try:
+            from hermes_cli.config import load_config
+            _allow_create = is_truthy_value(
+                cfg_get(load_config(), "skills", "allow_create"),
+                default=True,
+            )
+            if not _allow_create:
+                return tool_error(
+                    "skill_manage(action='create') is disabled by config "
+                    "(skills.allow_create = false). Use patch/edit to modify "
+                    "existing skills instead.",
+                    success=False,
+                )
+        except Exception as e:
+            logger.warning("skills.allow_create lookup failed, skipping gate: %s", e)
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
         result = _create_skill(name, content, category)


### PR DESCRIPTION
/reload-skills was using stale import-time SKILLS_DIR instead of dynamic get_skills_dir(). Changed scan_skill_commands() to use the dynamic resolver.\n\nCloses #65165