### PR TITLE
fix(google-workspace): support credential path overrides

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -30,6 +30,8 @@ Gmail, Calendar, Drive, Contacts, Sheets, and Docs — through Hermes-managed OA
 - `scripts/setup.py` — OAuth2 setup (run once to authorize)
 - `scripts/google_api.py` — compatibility wrapper CLI. It prefers `gws` for operations when available, while preserving Hermes' existing JSON output contract.
 
+Credential paths default to `${HERMES_HOME:-~/.hermes}/google_token.json`, `${HERMES_HOME:-~/.hermes}/google_client_secret.json`, and `${HERMES_HOME:-~/.hermes}/google_oauth_pending.json`. For local/scripted runs, override them with `GOOGLE_TOKEN_PATH`, `GOOGLE_CLIENT_SECRET_PATH`, and `GOOGLE_PENDING_PATH`; blank override values are ignored and fall back to the profile defaults. Remote backend credential mounting still uses the `required_credential_files` entries above.
+
 ## First-Time Setup
 
 The setup is fully non-interactive — you drive it step by step so it works

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -39,8 +39,21 @@ if _SCRIPTS_DIR not in sys.path:
 from _hermes_home import get_hermes_home
 
 HERMES_HOME = get_hermes_home()
-TOKEN_PATH = HERMES_HOME / "google_token.json"
-CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
+
+
+def _path_from_env(var_name: str, default: Path) -> Path:
+    """Return an expanded path override, treating blank env vars as unset."""
+    override = os.getenv(var_name)
+    if override and override.strip():
+        return Path(override).expanduser()
+    return default
+
+
+TOKEN_PATH = _path_from_env("GOOGLE_TOKEN_PATH", HERMES_HOME / "google_token.json")
+CLIENT_SECRET_PATH = _path_from_env(
+    "GOOGLE_CLIENT_SECRET_PATH",
+    HERMES_HOME / "google_client_secret.json",
+)
 
 SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -39,9 +39,25 @@ if _SCRIPTS_DIR not in sys.path:
 from _hermes_home import display_hermes_home, get_hermes_home
 
 HERMES_HOME = get_hermes_home()
-TOKEN_PATH = HERMES_HOME / "google_token.json"
-CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
-PENDING_AUTH_PATH = HERMES_HOME / "google_oauth_pending.json"
+
+
+def _path_from_env(var_name: str, default: Path) -> Path:
+    """Return an expanded path override, treating blank env vars as unset."""
+    override = os.getenv(var_name)
+    if override and override.strip():
+        return Path(override).expanduser()
+    return default
+
+
+TOKEN_PATH = _path_from_env("GOOGLE_TOKEN_PATH", HERMES_HOME / "google_token.json")
+CLIENT_SECRET_PATH = _path_from_env(
+    "GOOGLE_CLIENT_SECRET_PATH",
+    HERMES_HOME / "google_client_secret.json",
+)
+PENDING_AUTH_PATH = _path_from_env(
+    "GOOGLE_PENDING_PATH",
+    HERMES_HOME / "google_oauth_pending.json",
+)
 
 SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",

--- a/tests/skills/test_google_workspace_path_overrides.py
+++ b/tests/skills/test_google_workspace_path_overrides.py
@@ -1,0 +1,86 @@
+"""Tests for Google Workspace credential path environment overrides."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/scripts"
+)
+
+
+def _load_script_module(script_name: str, module_name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPTS_DIR / script_name)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_google_api_uses_profile_defaults_when_overrides_absent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("GOOGLE_TOKEN_PATH", raising=False)
+    monkeypatch.delenv("GOOGLE_CLIENT_SECRET_PATH", raising=False)
+
+    module = _load_script_module("google_api.py", "google_api_default_paths_test")
+
+    assert module.TOKEN_PATH == tmp_path / "google_token.json"
+    assert module.CLIENT_SECRET_PATH == tmp_path / "google_client_secret.json"
+
+
+def test_google_api_uses_nonblank_path_overrides(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    monkeypatch.setenv("GOOGLE_TOKEN_PATH", str(tmp_path / "tokens" / "token.json"))
+    monkeypatch.setenv(
+        "GOOGLE_CLIENT_SECRET_PATH",
+        str(tmp_path / "secrets" / "client_secret.json"),
+    )
+
+    module = _load_script_module("google_api.py", "google_api_override_paths_test")
+
+    assert module.TOKEN_PATH == tmp_path / "tokens" / "token.json"
+    assert module.CLIENT_SECRET_PATH == tmp_path / "secrets" / "client_secret.json"
+
+
+def test_google_api_treats_blank_overrides_as_unset(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("GOOGLE_TOKEN_PATH", "")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET_PATH", "   ")
+
+    module = _load_script_module("google_api.py", "google_api_blank_paths_test")
+
+    assert module.TOKEN_PATH == tmp_path / "google_token.json"
+    assert module.CLIENT_SECRET_PATH == tmp_path / "google_client_secret.json"
+
+
+def test_setup_uses_nonblank_path_overrides(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    monkeypatch.setenv("GOOGLE_TOKEN_PATH", str(tmp_path / "token.json"))
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET_PATH", str(tmp_path / "secret.json"))
+    monkeypatch.setenv("GOOGLE_PENDING_PATH", str(tmp_path / "pending.json"))
+
+    module = _load_script_module("setup.py", "google_setup_override_paths_test")
+
+    assert module.TOKEN_PATH == tmp_path / "token.json"
+    assert module.CLIENT_SECRET_PATH == tmp_path / "secret.json"
+    assert module.PENDING_AUTH_PATH == tmp_path / "pending.json"
+
+
+def test_setup_treats_blank_overrides_as_unset(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("GOOGLE_TOKEN_PATH", "")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET_PATH", "\t")
+    monkeypatch.setenv("GOOGLE_PENDING_PATH", "   ")
+
+    module = _load_script_module("setup.py", "google_setup_blank_paths_test")
+
+    assert module.TOKEN_PATH == tmp_path / "google_token.json"
+    assert module.CLIENT_SECRET_PATH == tmp_path / "google_client_secret.json"
+    assert module.PENDING_AUTH_PATH == tmp_path / "google_oauth_pending.json"


### PR DESCRIPTION
## Summary
- Add Google Workspace credential path overrides for token, client secret, and pending OAuth state files.
- Treat blank override env vars as unset so profile defaults still apply.
- Document that remote backend credential mounting continues to use required_credential_files.
- Add tests for default, override, and blank override behavior.

Supersedes #48680 with a narrow branch that excludes the unrelated Mission Control skill changes.

## Test Plan
- [x] scripts/run_tests.sh tests/skills/test_google_workspace_credential_files.py tests/skills/test_google_workspace_path_overrides.py -v