### PR TITLE
fix(desktop): preserve complete project membership 🩷

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5,6 +5,7 @@ import sys
 import threading
 import time
 import types
+from contextlib import nullcontext
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -36,6 +37,40 @@ def _neuter_agent_prewarm_timer(request, monkeypatch):
         return
     monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
     yield
+
+
+def test_project_tree_inputs_query_complete_session_membership_once(monkeypatch):
+    class FakeDB:
+        def __init__(self):
+            self.calls = []
+
+        def list_sessions_rich(self, **kwargs):
+            self.calls.append(kwargs)
+            rows = [
+                {"id": "new-1", "cwd": "/new", "message_count": 1},
+                {"id": "new-2", "cwd": "/new", "message_count": 1},
+                {"id": "old-project", "cwd": "/project", "message_count": 1},
+            ]
+            limit = kwargs["limit"]
+            return rows if limit < 0 else rows[:limit]
+
+    from hermes_cli import projects_db
+
+    db = FakeDB()
+    monkeypatch.setattr(server.git_probe, "warm_roots", lambda _roots: None)
+    monkeypatch.setattr(projects_db, "connect_closing", lambda: nullcontext(object()))
+    monkeypatch.setattr(projects_db, "list_projects", lambda _conn: [])
+    monkeypatch.setattr(projects_db, "get_active_id", lambda _conn: None)
+
+    sessions, _projects, _discovered, _active_id = server._project_tree_inputs(
+        db, session_limit=2, include_discovered=False
+    )
+
+    assert [session["id"] for session in sessions] == ["new-1", "new-2", "old-project"]
+    assert len(db.calls) == 1
+    assert db.calls[0]["limit"] == -1
+    assert db.calls[0]["offset"] == 0
+    assert all(call["compact_rows"] is True for call in db.calls)
 
 
 def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_path):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11698,14 +11698,20 @@ def _project_tree_inputs(
     which already has sessions — avoiding the distinct-cwd scan + git probes on
     that per-turn path. One projects.db connection serves both reads.
     """
+    # Project ownership is computed below from cwd/repo metadata, so truncating
+    # the global recents query first makes an old project's sessions disappear
+    # while the project itself remains visible. Read the complete compact set in
+    # one SQLite statement: unlike offset paging this is one consistent snapshot
+    # even while new messages reorder sessions by effective activity.
     rows = db.list_sessions_rich(
-        limit=session_limit,
+        limit=-1,
         offset=0,
         order_by_last_active=True,
         min_message_count=1,
         include_children=False,
         exclude_sources=_PROJECT_TREE_EXCLUDED_SOURCES,
         include_archived=False,
+        compact_rows=True,
     )
     sessions = [_project_tree_row(r) for r in rows]
     # Parallel-warm the git cache so build_tree's resolver reads it instead of


### PR DESCRIPTION
## Summary
- stop applying a global recent-session cap before project cwd/repo membership is computed
- load the complete eligible compact session set in one SQLite statement, preserving a consistent membership snapshot under concurrent activity
- keep overview payload hydration bounded by `preview_limit` while omitting the unused `system_prompt` blob from project-tree input rows

## Why one query instead of pagination
Offset pagination is not safe here because the sort key includes mutable effective activity. A new message between pages can duplicate one row and skip another. Re-running the recursive compression query per page also trends toward O(n²). `LIMIT -1` gives SQLite one consistent result snapshot without an upper membership cap.

## Tests
- `python -m pytest -q tests/test_tui_gateway_server.py` (324 passed)
- `python -m pytest -q tests/tui_gateway/test_project_tree.py tests/test_state_db_*.py -k "project or session or list_sessions_rich"` (28 passed, 12 deselected)
- `ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `git diff --check`

## Performance check
On a migrated temporary copy of a real `state.db`, the complete compact query returned 146 eligible sessions in 0.0808s. The live database was not modified.

Closes #65004