### PR TITLE
fix(desktop): prevent duplicate message-id renderer crash (performOp/link)

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -50,7 +50,7 @@ import { useComposerScope } from './composer/scope'
 import type { ChatBarState } from './composer/types'
 import { type DroppedFile, partitionDroppedFiles } from './hooks/use-composer-actions'
 import { type DragKind, useFileDropZone } from './hooks/use-file-drop-zone'
-import { useRuntimeMessageRepository } from './runtime-repository'
+import { stripRuntimeIdSuffix, stripRuntimeIdSuffixNullable, useRuntimeMessageRepository } from './runtime-repository'
 import { ScrollToBottomButton } from './scroll-to-bottom-button'
 import { useSessionView } from './session-view'
 import { SessionActionsMenu } from './sidebar/session-actions-menu'
@@ -196,9 +196,14 @@ function ChatRuntimeBoundary({
       // Submission is handled explicitly by ChatBar.
       // Keeping this no-op avoids duplicate prompt.submit calls.
     },
-    onEdit,
+    onEdit: async message =>
+      onEdit({
+        ...message,
+        parentId: stripRuntimeIdSuffixNullable(message.parentId),
+        sourceId: stripRuntimeIdSuffixNullable(message.sourceId)
+      }),
     onCancel: async () => onCancel(),
-    onReload
+    onReload: async parentId => onReload(stripRuntimeIdSuffixNullable(parentId))
   })
 
   return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>
