### PR TITLE
feat(webhooks): validate Linear signatures

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -895,13 +895,23 @@ class WebhookAdapter(BasePlatformAdapter):
     def _validate_signature(
         self, request: "web.Request", body: bytes, secret: str
     ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256)."""
+        """Validate webhook signature (Linear, GitHub, GitLab, Svix, generic HMAC)."""
         def _header(name: str) -> str:
             return (
                 request.headers.get(name, "")
                 or request.headers.get(name.lower(), "")
                 or request.headers.get(name.upper(), "")
             )
+
+        # Linear: Linear-Signature = <hex HMAC-SHA256 of raw body>.
+        # Presence commits to this scheme so invalid Linear signatures cannot
+        # fall through to another recognized signature header.
+        if any(name.lower() == "linear-signature" for name in request.headers):
+            linear_signature = _header("Linear-Signature")
+            expected = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(linear_signature, expected)
 
         # Svix / AgentMail:
         #   svix-id: msg_...

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -25,7 +25,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
-from aiohttp.test_utils import TestClient, TestServer
+from aiohttp.test_utils import TestClient, TestServer, make_mocked_request
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import SendResult
@@ -103,6 +103,11 @@ def _generic_signature(body: bytes, secret: str) -> str:
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
+def _linear_signature(body: bytes, secret: str) -> str:
+    """Compute Linear-Signature for *body* using *secret*."""
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
 def _generic_v2_signature(body: bytes, secret: str, timestamp: str) -> str:
     """Compute X-Webhook-Signature-V2 (HMAC-SHA256 of "<timestamp>.<body>")."""
     signed_content = timestamp.encode() + b"." + body
@@ -128,6 +133,68 @@ def _svix_signature(body: bytes, secret: str, msg_id: str, timestamp: str) -> st
 
 class TestValidateSignature:
     """Tests for WebhookAdapter._validate_signature."""
+
+    def test_validate_linear_signature_valid(self):
+        """Valid Linear-Signature over the exact raw body is accepted."""
+        adapter = _make_adapter()
+        body = b'{"action":"update","data":{"id":"ENG-131"}}'
+        secret = "linear-webhook-secret"
+        sig = _linear_signature(body, secret)
+        req = _mock_request(headers={"linear-signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_linear_signature_mixed_case_aiohttp_headers(self):
+        """Linear signatures honor aiohttp's case-insensitive header semantics."""
+        adapter = _make_adapter()
+        body = b'{"action":"update","data":{"id":"ENG-131"}}'
+        secret = "linear-webhook-secret"
+        sig = _linear_signature(body, secret)
+        req = make_mocked_request(
+            "POST",
+            "/webhooks/linear",
+            headers={"lInEaR-SiGnAtUrE": sig},
+        )
+
+        assert req.headers["Linear-Signature"] == sig
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_linear_signature_invalid(self):
+        """Linear signatures are bound to the exact raw request body."""
+        adapter = _make_adapter()
+        signed_body = b'{"action":"update","data":{"id":"ENG-131"}}'
+        received_body = b'{"action": "update", "data": {"id": "ENG-131"}}'
+        secret = "linear-webhook-secret"
+        sig = _linear_signature(signed_body, secret)
+        req = _mock_request(headers={"Linear-Signature": sig})
+        assert adapter._validate_signature(req, received_body, secret) is False
+
+    def test_validate_linear_signature_malformed(self):
+        """Non-hex Linear signature formats are rejected."""
+        adapter = _make_adapter()
+        body = b'{"action":"update"}'
+        req = _mock_request(
+            headers={"Linear-Signature": "sha256=not-a-linear-hex-digest"}
+        )
+        assert adapter._validate_signature(req, body, "linear-secret") is False
+
+    def test_validate_empty_linear_signature_rejects(self):
+        """An explicitly empty Linear-Signature fails closed."""
+        adapter = _make_adapter()
+        req = _mock_request(headers={"Linear-Signature": ""})
+        assert adapter._validate_signature(req, b"{}", "linear-secret") is False
+
+    def test_invalid_linear_signature_does_not_fall_through(self):
+        """A present invalid Linear signature cannot use another valid scheme."""
+        adapter = _make_adapter()
+        body = b'{"action":"update"}'
+        secret = "linear-webhook-secret"
+        req = _mock_request(
+            headers={
+                "Linear-Signature": "0" * 64,
+                "X-Webhook-Signature": _generic_signature(body, secret),
+            }
+        )
+        assert adapter._validate_signature(req, body, secret) is False
 
     def test_validate_github_signature_valid(self):
         """Valid X-Hub-Signature-256 is accepted."""
@@ -451,6 +518,66 @@ class TestValidateSignature:
             }
         )
         assert adapter._validate_signature(req, body, secret) is True
