### PR TITLE
feat(telegram): add plugin-owned callback actions

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1036,6 +1036,29 @@ def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Opti
     )
 
 
+def normalize_inline_buttons(buttons: Optional[List[str]]) -> Optional[List[List[Dict[str, str]]]]:
+    """Normalize repeatable ``LABEL=CALLBACK_DATA`` values for Telegram."""
+    if buttons is None:
+        return None
+    if not isinstance(buttons, list) or not 1 <= len(buttons) <= 8:
+        raise ValueError("buttons must contain between 1 and 8 LABEL=CALLBACK_DATA values")
+    row: List[Dict[str, str]] = []
+    seen = set()
+    for raw in buttons:
+        if not isinstance(raw, str) or "=" not in raw:
+            raise ValueError("each button must use LABEL=CALLBACK_DATA")
+        label, callback_data = (part.strip() for part in raw.split("=", 1))
+        if not label or len(label) > 64:
+            raise ValueError("button labels must contain 1 to 64 characters")
+        if not callback_data or len(callback_data.encode("utf-8")) > 64:
+            raise ValueError("button callback data must contain 1 to 64 bytes")
+        if callback_data in seen:
+            raise ValueError("button callback data must be unique within a job")
+        seen.add(callback_data)
+        row.append({"text": label, "callback_data": callback_data})
+    return [row]
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -1054,6 +1077,7 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    buttons: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1130,6 +1154,7 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
+    normalized_inline_keyboard = normalize_inline_buttons(buttons)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -1220,6 +1245,8 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    if normalized_inline_keyboard is not None:
+        job["inline_keyboard"] = normalized_inline_keyboard
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
     # global cron.mirror_delivery config, default off).

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1488,6 +1488,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         return msg
 
     delivery_errors = []
+    inline_keyboard = job.get("inline_keyboard")
 
     for target in targets:
         platform_name = target["platform"]
@@ -1676,6 +1677,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
                 media_metadata = {"thread_id": thread_id} if thread_id else None
+
+            if platform == Platform.TELEGRAM and inline_keyboard is not None:
+                route_metadata["inline_keyboard"] = inline_keyboard
 
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.
@@ -1900,7 +1904,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                thread_id=thread_id,
+                media_files=media_files,
+                inline_keyboard=inline_keyboard,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -1929,7 +1941,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        future = pool.submit(
+                            asyncio.run,
+                            _send_to_platform(
+                                platform,
+                                pconfig,
+                                chat_id,
+                                cleaned_delivery_content,
+                                thread_id=thread_id,
+                                media_files=media_files,
+                                inline_keyboard=inline_keyboard,
+                            ),
+                        )
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -310,6 +310,7 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        buttons=getattr(args, "buttons", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -373,6 +374,7 @@ def cron_edit(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", None),
+        buttons=getattr(args, "buttons", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -171,6 +171,11 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Platform-native interaction hook. Fired for authorized callback actions
+    # that were not claimed by a built-in platform handler. The first plugin
+    # returning {"handled": True, ...} owns the action. Platform adapters pass
+    # normalized scalar context only; transport objects stay inside the host.
+    "platform_callback",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -67,6 +67,17 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         ),
     )
     cron_create.add_argument(
+        "--button",
+        dest="buttons",
+        action="append",
+        metavar="LABEL=CALLBACK_DATA",
+        help=(
+            "Attach a Telegram inline action to the delivered message. "
+            "Repeat for multiple buttons. Callback data is handled by an "
+            "enabled platform_callback plugin."
+        ),
+    )
+    cron_create.add_argument(
         "--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
@@ -129,6 +140,13 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         action="store_const",
         const=False,
         help="Disable no-agent mode on this job (reverts to LLM-driven execution).",
+    )
+    cron_edit.add_argument(
+        "--button",
+        dest="buttons",
+        action="append",
+        metavar="LABEL=CALLBACK_DATA",
+        help="Replace the job's Telegram inline actions. Repeat for multiple buttons.",
     )
     cron_edit.add_argument(
         "--workdir",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3881,6 +3881,18 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+
+        inline_keyboard = None
+        if metadata and "inline_keyboard" in metadata:
+            inline_keyboard = self._plugin_callback_keyboard(
+                metadata.get("inline_keyboard")
+            )
+            if inline_keyboard is None:
+                return SendResult(
+                    success=False,
+                    error="invalid inline_keyboard metadata",
+                    retryable=False,
+                )
         
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
@@ -3888,7 +3900,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # through to the legacy MarkdownV2 path on permanent/capability
             # errors or DM-topic routing skips; returns directly on success or
             # on a transient failure (which must NOT be legacy-resent).
-            if self._should_attempt_rich(content, metadata=metadata):
+            if inline_keyboard is None and self._should_attempt_rich(content, metadata=metadata):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:
@@ -3942,6 +3954,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 _TimedOut = None  # type: ignore[assignment,misc]
 
             for i, chunk in enumerate(chunks):
+                action_kwargs = (
+                    {"reply_markup": inline_keyboard}
+                    if inline_keyboard is not None and i == len(chunks) - 1
+                    else {}
+                )
                 retried_thread_not_found = False
                 metadata_reply_to = self._metadata_reply_to_message_id(metadata)
                 private_dm_topic_send = self._is_private_dm_topic_send(chat_id, thread_id, metadata)
@@ -3997,6 +4014,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
+                                **action_kwargs,
                             )
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
@@ -4011,6 +4029,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
+                                    **action_kwargs,
                                 )
                             else:
                                 raise
