### PR TITLE
fix(mcp_catalog): add timeout and stdin=DEVNULL to _run_bootstrap subprocess.run

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -380,7 +380,7 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        proc = subprocess.run(cmd, cwd=str(cwd), shell=True, timeout=300, stdin=subprocess.DEVNULL)
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"


### PR DESCRIPTION
## Summary

Add timeout and stdin=DEVNULL to the subprocess.run call in _run_bootstrap that executes MCP server bootstrap commands.

## Problem

The _run_bootstrap function (hermes_cli/mcp_catalog.py:383) runs arbitrary shell commands during MCP server installation with no timeout. If a bootstrap command hangs (e.g., waiting for user input, network stall, or a broken Makefile), it will permanently block the entire CLI process with no way to recover.

Additionally, without stdin=subprocess.DEVNULL, a shell command that attempts to read from stdin could deadlock in non-interactive contexts.

## Fix

Added timeout=300 (5 minutes, generous enough for npm/pip install) and stdin=subprocess.DEVNULL to the subprocess.run call in _run_bootstrap. This matches the pattern already applied to sibling subprocess.run calls in the same module (_do_git_install, line 416+).

## Testing
- Syntax check passed (py_compile)
- Behavior verified (same returncode check logic, just with a safety timeout)