### PR TITLE
fix(kanban): prevent archived board watcher resurrection

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -231,7 +231,10 @@ class GatewayKanbanWatchersMixin:
                             continue
                         seen_db_paths.add(resolved_db_path)
                         try:
-                            conn = _kb.connect(board=slug)
+                            conn = _kb.connect(
+                                board=slug,
+                                create_if_missing=(slug == _kb.DEFAULT_BOARD),
+                            )
                         except Exception as exc:
                             logger.debug("kanban notifier: cannot open board %s: %s", slug, exc)
                             continue
@@ -582,7 +585,10 @@ class GatewayKanbanWatchersMixin:
         subscription. Unsub cursors in one board can't touch another's.
         """
         from hermes_cli import kanban_db as _kb
-        conn = _kb.connect(board=board)
+        conn = _kb.connect(
+            board=board,
+            create_if_missing=(not board or board == _kb.DEFAULT_BOARD),
+        )
         try:
             _kb.advance_notify_cursor(
                 conn,
@@ -597,7 +603,10 @@ class GatewayKanbanWatchersMixin:
 
     def _kanban_unsub(self, sub: dict, board: Optional[str] = None) -> None:
         from hermes_cli import kanban_db as _kb
-        conn = _kb.connect(board=board)
+        conn = _kb.connect(
+            board=board,
+            create_if_missing=(not board or board == _kb.DEFAULT_BOARD),
+        )
         try:
             _kb.remove_notify_sub(
                 conn,
@@ -618,7 +627,10 @@ class GatewayKanbanWatchersMixin:
     ) -> None:
         """Sync helper: undo a claimed notification cursor after send failure."""
         from hermes_cli import kanban_db as _kb
-        conn = _kb.connect(board=board)
+        conn = _kb.connect(
+            board=board,
+            create_if_missing=(not board or board == _kb.DEFAULT_BOARD),
+        )
         try:
             _kb.rewind_notify_cursor(
                 conn,
@@ -1006,7 +1018,10 @@ class GatewayKanbanWatchersMixin:
                     )
                 disabled_corrupt_boards.pop(slug, None)
             try:
-                conn = _kb.connect(board=slug)
+                conn = _kb.connect(
+                    board=slug,
+                    create_if_missing=(slug == _kb.DEFAULT_BOARD),
+                )
                 # `connect()` runs the schema + idempotent migration on
                 # first open per process; the previous explicit
                 # `init_db()` call here busted the per-process cache and
@@ -1097,7 +1112,10 @@ class GatewayKanbanWatchersMixin:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 conn = None
                 try:
-                    conn = _kb.connect(board=slug)
+                    conn = _kb.connect(
+                        board=slug,
+                        create_if_missing=(slug == _kb.DEFAULT_BOARD),
+                    )
                     if _kb.has_spawnable_ready(conn):
                         return True
                     if _kb.has_spawnable_review(conn):

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1171,15 +1171,20 @@ class GatewayKanbanWatchersMixin:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 if attempted >= auto_decompose_per_tick:
                     break
-                # Pin this board for the duration of the call — same
-                # pattern as the dashboard specify endpoint. The
-                # decomposer module connects with no board kwarg and
-                # relies on the env var.
+                # Pin this board for the duration of the call — same pattern
+                # as the dashboard specify endpoint. Pass the slug explicitly
+                # to every decomposer DB open too: after an archive,
+                # get_current_board() intentionally ignores a missing env slug
+                # and falls back to default, which is not safe for a stale
+                # watcher snapshot.
                 prev_env = os.environ.get("HERMES_KANBAN_BOARD")
                 try:
                     os.environ["HERMES_KANBAN_BOARD"] = slug
                     try:
-                        triage_ids = _decomp.list_triage_ids()
+                        triage_ids = _decomp.list_triage_ids(
+                            board=slug,
+                            create_if_missing=False,
+                        )
                     except Exception as exc:
                         logger.debug(
                             "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
@@ -1192,7 +1197,10 @@ class GatewayKanbanWatchersMixin:
                         attempted += 1
                         try:
                             outcome = _decomp.decompose_task(
-                                tid, author="auto-decomposer",
+                                tid,
+                                author="auto-decomposer",
+                                board=slug,
+                                create_if_missing=False,
                             )
                         except Exception:
                             logger.exception(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -513,6 +513,30 @@ def board_exists(board: Optional[str] = None) -> bool:
     return (d / "board.json").exists() or (d / "kanban.db").exists()
 
 
+def _is_db_only_archived_residue(slug: str, directory: Path) -> bool:
+    """Return whether ``directory`` is a pre-fix ghost of an archived board.
+
+    Named boards created through the supported API always have ``board.json``.
+    Older gateway watchers could race ``remove_board()`` after enumerating a
+    slug and recreate only ``kanban.db`` at the active path. Keep supporting
+    legacy DB-only boards unless an archived directory for the same slug proves
+    this active directory is residue from that race.
+    """
+    if (directory / "board.json").exists() or not (
+        directory / "kanban.db"
+    ).exists():
+        return False
+    archive_root = boards_root() / "_archived"
+    archived_name = re.compile(rf"^{re.escape(slug)}-\d+(?:-\d+)?$")
+    try:
+        return any(
+            child.is_dir() and archived_name.fullmatch(child.name)
+            for child in archive_root.iterdir()
+        )
+    except OSError:
+        return False
+
+
 def kanban_db_path(board: Optional[str] = None) -> Path:
     """Return the path to the ``kanban.db`` for ``board``.
 