@@ -5940,8 +5959,16 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
             return
 
-        # --- Update prompt callbacks ---
+        # --- Plugin-owned platform callbacks ---
         if not data.startswith("update_prompt:"):
+            await self._handle_platform_callback_hook(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
             return
         answer = data.split(":", 1)[1]  # "y" or "n"
         caller_id = str(getattr(query.from_user, "id", ""))
@@ -5977,6 +6004,113 @@ class TelegramAdapter(BasePlatformAdapter):
                         answer, getattr(query.from_user, "id", "unknown"))
         except Exception as exc:
             logger.error("Failed to write update response from callback: %s", exc)
+
+    @staticmethod
+    def _plugin_callback_keyboard(rows: object):
+        """Build a bounded Telegram keyboard from normalized plugin output."""
+        if not isinstance(rows, list) or not 1 <= len(rows) <= 8:
+            return None
+        keyboard = []
+        for row in rows:
+            if not isinstance(row, list) or not 1 <= len(row) <= 8:
+                return None
+            built_row = []
+            for button in row:
+                if not isinstance(button, dict):
+                    return None
+                text = button.get("text")
+                callback_data = button.get("callback_data")
+                if not isinstance(text, str) or not text.strip() or len(text) > 64:
+                    return None
+                if (
+                    not isinstance(callback_data, str)
+                    or not callback_data
+                    or len(callback_data.encode("utf-8")) > 64
+                ):
+                    return None
+                built_row.append(
+                    InlineKeyboardButton(text=text, callback_data=callback_data)
+                )
+            keyboard.append(built_row)
+        return InlineKeyboardMarkup(keyboard)
+
+    async def _handle_platform_callback_hook(
+        self,
+        query,
+        data: str,
+        *,
+        query_chat_id,
+        query_chat_type,
+        query_thread_id,
+        query_user_name,
+    ) -> None:
+        """Offer an unclaimed, authorized callback to enabled plugins."""
+        caller_id = str(getattr(query.from_user, "id", ""))
+        chat_type_value = getattr(query_chat_type, "value", query_chat_type)
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(chat_type_value) if chat_type_value is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ You are not authorized to use this action.")
+            return
+
+        message = getattr(query, "message", None)
+        try:
+            from hermes_cli.plugins import invoke_hook
+
+            results = await asyncio.to_thread(
+                invoke_hook,
+                "platform_callback",
+                platform="telegram",
+                callback_data=data,
+                user_id=caller_id,
+                user_name=str(query_user_name or ""),
+                chat_id=str(query_chat_id) if query_chat_id is not None else None,
+                chat_type=str(chat_type_value) if chat_type_value is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                message_id=(
+                    str(getattr(message, "message_id"))
+                    if getattr(message, "message_id", None) is not None
+                    else None
+                ),
+                message_text=str(getattr(message, "text", "") or ""),
+            )
+        except Exception:
+            logger.warning("[%s] platform callback hook dispatch failed", self.name, exc_info=True)
+            results = []
+
+        handled = next(
+            (
+                result
+                for result in results
+                if isinstance(result, dict) and result.get("handled") is True
+            ),
+            None,
+        )
+        if handled is None:
+            await query.answer(text="Action unavailable.")
+            return
+
+        answer = handled.get("answer")
+        if not isinstance(answer, str) or not answer.strip():
+            answer = "Done"
+        await query.answer(
+            text=answer.strip()[:200],
+            show_alert=bool(handled.get("show_alert", False)),
+        )
+
+        if "buttons" in handled:
+            reply_markup = self._plugin_callback_keyboard(handled.get("buttons"))
+            if reply_markup is None:
+                logger.warning("[%s] platform callback returned an invalid keyboard", self.name)
+                return
+            try:
+                await query.edit_message_reply_markup(reply_markup=reply_markup)
+            except Exception:
+                logger.debug("[%s] platform callback keyboard update failed", self.name, exc_info=True)
 
     # Maps `gt:<verb>` -> (script-name, extra-args, success-label, is_state).
     # Scripts live in ~/.hermes/scripts/gmail-triage/. `arg` from the callback

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6076,7 +6076,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     if getattr(message, "message_id", None) is not None
                     else None
                 ),
