### PR TITLE
fix(gateway): preserve shared route transport adapter

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -77,12 +77,52 @@ class GatewayAuthorizationMixin:
         """Resolve the live adapter for an inbound ``SessionSource``."""
         if source is None:
             return None
+        transport_adapter = self._registered_transport_adapter(source)
+        if transport_adapter is not None:
+            return transport_adapter
         # ``getattr`` guards test fixtures that build a bare source via
         # SimpleNamespace and omit ``profile`` (see AGENTS.md pitfall #17).
         return self._authorization_adapter(
             getattr(source, "platform", None),
             getattr(source, "profile", None),
         )
+
+    def _registered_transport_adapter(self, source: SessionSource):
+        """Return the registered adapter that created *source*, if retained.
+
+        ``source.profile`` is the runtime/session namespace. A chat-based
+        profile route can therefore differ from the adapter profile when one
+        shared credential serves several routed runtimes. ``build_source``
+        keeps the receiving adapter as in-process provenance so replies and
+        intake-policy checks stay on that transport without weakening the
+        fail-closed fallback for restored or hand-built sources.
+        """
+        adapter_ref = getattr(source, "_transport_adapter_ref", None)
+        adapter = adapter_ref() if callable(adapter_ref) else None
+        platform = getattr(source, "platform", None)
+        if adapter is None or platform is None:
+            return None
+        if adapter is (getattr(self, "adapters", None) or {}).get(platform):
+            return adapter
+        profile_maps = getattr(self, "_profile_adapters", None) or {}
+        for profile_adapters in profile_maps.values():
+            if adapter is profile_adapters.get(platform):
+                return adapter
+        return None
+
+    def _adapter_profile_for_source(self, source: SessionSource) -> Optional[str]:
+        """Resolve the transport-owning profile for adapter policy lookups."""
+        adapter = self._registered_transport_adapter(source)
+        platform = getattr(source, "platform", None)
+        if adapter is not None:
+            if adapter is (getattr(self, "adapters", None) or {}).get(platform):
+                return None
+            for profile, profile_adapters in (
+                getattr(self, "_profile_adapters", None) or {}
+            ).items():
+                if adapter is profile_adapters.get(platform):
+                    return profile
+        return getattr(source, "profile", None)
 
     def _adapter_authorization_is_upstream(
         self,
@@ -296,6 +336,8 @@ class GatewayAuthorizationMixin:
         if source.platform in {Platform.HOMEASSISTANT, Platform.WEBHOOK}:
             return True
 
+        adapter_profile = self._adapter_profile_for_source(source)
+
         # Relay (and any adapter whose authorization is enforced by a trusted
         # authenticated upstream): the Team Gateway connector authenticates this
         # gateway's WS with a per-instance secret and resolves owner-only author
@@ -325,7 +367,7 @@ class GatewayAuthorizationMixin:
         # tests) — defensive against accidental fail-open.
         if source.delivered_via_upstream_relay is True or self._adapter_authorization_is_upstream(
             source.platform,
-            profile=source.profile,
+            profile=adapter_profile,
         ):
             return True
 
@@ -505,23 +547,23 @@ class GatewayAuthorizationMixin:
             # fail-open.)
             if self._adapter_enforces_own_access_policy(
                 source.platform,
-                profile=source.profile,
+                profile=adapter_profile,
             ):
                 if source.chat_type in {"group", "forum", "channel"}:
                     effective_policy = self._adapter_group_policy(
                         source.platform,
-                        profile=source.profile,
+                        profile=adapter_profile,
                     )
                     if self._adapter_group_has_sender_allowlist(
                         source.platform,
                         source.chat_id,
-                        profile=source.profile,
+                        profile=adapter_profile,
                     ):
                         return True
                 else:
                     effective_policy = self._adapter_dm_policy(
                         source.platform,
-                        profile=source.profile,
+                        profile=adapter_profile,
                     )
                 if effective_policy == "allowlist":
                     return True

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import time
 import uuid
+import weakref
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
@@ -5570,7 +5571,7 @@ class BasePlatformAdapter(ABC):
                     self.platform, chat_id, exc_info=True,
                 )
 
-        return SessionSource(
+        source = SessionSource(
             platform=self.platform,
             chat_id=str(chat_id),
             chat_name=chat_name,
@@ -5591,6 +5592,11 @@ class BasePlatformAdapter(ABC):
             auto_thread_created=auto_thread_created,
             auto_thread_initial_name=auto_thread_initial_name,
         )
+        # In-process transport provenance is deliberately not serialized by
+        # SessionSource.to_dict(). The live receiving adapter is authoritative
+        # for this turn even when profile_routes selects a different runtime.
+        source._transport_adapter_ref = weakref.ref(self)
+        return source
     
     @abstractmethod
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:

--- a/tests/gateway/test_multiplex_profile_authz.py
+++ b/tests/gateway/test_multiplex_profile_authz.py
@@ -127,6 +127,32 @@ def test_adapter_for_source_resolves_secondary_profile_adapter(monkeypatch):
     ) is default_adapter
 
 
