### PR TITLE
fix(cli): route post-approval buffer through normal input semantics

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13576,9 +13576,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             # --- Approval selection: confirm the highlighted choice ---
             if self._approval_state:
+                # Snapshot buffer text and images before resolving — the
+                # approval handler clears _approval_state when the choice
+                # is anything other than "view".
+                text = event.app.current_buffer.text.strip()
+                has_images = bool(self._attached_images)
                 self._handle_approval_selection()
-                event.app.invalidate()
-                return
+                # Forward buffered input only when the approval was actually
+                # resolved (not when "view" expanded the command in-place).
+                # When there is pending content, fall through to the normal
+                # input routing below so ALL busy_input_mode semantics
+                # (queue / interrupt / steer) and inline command handling
+                # (/model, /steer) are preserved — not hardcoded.
+                if self._approval_state is None and (text or has_images):
+                    # Approval resolved with pending input — fall through.
+                    pass
+                else:
+                    event.app.invalidate()
+                    return
 
             # --- Slash-command confirmation: submit typed or highlighted choice ---
             if self._slash_confirm_state:

--- a/tests/cli/test_cli_approval_ast.py
+++ b/tests/cli/test_cli_approval_ast.py
@@ -1,0 +1,147 @@
+"""Structural AST regression test for approval buffer forward (issue #35999).
+
+Verifies the invariant inside ``handle_enter``: after resolving the
+approval panel, if there is pending buffer text, the handler falls through
+to the Normal Input Routing section instead of returning early with an
+``event.app.invalidate()`` call.
+
+This is an *invariant* test — it checks the control flow structure, not a
+snapshot of current source.  If someone later adds an early return in the
+approval-resolved branch, this test catches the regression.
+
+See also test_steer_inline_repaint_34569.py for the same structural pattern.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _load_handle_enter_node() -> ast.FunctionDef:
+    """Extract the ``handle_enter`` nested function node from cli.py."""
+    cli_path = Path(__file__).resolve().parents[2] / "cli.py"
+    tree = ast.parse(cli_path.read_text(encoding="utf-8"))
+
+    target = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "handle_enter":
+            target = node
+            break
+    assert target is not None, "handle_enter closure not found in cli.py"
+    return target
+
+
+def _collect_if_nodes(func: ast.FunctionDef, target_test: str, exact: bool = False) -> list[ast.If]:
+    """Find ``if`` nodes inside *func* whose test attribute string contains
+    *target_test* when rendered by ast.dump.  When *exact* is True, the
+    match must be exact (the dump of the test equals *target_test*)."""
+    results: list[ast.If] = []
+    for node in ast.walk(func):
+        if isinstance(node, ast.If):
+            dump = ast.dump(node.test)
+            if (exact and dump == target_test) or (not exact and target_test in dump):
+                results.append(node)
+    return results
+
+
+def test_approval_resolved_with_buffer_does_not_return_early():
+    """When approval resolves (``_approval_state is None``) AND buffer text
+    is present, ``handle_enter`` must NOT return early — it must fall through
+    to the Normal Input Routing section so that busy_input_mode semantics are
+    preserved.
+
+    The early return (``event.app.invalidate(); return``) is only valid when
+    ``_approval_state is not None`` (view expanded in-place) OR when there is
+    no buffer text to forward.
+    """
+    func = _load_handle_enter_node()
+
+    # Find the outer approval-state if block (exact match avoids picking
+    # up the nested ``if self._approval_state is None and ...`` inside it).
+    approval_ifs = _collect_if_nodes(func, "Attribute(value=Name(id='self', ctx=Load()), attr='_approval_state', ctx=Load())", exact=True)
+    assert len(approval_ifs) == 1, (
+        f"expected exactly one '_approval_state' if in handle_enter, "
+        f"found {len(approval_ifs)}"
+    )
+    approval_if = approval_ifs[0]
+
+    # Walk the body of the approval if looking for the nested check:
+    #   if self._approval_state is None and (text or has_images):
+    #       pass  # fall through
+    #   else:
+    #       event.app.invalidate()
+    #       return
+    fall_through_pattern = False
+    early_return_pattern = False
+
+    for stmt in approval_if.body:
+        if isinstance(stmt, ast.If):
+            # This should be the nested if (approval resolved + has content)
+            # Check that the else branch has return + invalidate
+            if stmt.orelse:
+                else_body = stmt.orelse
+                # Could be a single If (elif) or a list of statements
+                else_stmts = else_body if isinstance(else_body, list) else else_body.body if hasattr(else_body, 'body') else []
+                # Check for invalidate + return in else
+                has_invalidate = any(
+                    isinstance(s, ast.Expr) and isinstance(s.value, ast.Call)
+                    and hasattr(s.value.func, 'attr') and s.value.func.attr == 'invalidate'
+                    for s in (else_stmts if isinstance(else_stmts, list) else [else_stmts])
+                )
+                has_return = any(
+                    isinstance(s, ast.Return) for s in (else_stmts if isinstance(else_stmts, list) else [else_stmts])
+                )
+                if has_invalidate and has_return:
+                    early_return_pattern = True
+
+            # Check that the if body has a 'pass' statement (fall-through)
+            for s in stmt.body:
+                if isinstance(s, ast.Pass):
+                    fall_through_pattern = True
+
+    assert fall_through_pattern, (
+        "handle_enter approval branch missing 'pass' fall-through "
+        "when approval is resolved with buffer text — the handler may "
+        "return early and discard buffered input (issue #35999)"
+    )
+    assert early_return_pattern, (
+        "handle_enter approval branch missing 'invalidate + return' in else "
+        "branch for the view/no-content case"
+    )
+
+
+def test_approval_view_branch_returns_early():
+    """When 'view' expands the command in-place (``_approval_state not None``),
+    ``handle_enter`` must return early WITHOUT falling through to normal input
+    routing — the buffer text stays in the buffer.
+    """
+    func = _load_handle_enter_node()
+
+    approval_ifs = _collect_if_nodes(func, "Attribute(value=Name(id='self', ctx=Load()), attr='_approval_state', ctx=Load())", exact=True)
+    approval_if = approval_ifs[0]
+
+    # Find the nested if: `_approval_state is None` — the else of this
+    # if is the case where approval_state IS NOT None (view mode).
+    view_returns_early = False
+    for stmt in approval_if.body:
+        if isinstance(stmt, ast.If):
+            # The else branch handles the case where approval_state is NOT None
+            if stmt.orelse:
+                else_body = stmt.orelse
+                else_stmts = else_body if isinstance(else_body, list) else else_body.body if hasattr(else_body, 'body') else []
+                for s in (else_stmts if isinstance(else_stmts, list) else [else_stmts]):
+                    if isinstance(s, ast.Return):
+                        view_returns_early = True
+
+    assert view_returns_early, (
+        "handle_enter missing early return in the view/no-content "
+        "approval branch — buffer text may be incorrectly forwarded "
+        "when approval panel stays open"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    test_approval_resolved_with_buffer_does_not_return_early()
+    test_approval_view_branch_returns_early()
+    print("ok")

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -769,3 +769,127 @@ class TestClearOverlaysForInterrupt:
         assert not t.is_alive(), "worker thread never unblocked"
         assert result["value"] == "deny"
 
+
+
+class TestApprovalBufferForward:
+    """Behavioral tests for buffer-text forwarding after approval resolves.
+
+    These tests verify the STATE transition after _handle_approval_selection()
+    — that when approval resolves and there's buffer text, the text is
+    preserved for the normal input routing to pick up (no early return, no
+    manual re-queueing in the test). The actual queueing path is verified by
+    the AST-level structural test in test_cli_approval_ast.py.
+    """
+
+    def test_approval_resolved_preserves_buffer_text(self):
+        """After a non-view approval resolves, buffer text is preserved for
+        normal routing fall-through (issue #35999)."""
+        cli = _make_cli_stub()
+        cli._pending_input = queue.Queue()
+        cli._interrupt_queue = queue.Queue()
+        cli._attached_images = []
+        cli._approval_state = {
+            "command": "rm -rf /tmp/test",
+            "description": "recursive delete",
+            "choices": ["once", "session", "always", "deny"],
+            "selected": 0,
+            "response_queue": queue.Queue(),
+        }
+        cli._approval_deadline = time.time() + 30
+
+        # Simulate buffer text typed while approval panel was showing
+        cli._app.current_buffer = _FakeBuffer("also clean /var/tmp")
+
+        text = cli._app.current_buffer.text.strip()
+        has_images = bool(cli._attached_images)
+        assert text == "also clean /var/tmp"
+
+        cli._handle_approval_selection()
+
+        # Approval resolved — state cleared
+        assert cli._approval_state is None
+
+        # Buffer text preserved for fall-through (not consumed/reset)
+        assert cli._app.current_buffer.text == "also clean /var/tmp"
+
+        # No manual queueing happened here — the actual routing happens
+        # in the normal input section of handle_enter.
+        assert cli._pending_input.empty()
+        assert cli._interrupt_queue.empty()
+
+    def test_approval_view_does_not_resolve(self):
+        """When 'view' is selected, approval_state is NOT cleared and buffer
+        text must NOT be forwarded — the approval panel stays open."""
+        cli = _make_cli_stub()
+        cli._pending_input = queue.Queue()
+        cli._interrupt_queue = queue.Queue()
+        cli._attached_images = []
+        cli._approval_state = {
+            "command": "rm -rf /tmp/test",
+            "description": "recursive delete",
+            "choices": ["once", "session", "always", "deny", "view"],
+            "selected": 4,  # "view" selected
+            "response_queue": queue.Queue(),
+        }
+        cli._approval_deadline = time.time() + 30
+        cli._app.current_buffer = _FakeBuffer("also clean /var/tmp")
+
+        cli._handle_approval_selection()
+
+        # Approval still active (view expanded in-place)
+        assert cli._approval_state is not None
+        assert cli._approval_state["show_full"] is True
+        assert "view" not in cli._approval_state["choices"]
+
+        # No messages queued — did NOT fall through to normal routing
+        assert cli._pending_input.empty()
+        assert cli._interrupt_queue.empty()
+
+    def test_approval_with_images_preserves_images(self):
+        """When images are attached during approval, they're preserved for
+        normal routing fall-through after approval resolves."""
+        cli = _make_cli_stub()
+        cli._pending_input = queue.Queue()
+        cli._interrupt_queue = queue.Queue()
+        cli._attached_images = ["data:image/png;base64,abc123"]
+        cli._approval_state = {
+            "command": "rm -rf /tmp/test",
+            "description": "recursive delete",
+            "choices": ["once", "session", "always", "deny"],
+            "selected": 0,
+            "response_queue": queue.Queue(),
+        }
+        cli._approval_deadline = time.time() + 30
+
+        cli._handle_approval_selection()
+
+        # Approval resolved
+        assert cli._approval_state is None
+
+        # Images still attached (normal routing will snapshot and clear)
+        assert cli._attached_images == ["data:image/png;base64,abc123"]
+
+    def test_approval_resolved_without_buffer_no_fallthrough(self):
+        """When approval resolves with no buffer text, nothing extra happens."""
+        cli = _make_cli_stub()
+        cli._pending_input = queue.Queue()
+        cli._interrupt_queue = queue.Queue()
+        cli._attached_images = []
+        cli._approval_state = {
+            "command": "rm -rf /tmp/test",
+            "description": "recursive delete",
+            "choices": ["once", "session", "always", "deny"],
+            "selected": 0,
+            "response_queue": queue.Queue(),
+        }
+        cli._approval_deadline = time.time() + 30
+
+        cli._handle_approval_selection()
+
+        # Approval resolved
+        assert cli._approval_state is None
+
+        # No content to forward — empty buffer stays empty
+        assert cli._app.current_buffer.text == ""
+        assert cli._pending_input.empty()
+        assert cli._interrupt_queue.empty()


### PR DESCRIPTION
When the user types a follow-up message while the dangerous-command approval panel is showing, pressing Enter now routes the buffered text through the normal input semantics (`busy_input_mode` with queue/interrupt/steer, inline /model and /steer handling) instead of hardcoding `_interrupt_queue` for active runs.

Closes #35999

### Changes vs original PR #36001
- **Routing**: Snapshots buffer text before `_handle_approval_selection()`, then falls through to the Normal Input Routing section instead of hardcoding `_interrupt_queue` — preserves all `busy_input_mode` modes
- **Tests**: Behavioral tests verify state after `_handle_approval_selection()` without reproducing routing logic. AST structural test (same pattern as `test_steer_inline_repaint_34569.py`) verifies the `handle_enter` control flow invariant