-                message_text=str(getattr(message, "text", "") or ""),
+                message_text=str(
+                    getattr(message, "text", None)
+                    or getattr(message, "caption", "")
+                    or ""
+                ),
             )
         except Exception:
             logger.warning("[%s] platform callback hook dispatch failed", self.name, exc_info=True)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -641,6 +641,34 @@ class TestDeliverResultWrapping:
         assert "Cronjob Response" not in sent_content
         assert "The agent cannot see" not in sent_content
 
+    def test_delivery_forwards_job_inline_keyboard(self):
+        """Cron keeps one delivery path while attaching configured actions."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        keyboard = [[
+            {"text": "Relevant", "callback_data": "zbr:relevant"},
+            {"text": "Zu technisch", "callback_data": "zbr:technical"},
+        ]]
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            _deliver_result(
+                {
+                    "id": "radar-job",
+                    "deliver": "origin",
+                    "origin": {"platform": "telegram", "chat_id": "123"},
+                    "inline_keyboard": keyboard,
+                },
+                "Daily Radar",
+            )
+
+        assert send_mock.await_args.kwargs["inline_keyboard"] == keyboard
+
     def test_delivery_extracts_media_tags_before_send(self, tmp_path, monkeypatch):
         """Cron delivery should pass MEDIA attachments separately to the send helper."""
         from gateway.config import Platform

--- a/tests/gateway/test_telegram_platform_callback_hook.py
+++ b/tests/gateway/test_telegram_platform_callback_hook.py
@@ -87,6 +87,26 @@ async def test_authorized_unknown_callback_is_handled_by_plugin_hook(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_media_callback_passes_caption_to_plugin_hook(monkeypatch):
+    """Plugin callbacks keep correlation markers from photo captions."""
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")
+    adapter = _make_adapter()
+    update, query = _make_update()
+    query.message.text = None
+    query.message.caption = (
+        "VISUAL BRIEF\n"
+        "[zoon-brain:output:visual-brief:2026-07-16:harness-staleness-01]"
+    )
+    hook_result = {"handled": True, "answer": "Gespeichert"}
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[hook_result]) as invoke:
+        await adapter._handle_callback_query(update, MagicMock())
+
+    assert invoke.call_args.kwargs["message_text"] == query.message.caption
+    query.answer.assert_awaited_once_with(text="Gespeichert", show_alert=False)
+
+
+@pytest.mark.asyncio
 async def test_send_attaches_normalized_keyboard_to_final_chunk(monkeypatch):
     """Callers can add actions without taking over Telegram delivery."""
     from plugins.platforms.telegram import adapter as telegram_adapter

--- a/tests/gateway/test_telegram_platform_callback_hook.py
+++ b/tests/gateway/test_telegram_platform_callback_hook.py
@@ -1,0 +1,129 @@
+"""Behavior contract for plugin-owned Telegram inline actions."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+def _make_adapter():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = config
+    adapter._config = config
+    adapter._platform = Platform.TELEGRAM
+    adapter._connected = True
+    adapter._message_handler = None
+    return adapter
+
+
+def _make_update(data: str = "zbr:relevant"):
+    query = AsyncMock()
+    query.data = data
+    query.message = MagicMock()
+    query.message.chat_id = 12345
+    query.message.chat = SimpleNamespace(type="channel")
+    query.message.message_id = 77
+    query.message.message_thread_id = None
+    query.message.text = "[zoon-brain:output:daily-radar:2026-07-16:01]"
+    query.from_user = SimpleNamespace(id=999, first_name="Peter")
+    query.answer = AsyncMock()
+    query.edit_message_reply_markup = AsyncMock()
+    return SimpleNamespace(callback_query=query), query
+
+
+@pytest.mark.asyncio
+async def test_authorized_unknown_callback_is_handled_by_plugin_hook(monkeypatch):
+    """A plugin can acknowledge an action and replace its inline keyboard."""
+    from plugins.platforms.telegram import adapter as telegram_adapter
+
+    class _Button(SimpleNamespace):
+        def __init__(self, *, text, callback_data):
+            super().__init__(text=text, callback_data=callback_data)
+
+    class _Markup(SimpleNamespace):
+        def __init__(self, rows):
+            super().__init__(inline_keyboard=rows)
+
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardButton", _Button)
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardMarkup", _Markup)
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "999")
+    adapter = _make_adapter()
+    update, query = _make_update()
+    hook_result = {
+        "handled": True,
+        "answer": "Gespeichert",
+        "buttons": [[
+            {"text": "✓ Relevant · 1", "callback_data": "zbr:relevant"},
+            {"text": "Zu technisch · 0", "callback_data": "zbr:technical"},
+        ]],
+    }
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[hook_result]) as invoke:
+        await adapter._handle_callback_query(update, MagicMock())
+
+    invoke.assert_called_once_with(
+        "platform_callback",
+        platform="telegram",
+        callback_data="zbr:relevant",
+        user_id="999",
+        user_name="Peter",
+        chat_id="12345",
+        chat_type="channel",
+        thread_id=None,
+        message_id="77",
+        message_text="[zoon-brain:output:daily-radar:2026-07-16:01]",
+    )
+    query.answer.assert_awaited_once_with(text="Gespeichert", show_alert=False)
+    markup = query.edit_message_reply_markup.await_args.kwargs["reply_markup"]
+    assert [[button.text for button in row] for row in markup.inline_keyboard] == [[
+        "✓ Relevant · 1",
+        "Zu technisch · 0",
+    ]]
+
+
+@pytest.mark.asyncio
+async def test_send_attaches_normalized_keyboard_to_final_chunk(monkeypatch):
+    """Callers can add actions without taking over Telegram delivery."""
+    from plugins.platforms.telegram import adapter as telegram_adapter
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    class _Button(SimpleNamespace):
+        def __init__(self, *, text, callback_data):
+            super().__init__(text=text, callback_data=callback_data)
+
+    class _Markup(SimpleNamespace):
+        def __init__(self, rows):
+            super().__init__(inline_keyboard=rows)
+
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardButton", _Button)
+    monkeypatch.setattr(telegram_adapter, "InlineKeyboardMarkup", _Markup)
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(
+        side_effect=[SimpleNamespace(message_id=1), SimpleNamespace(message_id=2)]
+    )
+    adapter.truncate_message = lambda *_args, **_kwargs: ["part one", "part two"]
+    buttons = [[
+        {"text": "Relevant", "callback_data": "zbr:relevant"},
+        {"text": "Zu technisch", "callback_data": "zbr:technical"},
+    ]]
+
+    result = await adapter.send(
+        "12345",
+        "Daily Radar",
+        metadata={"inline_keyboard": buttons, "notify": True},
+    )
+
+    assert result.success is True
+    calls = adapter._bot.send_message.await_args_list
+    assert "reply_markup" not in calls[0].kwargs
+    markup = calls[1].kwargs["reply_markup"]
+    assert [[button.callback_data for button in row] for row in markup.inline_keyboard] == [[
+        "zbr:relevant",
+        "zbr:technical",
+    ]]

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -381,6 +381,44 @@ def test_cron_create_success_prints_job_details(monkeypatch, capsys):
     assert "Next run: 2026-06-01T00:00:00Z" in out
 
 