+def test_chat_routed_source_keeps_receiving_shared_adapter(monkeypatch):
+    """A runtime-only profile route must not discard the shared transport.
+
+    ``source.profile`` selects the routed runtime/session namespace, but the
+    adapter that built the source still owns outbound delivery and intake
+    policy when that profile has no credential of its own.
+    """
+    runner, default_adapter, _secondary_adapter = _make_multiplex_runner(
+        monkeypatch
+    )
+    runner._profile_adapters["routed"] = {}
+
+    source = SessionSource(
+        platform=Platform.WECOM,
+        user_id="allowed-user",
+        chat_id="dm-chat",
+        user_name="allowed-user",
+        chat_type="dm",
+        profile="routed",
+    )
+    assert runner._adapter_for_source(source) is None
+    source._transport_adapter_ref = lambda: default_adapter
+    assert runner._adapter_for_source(source) is default_adapter
+    assert runner._is_user_authorized(source) is True
+
+
 def test_secondary_allowlist_dm_behavior_ignores_unauthorized(monkeypatch):
     """Unauthorized-DM behavior must read the secondary adapter's dm_policy."""
     runner, _default_adapter, secondary_adapter = _make_multiplex_runner(monkeypatch)

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -406,7 +406,8 @@ class TestAdapterToSessionKeyIntegration:
         assert key.startswith("agent:ops:"), key
         assert key != build_session_key(source, profile=None)
 
-    def test_chat_route_keeps_shared_adapter_for_delivery(self):
+    @pytest.mark.asyncio
+    async def test_chat_route_keeps_shared_adapter_for_delivery(self):
         runner = object.__new__(GatewayRunner)
         runner.config = GatewayConfig(
             multiplex_profiles=True,
@@ -414,6 +415,7 @@ class TestAdapterToSessionKeyIntegration:
         )
         runner._profile_adapters = {"ops": {}}
         adapter = _stub_adapter(Platform.TELEGRAM, runner)
+        adapter.send = AsyncMock()
         runner.adapters = {Platform.TELEGRAM: adapter}
 
         source = adapter.build_source(
@@ -422,6 +424,12 @@ class TestAdapterToSessionKeyIntegration:
 
         assert source.profile == "ops"
         assert runner._adapter_for_source(source) is adapter
+        await runner._deliver_platform_notice(source, "routed reply")
+        adapter.send.assert_awaited_once_with(
+            "-1001234567890",
+            "routed reply",
+            metadata=None,
+        )
 
     def test_adapter_without_runner_falls_back_to_default_namespace(self, mock_runner):
         """Regression anchor: with no ``gateway_runner`` injected (the pre-fix

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -9,7 +9,7 @@ import pytest
 from gateway.session import SessionSource, build_session_key
 from gateway.run import GatewayRunner
 from gateway.profile_routing import ProfileRoute
-from gateway.config import Platform
+from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import BasePlatformAdapter
 
 
@@ -400,10 +400,28 @@ class TestAdapterToSessionKeyIntegration:
             chat_id="-1001234567890", chat_type="group", user_id="u1",
         )
         assert source.profile == "ops"
+        assert source._transport_adapter_ref() is adapter
 
         key = build_session_key(source, profile=source.profile)
         assert key.startswith("agent:ops:"), key
         assert key != build_session_key(source, profile=None)
+
+    def test_chat_route_keeps_shared_adapter_for_delivery(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            multiplex_profiles=True,
+            profile_routes=self._routes(),
+        )
+        runner._profile_adapters = {"ops": {}}
+        adapter = _stub_adapter(Platform.TELEGRAM, runner)
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        source = adapter.build_source(
+            chat_id="-1001234567890", chat_type="group", user_id="u1",
+        )
+
+        assert source.profile == "ops"
+        assert runner._adapter_for_source(source) is adapter
 
     def test_adapter_without_runner_falls_back_to_default_namespace(self, mock_runner):
         """Regression anchor: with no ``gateway_runner`` injected (the pre-fix


### PR DESCRIPTION
## Summary

- retain the registered adapter that built an inbound source as weak in-process transport provenance
- use the receiving adapter for outbound delivery and adapter-owned intake policy when `profile_routes` selects a different runtime profile
- preserve the existing fail-closed lookup for restored or hand-built sources without registered transport provenance

## Root Cause

`source.profile` identifies the runtime and session namespace selected by a chat route, but adapter lookup also treated it as the transport owner. A routed profile without its own credential therefore resolved to no adapter even though the shared adapter had received the message.

The fix keeps runtime routing unchanged while binding the live turn to the already-registered receiving adapter. The provenance is a weak reference and is deliberately excluded from `SessionSource` serialization.

## Tests

- `scripts/run_tests.sh tests/gateway/test_multiplex_profile_authz.py tests/gateway/test_profile_resolution.py tests/gateway/test_config_driven_access_policy.py tests/gateway/test_own_policy_startup_gate.py -- -q` (105 passed)
- `python3 -m py_compile gateway/authz_mixin.py gateway/platforms/base.py tests/gateway/test_multiplex_profile_authz.py tests/gateway/test_profile_resolution.py`
- `git diff --check`

Fixes #65236
