### PR TITLE
fix: make Hermes launcher survive home directory changes

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1624,6 +1624,7 @@ setup_path() {
 
     local command_link_dir
     local command_link_display_dir
+    local exec_target
     command_link_dir="$(get_command_link_dir)"
     command_link_display_dir="$(get_command_link_display_dir)"
 
@@ -1631,6 +1632,23 @@ setup_path() {
     # We intentionally clear PYTHONPATH/PYTHONHOME here so inherited env vars
     # can't make this launcher import modules from another checkout.
     mkdir -p "$command_link_dir"
+    # Pick the shim's exec target. When $HERMES_BIN lives under the installing
+    # user's home, emit a $HOME-relative path that the shim expands at *launch*
+    # time instead of the absolute path resolved here at install time: a
+    # username change, profile restore, or move to a new machine relocates the
+    # install, and an install-time absolute path would leave `hermes` pointing
+    # at a home that no longer exists.
+    #
+    # Installs that do NOT live under $HOME keep the absolute resolved path,
+    # preserving every other supported layout: an explicit --dir /
+    # $HERMES_INSTALL_DIR, the root FHS layout under /usr/local/lib, and
+    # USE_VENV=false installs whose $HERMES_BIN came from PATH.
+    exec_target="$HERMES_BIN"
+    if [ -n "${HOME:-}" ]; then
+        case "$HERMES_BIN" in
+            "${HOME%/}"/*) exec_target="\$HOME/${HERMES_BIN#"${HOME%/}"/}" ;;
+        esac
+    fi
     # Older installs created this path as a symlink to $HERMES_BIN. Without
     # the rm, `cat >` follows the symlink and overwrites the venv pip entry
     # point with this shim — making `exec "$HERMES_BIN"` self-recurse. (#21454)
@@ -1639,7 +1657,7 @@ setup_path() {
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
-exec "$HERMES_BIN" "\$@"
+exec "$exec_target" "\$@"
 EOF
     chmod +x "$command_link_dir/hermes"
     log_success "Installed hermes launcher → $command_link_display_dir/hermes"

--- a/tests/test_install_sh_launcher_home_migration.py
+++ b/tests/test_install_sh_launcher_home_migration.py
@@ -1,0 +1,148 @@
+"""Behavioral tests for the install.sh launcher surviving a home directory change.
+
+``setup_path()`` resolves ``$HERMES_BIN`` at install time. Baking that absolute
+path into the shim breaks ``hermes`` outright when the user's home later moves —
+a username change, a profile restored onto a new machine, or a migration — because
+the shim keeps exec'ing a home that no longer exists.
+
+The fix emits a ``$HOME``-relative exec target *only* for installs that live under
+the installing user's home, so the path is expanded at launch time. Installs
+outside ``$HOME`` (explicit ``--dir``/``$HERMES_INSTALL_DIR``, the root FHS layout
+under ``/usr/local/lib``, and ``USE_VENV=false`` PATH installs) must keep their
+absolute resolved path.
+
+These tests execute the generated launcher rather than inspecting install.sh's
+source text — see AGENTS.md "Never read source code in tests".
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+FAKE_BIN_BODY = """#!/usr/bin/env bash
+echo "HERMES_LAUNCHED args=$*"
+"""
+
+
+def _extract_setup_path_shim_block() -> str:
+    """Return the install.sh shim-write block used by setup_path()."""
+    text = INSTALL_SH.read_text()
+    match = re.search(
+        r"(?P<block>mkdir -p \"\$command_link_dir\".*?chmod \+x \"\$command_link_dir/hermes\")",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, (
+        "Could not locate the setup_path shim-write block in scripts/install.sh"
+    )
+    return match["block"]
+
+
+def _write_fake_hermes(path: Path) -> None:
+    """Create an executable stand-in for the pip-generated venv entry point."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(FAKE_BIN_BODY)
+    path.chmod(0o755)
+
+
+def _run_shim_block(*, home: Path, hermes_bin: Path, command_link_dir: Path) -> None:
+    """Drive the real setup_path() shim-write block with a controlled env."""
+    block = _extract_setup_path_shim_block()
+    script = (
+        "set -e\n"
+        f"HOME={home!s}\n"
+        f"HERMES_BIN={hermes_bin!s}\n"
+        f"command_link_dir={command_link_dir!s}\n"
+        f"{block}\n"
+    )
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True
+    )
+    assert result.returncode == 0, (
+        f"shim-write block failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+
+def _run_shim(shim: Path, home: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Execute the generated launcher under the given HOME."""
+    return subprocess.run(
+        [str(shim), *args],
+        capture_output=True,
+        text=True,
+        env={"HOME": str(home), "PATH": "/usr/bin:/bin"},
+    )
+
+
+def test_launcher_still_runs_after_the_home_directory_moves(tmp_path: Path) -> None:
+    """The regression: install under one home, then relocate it and launch.
+
+    Mirrors a username change / profile restore — the whole home directory is
+    installed at one path and later exists at another. The launcher must still
+    exec the interpreter inside the *current* home.
+    """
+    old_home = tmp_path / "homes" / "alice"
+    hermes_bin = old_home / ".hermes" / "hermes-agent" / "venv" / "bin" / "hermes"
+    command_link_dir = old_home / ".local" / "bin"
+    _write_fake_hermes(hermes_bin)
+
+    _run_shim_block(home=old_home, hermes_bin=hermes_bin, command_link_dir=command_link_dir)
+
+    # Sanity: the launcher works in its original home.
+    shim = command_link_dir / "hermes"
+    before = _run_shim(shim, old_home)
+    assert before.returncode == 0, f"launcher broken pre-move: {before.stderr}"
+    assert "HERMES_LAUNCHED" in before.stdout
+
+    # The home directory moves (new username / restored profile / new machine).
+    new_home = tmp_path / "homes" / "bob"
+    old_home.rename(new_home)
+
+    after = _run_shim(new_home / ".local" / "bin" / "hermes", new_home, "--version")
+    assert after.returncode == 0, (
+        "launcher must survive the home directory moving, but it failed:\n"
+        f"stdout={after.stdout}\nstderr={after.stderr}"
+    )
+    assert "HERMES_LAUNCHED" in after.stdout
+    assert "args=--version" in after.stdout, "launcher must forward args untouched"
+
+
+def test_launcher_preserves_absolute_path_for_installs_outside_home(tmp_path: Path) -> None:
+    """Non-default layouts must keep the install-time resolved path.
+
+    Covers explicit --dir/$HERMES_INSTALL_DIR, the root FHS layout
+    (/usr/local/lib/hermes-agent), and USE_VENV=false PATH installs: none of
+    those live under $HOME, so rewriting them to a $HOME-relative path would
+    point the launcher at a nonexistent executable.
+    """
+    home = tmp_path / "homes" / "alice"
+    home.mkdir(parents=True)
+    # Stands in for /usr/local/lib/hermes-agent — deliberately outside $HOME.
+    hermes_bin = tmp_path / "opt" / "hermes-agent" / "venv" / "bin" / "hermes"
+    command_link_dir = tmp_path / "usr_local_bin"
+    _write_fake_hermes(hermes_bin)
+
+    _run_shim_block(home=home, hermes_bin=hermes_bin, command_link_dir=command_link_dir)
+
+    shim = command_link_dir / "hermes"
+    assert str(hermes_bin) in shim.read_text(), (
+        "an install outside $HOME must keep its absolute resolved path in the shim"
+    )
+
+    result = _run_shim(shim, home)
+    assert result.returncode == 0, f"launcher broken: {result.stderr}"
+    assert "HERMES_LAUNCHED" in result.stdout
+
+    # A home change must not disturb an install that never lived under home.
+    other_home = tmp_path / "homes" / "carol"
+    other_home.mkdir(parents=True)
+    moved = _run_shim(shim, other_home)
+    assert moved.returncode == 0, (
+        f"launcher outside $HOME must be unaffected by HOME changing: {moved.stderr}"
+    )
+    assert "HERMES_LAUNCHED" in moved.stdout

--- a/tests/test_install_sh_pythonpath_sanitization.py
+++ b/tests/test_install_sh_pythonpath_sanitization.py
@@ -5,6 +5,10 @@ PYTHONPATH/PYTHONHOME can shadow the freshly installed checkout. The installer
 must sanitize those vars both during installation and at runtime launch.
 """
 
+from __future__ import annotations
+
+import re
+import subprocess
 from pathlib import Path
 
 
@@ -20,11 +24,64 @@ def test_install_script_unsets_pythonpath_and_pythonhome_early() -> None:
     assert 'unset PYTHONHOME' in text
 
 
-def test_hermes_launcher_wrapper_clears_python_env_before_exec() -> None:
-    text = INSTALL_SH.read_text()
+def test_hermes_launcher_wrapper_clears_python_env_before_exec(tmp_path: Path) -> None:
+    """Behavioral: run the generated launcher with a poisoned Python env.
 
-    # Wrapper should clear env and forward args untouched to the venv entrypoint.
-    assert 'cat > "$command_link_dir/hermes" <<EOF' in text
-    assert 'unset PYTHONPATH' in text
-    assert 'unset PYTHONHOME' in text
-    assert 'exec "$HERMES_BIN" "\\$@"' in text
+    The shim must clear PYTHONPATH/PYTHONHOME before exec'ing the entry point,
+    and forward its arguments untouched.
+    """
+    text = INSTALL_SH.read_text()
+    match = re.search(
+        r"(?P<block>mkdir -p \"\$command_link_dir\".*?chmod \+x \"\$command_link_dir/hermes\")",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, (
+        "Could not locate the setup_path shim-write block in scripts/install.sh"
+    )
+
+    home = tmp_path / "home"
+    hermes_bin = home / ".hermes" / "hermes-agent" / "venv" / "bin" / "hermes"
+    hermes_bin.parent.mkdir(parents=True)
+    # Stand-in entry point that reports the Python env it was exec'd with.
+    hermes_bin.write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "PYTHONPATH=[${PYTHONPATH-<unset>}]"\n'
+        'echo "PYTHONHOME=[${PYTHONHOME-<unset>}]"\n'
+        'echo "args=$*"\n'
+    )
+    hermes_bin.chmod(0o755)
+
+    command_link_dir = home / ".local" / "bin"
+    script = (
+        "set -e\n"
+        f"HOME={home!s}\n"
+        f"HERMES_BIN={hermes_bin!s}\n"
+        f"command_link_dir={command_link_dir!s}\n"
+        f"{match['block']}\n"
+    )
+    written = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert written.returncode == 0, (
+        f"shim-write block failed:\nstdout={written.stdout}\nstderr={written.stderr}"
+    )
+
+    result = subprocess.run(
+        [str(command_link_dir / "hermes"), "chat"],
+        capture_output=True,
+        text=True,
+        env={
+            "HOME": str(home),
+            "PATH": "/usr/bin:/bin",
+            # Poison the env the way a parent Python tool session would.
+            "PYTHONPATH": "/some/other/checkout",
+            "PYTHONHOME": "/some/other/python",
+        },
+    )
+    assert result.returncode == 0, f"launcher failed: {result.stderr}"
+    assert "PYTHONPATH=[<unset>]" in result.stdout, (
+        "launcher must unset an inherited PYTHONPATH before exec"
+    )
+    assert "PYTHONHOME=[<unset>]" in result.stdout, (
+        "launcher must unset an inherited PYTHONHOME before exec"
+    )
+    assert "args=chat" in result.stdout, "launcher must forward args untouched"

--- a/tests/test_install_sh_symlink_stomp.py
+++ b/tests/test_install_sh_symlink_stomp.py
@@ -89,8 +89,16 @@ def test_re_running_setup_path_block_preserves_pip_entry_point(tmp_path: Path) -
     assert shim_path.is_symlink()
 
     block = _extract_setup_path_shim_block()
-    # Drive the block with the real env vars setup_path() sets.
-    script = f'set -e\nHERMES_BIN={pip_entry!s}\ncommand_link_dir={command_link_dir!s}\n{block}\n'
+    # Drive the block with the real env vars setup_path() sets. HOME is pinned
+    # away from the fixture so this install reads as an out-of-home layout and
+    # the shim keeps the absolute $HERMES_BIN — see
+    # test_install_sh_launcher_home_migration.py for the in-home case.
+    fake_home = tmp_path / "nothome"
+    fake_home.mkdir()
+    script = (
+        f'set -e\nHOME={fake_home!s}\nHERMES_BIN={pip_entry!s}\n'
+        f'command_link_dir={command_link_dir!s}\n{block}\n'
+    )
     result = subprocess.run(
         ["bash", "-c", script],
         capture_output=True,


### PR DESCRIPTION
This fixes Hermes launcher behavior for users who change usernames, restore a profile onto a new machine, or otherwise end up with a different home directory than the one used at install time.

Today the installer-generated launcher can keep pointing at an old absolute path, which breaks `hermes` before the app even starts. That forces users to understand and repair internal launcher paths just to get back to a working state.

This change makes the launcher home-agnostic so it resolves from the current environment instead of assuming one fixed user directory.

Why this matters:
- Users should not have to know where the launcher lives internally.
- A username or machine change should not silently break the CLI.
- The fix belongs in the installer-generated launcher, not as an isolated uninstall workaround.

Scope:
- `scripts/install.sh` launcher generation
- launcher regression tests

Verification:
- Ran the targeted regression tests with `uv run --with pytest python -m pytest tests/test_install_sh_pythonpath_sanitization.py tests/test_install_sh_symlink_stomp.py`
- Confirmed both tests pass.
