### PR TITLE
fix: release active_pr guard after closed PR handoff

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5909,6 +5909,14 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Terminal status signals in PR handoff comments.  When the latest PR comment
+# says the PR is already closed/merged, the active_pr guard must release the
+# card for review/follow-up instead of livelocking it in ready forever.
+_RESPAWN_GUARD_PR_TERMINAL_RE = re.compile(
+    r"\b(?:closed|merged|merge\s+complete)\b|머지(?:\s*완료)?",
+    re.IGNORECASE,
+)
+
 
 @dataclass
 class DispatchResult:
@@ -7257,12 +7265,19 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    A newer handoff comment that marks that PR closed/merged releases the
+    #    guard; otherwise review cards can livelock forever after the PR closes.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? "
+        "ORDER BY created_at DESC, id DESC",
         (task_id, pr_cutoff),
     ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+        body = c["body"] or ""
+        if _RESPAWN_GUARD_PR_URL_RE.search(body):
+            if _RESPAWN_GUARD_PR_TERMINAL_RE.search(body):
+                return None
             return "active_pr"
 
     return None

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1929,6 +1929,46 @@ def test_respawn_guard_active_pr_in_comment(kanban_home):
     assert reason == "active_pr"
 
 
+def test_respawn_guard_closed_pr_comment_not_guarded(kanban_home):
+    """A closed/merged PR handoff releases the active_pr guard."""
+    terminal_comments = [
+        "PR MERGED: https://github.com/totemx-AI/subsidysmart/pull/42",
+        "PR CLOSED: https://github.com/totemx-AI/subsidysmart/pull/43",
+        "머지 완료: https://github.com/totemx-AI/subsidysmart/pull/44",
+    ]
+    with kb.connect() as conn:
+        for body in terminal_comments:
+            t = kb.create_task(conn, title="closed-pr", assignee="alice")
+            kb.add_comment(conn, t, "worker", body)
+            assert kb.check_respawn_guard(conn, t) is None
+
+
+def test_respawn_guard_latest_pr_comment_controls_terminal_state(kanban_home):
+    """A newer merged handoff overrides an older open PR handoff."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="merged-after-open", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', ?, ?)",
+            (
+                t,
+                "PR created: https://github.com/totemx-AI/subsidysmart/pull/42",
+                now - 60,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'worker', ?, ?)",
+            (
+                t,
+                "PR merged: https://github.com/totemx-AI/subsidysmart/pull/42",
+                now,
+            ),
+        )
+        assert kb.check_respawn_guard(conn, t) is None
+
+
 def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
     """A GitHub PR URL in a comment older than the PR window does not block."""
     with kb.connect() as conn:


### PR DESCRIPTION
## Source
Hermes kanban-dispatch dev lane (claude lane) — active_pr guard livelock item t_01db2b9c.

## Change
Release the respawn active_pr guard when the latest recent PR handoff comment marks the referenced PR as CLOSED/MERGED/머지 완료, while preserving active_pr for open PR handoffs and the existing guard priority order.

## Evidence
Tests: `uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_db.py tests/gateway/test_pre_gateway_dispatch.py tests/hermes_cli/test_gateway_s6_dispatch.py -q` → 264 passed in 9.73s.
Diff: 2 files changed, 57 insertions(+), 2 deletions(-).

## Auth-only Proof
N/A