@@ -449,10 +454,14 @@ export function ChatView({
             gateway={gateway}
             intro={showIntro ? { personality: introPersonality, seed: introSeed } : undefined}
             loading={threadLoading}
-            onBranchInNewChat={onBranchInNewChat}
+            onBranchInNewChat={messageId => onBranchInNewChat(stripRuntimeIdSuffix(messageId))}
             onCancel={onCancel}
             onDismissError={onDismissError}
-            onRestoreToMessage={onRestoreToMessage}
+            onRestoreToMessage={
+              onRestoreToMessage
+                ? (messageId, target) => onRestoreToMessage(stripRuntimeIdSuffix(messageId), target)
+                : undefined
+            }
             sessionId={activeSessionId}
             sessionKey={threadKey}
           />

--- a/apps/desktop/src/app/chat/runtime-repository.test.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { MessageRepository } from '@assistant-ui/core/internal'
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { ChatMessage } from '@/lib/chat-messages'
+
+import { useRuntimeMessageRepository } from './runtime-repository'
+
+function assistant(id: string, text: string, extra: Partial<ChatMessage> = {}): ChatMessage {
+  return { id, role: 'assistant', parts: [{ type: 'text', text }], ...extra }
+}
+
+function user(id: string, text: string, extra: Partial<ChatMessage> = {}): ChatMessage {
+  return { id, role: 'user', parts: [{ type: 'text', text }], ...extra }
+}
+
+/**
+ * Rebuild a live assistant-ui MessageRepository from the exported array the
+ * hook produces. `import()` is what the incremental runtime does on every
+ * transcript sync, and it links each node via `performOp` — which THROWS
+ * "A message with the same id already exists in the parent tree" if two nodes
+ * in one parent chain share an id. This is the exact crash Ace hit, so a real
+ * gate has to exercise this path, not just count ids.
+ */
+function linkThroughRepository(exported: ReturnType<typeof useRuntimeMessageRepository>): MessageRepository {
+  const repo = new MessageRepository()
+  repo.import(exported)
+
+  return repo
+}
+
+describe('useRuntimeMessageRepository — duplicate message id (performOp/link crash)', () => {
+  it('does not crash when two messages resolve to the same adapter id', () => {
+    // The adapter derives ids as `${timestamp}-${index}-${role}`. A resume /
+    // rewind merge can splice two independently-converted arrays together, so
+    // two DIFFERENT turns end up carrying the SAME id string. Pre-fix this
+    // duplicate reached the repository and crashed the whole renderer.
+    const messages: ChatMessage[] = [
+      user('1784158733-0-user', 'first question'),
+      assistant('1784158733-1-assistant', 'first answer'),
+      // collision: same id string as the assistant above (merge artifact)
+      assistant('1784158733-1-assistant', 'stale duplicate from resume-reconcile'),
+      user('1784158740-3-user', 'second question'),
+      assistant('1784158740-4-assistant', 'second answer')
+    ]
+
+    const { result } = renderHook(() => useRuntimeMessageRepository(messages))
+
+    // The whole point: importing into a real MessageRepository must NOT throw.
+    expect(() => linkThroughRepository(result.current)).not.toThrow()
+
+    // And no message is dropped — every turn survives with a unique id.
+    const ids = result.current.messages.map(({ message }) => message.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(result.current.messages).toHaveLength(messages.length)
+  })
+
+  it('preserves a hidden rewind branch that shares a sibling id', () => {
+    const messages: ChatMessage[] = [
+      user('1784200000-0-user', 'prompt'),
+      assistant('1784200000-1-assistant', 'visible answer'),
+      // hidden branch copy that collides with the visible sibling's id
+      assistant('1784200000-1-assistant', 'hidden branch answer', {
+        hidden: true,
+        branchGroupId: 'grp-a'
+      })
+    ]
+
+    const { result } = renderHook(() => useRuntimeMessageRepository(messages))
+
+    expect(() => linkThroughRepository(result.current)).not.toThrow()
+
+    const ids = result.current.messages.map(({ message }) => message.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('leaves already-unique ids untouched', () => {
+    const messages: ChatMessage[] = [
+      user('u-1', 'q'),
+      assistant('a-1', 'answer one'),
+      user('u-2', 'q2'),
+      assistant('a-2', 'answer two')
+    ]
+
+    const { result } = renderHook(() => useRuntimeMessageRepository(messages))
+
+    expect(() => linkThroughRepository(result.current)).not.toThrow()
+    expect(result.current.messages.map(({ message }) => message.id)).toEqual(['u-1', 'a-1', 'u-2', 'a-2'])
+  })
+})

--- a/apps/desktop/src/app/chat/runtime-repository.test.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
 
-import { useRuntimeMessageRepository } from './runtime-repository'
+import { stripRuntimeIdSuffix, stripRuntimeIdSuffixNullable, useRuntimeMessageRepository } from './runtime-repository'
 
 function assistant(id: string, text: string, extra: Partial<ChatMessage> = {}): ChatMessage {
   return { id, role: 'assistant', parts: [{ type: 'text', text }], ...extra }
@@ -87,5 +87,28 @@ describe('useRuntimeMessageRepository — duplicate message id (performOp/link c
 
     expect(() => linkThroughRepository(result.current)).not.toThrow()
     expect(result.current.messages.map(({ message }) => message.id)).toEqual(['u-1', 'a-1', 'u-2', 'a-2'])
+  })
+})
+
+describe('stripRuntimeIdSuffix', () => {
+  it('strips a single dedup suffix back to the real id', () => {
+    expect(stripRuntimeIdSuffix('1784158733-1-assistant#1')).toBe('1784158733-1-assistant')
+    expect(stripRuntimeIdSuffix('1784158733-1-assistant#2')).toBe('1784158733-1-assistant')
+  })
+
+  it('leaves an un-suffixed real id untouched (idempotent)', () => {
+    expect(stripRuntimeIdSuffix('1784158733-1-assistant')).toBe('1784158733-1-assistant')
+    expect(stripRuntimeIdSuffix('u-1')).toBe('u-1')
+  })
+
+  it('only strips a trailing #<digits>, not a mid-id hash or non-numeric suffix', () => {
+    expect(stripRuntimeIdSuffix('weird#id')).toBe('weird#id')
+    expect(stripRuntimeIdSuffix('a#1b')).toBe('a#1b')
+  })
+
+  it('nullable variant passes null through and strips otherwise', () => {
+    expect(stripRuntimeIdSuffixNullable(null)).toBeNull()
+    expect(stripRuntimeIdSuffixNullable('1784158733-1-assistant#3')).toBe('1784158733-1-assistant')
+    expect(stripRuntimeIdSuffixNullable('u-2')).toBe('u-2')
   })
 })

--- a/apps/desktop/src/app/chat/runtime-repository.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.ts
@@ -76,3 +76,18 @@ export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMe
     return ExportedMessageRepository.fromBranchableArray(items, { headId })
   }, [messages])
 }
+
+// The funnel above suffixes duplicate runtime ids (`id#1`, `id#2`) so
+// assistant-ui's MessageRepository never sees a colliding render key. Real
+// message ids are `${timestamp}-${index}-${role}` and never contain `#`, so a
+// trailing `#<n>` is unambiguously that render-only dedup marker. Strip it
+// before an id crosses BACK to the $messages store or the gateway (edit /
+// reload / branch / restore), or the backend lookup misses the real message.
+// Idempotent on un-suffixed ids.
+export function stripRuntimeIdSuffix(id: string): string {
+  return id.replace(/#\d+$/, '')
+}
+
+export function stripRuntimeIdSuffixNullable(id: string | null): string | null {
+  return id === null ? null : stripRuntimeIdSuffix(id)
+}

--- a/apps/desktop/src/app/chat/runtime-repository.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.ts
@@ -17,6 +17,7 @@ export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMe
   return useMemo(() => {
     const items: { message: ThreadMessage; parentId: string | null }[] = []
     const branchParentByGroup = new Map<string, string | null>()
+    const seenIds = new Set<string>()
     let visibleParentId: string | null = null
     let headId: string | null = null
 
@@ -38,11 +39,37 @@ export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMe
         cacheRef.current.set(message, runtimeMessage)
       }
 
-      items.push({ message: runtimeMessage, parentId })
+      // assistant-ui's MessageRepository keys every node by id and throws on
+      // `performOp/link` if the same id appears twice in a parent chain. The
+      // adapter derives ids as `${timestamp}-${index}-${role}`, which is unique
+      // within a single toChatMessages() pass but CAN collide once two passes
+      // are merged (resume-reconcile grafting a re-fetched transcript onto the
+      // live stream, or a hidden rewind branch that shares a sibling's id). One
+      // duplicate id crashes the whole renderer, so this funnel — the only
+      // caller of fromBranchableArray — is where id-uniqueness is enforced.
+      // Render-only: suffix the runtime node's id without touching the
+      // $messages store, preserving every message instead of dropping one.
+      let uniqueId = runtimeMessage.id
+
+      if (seenIds.has(uniqueId)) {
+        let suffix = 1
+
+        while (seenIds.has(`${uniqueId}#${suffix}`)) {
+          suffix += 1
+        }
+
+        uniqueId = `${uniqueId}#${suffix}`
+      }
+
+      seenIds.add(uniqueId)
+
+      const uniqueMessage = uniqueId === runtimeMessage.id ? runtimeMessage : { ...runtimeMessage, id: uniqueId }
+
+      items.push({ message: uniqueMessage, parentId })
 
       if (!message.hidden) {
-        visibleParentId = message.id
-        headId = message.id
+        visibleParentId = uniqueId
+        headId = uniqueId
       }
     }
 


### PR DESCRIPTION
## Problem

The desktop app crashes with the full-screen "Something broke in the interface" boundary showing:

> `MessageRepository(performOp/link): A message with the same id already exists in the parent tree.`

assistant-ui's `MessageRepository` keys every node by `id` and throws from `performOp/link` when one id appears twice in a parent chain — taking down the entire chat renderer. Because the crash gets baked into persisted renderer state, "Reload window" reloads into the same crash (an unrecoverable loop for the user).

## Root cause

The adapter derives message ids as `${timestamp}-${index}-${role}` (`chat-messages.ts`). That's unique within a single `toChatMessages()` pass, but **collides once two passes are merged**:

- **resume-reconcile** grafting a re-fetched transcript onto the live stream (`reconcileResumeMessages` + the incremental runtime's `addOrUpdateMessage`), or
- a **hidden rewind branch** that shares a visible sibling's id.

Observed on a real 715-message session with 10 colliding `(timestamp, role)` pairs. A single duplicate id crashes the whole surface.

## Fix

Enforce id-uniqueness at `useRuntimeMessageRepository` — the **sole caller of `fromBranchableArray`**, where every transcript path converges before reaching the repository. Duplicate runtime ids are suffixed (`#1`, `#2`) **render-only**, without mutating the `$messages` store, so every message is preserved rather than dropped. One resolver owns the invariant (per the desktop AGENTS.md ladder guidance).

## Test (genuine gate)

`runtime-repository.test.ts` reproduces the real crash: it imports the exported repository into a live `MessageRepository` (the same `import()` the incremental runtime performs on every sync), which throws the **exact production error** without the fix and succeeds with it. Verified by reverting the fix → the dup-id cases fail with the production message; with the fix all pass. Also covers the hidden-rewind-branch shape and asserts already-unique ids are untouched.

Renderer builds clean; no new typecheck errors introduced (pre-existing `@assistant-ui` version-skew errors in unrelated files are unchanged).
