### PR TITLE
fix(slack): avoid null entries in table column settings

### DIFF
--- a/plugins/platforms/slack/block_kit.py
+++ b/plugins/platforms/slack/block_kit.py
@@ -285,18 +285,17 @@ def _table_block(rows: List[str], sep_line: str) -> Optional[Block]:
         return None
 
     aligns = _parse_alignment(sep_line)
-    column_settings: List[Optional[Dict[str, Any]]] = []
+    column_settings: List[Dict[str, Any]] = []
     for c in range(min(ncols, MAX_TABLE_COLS)):
         align = aligns[c] if c < len(aligns) else "left"
-        # Only emit a setting when it differs from the default (left, no wrap);
-        # use null to skip a column, per the Slack schema.
-        column_settings.append({"align": align} if align != "left" else None)
+        # Slack requires every column setting to be an object.
+        column_settings.append({"align": align} if align != "left" else {})
 
     block: Block = {
         "type": "table",
         "rows": [[_rich_text_cell(cell) for cell in row] for row in parsed],
     }
-    if any(cs is not None for cs in column_settings):
+    if any(column_settings):
         block["column_settings"] = column_settings
     return block
 

--- a/tests/gateway/test_slack_block_kit.py
+++ b/tests/gateway/test_slack_block_kit.py
@@ -159,10 +159,7 @@ class TestTables:
         )
         blocks = render_blocks(md)
         cs = blocks[0]["column_settings"]
-        # left is default -> null; center/right emitted
-        assert cs[0] is None
-        assert cs[1] == {"align": "center"}
-        assert cs[2] == {"align": "right"}
+        assert cs == [{}, {"align": "center"}, {"align": "right"}]
 
     def test_inline_formatting_inside_cells(self):
         md = (


### PR DESCRIPTION
## What does this PR do?

  Fixes invalid Slack Block Kit table payloads generated from Markdown tables with mixed
  column alignment.

  Left-aligned columns previously produced `null` entries inside `column_settings`, while
  centered and right-aligned columns produced objects. Slack requires every entry in
  `column_settings` to be an object, so these payloads were rejected with
  `invalid_blocks`.

  This change uses empty objects for default left-aligned columns while preserving
  omission of `column_settings` when all columns use the default alignment.

  ## Related Issue

  N/A — reported from production Slack error logs.

  <!-- If an issue exists, replace the line above with: Fixes #123 -->

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Replaced `None` placeholders in Slack table `column_settings` with empty objects.
  - Updated the `column_settings` type to contain objects only.
  - Preserved omission of `column_settings` when every column uses default left alignment.
  - Updated the alignment regression test to verify the exact valid Slack payload.

  ## How to Test

  Run the targeted Slack Block Kit test suite:

  ```bash
  scripts/run_tests.sh tests/gateway/test_slack_block_kit.py -q

  Result:

  22 tests passed, 0 failed

  Optional manual verification with rich_blocks enabled:

  1. Ask Hermes to reply with this Markdown table:

      L       C       R
     ━━━━━  ━━━━━  ━━━━━
      1       2       3

  2. Confirm the response is delivered as a Slack table.
  3. Confirm Slack logs contain no invalid_blocks error.

  ## Checklist

  ### Code

  - [ ] I've read the Contributing Guide
  - [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
  - [ ] I searched for existing PRs to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass
      - Targeted suite completed successfully: 22 tests passed

  - [x] I've added tests for my changes
  - [x] I've tested on my platform: macOS

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation — N/A, no user-facing behavior or API changed
  - [x] I've updated cli-config.yaml.example — N/A, no configuration changes
  - [x] I've updated CONTRIBUTING.md or AGENTS.md — N/A, no architecture or workflow
    changes

  - [x] I've considered cross-platform impact — N/A, this only changes a platform-
    independent JSON payload

  - [x] I've updated tool descriptions/schemas — N/A, no tool changes

  ### For New Skills

  N/A — this PR does not add or modify a skill.

  ## Screenshots / Logs

  Before:

  error: invalid_blocks
  must provide an object [json-pointer:/blocks/3/column_settings/0]

  After:

  22 tests passed, 0 failed