+def test_cron_create_forwards_inline_buttons(monkeypatch):
+    captured = {}
+
+    def _capture(**kwargs):
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "job_id": "job-1",
+            "name": "Daily Radar",
+            "schedule": "every day",
+            "next_run_at": "2026-07-17T18:00:00Z",
+            "job": {},
+        }
+
+    monkeypatch.setattr(cron_cli, "_cron_api", _capture)
+    monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+    args = SimpleNamespace(
+        schedule="0 18 * * 1-5",
+        prompt=None,
+        name="Daily Radar",
+        deliver="telegram",
+        repeat=None,
+        skill=None,
+        skills=None,
+        script="brain-news-publish.py",
+        workdir=None,
+        no_agent=True,
+        buttons=[
+            "Relevant=zbr:relevant",
+            "Zu technisch=zbr:technical",
+            "Bezug fehlt=zbr:missing",
+        ],
+    )
+
+    assert cron_cli.cron_create(args) == 0
+    assert captured["buttons"] == args.buttons
+
+
 def test_cron_create_failure_returns_nonzero(monkeypatch, capsys):
     monkeypatch.setattr(cron_cli, "_cron_api", lambda **kwargs: {"success": False, "error": "boom"})
 

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -50,6 +50,8 @@ def test_cron_create_options():
         "cron", "create", "0 9 * * *", "daily task prompt",
         "--name", "daily", "--deliver", "origin", "--repeat", "3",
         "--skill", "a", "--skill", "b", "--no-agent",
