### PR TITLE
feat(plugins): initialize manifest config defaults

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -312,6 +312,7 @@ class PluginManifest:
     # category plugin at ``plugins/image_gen/openai/`` the key is
     # ``image_gen/openai``. When empty, falls back to ``name``.
     key: str = ""
+    config_defaults: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -1640,6 +1641,7 @@ class PluginManager:
                 requires_env=data.get("requires_env", []),
                 provides_tools=data.get("provides_tools", []),
                 provides_hooks=data.get("provides_hooks", []),
+                config_defaults=data.get("config_defaults", {}),
                 source=source,
                 path=str(plugin_dir),
                 kind=kind,

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -69,9 +69,9 @@ class PluginOperationError(Exception):
 
 
 # Minimum manifest version this installer understands.
-# Plugins may declare ``manifest_version: 2`` in plugin.yaml;
+# Plugins may declare ``manifest_version: 1`` in plugin.yaml;
 # future breaking changes to the manifest schema bump this.
-_SUPPORTED_MANIFEST_VERSION = 2
+_SUPPORTED_MANIFEST_VERSION = 1
 
 
 def _plugins_dir() -> Path:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -9,11 +9,13 @@ rendered with Rich Markdown.  Otherwise a default confirmation is shown.
 
 from __future__ import annotations
 
+import copy
 import functools
 import importlib.metadata
 import json
 import logging
 import os
+import secrets
 import shutil
 import subprocess
 import sys
@@ -67,9 +69,9 @@ class PluginOperationError(Exception):
 
 
 # Minimum manifest version this installer understands.
-# Plugins may declare ``manifest_version: 1`` in plugin.yaml;
+# Plugins may declare ``manifest_version: 2`` in plugin.yaml;
 # future breaking changes to the manifest schema bump this.
-_SUPPORTED_MANIFEST_VERSION = 1
+_SUPPORTED_MANIFEST_VERSION = 2
 
 
 def _plugins_dir() -> Path:
@@ -273,6 +275,118 @@ def _read_manifest(plugin_dir: Path) -> dict:
     except Exception as e:
         logger.warning("Failed to read plugin.yaml in %s: %s", plugin_dir, e)
         return {}
+
+
+def _resolve_config_default(value: Any, hermes_home: Path) -> Any:
+    if isinstance(value, dict):
+        if set(value) == {"$profile_path"}:
+            relative = value["$profile_path"]
+            if not isinstance(relative, str) or not relative or Path(relative).is_absolute():
+                raise ValueError("$profile_path must be a non-empty relative path")
+            resolved = (hermes_home / relative).resolve()
+            if not resolved.is_relative_to(hermes_home.resolve()):
+                raise ValueError("$profile_path must stay inside the active profile")
+            return str(resolved)
+        if set(value) == {"$random_digits"}:
+            length = value["$random_digits"]
+            if isinstance(length, bool) or not isinstance(length, int) or not 1 <= length <= 64:
+                raise ValueError("$random_digits must be an integer from 1 to 64")
+            lower = 1 if length == 1 else 10 ** (length - 1)
+            return str(secrets.randbelow(9 * lower) + lower)
+        return {
+            key: _resolve_config_default(nested, hermes_home)
+            for key, nested in value.items()
+        }
+    if isinstance(value, list):
+        return [_resolve_config_default(item, hermes_home) for item in value]
+    return copy.deepcopy(value)
+
+
+def _default_leaf_count(value: Any) -> int:
+    if isinstance(value, dict) and not any(
+        isinstance(key, str) and key.startswith("$") for key in value
+    ):
+        return max(1, sum(_default_leaf_count(nested) for nested in value.values()))
+    return 1
+
+
+def _merge_missing_config_defaults(
+    target: dict[str, Any], defaults: dict[str, Any], hermes_home: Path
+) -> int:
+    changed = 0
+    for key, default in defaults.items():
+        if not isinstance(key, str):
+            raise ValueError("config_defaults keys must be strings")
+        if key not in target:
+            target[key] = _resolve_config_default(default, hermes_home)
+            changed += _default_leaf_count(default)
+        elif (
+            isinstance(target[key], dict)
+            and isinstance(default, dict)
+            and not any(
+                isinstance(nested, str) and nested.startswith("$")
+                for nested in default
+            )
+        ):
+            changed += _merge_missing_config_defaults(
+                target[key], default, hermes_home
+            )
+    return changed
+
+
+def _apply_plugin_config_defaults(
+    plugin_id: str, manifest: dict, console: Any = None
+) -> int:
+    """Fill missing namespaced config values declared by a plugin manifest."""
+    defaults = manifest.get("config_defaults")
+    if defaults is None:
+        return 0
+    if not isinstance(defaults, dict):
+        logger.warning("Plugin %s has non-mapping config_defaults", plugin_id)
+        return 0
+
+    try:
+        from hermes_cli.config import is_managed, read_raw_config, save_config
+
+        if is_managed():
+            return 0
+        raw = read_raw_config()
+        if not isinstance(raw, dict):
+            raise ValueError("Hermes config is not a mapping")
+        updated = copy.deepcopy(raw)
+
+        plugins = updated.setdefault("plugins", {})
+        if not isinstance(plugins, dict):
+            raise ValueError("plugins config is not a mapping")
+        entries = plugins.setdefault("entries", {})
+        if not isinstance(entries, dict):
+            raise ValueError("plugins.entries config is not a mapping")
+        entry = entries.setdefault(plugin_id, {})
+        if not isinstance(entry, dict):
+            raise ValueError(f"plugins.entries.{plugin_id} is not a mapping")
+        plugin_config = entry.setdefault("config", {})
+        if not isinstance(plugin_config, dict):
+            raise ValueError(f"plugins.entries.{plugin_id}.config is not a mapping")
+
+        changed = _merge_missing_config_defaults(
+            plugin_config, defaults, get_hermes_home().resolve()
+        )
+        if not changed:
+            return 0
+        save_config(updated)
+        if console is not None:
+            console.print(
+                f"[dim]  Initialized {changed} config default(s) for {plugin_id}.[/dim]"
+            )
+        return changed
+    except Exception as exc:
+        logger.warning("Could not initialize config defaults for %s: %s", plugin_id, exc)
+        if console is not None:
+            console.print(
+                f"[yellow]Warning:[/yellow] Could not initialize config defaults "
+                f"for {plugin_id}: {exc}"
+            )
+        return 0
 
 
 def _copy_example_files(plugin_dir: Path, console) -> None:
