### PR TITLE
Fix unsafe use of `vars()` in error handling paths

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2431,8 +2431,12 @@ class AIAgent:
         except Exception:
             pass
         if isinstance(value, SimpleNamespace):
+            try:
+                sn_vars = vars(value)
+            except TypeError:
+                sn_vars = {}
             return cls._hook_jsonable(
-                vars(value),
+                sn_vars,
                 depth=depth + 1,
                 max_depth=max_depth,
                 max_string=max_string,
@@ -2440,9 +2444,14 @@ class AIAgent:
             )
         if hasattr(value, "__dict__"):
             try:
+                try:
+                    # Safe vars() handling - some objects may have __dict__ attribute but vars() fails
+                    dict_items = list(vars(value).items())
+                except TypeError:
+                    dict_items = []
                 public_attrs = {
                     k: v
-                    for k, v in vars(value).items()
+                    for k, v in dict_items
                     if not str(k).startswith("_")
                 }
                 return cls._hook_jsonable(

--- a/tools/feishu_drive_tool.py
+++ b/tools/feishu_drive_tool.py
@@ -81,7 +81,11 @@ def _do_request(client, method, uri, paths=None, queries=None, body=None):
         if isinstance(resp_data, dict):
             data = resp_data
         elif resp_data and hasattr(resp_data, "__dict__"):
-            data = vars(resp_data)
+            try:
+                data = vars(resp_data)
+            except (TypeError, AttributeError):
+                # Some objects have __dict__ attribute but vars() fails
+                data = {}
 
     return code, msg, data
 


### PR DESCRIPTION
**Issue**: Cron jobs and other tasks fail with `TypeError: vars() argument must have __dict__ attribute` when handling certain error response objects.

**Root Cause**: The `hasattr(obj, "__dict__")` check is insufficient because:
1. Some objects may have a `__dict__` attribute that's `None` or a `property`
2. Some objects (like `object()`) have no `__dict__` at all
3. The Python `vars()` function requires the object to have a proper `__dict__` attribute

**Locations fixed**:
1. `agent/conversation_loop.py`: Extended `except TypeError` to also catch `AttributeError`
2. `run_agent.py`: Added `try/except TypeError` around `vars()` calls in `_hook_jsonable()`
3. `tools/feishu_drive_tool.py`: Added `try/except (TypeError, AttributeError)` protection

**Impact**: Prevents cron jobs and other tasks from failing with confusing `vars() argument must have __dict__ attribute` errors when handling malformed API responses or edge-case error objects.

**Testing consideration**: Objects like `object()` or custom classes with `__slots__` will now be handled gracefully instead of crashing the agent.

**Related issue**: This was observed specifically with the `finna_glm` provider when it returns certain error responses, but the fix applies to all providers and error paths.

**Files changed**:
- `agent/conversation_loop.py`
- `run_agent.py`  
- `tools/feishu_drive_tool.py`