### PR TITLE
test(gateway): isolate complete.path tests from real terminal.cwd config

### DIFF
--- a/tests/gateway/test_complete_path_at_filter.py
+++ b/tests/gateway/test_complete_path_at_filter.py
@@ -40,10 +40,20 @@ def _items(word: str):
 
 
 @pytest.fixture(autouse=True)
-def _reset_fuzzy_cache(monkeypatch):
+def _reset_fuzzy_cache(monkeypatch, tmp_path):
     # Each test walks a fresh tmp dir; clear the cached listing so prior
     # roots can't leak through the TTL window.
     server._fuzzy_cache.clear()
+    # Neutralize the launch-profile config source. `_completion_cwd` resolves a
+    # base dir from (among others) `_launch_configured_cwd()`, which reads
+    # `terminal.cwd` from the module's `_hermes_home` config. On a dev box that
+    # key points at $HOME, so it would override the test's `monkeypatch.chdir`
+    # and make completion list the real home dir instead of the tmp fixture.
+    # Point `_hermes_home` at an empty dir (no config.yaml) so the resolver
+    # falls through to the chdir'd cwd, exactly as it does for a plain CLI run.
+    empty_home = tmp_path / "_empty_hermes_home"
+    empty_home.mkdir(exist_ok=True)
+    monkeypatch.setattr(server, "_hermes_home", empty_home)
     yield
     server._fuzzy_cache.clear()
 


### PR DESCRIPTION
## Problem

The tests in `tests/gateway/test_complete_path_at_filter.py` `monkeypatch.chdir(tmp_path)` and assert that `@folder:` / `@file:` / fuzzy completion resolves paths relative to the **current working directory**. They pass in CI (where no `terminal.cwd` is configured) but fail **13 of 15** on any developer machine that has `terminal.cwd` set in `config.yaml`.

Root cause: `_completion_cwd()` resolves its base directory from a priority chain that includes `_launch_configured_cwd()`, which reads `terminal.cwd` from the launch profile's `config.yaml` (via the import-time `_hermes_home` global). That source is **not** isolated by conftest — conftest blanks `TERMINAL_CWD` but not the config-file source — and it **outranks** `os.getcwd()`. So when `terminal.cwd` points at (e.g.) `$HOME`, completion lists the real home directory's contents instead of the test's tmp fixture:

```
AssertionError: assert '@folder:src/' in ['@folder:.claude/', '@folder:.codex/', '@folder:.config/', ...]
```

## Fix

Extend the existing autouse `_reset_fuzzy_cache` fixture to point `server._hermes_home` at an empty per-test directory (no `config.yaml`), so `_launch_configured_cwd()` returns `None` and the resolver falls through to the chdir'd cwd — exactly as it does for a plain CLI run.

This matches the `monkeypatch.setattr(server, "_hermes_home", ...)` isolation pattern already used by sibling tests in `test_tui_gateway_server.py`.

**Test-only change; no production code is touched.**

## Verification

- With fix: `15 passed`
- Without fix (RED proof): `13 failed, 2 passed` — the developer's real `$HOME` dotfolders leak into completion results, confirming the isolation is load-bearing.
