### PR TITLE
fix(delegation): honor worker approval callbacks in gateways

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -3107,6 +3107,68 @@ class TestSubagentApprovalCallback(unittest.TestCase):
         # Parent's callback slot is still empty (TLS isolates threads).
         self.assertIsNone(_get_approval_callback())
 
+    def test_gateway_dangerous_command_honors_worker_callback(self):
+        """Gateway routing must not bypass the subagent worker's safe default."""
+        from tools import approval
+        from tools.delegate_tool import _subagent_auto_deny
+
+        session_key = "test-subagent-gateway-approval"
+        approval._pending.clear()
+        approval._session_approved.clear()
+        approval._permanent_approved.clear()
+        callback = MagicMock(wraps=_subagent_auto_deny)
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_GATEWAY_SESSION": "1",
+                "HERMES_SESSION_KEY": session_key,
+                "HERMES_EXEC_ASK": "1",
+            },
+            clear=False,
+        ):
+            os.environ.pop("HERMES_CRON_SESSION", None)
+            result = approval.check_all_command_guards(
+                "rm -rf /tmp/subagent-test",
+                "local",
+                approval_callback=callback,
+            )
+
+        callback.assert_called_once()
+        self.assertFalse(result["approved"])
+        self.assertNotEqual(result.get("status"), "approval_required")
+        self.assertNotIn(session_key, approval._pending)
+
+    def test_gateway_honors_worker_auto_approve_opt_in(self):
+        """The explicit subagent auto-approve policy also bypasses the parent queue."""
+        from tools import approval
+        from tools.delegate_tool import _subagent_auto_approve
+
+        session_key = "test-subagent-gateway-auto-approve"
+        approval._pending.clear()
+        approval._session_approved.clear()
+        approval._permanent_approved.clear()
+        callback = MagicMock(wraps=_subagent_auto_approve)
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_GATEWAY_SESSION": "1",
+                "HERMES_SESSION_KEY": session_key,
+                "HERMES_EXEC_ASK": "1",
+            },
+            clear=False,
+        ):
+            os.environ.pop("HERMES_CRON_SESSION", None)
+            result = approval.check_all_command_guards(
+                "rm -rf /tmp/subagent-test",
+                "local",
+                approval_callback=callback,
+            )
+
+        callback.assert_called_once()
+        self.assertTrue(result["approved"])
+        self.assertNotIn(session_key, approval._pending)
 
 class TestFallbackModelInheritance(unittest.TestCase):
     """Subagents must inherit the parent's fallback provider chain."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2128,9 +2128,11 @@ def _run_approval_gate(
         description: Human-facing reason shown in the prompt.
         display_target: The command string or synthetic tool label shown
             to the user (redacted by ``prompt_dangerous_approval``).
-        approval_callback: Optional CLI prompt callback. When ``None`` the
-            per-thread callback registered via
-            ``tools.terminal_tool.set_approval_callback`` is used.
+        approval_callback: Optional explicit approval callback. When ``None``
+            the per-thread callback registered via
+            ``tools.terminal_tool.set_approval_callback`` is used. A callback
+            takes precedence over gateway routing, including the
+            ``HERMES_EXEC_ASK`` flag installed during gateway startup.
         cron_deny_message: Message returned when a cron job hits this gate
             under ``cron_mode: deny``.
         autoapprove_log_prefix: Log line prefix for the non-interactive
@@ -2206,7 +2208,12 @@ def _run_approval_gate(
         )
         return {"approved": True, "message": None}
 
-    if is_gateway or env_var_enabled("HERMES_EXEC_ASK"):
+    # A thread-local callback is an explicit approval policy installed by the
+    # caller.  Subagent workers use this to fail closed (or explicitly opt in
+    # to auto-approval) without borrowing the parent gateway session's queue.
+    # HERMES_EXEC_ASK is installed by gateway startup, so it cannot override
+    # a worker-local policy without recreating the parent-queue leak.
+    if (is_gateway or env_var_enabled("HERMES_EXEC_ASK")) and approval_callback is None:
         # Interactive gateway round-trip when a notify callback is
         # registered for this session (Discord/Telegram/Slack embed +
         # buttons, same mechanism as check_dangerous_command). Blocks the
@@ -2884,7 +2891,10 @@ def check_all_command_guards(command: str, env_type: str,
     # responds with /approve or /deny, mirroring the CLI's synchronous
     # input() flow.  The agent never sees "approval_required"; it either
     # gets the command output (approved) or a definitive "BLOCKED" message.
-    if is_gateway or is_ask:
+    # An explicit callback belongs to the current worker and must take
+    # precedence over the parent gateway's approval queue.  HERMES_EXEC_ASK is
+    # set by gateway startup, so it follows the same callback-precedence rule.
+    if (is_gateway or is_ask) and approval_callback is None:
         notify_cb = None
         with _lock:
             notify_cb = _gateway_notify_cbs.get(session_key)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -68,9 +68,9 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
 # The callback is chosen by the `delegation.subagent_auto_approve` config:
 #   false (default) → _subagent_auto_deny (safe; matches leaf tool blocklist)
 #   true            → _subagent_auto_approve (opt-in YOLO for cron/batch)
-# Both emit a logger.warning for audit; gateway sessions are unaffected
-# because they resolve approvals via tools/approval.py's per-session queue,
-# not through these TLS callbacks.
+# Both emit a logger.warning for audit.  The approval gate gives this explicit
+# worker policy precedence over a gateway queue, so a subagent cannot borrow
+# the parent session's approval channel or block it waiting for a decision.
 def _subagent_auto_deny(command: str, description: str, **kwargs) -> str:
     """Auto-deny dangerous commands in subagent threads (safe default).
 


### PR DESCRIPTION
## Summary

- give explicit subagent worker approval callbacks precedence over the parent gateway approval queue
- apply the rule in both the shared approval gate and the consolidated terminal command guard
- preserve the default auto-deny and opt-in auto-approve policies even when gateway startup sets `HERMES_EXEC_ASK=1`
- replace the stale comment that said gateway sessions bypass worker callbacks

This prevents dangerous subagent commands from borrowing the parent session key, blocking on an unrelated approval queue, and leaving stale pending approvals. Existing session/permanent approvals and smart-approval policy continue to retain their established precedence; this change fixes the gateway routing boundary described by the issue.

## Tests

- `pytest -n auto tests/tools/test_delegate.py::TestSubagentApprovalCallback -q` — 9 passed
- `scripts/run_tests.sh --files 'tests/tools/test_delegate.py:tests/tools/test_approval.py:tests/tools/test_command_guards.py:tests/tools/test_cron_approval_mode.py:tests/acp/test_approval_isolation.py:tests/gateway/test_approve_deny_commands.py'` — 565 passed
- `ruff check tools/approval.py tools/delegate_tool.py tests/tools/test_delegate.py`
- `git diff --check`

Fixes #65291