+        "--button", "Relevant=zbr:relevant",
+        "--button", "Zu technisch=zbr:technical",
         "--workdir", "/tmp/x",
     ])
     assert ns.schedule == "0 9 * * *"
@@ -59,6 +61,10 @@ def test_cron_create_options():
     assert ns.repeat == 3
     assert ns.skills == ["a", "b"]
     assert ns.no_agent is True
+    assert ns.buttons == [
+        "Relevant=zbr:relevant",
+        "Zu technisch=zbr:technical",
+    ]
     assert ns.workdir == "/tmp/x"
 
 

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -264,6 +264,30 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_create_persists_validated_inline_buttons(self):
+        from cron.jobs import get_job
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Daily Radar",
+                schedule="every 1h",
+                deliver="telegram",
+                buttons=[
+                    "Relevant=zbr:relevant",
+                    "Zu technisch=zbr:technical",
+                    "Bezug fehlt=zbr:missing",
+                ],
+            )
+        )
+
+        assert created["success"] is True
+        assert get_job(created["job_id"])["inline_keyboard"] == [[
+            {"text": "Relevant", "callback_data": "zbr:relevant"},
+            {"text": "Zu technisch", "callback_data": "zbr:technical"},
+            {"text": "Bezug fehlt", "callback_data": "zbr:missing"},
+        ]]
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tests/tools/test_send_message_telegram_proxy.py
+++ b/tests/tools/test_send_message_telegram_proxy.py
@@ -155,3 +155,38 @@ class TestSendTelegramStandaloneProxy:
         assert "get_updates_request" not in call_kwargs
         httpx_request_factory.assert_not_called()
         bot.send_message.assert_awaited_once()
