### PR TITLE
feat(telemetry): opt-in per-turn waterfall tracing (config: agent.turn_trace)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3028,6 +3028,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         usage_obj = None
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
+        # Also stamped on the agent so the turn-trace retrofit in
+        # conversation_loop can tag ttft_ms on the llm.call span (the
+        # conversation loop clears this per attempt).
+        agent._last_stream_diag = _diag
         _writer_token = {"value": None}
         attempt_request_client = {"value": None}
 
@@ -3523,6 +3527,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         last_chunk_time["t"] = time.time()
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
+        # Also stamped on the agent so the turn-trace retrofit in
+        # conversation_loop can tag ttft_ms on the llm.call span (the
+        # conversation loop clears this per attempt).
+        agent._last_stream_diag = _diag
         _writer_token = {"value": None}
         _stream_context = {"manager": None, "stream": None}
         base_final_message = None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -38,6 +38,7 @@ from agent.conversation_compression import (
 from agent.context_engine import automatic_compaction_status_message
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
+from agent import turn_trace
 from agent.turn_context import (
     _compression_warrants_another_preflight_pass,
     build_turn_context,
@@ -1284,6 +1285,16 @@ def _run_conversation_impl(
     # cached gateway agent must recover on the next message if storage did.
     agent._incremental_persistence_failed = False
 
+    # Per-turn trace (None when tracing is disabled) — resolved once; every
+    # instrumentation site below is skipped/no-op when this is None.
+    _tt = turn_trace.get_bound(agent)
+    _iter_started = None  # start of the in-flight `iteration` span
+    # Monotonic pass ordinal for `iteration` spans. api_call_count is NOT
+    # unique per pass: the pre-API compression path refunds it (continue) and
+    # the interrupt check breaks before it increments, both of which would
+    # produce two spans tagged with the same i.
+    _iter_pass = 0
+
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
     final_response = None
@@ -1349,6 +1360,20 @@ def _run_conversation_impl(
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+        # Close the previous pass's `iteration` span and open the next one.
+        # Retrofitted from timestamps (no context manager) because the loop
+        # body exits through many continue/break/return paths.
+        if _tt is not None:
+            _iter_now = time.time()
+            if _iter_started is not None:
+                _tt.add_span("iteration", _iter_started, _iter_now, i=_iter_pass)
+            _iter_started = _iter_now
+            _iter_pass += 1
+            # Mirrored onto the trace so the run_conversation wrapper's
+            # finally can close the in-flight span on the loop's early
+            # `return` paths, which bypass the post-loop close below.
+            _tt._pending_iteration = (_iter_started, _iter_pass)
+
         _redirect_text = agent._drain_pending_redirect()
         if _redirect_text:
             _apply_active_turn_redirect(agent, messages, _redirect_text)
@@ -1475,6 +1500,7 @@ def _run_conversation_impl(
         # Note: Reasoning is embedded in content via <think> tags for trajectory storage.
         # However, providers like Moonshot AI require a separate 'reasoning_content' field
         # on assistant messages with tool_calls. We handle both cases here.
+        _ctx_asm_started = time.time() if _tt is not None else None
         request_logger = getattr(agent, "logger", None) or logging.getLogger(__name__)
         # Per-agent validation cursor: skips re-json.loads-ing tool_call
         # arguments on history messages already validated in a previous
@@ -1853,6 +1879,8 @@ def _run_conversation_impl(
             _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
         )
         total_chars = approx_tokens * 4
+        if _ctx_asm_started is not None:
+            _tt.add_span("iteration.context_assemble", _ctx_asm_started, time.time())
 
         _runtime_context_error = _ollama_context_limit_error(
             agent, request_pressure_tokens
@@ -2086,6 +2114,7 @@ def _run_conversation_impl(
         finish_reason = "stop"
         response = None  # Guard against UnboundLocalError if all retries fail
         api_kwargs = None  # Guard against UnboundLocalError in except handler
+        _llm_call_started = None  # trace: start of the in-flight llm.call attempt
         api_request_id = f"{turn_id}:api:{api_call_count}"
         agent._current_api_request_id = api_request_id
 
@@ -2141,6 +2170,7 @@ def _run_conversation_impl(
                     pass  # Never let rate guard break the agent loop
 
             try:
+                _req_setup_started = time.time() if _tt is not None else None
                 agent._reset_stream_delivery_tracking()
                 # api_messages is built once, before this retry loop, while the
                 # primary provider is active.  A mid-conversation fallback can
@@ -2269,6 +2299,9 @@ def _run_conversation_impl(
                 if _moa_prepared_request is not None and agent.provider == "moa":
                     api_kwargs["_moa_prepared_request"] = _moa_prepared_request
 
+                if _req_setup_started is not None:
+                    _tt.add_span("iteration.request_setup", _req_setup_started, time.time())
+
                 # Always prefer the streaming path — even without stream
                 # consumers.  Streaming gives us fine-grained health
                 # checking (90s stale-stream detection, 60s read timeout)
@@ -2359,6 +2392,13 @@ def _run_conversation_impl(
 
                 from hermes_cli.middleware import run_llm_execution_middleware
 
+                _llm_call_started = None
+                if _tt is not None:
+                    _llm_call_started = time.time()
+                    # Cleared per attempt so a stale diag from a previous
+                    # streaming call can't leak a wrong ttft_ms onto this one.
+                    agent._last_stream_diag = None
+
                 _model_request_active = getattr(agent, "_model_request_active", None)
                 _redirect_lock = getattr(agent, "_pending_redirect_lock", None)
                 if _redirect_lock is not None:
@@ -2414,7 +2454,24 @@ def _run_conversation_impl(
                     break
                 
                 api_duration = time.time() - api_start_time
-                
+
+                # The API call itself ran on a worker thread; retrofit the span
+                # from timings measured here to avoid adopt() plumbing there.
+                if _llm_call_started is not None:
+                    try:
+                        _llm_tags = {"api_request_id": api_request_id, "model": agent.model}
+                        _sd = getattr(agent, "_last_stream_diag", None)
+                        if isinstance(_sd, dict) and _sd.get("first_chunk_at"):
+                            _llm_tags["ttft_ms"] = round(
+                                (_sd["first_chunk_at"] - _sd["started_at"]) * 1000.0, 1
+                            )
+                        _tt.add_span("llm.call", _llm_call_started, time.time(), **_llm_tags)
+                    except Exception:
+                        pass
+                    # Consumed: a later exception in this try (post-response
+                    # processing) must not retrofit a second llm.call span.
+                    _llm_call_started = None
+
                 # Stop thinking spinner silently -- the response box or tool
                 # execution messages that follow are more informative.
                 if thinking_spinner:
@@ -3163,6 +3220,7 @@ def _run_conversation_impl(
                         }
                 
                 # Track actual token usage from response for context management
+                _acct_started = time.time() if _tt is not None else None
                 if hasattr(response, 'usage') and response.usage:
                     canonical_usage = normalize_usage(
                         response.usage,
@@ -3398,6 +3456,18 @@ def _run_conversation_impl(
                             f"({hit_pct:.0f}% hit, {written:,} written)"
                         )
                 
+                if _acct_started is not None:
+                    try:
+                        _acct_tags = {}
+                        if (hasattr(response, "usage") and response.usage
+                                and canonical_usage.cache_read_tokens and prompt_tokens):
+                            _acct_tags["cache_pct"] = round(
+                                100.0 * canonical_usage.cache_read_tokens / prompt_tokens, 1
+                            )
+                    except Exception:
+                        _acct_tags = {}
+                    _tt.add_span("llm.accounting", _acct_started, time.time(), **_acct_tags)
+
                 _retry.has_retried_429 = False  # Reset on success
                 # Note: don't clear the retry buffer here — an "API call
                 # success" only means we got bytes back, not that we got
@@ -3423,6 +3493,17 @@ def _run_conversation_impl(
                 break  # Success, exit retry loop
 
             except InterruptedError:
+                # Retrofit the llm.call span for the interrupted attempt so
+                # its (possibly long) wall time isn't misread as hermes
+                # overhead in the waterfall.
+                if _llm_call_started is not None:
+                    try:
+                        _tt.add_span("llm.call", _llm_call_started, time.time(),
+                                     api_request_id=api_request_id, model=agent.model,
+                                     error="InterruptedError")
+                    except Exception:
+                        pass
+                    _llm_call_started = None
                 if thinking_spinner:
                     thinking_spinner.stop("")
                     thinking_spinner = None
@@ -3457,6 +3538,16 @@ def _run_conversation_impl(
                 break
 
             except Exception as api_error:
+                # Retrofit the llm.call span for the failed attempt (retried
+                # or not) so its wall time isn't misread as hermes overhead.
+                if _llm_call_started is not None:
+                    try:
+                        _tt.add_span("llm.call", _llm_call_started, time.time(),
+                                     api_request_id=api_request_id, model=agent.model,
+                                     error=type(api_error).__name__)
+                    except Exception:
+                        pass
+                    _llm_call_started = None
                 # Stop spinner silently — retry status is buffered and
                 # only flushed when every retry+fallback is exhausted.
                 if thinking_spinner:
@@ -6827,6 +6918,7 @@ def _run_conversation_impl(
                 ):
                     messages.pop()
 
+                _verify_gate_started = time.time() if _tt is not None else None
                 try:
                     from agent.verification_stop import (
                         build_verify_on_stop_nudge,
@@ -6884,6 +6976,9 @@ def _run_conversation_impl(
                         agent._interim_content_was_streamed(final_response or "")
                     )
                     final_response = None
+                    if _verify_gate_started is not None:
+                        _tt.add_span("turn.verify_gate", _verify_gate_started, time.time(),
+                                     nudge_fired=True)
                     continue
 
                 # User verification-loop gate: when the agent edited code this
@@ -6946,6 +7041,9 @@ def _run_conversation_impl(
                         agent._interim_content_was_streamed(final_response or "")
                     )
                     final_response = None
+                    if _verify_gate_started is not None:
+                        _tt.add_span("turn.verify_gate", _verify_gate_started, time.time(),
+                                     nudge_fired=True)
                     continue
 
                 # ── Kanban worker terminal-tool stop guard ─────────────
@@ -6997,6 +7095,9 @@ def _run_conversation_impl(
                     )
                     final_response = None
                     continue
+
+                if _verify_gate_started is not None:
+                    _tt.add_span("turn.verify_gate", _verify_gate_started, time.time())
 
                 messages.append(final_msg)
                 
@@ -7100,6 +7201,17 @@ def _run_conversation_impl(
                 messages.append({"role": "assistant", "content": final_response})
                 break
     
+    if _tt is not None:
+        if _iter_started is not None:
+            _tt.add_span("iteration", _iter_started, time.time(), i=_iter_pass)
+        _tt._pending_iteration = None
+        try:
+            # Trace-level tag; the run_conversation wrapper copies it onto the
+            # root `turn` span (exit reason is a local of this function).
+            _tt.tag(exit_reason=_turn_exit_reason)
+        except Exception:
+            pass
+
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.
@@ -7122,6 +7234,10 @@ def _run_conversation_impl(
         _pending_verification_response_previewed=_pending_verification_response_previewed,
     )
 
+
+# run_conversation is a thin tracing wrapper; expose the real body to
+# inspect.getsource/signature (source-inspecting tests count code in it).
+run_conversation.__wrapped__ = _run_conversation_impl
 
 
 __all__ = ["run_conversation"]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1094,6 +1094,99 @@ def run_conversation(
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     moa_config: Optional[dict[str, Any]] = None,
 ) -> Dict[str, Any]:
+    """Public entry — wraps ``_run_conversation_impl`` with per-turn tracing.
+
+    Trace ownership (see ``agent/turn_trace.py``): when a gateway already
+    began a trace and bound it to ``agent`` before dispatching here, this
+    function only adopts it for the current thread; the gateway finishes it
+    after delivery.  CLI/direct callers have no bound trace, so this function
+    begins and finishes one itself.  When tracing is disabled everything here
+    is a cheap no-op passthrough.
+    """
+    trace = turn_trace.get_bound(agent)
+    owner = False
+    if trace is None:
+        if turn_trace.enabled():
+            trace = turn_trace.begin(
+                key=agent.session_id or None,
+                platform=getattr(agent, "platform", None) or "cli",
+                session_key=agent.session_id or "",
+            )
+            owner = trace is not None
+            if owner:
+                turn_trace.bind(agent, trace)
+    else:
+        # Gateway-owned trace: make it current for THIS (run_sync worker) thread.
+        turn_trace.adopt(trace)
+    if trace is None:
+        return _run_conversation_impl(
+            agent, user_message, system_message, conversation_history, task_id,
+            stream_callback, persist_user_message, persist_user_timestamp,
+            moa_config,
+            persist_user_display_kind=persist_user_display_kind,
+            persist_user_display_metadata=persist_user_display_metadata,
+        )
+    _turn_started = time.time()
+    _result = None
+    try:
+        _result = _run_conversation_impl(
+            agent, user_message, system_message, conversation_history, task_id,
+            stream_callback, persist_user_message, persist_user_timestamp,
+            moa_config,
+            persist_user_display_kind=persist_user_display_kind,
+            persist_user_display_metadata=persist_user_display_metadata,
+        )
+        return _result
+    finally:
+        try:
+            # The loop body exits through many early `return` paths that skip
+            # its own post-loop close/tagging; close the in-flight iteration
+            # span and backfill exit_reason here so those turns still render.
+            _pending_iter = getattr(trace, "_pending_iteration", None)
+            if _pending_iter:
+                trace.add_span("iteration", _pending_iter[0], time.time(), i=_pending_iter[1])
+                trace._pending_iteration = None
+            if "exit_reason" not in trace.tags:
+                if _result is None:
+                    trace.tag(exit_reason="exception")
+                else:
+                    _err = _result.get("error") if isinstance(_result, dict) else None
+                    trace.tag(exit_reason=f"early_return({str(_err)[:80]})" if _err else "early_return")
+        except Exception:
+            pass
+        try:
+            _turn_tags = {
+                "model": agent.model,
+                "iterations": getattr(agent, "_api_call_count", 0),
+                "turn_id": getattr(agent, "_current_turn_id", "") or "",
+            }
+            # tool_calls / exit_reason are accumulated as trace-level tags by
+            # the loop body (they are locals there); surface them on the span.
+            for _k in ("tool_calls", "exit_reason"):
+                if _k in trace.tags:
+                    _turn_tags[_k] = trace.tags[_k]
+            trace.add_span("turn", _turn_started, time.time(), **_turn_tags)
+        except Exception:
+            pass
+        if owner:
+            trace.finish()
+            turn_trace.bind(agent, None)
+            turn_trace.adopt(None)
+
+
+def _run_conversation_impl(
+    agent,
+    user_message: str,
+    system_message: str = None,
+    conversation_history: List[Dict[str, Any]] = None,
+    task_id: str = None,
+    stream_callback: Optional[callable] = None,
+    persist_user_message: Optional[str] = None,
+    persist_user_timestamp: Optional[float] = None,
+    moa_config: Optional[dict[str, Any]] = None,
+    persist_user_display_kind: Optional[str] = None,
+    persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -23,6 +23,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from agent import turn_trace
 from agent.display import (
     KawaiiSpinner,
     build_tool_preview as _build_tool_preview,
@@ -760,6 +761,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     agent._current_tool = tool_names_str
     agent._touch_activity(f"executing {num_tools} tools concurrently: {tool_names_str}")
 
+    # Turn trace captured ONCE at fan-out. Workers must not resolve it via
+    # get_bound(agent) at completion time: a worker abandoned on deadline or
+    # interrupt (shutdown(wait=False) below) can outlive this batch and would
+    # otherwise inject its tools.call span into the NEXT turn's trace bound to
+    # the same cached agent instance.
+    _tt_batch = turn_trace.get_bound(agent)
+
     def _run_tool(
         index,
         tool_call,
@@ -867,6 +875,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     False,
                     middleware_trace,
                 )
+                # Worker threads never adopt() the trace — use the batch's
+                # own trace captured at fan-out (see comment there).
+                if _tt_batch is not None:
+                    _tt_batch.add_span("tools.call", start, time.time(), tool=function_name,
+                                       execute_ms=round(duration * 1000.0, 1), error="cancelled")
                 return
             except Exception as tool_error:
                 result = f"Error executing tool '{function_name}': {tool_error}"
@@ -886,6 +899,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 blocked,
                 middleware_trace,
             )
+            # Worker threads never adopt() the trace — use the batch's own
+            # trace captured at fan-out (see comment there).
+            if _tt_batch is not None:
+                _tt_batch.add_span("tools.call", start, time.time(), tool=function_name,
+                                   execute_ms=round(duration * 1000.0, 1))
         finally:
             _advance_start()
             # Tear down worker-tid tracking.  Clear any interrupt bit we may
@@ -1323,6 +1341,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
+    # Per-turn trace (None when tracing is disabled).
+    _tt = turn_trace.get_bound(agent)
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         if getattr(agent, "_incremental_persistence_failed", False):
             return
@@ -1350,6 +1370,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             break
 
         function_name = tool_call.function.name
+        _call_started = time.time() if _tt is not None else None
+        _flush_ms = None
 
         function_args, malformed_args_result = _parse_tool_arguments(
             tool_call.function.arguments
@@ -1894,12 +1916,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         tool_message = make_tool_result_message(function_name, _tool_content, tool_call.id)
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
+        _flush_started = time.time() if _tt is not None else None
         if not _flush_session_db_after_tool_progress(
             agent,
             messages,
             stage=f"tool result {function_name}",
         ):
             return
+        if _flush_started is not None:
+            _flush_ms = round((time.time() - _flush_started) * 1000.0, 1)
 
         # UI completion/progress events are projections of the canonical tool
         # row, never a competing in-memory authority.
@@ -1950,6 +1975,18 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # injection lands as soon as a tool finishes — not after the
         # entire batch.  The model sees it on the next API iteration.
         agent._apply_pending_steer_to_tool_results(messages, 1)
+
+        # Retrofitted (no context manager): the loop body exits through
+        # several continue/break paths before reaching here.
+        if _call_started is not None:
+            try:
+                _tt.add_span(
+                    "tools.call", _call_started, time.time(), tool=function_name,
+                    execute_ms=round(tool_duration * 1000.0, 1),
+                    flush_ms=_flush_ms,
+                )
+            except Exception:
+                pass
 
         if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
             if agent.verbose_logging:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -31,6 +31,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional
 
+from agent import turn_trace
 from agent.conversation_compression import (
     IDLE_COMPACTION_STATUS_TEMPLATE,
     PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
@@ -353,6 +354,10 @@ def build_turn_context(
     ``conversation_loop`` module are passed in explicitly to keep this module
     free of an import cycle with ``agent.conversation_loop``.
     """
+    # Per-turn trace (None when tracing is disabled).
+    _tt = turn_trace.get_bound(agent)
+    _prologue_started = time.time() if _tt is not None else None
+
     # Guard stdio against OSError from broken pipes (systemd/headless/daemon).
     install_safe_stdio()
 
@@ -611,8 +616,10 @@ def build_turn_context(
         )
 
     # ── System prompt (cached per session for prefix caching) ──
-    if agent._cached_system_prompt is None:
-        restore_or_build_system_prompt(agent, system_message, conversation_history)
+    _sp_rebuilt = agent._cached_system_prompt is None
+    with turn_trace.span("prologue.system_prompt", trace=_tt, rebuilt=_sp_rebuilt):
+        if _sp_rebuilt:
+            restore_or_build_system_prompt(agent, system_message, conversation_history)
 
     active_system_prompt = agent._cached_system_prompt
 
@@ -628,26 +635,27 @@ def build_turn_context(
     # once with its final api_content — both steps take the same per-agent
     # persist lock as CLI close persistence.
     persist_lock = getattr(agent, "_session_persist_lock", None)
-    try:
-        if persist_lock is None:
-            agent._ensure_db_session()
-        else:
-            with persist_lock:
+    with turn_trace.span("prologue.session_row", trace=_tt):
+        try:
+            if persist_lock is None:
                 agent._ensure_db_session()
-    except Exception:
-        logger.warning(
-            "Turn-start session row creation failed for session=%s",
-            agent.session_id or "none",
-            exc_info=True,
-        )
-    finally:
-        # Clear the staged CLI input eagerly (as the pre-refactor code did)
-        # so a crash in preflight compression — which runs between this row
-        # create and the late crash-persist below — doesn't leave a stale
-        # _pending_cli_user_message that the next turn would mistake for a
-        # fresh staged input.
-        if not isinstance(pending_cli_message, dict) or pending_cli_message.get("_db_persisted"):
-            agent._pending_cli_user_message = None
+            else:
+                with persist_lock:
+                    agent._ensure_db_session()
+        except Exception:
+            logger.warning(
+                "Turn-start session row creation failed for session=%s",
+                agent.session_id or "none",
+                exc_info=True,
+            )
+        finally:
+            # Clear the staged CLI input eagerly (as the pre-refactor code did)
+            # so a crash in preflight compression — which runs between this row
+            # create and the late crash-persist below — doesn't leave a stale
+            # _pending_cli_user_message that the next turn would mistake for a
+            # fresh staged input.
+            if not isinstance(pending_cli_message, dict) or pending_cli_message.get("_db_persisted"):
+                agent._pending_cli_user_message = None
 
     # ── Idle-triggered compaction (opt-in; ``idle_compact_after_seconds``) ──
     # When a session resumes after a long idle gap, compact the accumulated
@@ -732,6 +740,7 @@ def build_turn_context(
     # Gate the (expensive) full token estimate behind a cheap pre-check.
     # See ``_should_run_preflight_estimate`` for the OR semantics that fix
     # issue #27405 (a few very large messages slipping past the count gate).
+    _cpf_started = time.time() if _tt is not None else None
     _preflight_compressed = False
     _preflight_compression_blocked = False
     agent._turn_received_provider_response = False
@@ -1034,6 +1043,10 @@ def build_turn_context(
                     agent._last_content_tools_all_housekeeping = False
                     agent._mute_post_response = False
 
+    if _cpf_started is not None:
+        _tt.add_span("prologue.compression_preflight", _cpf_started, time.time(),
+                     compressed=_preflight_compressed)
+
     if _preflight_compressed:
         # Compression rebuilt the list (tail messages are fresh compaction
         # copies), so the pre-compression index of this turn's user message
@@ -1049,6 +1062,7 @@ def build_turn_context(
 
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""
+    _hook_started = time.time() if _tt is not None else None
     try:
         from hermes_cli.lifecycle import invoke_hook as _invoke_hook
         _pre_results = _invoke_hook(
@@ -1100,6 +1114,8 @@ def build_turn_context(
             plugin_user_context = "\n\n".join(_ctx_parts)
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
+    if _hook_started is not None:
+        _tt.add_span("prologue.pre_llm_hook", _hook_started, time.time())
 
     # Gateway must-deliver notes (auto-reset note, first-contact intro,
     # voice-channel change) ride the same user-message injection channel as
@@ -1154,11 +1170,13 @@ def build_turn_context(
     # External memory provider: prefetch once before the tool loop.
     ext_prefetch_cache = ""
     if agent._memory_manager:
-        try:
-            _query = original_user_message if isinstance(original_user_message, str) else ""
-            ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
-        except Exception:
-            pass
+        with turn_trace.span("prologue.memory_prefetch", trace=_tt) as _mp_span:
+            try:
+                _query = original_user_message if isinstance(original_user_message, str) else ""
+                ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
+            except Exception:
+                pass
+            _mp_span.tag(decision="hit" if ext_prefetch_cache else "empty")
 
     # ── api_content sidecar: persist what you send ──
     # The prefetch/plugin context above is injected into the API copy of this
@@ -1227,24 +1245,28 @@ def build_turn_context(
         agent._ensure_db_session()
         agent._persist_session(messages, conversation_history)
 
-    try:
-        if persist_lock is None:
-            _ensure_and_persist()
-        else:
-            with persist_lock:
+    with turn_trace.span("prologue.persist_early", trace=_tt):
+        try:
+            if persist_lock is None:
                 _ensure_and_persist()
-    except Exception:
-        logger.warning(
-            "Early turn-start session persistence failed for session=%s",
-            agent.session_id or "none",
-            exc_info=True,
-        )
-    finally:
-        # Keep an unmarked staged input available to a later close retry if the
-        # normal persistence attempt failed. Once the marker is present, the
-        # close path must no longer treat it as a pre-worker UI input.
-        if not isinstance(pending_cli_message, dict) or pending_cli_message.get("_db_persisted"):
-            agent._pending_cli_user_message = None
+            else:
+                with persist_lock:
+                    _ensure_and_persist()
+        except Exception:
+            logger.warning(
+                "Early turn-start session persistence failed for session=%s",
+                agent.session_id or "none",
+                exc_info=True,
+            )
+        finally:
+            # Keep an unmarked staged input available to a later close retry if the
+            # normal persistence attempt failed. Once the marker is present, the
+            # close path must no longer treat it as a pre-worker UI input.
+            if not isinstance(pending_cli_message, dict) or pending_cli_message.get("_db_persisted"):
+                agent._pending_cli_user_message = None
+
+    if _prologue_started is not None:
+        _tt.add_span("turn.prologue", _prologue_started, time.time())
 
     return TurnContext(
         user_message=user_message,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -23,7 +23,9 @@ keep the exact logger name (``"agent.conversation_loop"``).
 from __future__ import annotations
 
 import os
+import time
 
+from agent import turn_trace
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.message_content import flatten_message_text
 
@@ -90,6 +92,10 @@ def finalize_turn(
     loop). See module docstring.
     """
     from agent.conversation_loop import logger
+
+    # Per-turn trace (None when tracing is disabled).
+    _tt = turn_trace.get_bound(agent)
+    _finalize_started = time.time() if _tt is not None else None
 
     budget_exhausted = (
         api_call_count >= agent.max_iterations
@@ -246,23 +252,26 @@ def finalize_turn(
 
     # Save trajectory if enabled.  ``user_message`` may be a multimodal
     # list of parts; the trajectory format wants a plain string.
-    try:
-        agent._save_trajectory(messages, _summarize_user_message_for_log(user_message), completed)
-    except Exception as _save_err:
-        _cleanup_errors.append(f"save_trajectory: {_save_err}")
-        logger.error("finalize_turn: _save_trajectory failed: %s", _save_err, exc_info=True)
+    with turn_trace.span("finalize.trajectory", trace=_tt):
+        try:
+            agent._save_trajectory(messages, _summarize_user_message_for_log(user_message), completed)
+        except Exception as _save_err:
+            _cleanup_errors.append(f"save_trajectory: {_save_err}")
+            logger.error("finalize_turn: _save_trajectory failed: %s", _save_err, exc_info=True)
 
     # Clean up VM and browser for this task after conversation completes
-    try:
-        agent._cleanup_task_resources(effective_task_id)
-    except Exception as _cleanup_err:
-        _cleanup_errors.append(f"cleanup_task_resources: {_cleanup_err}")
-        logger.error("finalize_turn: _cleanup_task_resources failed: %s", _cleanup_err, exc_info=True)
+    with turn_trace.span("finalize.resource_cleanup", trace=_tt):
+        try:
+            agent._cleanup_task_resources(effective_task_id)
+        except Exception as _cleanup_err:
+            _cleanup_errors.append(f"cleanup_task_resources: {_cleanup_err}")
+            logger.error("finalize_turn: _cleanup_task_resources failed: %s", _cleanup_err, exc_info=True)
 
     # Persist session to both JSON log and SQLite only after private retry
     # scaffolding has been removed. Otherwise a later user "continue" turn
     # can replay assistant("(empty)") / recovery nudges and fall into the
     # same empty-response loop again.
+    _persist_started = time.time() if _tt is not None else None
     try:
         agent._drop_trailing_empty_response_scaffolding(messages)
 
@@ -353,6 +362,8 @@ def finalize_turn(
     except Exception as _persist_err:
         _cleanup_errors.append(f"persist_session: {_persist_err}")
         logger.error("finalize_turn: _persist_session failed: %s", _persist_err, exc_info=True)
+    if _persist_started is not None:
+        _tt.add_span("finalize.persist", _persist_started, time.time())
 
     # ── Turn-exit diagnostic log ─────────────────────────────────────
     # Always logged at INFO so agent.log captures WHY every turn ended.
@@ -413,6 +424,7 @@ def finalize_turn(
     # Gate: only applied when a real text response exists for this
     # turn and the user didn't interrupt.  Empty/interrupted turns
     # already have other surface text that shouldn't be augmented.
+    _hooks_started = time.time() if _tt is not None else None
     if final_response and not interrupted:
         try:
             _failed = getattr(agent, "_turn_failed_file_mutations", None) or {}
@@ -605,6 +617,8 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    if _hooks_started is not None:
+        _tt.add_span("finalize.post_hooks", _hooks_started, time.time())
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Surface any post-loop cleanup failures so the caller can distinguish a
@@ -639,6 +653,7 @@ def finalize_turn(
         agent._iters_since_skill = 0
 
     # External memory provider: sync the completed turn + queue next prefetch.
+    _md_started = time.time() if _tt is not None else None
     agent._sync_external_memory_for_turn(
         original_user_message=original_user_message,
         final_response=final_response,
@@ -687,5 +702,10 @@ def finalize_turn(
 
     agent._turn_preflight_display_snapshot = None
     agent._turn_received_provider_response = False
+
+    if _md_started is not None:
+        _tt.add_span("finalize.memory_dispatch", _md_started, time.time())
+    if _finalize_started is not None:
+        _tt.add_span("turn.finalize", _finalize_started, time.time())
 
     return result

--- a/agent/turn_trace.py
+++ b/agent/turn_trace.py
@@ -1,0 +1,241 @@
+"""Per-turn waterfall tracing.
+
+Records timing spans for everything hermes does around the LLM call in a turn
+(gateway ingress, prologue, context assembly, LLM calls, tool dispatch,
+finalize, delivery) and emits ONE JSON line per turn to a rotating
+``<hermes_home>/logs/turn_traces.jsonl`` sink, so turns can be rendered as a
+waterfall and hermes-added overhead separated from model inference time.
+
+Activation: ``HERMES_TURN_TRACE=1`` (also ``true``/``on``). When disabled every
+entry point is a cheap no-op. Sink override: ``HERMES_TURN_TRACE_FILE``.
+
+Threading model: a turn crosses threads (gateway asyncio loop -> run_sync
+worker -> per-LLM-call worker -> concurrent tool executors), so the trace is
+carried explicitly — instrumentation sites bind the trace to the object they
+already share (the agent instance) via :func:`bind` / :func:`get_bound`, with a
+thread-local *current* as a convenience for same-thread nesting. Spans store
+absolute wall-clock start/end; parent/child nesting is derived at render time
+from interval containment, so cross-thread and overlapping (concurrent tool
+batch) spans need no stack bookkeeping.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+_TRUTHY = ("1", "true", "on", "yes")
+
+# Single rotation keeps the sink bounded without a logging-handler dependency.
+_MAX_SINK_BYTES = 64 * 1024 * 1024
+
+_write_lock = threading.Lock()
+_tls = threading.local()
+
+
+def enabled() -> bool:
+    return os.environ.get("HERMES_TURN_TRACE", "").strip().lower() in _TRUTHY
+
+
+def sink_path() -> str:
+    override = os.environ.get("HERMES_TURN_TRACE_FILE", "").strip()
+    if override:
+        return os.path.expanduser(override)
+    from hermes_constants import get_hermes_home
+
+    return str(get_hermes_home() / "logs" / "turn_traces.jsonl")
+
+
+class Span:
+    __slots__ = ("name", "start", "end", "thread", "tags")
+
+    def __init__(self, name: str, start: float, end: float, thread: str, tags: Dict[str, Any]):
+        self.name = name
+        self.start = start
+        self.end = end
+        self.thread = thread
+        self.tags = tags
+
+    def to_wire(self, t0: float) -> Dict[str, Any]:
+        wire: Dict[str, Any] = {
+            "n": self.name,
+            "t0": round((self.start - t0) * 1000.0, 2),
+            "d": round((self.end - self.start) * 1000.0, 2),
+            "th": self.thread,
+        }
+        if self.tags:
+            wire["tags"] = self.tags
+        return wire
+
+
+class _SpanHandle:
+    """Context manager for an in-flight span; ``tag()`` adds attributes late."""
+
+    __slots__ = ("_trace", "name", "tags", "_start")
+
+    def __init__(self, trace: "TurnTrace", name: str, tags: Dict[str, Any]):
+        self._trace = trace
+        self.name = name
+        self.tags = tags
+        self._start = time.time()
+
+    def tag(self, **tags: Any) -> "_SpanHandle":
+        self.tags.update(tags)
+        return self
+
+    def __enter__(self) -> "_SpanHandle":
+        self._start = time.time()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if exc_type is not None:
+            self.tags.setdefault("error", exc_type.__name__)
+        self._trace.add_span(self.name, self._start, time.time(), **self.tags)
+
+
+class _NullSpan:
+    __slots__ = ()
+
+    def tag(self, **tags: Any) -> "_NullSpan":
+        return self
+
+    def __enter__(self) -> "_NullSpan":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+_NULL_SPAN = _NullSpan()
+
+
+class TurnTrace:
+    """Mutable collector for one turn; thread-safe span appends."""
+
+    def __init__(self, key: Optional[str] = None, started_at: Optional[float] = None, **tags: Any):
+        self.trace_id = uuid.uuid4().hex[:12]
+        self.key = key or self.trace_id
+        self.started_at = started_at if started_at is not None else time.time()
+        self.tags: Dict[str, Any] = dict(tags)
+        self._spans: List[Span] = []
+        self._lock = threading.Lock()
+        self._finished = False
+
+    def span(self, name: str, **tags: Any) -> _SpanHandle:
+        return _SpanHandle(self, name, tags)
+
+    def add_span(self, name: str, start: float, end: float, **tags: Any) -> None:
+        """Retrofit a span from timings measured elsewhere (e.g. api_duration)."""
+        s = Span(name, start, end, threading.current_thread().name, tags)
+        with self._lock:
+            self._spans.append(s)
+
+    def mark(self, name: str, at: Optional[float] = None, **tags: Any) -> None:
+        """Point-in-time event (zero-duration span)."""
+        ts = at if at is not None else time.time()
+        self.add_span(name, ts, ts, **tags)
+
+    def tag(self, **tags: Any) -> None:
+        with self._lock:
+            self.tags.update(tags)
+
+    def finish(self, **tags: Any) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            if self._finished:
+                return None
+            self._finished = True
+            self.tags.update(tags)
+            spans = list(self._spans)
+            # Snapshot: another thread (e.g. the run_sync executor after a
+            # cancel) can still tag() while json.dumps iterates the record.
+            final_tags = dict(self.tags)
+        ended_at = time.time()
+        record = {
+            "schema": 1,
+            "trace_id": self.trace_id,
+            "key": self.key,
+            "started_at": round(self.started_at, 3),
+            "duration_ms": round((ended_at - self.started_at) * 1000.0, 2),
+            "tags": final_tags,
+            "spans": [s.to_wire(self.started_at) for s in sorted(spans, key=lambda s: s.start)],
+        }
+        _emit(record)
+        return record
+
+
+def _emit(record: Dict[str, Any]) -> None:
+    try:
+        path = sink_path()
+        data = (json.dumps(record, ensure_ascii=False, default=str) + "\n").encode("utf-8")
+        with _write_lock:
+            parent = os.path.dirname(path)
+            if parent:  # bare relative sink filename: dirname is "" — append to CWD
+                os.makedirs(parent, exist_ok=True)
+            try:
+                if os.path.getsize(path) > _MAX_SINK_BYTES:
+                    os.replace(path, path + ".1")
+            except OSError:
+                pass
+            # Single O_APPEND write: atomic per record even when the gateway
+            # daemon and a CLI run share the default sink.
+            fd = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+            try:
+                os.write(fd, data)
+            finally:
+                os.close(fd)
+    except Exception:
+        # Tracing must never break a turn.
+        pass
+
+
+# --- carrying the trace ------------------------------------------------------
+
+_BIND_ATTR = "_hermes_turn_trace"
+
+
+def begin(key: Optional[str] = None, started_at: Optional[float] = None, **tags: Any) -> Optional[TurnTrace]:
+    """Start a trace (returns None when tracing is disabled)."""
+    if not enabled():
+        return None
+    trace = TurnTrace(key=key, started_at=started_at, **tags)
+    adopt(trace)
+    return trace
+
+
+def adopt(trace: Optional[TurnTrace]) -> None:
+    """Make ``trace`` current for THIS thread (worker-thread entry points)."""
+    _tls.trace = trace
+
+
+def current() -> Optional[TurnTrace]:
+    return getattr(_tls, "trace", None)
+
+
+def bind(obj: Any, trace: Optional[TurnTrace]) -> None:
+    """Attach the trace to a shared object (typically the agent instance)."""
+    try:
+        setattr(obj, _BIND_ATTR, trace)
+    except Exception:
+        pass
+
+
+def get_bound(obj: Any) -> Optional[TurnTrace]:
+    return getattr(obj, _BIND_ATTR, None)
+
+
+def span(name: str, trace: Optional[TurnTrace] = None, obj: Any = None, **tags: Any):
+    """No-op-safe span: resolves trace from arg, bound object, or thread-local."""
+    t = trace or (get_bound(obj) if obj is not None else None) or current()
+    if t is None or t._finished:
+        return _NULL_SPAN
+    return t.span(name, **tags)
+
+
+def mark(name: str, trace: Optional[TurnTrace] = None, obj: Any = None, **tags: Any) -> None:
+    t = trace or (get_bound(obj) if obj is not None else None) or current()
+    if t is not None and not t._finished:
+        t.mark(name, **tags)

--- a/agent/turn_trace.py
+++ b/agent/turn_trace.py
@@ -6,8 +6,11 @@ finalize, delivery) and emits ONE JSON line per turn to a rotating
 ``<hermes_home>/logs/turn_traces.jsonl`` sink, so turns can be rendered as a
 waterfall and hermes-added overhead separated from model inference time.
 
-Activation: ``HERMES_TURN_TRACE=1`` (also ``true``/``on``). When disabled every
-entry point is a cheap no-op. Sink override: ``HERMES_TURN_TRACE_FILE``.
+Activation: config.yaml ``agent.turn_trace: {enabled: true, file: ...}``
+(or shorthand ``agent.turn_trace: true``); the ``HERMES_TURN_TRACE`` /
+``HERMES_TURN_TRACE_FILE`` environment variables act as process-level
+overrides for service managers. When disabled every entry point is a cheap
+no-op.
 
 Threading model: a turn crosses threads (gateway asyncio loop -> run_sync
 worker -> per-LLM-call worker -> concurrent tool executors), so the trace is
@@ -37,12 +40,59 @@ _write_lock = threading.Lock()
 _tls = threading.local()
 
 
+_config_cache: Dict[str, dict] = {}
+
+
+def _config() -> dict:
+    """Read the ``agent.turn_trace`` config block for the active Hermes home.
+
+    config.yaml is the user-facing surface for this feature; the
+    ``HERMES_TURN_TRACE`` / ``HERMES_TURN_TRACE_FILE`` environment variables
+    are process-level overrides for service managers (same contract as the
+    other config bridges). The read is cached: tracing is a
+    restart-scoped diagnostic, and per-call config loads would put file IO
+    on every instrumentation site. The cache is keyed by the active
+    ``get_hermes_home()`` — a multiplexed gateway scopes each routed profile
+    to its own home (``_profile_runtime_scope``), and tracing can begin
+    before that scope is entered, so a single process-wide entry would let
+    one profile's gate/sink leak into another's turns.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = str(get_hermes_home())
+    except Exception:
+        home = ""
+    cached = _config_cache.get(home)
+    if cached is None:
+        resolved: dict = {}
+        try:
+            from hermes_cli.config import load_config
+
+            cfg = load_config() or {}
+            agent_cfg = cfg.get("agent") or {}
+            raw = agent_cfg.get("turn_trace")
+            if isinstance(raw, dict):
+                resolved = dict(raw)
+            elif raw is not None:
+                resolved = {"enabled": raw}
+        except Exception:
+            resolved = {}
+        _config_cache[home] = cached = resolved
+    return cached
+
+
 def enabled() -> bool:
-    return os.environ.get("HERMES_TURN_TRACE", "").strip().lower() in _TRUTHY
+    env = os.environ.get("HERMES_TURN_TRACE", "").strip().lower()
+    if env:
+        return env in _TRUTHY
+    return str(_config().get("enabled", "")).strip().lower() in _TRUTHY
 
 
 def sink_path() -> str:
     override = os.environ.get("HERMES_TURN_TRACE_FILE", "").strip()
+    if not override:
+        override = str(_config().get("file", "") or "").strip()
     if override:
         return os.path.expanduser(override)
     from hermes_constants import get_hermes_home

--- a/agent/turn_trace_render.py
+++ b/agent/turn_trace_render.py
@@ -1,0 +1,613 @@
+"""Waterfall renderer for per-turn traces emitted by :mod:`agent.turn_trace`.
+
+Reads the JSONL sink (one record per turn) and renders each selected trace as
+an indented terminal waterfall — nesting derived from interval containment,
+bars drawn over the turn timeline with sub-cell unicode blocks, model time
+(``llm.call``) separated from hermes overhead. Also provides an aggregate
+``--summary`` table and a self-contained interactive ``--html`` export.
+
+Usage::
+
+    python -m agent.turn_trace_render [--file PATH] [--last N] [--trace ID]
+        [--min-ms F] [--width N] [--summary] [--html OUT] [--no-color] [--demo]
+
+Stdlib only; pure reader — never touches the live tracing hot path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html as _html
+import json
+import os
+import random
+import shutil
+import sys
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import turn_trace
+
+# Parent = smallest span fully containing this one, within this slack (ms).
+_SLACK_MS = 1.0
+
+# Left-anchored partial blocks for the trailing bar cell (~1/8 .. 8/8).
+_BLOCKS = "▏▎▍▌▊█"
+
+_DUR_W = 10  # "  1234.5ms"
+
+
+# --- data model ---------------------------------------------------------------
+
+
+class Node:
+    __slots__ = ("name", "t0", "d", "tags", "thread", "parent", "children", "depth")
+
+    def __init__(self, wire: Dict[str, Any]):
+        self.name = str(wire.get("n", "?"))
+        self.t0 = _f(wire.get("t0", 0.0))
+        self.d = max(0.0, _f(wire.get("d", 0.0)))
+        tags = wire.get("tags")
+        self.tags: Dict[str, Any] = tags if isinstance(tags, dict) else {}
+        self.thread = str(wire.get("th", ""))
+        self.parent: Optional["Node"] = None
+        self.children: List["Node"] = []
+        self.depth = 0
+
+    @property
+    def end(self) -> float:
+        return self.t0 + self.d
+
+    @property
+    def self_ms(self) -> float:
+        # Subtract the UNION of child intervals, not their sum: concurrent
+        # children overlap, and summing would zero out the parent's real
+        # dispatch/collection overhead.
+        covered = 0.0
+        cursor = self.t0
+        for c in sorted(self.children, key=lambda c: c.t0):
+            lo, hi = max(c.t0, cursor), min(c.end, self.end)
+            if hi > lo:
+                covered += hi - lo
+                cursor = hi
+        return max(0.0, self.d - covered)
+
+    def is_hot(self) -> bool:
+        return self.name == "tools.delay" or bool(self.tags.get("error"))
+
+
+def _f(v: Any) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def build_tree(span_wires: List[Any]) -> List[Node]:
+    """Return all nodes sorted by start, with parent/children/depth assigned.
+
+    Parent = smallest (by duration) other span that contains this one within
+    ``_SLACK_MS``; equal-duration ties resolve to the earlier-sorted span so
+    identical intervals cannot parent each other cyclically.
+    """
+    nodes = [Node(w) for w in span_wires if isinstance(w, dict)]
+    nodes.sort(key=lambda n: (n.t0, -n.d))
+    for i, s in enumerate(nodes):
+        best: Optional[Node] = None
+        for j, p in enumerate(nodes):
+            if j == i or p.d < s.d or (p.d == s.d and j > i):
+                continue
+            if p.t0 - _SLACK_MS <= s.t0 and s.end <= p.end + _SLACK_MS:
+                if best is None or p.d < best.d:
+                    best = p
+        s.parent = best
+    for n in nodes:
+        if n.parent is not None:
+            n.parent.children.append(n)
+    for n in nodes:
+        d, p = 0, n.parent
+        while p is not None:
+            d, p = d + 1, p.parent
+        n.depth = d
+    return nodes
+
+
+def visible_rows(nodes: List[Node], min_ms: float) -> List[Node]:
+    """Depth-first row order (children already sorted by start), filtered."""
+    roots = [n for n in nodes if n.parent is None]
+    out: List[Node] = []
+
+    def walk(n: Node) -> None:
+        if n.d >= min_ms:
+            out.append(n)
+        for c in n.children:
+            walk(c)
+
+    for r in roots:
+        walk(r)
+    return out
+
+
+# --- loading -------------------------------------------------------------------
+
+
+def load_traces(path: str) -> List[Dict[str, Any]]:
+    traces: List[Dict[str, Any]] = []
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for i, line in enumerate(fh, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                    if isinstance(rec, dict) and isinstance(rec.get("spans"), list):
+                        traces.append(rec)
+                    else:
+                        raise ValueError("not a trace record")
+                except Exception:
+                    sys.stderr.write(f"turn_trace_render: skipped corrupt line {i} in {path}\n")
+    except OSError as e:
+        sys.stderr.write(f"turn_trace_render: cannot read {path}: {e}\n")
+    return traces
+
+
+def select_traces(traces: List[Dict[str, Any]], trace_id: Optional[str], last: int) -> List[Dict[str, Any]]:
+    if trace_id:
+        return [t for t in traces if str(t.get("trace_id", "")).startswith(trace_id)]
+    return traces[-max(1, last):]
+
+
+# --- terminal rendering ---------------------------------------------------------
+
+
+class _Colors:
+    def __init__(self, on: bool):
+        self.model = "\x1b[34m" if on else ""
+        self.over = "\x1b[32m" if on else ""
+        self.hot = "\x1b[31;1m" if on else ""
+        self.dim = "\x1b[2m" if on else ""
+        self.bold = "\x1b[1m" if on else ""
+        self.reset = "\x1b[0m" if on else ""
+
+
+def _fmt_val(v: Any) -> str:
+    if isinstance(v, float):
+        return f"{v:g}"
+    return str(v)
+
+
+def _fmt_tags(tags: Dict[str, Any], limit: int = 0) -> str:
+    s = " ".join(f"{k}={_fmt_val(v)}" for k, v in tags.items())
+    if limit and len(s) > limit:
+        s = s[: max(0, limit - 1)] + "…"
+    return s
+
+
+def _bar(t0: float, d: float, total: float, width: int) -> Tuple[str, str, str]:
+    """(lead spaces, block chars, trailing pad) for one timeline row."""
+    scale = width / max(total, 0.001)
+    x0, x1 = t0 * scale, (t0 + d) * scale
+    i0 = min(width - 1, max(0, int(round(x0))))
+    cells = x1 - i0
+    if cells <= 0:
+        blocks = _BLOCKS[0]
+    else:
+        full = min(width - i0, int(cells))
+        frac = cells - full
+        blocks = _BLOCKS[-1] * full
+        if frac > 0 and i0 + full < width:
+            blocks += _BLOCKS[min(len(_BLOCKS) - 1, int(frac * len(_BLOCKS)))]
+        if not blocks:
+            blocks = _BLOCKS[0]
+    pad = max(0, width - i0 - len(blocks))
+    return " " * i0, blocks, " " * pad
+
+
+def _trace_stats(nodes: List[Node], duration_ms: float) -> Tuple[float, float]:
+    """(model_ms, overhead_ms) — model = sum of llm.call durations."""
+    model = sum(n.d for n in nodes if n.name == "llm.call")
+    return model, max(0.0, duration_ms - model)
+
+
+def render_waterfall(rec: Dict[str, Any], min_ms: float, width: int, colors: _Colors, out=None) -> None:
+    out = out or sys.stdout
+    c = colors
+    nodes = build_tree(rec.get("spans", []))
+    total = max(_f(rec.get("duration_ms", 0.0)), max((n.end for n in nodes), default=0.0), 0.001)
+    started = _f(rec.get("started_at", 0.0))
+    when = datetime.fromtimestamp(started).strftime("%Y-%m-%d %H:%M:%S") if started else "?"
+    tags = rec.get("tags") if isinstance(rec.get("tags"), dict) else {}
+
+    out.write(
+        f"{c.bold}── trace {rec.get('trace_id', '?')}{c.reset}  key={rec.get('key', '?')}"
+        f"  {when}  total {total:.1f}ms\n"
+    )
+    if tags:
+        out.write(f"   {c.dim}{_fmt_tags(tags)}{c.reset}\n")
+
+    rows = visible_rows(nodes, min_ms)
+    if not rows:
+        out.write("   (no spans" + ("" if nodes else " recorded") + f" >= {min_ms:g}ms)\n")
+    else:
+        name_w = min(40, max(16, max(len("  " * r.depth + r.name) for r in rows)))
+        tag_strs = [_fmt_tags(r.tags, 32) for r in rows]
+        tag_w = min(32, max(len(s) for s in tag_strs))
+        bar_w = max(16, width - name_w - _DUR_W - tag_w - 5)
+        for r, ts in zip(rows, tag_strs):
+            label = "  " * r.depth + r.name
+            if len(label) > name_w:
+                label = label[: name_w - 1] + "…"
+            lead, blocks, pad = _bar(r.t0, r.d, total, bar_w)
+            col = c.hot if r.is_hot() else (c.model if r.name == "llm.call" else c.over)
+            out.write(
+                f" {label:<{name_w}} {lead}{col}{blocks}{c.reset}{pad}"
+                f" {r.d:>{_DUR_W - 2}.1f}ms {c.dim}{ts}{c.reset}\n"
+            )
+
+    model, over = _trace_stats(nodes, total)
+    mp, op = 100.0 * model / total, 100.0 * over / total
+    out.write(
+        f"   total {total:.1f}ms   {c.model}model {model:.1f}ms ({mp:.1f}%){c.reset}"
+        f"   {c.over}hermes overhead {over:.1f}ms ({op:.1f}%){c.reset}\n"
+    )
+    top = sorted((n for n in nodes if n.name != "llm.call"), key=lambda n: n.self_ms, reverse=True)[:5]
+    if top:
+        parts = "  ".join(f"{n.name} {n.self_ms:.1f}" for n in top)
+        out.write(f"   top overhead self-time (ms): {parts}\n")
+    out.write("\n")
+
+
+# --- summary --------------------------------------------------------------------
+
+
+def _pctl(sorted_vals: List[float], p: float) -> float:
+    if not sorted_vals:
+        return 0.0
+    k = (len(sorted_vals) - 1) * p
+    lo, hi = int(k), min(int(k) + 1, len(sorted_vals) - 1)
+    return sorted_vals[lo] + (sorted_vals[hi] - sorted_vals[lo]) * (k - lo)
+
+
+def summarize(traces: List[Dict[str, Any]]) -> Dict[str, Any]:
+    per_name: Dict[str, Dict[str, Any]] = {}
+    model_pcts: List[float] = []
+    turn_ms: List[float] = []
+    for rec in traces:
+        nodes = build_tree(rec.get("spans", []))
+        total = max(_f(rec.get("duration_ms", 0.0)), max((n.end for n in nodes), default=0.0), 0.001)
+        turn_ms.append(total)
+        model, _ = _trace_stats(nodes, total)
+        model_pcts.append(100.0 * model / total)
+        self_by_name: Dict[str, float] = {}
+        for n in nodes:
+            st = per_name.setdefault(n.name, {"count": 0, "durs": [], "shares": [], "self_total": 0.0})
+            st["count"] += 1
+            st["durs"].append(n.d)
+            self_by_name[n.name] = self_by_name.get(n.name, 0.0) + n.self_ms
+        for name, self_ms in self_by_name.items():
+            per_name[name]["shares"].append(100.0 * self_ms / total)
+            per_name[name]["self_total"] += self_ms
+    return {
+        "n_traces": len(traces),
+        "turn_ms": turn_ms,
+        "model_pcts": model_pcts,
+        "per_name": per_name,
+    }
+
+
+def summary_rows(agg: Dict[str, Any]) -> List[Tuple[str, float, float, float, float]]:
+    """(name, count/turn, p50, p95, mean self%) sorted by pooled self-time."""
+    n = max(1, agg["n_traces"])
+    rows = []
+    for name, st in agg["per_name"].items():
+        durs = sorted(st["durs"])
+        shares = st["shares"]
+        rows.append(
+            (
+                name,
+                st["count"] / n,
+                _pctl(durs, 0.5),
+                _pctl(durs, 0.95),
+                sum(shares) / len(shares) if shares else 0.0,
+            )
+        )
+    rows.sort(key=lambda r: agg["per_name"][r[0]]["self_total"], reverse=True)
+    return rows
+
+
+def render_summary(traces: List[Dict[str, Any]], colors: _Colors, out=None) -> None:
+    out = out or sys.stdout
+    c = colors
+    agg = summarize(traces)
+    if not agg["n_traces"]:
+        out.write("no traces selected\n")
+        return
+    rows = summary_rows(agg)
+    name_w = max(4, max((len(r[0]) for r in rows), default=4))
+    out.write(f"{c.bold}summary over {agg['n_traces']} trace(s){c.reset}\n")
+    hdr = f" {'span':<{name_w}} {'n/turn':>7} {'p50 ms':>9} {'p95 ms':>9} {'self%':>7}"
+    out.write(hdr + "\n")
+    out.write(" " + "-" * (len(hdr) - 1) + "\n")
+    for name, cnt, p50, p95, share in rows:
+        out.write(f" {name:<{name_w}} {cnt:>7.1f} {p50:>9.1f} {p95:>9.1f} {share:>6.1f}%\n")
+    mean_turn = sum(agg["turn_ms"]) / agg["n_traces"]
+    mean_model = sum(agg["model_pcts"]) / agg["n_traces"]
+    out.write(
+        f"\n mean turn {mean_turn:.1f}ms   {c.model}model {mean_model:.1f}%{c.reset}"
+        f"   {c.over}hermes overhead {100.0 - mean_model:.1f}%{c.reset}\n"
+    )
+
+
+# --- html export ------------------------------------------------------------------
+
+_HTML_CSS = """
+:root { --bg:#ffffff; --fg:#1b1f24; --muted:#5b6470; --track:#eceff3; --border:#d7dce2;
+        --model:#3b82f6; --over:#10b981; --hot:#ef4444; }
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#101418; --fg:#e4e8ec; --muted:#8b96a3; --track:#1d232b; --border:#2c343e; }
+}
+body { background:var(--bg); color:var(--fg); font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;
+       max-width:1100px; margin:2rem auto; padding:0 1rem; }
+h1 { font-size:1.15rem; } h2 { font-size:1rem; margin:1.6rem 0 .4rem; }
+.meta { color:var(--muted); margin:.15rem 0 .6rem; }
+.row { display:grid; grid-template-columns:280px 1fr 90px; gap:8px; align-items:center; padding:1px 0; }
+.row.haskids .nm { cursor:pointer; }
+.nm { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; padding-left:calc(var(--depth)*14px); }
+.tw { display:inline-block; width:1em; color:var(--muted); }
+.track { position:relative; height:12px; background:var(--track); border-radius:3px; }
+.bar { position:absolute; top:0; height:100%; border-radius:2px; background:var(--over); min-width:2px; }
+.bar.model { background:var(--model); } .bar.hot { background:var(--hot); }
+.dur { text-align:right; font-variant-numeric:tabular-nums; color:var(--muted); }
+.footer { color:var(--muted); margin:.4rem 0 1.2rem; }
+.legend span { margin-right:1.2rem; }
+.dot { display:inline-block; width:.7em; height:.7em; border-radius:2px; margin-right:.35em; vertical-align:baseline; }
+table { border-collapse:collapse; margin:.6rem 0 1.5rem; }
+th, td { padding:3px 12px; border-bottom:1px solid var(--border); text-align:right; }
+th:first-child, td:first-child { text-align:left; }
+"""
+
+_HTML_JS = """
+document.querySelectorAll('.rows').forEach(function (root) {
+  var rows = Array.prototype.slice.call(root.querySelectorAll('.row'));
+  function kids(id) { return rows.filter(function (r) { return r.dataset.parent === id; }); }
+  function hideAll(id) {
+    kids(id).forEach(function (r) { r.style.display = 'none'; hideAll(r.dataset.id); });
+  }
+  function showKids(id) {
+    kids(id).forEach(function (r) {
+      r.style.display = '';
+      if (!r.classList.contains('collapsed')) showKids(r.dataset.id);
+    });
+  }
+  rows.forEach(function (r) {
+    if (!r.classList.contains('haskids')) return;
+    r.addEventListener('click', function () {
+      var closed = r.classList.toggle('collapsed');
+      r.querySelector('.tw').textContent = closed ? '\\u25b8' : '\\u25be';
+      if (closed) hideAll(r.dataset.id); else showKids(r.dataset.id);
+    });
+  });
+});
+"""
+
+
+def render_html(traces: List[Dict[str, Any]], min_ms: float, path: str) -> None:
+    e = _html.escape
+    parts: List[str] = []
+    parts.append(f"<style>{_HTML_CSS}</style>")
+    parts.append("<h1>hermes turn traces</h1>")
+    parts.append(
+        '<p class="legend"><span><i class="dot" style="background:var(--model)"></i>model (llm.call)</span>'
+        '<span><i class="dot" style="background:var(--over)"></i>hermes overhead</span>'
+        '<span><i class="dot" style="background:var(--hot)"></i>tools.delay / error</span>'
+        "<span>click a row to collapse its children</span></p>"
+    )
+    for rec in traces:
+        nodes = build_tree(rec.get("spans", []))
+        total = max(_f(rec.get("duration_ms", 0.0)), max((n.end for n in nodes), default=0.0), 0.001)
+        started = _f(rec.get("started_at", 0.0))
+        when = datetime.fromtimestamp(started).strftime("%Y-%m-%d %H:%M:%S") if started else "?"
+        tags = rec.get("tags") if isinstance(rec.get("tags"), dict) else {}
+        model, over = _trace_stats(nodes, total)
+        parts.append(f"<h2>trace {e(str(rec.get('trace_id', '?')))} &mdash; key={e(str(rec.get('key', '?')))}</h2>")
+        parts.append(f'<div class="meta">{e(when)} &middot; total {total:.1f}ms &middot; {e(_fmt_tags(tags))}</div>')
+        rows = visible_rows(nodes, min_ms)
+        ids = {id(n): str(i) for i, n in enumerate(rows)}
+        parts.append('<div class="rows">')
+        for n in rows:
+            rid = ids[id(n)]
+            pid = ids.get(id(n.parent), "") if n.parent is not None else ""
+            has_kids = any(c.d >= min_ms for c in n.children)
+            cls = "model" if n.name == "llm.call" else ("hot" if n.is_hot() else "")
+            left = 100.0 * n.t0 / total
+            w = max(0.05, 100.0 * n.d / total)
+            tip = f"{n.name}  {n.d:.1f}ms  @{n.t0:.1f}ms"
+            if n.tags:
+                tip += "\n" + "\n".join(f"{k}={_fmt_val(v)}" for k, v in n.tags.items())
+            tw = "▾" if has_kids else "&nbsp;"
+            parts.append(
+                f'<div class="row{" haskids" if has_kids else ""}" data-id="{rid}" data-parent="{pid}"'
+                f' style="--depth:{n.depth}" title="{e(tip)}">'
+                f'<span class="nm"><span class="tw">{tw}</span>{e(n.name)}</span>'
+                f'<span class="track"><span class="bar {cls}" style="left:{left:.3f}%;width:{w:.3f}%"></span></span>'
+                f'<span class="dur">{n.d:.1f}ms</span></div>'
+            )
+        parts.append("</div>")
+        mp = 100.0 * model / total
+        parts.append(
+            f'<div class="footer">model {model:.1f}ms ({mp:.1f}%) &middot; '
+            f"hermes overhead {over:.1f}ms ({100.0 - mp:.1f}%)</div>"
+        )
+    agg = summarize(traces)
+    if agg["n_traces"]:
+        parts.append(f"<h2>summary over {agg['n_traces']} trace(s)</h2>")
+        parts.append("<table><tr><th>span</th><th>n/turn</th><th>p50 ms</th><th>p95 ms</th><th>self%</th></tr>")
+        for name, cnt, p50, p95, share in summary_rows(agg):
+            parts.append(
+                f"<tr><td>{e(name)}</td><td>{cnt:.1f}</td><td>{p50:.1f}</td>"
+                f"<td>{p95:.1f}</td><td>{share:.1f}%</td></tr>"
+            )
+        parts.append("</table>")
+        mean_model = sum(agg["model_pcts"]) / agg["n_traces"]
+        parts.append(
+            f'<div class="footer">mean split: model {mean_model:.1f}% / overhead {100.0 - mean_model:.1f}%</div>'
+        )
+    parts.append(f"<script>{_HTML_JS}</script>")
+    doc = "<!doctype html><meta charset='utf-8'><title>turn traces</title>" + "".join(parts)
+    with open(os.path.expanduser(path), "w", encoding="utf-8") as fh:
+        fh.write(doc)
+
+
+# --- demo data --------------------------------------------------------------------
+
+
+def demo_traces(n: int = 3, seed: int = 7) -> List[Dict[str, Any]]:
+    """Synthetic-but-realistic traces so the renderer is testable without data."""
+    rng = random.Random(seed)
+    out = []
+    base = time.time() - 3600.0
+    for k in range(n):
+        spans: List[Dict[str, Any]] = []
+
+        def add(name: str, t0: float, d: float, **tags: Any) -> None:
+            w: Dict[str, Any] = {"n": name, "t0": round(t0, 2), "d": round(d, 2), "th": "demo"}
+            if tags:
+                w["tags"] = tags
+            spans.append(w)
+
+        # gateway ingress (~400ms)
+        add("gateway.session_resolve", 4, 38)
+        add("gateway.transcript_load", 46, rng.uniform(90, 150))
+        add("gateway.hygiene", 205, 32)
+        add("gateway.agent_setup", 242, rng.uniform(110, 150), rebuild=(k == 0))
+        add("gateway.ingest", 0, 400, platform="telegram", session_key=f"demo:{k}")
+
+        # prologue (~180ms)
+        t = 402.0
+        add("prologue.system_prompt", t + 2, 55, rebuilt=(k == 0))
+        add("prologue.persist_early", t + 60, 26)
+        add("prologue.compression_preflight", t + 88, 9, compressed=False)
+        add("prologue.pre_llm_hook", t + 99, 11)
+        add("prologue.memory_prefetch", t + 112, 62, decision="skip")
+        add("turn.prologue", t, 180)
+        t += 184
+
+        tool_calls = 0
+        for i in range(1, 4):
+            it0 = t
+            ca = rng.uniform(18, 55)
+            add("iteration.context_assemble", t, ca)
+            t += ca + 2
+            add("iteration.request_setup", t, 8)
+            t += 10
+            add("llm.client_create", t, 3)
+            t += 4
+            llm = rng.uniform(2000, 6000)
+            add(
+                "llm.call", t, llm,
+                api_request_id=f"req_{k}{i}{rng.randrange(16**6):06x}",
+                ttft_ms=round(rng.uniform(400, 1200)),
+                cache_pct=round(rng.uniform(40, 95), 1),
+                model="claude-opus-4",
+            )
+            t += llm + 1
+            add("llm.accounting", t, 5)
+            t += 7
+            if i < 3:
+                b0 = t
+                ncalls = rng.choice((1, 2))
+                for _ in range(ncalls):
+                    ex = rng.uniform(120, 700)
+                    add(
+                        "tools.call", t, ex + 40, tool=rng.choice(("terminal", "web_search", "read_file")),
+                        checkpoint_ms=round(rng.uniform(2, 15), 1), execute_ms=round(ex, 1),
+                        flush_ms=round(rng.uniform(5, 25), 1),
+                    )
+                    t += ex + 42
+                    tool_calls += 1
+                add("tools.delay", t, 1000)
+                t += 1001
+                add("tools.batch", b0, t - b0 - 1, count=ncalls, mode="sequential")
+            add("iteration", it0, t - it0, i=i)
+            t += 2
+        add("turn.verify_gate", t, 12, nudge_fired=False)
+        t += 14
+
+        f0 = t
+        add("finalize.trajectory", t + 2, 80)
+        add("finalize.resource_cleanup", t + 85, 28)
+        add("finalize.persist", t + 116, 120)
+        add("finalize.post_hooks", t + 240, 18)
+        add("finalize.memory_dispatch", t + 260, 38)
+        add("turn.finalize", f0, 300)
+        t = f0 + 302
+        add(
+            "turn", 400, t - 400,
+            turn_id=f"turn_{k}", model="claude-opus-4", iterations=3,
+            tool_calls=tool_calls, exit_reason="end_turn",
+        )
+        add("gateway.persist", t + 2, 250)
+        add("transport.delivery", t + 256, rng.uniform(40, 90))
+        end = t + 350
+
+        out.append(
+            {
+                "schema": 1,
+                "trace_id": "".join(rng.choice("0123456789abcdef") for _ in range(12)),
+                "key": f"demo:{k}",
+                "started_at": round(base + k * 120.0, 3),
+                "duration_ms": round(end, 2),
+                "tags": {
+                    "platform": "telegram", "model": "claude-opus-4", "iterations": 3,
+                    "tool_calls": tool_calls, "exit_reason": "end_turn",
+                },
+                "spans": sorted(spans, key=lambda s: s["t0"]),
+            }
+        )
+    return out
+
+
+# --- cli ----------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(prog="python -m agent.turn_trace_render", description=__doc__.split("\n")[0])
+    ap.add_argument("--file", default=None, help="trace jsonl (default: the turn_trace sink)")
+    ap.add_argument("--last", type=int, default=1, help="render the last N traces (default 1)")
+    ap.add_argument("--trace", default=None, help="select by trace_id (prefix match)")
+    ap.add_argument("--min-ms", type=float, default=1.0, help="hide spans shorter than this (default 1.0)")
+    ap.add_argument("--width", type=int, default=0, help="output width (default: terminal width)")
+    ap.add_argument("--summary", action="store_true", help="aggregate table instead of waterfalls")
+    ap.add_argument("--html", default=None, metavar="PATH", help="write a self-contained interactive HTML file")
+    ap.add_argument("--no-color", action="store_true", help="disable ANSI color")
+    ap.add_argument("--demo", action="store_true", help="render embedded synthetic traces (no sink needed)")
+    args = ap.parse_args(argv)
+
+    if args.demo:
+        traces = demo_traces()
+    else:
+        traces = load_traces(os.path.expanduser(args.file) if args.file else turn_trace.sink_path())
+    selected = select_traces(traces, args.trace, args.last)
+    if not selected:
+        sys.stderr.write("turn_trace_render: no matching traces\n")
+        return 1
+
+    width = args.width or shutil.get_terminal_size((120, 24)).columns
+    color_on = not args.no_color and "NO_COLOR" not in os.environ and sys.stdout.isatty()
+    colors = _Colors(color_on)
+
+    if args.html:
+        render_html(selected, args.min_ms, args.html)
+        print(f"wrote {args.html} ({len(selected)} trace(s))")
+    if args.summary:
+        render_summary(selected, colors)
+    elif not args.html:
+        for rec in selected:
+            render_waterfall(rec, args.min_ms, width, colors)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -551,6 +551,13 @@ from gateway.config import Platform, PlatformConfig
 from gateway.session import SessionSource, build_session_key
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home
 
+try:
+    # Turn-waterfall tracing (no-op unless HERMES_TURN_TRACE is set).  Guarded
+    # so base.py stays importable without the agent package.
+    from agent import turn_trace as _turn_trace_mod
+except Exception:  # pragma: no cover
+    _turn_trace_mod = None
+
 
 # ---------------------------------------------------------------------------
 # Streaming TTS format descriptor and handle (#60671)
@@ -5455,6 +5462,25 @@ class BasePlatformAdapter(ABC):
             return
         self._start_session_processing(pending_event, session_key)
 
+    def _finish_inline_turn_trace(self, event: MessageEvent) -> None:
+        """Finish (idempotent) a turn trace begun for an inline dispatch.
+
+        Call sites that await ``self._message_handler(event)`` OUTSIDE
+        ``_process_message_background`` (bypass commands, the clarify
+        text-intercept) own the trace lifecycle themselves: nothing downstream
+        finishes a trace the runner began and bound to the event, so without
+        this the record would be dropped un-emitted.
+        """
+        try:
+            _t = _turn_trace_mod.get_bound(event) if _turn_trace_mod is not None else None
+            if _t is None and _turn_trace_mod is not None:
+                _t = _turn_trace_mod.get_bound(getattr(event, "source", None))
+            if _t is not None:
+                _t.finish(status="ok")
+                _turn_trace_mod.bind(getattr(event, "source", None), None)
+        except Exception:
+            pass
+
     async def _dispatch_active_session_command(
         self,
         event: MessageEvent,
@@ -5529,6 +5555,8 @@ class BasePlatformAdapter(ABC):
                 else:
                     self._release_session_guard(session_key, guard=command_guard)
             raise
+        finally:
+            self._finish_inline_turn_trace(event)
 
         await self._drain_pending_after_session_command(session_key, command_guard)
 
@@ -5626,6 +5654,8 @@ class BasePlatformAdapter(ABC):
                             )
                 except Exception as e:
                     logger.error("[%s] Command '/%s' dispatch failed: %s", self.name, cmd, e, exc_info=True)
+                finally:
+                    self._finish_inline_turn_trace(event)
                 return
 
             # Clarify reply bypass: if the agent is blocked on a
@@ -5682,6 +5712,8 @@ class BasePlatformAdapter(ABC):
                             "[%s] Clarify text-intercept dispatch failed: %s",
                             self.name, e, exc_info=True,
                         )
+                    finally:
+                        self._finish_inline_turn_trace(event)
                     return
 
             if self._busy_session_handler is not None:
@@ -5806,12 +5838,41 @@ class BasePlatformAdapter(ABC):
                 typing_task,
                 metadata=_thread_metadata,
             )
-        
+
+        def _resolve_turn_trace():
+            # The runner binds the trace to the event AND to event.source: the
+            # pre-dispatch hook loop may have swapped the runner's event for a
+            # dataclasses.replace copy (prepend/rewrite directives), in which
+            # case only the shared SessionSource still carries the binding.
+            if _turn_trace_mod is None:
+                return None
+            _t = _turn_trace_mod.get_bound(event)
+            if _t is None:
+                _t = _turn_trace_mod.get_bound(getattr(event, "source", None))
+            return _t
+
+        def _finish_turn_trace(status: str) -> None:
+            # Gateway owns the turn-trace lifecycle: the runner begin()s it at
+            # message ingress and binds it to this event; delivery timing and
+            # the (idempotent, first-status-wins) finish() happen here so the
+            # trace covers the full ingress → delivery interval.  Clear the
+            # source binding afterwards — SessionSource can outlive the event,
+            # and a stale trace must not leak into a later turn.
+            try:
+                _t = _resolve_turn_trace()
+                if _t is not None:
+                    _t.finish(status=status)
+                    _turn_trace_mod.bind(getattr(event, "source", None), None)
+            except Exception:
+                pass
+
+        _turn_trace = None
         try:
             await self._run_processing_hook("on_processing_start", event)
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            _turn_trace = _resolve_turn_trace()
             is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to
@@ -5844,6 +5905,7 @@ class BasePlatformAdapter(ABC):
                 response = None
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
+            _delivery_start = time.time() if _turn_trace is not None else 0.0
             if response:
                 # Capture [[as_document]] before extract_media strips it, so the
                 # dispatch partition below can route image-extension files
@@ -6255,6 +6317,16 @@ class BasePlatformAdapter(ABC):
                         self.name, len(_response_pre_extract), event.source.chat_id,
                     )
 
+            if _turn_trace is not None:
+                if response:
+                    _turn_trace.add_span(
+                        "transport.delivery", _delivery_start, time.time(),
+                        delivered=delivery_succeeded,
+                    )
+                _turn_trace.finish(status="ok")
+                if _turn_trace_mod is not None:
+                    _turn_trace_mod.bind(getattr(event, "source", None), None)
+
             # Determine overall success for the processing hook
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
             # Clean up the per-turn streaming-TTS flag (#60671).
@@ -6317,6 +6389,7 @@ class BasePlatformAdapter(ABC):
                 return  # Drain task owns the session now.
                 
         except asyncio.CancelledError:
+            _finish_turn_trace("cancelled")
             current_task = asyncio.current_task()
             outcome = ProcessingOutcome.CANCELLED
             if current_task is None or current_task not in self._expected_cancelled_tasks:
@@ -6324,6 +6397,7 @@ class BasePlatformAdapter(ABC):
             await self._run_processing_hook("on_processing_complete", event, outcome)
             raise
         except Exception as e:
+            _finish_turn_trace("error")
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             # Send the error to the user so they aren't left with radio silence
@@ -6346,6 +6420,10 @@ class BasePlatformAdapter(ABC):
                     self.name, notify_err, exc_info=True,
                 )  # Last resort — don't let error reporting crash the handler
         finally:
+            # Belt-and-braces: every exit path above already finished the
+            # trace (finish() is idempotent, so this only fires if one was
+            # somehow missed).
+            _finish_turn_trace("error")
             # Stop typing before any deferred callback work.  Post-delivery
             # callbacks may perform platform I/O; a stuck callback must not
             # leave the typing refresh task running indefinitely.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2017,6 +2017,14 @@ if _config_path.exists():
                 os.environ["HERMES_STARTUP_RESTORE_DRAIN_TIMEOUT"] = str(
                     _agent_cfg["gateway_startup_restore_drain_timeout"]
                 )
+            if "turn_trace" in _agent_cfg:
+                _tt_cfg = _agent_cfg["turn_trace"]
+                if isinstance(_tt_cfg, dict):
+                    os.environ["HERMES_TURN_TRACE"] = str(_tt_cfg.get("enabled", False))
+                    if _tt_cfg.get("file"):
+                        os.environ["HERMES_TURN_TRACE_FILE"] = str(_tt_cfg["file"])
+                else:
+                    os.environ["HERMES_TURN_TRACE"] = str(_tt_cfg)
         # config-authoritative knobs for the session-search index; same
         # bridge semantics as the agent settings above.
         _sessions_cfg = _cfg.get("sessions", {})

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from datetime import datetime
 from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
 
+from agent import turn_trace
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_compression import (
     COMPACTION_STATUS,
@@ -4066,6 +4067,13 @@ class TurnRunner:
         # writes `ctx.message`, so the outer `_run_agent_inner` body observes
         # the updated value exactly as it did through the closure cell.
 
+        # Executor-thread entry: make the turn trace this thread's current
+        # so same-thread instrumentation resolves it before the agent is
+        # bound.  (Executor threads are pooled; a previous turn's trace is
+        # already finished and therefore inert.)
+        if ctx.turn_trace_obj is not None:
+            turn_trace.adopt(ctx.turn_trace_obj)
+
         # session_key is propagated via contextvars in _set_session_env()
         # (_SESSION_KEY) and via set_current_session_key() (_approval_session_key)
         # below — both concurrency-safe and inherited by tool worker threads.
@@ -4226,6 +4234,7 @@ class TurnRunner:
                 log_message="interim_assistant_callback scheduling error",
             )
 
+        _t_setup = time.time() if ctx.turn_trace_obj is not None else 0.0
         turn_route = self._runner._resolve_turn_agent_config(ctx.message, model, runtime_kwargs)
 
         # Check agent cache — reuse the AIAgent from the previous message
@@ -4487,6 +4496,12 @@ class TurnRunner:
                     )
                     self._runner._enforce_agent_cache_cap()
             logger.debug("Created new agent for session %s (sig=%s)", ctx.session_key, _sig)
+
+        if ctx.turn_trace_obj is not None:
+            ctx.turn_trace_obj.add_span(
+                "gateway.agent_setup", _t_setup, time.time(),
+                rebuild=not reused_cached_agent,
+            )
 
         # Per-message state — callbacks and reasoning config change every
         # turn and must not be baked into the cached agent constructor.
@@ -5026,6 +5041,13 @@ class TurnRunner:
         _approval_session_token = set_current_session_key(_approval_session_key)
         register_gateway_notify(_approval_session_key, _approval_notify_sync)
         try:
+            # Bind the trace to the agent instance so agent-side spans
+            # resolve it (run_conversation sees a bound trace and does not
+            # begin/finish its own).  Cached agents outlive the turn, so
+            # the finally below MUST clear the binding — a stale trace
+            # must not leak into the next turn.
+            if ctx.turn_trace_obj is not None:
+                turn_trace.bind(agent, ctx.turn_trace_obj)
             # If _prepare_inbound_message_text buffered image paths for native
             # attachment, wrap the user turn as an OpenAI-style multimodal
             # content list. Consume-and-clear so subsequent turns on the same
@@ -5085,6 +5107,8 @@ class TurnRunner:
             except Exception:
                 pass
             reset_current_session_key(_approval_session_token)
+            if ctx.turn_trace_obj is not None:
+                turn_trace.bind(agent, None)
         ctx.result_holder[0] = result
 
         # Signal the stream consumer that the agent is done
@@ -11383,7 +11407,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # adapter.handle_message would spawn a background task and we'd
         # lose synchronous error visibility; calling _handle_message inline
         # keeps the success/failure path observable for the watcher.
-        response_text = await self._handle_message(synthetic_event)
+        try:
+            response_text = await self._handle_message(synthetic_event)
+        finally:
+            # Inline dispatch bypasses the adapter's
+            # _process_message_background — the only place turn traces begun
+            # in _handle_message_with_agent are normally finished — so this
+            # caller owns finish() (idempotent) for the bound trace.
+            try:
+                _handoff_trace = turn_trace.get_bound(synthetic_event)
+                if _handoff_trace is None:
+                    # Pre-dispatch hooks may have replaced the runner's event
+                    # copy; the shared SessionSource still carries the binding.
+                    _handoff_trace = turn_trace.get_bound(
+                        getattr(synthetic_event, "source", None)
+                    )
+                if _handoff_trace is not None:
+                    _handoff_trace.finish(status="ok")
+                    turn_trace.bind(getattr(synthetic_event, "source", None), None)
+            except Exception:
+                pass
         if not response_text:
             # Streaming may have already delivered the response inline.
             # Either way, agent ran without raising — count as success.
@@ -15500,6 +15543,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             source.chat_id or "unknown", _msg_preview, _reply_id, _reply_txt,
         )
 
+        # Turn trace: gateway owns begin(); finish() happens in the adapter's
+        # _process_message_background after delivery (bound to the event so it
+        # is reachable there).  None when HERMES_TURN_TRACE is unset — every
+        # use below is guarded.  Carried in locals/bound objects, never via
+        # thread-local: this coroutine shares the event loop thread with
+        # concurrent sessions.
+        _trace = turn_trace.begin(
+            key=_quick_key, started_at=_msg_start_time, platform=_platform_name,
+        )
+        if _trace is not None:
+            turn_trace.bind(event, _trace)
+            # The pre-dispatch hook loop may swap `event` for a copy
+            # (dataclasses.replace on prepend/rewrite directives), but the
+            # adapter's finish site still holds the ORIGINAL event.  The
+            # SessionSource object survives the replace, so bind it as the
+            # durable carrier; adapters resolve event-then-source and clear
+            # both after finish.
+            turn_trace.bind(source, _trace)
+            try:
+                _dbnc_ts = getattr(event, "_hermes_debounce_enqueue_ts", None)
+                if _dbnc_ts:
+                    _trace.mark("transport.inbound_debounce", at=float(_dbnc_ts))
+                    _trace.tag(debounce_ms=round(
+                        (_msg_start_time - float(_dbnc_ts)) * 1000.0, 1,
+                    ))
+            except Exception:
+                pass
+        _t_span = time.time() if _trace is not None else 0.0
+
         # Get or create session
         # Topic-mode DMs: rewrite a stale/foreign thread_id to the user's
         # last-active topic so a cross-topic Reply or stripped plain reply
@@ -15587,6 +15659,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await asyncio.to_thread(self._record_telegram_topic_binding, source, session_entry)
                 except Exception:
                     logger.debug("Failed to record Telegram topic binding", exc_info=True)
+        if _trace is not None:
+            _trace.add_span("gateway.session_resolve", _t_span, time.time())
+            _trace.tag(session_key=session_key)
         # Capture and immediately consume was_auto_reset so it does not
         # re-fire on subsequent messages — preventing the cleanup from
         # wiping model/reasoning overrides set between turns (Closes #48031).
@@ -15807,8 +15882,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _lease_state.lease_generation = run_generation
 
         # Load conversation history from transcript
+        _t_span = time.time() if _trace is not None else 0.0
         history = await self.async_session_store.load_transcript(session_entry.session_id)
-        
+        if _trace is not None:
+            _trace.add_span("gateway.transcript_load", _t_span, time.time())
+            _t_span = time.time()
+
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
         #
@@ -16445,6 +16524,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Session hygiene auto-compress failed: %s", e
                         )
 
+        if _trace is not None:
+            _trace.add_span("gateway.hygiene", _t_span, time.time())
+
         # First-message onboarding -- only on the very first interaction ever.
         # Delivered on the current user message (sidecar), NOT the ephemeral
         # system prompt: present-on-turn-1/absent-on-turn-2 was a guaranteed
@@ -16659,7 +16741,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 message_type=event.message_type,
+                turn_trace_obj=_trace,
             )
+            _t_persist = time.time() if _trace is not None else 0.0
 
             # Stop persistent typing indicator now that the agent is done.
             # Slack AI status is scoped to a thread/workspace, so preserve the
@@ -17210,6 +17294,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key, session_entry.session_id
             )
 
+            if _trace is not None:
+                _trace.add_span("gateway.persist", _t_persist, time.time())
+
             # Intentional silence is a delivery decision, not a transcript
             # mutation.  The agent's [SILENT]/NO_REPLY assistant turn above is
             # still persisted in session history so later turns keep normal
@@ -17294,6 +17381,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
             logger.exception("Agent error in session %s", session_key)
+            if _trace is not None:
+                _trace.tag(gateway_error=type(e).__name__)
             # Crash-resilience for failures that happen before AIAgent enters
             # run_conversation() (for example: provider/httpx client init
             # failures). In that path the agent cannot persist the current
@@ -22970,6 +23059,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         message_type: Optional[str] = None,
+        turn_trace_obj: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -22989,6 +23079,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 message_type=message_type,
+                turn_trace_obj=turn_trace_obj,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -23001,6 +23092,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 message_type=message_type,
+                turn_trace_obj=turn_trace_obj,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -23123,6 +23215,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         message_type: Optional[str] = None,
+        turn_trace_obj: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -23138,6 +23231,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
+            if turn_trace_obj is not None:
+                turn_trace_obj.add_span(
+                    "gateway.ingest", turn_trace_obj.started_at, time.time(),
+                    platform=source.platform.value if source.platform else "",
+                    session_key=session_key,
+                )
             return await self._run_agent_via_proxy(
                 message=message,
                 context_prompt=context_prompt,
@@ -23407,6 +23506,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             moa_config=moa_config,
             persist_user_message=persist_user_message,
             persist_user_timestamp=persist_user_timestamp,
+            turn_trace_obj=turn_trace_obj,
         )
         turn_runner = TurnRunner(self, turn_ctx)
         # Callback invoked by agent on tool lifecycle events — extracted to
@@ -23915,6 +24015,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _agent_warning_raw = _float_env("HERMES_AGENT_TIMEOUT_WARNING", 900)
             _agent_warning = _agent_warning_raw if _agent_warning_raw > 0 else None
             _warning_fired = False
+            # gateway.ingest envelope: message ingress up to the run_sync
+            # dispatch.  (gateway.agent_setup happens inside the worker and
+            # renders as a sibling — interval containment, not a stack.)
+            if turn_trace_obj is not None:
+                turn_trace_obj.add_span(
+                    "gateway.ingest", turn_trace_obj.started_at, time.time(),
+                    platform=source.platform.value if source.platform else "",
+                    session_key=session_key,
+                )
             _executor_task = asyncio.ensure_future(
                 self._run_in_executor_with_context(run_sync)
             )

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -89,6 +89,9 @@ class TurnContext:
     moa_config: Optional[dict] = None
     persist_user_message: Optional[Any] = None
     persist_user_timestamp: Optional[float] = None
+    # Per-turn trace begun by _handle_message_with_agent (None when
+    # HERMES_TURN_TRACE is unset — every use is guarded).
+    turn_trace_obj: Optional[Any] = None
     user_config: Any = None
     enabled_toolsets: Any = None
     disabled_toolsets: Any = None

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -233,6 +233,19 @@ DEFAULT_CONFIG = {
         # matches a key in this dict.
         # Edit directly in config.yaml (no CLI support due to dots in keys).
         "reasoning_overrides": {},
+
+        # Per-turn waterfall tracing — when enabled, every turn appends one
+        # JSON line of timing spans (gateway ingress, context assembly, LLM
+        # calls, tool dispatch, delivery) to
+        # <hermes_home>/logs/turn_traces.jsonl; render with
+        # `python -m agent.turn_trace_render`.  `file` overrides the sink
+        # path (empty = the default above).  Off by default — when disabled
+        # every instrumentation site is a cheap no-op.  Shorthand
+        # `turn_trace: true` is also accepted in config.yaml.
+        "turn_trace": {
+            "enabled": False,
+            "file": "",
+        },
     },
 
     "terminal": {

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -19,6 +19,7 @@ import re
 import threading
 import time
 from contextvars import ContextVar
+import time
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
@@ -8811,6 +8812,9 @@ class TelegramAdapter(BasePlatformAdapter):
         chunk_len = len(event.text or "")
         if existing is None:
             event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            # First-chunk enqueue time; the gateway runner uses it to surface
+            # the debounce delay in turn traces (transport.inbound_debounce).
+            event._hermes_debounce_enqueue_ts = time.time()  # type: ignore[attr-defined]
             self._pending_text_batches[key] = event
         else:
             # Append text from the follow-up chunk

--- a/run_agent.py
+++ b/run_agent.py
@@ -114,6 +114,7 @@ from agent.process_bootstrap import (
     _SafeWriter,  # noqa: F401  # re-exported for tests that `from run_agent import _SafeWriter`
     _get_proxy_for_base_url,
 )
+from agent import turn_trace
 from agent.iteration_budget import IterationBudget
 
 
@@ -4696,78 +4697,81 @@ class AIAgent:
     def _create_request_openai_client(self, *, reason: str, api_kwargs: Optional[dict] = None) -> Any:
         from unittest.mock import Mock
 
-        primary_client = self._ensure_primary_openai_client(reason=reason)
-        if self.provider == "moa":
-            return primary_client
-        if isinstance(primary_client, Mock):
-            return primary_client
-        with self._openai_client_lock():
-            request_kwargs = dict(self._client_kwargs)
-        # Per-request OpenAI-wire clients (used by both the non-streaming
-        # chat-completions path and the streaming chat-completions path
-        # in `_interruptible_api_call`) should not run the SDK's built-in
-        # retry loop: the agent's outer loop owns retries with credential
-        # rotation, provider fallback, and backoff that the SDK can't
-        # see. Leaving SDK retries on (default 2) compounds with our outer
-        # retries and lets a single hung provider request stretch to ~3x
-        # the per-call timeout before our stale detector reports it.
-        # Shared/primary clients and Anthropic / Bedrock paths are
-        # unaffected (they don't go through here).
-        request_kwargs["max_retries"] = 0
-        if (
-            base_url_host_matches(str(request_kwargs.get("base_url", "")), "githubcopilot.com")
-            and self._api_kwargs_have_image_parts(api_kwargs or {})
-        ):
-            request_kwargs["default_headers"] = self._copilot_headers_for_request(is_vision=True)
-        # Reuse the cached wire client while the effective kwargs are
-        # unchanged: constructing openai.OpenAI + its httpx pool costs
-        # ~19-35ms per LLM call (fresh TCP+TLS handshake), ~5x per turn.
-        # The cache is a single checked-out slot: `in_use` prevents two
-        # concurrent calls from sharing one pool's close/abort lifecycle
-        # (a second concurrent call gets a fresh untracked client with
-        # the old build-per-request behavior).
-        stale = None
-        with self._openai_client_lock():
-            cache = self._request_client_cache_ref()
-            cached = cache["client"]
-            if cached is not None and not cache["in_use"]:
-                if (
-                    not cache["poisoned"]
-                    and cache["kwargs"] == request_kwargs
-                    and not self._is_openai_client_closed(cached)
-                ):
+        # obj=self: this can run on a per-LLM-call worker thread, where the
+        # thread-local trace is not adopted — resolve via the bound agent.
+        with turn_trace.span("llm.client_create", obj=self):
+            primary_client = self._ensure_primary_openai_client(reason=reason)
+            if self.provider == "moa":
+                return primary_client
+            if isinstance(primary_client, Mock):
+                return primary_client
+            with self._openai_client_lock():
+                request_kwargs = dict(self._client_kwargs)
+            # Per-request OpenAI-wire clients (used by both the non-streaming
+            # chat-completions path and the streaming chat-completions path
+            # in `_interruptible_api_call`) should not run the SDK's built-in
+            # retry loop: the agent's outer loop owns retries with credential
+            # rotation, provider fallback, and backoff that the SDK can't
+            # see. Leaving SDK retries on (default 2) compounds with our outer
+            # retries and lets a single hung provider request stretch to ~3x
+            # the per-call timeout before our stale detector reports it.
+            # Shared/primary clients and Anthropic / Bedrock paths are
+            # unaffected (they don't go through here).
+            request_kwargs["max_retries"] = 0
+            if (
+                base_url_host_matches(str(request_kwargs.get("base_url", "")), "githubcopilot.com")
+                and self._api_kwargs_have_image_parts(api_kwargs or {})
+            ):
+                request_kwargs["default_headers"] = self._copilot_headers_for_request(is_vision=True)
+            # Reuse the cached wire client while the effective kwargs are
+            # unchanged: constructing openai.OpenAI + its httpx pool costs
+            # ~19-35ms per LLM call (fresh TCP+TLS handshake), ~5x per turn.
+            # The cache is a single checked-out slot: `in_use` prevents two
+            # concurrent calls from sharing one pool's close/abort lifecycle
+            # (a second concurrent call gets a fresh untracked client with
+            # the old build-per-request behavior).
+            stale = None
+            with self._openai_client_lock():
+                cache = self._request_client_cache_ref()
+                cached = cache["client"]
+                if cached is not None and not cache["in_use"]:
+                    if (
+                        not cache["poisoned"]
+                        and cache["kwargs"] == request_kwargs
+                        and not self._is_openai_client_closed(cached)
+                    ):
+                        cache["in_use"] = True
+                        return cached
+                    # kwargs changed (credential rotation, provider failover),
+                    # poisoned by a cross-thread abort (#29507), or externally
+                    # closed — never reuse; discard and rebuild below.
+                    stale = cached
+                    cache["client"] = None
+                    cache["kwargs"] = None
+                    cache["poisoned"] = False
+            if stale is not None:
+                # Safe to close from this thread: in_use was False, so no
+                # worker thread owns the pool's FDs (#29507 concerns clients
+                # with an in-flight request on another thread).
+                self._close_openai_client(stale, reason=f"reuse_evict:{reason}", shared=False)
+            client = self._create_openai_client(request_kwargs, reason=reason, shared=False)
+            with self._openai_client_lock():
+                cache = self._request_client_cache_ref()
+                if cache["client"] is None:
+                    cache["client"] = client
+                    # Snapshot nested dicts (default_headers): rotation sites
+                    # assign fresh inner dicts today, but an aliased inner
+                    # object would compare equal even after in-place mutation.
+                    cache["kwargs"] = {
+                        k: dict(v) if isinstance(v, dict) else v
+                        for k, v in request_kwargs.items()
+                    }
+                    cache["poisoned"] = False
                     cache["in_use"] = True
-                    return cached
-                # kwargs changed (credential rotation, provider failover),
-                # poisoned by a cross-thread abort (#29507), or externally
-                # closed — never reuse; discard and rebuild below.
-                stale = cached
-                cache["client"] = None
-                cache["kwargs"] = None
-                cache["poisoned"] = False
-        if stale is not None:
-            # Safe to close from this thread: in_use was False, so no
-            # worker thread owns the pool's FDs (#29507 concerns clients
-            # with an in-flight request on another thread).
-            self._close_openai_client(stale, reason=f"reuse_evict:{reason}", shared=False)
-        client = self._create_openai_client(request_kwargs, reason=reason, shared=False)
-        with self._openai_client_lock():
-            cache = self._request_client_cache_ref()
-            if cache["client"] is None:
-                cache["client"] = client
-                # Snapshot nested dicts (default_headers): rotation sites
-                # assign fresh inner dicts today, but an aliased inner
-                # object would compare equal even after in-place mutation.
-                cache["kwargs"] = {
-                    k: dict(v) if isinstance(v, dict) else v
-                    for k, v in request_kwargs.items()
-                }
-                cache["poisoned"] = False
-                cache["in_use"] = True
-            # else: a concurrent call holds the slot — hand this client
-            # out untracked; _close_request_openai_client fully closes
-            # untracked clients, preserving the per-request lifecycle.
-        return client
+                # else: a concurrent call holds the slot — hand this client
+                # out untracked; _close_request_openai_client fully closes
+                # untracked clients, preserving the per-request lifecycle.
+            return client
 
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
         with self._openai_client_lock():
@@ -6851,13 +6855,23 @@ class AIAgent:
         """
         tool_calls = assistant_message.tool_calls
 
+        # Per-turn trace: running tool_calls total lives in the trace tags so
+        # the run_conversation wrapper can copy it onto the root `turn` span.
+        _tt = turn_trace.get_bound(self)
+        if _tt is not None:
+            try:
+                _tt.tag(tool_calls=_tt.tags.get("tool_calls", 0) + len(tool_calls))
+            except Exception:
+                pass
+
         # Allow _vprint during tool execution even with stream consumers
         self._executing_tools = True
         try:
             if len(tool_calls) <= 1:
-                return self._execute_tool_calls_sequential(
-                    assistant_message, messages, effective_task_id, api_call_count
-                )
+                with turn_trace.span("tools.batch", trace=_tt, count=len(tool_calls), mode="sequential"):
+                    return self._execute_tool_calls_sequential(
+                        assistant_message, messages, effective_task_id, api_call_count
+                    )
 
             from agent.tool_dispatch_helpers import _plan_tool_batch_segments
             _active_env = get_active_env(effective_task_id)
@@ -6866,19 +6880,22 @@ class AIAgent:
 
             if len(segments) == 1:
                 kind = segments[0][0]
-                if kind == "parallel":
-                    return self._execute_tool_calls_concurrent(
+                _mode = "parallel" if kind == "parallel" else "sequential"
+                with turn_trace.span("tools.batch", trace=_tt, count=len(tool_calls), mode=_mode):
+                    if kind == "parallel":
+                        return self._execute_tool_calls_concurrent(
+                            assistant_message, messages, effective_task_id, api_call_count
+                        )
+                    return self._execute_tool_calls_sequential(
                         assistant_message, messages, effective_task_id, api_call_count
                     )
-                return self._execute_tool_calls_sequential(
-                    assistant_message, messages, effective_task_id, api_call_count
-                )
 
             from agent.tool_executor import execute_tool_calls_segmented
-            return execute_tool_calls_segmented(
-                self, assistant_message, messages, effective_task_id, api_call_count,
-                segments=segments,
-            )
+            with turn_trace.span("tools.batch", trace=_tt, count=len(tool_calls), mode="segmented"):
+                return execute_tool_calls_segmented(
+                    self, assistant_message, messages, effective_task_id, api_call_count,
+                    segments=segments,
+                )
         finally:
             self._executing_tools = False
 

--- a/tests/agent/test_turn_trace.py
+++ b/tests/agent/test_turn_trace.py
@@ -16,6 +16,7 @@ import time
 from pathlib import Path
 
 import pytest
+from unittest.mock import patch
 
 from agent import turn_trace
 from agent.turn_trace import _NULL_SPAN, TurnTrace
@@ -341,3 +342,88 @@ class TestRenderer:
         assert proc.returncode == 0, proc.stderr
         # The demo traces carry the contract's root span name.
         assert "turn" in proc.stdout
+
+
+class TestConfigSurface:
+    def test_config_enables_tracing(self, monkeypatch):
+        monkeypatch.delenv("HERMES_TURN_TRACE", raising=False)
+        monkeypatch.setattr(turn_trace, "_config_cache", {})
+        with patch("hermes_cli.config.load_config", return_value={"agent": {"turn_trace": {"enabled": True}}}):
+            assert turn_trace.enabled() is True
+
+    def test_config_shorthand_bool(self, monkeypatch):
+        monkeypatch.delenv("HERMES_TURN_TRACE", raising=False)
+        monkeypatch.setattr(turn_trace, "_config_cache", {})
+        with patch("hermes_cli.config.load_config", return_value={"agent": {"turn_trace": True}}):
+            assert turn_trace.enabled() is True
+
+    def test_env_overrides_config_off(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TURN_TRACE", "0")
+        monkeypatch.setattr(turn_trace, "_config_cache", {})
+        with patch("hermes_cli.config.load_config", return_value={"agent": {"turn_trace": True}}):
+            assert turn_trace.enabled() is False
+
+    def test_config_file_key_sets_sink(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("HERMES_TURN_TRACE_FILE", raising=False)
+        monkeypatch.setattr(turn_trace, "_config_cache", {})
+        with patch("hermes_cli.config.load_config", return_value={"agent": {"turn_trace": {"enabled": True, "file": str(tmp_path / "t.jsonl")}}}):
+            assert turn_trace.sink_path() == str(tmp_path / "t.jsonl")
+
+    def test_config_failure_defaults_off(self, monkeypatch):
+        monkeypatch.delenv("HERMES_TURN_TRACE", raising=False)
+        monkeypatch.setattr(turn_trace, "_config_cache", {})
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError):
+            assert turn_trace.enabled() is False
+
+    def test_multiplexed_profiles_resolve_their_own_config(self, tmp_path, monkeypatch):
+        # A multiplexed gateway routes turns across profiles with independent
+        # HERMES_HOME directories (installed via the profile runtime scope's
+        # home override). The config cache is keyed by the active home, so
+        # one profile's gate/sink must never leak into another's turns.
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        monkeypatch.setattr(turn_trace, "_config_cache", {})
+
+        home_a = tmp_path / "profile-a"
+        home_b = tmp_path / "profile-b"
+        home_a.mkdir()
+        home_b.mkdir()
+        (home_a / "config.yaml").write_text(
+            f"agent:\n  turn_trace:\n    enabled: true\n    file: {home_a / 'a.jsonl'}\n",
+            encoding="utf-8",
+        )
+        (home_b / "config.yaml").write_text(
+            "agent:\n  turn_trace:\n    enabled: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(home_a))
+        assert turn_trace.enabled() is True
+        assert turn_trace.sink_path() == str(home_a / "a.jsonl")
+
+        # Routed profile: same process, home B scoped via the contextvar
+        # override — must resolve B's config, not A's cached entry.
+        token = set_hermes_home_override(str(home_b))
+        try:
+            assert turn_trace.enabled() is False
+            assert turn_trace.sink_path() == str(home_b / "logs" / "turn_traces.jsonl")
+        finally:
+            reset_hermes_home_override(token)
+
+        # Back on A: its cached entry still resolves A's gate and sink.
+        assert turn_trace.enabled() is True
+        assert turn_trace.sink_path() == str(home_a / "a.jsonl")
+
+    def test_default_config_declares_disabled_default(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["agent"]["turn_trace"] == {"enabled": False, "file": ""}
+
+    def test_dashboard_schema_exposes_turn_trace(self):
+        # The dashboard schema is generated from DEFAULT_CONFIG
+        # (hermes_cli.web_server._build_schema_from_config), so the feature
+        # only appears in the settings UI if the default tree declares it.
+        from hermes_cli.web_server import CONFIG_SCHEMA
+
+        assert CONFIG_SCHEMA["agent.turn_trace.enabled"]["type"] == "boolean"
+        assert CONFIG_SCHEMA["agent.turn_trace.file"]["type"] == "string"

--- a/tests/agent/test_turn_trace.py
+++ b/tests/agent/test_turn_trace.py
@@ -1,0 +1,343 @@
+"""Tests for agent.turn_trace (per-turn waterfall tracing).
+
+Covers the env gate (everything is a no-op when HERMES_TURN_TRACE is unset),
+the single-JSON-line-per-turn sink contract, trace carrying across threads
+(bind/get_bound, adopt), and error tolerance (tracing must never raise into
+the turn).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from agent import turn_trace
+from agent.turn_trace import _NULL_SPAN, TurnTrace
+
+
+class _Carrier:
+    """Stand-in for the shared object (agent instance) traces bind to."""
+
+
+@pytest.fixture(autouse=True)
+def _clean_trace_state(monkeypatch):
+    """Isolate env gate and thread-local current between tests."""
+    monkeypatch.delenv("HERMES_TURN_TRACE", raising=False)
+    monkeypatch.delenv("HERMES_TURN_TRACE_FILE", raising=False)
+    turn_trace.adopt(None)
+    yield
+    turn_trace.adopt(None)
+
+
+@pytest.fixture
+def sink(tmp_path, monkeypatch):
+    """Enable tracing with the sink redirected into tmp_path."""
+    path = tmp_path / "turn_traces.jsonl"
+    monkeypatch.setenv("HERMES_TURN_TRACE", "1")
+    monkeypatch.setenv("HERMES_TURN_TRACE_FILE", str(path))
+    return path
+
+
+def _read_records(path):
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return [json.loads(line) for line in lines]
+
+
+# ---------------------------------------------------------------------------
+# Disabled by default
+# ---------------------------------------------------------------------------
+
+class TestDisabled:
+    def test_enabled_false_when_env_unset(self):
+        assert turn_trace.enabled() is False
+
+    def test_begin_returns_none(self):
+        assert turn_trace.begin(key="k", platform="test") is None
+
+    def test_span_without_trace_is_working_noop(self):
+        handle = turn_trace.span("x")
+        assert handle is _NULL_SPAN
+        # Must behave as a full context manager with a chainable tag().
+        with turn_trace.span("x", foo=1) as h:
+            assert h.tag(bar=2) is h
+
+    def test_mark_without_trace_is_noop(self):
+        turn_trace.mark("x", foo=1)  # must not raise
+
+    def test_null_span_swallows_nothing(self):
+        # Exceptions still propagate through the null span.
+        with pytest.raises(ValueError):
+            with turn_trace.span("x"):
+                raise ValueError("boom")
+
+
+# ---------------------------------------------------------------------------
+# Enabled: full begin -> span -> finish cycle
+# ---------------------------------------------------------------------------
+
+class TestEnabled:
+    def test_full_cycle_emits_one_json_line(self, sink):
+        trace = turn_trace.begin(key="sess:1", platform="test")
+        assert isinstance(trace, TurnTrace)
+        assert turn_trace.current() is trace
+
+        trace.tag(model="fake-model")
+        with turn_trace.span("iteration", trace=trace, i=1) as h:
+            time.sleep(0.01)
+            h.tag(late="yes")
+        turn_trace.mark("event", trace=trace, kind="ping")
+
+        record = trace.finish(exit_reason="done")
+        assert record is not None
+
+        records = _read_records(sink)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec == record
+        assert rec["schema"] == 1
+        assert rec["key"] == "sess:1"
+        assert rec["tags"] == {
+            "platform": "test",
+            "model": "fake-model",
+            "exit_reason": "done",
+        }
+
+        by_name = {s["n"]: s for s in rec["spans"]}
+        assert set(by_name) == {"iteration", "event"}
+
+        span = by_name["iteration"]
+        assert span["tags"] == {"i": 1, "late": "yes"}
+        # t0/d are relative milliseconds; the sleep(0.01) must be visible
+        # but the whole test ran in well under a second.
+        assert 0 <= span["t0"] < 1000
+        assert 10 <= span["d"] < 1000
+
+        mark = by_name["event"]
+        assert mark["d"] == 0
+        assert mark["tags"] == {"kind": "ping"}
+
+        assert rec["duration_ms"] >= span["d"]
+
+    def test_finish_is_idempotent(self, sink):
+        trace = turn_trace.begin(key="k")
+        assert trace.finish() is not None
+        assert trace.finish() is None
+        assert len(_read_records(sink)) == 1
+
+    def test_span_after_finish_is_noop(self, sink):
+        trace = turn_trace.begin(key="k")
+        trace.finish()
+        assert turn_trace.span("late", trace=trace) is _NULL_SPAN
+        turn_trace.mark("late", trace=trace)
+        assert len(_read_records(sink)) == 1
+        assert _read_records(sink)[0]["spans"] == []
+
+    def test_add_span_retrofit(self, sink):
+        trace = turn_trace.begin(key="k")
+        start = trace.started_at + 0.100
+        end = start + 0.250
+        trace.add_span("llm.call", start, end, model="fake")
+        rec = trace.finish()
+
+        spans = rec["spans"]
+        assert len(spans) == 1
+        assert spans[0]["n"] == "llm.call"
+        assert spans[0]["t0"] == pytest.approx(100.0, abs=0.5)
+        assert spans[0]["d"] == pytest.approx(250.0, abs=0.5)
+        assert spans[0]["tags"] == {"model": "fake"}
+
+    def test_spans_sorted_by_start(self, sink):
+        trace = turn_trace.begin(key="k")
+        t0 = trace.started_at
+        trace.add_span("second", t0 + 0.2, t0 + 0.3)
+        trace.add_span("first", t0 + 0.1, t0 + 0.4)
+        rec = trace.finish()
+        assert [s["n"] for s in rec["spans"]] == ["first", "second"]
+
+    def test_default_sink_follows_hermes_home(self, tmp_path, monkeypatch):
+        # Named profiles have independent HERMES_HOME dirs — the default sink
+        # must land in the active profile's logs/, not a hardcoded ~/.hermes.
+        profile_home = tmp_path / "profile-a"
+        monkeypatch.setenv("HERMES_TURN_TRACE", "1")
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        expected = profile_home / "logs" / "turn_traces.jsonl"
+        assert turn_trace.sink_path() == str(expected)
+
+        turn_trace.begin(key="k").finish()
+        assert len(_read_records(expected)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Carrying the trace: bind / get_bound / adopt
+# ---------------------------------------------------------------------------
+
+class TestCarrying:
+    def test_bind_and_get_bound(self):
+        obj = _Carrier()
+        assert turn_trace.get_bound(obj) is None
+        trace = TurnTrace(key="k")
+        turn_trace.bind(obj, trace)
+        assert turn_trace.get_bound(obj) is trace
+
+    def test_span_resolves_bound_object(self, sink):
+        obj = _Carrier()
+        trace = TurnTrace(key="k")
+        turn_trace.bind(obj, trace)
+        # No thread-local current (begin() was not used).
+        assert turn_trace.current() is None
+
+        with turn_trace.span("gateway.ingest", obj=obj, platform="test"):
+            pass
+        rec = trace.finish()
+        assert [s["n"] for s in rec["spans"]] == ["gateway.ingest"]
+
+    def test_bind_none_clears(self):
+        obj = _Carrier()
+        trace = TurnTrace(key="k")
+        turn_trace.bind(obj, trace)
+        turn_trace.bind(obj, None)
+        assert turn_trace.get_bound(obj) is None
+        assert turn_trace.span("x", obj=obj) is _NULL_SPAN
+
+    def test_bind_swallows_setattr_failure(self):
+        # e.g. objects with __slots__ — must not raise.
+        turn_trace.bind(object(), TurnTrace(key="k"))
+
+    def test_explicit_trace_wins_over_bound_and_current(self, sink):
+        obj = _Carrier()
+        bound = TurnTrace(key="bound")
+        explicit = turn_trace.begin(key="explicit")  # also becomes current
+        turn_trace.bind(obj, bound)
+
+        with turn_trace.span("x", trace=explicit, obj=obj):
+            pass
+        assert len(explicit.finish()["spans"]) == 1
+        assert len(bound.finish()["spans"]) == 0
+
+    def test_adopt_makes_trace_current_in_worker_thread(self, sink):
+        trace = TurnTrace(key="k")
+        results = {}
+
+        def adopting_worker():
+            turn_trace.adopt(trace)
+            results["adopting"] = turn_trace.current()
+            with turn_trace.span("tools.call", tool="x"):
+                pass
+
+        def non_adopting_worker():
+            results["non_adopting_current"] = turn_trace.current()
+            results["non_adopting_span"] = turn_trace.span("orphan")
+
+        t1 = threading.Thread(target=adopting_worker)
+        t2 = threading.Thread(target=non_adopting_worker)
+        t1.start(); t1.join()
+        t2.start(); t2.join()
+
+        assert results["adopting"] is trace
+        # Thread-local does not leak into a thread that never adopted.
+        assert results["non_adopting_current"] is None
+        assert results["non_adopting_span"] is _NULL_SPAN
+
+        rec = trace.finish()
+        assert [s["n"] for s in rec["spans"]] == ["tools.call"]
+
+
+# ---------------------------------------------------------------------------
+# Error tolerance
+# ---------------------------------------------------------------------------
+
+class TestErrorTolerance:
+    def test_finish_survives_unwritable_sink(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_TURN_TRACE", "1")
+        # A directory is not appendable — the emit must swallow the error.
+        monkeypatch.setenv("HERMES_TURN_TRACE_FILE", str(tmp_path))
+        trace = turn_trace.begin(key="k")
+        record = trace.finish()  # must not raise
+        assert record is not None
+
+    def test_span_records_error_tag_and_reraises(self, sink):
+        trace = turn_trace.begin(key="k")
+        with pytest.raises(RuntimeError, match="boom"):
+            with turn_trace.span("tools.call", trace=trace, tool="x"):
+                raise RuntimeError("boom")
+
+        rec = trace.finish()
+        spans = rec["spans"]
+        assert len(spans) == 1
+        assert spans[0]["tags"]["error"] == "RuntimeError"
+        assert spans[0]["tags"]["tool"] == "x"
+
+    def test_span_error_tag_does_not_clobber_explicit(self, sink):
+        trace = turn_trace.begin(key="k")
+        with pytest.raises(RuntimeError):
+            with turn_trace.span("x", trace=trace) as h:
+                h.tag(error="Custom")
+                raise RuntimeError("boom")
+        assert trace.finish()["spans"][0]["tags"]["error"] == "Custom"
+
+    def test_non_serializable_tag_falls_back_to_str(self, sink):
+        trace = turn_trace.begin(key="k")
+        trace.tag(weird=object())
+        rec = trace.finish()
+        assert rec is not None
+        # default=str in the sink keeps the emitted line valid JSON.
+        records = _read_records(sink)
+        assert len(records) == 1
+        assert isinstance(records[0]["tags"]["weird"], str)
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+class TestConcurrency:
+    def test_concurrent_span_appends_all_land(self, sink):
+        trace = turn_trace.begin(key="k")
+        n = 16
+        barrier = threading.Barrier(n)
+
+        def worker(i: int):
+            turn_trace.adopt(trace)
+            barrier.wait()
+            with turn_trace.span("tools.call", tool=f"t{i}"):
+                time.sleep(0.001)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        trace.finish()
+        records = _read_records(sink)
+        assert len(records) == 1
+        spans = records[0]["spans"]
+        assert len(spans) == n
+        assert {s["tags"]["tool"] for s in spans} == {f"t{i}" for i in range(n)}
+        assert all(s["n"] == "tools.call" for s in spans)
+
+
+# ---------------------------------------------------------------------------
+# Renderer smoke test
+# ---------------------------------------------------------------------------
+
+class TestRenderer:
+    def test_demo_mode_renders(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        proc = subprocess.run(
+            [sys.executable, "-m", "agent.turn_trace_render", "--demo", "--no-color"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert proc.returncode == 0, proc.stderr
+        # The demo traces carry the contract's root span name.
+        assert "turn" in proc.stdout

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -864,6 +864,21 @@ When the iteration budget is fully exhausted, the CLI shows a notification to th
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 
+### Turn tracing (`agent.turn_trace`)
+
+Opt-in per-turn waterfall tracing for latency diagnosis. When enabled, every turn appends one JSON line of timing spans (gateway ingress, prologue, per-iteration model calls, tool batches, finalize, delivery) to `logs/turn_traces.jsonl` under the active Hermes home (default `~/.hermes`, per-profile under `HERMES_HOME`), 64 MB single rotation, rendered with `python -m agent.turn_trace_render`.
+
+```yaml
+agent:
+  turn_trace: true              # shorthand — enable with the default sink
+  # or the full form:
+  turn_trace:
+    enabled: true
+    file: /var/log/hermes/turn_traces.jsonl   # optional sink override
+```
+
+Disabled by default; when off, every instrumentation site is a no-op and tracing can never raise into a turn. The `HERMES_TURN_TRACE` / `HERMES_TURN_TRACE_FILE` environment variables act as process-level overrides for service managers, mirroring the other config bridges.
+
 ## Verify-on-Stop (coding verification)
 
 When enabled, Hermes refuses to accept a final answer on a turn where the agent edited code in a workspace but produced no fresh verification evidence (a passing test run, build, lint, etc.) — it injects a synthetic follow-up asking the agent to verify or explain why it can't. Doc/markdown/skill-only edits never trigger it, and the loop is bounded so it can never trap the agent.


### PR DESCRIPTION
> [!NOTE]
> Resubmission of #64295, re-scoped per the `env-var-for-config` policy from its close review: activation now lives in **config.yaml** (`agent.turn_trace: {enabled, file}`, boolean shorthand supported) and is documented in the configuration guide. The `HERMES_TURN_TRACE` / `HERMES_TURN_TRACE_FILE` env vars remain only as process-level overrides for service managers and as the gateway's config→env bridge carrier — the same contract as the existing bridges (`busy_input_mode`, `gateway_timeout`, `busy_steer_ack_enabled`). Commit split unchanged from the previous review (core / wiring), plus one commit for the config surface.

## Problem

When a turn feels slow there is no way to tell where the time went. A single user message crosses the gateway asyncio loop, the run_sync executor, the per-LLM-call worker, and concurrent tool executor threads; existing logs record isolated durations at best, so hermes-added overhead (persistence, compression preflight, context assembly, inter-tool delays, delivery) cannot be separated from model inference time, and regressions in the non-LLM portion of the turn go unnoticed until they are large.

## Change

Adds an opt-in, zero-dependency tracing instrument:

- `agent/turn_trace.py` — span collector gated by `HERMES_TURN_TRACE=1` (default off). One JSON line per turn is appended to `~/.hermes/logs/turn_traces.jsonl` (override: `HERMES_TURN_TRACE_FILE`; 64 MB single-rotation cap; single `O_APPEND` write per record so a gateway daemon and a CLI run can share the sink). Spans store absolute wall-clock start/end; parent/child nesting is derived at render time from interval containment, so cross-thread and overlapping (concurrent tool batch) spans need no stack bookkeeping.
- `agent/turn_trace_render.py` — `python -m agent.turn_trace_render` renders traces as a terminal waterfall (plus `--summary` cross-turn aggregation and `--html` export; `--demo` renders a built-in sample).
- Span sites across the turn lifecycle: gateway ingest / session resolve / transcript load / hygiene / agent setup; turn prologue (system-prompt restore, early persist, compression preflight, pre-LLM hook, memory prefetch); per-iteration context assembly, request setup, LLM call (with TTFT and error attempts), accounting; tool batches including per-tool calls and the inter-tool delay sleep; verify gates; finalize children (trajectory, persist, post hooks, memory dispatch, resource cleanup); gateway persist; transport delivery.

Trace ownership: for gateway turns the runner `begin()`s the trace at message ingress and the platform adapter `finish()`es it after delivery, so the record covers the full ingress-to-delivery interval; CLI turns begin/finish inside `run_conversation`. Because a turn crosses threads, the trace is carried explicitly — bound to objects the instrumentation sites already share (the event, its `SessionSource`, the agent instance) with a thread-local current as a same-thread convenience — never via ambient globals that could bleed across concurrent sessions.

## Correctness notes

- **Default off is a strict no-op**: every site is guarded by `trace is not None` (or the no-op-safe `turn_trace.span()` which returns a shared null context manager), so the disabled cost is one env/attribute check per site. No behavior change when disabled.
- **Tracing can never break a turn**: sink emission catches all exceptions (unwritable sink, non-serializable tags fall back to `str`), `bind()` swallows `setattr` failures on slotted objects, and span context managers record-and-reraise without altering control flow.
- **Pre-dispatch event replacement**: the `pre_gateway_dispatch` hook loop may swap the runner's event for a `dataclasses.replace` copy (prepend/rewrite directives), while the adapter's finish site holds the original event. The trace is therefore also bound to the shared `SessionSource`; finish sites resolve event-then-source and clear the source binding afterwards so a stale trace cannot leak into a later turn on a reused source.
- **Lifecycle safety**: `finish()` is idempotent and first-status-wins; adapter cancel/error paths and a belt-and-braces `finally` all funnel through it. Cached agents outlive the turn, so the gateway clears the agent binding in a `finally`; pooled executor threads adopt the trace on entry (a previous turn's trace is already finished and inert). Span appends are lock-protected for concurrent tool executors, and `finish()` snapshots spans/tags before serializing.
- Inline dispatches that bypass the adapter's background processing (bypass commands, clarify text-intercept, kanban watcher synthetic events) own the finish themselves so those records are not dropped.

## Tests

`tests/agent/test_turn_trace.py` (22 tests): disabled-path no-ops, full-cycle JSONL emission, idempotent finish, post-finish spans ignored, span sorting, bind/resolve precedence (explicit > bound > thread-local), worker-thread adoption, unwritable-sink survival, error tagging and re-raise, non-serializable tag fallback, concurrent span appends, and renderer demo mode.

Suites run on this branch: `tests/agent` (5490 passed), `tests/gateway` + `tests/plugins` + `tests/run_agent` + `tests/scripts` (12876 passed) — failure sets are identical to a clean checkout of `main` run in the same environment (environment-dependent and order-dependent failures only; every difference between the two runs passes repeatedly when run standalone on this branch). `tests/run_agent` alone on this branch: 1974 passed, 0 failed.

## Measured impact

Used in production to attribute a "turns feel ~30% slower" report to concrete, fixable causes — first-call prompt-cache loss costing ~20 s per turn at 150k context, fixed 1.0 s inter-tool delay sleeps, ~19 ms-per-call HTTP client rebuilds, and synchronous persistence/accounting work sitting on the turn thread — findings that seeded the follow-up perf PRs #64169–#64172. When disabled (the default), overhead is a single env check per instrumentation site; when enabled, per-turn cost is one JSON serialization and one appending write.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
