### PR TITLE
fix(skills): tolerate UTF-8 BOM in SKILL.md frontmatter across all parsers (salvage #44002)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -114,6 +114,7 @@ def _strip_yaml_frontmatter(content: str) -> str:
     strip it so only the human-readable markdown body is injected into the
     system prompt.
     """
+    content = content.lstrip("\ufeff")  # tolerate UTF-8 BOM (Windows editors)
     if content.startswith("---"):
         end = content.find("\n---", 3)
         if end != -1:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -126,10 +126,22 @@ def parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     Uses yaml with CSafeLoader for full YAML support (nested metadata, lists)
     with a fallback to simple key:value splitting for robustness.
 
+    A single leading UTF-8 BOM (U+FEFF) is stripped before parsing. Windows
+    GUI editors (Notepad, PowerShell ``>``) prepend one when saving a SKILL.md
+    as UTF-8, and ``read_text(encoding="utf-8")`` preserves it (only
+    ``utf-8-sig`` strips it). Left in place, the BOM defeats the ``---`` fence
+    check below and the whole frontmatter is silently discarded — name,
+    description, ``platforms`` gating, env-var setup, and conditional
+    activation all vanish. See CONTRIBUTING.md "File encoding".
+
     Returns:
         (frontmatter_dict, remaining_body)
     """
     frontmatter: Dict[str, Any] = {}
+
+    # Strip only a leading BOM; a BOM mid-content is data, not a marker.
+    if content.startswith("\ufeff"):
+        content = content[1:]
     body = content
 
     if not content.startswith("---"):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2228,6 +2228,7 @@ def _skill_slug_from_frontmatter(skill_md: Path) -> tuple[str | None, str | None
         content = skill_md.read_text(encoding="utf-8", errors="replace")
     except Exception:
         return None, None
+    content = content.lstrip("\ufeff")  # tolerate UTF-8 BOM (Windows editors)
     if not content.startswith("---"):
         return None, None
     end = content.find("\n---", 3)

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1461,6 +1461,7 @@ def do_publish(skill_path: str, target: str = "github", repo: str = "",
     # Validate the skill
     import yaml
     skill_md = (path / "SKILL.md").read_text(encoding="utf-8")
+    skill_md = skill_md.lstrip("\ufeff")  # tolerate UTF-8 BOM (Windows editors)
     fm = {}
     if skill_md.startswith("---"):
         import re

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -474,3 +474,43 @@ class TestParseFrontmatterBOM:
         fm, _ = parse_frontmatter(raw)
         assert fm["name"] == "my-skill"
         assert fm["platforms"] == ["macos"]
+
+
+class TestBOMToleranceSiblingSites:
+    """The BOM fix must cover every independent frontmatter parser, not just
+    the canonical ``parse_frontmatter`` — several modules reimplement the
+    ``---`` fence check locally."""
+
+    SKILL = "---\nname: bom-skill\ndescription: Saved by Notepad\n---\n\n# Body\n"
+
+    def test_skill_manager_validate_accepts_bom(self):
+        from tools.skill_manager_tool import _validate_frontmatter
+
+        assert _validate_frontmatter("\ufeff" + self.SKILL) is None
+
+    def test_prompt_builder_strips_bom_frontmatter(self):
+        # A BOM'd context file (AGENTS.md etc.) must not leak raw
+        # frontmatter into the system prompt.
+        from agent.prompt_builder import _strip_yaml_frontmatter
+
+        out = _strip_yaml_frontmatter("\ufeff---\nfoo: bar\n---\nBody text\n")
+        assert out.strip() == "Body text"
+
+    def test_blueprints_split_frontmatter_bom(self):
+        # str.lstrip() does NOT strip U+FEFF (it is not whitespace), so the
+        # pre-existing lstrip() in _split_frontmatter never covered it.
+        from tools.blueprints import _split_frontmatter
+
+        fm = _split_frontmatter("\ufeff---\nname: bp\n---\nbody")
+        assert fm is not None
+        assert fm.get("name") == "bp"
+
+    def test_skills_hub_parsers_accept_bom(self):
+        from tools.skills_hub import GitHubSource, OptionalSkillSource
+
+        for parser in (
+            GitHubSource._parse_frontmatter_quick,
+            OptionalSkillSource._parse_frontmatter,
+        ):
+            fm = parser("\ufeff" + self.SKILL)
+            assert fm.get("name") == "bom-skill", parser.__qualname__

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from agent.skill_utils import (
+    extract_skill_config_vars,
     extract_skill_conditions,
     get_disabled_skill_names,
     get_external_skills_dirs,
@@ -10,6 +11,7 @@ from agent.skill_utils import (
     is_external_skill_path,
     is_skill_support_path,
     iter_skill_index_files,
+    parse_frontmatter,
     resolve_skill_config_values,
     skill_matches_platform,
     skill_matches_platform_list,
@@ -386,3 +388,89 @@ class TestNormalizeSkillLookupName:
         monkeypatch.setattr("agent.skill_utils.get_skills_dir", lambda: tmp_path / "skills")
         outside = str(tmp_path / "outside" / "skill")
         assert normalize_skill_lookup_name(outside) == outside
+
+
+# ── parse_frontmatter: UTF-8 BOM tolerance ─────────────────────────────────
+
+
+class TestParseFrontmatterBOM:
+    """A UTF-8 BOM (U+FEFF) on a Windows-saved SKILL.md must not defeat
+    frontmatter parsing.
+
+    Notepad and PowerShell ``>`` prepend a BOM when saving UTF-8;
+    ``read_text(encoding="utf-8")`` (what ``_parse_skill_file`` uses) keeps
+    it, so the bytes handed to ``parse_frontmatter`` start with a BOM ahead of
+    the ``---`` fence. Before the fix the ``startswith("---")`` check returned
+    False and the whole frontmatter was silently dropped — the skill loaded
+    nameless, platform gating fell open, and env-var/config setup never fired.
+    """
+
+    SKILL = (
+        "---\n"
+        "name: my-skill\n"
+        "description: Does a thing.\n"
+        "platforms: [macos]\n"
+        "metadata:\n"
+        "  hermes:\n"
+        "    config:\n"
+        "      - key: my.key\n"
+        "        description: A configured value\n"
+        "---\n\n"
+        "# My Skill\n\nBody text.\n"
+    )
+
+    def test_bom_frontmatter_matches_plain(self):
+        plain_fm, plain_body = parse_frontmatter(self.SKILL)
+        bom_fm, bom_body = parse_frontmatter("\ufeff" + self.SKILL)
+        assert bom_fm == plain_fm
+        assert bom_body == plain_body
+        assert bom_fm["name"] == "my-skill"
+        assert bom_fm["description"] == "Does a thing."
+
+    def test_bom_body_has_no_leading_marker(self):
+        _, body = parse_frontmatter("\ufeff" + self.SKILL)
+        assert not body.startswith("\ufeff")
+        assert body.lstrip().startswith("# My Skill")
+
+    def test_bom_without_frontmatter_strips_marker(self):
+        # A BOM'd file with no frontmatter still gets the invisible marker
+        # removed from the body so it never reaches the system prompt.
+        fm, body = parse_frontmatter("\ufeff# Heading\nText.\n")
+        assert fm == {}
+        assert body == "# Heading\nText.\n"
+
+    def test_interior_bom_is_preserved(self):
+        # Only the leading marker is stripped; a U+FEFF in the body is data.
+        fm, body = parse_frontmatter("\ufeff---\nname: x\n---\nbo\ufeffdy\n")
+        assert fm["name"] == "x"
+        assert "\ufeff" in body
+
+    def test_bom_platform_gating_regression(self):
+        # The concrete harm: a macOS-only skill must stay hidden on non-macOS
+        # whether or not the file carries a BOM. Empty frontmatter (the bug)
+        # reads as "no platform restriction" and leaks the skill everywhere.
+        with patch("agent.skill_utils.sys.platform", "win32"), patch(
+            "agent.skill_utils.is_termux", return_value=False
+        ):
+            plain_fm, _ = parse_frontmatter(self.SKILL)
+            bom_fm, _ = parse_frontmatter("\ufeff" + self.SKILL)
+            assert skill_matches_platform(plain_fm) is False
+            assert skill_matches_platform(bom_fm) is False
+
+    def test_bom_config_vars_preserved(self):
+        # metadata.hermes.config drives secure setup-on-load; it must survive
+        # a BOM so Windows users still get prompted for the value.
+        bom_fm, _ = parse_frontmatter("\ufeff" + self.SKILL)
+        assert [v["key"] for v in extract_skill_config_vars(bom_fm)] == ["my.key"]
+
+    def test_real_file_read_path(self, tmp_path):
+        # End-to-end: write the file the way a Windows editor does (utf-8-sig
+        # emits a BOM), read it the way _parse_skill_file does (plain utf-8),
+        # and confirm the frontmatter survives the round trip.
+        f = tmp_path / "SKILL.md"
+        f.write_text(self.SKILL, encoding="utf-8-sig")
+        raw = f.read_text(encoding="utf-8")
+        assert raw.startswith("\ufeff")  # BOM really is present on disk
+        fm, _ = parse_frontmatter(raw)
+        assert fm["name"] == "my-skill"
+        assert fm["platforms"] == ["macos"]

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -94,6 +94,17 @@ class TestParseFrontmatter:
         # Should still parse what it can via fallback
         assert "name" in fm
 
+    def test_utf8_bom_frontmatter(self):
+        """A leading UTF-8 BOM (Windows Notepad / PowerShell ``>`` save) must
+        not drop the frontmatter. Confirms the fix reaches the tools/ surface
+        via the _parse_frontmatter re-export."""
+        bom = chr(0xFEFF)
+        content = bom + "---\nname: test\ndescription: A test.\n---\n\n# Body\n"
+        fm, body = _parse_frontmatter(content)
+        assert fm["name"] == "test"
+        assert fm["description"] == "A test."
+        assert not body.startswith(bom)
+
 
 # ---------------------------------------------------------------------------
 # _parse_tags

--- a/tools/blueprints.py
+++ b/tools/blueprints.py
@@ -73,7 +73,7 @@ def _split_frontmatter(text: str) -> Optional[Dict[str, Any]]:
     """Return the parsed YAML frontmatter mapping, or None if absent/invalid."""
     if not isinstance(text, str):
         return None
-    stripped = text.lstrip()
+    stripped = text.lstrip("\ufeff").lstrip()  # BOM is not whitespace; strip explicitly
     if not stripped.startswith("---"):
         return None
     # Find the closing fence after the opening one.

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -529,6 +529,9 @@ def _validate_frontmatter(content: str) -> Optional[str]:
     if not content.strip():
         return "Content cannot be empty."
 
+    # Tolerate a leading UTF-8 BOM (Windows editors) before the fence.
+    content = content.lstrip("\ufeff")
+
     if not content.startswith("---"):
         return "SKILL.md must start with YAML frontmatter (---). See existing skills for format."
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1165,6 +1165,7 @@ class GitHubSource(SkillSource):
     @staticmethod
     def _parse_frontmatter_quick(content: str) -> dict:
         """Parse YAML frontmatter from SKILL.md content."""
+        content = content.lstrip("\ufeff")  # tolerate UTF-8 BOM (Windows editors)
         if not content.startswith("---"):
             return {}
         match = re.search(r'\n---\s*\n', content[3:])
@@ -3317,6 +3318,7 @@ class OptionalSkillSource(SkillSource):
     @staticmethod
     def _parse_frontmatter(content: str) -> dict:
         """Parse YAML frontmatter from SKILL.md content."""
+        content = content.lstrip("\ufeff")  # tolerate UTF-8 BOM (Windows editors)
         if not content.startswith("---"):
             return {}
         match = re.search(r'\n---\s*\n', content[3:])


### PR DESCRIPTION
## Summary
SKILL.md files saved with a UTF-8 BOM (Windows Notepad, PowerShell `>` redirects) now parse their frontmatter correctly at every parser site. Previously the BOM defeated the `startswith("---")` fence check, silently dropping the skill's name, description, `platforms:` gating, and `metadata.hermes.config` setup — a macOS-only skill leaked onto every platform, and `skill_manage` rejected BOM'd content outright.

**Salvages #44002 by @Que0x** (earliest fix, June 11 — canonical `parse_frontmatter` + thorough tests, cherry-picked with authorship preserved), then widens the fix to the six sibling parsers that reimplement the fence check locally. Same bug class was independently fixed upstream in [cline/cline#12218](https://github.com/cline/cline/pull/12218), which is how the weekly Cline PR scout surfaced it.

## Changes
- `agent/skill_utils.py`: strip a single leading U+FEFF in `parse_frontmatter` (canonical — covers `skills_tool`, `learning_graph`, `skill_commands` delegation; interior BOMs preserved as data) — @Que0x's commit
- `tools/skill_manager_tool.py`: `_validate_frontmatter` accepts BOM instead of rejecting the skill
- `tools/skills_hub.py`: `GitHubSource._parse_frontmatter_quick` + `OptionalSkillSource._parse_frontmatter`
- `hermes_cli/skills_hub.py`: local skill install validation
- `gateway/run.py`: skill slug discovery for disabled/uninstalled-skill hints
- `agent/prompt_builder.py`: `_strip_yaml_frontmatter` — BOM'd context files (AGENTS.md) no longer leak raw frontmatter into the system prompt
- `tools/blueprints.py`: `_split_frontmatter` — note `str.lstrip()` does NOT strip U+FEFF (it is not whitespace)
- Tests: @Que0x's 7 canonical-parser tests (incl. platform-gating regression + utf-8-sig disk roundtrip) + 4 sibling-surface tests

## Validation
| | Before | After |
|---|---|---|
| `parse_frontmatter("\ufeff---\nname: x...")` | `{}` (frontmatter lost) | full frontmatter |
| macOS-only skill with BOM on win32 | gating fell open (visible) | correctly hidden |
| `_validate_frontmatter` on BOM'd content | rejected with fence error | accepted |
| utf-8-sig write → utf-8 read roundtrip | frontmatter lost | parses (E2E) |
| Targeted tests | — | 406/406 across the 5 affected test files |

Merge note: **rebase-merge** (contributor commit from #44002 must keep authorship). Opened autonomously by the weekly Cline PR scout cron job — needs Teknium's review before merge. On merge, #44002 should be closed with credit.