@@ -619,6 +733,7 @@ def cmd_install(
         disabled.discard(installed_name)
         _save_enabled_set(enabled)
         _save_disabled_set(disabled)
+        _apply_plugin_config_defaults(installed_name, installed_manifest, console)
         console.print(
             f"[green]✓[/green] Plugin [bold]{installed_name}[/bold] enabled.",
         )
@@ -662,6 +777,13 @@ def cmd_update(name: str) -> None:
 
     # Copy any new .example files
     _copy_example_files(target, console)
+
+    updated_manifest = _read_manifest(target)
+    updated_name = updated_manifest.get("name") or target.name
+    updated_key = _resolve_plugin_key(name) or updated_name
+    enabled = _get_enabled_set()
+    if updated_key in enabled or updated_name in enabled:
+        _apply_plugin_config_defaults(updated_key, updated_manifest, console)
 
     out = output.strip()
     if "Already up to date" in out:
@@ -791,6 +913,13 @@ def _resolve_plugin_key_and_source(name: str) -> Optional[tuple]:
     return None
 
 
+def _manifest_for_plugin_key(plugin_key: str) -> dict:
+    for entry in _discover_all_plugins():
+        if entry[5] == plugin_key:
+            return _read_manifest(Path(entry[4]))
+    return {}
+
+
 def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
     """Write ``plugins.entries.<plugin_id>.<key> = value`` into config.yaml."""
     from hermes_cli.config import load_config, save_config
@@ -863,6 +992,8 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
         )
     else:
         console.print(f"[dim]Plugin '{key}' is already enabled.[/dim]")
+
+    _apply_plugin_config_defaults(key, _manifest_for_plugin_key(key), console)
 
     # Built-in tool override is a privileged grant. Bundled plugins ship with
     # Hermes core and are trusted; every other source needs operator opt-in.

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -394,8 +394,143 @@ class TestReadManifest:
 # ── cmd_install tests ─────────────────────────────────────────────────────────
 
 
