### PR TITLE
fix: prevent resume recap from duplicating on first message (#65293)

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -684,6 +684,9 @@ class CLIAgentSetupMixin:
             padding=(0, 1),
             style=_history_text_c,
         )
-        _record_output_history_entry(lambda: self._render_resume_history_panel_lines(panel))
+        # NOTE: intentionally NOT recording in output history — the resume
+        # recap is a one-shot display artifact. If recorded, _replay_output_history
+        # would re-emit it on resize/Ctrl+L, duplicating the panel content
+        # after the user sends their first message (#65293).
         with _suspend_output_history():
             self._console_print(panel)


### PR DESCRIPTION
Removed the  for the resume recap panel so it's not replayed on resize/Ctrl+L after the first message.\n\nThe resume recap is a one-shot display artifact — it does not need to survive  cycles.\n\nCloses #65293