+
+
+@pytest.mark.asyncio
+async def test_invalid_linear_signature_precedes_rate_limit_and_json_parsing():
+    """Linear auth failure returns 401 before rate limiting or malformed JSON."""
+    secret = "global-linear-secret"
+    adapter = _make_adapter(
+        routes={"linear": {"prompt": "Linear event: {action}"}},
+        secret=secret,
+    )
+    adapter._record_rate_limit_hit = MagicMock(return_value=True)
+    request = _mock_request(
+        headers={"Linear-Signature": "0" * 64},
+        body=b"not-json",
+        match_info={"route_name": "linear"},
+    )
+
+    response = await adapter._handle_webhook(request)
+
+    assert response.status == 401
+    adapter._record_rate_limit_hit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_valid_linear_signature_parses_json_and_dispatches_event():
+    """A valid Linear request reaches JSON parsing and background dispatch."""
+    secret = "global-linear-secret"
+    payload = {"action": "update", "data": {"id": "ENG-131"}}
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    delivery_id = "linear-delivery-valid"
+    adapter = _make_adapter(
+        routes={"linear": {"prompt": "Linear event: {action}"}},
+        secret=secret,
+    )
+    adapter.handle_message = AsyncMock()
+    request = _mock_request(
+        headers={
+            "Linear-Signature": _linear_signature(body, secret),
+            "X-Request-ID": delivery_id,
+        },
+        body=body,
+        match_info={"route_name": "linear"},
+    )
+
+    response = await adapter._handle_webhook(request)
+    pending_dispatches = tuple(adapter._background_tasks)
+    await asyncio.gather(*pending_dispatches)
+
+    assert response.status == 202
+    assert json.loads(response.body) == {
+        "status": "accepted",
+        "route": "linear",
+        "event": "unknown",
+        "delivery_id": delivery_id,
+    }
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.raw_message == payload
+    assert event.text == "Linear event: update"
+    assert event.message_id == delivery_id
 
 
 # ===================================================================

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 13
 title: "Webhooks"
-description: "Receive events from GitHub, GitLab, and other services to trigger Hermes agent runs"
+description: "Receive events from GitHub, GitLab, Linear, and other services to trigger Hermes agent runs"
 ---
 
 # Webhooks
 
-Receive events from external services (GitHub, GitLab, JIRA, Stripe, etc.) and trigger Hermes agent runs automatically. The webhook adapter runs an HTTP server that accepts POST requests, validates HMAC signatures, transforms payloads into agent prompts, and routes responses back to the source or to another configured platform.
+Receive events from external services (GitHub, GitLab, Linear, JIRA, Stripe, etc.) and trigger Hermes agent runs automatically. The webhook adapter runs an HTTP server that accepts POST requests, validates HMAC signatures, transforms payloads into agent prompts, and routes responses back to the source or to another configured platform.
 
 The agent processes the event and can respond by posting comments on PRs, sending messages to Telegram/Discord, or logging the result.
 
@@ -453,10 +453,14 @@ The webhook adapter includes multiple layers of security:
 
 The adapter validates incoming webhook signatures using the appropriate method for each source:
 
-- **GitHub**: `X-Hub-Signature-256` header — HMAC-SHA256 hex digest prefixed with `sha256=`
-- **GitLab**: `X-Gitlab-Token` header — plain secret string match
-- **Generic (V2, recommended)**: `X-Webhook-Signature-V2` + `X-Webhook-Timestamp` headers — HMAC-SHA256 hex digest of `<timestamp>.<body>`. The timestamp (Unix seconds) must be within ±300 seconds of the server clock, which prevents captured requests from being replayed later.
-- **Generic (V1, legacy)**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest of the body only. Still accepted for backward compatibility, but it has no replay protection (a captured request replays indefinitely); the gateway logs a deprecation warning once per route. Switch senders to V2.
+| Source | Header | Signed content and validation |
+|--------|--------|-------------------------------|
+| GitHub | `X-Hub-Signature-256` | HMAC-SHA256 hex digest of the exact raw request body, prefixed with `sha256=`. |
+| GitLab | `X-Gitlab-Token` | Plain secret string match. |
+| Linear | `Linear-Signature` | Lowercase hex HMAC-SHA256 digest of the exact raw request body, using the route or global secret as the signing key. This body-only scheme has no timestamp-based replay protection. |
+| Svix / AgentMail | `svix-id`, `svix-timestamp`, `svix-signature` | Base64 HMAC-SHA256 of `<id>.<timestamp>.<body>`; the timestamp must be within ±300 seconds of the server clock. |
+| Generic (V2, recommended) | `X-Webhook-Signature-V2`, `X-Webhook-Timestamp` | HMAC-SHA256 hex digest of `<timestamp>.<body>`. The timestamp (Unix seconds) must be within ±300 seconds of the server clock, which prevents captured requests from being replayed later. |
+| Generic (V1, legacy) | `X-Webhook-Signature` | Raw HMAC-SHA256 hex digest of the body only. Still accepted for backward compatibility, but it has no replay protection (a captured request replays indefinitely); the gateway logs a deprecation warning once per route. Switch senders to V2. |
 
 If a secret is configured but no recognized signature header is present, the request is rejected.
 
@@ -523,6 +527,7 @@ This is the same trust model that applies to everything the agent reads: web pag
 - Ensure the secret in your route config exactly matches the secret configured in the webhook source
 - For GitHub, the secret is HMAC-based — check `X-Hub-Signature-256`
 - For GitLab, the secret is a plain token match — check `X-Gitlab-Token`
+- For Linear, check `Linear-Signature` and ensure the sender signs the exact raw request body
 - Check gateway logs for `Invalid signature` warnings
 
 ### Event being ignored


### PR DESCRIPTION
## Summary

- add native validation for Linear's `Linear-Signature` webhook header
- compute HMAC-SHA256 over the exact raw request body and compare in constant time
- fail closed when a Linear signature header is present but invalid, empty, or malformed, without falling through to another provider scheme
- document Linear's body-only signature format and replay limitation

## Security behavior

- authentication remains before rate limiting and JSON parsing
- no request bodies, signatures, or secrets are logged
- existing GitHub, GitLab, Svix, and generic webhook behavior remains unchanged

## Verification

- `python -m pytest tests/gateway/test_webhook_adapter.py -q` — **92 passed** in an isolated Python 3.11 environment with the repository's `dev` and `messaging` extras
- `ruff check gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py` — passed
- `git diff --check` — passed
- independent Claude review — no security concerns, logic errors, or test errors

## Scope

This PR adds provider-compatible signature validation only. It does not add Linear-specific business logic, public ingress, live webhook configuration, or merge automation.
