### PR TITLE
fix: call registry.recheck_availability() after compression dedup reset

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1095,6 +1095,19 @@ def compress_context(
         except Exception:
             pass
 
+        # Force re-availability probe after compression boundary.
+        # Tool availability checks (Docker daemon, API keys, etc.) are
+        # cached for 30 s with a 60 s grace window. After a compression
+        # pause — which can span minutes — those caches may be stale and
+        # pin a false-negative "unavailable" verdict from a transient
+        # failure during the summarisation. Invalidate the cache so the
+        # next get_tool_definitions() re-probes fresh.
+        try:
+            from tools.registry import registry
+            registry.recheck_availability()
+        except Exception:
+            pass
+
         logger.info(
             "context compression done: session=%s messages=%d->%d rough_tokens=~%s awaiting_real_usage=true",
             agent.session_id or "none", _pre_msg_count, len(compressed),
@@ -1215,6 +1228,14 @@ def _compress_context_via_codex_app_server(
         from tools.file_tools import reset_file_dedup
 
         reset_file_dedup(task_id)
+    except Exception:
+        pass
+
+    # Force re-availability probe after compression boundary
+    # (see same block in compress_context above for rationale).
+    try:
+        from tools.registry import registry
+        registry.recheck_availability()
     except Exception:
         pass
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -743,6 +743,17 @@ class ToolRegistry:
                     result[ts]["env_vars"].append(env)
         return result
 
+    def recheck_availability(self) -> None:
+        """Force re-probe of all tool availability checks on next query.
+
+        Invalidates the module-level ``check_fn`` cache so that the next
+        ``get_tool_definitions()`` / ``check_tool_availability()`` call
+        re-evaluates every toolset's ``is_available()`` check from scratch.
+        Call after events that may change tool availability — compression
+        boundaries (dedup cache resets), config changes, credential refreshes.
+        """
+        invalidate_check_fn_cache()
+
     def check_tool_availability(self, quiet: bool = False):
         """Return (available_toolsets, unavailable_info) like the old function."""
         available = []


### PR DESCRIPTION
## Problem

After a compression boundary, tool availability checks cached during summarisation (30s TTL + 60s grace window) can pin stale false-negative verdicts. For example: Docker daemon probe timing out during compression strips terminal tools for the entire rest of the session, even after the daemon recovers.

## Solution

1. **Add `ToolRegistry.recheck_availability()`** in `tools/registry.py` — delegates to the existing module-level `invalidate_check_fn_cache()`, which clears the check-fn TTL cache so the next `get_tool_definitions()` / `check_tool_availability()` re-probes every toolset's `is_available()` from scratch.

2. **Call it after dedup reset** in both compression paths:
   - `compress_context()` — regular Hermes compression
   - `_compress_context_via_codex_app_server()` — Codex app-server compaction

Both calls are placed immediately after the file-read dedup cache reset, keeping the pattern consistent.

## Changes

| File | Change |
|------|--------|
| `tools/registry.py` | +11 lines: new `recheck_availability()` method |
| `agent/conversation_compression.py` | +21 lines: call in both compression paths |

## Testing

- ✅ Python syntax check
- ✅ Import verification (`registry.recheck_availability` exists, delegates to `invalidate_check_fn_cache`)
- ✅ `conversation_compression` module imports cleanly