### PR TITLE
feat(kanban): add opt-in CLI event reporting

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8356,6 +8356,48 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """Print through the active command-safe console."""
         self._output_console().print(*args, **kwargs)
 
+    def _start_kanban_event_bridge(self) -> None:
+        """Start opt-in local Kanban event delivery for this CLI session.
+
+        Normal CLI sessions remain untouched. A caller must explicitly provide
+        ``HERMES_KANBAN_TASKS`` (comma-separated task IDs) or
+        ``HERMES_KANBAN_TASK``. Events are rendered locally; this hook never
+        submits input, resumes work, or mutates Kanban task state.
+        """
+        raw_task_ids = os.environ.get("HERMES_KANBAN_TASKS", "")
+        if not raw_task_ids:
+            raw_task_ids = os.environ.get("HERMES_KANBAN_TASK", "")
+        task_ids = [task_id.strip() for task_id in raw_task_ids.split(",") if task_id.strip()]
+        if not task_ids:
+            return
+
+        try:
+            from hermes_cli.kanban_cli_events import KanbanEventBridge
+
+            bridge = KanbanEventBridge(
+                on_render=self._console_print,
+                is_agent_running=lambda: bool(getattr(self, "_agent_running", False)),
+                board=os.environ.get("HERMES_KANBAN_BOARD") or None,
+                task_ids=set(task_ids),
+            )
+            bridge.deliver_events(bridge.catch_up())
+            bridge.start()
+            self._kanban_event_bridge = bridge
+            atexit.register(self._stop_kanban_event_bridge)
+            logger.debug("opt-in Kanban CLI event bridge started for %s", task_ids)
+        except Exception:
+            logger.debug("failed to start opt-in Kanban CLI event bridge", exc_info=True)
+
+    def _stop_kanban_event_bridge(self) -> None:
+        bridge = getattr(self, "_kanban_event_bridge", None)
+        if bridge is None:
+            return
+        self._kanban_event_bridge = None
+        try:
+            bridge.stop()
+        except Exception:
+            logger.debug("failed to stop Kanban CLI event bridge", exc_info=True)
+
     @staticmethod
     def _resolve_personality_prompt(value) -> str:
         """Accept string or dict personality value; return system prompt string."""
@@ -13433,6 +13475,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._last_turn_interrupted = False
         self._should_exit = False
         self._last_ctrl_c_time = 0  # Track double Ctrl+C for force exit
+        self._start_kanban_event_bridge()
 
         # Give plugin manager a CLI reference so plugins can inject messages
         from hermes_cli.plugins import get_plugin_manager

--- a/hermes_cli/kanban_cli_events.py
+++ b/hermes_cli/kanban_cli_events.py
@@ -148,7 +148,7 @@ class KanbanEventBridge:
                 payload = json.loads(r["payload"]) if r["payload"] else None
             except Exception:
                 payload = None
-            run_id = int(r["run_id"] if r["run_id"] is not None else None)
+            run_id = int(r["run_id"]) if r["run_id"] is not None else None
             events.append(Event(
                 id=r["id"],
                 task_id=r["task_id"],

--- a/hermes_cli/kanban_cli_events.py
+++ b/hermes_cli/kanban_cli_events.py
@@ -59,6 +59,7 @@ class KanbanEventBridge:
     on_queue_nonempty: Optional[Callable[[], None]] = None
     board: Optional[str] = None
     poll_interval: float = DEFAULT_POLL_INTERVAL
+    task_ids: Optional[set[str]] = None
 
     # Internal mutable state
     _cursor: int = field(default=0, repr=False)
@@ -111,7 +112,7 @@ class KanbanEventBridge:
     # ------------------------------------------------------------------
 
     def _query_events(self, after_id: int, limit: int) -> list[Event]:
-        """Query task_events > after_id, limited to NOTABLE_KINDS."""
+        """Query notable task events after a cursor, optionally by task."""
         if not self._db_path or not Path(self._db_path).exists():
             return []
 
@@ -120,12 +121,20 @@ class KanbanEventBridge:
             conn.row_factory = sqlite3.Row
             conn.execute("PRAGMA journal_mode=WAL")
             try:
+                kind_placeholders = ", ".join("?" for _ in NOTABLE_KINDS)
+                params: list[object] = [after_id, *sorted(NOTABLE_KINDS)]
+                task_clause = ""
+                if self.task_ids:
+                    task_placeholders = ", ".join("?" for _ in self.task_ids)
+                    task_clause = f" AND task_id IN ({task_placeholders})"
+                    params.extend(sorted(self.task_ids))
+                params.append(limit)
                 rows = conn.execute(
                     "SELECT id, task_id, kind, payload, created_at, run_id "
                     "FROM task_events "
-                    "WHERE id > ? AND kind IN (?, ?, ?, ?, ?) "
+                    f"WHERE id > ? AND kind IN ({kind_placeholders}){task_clause} "
                     "ORDER BY id ASC LIMIT ?",
-                    (after_id, *NOTABLE_KINDS, limit),
+                    params,
                 ).fetchall()
             finally:
                 conn.close()
@@ -149,6 +158,20 @@ class KanbanEventBridge:
                 run_id=run_id,
             ))
         return events
