### PR TITLE
fix(gateway): close background tasks before reporting

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -94,7 +94,14 @@ result. If a concrete external blocker remains, report it plainly.
 """.strip()
 _BACKGROUND_INCOMPLETE_RESPONSE_RE = re.compile(
     r"\b(?:incomplete|(?:verification|status)\s+(?:(?:is|still)\s+)?pending|pending\s+verification|"
-    r"needs?\s+verification|not\s+(?:yet\s+)?verified)\b",
+    r"needs?\s+verification|not\s+(?:yet\s+)?verified)\b"
+    r"|아직\s+완료로\s+보고할\s+수\s+없습니다"
+    r"|마지막\s+상태\s+확인이\s+끝나지\s+않았습니다",
+    re.IGNORECASE,
+)
+_BACKGROUND_EXTERNAL_BLOCKER_QUESTION_RE = re.compile(
+    r"\b(?:need|require|waiting\s+for)\b(?=[\s\S]{0,160}\?)"
+    r"[\s\S]{0,120}\b(?:api\s+key|credentials?|approval|access|permission)\b",
     re.IGNORECASE,
 )
 
@@ -102,6 +109,14 @@ _BACKGROUND_INCOMPLETE_RESPONSE_RE = re.compile(
 def _background_response_needs_closure(response: str) -> bool:
     """Return whether a final response explicitly asks for closure work."""
     return bool(_BACKGROUND_INCOMPLETE_RESPONSE_RE.search(str(response or "")))
+
+
+def _background_response_needs_nonfinished_status(response: str) -> bool:
+    """Return whether a response still requires verification or external input."""
+    response = str(response or "")
+    return _background_response_needs_closure(response) or bool(
+        _BACKGROUND_EXTERNAL_BLOCKER_QUESTION_RE.search(response)
+    )
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
@@ -13751,7 +13766,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
                 status = (
                     "Background task needs verification"
-                    if _background_response_needs_closure(response)
+                    if _background_response_needs_nonfinished_status(response)
                     else "Background task finished"
                 )
                 header = f'{status}\nPrompt: "{preview}"\n\n'

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -71,6 +71,38 @@ _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
+# /background creates an otherwise independent agent session. Its initial
+# prompt must make the durable outer agent responsible for any work it starts,
+# rather than allowing it to return while an untracked child is still running.
+_BACKGROUND_EXECUTION_CONTRACT = """
+
+Background execution contract:
+- You are the durable outer agent for this task. Do not spawn an untracked
+  dependent child and then return.
+- If you start a dependent child, wait/poll for it, consume its result,
+  continue all remaining safe actions yourself, and do a post-closure readback
+  before your final response.
+- Do not claim completion while verification or a safe remaining action is
+  pending. Preserve concrete external blockers plainly when they prevent work.
+""".strip()
+_BACKGROUND_CLOSURE_PROMPT = """
+Your previous final response clearly reported incomplete work or verification
+pending. Perform one bounded closure pass in this same session: finish only
+safe remaining actions within the original scope, consume any dependent-child
+result, and do the required readback. Do not bypass approvals or invent a
+result. If a concrete external blocker remains, report it plainly.
+""".strip()
+_BACKGROUND_INCOMPLETE_RESPONSE_RE = re.compile(
+    r"\b(?:incomplete|(?:verification|status)\s+(?:(?:is|still)\s+)?pending|pending\s+verification|"
+    r"needs?\s+verification|not\s+(?:yet\s+)?verified)\b",
+    re.IGNORECASE,
+)
+
+
+def _background_response_needs_closure(response: str) -> bool:
+    """Return whether a final response explicitly asks for closure work."""
+    return bool(_BACKGROUND_INCOMPLETE_RESPONSE_RE.search(str(response or "")))
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
     r"auxiliary\s+.+\s+failed"
@@ -13599,6 +13631,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+            try:
+                background_timeout = float(agent_cfg.get("background_timeout", 10_800))
+            except (TypeError, ValueError):
+                background_timeout = 10_800
+            # 0 keeps the historical unlimited behavior. A positive budget is
+            # cooperative: we interrupt the agent at its deadline but continue
+            # awaiting the executor future so a worker thread is never left
+            # running after its coroutine has been cancelled.
+            background_timeout = background_timeout if background_timeout > 0 else None
 
             pr = self._provider_routing
             max_iterations = _current_max_iterations()
@@ -13625,6 +13666,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                     except Exception as e:
                         logger.warning("Background task vision enrichment failed: %s", e)
+
+            agent_holder: List[Optional[Any]] = [None]
 
             def run_sync():
                 agent = AIAgent(
@@ -13657,15 +13700,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),
                 )
+                agent_holder[0] = agent
                 try:
-                    return agent.run_conversation(
-                        user_message=enriched_prompt,
+                    result = agent.run_conversation(
+                        user_message=f"{enriched_prompt}\n\n{_BACKGROUND_EXECUTION_CONTRACT}",
                         task_id=task_id,
                     )
+                    if _background_response_needs_closure(
+                        result.get("final_response", "") if result else ""
+                    ):
+                        result = agent.run_conversation(
+                            user_message=_BACKGROUND_CLOSURE_PROMPT,
+                            task_id=task_id,
+                        )
+                    return result
                 finally:
                     self._cleanup_agent_resources(agent)
 
-            result = await self._run_in_executor_with_context(run_sync)
+            executor_task = asyncio.ensure_future(self._run_in_executor_with_context(run_sync))
+            if background_timeout is None:
+                result = await executor_task
+            else:
+                done, _ = await asyncio.wait({executor_task}, timeout=background_timeout)
+                if done:
+                    result = executor_task.result()
+                else:
+                    background_agent = agent_holder[0]
+                    logger.warning(
+                        "Background task %s reached its %.0fs budget; requesting cooperative stop",
+                        task_id,
+                        background_timeout,
+                    )
+                    if background_agent is not None and hasattr(background_agent, "interrupt"):
+                        background_agent.interrupt("background execution budget reached")
+                    # Do not cancel this Future: cancelling its asyncio wrapper
+                    # does not stop the underlying worker thread.
+                    result = await executor_task
 
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
@@ -13679,7 +13749,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 images, text_content = adapter.extract_images(response)
 
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
-                header = f'✅ Background task complete\nPrompt: "{preview}"\n\n'
+                status = (
+                    "Background task needs verification"
+                    if _background_response_needs_closure(response)
+                    else "Background task finished"
+                )
+                header = f'{status}\nPrompt: "{preview}"\n\n'
 
                 if text_content:
                     await adapter.send(
@@ -13747,7 +13822,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
                 await adapter.send(
                     chat_id=source.chat_id,
-                    content=f'✅ Background task complete\nPrompt: "{preview}"\n\n(No response generated)',
+                    content=f'Background task finished\nPrompt: "{preview}"\n\n(No response generated)',
                     metadata=_thread_metadata,
                 )
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -994,6 +994,11 @@ DEFAULT_CONFIG = {
         # tools or receiving API responses.  Only fires when the agent has
         # been completely idle for this duration.  0 = unlimited.
         "gateway_timeout": 1800,
+        # Wall-clock budget for a /background task (seconds). A positive value
+        # requests a cooperative agent stop at the deadline, then waits for its
+        # worker thread to close; it never abandons a running worker. 0 = no
+        # wall-clock budget. The 3-hour default supports long autonomous work.
+        "background_timeout": 10_800,
         # Graceful drain timeout for gateway stop/restart (seconds).
         # The gateway stops accepting new work, waits for running agents
         # to finish, then interrupts any remaining runs after the timeout.

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -295,8 +295,8 @@ class TestRunBackgroundTask:
         assert "post-closure readback" in first_message
 
     @pytest.mark.asyncio
-    async def test_incomplete_first_pass_continues_same_agent_session(self):
-        """A clear pending-verification response gets one bounded closure pass."""
+    async def test_korean_incomplete_first_pass_continues_same_agent_session(self):
+        """The reported Korean verification-pending response gets one closure pass."""
         runner = _make_runner()
         mock_adapter = AsyncMock()
         mock_adapter.send = AsyncMock()
@@ -310,7 +310,13 @@ class TestRunBackgroundTask:
             agent.shutdown_memory_provider = MagicMock()
             agent.close = MagicMock()
             agent.run_conversation.side_effect = [
-                {"final_response": "Status still pending.", "messages": []},
+                {
+                    "final_response": (
+                        "아직 완료로 보고할 수 없습니다. 마지막 상태 확인이 끝나지 "
+                        "않았습니다. 확인된 결과만 다시 보고하겠습니다."
+                    ),
+                    "messages": [],
+                },
                 {"final_response": "verification complete", "messages": []},
             ]
             MockAgent.return_value = agent
@@ -325,13 +331,17 @@ class TestRunBackgroundTask:
         assert "verification complete" in content
 
     @pytest.mark.asyncio
-    async def test_repeated_incomplete_response_is_bounded_and_needs_verification(self):
-        """A second incomplete response is delivered without a green completion wrapper."""
+    async def test_repeated_korean_incomplete_response_is_bounded_and_needs_verification(self):
+        """Repeated Korean incomplete work is never delivered as finished or green."""
         runner = _make_runner()
         mock_adapter = AsyncMock()
         mock_adapter.send = AsyncMock()
-        mock_adapter.extract_media = MagicMock(return_value=([], "INCOMPLETE: verification pending"))
-        mock_adapter.extract_images = MagicMock(return_value=([], "INCOMPLETE: verification pending"))
+        korean_incomplete = (
+            "아직 완료로 보고할 수 없습니다. 마지막 상태 확인이 끝나지 "
+            "않았습니다. 확인된 결과만 다시 보고하겠습니다."
+        )
+        mock_adapter.extract_media = MagicMock(return_value=([], korean_incomplete))
+        mock_adapter.extract_images = MagicMock(return_value=([], korean_incomplete))
         runner.adapters[Platform.TELEGRAM] = mock_adapter
 
         with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
@@ -340,8 +350,8 @@ class TestRunBackgroundTask:
             agent.shutdown_memory_provider = MagicMock()
             agent.close = MagicMock()
             agent.run_conversation.side_effect = [
-                {"final_response": "INCOMPLETE: verification pending.", "messages": []},
-                {"final_response": "INCOMPLETE: verification pending.", "messages": []},
+                {"final_response": korean_incomplete, "messages": []},
+                {"final_response": korean_incomplete, "messages": []},
             ]
             MockAgent.return_value = agent
 
@@ -350,7 +360,34 @@ class TestRunBackgroundTask:
         assert agent.run_conversation.call_count == 2
         content = mock_adapter.send.call_args.kwargs["content"]
         assert "Background task needs verification" in content
+        assert "Background task finished" not in content
         assert "✅" not in content
+
+    @pytest.mark.asyncio
+    async def test_external_blocker_question_is_not_delivered_as_finished(self):
+        """A concrete external blocker remains explicitly non-finished without retrying."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        response = "I need the production API key to finish the deploy. Can you provide it?"
+        mock_adapter.extract_media = MagicMock(return_value=([], response))
+        mock_adapter.extract_images = MagicMock(return_value=([], response))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            agent = MagicMock()
+            agent.shutdown_memory_provider = MagicMock()
+            agent.close = MagicMock()
+            agent.run_conversation.return_value = {"final_response": response, "messages": []}
+            MockAgent.return_value = agent
+
+            await runner._run_background_task("deploy", _make_event().source, "bg_test")
+
+        assert agent.run_conversation.call_count == 1
+        content = mock_adapter.send.call_args.kwargs["content"]
+        assert "Background task needs verification" in content
+        assert "Background task finished" not in content
 
     def test_background_timeout_defaults_to_three_hours(self):
         """Background work gets a real, configurable three-hour budget by default."""

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -262,10 +262,101 @@ class TestRunBackgroundTask:
         mock_adapter.send.assert_called_once()
         call_args = mock_adapter.send.call_args
         content = call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")
