### PR TITLE
fix: handle Anthropic dash-to-dot version mismatch in openrouter slug (#65152)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2037,6 +2037,15 @@ def _find_openrouter_slug(model_name: str) -> Optional[str]:
             if name_lower == model_part.lower():
                 return mid
 
+    # Anthropic uses dashes in version numbers (claude-opus-4-8) while
+    # OpenRouter uses dots (claude-opus-4.8). Normalize both sides to
+    # dots for a lenient match.
+    for mid in model_ids():
+        if "/" in mid:
+            _, model_part = mid.split("/", 1)
+            if name_lower.replace("-", ".") == model_part.lower().replace("-", "."):
+                return mid
+
     return None
 
 


### PR DESCRIPTION
Added a third matching pass in `_find_openrouter_slug` that normalizes dashes to dots before comparing, so `claude-opus-4-8` resolves to `anthropic/claude-opus-4.8`.\n\nCloses #65152