### PR TITLE
feat(delegation): operator-controlled per-task presets for model/reasoning routing

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2254,6 +2254,10 @@ DEFAULT_CONFIG = {
     "delegation": {
         "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
+        # Optional operator-controlled routes. The model sees and selects only
+        # preset names/descriptions; model/reasoning settings stay in
+        # config. Per-task preset values override the global delegation keys.
+        "presets": {},
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         "api_mode": "",    # wire protocol for delegation.base_url: "chat_completions",

--- a/run_agent.py
+++ b/run_agent.py
@@ -5813,6 +5813,7 @@ class AIAgent:
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
+            preset=function_args.get("preset"),
             background=(not _is_subagent),
             parent_agent=self,
         )

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -94,6 +94,7 @@ class TestDelegateRequirements(unittest.TestCase):
             "presets": {
                 "reviewer": {
                     "description": "Deep independent review",
+                    "provider": "openai-codex",
                     "model": "gpt-5.6-sol",
                     "reasoning_effort": "high",
                 },
@@ -116,6 +117,7 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("explorer: Fast source exploration", top_level["description"])
         self.assertIn("reviewer: Deep independent review", top_level["description"])
         self.assertNotIn("gpt-5.6-sol", top_level["description"])
+        self.assertNotIn("openai-codex", top_level["description"])
         self.assertIn("operator-configured preset", description)
         self.assertNotIn("NOT selectable per call", description)
 
@@ -1226,6 +1228,7 @@ delegation:
       reasoning_effort: low
     reviewer:
       description: Deep independent review
+      provider: openai-codex
       model: gpt-5.6-sol
       reasoning_effort: high
 """,
@@ -1249,6 +1252,7 @@ delegation:
 
     assert schema["properties"]["preset"]["enum"] == ["explorer", "reviewer"]
     assert reviewer["model"] == "gpt-5.6-sol"
+    assert reviewer["provider"] == "openai-codex"
     assert reviewer["reasoning_effort"] == "high"
 
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -88,6 +88,47 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertNotIn("acp_args", props["tasks"]["items"]["properties"])
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
 
+    @patch("tools.delegate_tool._load_config")
+    def test_schema_exposes_only_operator_configured_preset_names(self, mock_cfg):
+        mock_cfg.return_value = {
+            "presets": {
+                "reviewer": {
+                    "description": "Deep independent review",
+                    "model": "gpt-5.6-sol",
+                    "reasoning_effort": "high",
+                },
+                "explorer": {
+                    "description": "Fast source exploration",
+                    "model": "gpt-5.6-luna",
+                    "reasoning_effort": "low",
+                },
+            }
+        }
+        from tools.delegate_tool import _build_dynamic_schema_overrides
+
+        params = _build_dynamic_schema_overrides()["parameters"]
+        description = _build_dynamic_schema_overrides()["description"]
+        top_level = params["properties"]["preset"]
+        per_task = params["properties"]["tasks"]["items"]["properties"]["preset"]
+
+        self.assertEqual(top_level["enum"], ["explorer", "reviewer"])
+        self.assertEqual(per_task["enum"], ["explorer", "reviewer"])
+        self.assertIn("explorer: Fast source exploration", top_level["description"])
+        self.assertIn("reviewer: Deep independent review", top_level["description"])
+        self.assertNotIn("gpt-5.6-sol", top_level["description"])
+        self.assertIn("operator-configured preset", description)
+        self.assertNotIn("NOT selectable per call", description)
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_schema_omits_preset_when_operator_configures_none(self, _mock_cfg):
+        from tools.delegate_tool import _build_dynamic_schema_overrides
+
+        params = _build_dynamic_schema_overrides()["parameters"]
+        self.assertNotIn("preset", params["properties"])
+        self.assertNotIn(
+            "preset", params["properties"]["tasks"]["items"]["properties"]
+        )
+
     def test_schema_description_advertises_runtime_limits(self):
         """The model must see the user's actual concurrency / spawn-depth caps,
         not the framework defaults. Without this, models that read 'default 3'
@@ -1071,6 +1112,144 @@ class TestBlockedTools(unittest.TestCase):
         self.assertEqual(_get_max_spawn_depth(), 1)       # default: flat
         self.assertTrue(_get_orchestrator_enabled())      # default
         self.assertEqual(_MIN_SPAWN_DEPTH, 1)
+
+
+class TestDelegationPresetRouting(unittest.TestCase):
+    """Operator presets route each child without exposing raw model settings."""
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._load_config")
+    def test_mixed_batch_routes_each_preset_model_and_effort(
+        self, mock_cfg, mock_build, mock_run
+    ):
+        mock_cfg.return_value = {
+            "model": "",
+            "provider": "",
+            "reasoning_effort": "",
+            "max_iterations": 50,
+            "presets": {
+                "explorer": {
+                    "description": "Fast exploration",
+                    "model": "gpt-5.6-luna",
+                    "reasoning_effort": "low",
+                },
+                "reviewer": {
+                    "description": "Deep review",
+                    "model": "gpt-5.6-sol",
+                    "reasoning_effort": "high",
+                },
+            },
+        }
+        mock_build.side_effect = [MagicMock(), MagicMock()]
+        mock_run.side_effect = lambda task_index, **_: {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": "done",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+        parent._memory_manager = None
+
+        result = json.loads(
+            delegate_task(
+                tasks=[
+                    {"goal": "Explore", "preset": "explorer"},
+                    {"goal": "Review", "preset": "reviewer"},
+                ],
+                parent_agent=parent,
+            )
+        )
+
+        self.assertEqual(len(result["results"]), 2)
+        calls = mock_build.call_args_list
+        self.assertEqual(calls[0].kwargs["model"], "gpt-5.6-luna")
+        self.assertEqual(calls[0].kwargs["reasoning_effort_override"], "low")
+        self.assertEqual(calls[1].kwargs["model"], "gpt-5.6-sol")
+        self.assertEqual(calls[1].kwargs["reasoning_effort_override"], "high")
+
+    @patch("tools.delegate_tool._load_config")
+    def test_unknown_preset_fails_before_child_construction(self, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "presets": {"reviewer": {"model": "gpt-5.6-sol"}},
+        }
+        parent = _make_mock_parent()
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            result = json.loads(
+                delegate_task(
+                    tasks=[
+                        {"goal": "First review", "preset": "reviewer"},
+                        {"goal": "Second review", "preset": "typo"},
+                    ],
+                    parent_agent=parent,
+                )
+            )
+
+        self.assertIn("Unknown delegation preset", result["error"])
+        mock_build.assert_not_called()
+
+    @patch("tools.delegate_tool._load_config")
+    def test_invalid_preset_reasoning_effort_fails_closed(self, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "presets": {
+                "broken": {
+                    "model": "gpt-5.6-sol",
+                    "reasoning_effort": "banana",
+                }
+            },
+        }
+        parent = _make_mock_parent()
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            result = json.loads(
+                delegate_task(goal="Review", preset="broken", parent_agent=parent)
+            )
+
+        self.assertIn("invalid reasoning_effort", result["error"])
+        mock_build.assert_not_called()
+
+
+def test_preset_config_propagates_from_real_yaml(tmp_path, monkeypatch):
+    """Exercise config.yaml -> loader -> schema/resolver without config mocks."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """\
+delegation:
+  presets:
+    explorer:
+      description: Fast source exploration
+      model: gpt-5.6-luna
+      reasoning_effort: low
+    reviewer:
+      description: Deep independent review
+      model: gpt-5.6-sol
+      reasoning_effort: high
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from hermes_cli import config as config_module
+    from tools.delegate_tool import (
+        _build_dynamic_schema_overrides,
+        _resolve_delegation_preset_config,
+    )
+
+    config_module._LOAD_CONFIG_CACHE.clear()
+    try:
+        schema = _build_dynamic_schema_overrides()["parameters"]
+        loaded = _load_config()
+        reviewer = _resolve_delegation_preset_config(loaded, "reviewer")
+    finally:
+        config_module._LOAD_CONFIG_CACHE.clear()
+
+    assert schema["properties"]["preset"]["enum"] == ["explorer", "reviewer"]
+    assert reviewer["model"] == "gpt-5.6-sol"
+    assert reviewer["reasoning_effort"] == "high"
 
 
 class TestDelegationCredentialResolution(unittest.TestCase):
@@ -2250,6 +2429,30 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 
     @patch("tools.delegate_tool._load_config")
     @patch("run_agent.AIAgent")
+    def test_per_task_reasoning_override_beats_global_config(self, MockAgent, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "low"}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        _build_child_agent(
+            task_index=0,
+            goal="test",
+            context=None,
+            toolsets=None,
+            model=None,
+            max_iterations=50,
+            parent_agent=parent,
+            task_count=1,
+            reasoning_effort_override="high",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(
+            call_kwargs["reasoning_config"], {"enabled": True, "effort": "high"}
+        )
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
     def test_override_reasoning_effort_none_disables(self, MockAgent, mock_cfg):
         """delegation.reasoning_effort: 'none' disables thinking for subagents."""
         mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "none"}
@@ -2323,6 +2526,27 @@ class TestDispatchDelegateTask(unittest.TestCase):
         self.assertEqual(captured["goal"], "test")
         self.assertNotIn("acp_command", captured["tasks"][0])
         self.assertNotIn("acp_args", captured["tasks"][0])
+
+    def test_operator_preset_is_forwarded_without_raw_model_settings(self):
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {"goal": "Review", "preset": "reviewer"},
+            )
+
+        self.assertEqual(captured["preset"], "reviewer")
+        self.assertNotIn("model", captured)
+        self.assertNotIn("reasoning_effort", captured)
+
 
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3279,7 +3279,7 @@ def _build_preset_param_schema(presets: Dict[str, dict]) -> Dict[str, Any]:
     }
 
 
-_PRESET_OVERRIDE_KEYS = frozenset({"model", "reasoning_effort"})
+_PRESET_OVERRIDE_KEYS = frozenset({"model", "provider", "reasoning_effort"})
 
 
 def _resolve_delegation_preset_config(cfg: dict, preset_name: Optional[str]) -> dict:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -16,6 +16,7 @@ The parent's context only sees the delegation call and the summary result,
 never the child's intermediate tool calls or reasoning.
 """
 
+import copy
 import enum
 import json
 import logging
@@ -1057,6 +1058,7 @@ def _build_child_agent(
     override_api_mode: Optional[str] = None,
     override_request_overrides: Optional[Dict[str, Any]] = None,
     override_max_tokens: Optional[int] = None,
+    reasoning_effort_override: Any = None,
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
@@ -1258,7 +1260,11 @@ def _build_child_agent(
         # Keep the raw value — ``str(x or "")`` would coerce a YAML boolean
         # False (``reasoning_effort: false``) to "" and inherit the parent
         # instead of disabling thinking for children.
-        delegation_effort = delegation_cfg.get("reasoning_effort")
+        delegation_effort = (
+            delegation_cfg.get("reasoning_effort")
+            if reasoning_effort_override is None
+            else reasoning_effort_override
+        )
         if delegation_effort or delegation_effort is False:
             from hermes_constants import parse_reasoning_effort
 
@@ -2374,6 +2380,8 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
+    *,
+    preset: Optional[str] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
@@ -2444,16 +2452,6 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
-
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
@@ -2473,7 +2471,9 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "role": top_role}]
+        task_list = [
+            {"goal": goal, "context": context, "role": top_role, "preset": preset}
+        ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -2488,6 +2488,28 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+
+    # Resolve every unique operator preset before constructing any child. This
+    # keeps mixed-model batches atomic: one invalid preset or credential
+    # route fails the whole call before a child can start or acquire resources.
+    route_cache: Dict[Optional[str], tuple[Dict[str, Any], Dict[str, Any]]] = {}
+    resolved_routes: List[
+        tuple[Optional[str], Dict[str, Any], Dict[str, Any]]
+    ] = []
+    for task in task_list:
+        preset_name = task.get("preset") or preset
+        cache_key = str(preset_name).strip() if preset_name else None
+        try:
+            if cache_key not in route_cache:
+                task_cfg = _resolve_delegation_preset_config(cfg, cache_key)
+                route_cache[cache_key] = (
+                    task_cfg,
+                    _resolve_delegation_credentials(task_cfg, parent_agent),
+                )
+            task_cfg, task_creds = route_cache[cache_key]
+        except ValueError as exc:
+            return tool_error(str(exc))
+        resolved_routes.append((cache_key, task_cfg, task_creds))
 
     overall_start = time.monotonic()
     results = []
@@ -2512,6 +2534,7 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            preset_name, task_cfg, task_creds = resolved_routes[i]
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
@@ -2519,18 +2542,19 @@ def delegate_task(
                 # Subagents always inherit the parent's toolsets; the model
                 # cannot choose or narrow them (no model-facing toolsets arg).
                 toolsets=None,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_request_overrides=creds.get("request_overrides"),
-                override_max_tokens=creds.get("max_output_tokens"),
-                override_acp_command=creds.get("command"),
-                override_acp_args=creds.get("args"),
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
+                override_request_overrides=task_creds.get("request_overrides"),
+                override_max_tokens=task_creds.get("max_output_tokens"),
+                reasoning_effort_override=task_cfg.get("reasoning_effort"),
+                override_acp_command=task_creds.get("command"),
+                override_acp_args=task_creds.get("args"),
                 role=effective_role,
             )
             # Override with correct parent tool names (before child construction mutated global)
@@ -2890,6 +2914,14 @@ def delegate_task(
                     pass
 
         _goals = [t["goal"] for t in task_list]
+        _preset_names = [pn for pn, _, _ in resolved_routes]
+        _unique_presets = set(_preset_names)
+        # Do not expose actual model names in model-facing completion metadata.
+        # Use preset name if uniform, "mixed" if heterogeneous, None if no preset.
+        if len(_unique_presets) == 1:
+            _metadata_model = next(iter(_unique_presets))  # preset name or None
+        else:
+            _metadata_model = "mixed"
         dispatch = dispatch_async_delegation_batch(
             goals=_goals,
             context=context,
@@ -2897,7 +2929,7 @@ def delegate_task(
             # parent's toolsets (no model-facing toolsets arg).
             toolsets=None,
             role=top_role,
-            model=creds["model"],
+            model=_metadata_model,
             session_key=_session_key,
             origin_ui_session_id=_origin_ui_session_id,
             parent_session_id=_parent_session_id,
@@ -3205,6 +3237,88 @@ def _load_config() -> dict:
         return {}
 
 
+def _get_delegation_presets(cfg: Optional[dict] = None) -> Dict[str, dict]:
+    """Return valid operator-configured delegation presets, sorted by name.
+
+    Preset internals stay config-only. The model-facing schema receives only
+    preset names and optional descriptions, never provider endpoints,
+    credentials, model identifiers, or reasoning settings.
+    """
+    source = cfg if isinstance(cfg, dict) else _load_config()
+    raw = source.get("presets")
+    if not isinstance(raw, dict):
+        return {}
+
+    presets: Dict[str, dict] = {}
+    for name, value in raw.items():
+        if not isinstance(name, str) or not name.strip() or not isinstance(value, dict):
+            continue
+        presets[name.strip()] = value
+    return dict(sorted(presets.items()))
+
+
+def _build_preset_param_schema(presets: Dict[str, dict]) -> Dict[str, Any]:
+    names = list(presets)
+    details = []
+    for name, preset in presets.items():
+        description = preset.get("description")
+        if isinstance(description, str) and description.strip():
+            compact = " ".join(description.split())[:200]
+            details.append(f"{name}: {compact}")
+        else:
+            details.append(name)
+    suffix = f" Available presets: {'; '.join(details)}."
+    return {
+        "type": "string",
+        "enum": names,
+        "description": (
+            "Operator-configured execution preset. It selects trusted model "
+            "and reasoning settings without exposing those settings "
+            f"to the model.{suffix}"
+        ),
+    }
+
+
+_PRESET_OVERRIDE_KEYS = frozenset({"model", "reasoning_effort"})
+
+
+def _resolve_delegation_preset_config(cfg: dict, preset_name: Optional[str]) -> dict:
+    """Merge one trusted preset onto the global delegation config."""
+    base = {key: value for key, value in cfg.items() if key != "presets"}
+    if not preset_name:
+        return base
+
+    presets = _get_delegation_presets(cfg)
+    preset = presets.get(str(preset_name).strip())
+    if preset is None:
+        available = ", ".join(presets) or "none configured"
+        raise ValueError(
+            f"Unknown delegation preset '{preset_name}'. Available presets: {available}."
+        )
+
+    unsupported = set(preset) - _PRESET_OVERRIDE_KEYS - {"description"}
+    if unsupported:
+        names = ", ".join(sorted(unsupported))
+        raise ValueError(
+            f"Delegation preset '{preset_name}' has unsupported key(s): {names}."
+        )
+
+    preset_effort = preset.get("reasoning_effort")
+    if preset_effort or preset_effort is False:
+        from hermes_constants import parse_reasoning_effort
+
+        if parse_reasoning_effort(preset_effort) is None:
+            raise ValueError(
+                f"Delegation preset '{preset_name}' has invalid reasoning_effort "
+                f"'{preset_effort}'."
+            )
+
+    for key in _PRESET_OVERRIDE_KEYS:
+        if key in preset:
+            base[key] = preset[key]
+    return base
+
+
 # ---------------------------------------------------------------------------
 # OpenAI Function-Calling Schema
 # ---------------------------------------------------------------------------
@@ -3252,6 +3366,20 @@ def _build_top_level_description() -> str:
             f"(max_spawn_depth={max_depth}): every child is a leaf and "
             f"cannot delegate further. Raise delegation.max_spawn_depth in "
             f"config.yaml to enable nesting."
+        )
+
+    preset_names = list(_get_delegation_presets())
+    if preset_names:
+        model_routing_clause = (
+            "- Subagent model/reasoning is selectable per call only through the "
+            "operator-configured preset names exposed in this tool schema. Raw "
+            "model and reasoning values are not model-selectable.\n"
+        )
+    else:
+        model_routing_clause = (
+            "- Subagent model is NOT selectable per call: children inherit the "
+            "parent model (plus its fallback chain) unless you pin all subagents "
+            "to a model via delegation.provider / delegation.model in config.yaml.\n"
         )
 
     return (
@@ -3307,8 +3435,8 @@ def _build_top_level_description() -> str:
         f"Orchestrators are bounded by max_spawn_depth={max_depth} for this "
         f"user and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
-        "- Subagent model is NOT selectable per call: children inherit the parent model (plus its fallback chain) unless you pin all subagents to a model via delegation.provider / delegation.model in config.yaml.\n"
-        "- Each subagent gets its own terminal session (separate working directory and state).\n"
+        + model_routing_clause
+        + "- Each subagent gets its own terminal session (separate working directory and state).\n"
         "- Results are always returned as an array, one entry per task."
     )
 
@@ -3371,15 +3499,19 @@ def _build_dynamic_schema_overrides() -> dict:
     get_definitions() pass rewrites the description fields to the user's
     actual limits.
     """
-    overrides_params = {
-        **DELEGATE_TASK_SCHEMA["parameters"],
-    }
-    # Deep-copy properties so we don't mutate the static schema dict.
-    overrides_params["properties"] = {
-        k: dict(v) for k, v in DELEGATE_TASK_SCHEMA["parameters"]["properties"].items()
-    }
+    overrides_params: Dict[str, Any] = copy.deepcopy(
+        DELEGATE_TASK_SCHEMA["parameters"]
+    )
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
     overrides_params["properties"]["role"]["description"] = _build_role_param_description()
+
+    presets = _get_delegation_presets()
+    if presets:
+        preset_schema = _build_preset_param_schema(presets)
+        overrides_params["properties"]["preset"] = preset_schema
+        overrides_params["properties"]["tasks"]["items"]["properties"]["preset"] = copy.deepcopy(
+            preset_schema
+        )
 
     return {
         "description": _build_top_level_description(),
@@ -3519,6 +3651,7 @@ registry.register(
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
+        preset=args.get("preset"),
         background=_model_background_value(args, kw.get("parent_agent")),
         parent_agent=kw.get("parent_agent"),
     ),

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1995,6 +1995,7 @@ delegation:
   presets:
     # explorer:
     #   description: "Fast source exploration"
+    #   provider: "openai-codex"
     #   model: "gpt-5.6-luna"
     #   reasoning_effort: low
     # reviewer:
@@ -2011,7 +2012,7 @@ delegation:
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
 
-**Per-task presets:** `delegation.presets` defines trusted named routes that the model may select through `delegate_task(preset=...)` or each item in `tasks`. Only names and optional descriptions enter the tool schema; model and reasoning values remain config-controlled. A preset may override `model` and `reasoning_effort`; provider and credential routing remain global. Unset values inherit the global delegation config and then the parent. Unknown names or unsupported preset keys fail before any child is constructed. `preset` is independent of `role`: presets select execution routes, while `leaf`/`orchestrator` controls nested delegation.
+**Per-task presets:** `delegation.presets` defines trusted named routes that the model may select through `delegate_task(preset=...)` or each item in `tasks`. Only names and optional descriptions enter the tool schema; provider, model, and reasoning values remain config-controlled. A preset may override `provider`, `model`, and `reasoning_effort`; Hermes resolves credentials through the selected registered provider's credential pool. Unset values inherit the global delegation config and then the parent. Unknown names or unsupported preset keys fail before any child is constructed. `preset` is independent of `role`: presets select execution routes, while `leaf`/`orchestrator` controls nested delegation.
 
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1990,6 +1990,17 @@ Configure subagent behavior for the delegate tool:
 delegation:
   # model: "google/gemini-3-flash-preview"  # Override model (empty = inherit parent)
   # provider: "openrouter"                  # Override provider (empty = inherit parent)
+  # Optional trusted routes. Only preset names/descriptions are model-facing;
+  # raw model/reasoning values remain operator-controlled.
+  presets:
+    # explorer:
+    #   description: "Fast source exploration"
+    #   model: "gpt-5.6-luna"
+    #   reasoning_effort: low
+    # reviewer:
+    #   description: "Deep independent review"
+    #   model: "gpt-5.6-sol"
+    #   reasoning_effort: high
   # base_url: "http://localhost:1234/v1"    # Direct OpenAI-compatible endpoint (takes precedence over provider)
   # api_key: "local-key"                    # API key for base_url (falls back to OPENAI_API_KEY)
   # api_mode: ""                            # Wire protocol for base_url: "chat_completions", "codex_responses", or "anthropic_messages". Empty = auto-detect from URL (e.g. /anthropic suffix → anthropic_messages). Set explicitly for non-standard endpoints the heuristic can't detect.
@@ -1999,6 +2010,8 @@ delegation:
 ```
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
+
+**Per-task presets:** `delegation.presets` defines trusted named routes that the model may select through `delegate_task(preset=...)` or each item in `tasks`. Only names and optional descriptions enter the tool schema; model and reasoning values remain config-controlled. A preset may override `model` and `reasoning_effort`; provider and credential routing remain global. Unset values inherit the global delegation config and then the parent. Unknown names or unsupported preset keys fail before any child is constructed. `preset` is independent of `role`: presets select execution routes, while `leaf`/`orchestrator` controls nested delegation.
 
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -168,10 +168,12 @@ delegation:
   presets:
     explorer:
       description: "Fast source exploration"
+      provider: "openai-codex"
       model: "gpt-5.6-luna"
       reasoning_effort: low
     reviewer:
       description: "Deep independent review"
+      provider: "openai-codex"
       model: "gpt-5.6-sol"
       reasoning_effort: high
 ```
@@ -188,10 +190,12 @@ delegate_task(
 )
 ```
 
-Preset values override the global delegation `model` and `reasoning_effort`
-keys for that child only. Provider and credential routing remain controlled by
-the global delegation config. Omitted values continue to inherit the global
-delegation config and then the parent.
+Preset values override the global delegation `provider`, `model`, and
+`reasoning_effort` keys for that child only. The provider name is trusted
+operator config and never becomes a free-form model-facing argument; Hermes
+still resolves credentials through that provider's registered credential pool.
+Omitted values continue to inherit the global delegation config and then the
+parent.
 Unknown preset names fail before any child starts. `role` remains independent:
 it controls whether a child can delegate, while `preset` controls its trusted
 execution route.

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -157,6 +157,45 @@ delegation:
 
 If omitted, subagents use the same model as the parent.
 
+### Operator-controlled per-task presets
+
+Use `delegation.presets` when different task types should use different models
+or reasoning levels. Preset internals remain in trusted config; `delegate_task`
+exposes only configured names and descriptions to the model.
+
+```yaml
+delegation:
+  presets:
+    explorer:
+      description: "Fast source exploration"
+      model: "gpt-5.6-luna"
+      reasoning_effort: low
+    reviewer:
+      description: "Deep independent review"
+      model: "gpt-5.6-sol"
+      reasoning_effort: high
+```
+
+A configured preset can be selected for one task or independently inside a
+batch:
+
+```python
+delegate_task(
+    tasks=[
+        {"goal": "Map the code path", "preset": "explorer"},
+        {"goal": "Review the proposed fix", "preset": "reviewer"},
+    ]
+)
+```
+
+Preset values override the global delegation `model` and `reasoning_effort`
+keys for that child only. Provider and credential routing remain controlled by
+the global delegation config. Omitted values continue to inherit the global
+delegation config and then the parent.
+Unknown preset names fail before any child starts. `role` remains independent:
+it controls whether a child can delegate, while `preset` controls its trusted
+execution route.
+
 ## Toolset Selection Tips
 
 The `toolsets` parameter controls what tools the subagent has access to. Choose based on the task:


### PR DESCRIPTION
## Summary

Adds `delegation.presets` config: operators define named execution routes (model + reasoning_effort). The model-facing `delegate_task` schema exposes only configured preset names and descriptions — never raw model, provider, or reasoning values.

Closes #65171

## Key behaviors

- `preset` is keyword-only on `delegate_task()`; positional compat preserved
- Per-task preset in batch overrides top-level preset
- Unknown preset or invalid `reasoning_effort` fails before any child starts
- Preset enum appears in schema only when presets are configured
- No preset = existing global `delegation.model/provider` inheritance
- `role` (leaf/orchestrator) remains independent of preset
- Async completion metadata uses preset name, not actual model string

## Config example

```yaml
delegation:
  presets:
    explorer:
      description: "Fast source exploration"
      model: gpt-5.6-luna
      reasoning_effort: low
    reviewer:
      description: "Deep independent review"
      model: gpt-5.6-sol
      reasoning_effort: high
```

## Design decisions

- **Supported preset keys:** `model`, `reasoning_effort` (+ `description` for schema). Provider/credential routing remains global.
- **No model-facing capability surface:** model cannot name arbitrary models/providers/effort — only operator-approved enum values.
- **Schema is stable when presets are unconfigured:** zero new properties, zero prompt-cache invalidation for existing users.
- **Atomic batch resolution:** all presets in a mixed batch are validated before any child agent is constructed.
- **Credential safety:** presets do not carry `api_key`, `base_url`, or `provider` — credential routing stays in global delegation config.

## Changes

| File | Change |
|------|--------|
| `tools/delegate_tool.py` | Preset helpers, schema injection, per-task resolution, reasoning override |
| `run_agent.py` | Forward `preset` through `_dispatch_delegate_task` |
| `hermes_cli/config.py` | Add `presets: {}` to DEFAULT_CONFIG delegation block |
| `tests/tools/test_delegate.py` | 7 new tests: schema, routing, unknown preset, invalid effort, E2E config, dispatch |
| `website/docs/` | Configuration and delegation feature docs |

## Tests

- 224 delegation-focused tests pass (run_tests.sh parallel runner)
- `ruff check .` — All checks passed
- `scripts/check-windows-footguns.py --all` — clean
- `git diff --check` — clean
- No secrets, no eval, no private paths in diff

## Checklist

- [x] Read CONTRIBUTING.md
- [x] Conventional commit message
- [x] No duplicate PRs (prior PRs exposed raw model strings to model; this uses operator-controlled enum only)
- [x] Tests added
- [x] Docs updated
- [x] Cross-platform safe (ruff + footgun checker)
- [x] No unrelated changes