### PR TITLE
fix(dashboard): spawn fresh PTY on session switch from sidebar

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15866,9 +15866,13 @@ async def pty_ws(ws: WebSocket) -> None:
         return
 
     # Keep-alive path: the PTY outlives this socket; reattach by token.
+    # Registry key includes the resume target so that switching sessions
+    # in the dashboard sidebar spawns a fresh PTY instead of reattaching
+    # to the old one (which is still running the previous conversation).
+    _registry_key = f"{attach_token}:{resume or ''}"
     try:
         session, _created = await PTY_REGISTRY.attach_or_spawn(
-            attach_token, spawn=_spawn
+            _registry_key, spawn=_spawn
         )
     except PtyUnavailableError as exc:
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
@@ -15916,7 +15920,7 @@ async def pty_ws(ws: WebSocket) -> None:
     finally:
         # Detach only — the PTY keeps running for a reattach; the registry
         # reaper closes it after the TTL (or immediately on process exit).
-        PTY_REGISTRY.detach(attach_token, ws)
+        PTY_REGISTRY.detach(_registry_key, ws)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When switching sessions via the dashboard Chat sidebar, the keep-alive PTY registry reuses the existing terminal process because the `attach_token` (browser localStorage identity) is unchanged. The old PTY is still running the previous conversation, so the user sees stale history and new messages go to the wrong session.

## Root Cause

In `pty_ws()` (`web_server.py`), the PTY registry key is the bare `attach_token`. When the user clicks a different session in the sidebar:

1. Frontend correctly sets `?resume=<new_session_id>` in the URL
2. `ChatPage` detects the change and triggers a WebSocket reconnect
3. Server calls `PTY_REGISTRY.attach_or_spawn(attach_token, spawn=_spawn)` 
4. The registry finds an existing live PTY with the same token and returns it
5. The old PTY (still running the previous session) is reused — wrong conversation

The `_spawn` closure (which would create a new PTY with `--resume <new_id>`) is never called.

## Fix

Include the `resume` session id in the PTY registry key (`attach_token:resume_id`) so each unique (session, tab) pair gets its own PTY. Switching back to a previously visited session reattaches to its still-alive PTY (correct behavior). The idle reaper continues to clean up detached sessions after TTL.

## Testing

1. Open dashboard Chat tab
2. Start a conversation (session A)
3. Click a different session in the sidebar (session B)
4. Verify: message history shows session B, new messages go to session B
5. Switch back to session A
6. Verify: message history shows session A, terminal state is preserved