@@ -776,6 +800,8 @@ def list_boards(*, include_archived: bool = True) -> list[dict]:
             has_db = (child / "kanban.db").exists()
             has_meta = (child / "board.json").exists()
             if not (has_db or has_meta):
+                continue
+            if _is_db_only_archived_residue(normed, child):
                 continue
             meta = read_board_metadata(normed)
             if meta.get("archived") and not include_archived:
@@ -1313,13 +1339,26 @@ def _resolve_busy_timeout_ms() -> int:
     return DEFAULT_BUSY_TIMEOUT_MS
 
 
-def _sqlite_connect(path: Path) -> sqlite3.Connection:
+def _sqlite_connect(
+    path: Path,
+    *,
+    create_if_missing: bool = True,
+) -> sqlite3.Connection:
     """Open a Kanban SQLite connection with consistent lock waiting."""
     busy_timeout_ms = _resolve_busy_timeout_ms()
+    target = str(path)
+    connect_kwargs: dict[str, Any] = {}
+    if not create_if_missing:
+        # SQLite's default open mode creates a missing file. Watchers operate
+        # on a snapshot returned by list_boards(); mode=rw makes a concurrent
+        # archive fail closed instead of resurrecting that stale slug.
+        target = path.resolve().as_uri() + "?mode=rw"
+        connect_kwargs["uri"] = True
     conn = sqlite3.connect(
-        str(path),
+        target,
         isolation_level=None,
         timeout=busy_timeout_ms / 1000.0,
+        **connect_kwargs,
     )
     # ``sqlite3.connect(timeout=...)`` normally maps to busy_timeout, but set
     # the PRAGMA explicitly so it is observable and survives future wrapper
@@ -1329,7 +1368,7 @@ def _sqlite_connect(path: Path) -> sqlite3.Connection:
 
 
 @contextlib.contextmanager
-def _cross_process_init_lock(path: Path):
+def _cross_process_init_lock(path: Path, *, create_if_missing: bool = True):
     """Serialize first-connect WAL/schema/integrity setup across processes.
 
     ``_INIT_LOCK`` only protects threads inside one Python process. During a
@@ -1352,7 +1391,8 @@ def _cross_process_init_lock(path: Path):
     is redundant work, not corruption. A bounded "proceed anyway" beats an
     unbounded hang that silently stops the board.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
+    if create_if_missing:
+        path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_name(path.name + ".init.lock")
     handle = lock_path.open("a+b")
     acquired = False
@@ -1661,7 +1701,7 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         return
     reason: Optional[str] = None
     try:
-        probe = _sqlite_connect(resolved)
+        probe = _sqlite_connect(resolved, create_if_missing=False)
         try:
             row = probe.execute("PRAGMA integrity_check").fetchone()
         finally:
@@ -1683,6 +1723,7 @@ def connect(
     db_path: Optional[Path] = None,
     *,
     board: Optional[str] = None,
+    create_if_missing: bool = True,
 ) -> sqlite3.Connection:
     """Open (and initialize if needed) the kanban DB.
 