-        assert "Background task complete" in content
+        assert "Background task finished" in content
+        assert "✅" not in content
         assert "Hello from background!" in content
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_background_prompt_requires_waiting_for_dependent_children(self):
+        """Background prompts require durable agents to close dependent child work."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "done"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "done"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            agent = MagicMock()
+            agent.shutdown_memory_provider = MagicMock()
+            agent.close = MagicMock()
+            agent.run_conversation.return_value = {"final_response": "done", "messages": []}
+            MockAgent.return_value = agent
+
+            await runner._run_background_task("do the work", _make_event().source, "bg_test")
+
+        first_message = agent.run_conversation.call_args.kwargs["user_message"]
+        assert "untracked" in first_message
+        assert "dependent child" in first_message
+        assert "wait/poll" in first_message
+        assert "post-closure readback" in first_message
+
+    @pytest.mark.asyncio
+    async def test_incomplete_first_pass_continues_same_agent_session(self):
+        """A clear pending-verification response gets one bounded closure pass."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "verification complete"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "verification complete"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            agent = MagicMock()
+            agent.shutdown_memory_provider = MagicMock()
+            agent.close = MagicMock()
+            agent.run_conversation.side_effect = [
+                {"final_response": "Status still pending.", "messages": []},
+                {"final_response": "verification complete", "messages": []},
+            ]
+            MockAgent.return_value = agent
+
+            await runner._run_background_task("do the work", _make_event().source, "bg_test")
+
+        assert agent.run_conversation.call_count == 2
+        closure_message = agent.run_conversation.call_args.kwargs["user_message"]
+        assert "bounded closure pass" in closure_message
+        content = mock_adapter.send.call_args.kwargs["content"]
+        assert "Background task finished" in content
+        assert "verification complete" in content
+
+    @pytest.mark.asyncio
+    async def test_repeated_incomplete_response_is_bounded_and_needs_verification(self):
+        """A second incomplete response is delivered without a green completion wrapper."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "INCOMPLETE: verification pending"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "INCOMPLETE: verification pending"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            agent = MagicMock()
+            agent.shutdown_memory_provider = MagicMock()
+            agent.close = MagicMock()
+            agent.run_conversation.side_effect = [
+                {"final_response": "INCOMPLETE: verification pending.", "messages": []},
+                {"final_response": "INCOMPLETE: verification pending.", "messages": []},
+            ]
+            MockAgent.return_value = agent
+
+            await runner._run_background_task("do the work", _make_event().source, "bg_test")
+
+        assert agent.run_conversation.call_count == 2
+        content = mock_adapter.send.call_args.kwargs["content"]
+        assert "Background task needs verification" in content
+        assert "✅" not in content
+
+    def test_background_timeout_defaults_to_three_hours(self):
+        """Background work gets a real, configurable three-hour budget by default."""
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["agent"]["background_timeout"] == 10_800
 
     @pytest.mark.asyncio
     async def test_media_files_routed_by_type(self, monkeypatch):
@@ -338,13 +429,13 @@ class TestRunBackgroundTask:
             await runner._run_background_task("make stuff", source, "bg_test")
 
             mock_adapter.send_voice.assert_called_once()
-            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg
+            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _os.path.realpath(_ogg)
             mock_adapter.send_video.assert_called_once()
-            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4
+            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _os.path.realpath(_mp4)
             mock_adapter.send_image_file.assert_called_once()
-            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png
+            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _os.path.realpath(_png)
             mock_adapter.send_document.assert_called_once()
-            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf
+            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _os.path.realpath(_pdf)
         finally:
             import shutil as _shutil
             _shutil.rmtree(_tmpdir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- give `/background` agents a durable execution contract and one same-session closure pass when their first response says work or verification is pending
- use a configurable three-hour cooperative background budget without cancelling an executor future that leaves a worker thread running
- replace the green completion wrapper with neutral `Background task finished` and report persistent incomplete results as `Background task needs verification`

## Verification
- `scripts/run_tests.sh tests/gateway/test_background_command.py tests/gateway/test_config_env_bridge_authority.py -q`
- `python -m py_compile gateway/run.py hermes_cli/config.py tests/gateway/test_background_command.py`
- `uvx ruff@0.15.10 check gateway/run.py hermes_cli/config.py tests/gateway/test_background_command.py`
- `git diff --check`

## Notes
- The default `agent.background_timeout` is 10,800 seconds; `0` disables the wall-clock budget.