### PR TITLE
fix(cli): honor explicit local working directory

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -594,14 +594,19 @@ def load_cli_config() -> Dict[str, Any]:
     
     # CWD resolution for CLI/TUI. The gateway has its own config bridge in
     # gateway/run.py but may lazily import cli.py (triggering this code).
-    # Local backend: always os.getcwd(). Use `cd /dir && hermes` to control it.
+    # Local backend: respect an explicit terminal.cwd; otherwise default to
+    # the current process directory so `cd /dir && hermes` still works.
     # Non-local with placeholder: pop so terminal_tool uses its per-backend default.
     # Non-local with explicit path: keep as-is.
     _CWD_PLACEHOLDERS = (".", "auto", "cwd")
     effective_backend = terminal_config.get("env_type", "local")
 
     if effective_backend == "local":
-        terminal_config["cwd"] = os.getcwd()
+        configured_cwd = terminal_config.get("cwd")
+        if isinstance(configured_cwd, str) and configured_cwd.strip() and configured_cwd.strip() not in _CWD_PLACEHOLDERS:
+            terminal_config["cwd"] = os.path.expanduser(configured_cwd.strip())
+        else:
+            terminal_config["cwd"] = os.getcwd()
         defaults["terminal"]["cwd"] = terminal_config["cwd"]
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1227,9 +1227,10 @@ def setup_terminal_backend(config: dict):
     if selected_backend == "local":
         print_success("Terminal backend: Local")
         print_info("Commands run directly on this machine.")
-        # Gateway working directory defaults to home; sudo stays off. Both are
-        # configurable later via `hermes setup terminal` / config.yaml.
-        config["terminal"].setdefault("cwd", str(Path.home()))
+        # Local sessions should start from the launch directory unless the
+        # user explicitly chooses a terminal.cwd. Keep the config at the
+        # placeholder so load_cli_config() resolves it at runtime.
+        config["terminal"].setdefault("cwd", ".")
 
     elif selected_backend == "docker":
         print_success("Terminal backend: Docker")

--- a/tests/cli/test_cwd_env_respect.py
+++ b/tests/cli/test_cwd_env_respect.py
@@ -1,10 +1,12 @@
 """Tests for CLI/TUI CWD resolution in load_cli_config().
 
 Rules:
-- Local backend CLI/TUI: always os.getcwd(), ignoring config and inherited env.
+- Local backend CLI/TUI: respect an explicit configured cwd; otherwise use os.getcwd().
 - Non-local with placeholder: pop cwd for backend default.
 - Non-local with explicit path: keep as-is.
 """
+
+import os
 
 
 _CWD_PLACEHOLDERS = (".", "auto", "cwd")
@@ -15,7 +17,11 @@ def _resolve_cwd(terminal_config: dict, defaults: dict, env: dict):
     effective_backend = terminal_config.get("env_type", "local")
 
     if effective_backend == "local":
-        terminal_config["cwd"] = "/fake/getcwd"
+        configured_cwd = terminal_config.get("cwd")
+        if isinstance(configured_cwd, str) and configured_cwd.strip() and configured_cwd.strip() not in _CWD_PLACEHOLDERS:
+            terminal_config["cwd"] = os.path.expanduser(configured_cwd.strip())
+        else:
+            terminal_config["cwd"] = "/fake/getcwd"
         defaults["terminal"]["cwd"] = terminal_config["cwd"]
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)
@@ -32,19 +38,19 @@ def _resolve_cwd(terminal_config: dict, defaults: dict, env: dict):
 
 
 class TestLocalBackendCli:
-    """Local backend always uses os.getcwd()."""
+    """Local backend respects explicit cwd and otherwise uses os.getcwd()."""
 
-    def test_explicit_config_ignored(self):
+    def test_explicit_config_respected(self):
         env = {}
         tc = {"cwd": "/explicit/path", "env_type": "local"}
         d = {"terminal": {"cwd": "/explicit/path"}}
-        assert _resolve_cwd(tc, d, env) == "/fake/getcwd"
+        assert _resolve_cwd(tc, d, env) == "/explicit/path"
 
-    def test_inherited_env_overwritten(self):
+    def test_inherited_env_overwritten_by_explicit_config(self):
         env = {"TERMINAL_CWD": "/parent/hermes"}
         tc = {"cwd": "/home/user", "env_type": "local"}
         d = {"terminal": {"cwd": "/home/user"}}
-        assert _resolve_cwd(tc, d, env) == "/fake/getcwd"
+        assert _resolve_cwd(tc, d, env) == "/home/user"
 
     def test_placeholder_resolved(self):
         env = {}
@@ -91,9 +97,9 @@ class TestGatewayLazyImport:
         result = _resolve_cwd(tc, d, env)
         assert result == "/home/user/project"
 
-    def test_cli_overwrites_stale_env(self):
+    def test_cli_overwrites_stale_env_with_explicit_config(self):
         env = {"TERMINAL_CWD": "/stale/from/dotenv"}
         tc = {"cwd": "/home/user", "env_type": "local"}
         d = {"terminal": {"cwd": "/home/user"}}
         result = _resolve_cwd(tc, d, env)
-        assert result == "/fake/getcwd"
+        assert result == "/home/user"

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -540,3 +540,25 @@ def test_prompt_yes_no_keyboard_interrupt_still_exits(monkeypatch):
     with pytest.raises(SystemExit):
         setup_mod.prompt_yes_no("Install it now?", True)
 
+
+
+
+def test_local_terminal_setup_defaults_to_launch_dir_placeholder(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = load_config()
+    config["terminal"]["backend"] = "docker"
+    config["terminal"].pop("cwd", None)
+
+    def fake_prompt_choice(question, choices, default=0):
+        if question == "Select terminal backend:":
+            return 0
+        raise AssertionError(f"Unexpected prompt_choice call: {question}")
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", fake_prompt_choice)
+
+    from hermes_cli.setup import setup_terminal_backend
+
+    setup_terminal_backend(config)
+
+    assert config["terminal"]["backend"] == "local"
+    assert config["terminal"]["cwd"] == "."


### PR DESCRIPTION
Closes #51636

Summary:
- Respect explicit local terminal.cwd values at CLI startup.
- Keep setup-generated local sessions on the launch-directory placeholder instead of persisting $HOME.
- Add regression tests for the CWD bridge and setup wizard defaults.

Verification:
- /Users/debuggerson/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/cli/test_cwd_env_respect.py tests/cli/test_cli_new_session.py tests/gateway/test_config_cwd_bridge.py tests/hermes_cli/test_setup.py
- git diff --check