### PR TITLE
fix(desktop): preserve local model provider endpoint

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -212,6 +212,53 @@ describe('ModelSettings', () => {
     expect(screen.queryByRole('button', { name: 'Set up provider' })).toBeNull()
   })
 
+  it('preserves a user-defined provider endpoint when applying the main model', async () => {
+    getGlobalModelOptions.mockResolvedValueOnce({
+      providers: [
+        {
+          name: 'Nous',
+          slug: 'nous',
+          models: ['hermes-4'],
+          authenticated: true
+        },
+        {
+          name: 'Ollama',
+          slug: 'local-ollama',
+          models: ['qwen3:latest'],
+          authenticated: true,
+          is_user_defined: true,
+          api_url: 'http://localhost:11434/v1'
+        }
+      ]
+    })
+    setModelAssignment.mockResolvedValueOnce({
+      provider: 'local-ollama',
+      model: 'qwen3:latest',
+      gateway_tools: []
+    })
+
+    await renderModelSettings()
+
+    const providerSelect = (await screen.findAllByRole('combobox'))[0]
+    fireEvent.click(providerSelect)
+    fireEvent.click(await screen.findByRole('option', { name: 'Ollama' }))
+
+    const modelSelect = (await screen.findAllByRole('combobox'))[1]
+    fireEvent.click(modelSelect)
+    fireEvent.click(await screen.findByRole('option', { name: 'qwen3:latest' }))
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Apply' }))
+
+    await waitFor(() =>
+      expect(setModelAssignment).toHaveBeenCalledWith({
+        model: 'qwen3:latest',
+        provider: 'local-ollama',
+        scope: 'main',
+        base_url: 'http://localhost:11434/v1'
+      })
+    )
+  })
+
   it('writes the profile default speed (service_tier) when the fast switch is toggled', async () => {
     await renderModelSettings()
     await waitFor(() => expect(getHermesConfigRecord).toHaveBeenCalled())

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -619,7 +619,12 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     setError('')
 
     try {
-      const result = await setModelAssignment({ model: selectedModel, provider: selectedProvider, scope: 'main' })
+      const result = await setModelAssignment({
+        model: selectedModel,
+        provider: selectedProvider,
+        scope: 'main',
+        ...(selectedProviderRow?.api_url ? { base_url: selectedProviderRow.api_url } : {})
+      })
 
       if (profileEpoch.current !== epoch) {
         return
@@ -636,7 +641,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
     } finally {
       setApplying(false)
     }
-  }, [onMainModelChanged, refresh, selectedModel, selectedProvider])
+  }, [onMainModelChanged, refresh, selectedModel, selectedProvider, selectedProviderRow])
 
   const setAuxiliaryToMain = useCallback(
     async (task: string) => {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -386,6 +386,10 @@ export interface ModelOptionProvider {
   key_env?: string
   /** True for providers defined via the user's `providers:` config block. */
   is_user_defined?: boolean
+  /** OpenAI-compatible endpoint for a user-defined provider. The backend
+   *  exposes this as `api_url`; model assignments send it back as `base_url`
+   *  so switching providers does not discard the selected local endpoint. */
+  api_url?: string
   /** Per-model pricing keyed by model id (present when the picker requested
    *  pricing and the provider supports live pricing). */
   pricing?: Record<string, ModelPricing>


### PR DESCRIPTION
Fixes #65201

## Summary

Preserves the configured endpoint when selecting a local or user-defined model provider in the Desktop model settings.

Previously, Desktop displayed the selected Ollama provider and model correctly, but the model assignment request omitted the provider endpoint. The backend then cleared the previous `base_url`, leaving the local provider without an endpoint and allowing runtime resolution to fall back to OpenRouter-compatible handling.

## Root cause

`/api/model/options` exposes the endpoint for user-defined providers as `api_url`.

The Desktop `ModelOptionProvider` type did not include that field, and `applyMainModel()` only submitted:

- `model`
- `provider`
- `scope`

As a result, switching to Ollama/custom persisted the provider selection without persisting its endpoint.

## Fix

- Add `api_url` to `ModelOptionProvider`.
- Pass the selected provider's `api_url` back as `base_url` when applying the main model.
- Preserve existing behavior for providers that do not expose a custom endpoint.
- Add a regression test covering a user-defined Ollama provider.

## Testing

- Added regression test:
  `preserves a user-defined provider endpoint when applying the main model`
- Focused Desktop test suite: 11 passed
- ESLint on changed files: 0 errors
  - One existing `react-hooks/exhaustive-deps` warning remains outside this change.
- `git diff --check`: passed
- Rebased onto the latest `origin/main` and reran the focused tests successfully.

## Typecheck note

The full Desktop typecheck is currently blocked by 7 unrelated errors in existing assistant-ui integration files involving installed package API mismatches. None of the reported errors are in the files changed by this PR.