### PR TITLE
fix(desktop): prevent Git status process buildup

### DIFF
--- a/apps/desktop/electron/git-review-ops.test.ts
+++ b/apps/desktop/electron/git-review-ops.test.ts
@@ -1,8 +1,34 @@
 import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 
-import { test } from 'vitest'
+import { afterEach, test } from 'vitest'
 
-import { resolveRenamePath } from './git-review-ops'
+import { repoStatus, resolveRenamePath } from './git-review-ops'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { force: true, recursive: true })
+  }
+})
+
+function makeRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-desktop-git-status-'))
+
+  tempDirs.push(dir)
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  execFileSync('git', ['config', 'user.email', 'hermes-test@example.com'], { cwd: dir })
+  execFileSync('git', ['config', 'user.name', 'Hermes Test'], { cwd: dir })
+  fs.writeFileSync(path.join(dir, 'tracked.txt'), 'tracked\n')
+  execFileSync('git', ['add', 'tracked.txt'], { cwd: dir })
+  execFileSync('git', ['commit', '-qm', 'initial'], { cwd: dir })
+
+  return dir
+}
 
 test('resolveRenamePath: plain path is unchanged', () => {
   assert.equal(resolveRenamePath('src/a.ts'), 'src/a.ts')
@@ -18,4 +44,22 @@ test('resolveRenamePath: brace rename resolves to the new path', () => {
 
 test('resolveRenamePath: brace rename collapsing a segment', () => {
   assert.equal(resolveRenamePath('src/{lib => }/file.ts'), 'src/file.ts')
+})
+
+test('repoStatus reports an untracked directory without recursively listing its contents', async () => {
+  const dir = makeRepo()
+  const nested = path.join(dir, 'generated', 'deep')
+
+  fs.mkdirSync(nested, { recursive: true })
+  fs.writeFileSync(path.join(nested, 'large-output.txt'), 'generated\n')
+
+  const status = await repoStatus(dir, 'git')
+
+  assert.ok(status)
+  assert.equal(status.untracked, 1)
+  assert.equal(status.changed, 1)
+  assert.deepEqual(
+    status.files.map(file => file.path),
+    ['generated/']
+  )
 })

--- a/apps/desktop/electron/git-review-ops.ts
+++ b/apps/desktop/electron/git-review-ops.ts
@@ -610,7 +610,11 @@ async function repoStatus(repoPath, gitBin) {
   let status
 
   try {
-    status = await git.status()
+    // The coding rail needs compact change truth, not every generated file.
+    // `simple-git` defaults bare `-u` to recursive `all`, which can make a
+    // generated workspace consume gigabytes before the 200-row UI cap is
+    // applied. `normal` reports each untracked directory as one entry.
+    status = await git.status(['--untracked-files=normal'])
   } catch {
     // Not a repo / git unavailable / remote backend.
     return null
@@ -652,11 +656,10 @@ async function repoStatus(repoPath, gitBin) {
   }
 
   // `git diff HEAD` ignores untracked files, so a turn that only creates new
-  // files (the common case — a fresh module, a demo dir) showed +0 in the rail
-  // while the review pane counted them. Fold untracked insertions into `added`
-  // so the rail matches reality. Bounded (size cap + concurrency) like the
-  // review tree; only the capped file slice is counted so a huge untracked tree
-  // can't stall the probe.
+  // files (the common case — a fresh module) showed +0 in the rail while the
+  // review pane counted them. Fold top-level untracked file insertions into
+  // `added`; directories reported by the compact `normal` scan intentionally
+  // remain at zero rather than recursively walking their contents.
   try {
     const untracked = status.not_added.slice(0, 500)
 

--- a/apps/desktop/src/store/coding-status.test.ts
+++ b/apps/desktop/src/store/coding-status.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesRepoStatus } from '@/global'
 
-import { $repoStatus, refreshRepoStatus } from './coding-status'
+import { $repoStatus, $repoStatusLoading, refreshRepoStatus } from './coding-status'
 import { $currentCwd } from './session'
 
 const sampleStatus: HermesRepoStatus = {
@@ -27,12 +27,15 @@ function stubProbe(impl: (cwd: string) => Promise<HermesRepoStatus | null>) {
 
 describe('refreshRepoStatus', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     $repoStatus.set(null)
     $currentCwd.set('')
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
   })
 
   afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
   })
 
@@ -70,5 +73,48 @@ describe('refreshRepoStatus', () => {
     $repoStatus.set(sampleStatus)
     await refreshRepoStatus('/repo')
     expect($repoStatus.get()).toBeNull()
+  })
+
+  it('runs one probe at a time and coalesces overlap into one trailing refresh', async () => {
+    const resolvers: Array<(status: HermesRepoStatus | null) => void> = []
+    const calls: string[] = []
+    let active = 0
+    let maxActive = 0
+
+    stubProbe(
+      cwd =>
+        new Promise(resolve => {
+          calls.push(cwd)
+          active++
+          maxActive = Math.max(maxActive, active)
+          resolvers.push(status => {
+            active--
+            resolve(status)
+          })
+        })
+    )
+
+    const first = refreshRepoStatus('/repo-a')
+    const second = refreshRepoStatus('/repo-b')
+    const third = refreshRepoStatus('/repo-c')
+
+    expect(calls).toEqual(['/repo-a'])
+    expect(maxActive).toBe(1)
+    expect($repoStatusLoading.get()).toBe(true)
+
+    resolvers.shift()?.(sampleStatus)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(calls).toEqual(['/repo-a', '/repo-c'])
+    expect(maxActive).toBe(1)
+    expect($repoStatus.get()).toBeNull()
+
+    resolvers.shift()?.(sampleStatus)
+    await Promise.all([first, second, third])
+
+    expect(maxActive).toBe(1)
+    expect($repoStatus.get()).toEqual(sampleStatus)
+    expect($repoStatusLoading.get()).toBe(false)
   })
 })

--- a/apps/desktop/src/store/coding-status.ts
+++ b/apps/desktop/src/store/coding-status.ts
@@ -66,9 +66,19 @@ async function loadWorktrees(target: string): Promise<void> {
   }
 }
 
+interface RepoStatusRefreshRequest {
+  probe: (cwd: string) => Promise<HermesRepoStatus | null>
+  seq: number
+  target: string
+}
+
 // Coalesce overlapping probes: many triggers can fire around a turn boundary
-// (busy flip + worktree token + focus), but only the latest cwd matters.
+// (busy flip + worktree token + focus), but only the latest cwd matters. Keep
+// one probe in flight and retain at most one trailing request so a slow Git
+// status cannot multiply into an unbounded subprocess pile-up.
 let inflightCwd: null | string = null
+let pendingRepoStatusRefresh: RepoStatusRefreshRequest | null = null
+let repoStatusRefreshInFlight: Promise<void> | null = null
 let repoStatusRefreshSeq = 0
 let repoStatusRefreshTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -79,21 +89,7 @@ const normalizeCwd = (cwd?: null | string): null | string => cwd?.trim() || null
  * Best-effort: a non-repo, a remote backend, or a missing probe clears the
  * status so the rail hides rather than showing stale data.
  */
-export async function refreshRepoStatus(cwd?: null | string): Promise<void> {
-  const target = normalizeCwd(cwd ?? $currentCwd.get())
-  const probe = desktopGit()?.repoStatus
-  const seq = (repoStatusRefreshSeq += 1)
-
-  if (!target || !probe) {
-    $repoStatus.set(null)
-    $repoWorktrees.set([])
-
-    return
-  }
-
-  inflightCwd = target
-  $repoStatusLoading.set(true)
-
+async function runRepoStatusRefresh({ probe, seq, target }: RepoStatusRefreshRequest): Promise<void> {
   try {
     const status = await probe(target)
 
@@ -114,11 +110,48 @@ export async function refreshRepoStatus(cwd?: null | string): Promise<void> {
       $repoStatus.set(null)
       $repoWorktrees.set([])
     }
-  } finally {
-    if (seq === repoStatusRefreshSeq && inflightCwd === target) {
-      $repoStatusLoading.set(false)
-    }
   }
+}
+
+async function drainRepoStatusRefreshes(): Promise<void> {
+  while (pendingRepoStatusRefresh) {
+    const request = pendingRepoStatusRefresh
+
+    pendingRepoStatusRefresh = null
+    await runRepoStatusRefresh(request)
+  }
+
+  // This reset is synchronous with the final empty-queue check. A refresh
+  // arriving before this continuation runs is drained above; one arriving
+  // afterward sees no in-flight promise and starts a new drain.
+  repoStatusRefreshInFlight = null
+  $repoStatusLoading.set(false)
+}
+
+export function refreshRepoStatus(cwd?: null | string): Promise<void> {
+  const target = normalizeCwd(cwd ?? $currentCwd.get())
+  const probe = desktopGit()?.repoStatus
+  const seq = (repoStatusRefreshSeq += 1)
+
+  if (!target || !probe) {
+    pendingRepoStatusRefresh = null
+    inflightCwd = null
+    $repoStatus.set(null)
+    $repoWorktrees.set([])
+    $repoStatusLoading.set(false)
+
+    return repoStatusRefreshInFlight || Promise.resolve()
+  }
+
+  inflightCwd = target
+  pendingRepoStatusRefresh = { probe, seq, target }
+  $repoStatusLoading.set(true)
+
+  if (!repoStatusRefreshInFlight) {
+    repoStatusRefreshInFlight = drainRepoStatusRefreshes()
+  }
+
+  return repoStatusRefreshInFlight
 }
 
 function scheduleRepoStatusRefresh(cwd?: null | string): void {


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes Desktop's coding-status refresh from spawning overlapping `git status` processes when a repository scan is slow.

A Windows support report captured seven simultaneous `git status --porcelain -b -u --null` process chains under the Electron main process, using about 3 GB combined. The renderer's 100 ms debounce only coalesced requests before launch; triggers arriving while Git was already running started additional probes. The sequence counter discarded stale results but did not limit subprocess concurrency.

This change makes status refresh single-flight with at most one latest trailing refresh. It also asks Git for `--untracked-files=normal` in the compact coding rail, so a generated directory is represented as one entry instead of recursively enumerating every file before the UI's 200-row cap is applied.

## Related Issue

No GitHub issue. Confirmed from Discord support thread:
<https://discord.com/channels/1053877538025386074/1526584501042548837>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Code style / refactor (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test improvement
- [ ] 🔧 CI / build / tooling change

## Changes Made

- Serialize coding-status refreshes so only one native repository probe runs at a time.
- Keep only the latest request that arrives while a probe is running, producing at most one trailing refresh.
- Request normal untracked-file reporting for the compact coding rail instead of recursively enumerating generated trees.
- Add a renderer behavior test for concurrency, latest-request coalescing, stale-result suppression, and loading-state transitions.
- Add a real temporary-repository test proving nested untracked content is summarized as one directory entry.

## How to Test

From `apps/desktop`:

1. `npx vitest run --project ui src/store/coding-status.test.ts`
2. `npx vitest run --project electron electron/git-review-ops.test.ts`
3. `npx tsc -p . --noEmit`
4. `npx tsc -p tsconfig.electron.json --noEmit`

These focused checks passed on Windows 11 Pro (build 26100). ESLint, Prettier, and `git diff --check` also pass for the changed files.

## Checklist

### Code

- [x] I've read the contributing guide
- [x] My commits follow the conventional commit format
- [x] I searched for existing PRs that cover this issue
- [x] The change is focused and does not include unrelated changes
- [ ] Python tests pass locally (`scripts/run_tests.sh`) — not run; this PR changes only Desktop TypeScript and the full suite is left to CI
- [x] I added or updated tests for the changed behavior
- [x] I tested platform-specific behavior on the relevant platform, or marked it N/A

### Docs and Compatibility

- [x] I updated user-facing docs, or marked docs as N/A — N/A; this restores expected internal refresh behavior
- [x] I updated config examples / `.env.example`, or marked them N/A — N/A; no config changes
- [x] I updated the root `AGENTS.md`, or marked it N/A — N/A; no project guidance changes
- [x] I considered cross-platform behavior — the renderer queue is platform-neutral and the Git option is supported across platforms
- [x] I updated tool schemas / toolsets, or marked them N/A — N/A; no model tools changed

## Screenshots / Logs

No visual UI change.

Support evidence showed seven concurrent status chains (14 `git.exe` processes) under one Hermes Electron main process, totaling approximately 3,056.7 MB. Each chain was executing `git status --porcelain -b -u --null`, matching the `simple-git` status path fixed here.