### PR TITLE
Add trusted Codex turn-start lifecycle callback

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -16,13 +16,47 @@ compatibility.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
 from types import SimpleNamespace
 from typing import Any, Dict, List
+from urllib.request import Request, urlopen
 
 logger = logging.getLogger(__name__)
+
+
+def _codex_turn_started_callback_from_environment():
+    """Build the trusted control-plane callback configured for worker turns.
+
+    The URL stays in Hermes' parent environment; the Codex subprocess receives
+    Hermes' filtered environment and therefore cannot impersonate this
+    lifecycle signal. A configured callback is fail-closed so the worker never
+    runs with an uncorrelated turn.
+    """
+
+    url = os.environ.get("HERMES_CODEX_TURN_STARTED_URL", "").strip()
+    if not url:
+        return None
+
+    def notify(thread_id: str, turn_id: str) -> None:
+        request = Request(
+            url,
+            data=json.dumps(
+                {"codex_thread_id": thread_id, "codex_turn_id": turn_id},
+                separators=(",", ":"),
+            ).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urlopen(request, timeout=5) as response:
+            if response.status < 200 or response.status >= 300:
+                raise RuntimeError(
+                    f"Codex turn-start callback failed with HTTP {response.status}"
+                )
+
+    return notify
 
 
 def _codex_note_to_tool_progress(note: dict) -> tuple[str, str, dict] | None:
@@ -404,6 +438,7 @@ def run_codex_app_server_turn(
                 auto_approve_apply_patch=auto_approve_requests,
             ),
             on_event=_on_codex_event,
+            on_turn_started=_codex_turn_started_callback_from_environment(),
         )
 
     # NOTE: the user message is ALREADY appended to messages by the

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -39,15 +39,32 @@ def _codex_turn_started_callback_from_environment():
     url = os.environ.get("HERMES_CODEX_TURN_STARTED_URL", "").strip()
     if not url:
         return None
+    callback_environment = {
+        "hermes_task_id": os.environ.get("HERMES_KANBAN_TASK", "").strip(),
+        "hermes_run_id": os.environ.get("HERMES_KANBAN_RUN_ID", "").strip(),
+        "hermes_profile": os.environ.get("HERMES_PROFILE", "").strip(),
+    }
+    token = os.environ.get("HERMES_CODEX_TURN_STARTED_TOKEN", "").strip()
+    if not token or not all(callback_environment.values()):
+        raise RuntimeError(
+            "HERMES_CODEX_TURN_STARTED_URL requires a token and Kanban worker identity"
+        )
 
     def notify(thread_id: str, turn_id: str) -> None:
         request = Request(
             url,
             data=json.dumps(
-                {"codex_thread_id": thread_id, "codex_turn_id": turn_id},
+                {
+                    **callback_environment,
+                    "codex_thread_id": thread_id,
+                    "codex_turn_id": turn_id,
+                },
                 separators=(",", ":"),
             ).encode(),
-            headers={"Content-Type": "application/json"},
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
             method="POST",
         )
         with urlopen(request, timeout=5) as response:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -20,11 +20,37 @@ import json
 import logging
 import os
 import time
+from base64 import urlsafe_b64encode
+from hashlib import sha256
+from hmac import new as hmac_new
 from types import SimpleNamespace
 from typing import Any, Dict, List
 from urllib.request import Request, urlopen
 
 logger = logging.getLogger(__name__)
+
+
+def _codex_attempt_environment() -> dict[str, str]:
+    """Return the attempt-scoped MCP capability exposed to Codex."""
+
+    if not os.environ.get("HERMES_CODEX_TURN_STARTED_URL", "").strip():
+        return {}
+    callback_environment = {
+        "hermes_profile": os.environ.get("HERMES_PROFILE", "").strip(),
+        "hermes_run_id": os.environ.get("HERMES_KANBAN_RUN_ID", "").strip(),
+        "hermes_task_id": os.environ.get("HERMES_KANBAN_TASK", "").strip(),
+    }
+    secret = os.environ.get("HERMES_CODEX_TURN_STARTED_TOKEN", "").strip()
+    if not secret or not all(callback_environment.values()):
+        raise RuntimeError(
+            "Codex attempt capability requires a callback token and Kanban identity"
+        )
+    payload = json.dumps(
+        callback_environment, sort_keys=True, separators=(",", ":")
+    ).encode()
+    encoded = urlsafe_b64encode(payload).decode().rstrip("=")
+    signature = hmac_new(secret.encode(), encoded.encode(), sha256).hexdigest()
+    return {"OMNICLAW_ATTEMPT_TOKEN": f"{encoded}.{signature}"}
 
 
 def _codex_turn_started_callback_from_environment():
@@ -456,6 +482,7 @@ def run_codex_app_server_turn(
             ),
             on_event=_on_codex_event,
             on_turn_started=_codex_turn_started_callback_from_environment(),