+class TestPluginConfigDefaults:
+    def test_applies_profile_defaults_and_preserves_existing_values(self, tmp_path):
+        from hermes_cli.plugins_cmd import _apply_plugin_config_defaults
+
+        plugin_config = {"headless": True, "nested": {"explicit": "keep"}}
+        raw = {
+            "plugins": {
+                "entries": {"example": {"config": plugin_config}}
+            }
+        }
+        manifest = {
+            "config_defaults": {
+                "headless": False,
+                "humanize": True,
+                "user_data_dir": {
+                    "$profile_path": "browser-profiles/example"
+                },
+                "fingerprint_seed": {"$random_digits": 5},
+                "nested": {"explicit": "replace", "added": 42},
+            }
+        }
+
+        with (
+            patch("hermes_cli.plugins_cmd.get_hermes_home", return_value=tmp_path),
+            patch("hermes_cli.config.read_raw_config", return_value=raw),
+            patch("hermes_cli.config.save_config") as save_config,
+            patch("hermes_cli.config.is_managed", return_value=False),
+        ):
+            changed = _apply_plugin_config_defaults("example", manifest)
+
+        assert changed == 4
+        persisted = save_config.call_args.args[0]
+        persisted_config = persisted["plugins"]["entries"]["example"]["config"]
+        assert persisted_config["headless"] is True
+        assert persisted_config["humanize"] is True
+        assert persisted_config["user_data_dir"] == str(
+            (tmp_path / "browser-profiles" / "example").resolve()
+        )
+        assert len(persisted_config["fingerprint_seed"]) == 5
+        assert persisted_config["fingerprint_seed"].isdigit()
+        assert persisted_config["nested"] == {"explicit": "keep", "added": 42}
+        assert plugin_config == {"headless": True, "nested": {"explicit": "keep"}}
+
+    def test_is_idempotent_and_does_not_regenerate_values(self, tmp_path):
+        from hermes_cli.plugins_cmd import _apply_plugin_config_defaults
+
+        raw = {"plugins": {"entries": {}}}
+        manifest = {
+            "config_defaults": {
+                "fingerprint_seed": {"$random_digits": 5},
+            }
+        }
+
+        with (
+            patch("hermes_cli.plugins_cmd.get_hermes_home", return_value=tmp_path),
+            patch("hermes_cli.config.read_raw_config", return_value=raw) as read_raw_config,
+            patch("hermes_cli.config.save_config") as save_config,
+            patch("hermes_cli.config.is_managed", return_value=False),
+        ):
+            assert _apply_plugin_config_defaults("example", manifest) == 1
+            persisted = save_config.call_args.args[0]
+            seed = persisted["plugins"]["entries"]["example"]["config"]["fingerprint_seed"]
+            read_raw_config.return_value = persisted
+            assert _apply_plugin_config_defaults("example", manifest) == 0
+
+        assert persisted["plugins"]["entries"]["example"]["config"]["fingerprint_seed"] == seed
+        assert save_config.call_count == 1
+
+    def test_rejects_unsafe_profile_path_without_writing(self, tmp_path):
+        from hermes_cli.plugins_cmd import _apply_plugin_config_defaults
+
+        raw = {"plugins": {"entries": {}}}
+        manifest = {
+            "config_defaults": {
+                "user_data_dir": {"$profile_path": "../other-profile"},
+            }
+        }
+
+        with (
+            patch("hermes_cli.plugins_cmd.get_hermes_home", return_value=tmp_path),
+            patch("hermes_cli.config.read_raw_config", return_value=raw),
+            patch("hermes_cli.config.save_config") as save_config,
+            patch("hermes_cli.config.is_managed", return_value=False),
+        ):
+            assert _apply_plugin_config_defaults("example", manifest) == 0
+
+        assert raw == {"plugins": {"entries": {}}}
+        save_config.assert_not_called()
+
+    def test_skips_managed_configuration(self):
+        from hermes_cli.plugins_cmd import _apply_plugin_config_defaults
+
+        manifest = {"config_defaults": {"enabled": True}}
+        with (
+            patch("hermes_cli.config.is_managed", return_value=True),
+            patch("hermes_cli.config.read_raw_config") as read_raw_config,
+            patch("hermes_cli.config.save_config") as save_config,
+        ):
+            assert _apply_plugin_config_defaults("example", manifest) == 0
+
+        read_raw_config.assert_not_called()
+        save_config.assert_not_called()
+
+
 class TestCmdInstall:
     """Test the install command."""
+
+    def test_install_with_enable_applies_manifest_config_defaults(self, tmp_path):
+        from hermes_cli.plugins_cmd import cmd_install
+
+        target = tmp_path / "example"
+        target.mkdir()
+        (target / "plugin.yaml").write_text("name: example\n", encoding="utf-8")
+        manifest = {
+            "name": "example",
+            "config_defaults": {"timeout": 30},
+        }
+        with (
+            patch(
+                "hermes_cli.plugins_cmd._resolve_git_url",
+                return_value=("https://example.test/plugin.git", None),
+            ),
+            patch(
+                "hermes_cli.plugins_cmd._install_plugin_core",
+                return_value=(target, manifest, "example"),
+            ),
+            patch("hermes_cli.plugins_cmd._prompt_plugin_env_vars"),
+            patch("hermes_cli.plugins_cmd._display_after_install"),
+            patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set()),
+            patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set()),
+            patch("hermes_cli.plugins_cmd._save_enabled_set"),
+            patch("hermes_cli.plugins_cmd._save_disabled_set"),
+            patch("hermes_cli.plugins_cmd._apply_plugin_config_defaults") as apply_defaults,
+        ):
+            cmd_install("owner/repo", enable=True)
+
+        assert apply_defaults.call_args.args[:2] == ("example", manifest)
 
     def test_install_requires_identifier(self):
         from hermes_cli.plugins_cmd import cmd_install

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -102,6 +102,33 @@ class TestResolvePluginKey:
 class TestEnableDisableNested:
     @patch("hermes_cli.plugins.get_bundled_plugins_dir")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
