### PR TITLE
fix(photon): hide Windows console popups for sidecar subprocesses

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -63,6 +63,8 @@ from gateway.platforms.base import (
 )
 from gateway.platforms.helpers import strip_markdown
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 from .auth import load_project_credentials
 
 logger = logging.getLogger(__name__)
@@ -182,6 +184,7 @@ def _reinstall_sidecar_deps() -> None:
             text=True,
             check=False,
             timeout=_NPM_REINSTALL_TIMEOUT,
+            creationflags=windows_hide_flags(),
         )
         if result.returncode != 0:
             logger.warning(
@@ -194,6 +197,7 @@ def _reinstall_sidecar_deps() -> None:
                 text=True,
                 check=False,
                 timeout=_NPM_REINSTALL_TIMEOUT,
+                creationflags=windows_hide_flags(),
             )
     except subprocess.TimeoutExpired:
         # A wedged npm (dead registry, network blackhole) must not stall the
@@ -955,6 +959,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 text=True,
                 timeout=10,
                 check=False,
+                creationflags=windows_hide_flags(),
             )
             if patch.returncode != 0:
                 raise RuntimeError((patch.stderr or patch.stdout or "").strip())
@@ -972,6 +977,7 @@ class PhotonAdapter(BasePlatformAdapter):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=env,
+            creationflags=windows_hide_flags(),
             start_new_session=(sys.platform != "win32"),
         )
 

--- a/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
+++ b/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
@@ -169,3 +169,36 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
     kwargs = spawned["kwargs"]
     assert kwargs["stdin"] is subprocess.PIPE
     assert kwargs["env"]["PHOTON_SIDECAR_WATCH_STDIN"] == "1"
+
+    # Windows console flash prevention — must use the shared hide-flags helper.
+    # Without this, every Photon reconnect pops a black conhost/node window.
+    from hermes_cli._subprocess_compat import windows_hide_flags
+
+    assert kwargs.get("creationflags") == windows_hide_flags()
+
+
+def test_reinstall_sidecar_deps_hides_console_windows(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """npm ci / npm install self-heal must not flash a console on Windows."""
+    from hermes_cli._subprocess_compat import windows_hide_flags
+
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", tmp_path)
+    monkeypatch.setattr(photon_adapter.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    captured: List[Tuple[List[str], Dict[str, Any]]] = []
+
+    class _Ok:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _fake_run(cmd: List[str], **kwargs: Any) -> _Ok:
+        captured.append((cmd, kwargs))
+        return _Ok()
+
+    monkeypatch.setattr(photon_adapter.subprocess, "run", _fake_run)
+    photon_adapter._reinstall_sidecar_deps()
+
+    assert captured, "expected npm ci to be invoked"
+    for cmd, kwargs in captured:
+        assert kwargs.get("creationflags") == windows_hide_flags(), (cmd, kwargs)


### PR DESCRIPTION
## Summary
- Photon sidecar/npm subprocesses on Windows were spawning visible black console windows on every connect, reconnect, and stale-deps self-heal after `hermes update`.
- Pass `creationflags=windows_hide_flags()` on the four spawn sites (`npm ci`, `npm install`, mixed-attachment patch, `index.mjs` Popen), matching WhatsApp/Discord adapters and `hermes_cli._subprocess_compat`.
- Add regression coverage so a future regression fails tests instead of forcing Windows users to re-apply a local patch after every update.

## Why
Without `CREATE_NO_WINDOW`, Windows allocates a console for each Node/npm child. Photon reconnects often (and after updates can reinstall sidecar deps), so users get repeated black popups that interrupt work. Local re-patching after every `hermes update` is not a durable fix.

## Test plan
- [x] `pytest tests/plugins/platforms/photon/test_sidecar_lifecycle.py::test_start_sidecar_spawns_with_stdin_pipe`
- [x] `pytest tests/plugins/platforms/photon/test_sidecar_lifecycle.py::test_reinstall_sidecar_deps_hides_console_windows`
- [ ] On Windows with Photon enabled: restart gateway, confirm no black console flash on sidecar start
- [ ] Force stale sidecar deps path (or reconnect after update) and confirm npm self-heal does not flash a console