+            codex_env=_codex_attempt_environment(),
         )
 
     # NOTE: the user message is ALREADY appended to messages by the

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -207,6 +207,7 @@ class CodexAppServerSession:
         permission_profile: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
+        on_turn_started: Optional[Callable[[str, str], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
     ) -> None:
@@ -221,6 +222,7 @@ class CodexAppServerSession:
         )
         self._approval_callback = approval_callback
         self._on_event = on_event  # Display hook (kawaii spinner ticks etc.)
+        self._on_turn_started = on_turn_started
         self._routing = request_routing or _ServerRequestRouting()
         self._client_factory = client_factory or CodexAppServerClient
 
@@ -541,6 +543,15 @@ class CodexAppServerSession:
                     self._on_event(note)
                 except Exception:  # pragma: no cover - display callback
                     logger.debug("on_event callback raised", exc_info=True)
+            if (
+                method == "turn/started"
+                and self._on_turn_started is not None
+                and self._thread_id is not None
+            ):
+                turn_obj = (note.get("params") or {}).get("turn") or {}
+                turn_id = turn_obj.get("id")
+                if isinstance(turn_id, str) and turn_id:
+                    self._on_turn_started(self._thread_id, turn_id)
 
             _apply_token_usage_notification(result, note)
             _apply_compaction_notification(result, note)
@@ -728,6 +739,15 @@ class CodexAppServerSession:
                     self._on_event(note)
                 except Exception:  # pragma: no cover - display callback
                     logger.debug("on_event callback raised", exc_info=True)
+            if (
+                method == "turn/started"
+                and self._on_turn_started is not None
+                and self._thread_id is not None
+            ):
+                turn_obj = (note.get("params") or {}).get("turn") or {}
+                turn_id = turn_obj.get("id")
+                if isinstance(turn_id, str) and turn_id:
+                    self._on_turn_started(self._thread_id, turn_id)
 
             _apply_token_usage_notification(result, note)
             _apply_compaction_notification(result, note)

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -208,6 +208,7 @@ class CodexAppServerSession:
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
         on_turn_started: Optional[Callable[[str, str], None]] = None,
+        codex_env: Optional[dict[str, str]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
     ) -> None:
@@ -223,6 +224,7 @@ class CodexAppServerSession:
         self._approval_callback = approval_callback
         self._on_event = on_event  # Display hook (kawaii spinner ticks etc.)
         self._on_turn_started = on_turn_started
+        self._codex_env = codex_env
         self._routing = request_routing or _ServerRequestRouting()
         self._client_factory = client_factory or CodexAppServerClient
 
@@ -247,7 +249,9 @@ class CodexAppServerSession:
             return self._thread_id
         if self._client is None:
             self._client = self._client_factory(
-                codex_bin=self._codex_bin, codex_home=self._codex_home
+                codex_bin=self._codex_bin,
+                codex_home=self._codex_home,
+                env=self._codex_env,
             )
         self._client.initialize(
             client_name="hermes",

--- a/tests/agent/test_codex_turn_started_callback.py
+++ b/tests/agent/test_codex_turn_started_callback.py
@@ -20,6 +20,10 @@ def test_configured_turn_callback_posts_actual_runtime_ids(monkeypatch) -> None:
     monkeypatch.setenv(
         "HERMES_CODEX_TURN_STARTED_URL", "http://127.0.0.1:8765/codex-turn"
     )
+    monkeypatch.setenv("HERMES_CODEX_TURN_STARTED_TOKEN", "callback-secret")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-live")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "run-live")
+    monkeypatch.setenv("HERMES_PROFILE", "engineering")
 
     with patch("agent.codex_runtime.urlopen", return_value=_Response()) as opened:
         callback = _codex_turn_started_callback_from_environment()
@@ -28,7 +32,11 @@ def test_configured_turn_callback_posts_actual_runtime_ids(monkeypatch) -> None:
 
     request = opened.call_args.args[0]
     assert request.full_url == "http://127.0.0.1:8765/codex-turn"
+    assert request.headers["Authorization"] == "Bearer callback-secret"
     assert json.loads(request.data) == {
+        "hermes_task_id": "task-live",
+        "hermes_run_id": "run-live",
+        "hermes_profile": "engineering",
         "codex_thread_id": "thread-live",
         "codex_turn_id": "turn-live",
     }

--- a/tests/agent/test_codex_turn_started_callback.py
+++ b/tests/agent/test_codex_turn_started_callback.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import json
 from unittest.mock import patch
 
-from agent.codex_runtime import _codex_turn_started_callback_from_environment
+from agent.codex_runtime import (
+    _codex_attempt_environment,
+    _codex_turn_started_callback_from_environment,
+)
 
 
 class _Response:
@@ -40,6 +43,7 @@ def test_configured_turn_callback_posts_actual_runtime_ids(monkeypatch) -> None:
         "codex_thread_id": "thread-live",
         "codex_turn_id": "turn-live",
     }
