### PR TITLE
fix(desktop): prefer unpacked icon path to avoid asar native image load failure

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -434,9 +434,11 @@ const WINDOW_BUTTON_POSITION = {
 // It's only the pre-layout fallback — the renderer measures the exact overlay
 // width live via the Window Controls Overlay API.
 const APP_ICON_PATHS = [
-  path.join(APP_ROOT, 'public', 'apple-touch-icon.png'),
+  // Prefer unpacked path: asar-packed files stat as existing but cannot be
+  // loaded as a native image by BrowserWindow, so the unpacked copy wins.
+  path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png'),
   path.join(APP_ROOT, 'dist', 'apple-touch-icon.png'),
-  path.join(unpackedPathFor(APP_ROOT), 'dist', 'apple-touch-icon.png')
+  path.join(APP_ROOT, 'public', 'apple-touch-icon.png')
 ]
 
 let rendererTitleBarTheme = null


### PR DESCRIPTION
## What\nFixes a startup crash on macOS where the packaged Hermes Desktop app fails to load \ from inside \.\n\n## Why\n\ can see files inside an asar archive, but Electron's \ icon cannot load a native image from an asar path. The first candidate path therefore "exists" but is unusable, causing an uncaught exception during \.\n\n## How\nReorder \ in \ to prefer the \ copy, which is a real file on disk and can be loaded as a native image.\n\n## Verification\n- Rebuilt the desktop app locally (\)\n- Confirmed the app launches without the \ error\n- No other error dialogs appeared