@@ -1701,12 +1742,19 @@ def connect(
     * Neither → :func:`kanban_db_path` resolves via
       ``HERMES_KANBAN_DB`` env → ``HERMES_KANBAN_BOARD`` env →
       ``<root>/kanban/current`` → ``default``.
+
+    ``create_if_missing=False`` opens SQLite in ``mode=rw`` and never creates
+    the parent directory. Long-lived watchers use this after enumerating named
+    boards so an archive racing their stale snapshot cannot resurrect a slug.
     """
     if db_path is not None:
         path = db_path
     else:
         path = kanban_db_path(board=board)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    if create_if_missing:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    elif not path.is_file():
+        raise FileNotFoundError(path)
 
     # Fast path: once THIS process has initialized this path, the expensive
     # first-open work (header validation, integrity probe, schema + additive
@@ -1720,7 +1768,7 @@ def connect(
     # connection with WAL/pragmas under the cheap in-process _INIT_LOCK.
     resolved = str(path.resolve())
     if resolved in _INITIALIZED_PATHS:
-        conn = _sqlite_connect(path)
+        conn = _sqlite_connect(path, create_if_missing=create_if_missing)
         try:
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:
@@ -1736,7 +1784,7 @@ def connect(
             raise
         return conn
 
-    with _cross_process_init_lock(path):
+    with _cross_process_init_lock(path, create_if_missing=create_if_missing):
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
         # and other invalid-header cases without opening a sqlite connection.
         _validate_sqlite_header(path)
@@ -1745,7 +1793,7 @@ def connect(
         # via _INITIALIZED_PATHS so it only runs once per process per path.
         _guard_existing_db_is_healthy(path)
         resolved = str(path.resolve())
-        conn = _sqlite_connect(path)
+        conn = _sqlite_connect(path, create_if_missing=create_if_missing)
         try:
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1838,6 +1838,7 @@ def connect_closing(
     db_path: Optional[Path] = None,
     *,
     board: Optional[str] = None,
+    create_if_missing: bool = True,
 ):
     """Open a kanban DB connection and guarantee it is closed on exit.
 
@@ -1854,11 +1855,20 @@ def connect_closing(
 
     See #33159 for the production incident.
 
+    ``create_if_missing`` is forwarded to :func:`connect`. Long-lived
+    watchers pass ``False`` after discovering a board so a stale snapshot
+    cannot recreate a board that was archived before this open. The default
+    remains ``True`` for explicit CLI and dashboard operations.
+
     The ``connect()`` function itself remains unchanged so callers that
-    intentionally manage the connection lifetime (tests, long-lived
-    callers) continue to work.
+    intentionally manage the connection lifetime (tests, long-lived callers)
+    continue to work.
     """
-    conn = connect(db_path=db_path, board=board)
+    conn = connect(
+        db_path=db_path,
+        board=board,
+        create_if_missing=create_if_missing,
+    )
     try:
         yield conn
     finally:

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -273,15 +273,25 @@ def decompose_task(
     *,
     author: Optional[str] = None,
     timeout: Optional[int] = None,
+    board: Optional[str] = None,
+    create_if_missing: bool = True,
 ) -> DecomposeOutcome:
     """Decompose a triage task into a graph of child tasks.
 
     Returns an outcome describing what happened. Never raises for
-    expected failure modes (task not in triage, no aux client
-    configured, API error, malformed response, decomposer returned
-    fanout=true with empty task list) — those surface via ``ok=False``.
+    expected failure modes (task not in triage, no aux client configured,
+    API error, malformed response, decomposer returned fanout=true with empty
+    task list) — those surface via ``ok=False``.
+
+    ``board`` pins every DB open to the same board. Gateway auto-decomposition
+    also passes ``create_if_missing=False`` so an archive racing a stale board
+    snapshot fails closed instead of falling back to or recreating a DB.
+    Explicit CLI and dashboard calls retain create-on-demand defaults.
     """
-    with kb.connect_closing() as conn:
+    with kb.connect_closing(
+        board=board,
+        create_if_missing=create_if_missing,
+    ) as conn:
         task = kb.get_task(conn, task_id)
     if task is None:
         return DecomposeOutcome(task_id, False, "unknown task id")
@@ -361,7 +371,10 @@ def decompose_task(
             return DecomposeOutcome(
                 task_id, False, "decomposer returned fanout=false with no title/body",
             )
-        with kb.connect_closing() as conn:
+        with kb.connect_closing(
+            board=board,
+            create_if_missing=create_if_missing,
+        ) as conn:
             ok = kb.specify_triage_task(
                 conn,
                 task_id,
@@ -430,7 +443,10 @@ def decompose_task(
         })
 
     try:
-        with kb.connect_closing() as conn:
+        with kb.connect_closing(
+            board=board,
+            create_if_missing=create_if_missing,
+        ) as conn:
             child_ids = kb.decompose_triage_task(
                 conn,
                 task_id,
@@ -456,9 +472,17 @@ def decompose_task(
     )
 
 
-def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
+def list_triage_ids(
+    *,
+    tenant: Optional[str] = None,
+    board: Optional[str] = None,
+    create_if_missing: bool = True,
+) -> list[str]:
     """Return task ids currently in the triage column."""
-    with kb.connect_closing() as conn:
+    with kb.connect_closing(
+        board=board,
+        create_if_missing=create_if_missing,
+    ) as conn:
         rows = kb.list_tasks(
             conn,
             status="triage",

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -105,6 +105,30 @@ def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatc
     assert adapter2.sent == []
 
 
+def test_kanban_notifier_stale_snapshot_does_not_recreate_archived_board(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    kb.create_board("notifier-race")
+    stale_meta = kb.read_board_metadata("notifier-race")
+    kb.remove_board("notifier-race")
+    active_dir = kb.board_dir("notifier-race")
+
+    # Simulate archive occurring immediately after this notifier tick took its
+    # list_boards() snapshot. The stale slug must fail closed on connect.
+    monkeypatch.setattr(
+        kb,
+        "list_boards",
+        lambda include_archived=False: [stale_meta],
+    )
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert adapter.sent == []
+    assert not active_dir.exists()
+
+
 def test_kanban_notifier_rewinds_claim_if_adapter_disconnects(tmp_path, monkeypatch):
     db_path = tmp_path / "adapter-disconnect.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -118,3 +118,69 @@ def test_dispatcher_stale_snapshot_does_not_recreate_archived_board(
     asyncio.run(asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=3))
 
     assert not active_dir.exists()
+
+
+def test_auto_decomposer_discovery_race_does_not_recreate_archived_board(
+    tmp_path, monkeypatch,
+):
+    from gateway.run import GatewayRunner
+    from hermes_cli import kanban_db as kb
+    import hermes_cli.config as config_module
+
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    kb.create_board("auto-decompose-race")
+    active_dir = kb.board_dir("auto-decompose-race")
+    default_db = kb.kanban_db_path(board=kb.DEFAULT_BOARD)
+    with kb.connect(board="auto-decompose-race") as conn:
+        kb.create_task(conn, title="rough idea", triage=True)
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "auto_decompose": True,
+                "auto_decompose_per_tick": 1,
+            }
+        },
+    )
+    real_list_boards = kb.list_boards
+    archived = False
+
+    def archive_after_discovery(include_archived=False):
+        nonlocal archived
+        boards = real_list_boards(include_archived=include_archived)
+        discovered = [
+            board for board in boards
+            if board.get("slug") == "auto-decompose-race"
+        ]
+        if not archived:
+            archived = True
+            kb.remove_board("auto-decompose-race")
+        return discovered
+
+    monkeypatch.setattr(kb, "list_boards", archive_after_discovery)
+    monkeypatch.setattr(kb, "reap_worker_zombies", lambda: [])
+
+    async def run_inline(fn, *args, **kwargs):
+        result = fn(*args, **kwargs)
+        if getattr(fn, "__name__", "") == "_ready_nonempty":
+            runner._running = False
+        return result
+
+    async def no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(asyncio, "to_thread", run_inline)
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    asyncio.run(asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=3))
+
+    assert archived is True
+    assert not active_dir.exists()
+    assert not default_db.exists()

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -7,6 +7,7 @@ that GatewayRunner picks them up via the MRO (behavior-neutral relocation).
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
@@ -67,3 +68,53 @@ def test_singleton_dispatcher_lock_is_exclusive(tmp_path):
     h3, st3 = _acquire_singleton_lock(lock)
     assert st3 == "held" and h3 is not None
     _release_singleton_lock(h3)
+
+
+def test_dispatcher_stale_snapshot_does_not_recreate_archived_board(
+    tmp_path, monkeypatch,
+):
+    from gateway.run import GatewayRunner
+    from hermes_cli import kanban_db as kb
+    import hermes_cli.config as config_module
+
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    kb.create_board("dispatcher-race")
+    stale_meta = kb.read_board_metadata("dispatcher-race")
+    kb.remove_board("dispatcher-race")
+    active_dir = kb.board_dir("dispatcher-race")
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    monkeypatch.setattr(
+        config_module,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        kb,
+        "list_boards",
+        lambda include_archived=False: [stale_meta],
+    )
+    monkeypatch.setattr(kb, "reap_worker_zombies", lambda: [])
+
+    async def run_inline(fn, *args, **kwargs):
+        result = fn(*args, **kwargs)
+        if getattr(fn, "__name__", "") == "_ready_nonempty":
+            runner._running = False
+        return result
+
+    async def no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(asyncio, "to_thread", run_inline)
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    asyncio.run(asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=3))
+
+    assert not active_dir.exists()

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -271,6 +271,48 @@ class TestBoardCRUD:
         kb.remove_board("pinned")
         assert kb.get_current_board() == "default"
 
+    def test_connect_existing_does_not_recreate_archived_board(self, fresh_home):
+        """A stale watcher snapshot must not resurrect an archived slug."""
+        kb.create_board("stale-snapshot")
+        active_dir = kb.board_dir("stale-snapshot")
+        archived = kb.remove_board("stale-snapshot")
+
+        with pytest.raises(FileNotFoundError):
+            kb.connect(board="stale-snapshot", create_if_missing=False)
+
+        assert not active_dir.exists()
+        assert Path(archived["new_path"]).exists()
+
+    def test_list_boards_ignores_db_only_residue_of_archived_slug(self, fresh_home):
+        """Pre-fix ghost DBs are not treated as live boards after an update."""
+        kb.create_board("archived-residue")
+        kb.remove_board("archived-residue")
+
+        # Reproduce the old watcher behaviour that recreated a schema-only
+        # active directory after it had already enumerated the board.
+        conn = kb.connect(board="archived-residue")
+        conn.close()
+
+        residue = kb.board_dir("archived-residue")
+        assert (residue / "kanban.db").exists()
+        assert not (residue / "board.json").exists()
+        assert "archived-residue" not in {
+            board["slug"] for board in kb.list_boards(include_archived=False)
+        }
+
+    def test_archived_longer_slug_does_not_hide_legacy_db_only_board(self, fresh_home):
+        kb.create_board("legacy-longer")
+        kb.remove_board("legacy-longer")
+
+        # DB-only named boards predate board.json and remain supported. An
+        # archive whose longer slug merely shares this prefix is unrelated.
+        conn = kb.connect(board="legacy")
+        conn.close()
+
+        assert "legacy" in {
+            board["slug"] for board in kb.list_boards(include_archived=False)
+        }
+
     @pytest.mark.parametrize("archive", [True, False])
     def test_remove_clears_init_cache_for_recreated_db(self, fresh_home, archive):
         # Regression for #23833: poll loops that call connect(board=slug) right

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -349,3 +349,72 @@ def test_decompose_no_aux_client_configured(kanban_home):
     assert outcome.ok is False
     # call_llm's no-provider RuntimeError surfaces via the LLM-error branch.
     assert "LLM error" in outcome.reason
+
+
+@pytest.mark.parametrize(
+    "llm_result",
+    [
+        {
+            "fanout": False,
+            "title": "Specified title",
+            "body": "Specified body",
+        },
+        {
+            "fanout": True,
+            "tasks": [
+                {
+                    "title": "child",
+                    "body": "child body",
+                    "assignee": "worker",
+                    "parents": [],
+                }
+            ],
+        },
+    ],
+    ids=["specify-write", "fanout-write"],
+)
+def test_existing_only_decompose_write_does_not_recreate_archived_board(
+    tmp_path, monkeypatch, llm_result,
+):
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "decompose-race")
+    kb.create_board("decompose-race")
+    active_dir = kb.board_dir("decompose-race")
+    with kb.connect(board="decompose-race") as conn:
+        tid = kb.create_task(conn, title="rough idea", triage=True)
+
+    def archive_during_llm(**_kwargs):
+        kb.remove_board("decompose-race")
+        return _fake_aux_response(jsonlib.dumps(llm_result))
+
+    patches = _patch_list_profiles(["orchestrator", "worker"])
+    for profile_patch in patches:
+        profile_patch.start()
+    try:
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            side_effect=archive_during_llm,
+        ), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={
+                "kanban": {
+                    "orchestrator_profile": "orchestrator",
+                    "default_assignee": "worker",
+                }
+            },
+        ):
+            try:
+                outcome = decomp.decompose_task(
+                    tid,
+                    author="auto-decomposer",
+                    board="decompose-race",
+                    create_if_missing=False,
+                )
+            except FileNotFoundError:
+                outcome = None
+    finally:
+        for profile_patch in patches:
+            profile_patch.stop()
+
+    assert outcome is None or outcome.ok is False
+    assert not active_dir.exists()


### PR DESCRIPTION
## Summary

- make named-board gateway watcher/notifier reads fail closed when a board disappears after discovery
- extend the same existing-only contract through gateway auto-decomposition: triage listing plus every decomposition read/write open
- prevent stale watcher snapshots from recreating an archived board directory/SQLite DB or silently falling back to the default board
- preserve create-on-demand defaults for explicit CLI/dashboard operations
- add behavioral archive-after-discovery coverage for triage listing and decomposition write paths

## Root cause (5 whys)

1. Why did an empty active board reappear after archive? A long-lived gateway tick still held a board slug captured before the archive.
2. Why could that stale tick recreate state? Multiple sibling watcher paths opened the named board after discovery: notifier/dispatcher direct opens and auto-decomposer calls through `list_triage_ids()` / `decompose_task()`.
3. Why were auto-decomposer opens still create-capable? `connect_closing()` did not expose `create_if_missing`, so its callers always inherited `connect()`'s create-on-demand default.
4. Why was passing only `HERMES_KANBAN_BOARD` insufficient? After archive, current-board resolution intentionally ignores a missing named-board environment slug and may fall back to the default board; a stale watcher therefore needed an explicit board pin as well as existing-only opens.
5. Why did the first remediation miss this? It fixed direct notifier/dispatcher connections but did not trace the full sibling call graph through the decomposer helper and each of its later read/write reconnections.

**Root cause:** the archive race affected a class of stale named-board watcher opens, but the initial fix covered only direct DB consumers. Auto-decomposition retained an indirect create-capable path through `connect_closing()` and could also resolve away from the archived slug.

**Corrective action:** `connect_closing()`, `list_triage_ids()`, and `decompose_task()` now accept and forward an existing-only mode. The gateway auto-decomposer explicitly pins the discovered slug and passes `create_if_missing=False` through triage listing and every decomposition DB open. Defaults remain create-capable for explicit user/dashboard operations. Regression tests archive after discovery and during decomposition, covering list/read and both specify/fanout write paths. No new lock, daemon, configuration, restart procedure, or cleanup process was added.

## Validation

Exact head: `6bb0994137f1afd86e2d6962012dca471dbd2451`

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_decompose.py tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_watchers_mixin.py -q` — 84 passed, 0 failed
- broader canonical Kanban suite from the remediation run — 1020 passed, 0 failed
- Ruff on all 5 changed files — passed
- `git diff --check 742918a47501dbc47091ca3643c3a79f7ca9fb82..6bb0994137f1afd86e2d6962012dca471dbd2451` — passed
- added-line security pattern scan — no matches

### SonarQube

- project: `hermes-agent-t-936d9597-archive-ghost`
- Compute Engine task: `8aa9d0ed-6a65-4c88-a989-40696612fa86` (`SUCCESS`)
- analysis: `4fcc3fbc-6f06-4082-b6e1-1a2f4af31774`
- SCM revision: `6bb0994137f1afd86e2d6962012dca471dbd2451`
- Quality Gate: `OK`
- coverage: 84.4%
- new bugs: 0; new vulnerabilities: 0; new security hotspots: 0
- one pre-existing fence-regex hotspot was reviewed as safe because it receives only an internal auxiliary-LLM response capped at 4000 tokens; the remediation does not alter that regex path

## Scope and safety

This PR does not modify archived databases, delete historical ghost stubs, deploy code, or restart the gateway. The unrelated local `package-lock.json` modification remains untouched. A later independently approved exact head still requires the externally managed gateway restart and isolated post-restart smoke described in the Kanban task.