+
+    def test_inline_keyboard_reaches_standalone_telegram_send(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tools.send_message_tool import _send_telegram
+
+        for var in (
+            "TELEGRAM_PROXY", "HTTPS_PROXY", "https_proxy", "HTTP_PROXY",
+            "http_proxy", "ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(sys, "platform", "linux")
+        bot = _make_bot()
+        _install_telegram_mock_with_request(
+            monkeypatch,
+            MagicMock(return_value=bot),
+            MagicMock(),
+        )
+        markup = object()
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.TelegramAdapter._plugin_callback_keyboard",
+            staticmethod(lambda _rows: markup),
+        )
+
+        result = asyncio.run(
+            _send_telegram(
+                "tok",
+                "123",
+                "Daily Radar",
+                inline_keyboard=[[{"text": "Relevant", "callback_data": "zbr:relevant"}]],
+            )
+        )
+
+        assert result["success"] is True
+        assert bot.send_message.await_args.kwargs["reply_markup"] is markup

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -598,6 +598,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("inline_keyboard"):
+        result["inline_keyboard"] = job["inline_keyboard"]
     return result
 
 
@@ -677,6 +679,7 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    buttons: Optional[List[str]] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -750,6 +753,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                buttons=buttons,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -923,6 +927,10 @@ def cronjob(
                 updates["enabled_toolsets"] = enabled_toolsets or None
             if attach_to_session is not None:
                 updates["attach_to_session"] = bool(attach_to_session)
+            if buttons is not None:
+                from cron.jobs import normalize_inline_buttons
+
+                updates["inline_keyboard"] = normalize_inline_buttons(buttons)
             if workdir is not None:
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -776,7 +776,16 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    inline_keyboard=None,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -856,6 +865,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            inline_keyboard=inline_keyboard,
         )
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
@@ -1113,7 +1123,16 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(
+    token,
+    chat_id,
+    message,
+    media_files=None,
+    thread_id=None,
+    disable_link_previews=False,
+    force_document=False,
+    inline_keyboard=None,
+):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1205,8 +1224,17 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         if disable_link_previews:
             text_kwargs["disable_web_page_preview"] = True
 
+        reply_markup = None
+        if inline_keyboard is not None:
+            from plugins.platforms.telegram.adapter import TelegramAdapter
+
+            reply_markup = TelegramAdapter._plugin_callback_keyboard(inline_keyboard)
+            if reply_markup is None:
+                return {"error": "invalid inline_keyboard metadata"}
+
         last_msg = None
         warnings = []
+        keyboard_sent = False
 
         # MEDIA:<path> caption: when a single captionable file is accompanied
         # by short text, attach the text to the media bubble as its native
@@ -1237,12 +1265,17 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             text_chunks = BasePlatformAdapter.truncate_message(
                 formatted, 4096, len_fn=utf16_len
             )
-            for chunk in text_chunks:
+            for chunk_index, chunk in enumerate(text_chunks):
+                action_kwargs = (
+                    {"reply_markup": reply_markup}
+                    if reply_markup is not None and chunk_index == len(text_chunks) - 1
+                    else {}
+                )
                 try:
                     last_msg = await _send_telegram_message_with_retry(
                         bot,
                         chat_id=int_chat_id, text=chunk,
-                        parse_mode=send_parse_mode, **text_kwargs
+                        parse_mode=send_parse_mode, **text_kwargs, **action_kwargs
                     )
                 except Exception as md_error:
                     # Thread not found — retry without message_thread_id so the
@@ -1257,7 +1290,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         last_msg = await _send_telegram_message_with_retry(
                             bot,
                             chat_id=int_chat_id, text=chunk,
-                            parse_mode=send_parse_mode, **text_kwargs
+                            parse_mode=send_parse_mode, **text_kwargs, **action_kwargs
                         )
                     elif "parse" in str(md_error).lower() or "markdown" in str(md_error).lower() or "html" in str(md_error).lower():
                         logger.warning(
@@ -1276,12 +1309,14 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         last_msg = await _send_telegram_message_with_retry(
                             bot,
                             chat_id=int_chat_id, text=plain,
-                            parse_mode=None, **text_kwargs
+                            parse_mode=None, **text_kwargs, **action_kwargs
                         )
                     else:
                         raise
+                if action_kwargs:
+                    keyboard_sent = True
 
-        for media_path, is_voice in media_files:
+        for media_index, (media_path, is_voice) in enumerate(media_files):
             if not os.path.exists(media_path):
                 warning = f"Media file not found, skipping: {media_path}"
                 logger.warning(warning)
@@ -1314,6 +1349,12 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                     if _tg_caption is not None and not (ext in _VOICE_EXTS and is_voice):
                         media_kwargs["caption"] = _tg_caption
                         media_kwargs["parse_mode"] = send_parse_mode
+                    if (
+                        reply_markup is not None
+                        and not keyboard_sent
+                        and media_index == len(media_files) - 1
+                    ):
+                        media_kwargs["reply_markup"] = reply_markup
                     try:
                         if ext in _IMAGE_EXTS and not force_document:
                             last_msg = await bot.send_photo(


### PR DESCRIPTION
## Summary
- adds a platform_callback plugin hook for authorized Telegram callbacks that are not claimed by built-in handlers
- lets cron jobs attach bounded inline keyboards through repeatable --button options
- carries keyboards through live gateway and standalone Telegram delivery

## Safety
- transport objects stay inside the Telegram adapter; plugins receive normalized scalar context
- existing Telegram callback authorization runs before plugin dispatch
- callback answers and replacement keyboards are strictly bounded
- existing jobs and sends remain byte-compatible when no buttons are configured

## Verification
- 357 focused gateway, cron, CLI, and standalone-send tests pass
- Ruff checks pass for all changed files