+    assert _codex_attempt_environment()["OMNICLAW_ATTEMPT_TOKEN"].startswith("eyJ")
 
 
 def test_unconfigured_turn_callback_is_disabled(monkeypatch) -> None:

--- a/tests/agent/test_codex_turn_started_callback.py
+++ b/tests/agent/test_codex_turn_started_callback.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from agent.codex_runtime import _codex_turn_started_callback_from_environment
+
+
+class _Response:
+    status = 204
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+
+def test_configured_turn_callback_posts_actual_runtime_ids(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "HERMES_CODEX_TURN_STARTED_URL", "http://127.0.0.1:8765/codex-turn"
+    )
+
+    with patch("agent.codex_runtime.urlopen", return_value=_Response()) as opened:
+        callback = _codex_turn_started_callback_from_environment()
+        assert callback is not None
+        callback("thread-live", "turn-live")
+
+    request = opened.call_args.args[0]
+    assert request.full_url == "http://127.0.0.1:8765/codex-turn"
+    assert json.loads(request.data) == {
+        "codex_thread_id": "thread-live",
+        "codex_turn_id": "turn-live",
+    }
+
+
+def test_unconfigured_turn_callback_is_disabled(monkeypatch) -> None:
+    monkeypatch.delenv("HERMES_CODEX_TURN_STARTED_URL", raising=False)
+    assert _codex_turn_started_callback_from_environment() is None

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -173,6 +173,28 @@ class TestLifecycle:
 # ---- turn loop ----
 
 class TestRunTurn:
+    def test_turn_started_callback_receives_real_thread_and_turn_ids(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/started",
+            threadId="thread-fake-001",
+            turn={"id": "turn-live-002"},
+        )
+        client.queue_notification(
+            "turn/completed",
+            threadId="thread-fake-001",
+            turn={"id": "turn-live-002", "status": "completed", "error": None},
+        )
+        started = []
+        s = make_session(
+            client,
+            on_turn_started=lambda thread, turn: started.append((thread, turn)),
+        )
+
+        s.run_turn("hi", turn_timeout=2.0)
+
+        assert started == [("thread-fake-001", "turn-live-002")]
+
     def test_simple_text_turn_returns_final_message(self):
         client = FakeClient()
         client.queue_notification("turn/started", threadId="t", turn={"id": "tu1"})

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -26,9 +26,10 @@ class FakeClient:
     """Stand-in for CodexAppServerClient that records calls and lets the test
     drive the notification / server-request streams synchronously."""
 
-    def __init__(self, *, codex_bin: str = "codex", codex_home=None) -> None:
+    def __init__(self, *, codex_bin: str = "codex", codex_home=None, env=None) -> None:
         self.codex_bin = codex_bin
         self.codex_home = codex_home
+        self.env = env
         self.requests: list[tuple[str, dict]] = []
         self.notifications_responses: list[dict] = []
         self.responses: list[tuple[Any, dict]] = []

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -461,6 +461,7 @@ _ALWAYS_STRIP_KEYS: frozenset[str] = frozenset({
     "HASS_TOKEN",
     "EMAIL_PASSWORD",
     "HERMES_DASHBOARD_SESSION_TOKEN",
+    "HERMES_CODEX_TURN_STARTED_URL",
     # Remote-compute / infrastructure secrets
     "MODAL_TOKEN_ID",
     "MODAL_TOKEN_SECRET",

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -462,6 +462,7 @@ _ALWAYS_STRIP_KEYS: frozenset[str] = frozenset({
     "EMAIL_PASSWORD",
     "HERMES_DASHBOARD_SESSION_TOKEN",
     "HERMES_CODEX_TURN_STARTED_URL",
+    "HERMES_CODEX_TURN_STARTED_TOKEN",
     # Remote-compute / infrastructure secrets
     "MODAL_TOKEN_ID",
     "MODAL_TOKEN_SECRET",


### PR DESCRIPTION
## Summary

- add an optional `HERMES_CODEX_TURN_STARTED_URL` callback for Codex app-server workers
- post the actual Kanban task/run/profile and Codex thread/turn IDs synchronously on `turn/started`
- authenticate the callback with a bearer capability stripped from the Codex child
- derive and inject a signed, attempt-scoped MCP capability so a shared service can route concurrent workers without exposing the control credential
- fail closed when a configured callback cannot complete
- strip the callback URL from the Codex subprocess environment

This supplies a narrow lifecycle seam for external control planes that must correlate Hermes/Codex runtime identities without exposing their ledger or external credentials to the Codex worker.

## Validation

- `uv run ruff check agent/codex_runtime.py agent/transports/codex_app_server_session.py tools/environments/local.py tests/agent/transports/test_codex_app_server_session.py tests/agent/test_codex_turn_started_callback.py`
- `uv run pytest -q tests/agent/transports/test_codex_app_server_session.py tests/agent/test_codex_turn_started_callback.py tests/tools/test_hermes_subprocess_env.py` (85 passed)
