### PR TITLE
fix(kanban): reject event streams for removed boards

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2482,6 +2482,11 @@ async def stream_events(ws: WebSocket):
                 conn.close()
 
         while True:
+            # Guard against a board deleted between handshake and this poll.
+            # connect(board=...) recreates its parent directory and empty DB;
+            # breaking here keeps the stream from resurrecting a removed board.
+            if ws_board and not kanban_db.board_exists(ws_board):
+                break
             cursor, events = await asyncio.to_thread(_fetch_new, cursor)
             if events:
                 await ws.send_json({"events": events, "cursor": cursor})

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2431,6 +2431,20 @@ async def stream_events(ws: WebSocket):
     if not _ws_upgrade_authorized(ws):
         await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
         return
+
+    # Board selection is pinned at the WS handshake; re-subscribe to switch
+    # boards.  Validate before accept: a stale browser may reconnect after its
+    # board was archived, and connect(board=...) would recreate its directory
+    # and empty DB.
+    ws_board_raw = ws.query_params.get("board")
+    try:
+        ws_board = kanban_db._normalize_board_slug(ws_board_raw) if ws_board_raw else None
+    except ValueError:
+        ws_board = None
+    if ws_board and not kanban_db.board_exists(ws_board):
+        await ws.close(code=http_status.WS_1008_POLICY_VIOLATION)
+        return
+
     await ws.accept()
     try:
         since_raw = ws.query_params.get("since", "0")
@@ -2438,16 +2452,6 @@ async def stream_events(ws: WebSocket):
             cursor = int(since_raw)
         except ValueError:
             cursor = 0
-
-        # Board selection — pinned at the WS handshake; re-subscribe to
-        # switch boards. Changing boards mid-stream would require
-        # reconciling two cursors, so the UI just opens a new WS on
-        # board change.
-        ws_board_raw = ws.query_params.get("board")
-        try:
-            ws_board = kanban_db._normalize_board_slug(ws_board_raw) if ws_board_raw else None
-        except ValueError:
-            ws_board = None
 
         def _fetch_new(cursor_val: int) -> tuple[int, list[dict]]:
             conn = kanban_db.connect(board=ws_board)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -909,6 +909,70 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
     assert not kb.board_exists("removed-board")
 
 
+def test_ws_events_poll_loop_does_not_resurrect_deleted_board(tmp_path, monkeypatch):
+    """A board deleted *after* the WS handshake must not be recreated by the
+    poll loop. The pre-accept check covers stale reconnects, but a board
+    removed while a stream is already live still reaches connect(board=...)
+    in _fetch_new, which mkdir(parents=True, exist_ok=True) on the DB dir.
+
+    Regression for the review concern on PR #65295.
+    """
+    import asyncio
+    import plugins.kanban.dashboard.plugin_api as pa
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    # Create a board, then remove it mid-stream.
+    kb.create_board("live-board")
+    # Short-circuit auth.
+    monkeypatch.setattr(pa, "_ws_upgrade_authorized", lambda ws: True)
+
+    class _FakeWS:
+        def __init__(self):
+            self.query_params = {"token": "x", "since": "0", "board": "live-board"}
+            self.accepted = False
+            self.closed = False
+            self.sent: list[dict] = []
+
+        async def accept(self):
+            self.accepted = True
+
+        async def send_json(self, data):
+            self.sent.append(data)
+
+        async def close(self, code=None):
+            self.closed = True
+
+    async def _run():
+        ws = _FakeWS()
+        task = asyncio.create_task(pa.stream_events(ws))
+        # Let the handler accept and complete at least one poll cycle.
+        await asyncio.sleep(0.5)
+        assert ws.accepted is True
+        # Now delete the board while the stream is live.
+        kb.remove_board("live-board")
+        assert not kb.board_exists("live-board")
+        # Give the poll loop one more cycle to detect the deletion.
+        await asyncio.sleep(0.5)
+        # The stream should have exited cleanly (break from while loop),
+        # not crashed and not recreated the board.
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass  # task already exited; cancel on a finished task is benign
+        # The board must NOT have been recreated.
+        assert not kb.board_exists("live-board"), (
+            "poll loop recreated a removed board through connect(board=...)"
+        )
+
+    asyncio.run(_run())
+
+
 def test_ws_events_accepts_gated_ticket(tmp_path, monkeypatch):
     """Gated OAuth mode: the WS must accept a single-use ?ticket= (and reject
     a bare ?token=, even one matching _SESSION_TOKEN). This is the regression

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -894,6 +894,20 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
     ) as ws:
         assert ws is not None  # handshake succeeded
 
+    # A stale browser must not resurrect an archived/removed board merely by
+    # reconnecting its old event-stream URL.  Create/remove a real board first
+    # so this exercises the exact on-disk state produced by `boards rm`.
+    kb.create_board("removed-board")
+    kb.remove_board("removed-board")
+    assert not kb.board_exists("removed-board")
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with c.websocket_connect(
+            "/api/plugins/kanban/events?token=secret-xyz&board=removed-board"
+        ):
+            pass
+    assert exc.value.code == 1008
+    assert not kb.board_exists("removed-board")
+
 
 def test_ws_events_accepts_gated_ticket(tmp_path, monkeypatch):
     """Gated OAuth mode: the WS must accept a single-use ?ticket= (and reject


### PR DESCRIPTION
## Summary
- Reject a Kanban event-stream WebSocket when its requested board no longer exists.
- Validate the board before accepting the WebSocket upgrade, so a stale browser reconnect cannot call `connect(board=...)` and recreate an archived board as an empty database.
- Add a regression test covering create → remove → stale WebSocket reconnect, asserting policy rejection and no board resurrection.

## Reproduction
1. Open the Kanban dashboard for a non-default board.
2. Archive/delete that board from another client or CLI.
3. Let the stale dashboard WebSocket reconnect using `?board=<removed-slug>`.
4. Before this fix, the event stream initializes a new empty database for the removed board.

## Test plan
- `scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py -q` (111 passed)
- `python -m py_compile plugins/kanban/dashboard/plugin_api.py`