+
+    def subscribe(self, task_ids: str | list[str] | set[str]) -> None:
+        """Restrict delivery to the supplied task IDs."""
+        if isinstance(task_ids, str):
+            task_ids = [task_ids]
+        self.task_ids = {task_id.strip() for task_id in task_ids if task_id.strip()}
+
+    def unsubscribe(self, task_ids: str | list[str] | set[str]) -> None:
+        """Stop delivering the supplied task IDs."""
+        if isinstance(task_ids, str):
+            task_ids = [task_ids]
+        if self.task_ids is None:
+            return
+        self.task_ids.difference_update(task_ids)
 
     def poll(self) -> list[Event]:
         """Poll for new events since _cursor. Advances and persists cursor."""

--- a/hermes_cli/kanban_cli_events.py
+++ b/hermes_cli/kanban_cli_events.py
@@ -1,0 +1,275 @@
+"""Kanban event bridge for the interactive CLI.
+
+Connects the kanban event stream to the CLI lifecycle:
+- Polls task_events from the kanban DB on a background thread.
+- Renders concise notices while the agent is idle.
+- Queues events while a model turn is active (no fake user messages).
+- Recovers missed events on session resume via persisted cursor.
+- Persists cursor on clean shutdown.
+
+Non-goals: no autonomous continuation, no policy routing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+from hermes_cli.kanban_db import Event, kanban_db_path
+
+_log = logging.getLogger(__name__)
+
+# Event kinds surfaced to the operator.
+NOTABLE_KINDS = frozenset({
+    "completed",
+    "blocked",
+    "failed",
+    "timed_out",
+    "crashed",
+})
+
+DEFAULT_POLL_INTERVAL = 5.0
+MAX_EVENTS_PER_TICK = 10
+MAX_CATCH_UP_EVENTS = 200
+
+
+@dataclass
+class KanbanEventBridge:
+    """Background kanban event watcher for the interactive CLI.
+
+    Args:
+        on_render:          Called with a formatted event line string.
+                            Signature: ``callback(line: str) -> None``.
+        is_agent_running:   Callable returning True while a model turn is active.
+        on_queue_nonempty:  Optional callback when events are queued during an
+                            active turn (so the CLI can show a badge/count).
+        board:              Kanban board slug. None means auto-resolve.
+        poll_interval:      Seconds between DB polls.
+    """
+
+    on_render: Callable[[str], None] = lambda line: print(line, flush=True)
+    is_agent_running: Callable[[], bool] = lambda: False
+    on_queue_nonempty: Optional[Callable[[], None]] = None
+    board: Optional[str] = None
+    poll_interval: float = DEFAULT_POLL_INTERVAL
+
+    # Internal mutable state
+    _cursor: int = field(default=0, repr=False)
+    _queue: list[Event] = field(default_factory=list, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _stop_event: threading.Event = field(default_factory=threading.Event, repr=False)
+    _watcher_thread: Optional[threading.Thread] = field(default=None, repr=False)
+    _db_path: Optional[str] = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        self._db_path = kanban_db_path(self.board)
+        self._cursor = self._load_cursor()
+
+    # ------------------------------------------------------------------
+    # Cursor persistence
+    # ------------------------------------------------------------------
+
+    def _cursor_file(self) -> Path:
+        """Per-board cursor file."""
+        root = self._resolve_root()
+        if self.board:
+            return root / "kanban" / "boards" / self.board / "cli_event_cursor"
+        return root / "kanban" / "cli_event_cursor"
+
+    def _resolve_root(self) -> Path:
+        hermes_home = os.environ.get("HERMES_HOME")
+        if hermes_home:
+            return Path(hermes_home)
+        return Path.home() / ".hermes"
+
+    def _load_cursor(self) -> int:
+        cf = self._cursor_file()
+        try:
+            if cf.exists():
+                return int(cf.read_text().strip())
+        except (ValueError, OSError):
+            pass
+        return 0
+
+    def _save_cursor(self) -> None:
+        cf = self._cursor_file()
+        try:
+            cf.parent.mkdir(parents=True, exist_ok=True)
+            cf.write_text(str(self._cursor))
+        except OSError as exc:
+            _log.debug("failed to persist kanban event cursor: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Event polling
+    # ------------------------------------------------------------------
+
+    def _query_events(self, after_id: int, limit: int) -> list[Event]:
+        """Query task_events > after_id, limited to NOTABLE_KINDS."""
+        if not self._db_path or not Path(self._db_path).exists():
+            return []
+
+        try:
+            conn = sqlite3.connect(self._db_path, timeout=5)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            try:
+                rows = conn.execute(
+                    "SELECT id, task_id, kind, payload, created_at, run_id "
+                    "FROM task_events "
+                    "WHERE id > ? AND kind IN (?, ?, ?, ?, ?) "
+                    "ORDER BY id ASC LIMIT ?",
+                    (after_id, *NOTABLE_KINDS, limit),
+                ).fetchall()
+            finally:
+                conn.close()
+        except Exception as exc:
+            _log.debug("kanban event query failed: %s", exc)
+            return []
+
+        events: list[Event] = []
+        for r in rows:
+            try:
+                payload = json.loads(r["payload"]) if r["payload"] else None
+            except Exception:
+                payload = None
+            run_id = int(r["run_id"] if r["run_id"] is not None else None)
+            events.append(Event(
+                id=r["id"],
+                task_id=r["task_id"],
+                kind=r["kind"],
+                payload=payload,
+                created_at=r["created_at"],
+                run_id=run_id,
+            ))
+        return events
+
+    def poll(self) -> list[Event]:
+        """Poll for new events since _cursor. Advances and persists cursor."""
+        events = self._query_events(self._cursor, MAX_EVENTS_PER_TICK)
+        if events:
+            self._cursor = max(self._cursor, max(e.id for e in events))
+            self._save_cursor()
+        return events
+
+    def catch_up(self) -> list[Event]:
+        """Fetch all missed events since last cursor (session resume)."""
+        events = self._query_events(self._cursor, MAX_CATCH_UP_EVENTS)
+        if events:
+            self._cursor = max(self._cursor, max(e.id for e in events))
+            self._save_cursor()
+        return events
+
+    # ------------------------------------------------------------------
+    # Event formatting
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def format_event(event: Event) -> str:
+        """Format a kanban event as a concise CLI status line."""
+        kind = event.kind
+        task_id = event.task_id
+
+        if kind == "completed":
+            icon, color = "✓", "#8FAF6A"
+            detail = ""
+            if event.payload:
+                s = event.payload.get("summary", "")
+                if s:
+                    detail = f": {s[:60]}"
+        elif kind == "blocked":
+            icon, color = "⛔", "#D4A26A"
+            detail = ""
+            if event.payload:
+                r = event.payload.get("reason", "")
+                if r:
+                    detail = f": {r[:60]}"
+        elif kind in ("failed", "crashed"):
+            icon, color = "✗", "#D46A6A"
+            detail = ""
+            if event.payload:
+                e = event.payload.get("error", "")
+                if e:
+                    detail = f": {e[:60]}"
+        elif kind == "timed_out":
+            icon, color = "⏱", "#D4A26A"
+            detail = ""
+        else:
+            icon, color = "•", "#888888"
+            detail = ""
+
+        return f"[dim {color}][{icon}] {task_id} {kind}{detail}[/]"
+
+    # ------------------------------------------------------------------
+    # Delivery
+    # ------------------------------------------------------------------
+
+    def deliver_events(self, events: list[Event]) -> None:
+        """Render if idle, queue if agent is running."""
+        if not events:
+            return
+
+        with self._lock:
+            if self.is_agent_running():
+                self._queue.extend(events)
+                if self.on_queue_nonempty:
+                    self.on_queue_nonempty()
+            else:
+                for event in events:
+                    self.on_render(self.format_event(event))
+                # Flush previously queued events too
+                if self._queue:
+                    for event in self._queue:
+                        self.on_render(self.format_event(event))
+                    self._queue.clear()
+
+    def drain_queue(self) -> list[Event]:
+        """Return and clear queued events (called after turn ends."""
+        with self._lock:
+            events = list(self._queue)
+            self._queue.clear()
+        return events
+
+    # ------------------------------------------------------------------
+    # Background watcher
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        if self._watcher_thread and self._watcher_thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._watcher_thread = threading.Thread(
+            target=self._watch_loop,
+            name="kanban-event-bridge",
+            daemon=True,
+        )
+        self._watcher_thread.start()
+        _log.debug("kanban event bridge started (poll=%ss)", self.poll_interval)
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._watcher_thread:
+            self._watcher_thread.join(timeout=10)
+        self._save_cursor()
+        _log.debug("kanban event bridge stopped")
+
+    def _watch_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                events = self.poll()
+                if events:
+                    self.deliver_events(events)
+            except Exception as exc:
+                _log.debug("kanban event bridge tick error: %s", exc)
+            deadline = time.monotonic() + self.poll_interval
+            while not self._stop_event.is_set():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._stop_event.wait(min(0.5, remaining))

--- a/hermes_cli/kanban_event_bridge.py
+++ b/hermes_cli/kanban_event_bridge.py
@@ -1,0 +1,362 @@
+"""Local Kanban event bridge for CLI sessions.
+
+Associates a set of task IDs with a local session (the CLI), reads
+``task_events`` incrementally with per-task cursors, persists an
+acknowledgement cursor to disk, and shuts down cleanly.
+
+This is a **read-only** layer on top of the kanban DB.  It does not
+modify task state, create subscriptions in ``kanban_notify_subs``, or
+depend on the gateway.  The cursor file is a small JSON blob that can
+be inspected or edited by hand.
+
+Usage (context manager, auto-shutdown):
+
+    from hermes_cli.kanban_event_bridge import KanbanEventBridge
+
+    with KanbanEventBridge(board="default", task_ids=["t_abc123"]) as bridge:
+        for ev in bridge.poll():
+            print(f"{ev.task_id} {ev.kind}")
+
+Usage (manual):
+
+    bridge = KanbanEventBridge(task_ids=["t_abc123"])
+    try:
+        for ev in bridge.poll():
+            ...
+        bridge.shutdown()
+    finally:
+        bridge.shutdown()
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+from hermes_cli import kanban_db as kb
+
+_log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BridgeEvent:
+    """One kanban event delivered by the bridge.
+
+    Thinner than ``kanban_db.Event``: drops ``payload`` and ``run_id``
+    by default (they are available via ``raw`` if needed).  The bridge
+    layer does not interpret payloads -- that is the consumer's job.
+    """
+    id: int
+    task_id: str
+    kind: str
+    created_at: int
+    # Optional: the raw Event from kanban_db, for consumers that need
+    # payload/run_id without adding them as first-class fields here.
+    raw: Optional[object] = None
+
+
+# ---------------------------------------------------------------------------
+# Cursor persistence
+# ---------------------------------------------------------------------------
+
+
+def _default_cursor_path(board: Optional[str]) -> Path:
+    """Return the default cursor file path for a board.
+
+    Lives next to the kanban DB so it travels with the board:
+    ``<kanban-dir>/kanban-event-bridge-cursors.json``.
+    """
+    import hermes_constants as hc
+
+    root = Path(hc.get_hermes_home())
+    if board and board != kb.DEFAULT_BOARD:
+        board_dir = root / "kanban" / "boards" / board
+    else:
+        board_dir = root  # default board DB is at root
+    return board_dir / "kanban-event-bridge-cursors.json"
+
+
+def _load_cursors(path: Path) -> dict[str, int]:
+    """Load persisted cursors from a JSON file. Returns {} on any error."""
+    try:
+        data = json.loads(path.read_text())
+        if isinstance(data, dict):
+            return {k: int(v) for k, v in data.items()}
+    except (OSError, json.JSONDecodeError, ValueError, TypeError):
+        pass
+    return {}
+
+
+def _save_cursors(path: Path, cursors: dict[str, int]) -> None:
+    """Atomically persist cursors to a JSON file.
+
+    Writes to a temp file then renames, so a crash mid-write does not
+    corrupt the cursor file.
+    """
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    try:
+        tmp.write_text(json.dumps(cursors, sort_keys=True) + "\n")
+        tmp.rename(path)
+    except OSError as exc:
+        _log.warning("kanban event bridge: failed to save cursors to %s: %s", path, exc)
+        # Best-effort cleanup of stale tmp
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Bridge
+# ---------------------------------------------------------------------------
+
+
+class KanbanEventBridge:
+    """Incremental event reader for a local CLI session.
+
+    Subscribes to a set of task IDs on a kanban board, reads new
+    ``task_events`` on each ``poll()`` call, and persists per-task
+    cursors so restarts do not replay old events.
+
+    Thread-safe for the common CLI pattern (single polling thread).
+    Not designed for concurrent pollers on the same cursor file.
+
+    Args:
+        board: Kanban board slug. Defaults to the active board
+            (env / current symlink / ``default``).
+        task_ids: Initial set of task IDs to subscribe to.
+        kinds: If given, only events whose ``kind`` is in this set
+            are returned.  ``None`` means all kinds.
+        cursor_file: Path to the cursor JSON file.  Defaults to a file
+            next to the board's kanban DB.
+        interval: Default poll interval in seconds (used by
+            ``stream()``).  Not used by ``poll()``.
+    """
+
+    def __init__(
+        self,
+        *,
+        board: Optional[str] = None,
+        task_ids: Iterable[str] = (),
+        kinds: Optional[set[str]] = None,
+        cursor_file: Optional[str | Path] = None,
+        interval: float = 1.0,
+    ):
+        self._board = board
+        self._task_ids: set[str] = set(task_ids)
+        self._kinds: Optional[frozenset[str]] = frozenset(kinds) if kinds else None
+        self._cursor_file = Path(cursor_file) if cursor_file else _default_cursor_path(board)
+        self._interval = interval
+        self._cursors: dict[str, int] = _load_cursors(self._cursor_file)
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def board(self) -> Optional[str]:
+        """The board slug, or None for the active board."""
+        return self._board
+
+    @property
+    def task_ids(self) -> frozenset[str]:
+        """Immutable view of subscribed task IDs."""
+        return frozenset(self._task_ids)
+
+    @property
+    def cursors(self) -> dict[str, int]:
+        """Current per-task cursors (id of last seen event)."""
+        return dict(self._cursors)
+
+    def subscribe(self, task_id: str) -> None:
+        """Add a task to the subscription set.
+
+        If the task already has a persisted cursor it is loaded;
+        otherwise the cursor starts at 0 (will begin at the next
+        event created after this call).
+        """
+        if self._closed:
+            raise RuntimeError("bridge is closed")
+        self._task_ids.add(task_id)
+        if task_id not in self._cursors:
+            self._cursors[task_id] = 0
+
+    def unsubscribe(self, task_id: str) -> None:
+        """Remove a task from the subscription set.
+
+        The cursor is preserved in the cursor file so re-subscribing
+        later picks up from where we left off.
+        """
+        self._task_ids.discard(task_id)
+
+    def poll(self, kinds: Optional[set[str]] = None) -> list[BridgeEvent]:
+        """Read new events for all subscribed tasks and advance cursors.
+
+        Returns a list of ``BridgeEvent`` sorted by ``id`` (oldest first).
+        The in-memory cursors are advanced immediately; the cursor file
+        is persisted at the end of ``poll()`` and on ``shutdown()``.
+
+        If ``kinds`` is given, it overrides the instance-level filter
+        for this call only.
+
+        Raises ``RuntimeError`` if the bridge is closed.
+        """
+        if self._closed:
+            raise RuntimeError("bridge is closed")
+        if not self._task_ids:
+            return []
+
+        effective_kinds: Optional[frozenset[str]] = None
+        if kinds is not None:
+            effective_kinds = frozenset(kinds)
+        elif self._kinds is not None:
+            effective_kinds = self._kinds
+
+        conn = kb.connect(board=self._board)
+        try:
+            all_events: list[BridgeEvent] = []
+            for task_id in self._task_ids:
+                cursor = self._cursors.get(task_id, 0)
+                raw_events = self._fetch_events(
+                    conn, task_id=task_id, cursor=cursor, kinds=effective_kinds
+                )
+                if raw_events:
+                    max_id = max(e.id for e in raw_events)
+                    self._cursors[task_id] = max_id
+                    for e in raw_events:
+                        all_events.append(BridgeEvent(
+                            id=e.id,
+                            task_id=e.task_id,
+                            kind=e.kind,
+                            created_at=e.created_at,
+                            raw=e,
+                        ))
+            # Sort by id for deterministic delivery order
+            all_events.sort(key=lambda e: e.id)
+            # Persist cursors after advancing
+            _save_cursors(self._cursor_file, self._cursors)
+            return all_events
+        finally:
+            conn.close()
+
+    def stream(
+        self, kinds: Optional[set[str]] = None
+    ) -> Iterator[BridgeEvent]:
+        """Blocking generator that yields events as they arrive.
+
+        Polls at ``self._interval`` seconds.  Stops when ``shutdown()``
+        is called (either explicitly or via the context manager).
+
+        Can be used as::
+
+            for ev in bridge.stream():
+                handle(ev)
+
+        Or broken out for explicit shutdown::
+
+            it = bridge.stream()
+            try:
+                for ev in it:
+                    handle(ev)
+            finally:
+                bridge.shutdown()
+        """
+        while not self._closed:
+            events = self.poll(kinds=kinds)
+            for ev in events:
+                yield ev
+            if not events:
+                time.sleep(self._interval)
+
+    def shutdown(self) -> None:
+        """Persist cursors and mark the bridge as closed.
+
+        Idempotent -- safe to call multiple times.  After shutdown,
+        ``poll()`` and ``subscribe()`` raise ``RuntimeError``.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        _save_cursors(self._cursor_file, self._cursors)
+        _log.info(
+            "kanban event bridge shutdown: cursors persisted to %s",
+            self._cursor_file,
+        )
+
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "KanbanEventBridge":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.shutdown()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _fetch_events(
+        conn,
+        *,
+        task_id: str,
+        cursor: int,
+        kinds: Optional[frozenset[str]] = None,
+    ) -> list[kb.Event]:
+        """Fetch unseen events for one task from the DB.
+
+        Reads directly from ``task_events`` -- no subscription table
+        needed (this is a local CLI reader, not a gateway notifier).
+        """
+        if kinds:
+            kind_list = list(kinds)
+            placeholders = ",".join("?" * len(kind_list))
+            query = (
+                f"SELECT * FROM task_events "
+                f"WHERE task_id = ? AND id > ? AND kind IN ({placeholders}) "
+                f"ORDER BY id ASC"
+            )
+            params = [task_id, cursor] + kind_list
+        else:
+            query = (
+                "SELECT * FROM task_events "
+                "WHERE task_id = ? AND id > ? "
+                "ORDER BY id ASC"
+            )
+            params = [task_id, cursor]
+
+        rows = conn.execute(query, params).fetchall()
+        out: list[kb.Event] = []
+        for r in rows:
+            try:
+                payload = json.loads(r["payload"]) if r["payload"] else None
+            except Exception:
+                payload = None
+            out.append(kb.Event(
+                id=r["id"],
+                task_id=r["task_id"],
+                kind=r["kind"],
+                payload=payload,
+                created_at=r["created_at"],
+                run_id=(
+                    int(r["run_id"])
+                    if "run_id" in r.keys() and r["run_id"] is not None
+                    else None
+                ),
+            ))
+        return out

--- a/tests/hermes_cli/test_kanban_cli_events.py
+++ b/tests/hermes_cli/test_kanban_cli_events.py
@@ -1,0 +1,96 @@
+"""Tests for the interactive CLI Kanban event watcher."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_cli_events as cli_events
+
+
+@pytest.fixture
+def event_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    db = home / "kanban.db"
+    kb.init_db(db, board="default")
+    monkeypatch.setattr(cli_events, "kanban_db_path", lambda board=None: db)
+    return db
+
+
+def _event(db: Path, task_id: str, kind: str, payload: dict | None = None) -> None:
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) VALUES (?, ?, ?, ?, ?)",
+        (task_id, 1, kind, json.dumps(payload) if payload else None, 1),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_poll_filters_terminal_events_and_persists_cursor(event_db: Path, tmp_path: Path) -> None:
+    _event(event_db, "t_one", "created")
+    _event(event_db, "t_one", "completed", {"summary": "done"})
+    _event(event_db, "t_two", "blocked", {"reason": "needs input"})
+
+    rendered: list[str] = []
+    bridge = cli_events.KanbanEventBridge(on_render=rendered.append, poll_interval=0)
+    events = bridge.poll()
+    bridge.stop()
+
+    assert [event.kind for event in events] == ["completed", "blocked"]
+    assert bridge._cursor == 3
+    cursor = tmp_path / ".hermes" / "kanban" / "cli_event_cursor"
+    assert cursor.read_text() == "3"
+
+
+def test_active_turn_queues_and_idle_delivery_flushes(event_db: Path) -> None:
+    _event(event_db, "t_one", "completed", {"summary": "done"})
+    running = True
+    rendered: list[str] = []
+    bridge = cli_events.KanbanEventBridge(
+        on_render=rendered.append,
+        is_agent_running=lambda: running,
+        poll_interval=0,
+    )
+
+    bridge.deliver_events(bridge.poll())
+    assert rendered == []
+    assert len(bridge.drain_queue()) == 1
+
+    running = False
+    _event(event_db, "t_one", "blocked", {"reason": "review"})
+    bridge.deliver_events(bridge.poll())
+    bridge.stop()
+    assert any("blocked" in line for line in rendered)
+
+
+def test_format_event_is_compact_and_contains_handoff(event_db: Path) -> None:
+    _event(event_db, "t_one", "completed", {"summary": "worker finished"})
+    bridge = cli_events.KanbanEventBridge(poll_interval=0)
+    event = bridge.poll()[0]
+    bridge.stop()
+
+    line = bridge.format_event(event)
+    assert "t_one" in line
+    assert "completed" in line
+    assert "worker finished" in line
+
+
+def test_resume_cursor_skips_acknowledged_events(event_db: Path) -> None:
+    _event(event_db, "t_one", "completed")
+    first = cli_events.KanbanEventBridge(poll_interval=0)
+    assert len(first.poll()) == 1
+    first.stop()
+
+    _event(event_db, "t_one", "blocked")
+    second = cli_events.KanbanEventBridge(poll_interval=0)
+    events = second.catch_up()
+    second.stop()
+    assert [event.kind for event in events] == ["blocked"]

