### PR TITLE
fix(desktop): reseed new chats from profile defaults

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useBackgroundSync } from './use-background-sync'
+
+describe('useBackgroundSync', () => {
+  it('force-reseeds the profile default for a fresh new-session draft', () => {
+    const refreshCurrentModel = vi.fn()
+
+    renderHook(() =>
+      useBackgroundSync({
+        activeIsMessaging: false,
+        activeSessionId: null,
+        freshDraftReady: true,
+        gatewayState: 'open',
+        refreshActiveMessagingTranscript: vi.fn(),
+        refreshCronJobs: vi.fn(),
+        refreshCurrentModel,
+        refreshHermesConfig: vi.fn(),
+        refreshMessagingSessions: vi.fn(),
+        refreshSessions: vi.fn(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    expect(refreshCurrentModel).toHaveBeenCalledWith(true)
+  })
+
+  it('does not reseed the profile default while a live session is active', () => {
+    const refreshCurrentModel = vi.fn()
+
+    renderHook(() =>
+      useBackgroundSync({
+        activeIsMessaging: false,
+        activeSessionId: 'runtime-1',
+        freshDraftReady: true,
+        gatewayState: 'open',
+        refreshActiveMessagingTranscript: vi.fn(),
+        refreshCronJobs: vi.fn(),
+        refreshCurrentModel,
+        refreshHermesConfig: vi.fn(),
+        refreshMessagingSessions: vi.fn(),
+        refreshSessions: vi.fn(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    expect(refreshCurrentModel).not.toHaveBeenCalledWith(true)
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -129,7 +129,7 @@ export function useBackgroundSync({
   // model + config so the composer pill reflects the profile default.
   useEffect(() => {
     if (gatewayState === 'open' && !activeSessionId && freshDraftReady) {
-      void refreshCurrentModel()
+      void refreshCurrentModel(true)
       void refreshHermesConfig()
     }
   }, [activeSessionId, freshDraftReady, gatewayState, refreshCurrentModel, refreshHermesConfig])

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -197,8 +197,10 @@ describe('useModelControls', () => {
     await result.current.refreshCurrentModel()
     expect($currentModel.get()).toBe('anthropic/claude-sonnet-4.6')
 
-    // A profile swap forces a reseed to the new profile's default.
+    // A fresh new chat (or profile swap) explicitly reseeds from the profile
+    // default instead of inheriting the prior sticky composer selection.
     await result.current.refreshCurrentModel(true)
     expect($currentModel.get()).toBe('openai/gpt-5.5')
+    expect($currentProvider.get()).toBe('openai-codex')
   })
 })


### PR DESCRIPTION
Fixes the fresh-new-chat model seeding regression reported in #65300 / related #50821.

### What changed
- Force the fresh new-session draft sync path to reseed the composer model/provider from the profile/global default instead of reusing the prior sticky selection.
- Add a regression test for the fresh-draft reseed path.
- Strengthen the model-controls test to assert the provider reseeds too.

### Verification
- `npm test -- src/app/contrib/hooks/use-background-sync.test.tsx src/app/session/hooks/use-model-controls.test.tsx` ✅
- `git diff --check` ✅
- `npm run lint -- src/app/contrib/hooks/use-background-sync.ts src/app/contrib/hooks/use-background-sync.test.tsx src/app/session/hooks/use-model-controls.test.tsx` ✅ (repo-level warnings only)
- `npm run typecheck` ❌ blocked by baseline missing/incompatible desktop dependencies in this environment
- `npm run build` ❌ blocked by baseline missing/incompatible assistant-ui exports in this environment

### Notes
This branch is published from fork/deniqlab due push permissions on the upstream repo.
