### PR TITLE
feat(desktop): add scrollable Markdown table layout

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -15,6 +15,7 @@ import { cn } from '@/lib/utils'
 import { $backdrop, setBackdrop } from '@/store/backdrop'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
+import { $tableLayout, setTableLayout } from '@/store/table-layout'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
@@ -251,6 +252,7 @@ export function AppearanceSettings() {
   const embedAllowed = useStore($embedAllowed)
   const translucency = useStore($translucency)
   const backdrop = useStore($backdrop)
+  const tableLayout = useStore($tableLayout)
   const installs = useStore($marketplaceInstalls)
   const profiles = useStore($profiles)
   const activeProfileKey = normalizeProfileKey(useStore($activeGatewayProfile))
@@ -295,6 +297,11 @@ export function AppearanceSettings() {
   ] as const satisfies readonly { id: EmbedMode; label: string }[]
 
   const uiScaleOptions = UI_SCALE_PRESETS.map(preset => ({ id: preset, label: `${preset}%` }))
+
+  const tableLayoutOptions = [
+    { id: 'fit', label: a.tableLayoutFit },
+    { id: 'scroll', label: a.tableLayoutScroll }
+  ] as const
 
   const matchedScalePreset = matchUiScalePreset(zoomPercent)
 
@@ -426,6 +433,21 @@ export function AppearanceSettings() {
             }
             description={a.uiScaleDesc(zoomPercent)}
             title={a.uiScaleTitle}
+          />
+
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={id => {
+                  triggerHaptic('selection')
+                  setTableLayout(id)
+                }}
+                options={tableLayoutOptions}
+                value={tableLayout}
+              />
+            }
+            description={a.tableLayoutDesc}
+            title={a.tableLayoutTitle}
           />
 
           <ListRow

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -436,6 +436,10 @@ export const en: Translations = {
       uiScaleTitle: 'UI Scale',
       uiScaleDesc: (percent: number) =>
         `Scales text and controls across the whole app. Cmd/Ctrl with +, - and 0 also works. Current: ${percent}%.`,
+      tableLayoutTitle: 'Markdown Tables',
+      tableLayoutDesc: 'Fit wraps tables inside the chat; Scroll preserves useful column widths with horizontal scrolling.',
+      tableLayoutFit: 'Fit',
+      tableLayoutScroll: 'Scroll',
       translucencyTitle: 'Window Translucency',
       translucencyDesc: 'See your desktop through the whole window. macOS and Windows only.',
       backdropTitle: 'Chat Backdrop',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -313,6 +313,10 @@ export const ja = defineLocale({
       uiScaleTitle: 'UI スケール',
       uiScaleDesc: (percent: number) =>
         `アプリ全体の文字と UI を拡大縮小します。Cmd/Ctrl と +、-、0 でも変更できます。現在: ${percent}%`,
+      tableLayoutTitle: 'Markdown テーブル',
+      tableLayoutDesc: '「合わせる」はチャット内で折り返し、「スクロール」は列幅を保って横スクロールできます。',
+      tableLayoutFit: '合わせる',
+      tableLayoutScroll: 'スクロール',
       translucencyTitle: 'ウィンドウの透過',
       translucencyDesc: 'ウィンドウ全体を透過させてデスクトップを表示します。macOS と Windows のみ。',
       backdropTitle: 'チャット背景',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -346,6 +346,10 @@ export interface Translations {
       toolViewDesc: string
       uiScaleTitle: string
       uiScaleDesc: (percent: number) => string
+      tableLayoutTitle: string
+      tableLayoutDesc: string
+      tableLayoutFit: string
+      tableLayoutScroll: string
       translucencyTitle: string
       translucencyDesc: string
       backdropTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -305,6 +305,10 @@ export const zhHant = defineLocale({
       uiScaleTitle: '介面縮放',
       uiScaleDesc: (percent: number) =>
         `縮放整個應用程式的文字與介面。也可使用 Cmd/Ctrl 加 +、- 或 0 調整。目前：${percent}%`,
+      tableLayoutTitle: 'Markdown 表格',
+      tableLayoutDesc: '「符合」會在聊天區域內換行；「捲動」會保留合適的欄寬並支援橫向捲動。',
+      tableLayoutFit: '符合',
+      tableLayoutScroll: '捲動',
       translucencyTitle: '視窗透明',
       translucencyDesc: '讓整個視窗透出桌面。僅支援 macOS 與 Windows。',
       backdropTitle: '聊天背景',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -428,6 +428,10 @@ export const zh: Translations = {
       uiScaleTitle: '界面缩放',
       uiScaleDesc: (percent: number) =>
         `缩放整个应用的文字和界面。也可使用 Cmd/Ctrl 加 +、- 或 0 调整。当前：${percent}%`,
+      tableLayoutTitle: 'Markdown 表格',
+      tableLayoutDesc: '“适应”会在聊天区域内换行；“滚动”会保留合适的列宽并支持横向滚动。',
+      tableLayoutFit: '适应',
+      tableLayoutScroll: '滚动',
       translucencyTitle: '窗口透明',
       translucencyDesc: '让整个窗口透出桌面。仅支持 macOS 和 Windows。',
       backdropTitle: '聊天背景',

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,7 +1,7 @@
 import './styles.css'
-// Side-effect: reports in-flight turns to the main process for the quit guard.
+// Side-effects: apply renderer-owned runtime state before the first app render.
 import './store/active-work'
-// Side-effect: applies the persisted window translucency on load.
+import './store/table-layout'
 import './store/translucency'
 // Dev-only render/state churn counters. MUST precede the `react-dom` import
 // below: react-dom captures the devtools hook at module init, so bippy has to

--- a/apps/desktop/src/store/table-layout.test.ts
+++ b/apps/desktop/src/store/table-layout.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const KEY = 'hermes.desktop.tableLayout.v1'
+
+async function loadStore() {
+  vi.resetModules()
+
+  return import('./table-layout')
+}
+
+describe('Markdown table layout store', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    delete document.documentElement.dataset.hermesTableLayout
+  })
+
+  it('defaults to the current fit behavior', async () => {
+    const { $tableLayout } = await loadStore()
+
+    expect($tableLayout.get()).toBe('fit')
+    expect(document.documentElement.dataset.hermesTableLayout).toBe('fit')
+  })
+
+  it('hydrates and applies the persisted scroll behavior', async () => {
+    window.localStorage.setItem(KEY, 'scroll')
+
+    const { $tableLayout } = await loadStore()
+
+    expect($tableLayout.get()).toBe('scroll')
+    expect(document.documentElement.dataset.hermesTableLayout).toBe('scroll')
+  })
+
+  it('persists layout changes', async () => {
+    const { setTableLayout } = await loadStore()
+
+    setTableLayout('scroll')
+
+    expect(window.localStorage.getItem(KEY)).toBe('scroll')
+    expect(document.documentElement.dataset.hermesTableLayout).toBe('scroll')
+  })
+
+  it('falls back safely when the persisted value is unknown', async () => {
+    window.localStorage.setItem(KEY, 'overflow')
+
+    const { $tableLayout } = await loadStore()
+
+    expect($tableLayout.get()).toBe('fit')
+    expect(document.documentElement.dataset.hermesTableLayout).toBe('fit')
+  })
+})

--- a/apps/desktop/src/store/table-layout.ts
+++ b/apps/desktop/src/store/table-layout.ts
@@ -1,0 +1,24 @@
+import type { Codec } from '@/lib/persisted'
+import { persistentAtom } from '@/lib/persisted'
+
+const KEY = 'hermes.desktop.tableLayout.v1'
+
+export const TABLE_LAYOUTS = ['fit', 'scroll'] as const
+export type TableLayout = (typeof TABLE_LAYOUTS)[number]
+
+const codec: Codec<TableLayout> = {
+  decode: raw => (TABLE_LAYOUTS.includes(raw as TableLayout) ? (raw as TableLayout) : 'fit'),
+  encode: value => value
+}
+
+export const $tableLayout = persistentAtom<TableLayout>(KEY, 'fit', codec)
+
+export function setTableLayout(layout: TableLayout): void {
+  $tableLayout.set(layout)
+}
+
+if (typeof document !== 'undefined') {
+  $tableLayout.subscribe(layout => {
+    document.documentElement.dataset.hermesTableLayout = layout
+  })
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1450,6 +1450,38 @@ text-* variant utilities. */ .btn-arc {
   border-bottom-color: var(--dt-border) !important;
 }
 
+/* Scroll mode keeps the table viewport inside the transcript gutters while
+   allowing the table itself to grow to a useful intrinsic width. */
+:root[data-hermes-table-layout='scroll']
+  [data-slot='aui_assistant-message-content']
+  .aui-md
+  .aui-md-table
+  > table {
+  width: max-content;
+  min-width: 100%;
+}
+
+:root[data-hermes-table-layout='scroll']
+  [data-slot='aui_assistant-message-content']
+  .aui-md
+  .aui-md-table
+  :where(th, td) {
+  min-width: 6rem;
+  max-width: 24rem;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+:root[data-hermes-table-layout='scroll']
+  [data-slot='aui_assistant-message-content']
+  .aui-md
+  .aui-md-table
+  :where(a, code) {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 /* Tool / thinking blocks are scaffolding around the model's reply, so we
    keep them transparent and fade them slightly. The reading column (prose)
    stays at full strength; scaffolding lifts back to full opacity on


### PR DESCRIPTION
## Summary

- adds an Appearance preference for Markdown table layout: **Fit** or **Scroll**
- keeps the current wrapping behavior as the default
- lets wide tables preserve useful column widths and scroll horizontally inside the transcript gutters
- persists the renderer-owned preference per Desktop installation

## Why

Wide comparison tables become difficult to read when every column is compressed into the conversation width. The existing table wrapper already provides the correct transcript-contained overflow viewport; this change adds an opt-in mode that lets the table grow to its intrinsic width without escaping that viewport.

## Validation on current main

- rebased onto `015718066` (2026-07-29)
- `NODE_OPTIONS=--no-experimental-webstorage npm -w apps/desktop run test:ui -- --run src/store/table-layout.test.ts` — 4/4 passed
- `npm -w apps/desktop run typecheck` — passed
- `npm -w apps/desktop run build` — passed
- `git diff --check` — passed