--- a/tests/hermes_cli/test_kanban_event_bridge.py
+++ b/tests/hermes_cli/test_kanban_event_bridge.py
@@ -1,0 +1,376 @@
+"""Tests for hermes_cli.kanban_event_bridge — KanbanEventBridge.
+
+Covers:
+- Event filtering (by task_id, by kind)
+- Cursor persistence (load/save, atomic rename, crash recovery)
+- No duplicate events across poll() calls
+- Clean shutdown (context manager, manual, idempotent)
+- subscribe/unsubscribe
+- Empty task set returns no events
+- Cursor file corruption tolerance
+"""
+
+import json
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Isolate hermes home before importing kanban_db
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def isolated_kanban(tmp_path, monkeypatch):
+    """Set up a fresh kanban DB in a temp dir and return (db_path, cursor_path)."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    kanban_dir = hermes_home / "kanban"
+    kanban_dir.mkdir()
+    db_path = hermes_home / "kanban.db"
+    cursor_path = hermes_home / "kanban-event-bridge-cursors.json"
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    # Prevent profile override from interfering
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+
+    # Initialize the DB
+    kb.init_db(db_path, board="default")
+
+    return db_path, cursor_path
+
+
+@pytest.fixture
+def bridge_module(tmp_path, monkeypatch, isolated_kanban):
+    """Import kanban_event_bridge with HERMES_HOME pointing to tmp_path."""
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+
+    # Force reimport so kanban_db picks up the new HERMES_HOME
+    import importlib
+    import hermes_cli.kanban_event_bridge as keb
+
+    importlib.reload(kb)
+    importlib.reload(keb)
+    return keb
+
+
+def _seed_events(db_path: Path, task_id: str, kinds: list[str]):
+    """Insert synthetic task_events into the kanban DB."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    for i, kind in enumerate(kinds, start=1):
+        conn.execute(
+            "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (task_id, 1, kind, json.dumps({"seq": i}), i * 1000),
+        )
+    conn.commit()
+    conn.close()
+
+
+class TestEventFiltering:
+    """Bridge returns only events for subscribed tasks and requested kinds."""
+
+    def test_poll_returns_events_for_subscribed_task(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        task_id = "t_filter01"
+        _seed_events(db_path, task_id, ["created", "claimed", "completed"])
+
+        bridge = bridge_module.KanbanEventBridge(
+            task_ids=[task_id], cursor_file=str(cursor_path)
+        )
+        try:
+            events = bridge.poll()
+            assert len(events) == 3
+            assert all(e.task_id == task_id for e in events)
+            assert [e.kind for e in events] == ["created", "claimed", "completed"]
+        finally:
+            bridge.shutdown()
+
+    def test_poll_filters_by_kind(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        task_id = "t_filter02"
+        _seed_events(db_path, task_id, ["created", "claimed", "completed"])
+
+        bridge = bridge_module.KanbanEventBridge(
+            task_ids=[task_id],
+            kinds={"completed"},
+            cursor_file=str(cursor_path),
+        )
+        try:
+            events = bridge.poll()
+            assert len(events) == 1
+            assert events[0].kind == "completed"
+        finally:
+            bridge.shutdown()
+
+    def test_poll_kind_override_per_call(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        task_id = "t_filter03"
+        _seed_events(db_path, task_id, ["created", "claimed", "completed"])
+
+        bridge = bridge_module.KanbanEventBridge(
+            task_ids=[task_id], cursor_file=str(cursor_path)
+        )
+        try:
+            # No instance-level filter, but override on this call
+            events = bridge.poll(kinds={"claimed"})
+            assert len(events) == 1
+            assert events[0].kind == "claimed"
+        finally:
+            bridge.shutdown()
+
+    def test_poll_ignores_unsubscribed_tasks(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        _seed_events(db_path, "t_sub", ["created"])
+        _seed_events(db_path, "t_other", ["created", "completed"])
+
+        bridge = bridge_module.KanbanEventBridge(
+            task_ids=["t_sub"], cursor_file=str(cursor_path)
+        )
+        try:
+            events = bridge.poll()
+            assert len(events) == 1
+            assert events[0].task_id == "t_sub"
+        finally:
+            bridge.shutdown()
+
+    def test_poll_empty_task_set_returns_no_events(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        bridge = bridge_module.KanbanEventBridge(cursor_file=str(cursor_path))
+        try:
+            events = bridge.poll()
+            assert events == []
+        finally:
+            bridge.shutdown()
+
+
+class TestCursorPersistence:
+    """Cursors are persisted after poll and survive restarts."""
+
+    def test_no_duplicate_events_after_restart(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        task_id = "t_cursor01"
+        _seed_events(db_path, task_id, ["created", "claimed"])
+
+        # First session: read events
+        bridge = bridge_module.KanbanEventBridge(
+            task_ids=[task_id], cursor_file=str(cursor_path)
+        )
+        events1 = bridge.poll()
+        assert len(events1) == 2
+        bridge.shutdown()
+
+        # Second session: should get nothing (cursor persisted)
+        bridge2 = bridge_module.KanbanEventBridge(
+            task_ids=[task_id], cursor_file=str(cursor_path)
+        )
+        events2 = bridge2.poll()
+        assert len(events2) == 0
+        bridge2.shutdown()
+
+    def test_cursor_file_is_json_and_inspectable(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        task_id = "t_cursor02"
+        _seed_events(db_path, task_id, ["created"])
+
+        bridge = bridge_module.KanbanEventBridge(
+            task_ids=[task_id], cursor_file=str(cursor_path)
+        )
+        bridge.poll()
+        bridge.shutdown()
+
+        # Verify file exists and is valid JSON
+        assert cursor_path.exists()
+        data = json.loads(cursor_path.read_text())
+        assert task_id in data
+        assert isinstance(data[task_id], int)
+        assert data[task_id] > 0
+
+    def test_corrupted_cursor_file_is_tolerated(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        task_id = "t_cursor03"
+        _seed_events(db_path, task_id, ["created"])
+
+        # Write garbage to cursor file
+        cursor_path.write_text("not valid json {{{")
+
+        bridge = bridge_module.KanbanEventBridge(
+            task_ids=[task_id], cursor_file=str(cursor_path)
+        )
+        events = bridge.poll()
+        assert len(events) == 1  # starts from cursor 0, gets all events
+        bridge.shutdown()
+
+    def test_cursor_advanced_after_each_poll(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        task_id = "t_cursor04"
+        _seed_events(db_path, task_id, ["created", "claimed", "completed"])
+
+        bridge = bridge_module.KanbanEventBridge(
+            task_ids=[task_id], cursor_file=str(cursor_path)
+        )
+        try:
+            e1 = bridge.poll()
+            assert len(e1) == 3
+
+            # Seed more events
+            _seed_events(db_path, task_id, ["spawned", "heartbeat"])
+
+            e2 = bridge.poll()
+            assert len(e2) == 2
+            assert e2[0].kind == "spawned"
+        finally:
+            bridge.shutdown()
+
+
+class TestSubscribeUnsubscribe:
+    """Dynamic subscription management."""
+
+    def test_subscribe_adds_task(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        task_id = "t_sub01"
+        _seed_events(db_path, task_id, ["created"])
+
+        bridge = bridge_module.KanbanEventBridge(cursor_file=str(cursor_path))
+        try:
+            bridge.subscribe(task_id)
+            events = bridge.poll()
+            assert len(events) == 1
+            assert events[0].task_id == task_id
+        finally:
+            bridge.shutdown()
+
+    def test_unsubscribe_stops_delivery(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        task_id = "t_sub02"
+        _seed_events(db_path, task_id, ["created"])
+
+        bridge = bridge_module.KanbanEventBridge(
+            task_ids=[task_id], cursor_file=str(cursor_path)
+        )
+        bridge.poll()  # consume initial
+        bridge.unsubscribe(task_id)
+
+        # Seed more events
+        _seed_events(db_path, task_id, ["completed"])
+
+        events = bridge.poll()
+        assert len(events) == 0
+        bridge.shutdown()
+
+
+class TestShutdown:
+    """Clean shutdown behavior."""
+
+    def test_context_manager_shuts_down(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        task_id = "t_shutdown01"
+        _seed_events(db_path, task_id, ["created"])
+
+        with bridge_module.KanbanEventBridge(
+            task_ids=[task_id], cursor_file=str(cursor_path)
+        ) as bridge:
+            events = bridge.poll()
+            assert len(events) == 1
+            assert not bridge._closed
+
+        # After context exit, should be closed
+        assert bridge._closed
+        with pytest.raises(RuntimeError, match="bridge is closed"):
+            bridge.poll()
+
+    def test_shutdown_idempotent(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        bridge = bridge_module.KanbanEventBridge(cursor_file=str(cursor_path))
+        bridge.shutdown()
+        bridge.shutdown()  # should not raise
+        assert bridge._closed
+
+    def test_poll_after_shutdown_raises(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        bridge = bridge_module.KanbanEventBridge(cursor_file=str(cursor_path))
+        bridge.shutdown()
+        with pytest.raises(RuntimeError, match="bridge is closed"):
+            bridge.poll()
+
+    def test_subscribe_after_shutdown_raises(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        bridge = bridge_module.KanbanEventBridge(cursor_file=str(cursor_path))
+        bridge.shutdown()
+        with pytest.raises(RuntimeError, match="bridge is closed"):
+            bridge.subscribe("t_new")
+
+
+class TestBridgeEvent:
+    """BridgeEvent dataclass properties."""
+
+    def test_event_fields(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        task_id = "t_evt01"
+        _seed_events(db_path, task_id, ["completed"])
+
+        bridge = bridge_module.KanbanEventBridge(
+            task_ids=[task_id], cursor_file=str(cursor_path)
+        )
+        events = bridge.poll()
+        ev = events[0]
+
+        assert ev.id > 0
+        assert ev.task_id == task_id
+        assert ev.kind == "completed"
+        assert ev.created_at > 0
+        assert ev.raw is not None
+        # raw is a kanban_db.Event with payload
+        assert ev.raw.payload == {"seq": 1}
+        bridge.shutdown()
+
+
+class TestMultiTask:
+    """Multiple tasks in one bridge, events sorted by id."""
+
+    def test_multiple_tasks_sorted_by_id(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        _seed_events(db_path, "t_multi_a", ["created"])
+        _seed_events(db_path, "t_multi_b", ["created"])
+
+        bridge = bridge_module.KanbanEventBridge(
+            task_ids=["t_multi_a", "t_multi_b"],
+            cursor_file=str(cursor_path),
+        )
+        events = bridge.poll()
+        assert len(events) == 2
+        # Should be sorted by id
+        assert events[0].id < events[1].id
+        bridge.shutdown()
+
+    def test_per_task_cursors_independent(self, bridge_module, isolated_kanban):
+        db_path, cursor_path = isolated_kanban
+        _seed_events(db_path, "t_ind_a", ["created", "claimed"])
+        _seed_events(db_path, "t_ind_b", ["created"])
+
+        bridge = bridge_module.KanbanEventBridge(
+            task_ids=["t_ind_a", "t_ind_b"],
+            cursor_file=str(cursor_path),
+        )
+        events = bridge.poll()
+        assert len(events) == 3
+
+        # Add more to only t_ind_b
+        _seed_events(db_path, "t_ind_b", ["completed"])
+
+        events2 = bridge.poll()
+        assert len(events2) == 1
+        assert events2[0].task_id == "t_ind_b"
+        bridge.shutdown()

--- a/tests/hermes_cli/test_kanban_event_bridge.py
+++ b/tests/hermes_cli/test_kanban_event_bridge.py
@@ -58,9 +58,11 @@ def bridge_module(tmp_path, monkeypatch, isolated_kanban):
 
     # Force reimport so kanban_db picks up the new HERMES_HOME
     import importlib
-    import hermes_cli.kanban_event_bridge as keb
 
+    global kb
+    kb = importlib.import_module("hermes_cli.kanban_db")
     importlib.reload(kb)
+    import hermes_cli.kanban_event_bridge as keb
     importlib.reload(keb)
     return keb
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -19,6 +19,16 @@ The board has two front doors, both backed by the same `~/.hermes/kanban.db`:
 
 Both surfaces route through the same `kanban_db` layer, so reads see a consistent view and writes can't drift. The rest of this page shows CLI examples because they're easy to copy-paste, but every CLI verb has a tool-call equivalent the model uses.
 
+### Opt-in local event delivery in the interactive CLI
+
+An interactive CLI session can display terminal task events without polling the board manually. Set `HERMES_KANBAN_TASKS` to a comma-separated list of task IDs before starting the session (or use `HERMES_KANBAN_TASK` for one task):
+
+```bash
+HERMES_KANBAN_TASKS=t_abc123,t_def456 hermes
+```
+
+The bridge renders `completed`, `blocked`, `failed`, `crashed`, and `timed_out` events locally, persists a cursor for resume, and queues notices while the agent is busy. It is deliberately report-only: it does not submit input, auto-resume work, route tasks, or mutate Kanban state. Normal CLI sessions do not start the bridge unless one of these environment variables is explicitly set.
+
 This is the shape that covers the workloads `delegate_task` can't:
 
 - **Research triage** — parallel researchers + analyst + writer, human-in-the-loop.


### PR DESCRIPTION
## Summary

- add a local event bridge for Kanban task events
- add opt-in, task-scoped CLI delivery for interactive sessions
- queue notices while the agent is busy and resume from a persisted cursor
- keep the default behavior unchanged unless explicitly enabled
- report events only; no automatic input submission, task mutation, routing, or model continuation

## Opt-in contract

```bash
HERMES_KANBAN_TASKS=t_abc123,t_def456 hermes
```

Also supports `HERMES_KANBAN_TASK=t_abc123`.

## Verification

- 22/22 focused event bridge/delivery tests pass with pytest -n auto
- Ruff/diff checks pass
- interactive CLI wiring and documentation included
- later continuation work is intentionally excluded and will be reviewed separately

## Review notes

The implementation is deliberately report-only. It does not synthesize user messages, wake the model, auto-resume tasks, or mutate Kanban state.