### PR TITLE
fix(gemini): emit thoughtSignature sentinel for cross-provider/MoA tool calls (#65092)

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -270,8 +270,12 @@ def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
         }
     }
     thought_signature = _tool_call_extra_signature(tool_call)
-    if thought_signature:
-        part["thoughtSignature"] = thought_signature
+    # Always emit thoughtSignature — Gemini 3 thinking models require it on
+    # every functionCall part.  Use the real signature when available (preserves
+    # the thinking context from the original response) or a standard sentinel
+    # fallback for tool_calls that lack extra_content (e.g. after serialization
+    # in MoA aggregator mode, cross-provider history replay, or session restore).
+    part["thoughtSignature"] = thought_signature or "skip_thought_signature_validator"
     return part
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -52,6 +52,41 @@ def test_build_native_request_preserves_thought_signature_on_tool_replay():
     assert parts[0]["thoughtSignature"] == "sig-123"
 
 
+def test_tool_call_without_thought_signature_emits_sentinel():
+    """Tool calls missing extra_content (MoA aggregator, cross-provider replay,
+    session restore) must still emit thoughtSignature so Gemini 3 thinking
+    models don't reject the request with 400 INVALID_ARGUMENT."""
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[
+            {"role": "system", "content": "Be helpful."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_no_sig",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"command": "ls"}',
+                        },
+                        # No extra_content — simulates serialized tool_call
+                        # from MoA aggregator or cross-provider history.
+                    }
+                ],
+            },
+        ],
+        tools=[],
+        tool_choice=None,
+    )
+
+    parts = request["contents"][0]["parts"]
+    assert parts[0]["functionCall"]["name"] == "terminal"
+    assert parts[0]["thoughtSignature"] == "skip_thought_signature_validator"
+
+
 def test_build_native_request_uses_original_function_name_for_tool_result():
     from agent.gemini_native_adapter import build_gemini_request
 


### PR DESCRIPTION
Fixes #65092

## Summary

Gemini 3 thinking models require `thoughtSignature` on every `functionCall` part in the request. When a tool_call lacks `extra_content` with a valid `thought_signature` — such as after serialization in MoA aggregator mode or cross-provider history replay — the native adapter omitted `thoughtSignature` entirely, causing `400 INVALID_ARGUMENT`.

## Fix

In `_translate_tool_call_to_gemini`, always emit `thoughtSignature` on every translated tool call, using the real signature when available or the standard `"skip_thought_signature_validator"` sentinel as fallback.

This matches the approach Google's own Cloud Code Assist adapter uses for the same scenario.

## Changes

| File | Change |
|------|--------|
| `agent/gemini_native_adapter.py` | Always emit `thoughtSignature` in `_translate_tool_call_to_gemini` — real sig when available, sentinel fallback otherwise |
| `tests/agent/test_gemini_native_adapter.py` | New test: `test_tool_call_without_thought_signature_emits_sentinel` |

## Test plan

- [x] `test_tool_call_without_thought_signature_emits_sentinel` — new test asserting that a tool call with no `extra_content` produces `thoughtSignature: "skip_thought_signature_validator"`
- [x] `test_build_native_request_preserves_thought_signature_on_tool_replay` — existing test still passes, real signatures are preferred
- [x] `pytest tests/agent/test_gemini_native_adapter.py` — 27 passed