+    def test_enable_applies_discovered_manifest_defaults(
+        self, mock_user, mock_bundled, nested_plugin_env
+    ):
+        from hermes_cli.plugins_cmd import cmd_enable
+
+        mock_user.return_value = nested_plugin_env
+        mock_bundled.return_value = nested_plugin_env / "nonexistent"
+        manifest = {
+            "name": "configured",
+            "version": "1.0.0",
+            "config_defaults": {"timeout": 30},
+        }
+        _make_plugin_dir(nested_plugin_env, "configured", manifest)
+
+        with (
+            patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set()),
+            patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set()),
+            patch("hermes_cli.plugins_cmd._save_enabled_set"),
+            patch("hermes_cli.plugins_cmd._save_disabled_set"),
+            patch("hermes_cli.plugins_cmd._apply_plugin_config_defaults") as apply_defaults,
+        ):
+            cmd_enable("configured", allow_tool_override=False)
+
+        assert apply_defaults.call_args.args[:2] == ("configured", manifest)
+
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
     @patch("hermes_cli.plugins_cmd._save_disabled_set")
     @patch("hermes_cli.plugins_cmd._save_enabled_set")
     @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -75,7 +75,7 @@ This tells Hermes: "I'm a plugin called calculator, I provide tools and hooks." 
 Optional fields you could add:
 ```yaml
 author: Your Name
-manifest_version: 2    # required when using config_defaults
+manifest_version: 1
 requires_env:          # gate loading on env vars; prompted during install
   - SOME_API_KEY       # simple format — plugin disabled if missing
   - name: OTHER_KEY    # rich format — shows description/url during install
@@ -90,7 +90,7 @@ config_defaults:       # fill missing plugins.entries.<name>.config values on en
     $random_digits: 5                   # generated once, then preserved
 ```
 
-`config_defaults` requires `manifest_version: 2`. Hermes applies these values when the plugin is enabled and when an already-enabled plugin is updated. Existing values are never replaced. Defaults may be nested; `$profile_path` resolves a safe path under the active profile, and `$random_digits` generates a persistent numeric string of the requested length (1-64 digits).
+Hermes applies `config_defaults` when the plugin is enabled and when an already-enabled plugin is updated. Existing values are never replaced. Defaults may be nested; `$profile_path` resolves a safe path under the active profile, and `$random_digits` generates a persistent numeric string of the requested length (1-64 digits). Older Hermes versions safely ignore this optional field.
 
 ## Step 3: Write the tool schemas
 

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -75,13 +75,22 @@ This tells Hermes: "I'm a plugin called calculator, I provide tools and hooks." 
 Optional fields you could add:
 ```yaml
 author: Your Name
+manifest_version: 2    # required when using config_defaults
 requires_env:          # gate loading on env vars; prompted during install
   - SOME_API_KEY       # simple format — plugin disabled if missing
   - name: OTHER_KEY    # rich format — shows description/url during install
     description: "Key for the Other service"
     url: "https://other.com/keys"
     secret: true
+config_defaults:       # fill missing plugins.entries.<name>.config values on enable
+  timeout: 30
+  data_dir:
+    $profile_path: plugin-data/example  # absolute path under the active profile
+  identity:
+    $random_digits: 5                   # generated once, then preserved
 ```
+
+`config_defaults` requires `manifest_version: 2`. Hermes applies these values when the plugin is enabled and when an already-enabled plugin is updated. Existing values are never replaced. Defaults may be nested; `$profile_path` resolves a safe path under the active profile, and `$random_digits` generates a persistent numeric string of the requested length (1-64 digits).
 
 ## Step 3: Write the tool schemas
 


### PR DESCRIPTION
## Summary
- add backward-compatible config_defaults initialization during plugin enable/install and enabled-plugin updates
- support safe active-profile paths and persistent random-digit values without executing plugin code
- preserve existing namespaced config values and document the manifest contract

## Tests
- targeted Hermes plugin suite: 240 passed
- Ruff checks: passed