### PR TITLE
fix(gateway): bind trusted session provenance

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2838,6 +2838,8 @@ def run_job(
     # below, so clearing HERMES_SESSION_* here does not affect delivery.
     _ctx_tokens = set_session_vars(
         platform="",
+        source="cron",
+        chat_type="cron",
         chat_id="",
         chat_name="",
     )

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4187,6 +4187,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return set_session_vars(
             platform="api_server",
+            source="api",
+            chat_type="api",
             chat_id=chat_id,
             session_key=session_key,
             session_id=session_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11124,7 +11124,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         context = build_session_context(source, self.config, session_entry)
         
         # Set session context variables for tools (task-local, concurrency-safe)
-        _session_env_tokens = self._set_session_env(context)
+        _session_env_tokens = self._set_session_env(
+            context,
+            source_kind="gateway_internal" if is_internal else "gateway_user",
+        )
         
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
@@ -15205,7 +15208,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return delivered
 
-    def _set_session_env(self, context: SessionContext) -> list:
+    def _set_session_env(
+        self,
+        context: SessionContext,
+        *,
+        source_kind: str = "gateway_unknown",
+    ) -> list:
         """Set session context variables for the current async task.
 
         Uses ``contextvars`` instead of ``os.environ`` so that concurrent
@@ -15227,12 +15235,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _async_delivery = getattr(_adapter, "supports_async_delivery", True)
         return set_session_vars(
             platform=context.source.platform.value,
+            source=source_kind,
+            chat_type=context.source.chat_type,
             chat_id=context.source.chat_id,
             chat_name=context.source.chat_name or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
+            session_id=context.session_id,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -72,6 +72,7 @@ def session_context_engaged() -> bool:
 
 _SESSION_PLATFORM: ContextVar = ContextVar("HERMES_SESSION_PLATFORM", default=_UNSET)
 _SESSION_SOURCE: ContextVar = ContextVar("HERMES_SESSION_SOURCE", default=_UNSET)
+_SESSION_CHAT_TYPE: ContextVar = ContextVar("HERMES_SESSION_CHAT_TYPE", default=_UNSET)
 _SESSION_CHAT_ID: ContextVar = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNSET)
 _SESSION_CHAT_NAME: ContextVar = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
 _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
@@ -123,6 +124,7 @@ _CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
     "HERMES_SESSION_SOURCE": _SESSION_SOURCE,
+    "HERMES_SESSION_CHAT_TYPE": _SESSION_CHAT_TYPE,
     "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
@@ -157,6 +159,7 @@ def set_current_session_id(session_id: str) -> None:
 def set_session_vars(
     platform: str = "",
     source: str = "",
+    chat_type: str = "",
     chat_id: str = "",
     chat_name: str = "",
     thread_id: str = "",
@@ -193,6 +196,7 @@ def set_session_vars(
     tokens = [
         _SESSION_PLATFORM.set(platform),
         _SESSION_SOURCE.set(source),
+        _SESSION_CHAT_TYPE.set(chat_type),
         _SESSION_CHAT_ID.set(chat_id),
         _SESSION_CHAT_NAME.set(chat_name),
         _SESSION_THREAD_ID.set(thread_id),
@@ -228,6 +232,7 @@ def clear_session_vars(tokens: list) -> None:
     for var in (
         _SESSION_PLATFORM,
         _SESSION_SOURCE,
+        _SESSION_CHAT_TYPE,
         _SESSION_CHAT_ID,
         _SESSION_CHAT_NAME,
         _SESSION_THREAD_ID,

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -46,26 +46,31 @@ def test_set_session_env_sets_contextvars(monkeypatch):
 
     monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
     monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_TYPE", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
 
-    tokens = runner._set_session_env(context)
+    context.session_id = "session-123"
+    tokens = runner._set_session_env(context, source_kind="gateway_user")
 
     # Values should be readable via get_session_env (contextvar path)
     assert get_session_env("HERMES_SESSION_PLATFORM") == "telegram"
-    assert get_session_env("HERMES_SESSION_SOURCE") == ""
+    assert get_session_env("HERMES_SESSION_SOURCE") == "gateway_user"
+    assert get_session_env("HERMES_SESSION_CHAT_TYPE") == "group"
     assert get_session_env("HERMES_SESSION_CHAT_ID") == "-1001"
     assert get_session_env("HERMES_SESSION_CHAT_NAME") == "Group"
     assert get_session_env("HERMES_SESSION_USER_ID") == "123456"
     assert get_session_env("HERMES_SESSION_USER_NAME") == "alice"
     assert get_session_env("HERMES_SESSION_THREAD_ID") == "17585"
+    assert get_session_env("HERMES_SESSION_ID") == "session-123"
 
     # os.environ should NOT be touched
     assert os.getenv("HERMES_SESSION_PLATFORM") is None
     assert os.getenv("HERMES_SESSION_SOURCE") is None
+    assert os.getenv("HERMES_SESSION_CHAT_TYPE") is None
     assert os.getenv("HERMES_SESSION_THREAD_ID") is None
 
     # Clean up
@@ -82,6 +87,22 @@ def test_session_source_uses_contextvars(monkeypatch):
     clear_session_vars(tokens)
 
     assert get_session_env("HERMES_SESSION_SOURCE") == ""
+
+
+def test_gateway_source_kind_fails_closed_when_caller_does_not_classify_turn():
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="owner-dm",
+        chat_type="dm",
+        user_id="owner",
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    tokens = runner._set_session_env(context)
+    assert get_session_env("HERMES_SESSION_SOURCE") == "gateway_unknown"
+    assert get_session_env("HERMES_SESSION_CHAT_TYPE") == "dm"
+    runner._clear_session_env(tokens)
 
 
 def test_clear_session_env_restores_previous_state(monkeypatch):
@@ -393,4 +414,3 @@ async def test_gateway_executor_refuses_resurrection_after_shutdown():
             await runner._run_in_executor_with_context(lambda: "second")
     finally:
         runner._shutdown_executor()
-


### PR DESCRIPTION
## Summary

- bind a task-local `HERMES_SESSION_CHAT_TYPE` alongside the existing gateway identity fields
- classify real authorized gateway turns as `gateway_user` and synthetic/internal turns as `gateway_internal`
- propagate the durable session ID through the same task-local binding
- explicitly classify API and cron contexts so security-sensitive plugins can fail closed

## Why

Session IDs and platform/chat IDs do not prove that a tool call came from a live authorized user turn. A product-neutral provenance field lets trusted plugins distinguish a real gateway message from background, internal, API, or cron work without parsing prompt text or reading process-global environment state.

The existing handler-entry reset and ContextVar propagation remain the concurrency boundary; this change adds fields to that established mechanism. Existing callers that do not classify a gateway turn receive `gateway_unknown` rather than an implicit user classification.

## Validation

- `uv run --extra dev pytest tests/gateway/test_session_env.py tests/gateway/test_session_context_inheritance.py -q` (23 passed)
- `python3 -m py_compile gateway/session_context.py gateway/run.py gateway/platforms/api_server.py cron/scheduler.py tests/gateway/test_session_env.py`
- `git diff --check`

This is a draft for maintainer feedback. It does not add a product integration or expose any secret values.
