### PR TITLE
feat(gateway): show provider account usage on bot profiles

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -56,6 +56,22 @@ class AccountUsageFetchOutcome:
     failed: bool = False
 
 
+class _OpenRouterRateLimitError(RuntimeError):
+    """Rate-limit failure that still carries a truthful credits snapshot."""
+
+    def __init__(
+        self,
+        response: httpx.Response,
+        partial_snapshot: AccountUsageSnapshot,
+    ):
+        super().__init__(
+            "OpenRouter rate limited the account-usage request "
+            f"({response.status_code})"
+        )
+        self.response = response
+        self.partial_snapshot = partial_snapshot
+
+
 def retry_after_seconds(
     exc: BaseException,
     *,
@@ -864,32 +880,10 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
     )
 
 
-def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
-    runtime = resolve_runtime_provider(
-        requested="openrouter",
-        explicit_base_url=base_url,
-        explicit_api_key=api_key,
-    )
-    token = str(runtime.get("api_key", "") or "").strip()
-    if not token:
-        return None
-    normalized = str(runtime.get("base_url", "") or "").rstrip("/")
-    credits_url = f"{normalized}/credits"
-    key_url = f"{normalized}/key"
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/json",
-    }
-    with httpx.Client(timeout=10.0) as client:
-        credits_resp = client.get(credits_url, headers=headers)
-        credits_resp.raise_for_status()
-        credits = (credits_resp.json() or {}).get("data") or {}
-        try:
-            key_resp = client.get(key_url, headers=headers)
-            key_resp.raise_for_status()
-            key_data = (key_resp.json() or {}).get("data") or {}
-        except Exception:
-            key_data = {}
+def _build_openrouter_account_usage_snapshot(
+    credits: dict[str, Any],
+    key_data: dict[str, Any],
+) -> AccountUsageSnapshot:
     total_credits = float(credits.get("total_credits") or 0.0)
     total_usage = float(credits.get("total_usage") or 0.0)
     details = [f"Credits balance: ${max(0.0, total_credits - total_usage):.2f}"]
@@ -936,6 +930,44 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+def _fetch_openrouter_account_usage(
+    base_url: Optional[str], api_key: Optional[str]
+) -> Optional[AccountUsageSnapshot]:
+    runtime = resolve_runtime_provider(
+        requested="openrouter",
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
+    )
+    token = str(runtime.get("api_key", "") or "").strip()
+    if not token:
+        return None
+    normalized = str(runtime.get("base_url", "") or "").rstrip("/")
+    credits_url = f"{normalized}/credits"
+    key_url = f"{normalized}/key"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    with httpx.Client(timeout=10.0) as client:
+        credits_resp = client.get(credits_url, headers=headers)
+        credits_resp.raise_for_status()
+        credits = (credits_resp.json() or {}).get("data") or {}
+        try:
+            key_resp = client.get(key_url, headers=headers)
+            key_resp.raise_for_status()
+            key_data = (key_resp.json() or {}).get("data") or {}
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 429:
+                raise _OpenRouterRateLimitError(
+                    exc.response,
+                    _build_openrouter_account_usage_snapshot(credits, {}),
+                ) from exc
+            key_data = {}
+        except Exception:
+            key_data = {}
+    return _build_openrouter_account_usage_snapshot(credits, key_data)
+
+
 def fetch_account_usage_outcome(
     provider: Optional[str],
     *,
@@ -959,7 +991,11 @@ def fetch_account_usage_outcome(
             snapshot = None
         return AccountUsageFetchOutcome(snapshot=snapshot)
     except Exception as exc:
+        partial_snapshot = getattr(exc, "partial_snapshot", None)
+        if not isinstance(partial_snapshot, AccountUsageSnapshot):
+            partial_snapshot = None
         return AccountUsageFetchOutcome(
+            snapshot=partial_snapshot,
             retry_after_seconds=retry_after_seconds(exc),
             failed=True,
         )

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
 from typing import TYPE_CHECKING, Any, Optional
 
 import httpx
@@ -44,6 +45,60 @@ class AccountUsageSnapshot:
     @property
     def available(self) -> bool:
         return bool(self.windows or self.details) and not self.unavailable_reason
+
+
+@dataclass(frozen=True)
+class AccountUsageFetchOutcome:
+    """Structured provider result that preserves rate-limit metadata."""
+
+    snapshot: Optional[AccountUsageSnapshot] = None
+    retry_after_seconds: Optional[float] = None
+    failed: bool = False
+
+
+def retry_after_seconds(
+    exc: BaseException,
+    *,
+    now: Optional[datetime] = None,
+) -> Optional[float]:
+    """Parse provider/platform Retry-After values into bounded seconds."""
+
+    value = getattr(exc, "retry_after", None)
+    if value is None:
+        response = getattr(exc, "response", None)
+        headers = getattr(response, "headers", None)
+        if headers:
+            try:
+                value = headers.get("Retry-After")
+            except Exception:
+                value = None
+    if value is None:
+        return None
+
+    seconds: Optional[float] = None
+    if isinstance(value, timedelta):
+        seconds = value.total_seconds()
+    elif isinstance(value, datetime):
+        current = now or datetime.now(timezone.utc)
+        target = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        seconds = (target - current).total_seconds()
+    else:
+        try:
+            seconds = float(value)
+        except (TypeError, ValueError):
+            if isinstance(value, str):
+                try:
+                    target = parsedate_to_datetime(value)
+                    current = now or datetime.now(timezone.utc)
+                    if target.tzinfo is None:
+                        target = target.replace(tzinfo=timezone.utc)
+                    seconds = (target - current).total_seconds()
+                except (TypeError, ValueError, OverflowError):
+                    seconds = None
+
+    if seconds is None or not math.isfinite(seconds):
+        return None
+    return max(1.0, seconds)
 
 
 def _title_case_slug(value: Optional[str]) -> Optional[str]:
@@ -881,22 +936,45 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+def fetch_account_usage_outcome(
+    provider: Optional[str],
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> AccountUsageFetchOutcome:
+    """Fetch one provider snapshot without discarding rate-limit metadata."""
+
+    normalized = str(provider or "").strip().lower()
+    if normalized in {"", "auto", "custom"}:
+        return AccountUsageFetchOutcome()
+    try:
+        snapshot: Optional[AccountUsageSnapshot]
+        if normalized == "openai-codex":
+            snapshot = _fetch_codex_account_usage(base_url=base_url, api_key=api_key)
+        elif normalized == "anthropic":
+            snapshot = _fetch_anthropic_account_usage()
+        elif normalized == "openrouter":
+            snapshot = _fetch_openrouter_account_usage(base_url, api_key)
+        else:
+            snapshot = None
+        return AccountUsageFetchOutcome(snapshot=snapshot)
+    except Exception as exc:
+        return AccountUsageFetchOutcome(
+            retry_after_seconds=retry_after_seconds(exc),
+            failed=True,
+        )
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
 ) -> Optional[AccountUsageSnapshot]:
-    normalized = str(provider or "").strip().lower()
-    if normalized in {"", "auto", "custom"}:
-        return None
-    try:
-        if normalized == "openai-codex":
-            return _fetch_codex_account_usage(base_url=base_url, api_key=api_key)
-        if normalized == "anthropic":
-            return _fetch_anthropic_account_usage()
-        if normalized == "openrouter":
-            return _fetch_openrouter_account_usage(base_url, api_key)
-    except Exception:
-        return None
-    return None
+    """Backward-compatible snapshot-only account-usage fetch."""
+
+    return fetch_account_usage_outcome(
+        provider,
+        base_url=base_url,
+        api_key=api_key,
+    ).snapshot

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -942,6 +942,23 @@ platform_toolsets:
   google_chat: [hermes-google_chat]
 
 # =============================================================================
+# Experimental Gateway Account Usage Presence
+# =============================================================================
+# Show one explicitly selected provider account's remaining usage on supported
+# global bot surfaces. Off by default because every user of the bot sees the
+# mutated Telegram name / Discord activity. The provider must already be
+# authenticated for `/usage` to expose a percentage window.
+#
+# gateway:
+#   account_usage_presence:
+#     enabled: false
+#     provider: openai-codex       # openai-codex | anthropic | openrouter
+#     platforms: [telegram, discord]
+#     update_interval_seconds: 300 # minimum 300; change-only writes
+#     stale_after_seconds: 900
+#     # window_label: Session      # optional provider window label
+#
+# =============================================================================
 # Gateway Platform Settings
 # =============================================================================
 # Optional per-platform messaging settings.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -953,7 +953,7 @@ platform_toolsets:
 #   account_usage_presence:
 #     enabled: false
 #     provider: openai-codex       # openai-codex | anthropic | openrouter
-#     platforms: [telegram, discord]
+#     platforms: [telegram, discord, matrix]
 #     update_interval_seconds: 300 # minimum 300; change-only writes
 #     stale_after_seconds: 900
 #     # window_label: Session      # optional provider window label

--- a/gateway/account_usage_presence.py
+++ b/gateway/account_usage_presence.py
@@ -32,7 +32,7 @@ from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
-_STATE_VERSION = 2
+_STATE_VERSION = 3
 _MAX_STATE_BYTES = 64 * 1024
 _MAX_STATE_ENTRIES = 32
 _STATE_PHASES = frozenset({"pending", "owned"})
@@ -81,12 +81,14 @@ class _JournalEntry:
     baseline: dict[str, Any]
     owned: dict[str, Any]
     phase: str
+    previous_owned: Optional[dict[str, Any]] = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "baseline": self.baseline,
             "owned": self.owned,
             "phase": self.phase,
+            "previous_owned": self.previous_owned,
         }
 
 
@@ -153,7 +155,8 @@ def _valid_state_mapping(value: Any) -> bool:
 def _parse_journal(raw: Any) -> dict[str, _JournalEntry]:
     if not isinstance(raw, dict) or set(raw) != {"version", "entries"}:
         raise ValueError("journal must contain exactly version and entries")
-    if raw["version"] != _STATE_VERSION:
+    version = raw["version"]
+    if version not in {2, _STATE_VERSION}:
         raise ValueError("unsupported journal version")
     entries = raw["entries"]
     if not isinstance(entries, dict) or len(entries) > _MAX_STATE_ENTRIES:
@@ -163,7 +166,10 @@ def _parse_journal(raw: Any) -> dict[str, _JournalEntry]:
     for key, value in entries.items():
         if not isinstance(key, str) or not key or len(key) > 256:
             raise ValueError("invalid journal state key")
-        if not isinstance(value, dict) or set(value) != {"baseline", "owned", "phase"}:
+        expected_fields = {"baseline", "owned", "phase"}
+        if version == _STATE_VERSION:
+            expected_fields.add("previous_owned")
+        if not isinstance(value, dict) or set(value) != expected_fields:
             raise ValueError("invalid journal entry schema")
         if not _valid_state_mapping(value["baseline"]):
             raise ValueError("invalid journal baseline")
@@ -172,10 +178,18 @@ def _parse_journal(raw: Any) -> dict[str, _JournalEntry]:
         phase = value["phase"]
         if phase not in _STATE_PHASES:
             raise ValueError("invalid journal phase")
+        previous_owned = value.get("previous_owned")
+        if previous_owned is not None and not _valid_state_mapping(previous_owned):
+            raise ValueError("invalid previous journal owned state")
+        if phase == "owned" and previous_owned is not None:
+            raise ValueError("owned journal entry cannot retain previous state")
         parsed[key] = _JournalEntry(
             baseline=dict(value["baseline"]),
             owned=dict(value["owned"]),
             phase=phase,
+            previous_owned=(
+                dict(previous_owned) if previous_owned is not None else None
+            ),
         )
     return parsed
 
@@ -610,6 +624,11 @@ class AccountUsagePresenceController:
                     baseline=dict(baseline),
                     owned=dict(owned),
                     phase="pending",
+                    previous_owned=(
+                        dict(prior_owned_entry.owned)
+                        if prior_owned_entry is not None
+                        else None
+                    ),
                 )
                 candidate = dict(self._journal)
                 candidate[state_key] = pending_entry
@@ -655,7 +674,11 @@ class AccountUsagePresenceController:
             if pending_entry is not None:
                 self._owned_in_process.add(state_key)
                 candidate = dict(self._journal)
-                candidate[state_key] = replace(pending_entry, phase="owned")
+                candidate[state_key] = replace(
+                    pending_entry,
+                    phase="owned",
+                    previous_owned=None,
+                )
                 if self._persist_journal(candidate):
                     self._journal = candidate
             self._last_applied[state_key] = (id(adapter), payload)
@@ -669,25 +692,41 @@ class AccountUsagePresenceController:
         restore = getattr(adapter, "restore_account_usage_presence", None)
         if not callable(restore):
             return AccountUsagePresenceRestoreResult.RETRY
-        try:
-            value = await self._await_adapter(
-                cast(Awaitable[Any], restore(entry.baseline, entry.owned))
-            )
-        except Exception:
-            logger.warning(
-                "Account-usage presence restore failed for %s",
-                platform,
-                exc_info=True,
-            )
-            return AccountUsagePresenceRestoreResult.RETRY
-        try:
-            return AccountUsagePresenceRestoreResult(value)
-        except (TypeError, ValueError):
-            logger.warning(
-                "Ignoring invalid account-usage restore result from %s",
-                platform,
-            )
-            return AccountUsagePresenceRestoreResult.RETRY
+        owned_candidates = [entry.owned]
+        if (
+            entry.phase == "pending"
+            and entry.previous_owned is not None
+            and entry.previous_owned != entry.owned
+        ):
+            # A crash or journal-write failure can leave a transition pending
+            # while the remote surface is either the new desired value or the
+            # previously owned value. Both are safe CAS expectations for
+            # restoring the captured baseline.
+            owned_candidates.append(entry.previous_owned)
+
+        for owned in owned_candidates:
+            try:
+                value = await self._await_adapter(
+                    cast(Awaitable[Any], restore(entry.baseline, owned))
+                )
+            except Exception:
+                logger.warning(
+                    "Account-usage presence restore failed for %s",
+                    platform,
+                    exc_info=True,
+                )
+                return AccountUsagePresenceRestoreResult.RETRY
+            try:
+                result = AccountUsagePresenceRestoreResult(value)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Ignoring invalid account-usage restore result from %s",
+                    platform,
+                )
+                return AccountUsagePresenceRestoreResult.RETRY
+            if result is not AccountUsagePresenceRestoreResult.EXTERNAL:
+                return result
+        return AccountUsagePresenceRestoreResult.EXTERNAL
 
     async def _restore_saved_baselines(self) -> None:
         self._load_state()

--- a/gateway/account_usage_presence.py
+++ b/gateway/account_usage_presence.py
@@ -484,8 +484,14 @@ class AccountUsagePresenceController:
                     exc_info=True,
                 )
                 outcome = AccountUsageFetchOutcome(failed=True)
+            # Retry-After is measured from when the response was observed, not
+            # from before a potentially slow provider request started.
+            now = self._monotonic()
             if outcome.retry_after_seconds is not None:
-                self._provider_retry_until = now + outcome.retry_after_seconds
+                self._provider_retry_until = max(
+                    self._provider_retry_until,
+                    now + outcome.retry_after_seconds,
+                )
                 logger.warning(
                     "Account-usage provider %s rate-limited; retrying in %.0fs",
                     provider,

--- a/gateway/account_usage_presence.py
+++ b/gateway/account_usage_presence.py
@@ -315,6 +315,7 @@ class AccountUsagePresenceController:
         self._state_loaded = False
         self._journal_blocked = False
         self._journal: dict[str, _JournalEntry] = {}
+        self._state_locks: dict[str, asyncio.Lock] = {}
         self._owned_in_process: set[str] = set()
         self._last_payload: Optional[AccountUsagePresencePayload] = None
         self._last_success_at: Optional[float] = None
@@ -544,6 +545,9 @@ class AccountUsagePresenceController:
     async def _await_adapter(self, result: Awaitable[Any]) -> Any:
         return await asyncio.wait_for(result, timeout=self._adapter_timeout_seconds)
 
+    def _state_lock(self, state_key: str) -> asyncio.Lock:
+        return self._state_locks.setdefault(state_key, asyncio.Lock())
+
     async def _apply_to_selected_adapters(
         self,
         payload: AccountUsagePresencePayload,
@@ -573,190 +577,234 @@ class AccountUsagePresenceController:
                 continue
 
             state_key = self._state_key(platform, adapter)
-            if now < self._adapter_retry_until.get(state_key, 0.0):
-                continue
-            if self._last_applied.get(state_key) == (id(adapter), payload):
-                continue
-            entry = self._journal.get(state_key)
-            if entry is not None and entry.phase == "pending":
-                # A pending transition may have changed the remote value even
-                # when its API call raised. Fail closed until stop/restart
-                # recovery reconciles the journaled generations.
-                continue
-            if entry is not None and state_key not in self._owned_in_process:
-                continue
-
-            prior_owned_entry = (
-                entry if entry is not None and entry.phase == "owned" else None
-            )
-            baseline = entry.baseline if entry is not None else None
-            if entry is None:
-                capture = getattr(adapter, "capture_account_usage_presence_baseline", None)
-                if callable(capture):
-                    try:
-                        captured = await self._await_adapter(cast(Awaitable[Any], capture()))
-                    except Exception:
-                        logger.warning(
-                            "Could not capture %s account-usage presence baseline",
-                            platform,
-                            exc_info=True,
-                        )
-                        continue
-                    if captured is not None:
-                        if not _valid_state_mapping(captured):
-                            logger.warning(
-                                "Ignoring invalid %s account-usage presence baseline",
-                                platform,
-                            )
-                            continue
-                        baseline = dict(captured)
-
-            pending_entry: Optional[_JournalEntry] = None
-            guarded_apply: Optional[Callable[..., Awaitable[Any]]] = None
-            if baseline is not None:
-                build_owned = getattr(
+            async with self._state_lock(state_key):
+                await self._apply_one(
+                    platform,
                     adapter,
-                    "build_account_usage_presence_owned_state",
-                    None,
+                    state_key,
+                    payload,
+                    now=now,
                 )
-                if not callable(build_owned):
-                    logger.warning(
-                        "Persistent account-usage surface %s has no ownership renderer",
-                        platform,
-                    )
-                    continue
-                guarded_apply = getattr(
-                    adapter,
-                    "apply_account_usage_presence_if_owned",
-                    None,
-                )
-                if not callable(guarded_apply):
-                    logger.warning(
-                        "Persistent account-usage surface %s has no guarded ownership updater",
-                        platform,
-                    )
-                    continue
+
+    async def _apply_one(
+        self,
+        platform: str,
+        adapter: Any,
+        state_key: str,
+        payload: AccountUsagePresencePayload,
+        *,
+        now: float,
+    ) -> None:
+        if now < self._adapter_retry_until.get(state_key, 0.0):
+            return
+        if self._last_applied.get(state_key) == (id(adapter), payload):
+            return
+        entry = self._journal.get(state_key)
+        if entry is not None and entry.phase == "pending":
+            # A pending transition may have changed the remote value even
+            # when its API call raised. Fail closed until stop/restart
+            # recovery reconciles the journaled generations.
+            return
+        if entry is not None and state_key not in self._owned_in_process:
+            return
+
+        prior_owned_entry = (
+            entry if entry is not None and entry.phase == "owned" else None
+        )
+        baseline = entry.baseline if entry is not None else None
+        if entry is None:
+            capture = getattr(adapter, "capture_account_usage_presence_baseline", None)
+            if callable(capture):
                 try:
-                    owned = build_owned(payload, baseline)
+                    captured = await self._await_adapter(cast(Awaitable[Any], capture()))
                 except Exception:
                     logger.warning(
-                        "Could not render %s account-usage ownership state",
+                        "Could not capture %s account-usage presence baseline",
                         platform,
                         exc_info=True,
                     )
-                    continue
-                if not _valid_state_mapping(owned):
-                    logger.warning(
-                        "Ignoring invalid %s account-usage ownership state",
-                        platform,
-                    )
-                    continue
-                pending_entry = _JournalEntry(
-                    baseline=dict(baseline),
-                    owned=dict(owned),
-                    phase="pending",
-                    previous_owned=(
-                        dict(prior_owned_entry.owned)
-                        if prior_owned_entry is not None
-                        else None
-                    ),
-                )
-                candidate = dict(self._journal)
-                candidate[state_key] = pending_entry
-                if not self._persist_journal(candidate):
-                    continue
-                self._journal = candidate
-
-            apply = getattr(adapter, "apply_account_usage_presence", None)
-            if not callable(apply):
-                continue
-            try:
-                if baseline is not None:
-                    assert guarded_apply is not None
-                    expected_owned = (
-                        prior_owned_entry.owned
-                        if prior_owned_entry is not None
-                        else baseline
-                    )
-                    raw_apply_result = await self._await_adapter(
-                        cast(
-                            Awaitable[Any],
-                            guarded_apply(payload, baseline, expected_owned),
-                        )
-                    )
-                    try:
-                        apply_result = AccountUsagePresenceApplyResult(
-                            raw_apply_result
-                        )
-                    except (TypeError, ValueError):
+                    return
+                if captured is not None:
+                    if not _valid_state_mapping(captured):
                         logger.warning(
-                            "Ignoring invalid guarded account-usage apply result from %s",
+                            "Ignoring invalid %s account-usage presence baseline",
                             platform,
                         )
-                        apply_result = AccountUsagePresenceApplyResult.RETRY
-                else:
-                    changed = await self._await_adapter(
-                        cast(Awaitable[Any], apply(payload, baseline))
-                    )
-                    apply_result = (
-                        AccountUsagePresenceApplyResult.APPLIED
-                        if changed
-                        else AccountUsagePresenceApplyResult.RETRY
-                    )
-            except Exception as exc:
-                retry_after = retry_after_seconds(exc)
-                if retry_after is not None:
-                    self._adapter_retry_until[state_key] = now + retry_after
-                    logger.warning(
-                        "Account-usage presence rate-limited by %s; retrying in %.0fs",
-                        platform,
-                        retry_after,
-                    )
-                else:
-                    logger.warning(
-                        "Account-usage presence update failed for %s",
-                        platform,
-                        exc_info=True,
-                    )
-                continue
+                        return
+                    baseline = dict(captured)
 
-            if apply_result is AccountUsagePresenceApplyResult.EXTERNAL:
-                candidate = dict(self._journal)
-                candidate.pop(state_key, None)
-                if self._persist_journal(candidate):
-                    self._journal = candidate
-                    self._owned_in_process.discard(state_key)
-                    self._last_applied.pop(state_key, None)
-                logger.info(
-                    "Account-usage presence no longer owns %s; preserving external value",
-                    state_key,
+        pending_entry: Optional[_JournalEntry] = None
+        guarded_apply: Optional[Callable[..., Awaitable[Any]]] = None
+        if baseline is not None:
+            build_owned = getattr(
+                adapter,
+                "build_account_usage_presence_owned_state",
+                None,
+            )
+            if not callable(build_owned):
+                logger.warning(
+                    "Persistent account-usage surface %s has no ownership renderer",
+                    platform,
                 )
-                continue
+                return
+            guarded_apply = getattr(
+                adapter,
+                "apply_account_usage_presence_if_owned",
+                None,
+            )
+            if not callable(guarded_apply):
+                logger.warning(
+                    "Persistent account-usage surface %s has no guarded ownership updater",
+                    platform,
+                )
+                return
+            try:
+                owned = build_owned(payload, baseline)
+            except Exception:
+                logger.warning(
+                    "Could not render %s account-usage ownership state",
+                    platform,
+                    exc_info=True,
+                )
+                return
+            if not _valid_state_mapping(owned):
+                logger.warning(
+                    "Ignoring invalid %s account-usage ownership state",
+                    platform,
+                )
+                return
+            pending_entry = _JournalEntry(
+                baseline=dict(baseline),
+                owned=dict(owned),
+                phase="pending",
+                previous_owned=(
+                    dict(prior_owned_entry.owned)
+                    if prior_owned_entry is not None
+                    else None
+                ),
+            )
+            candidate = dict(self._journal)
+            candidate[state_key] = pending_entry
+            if not self._persist_journal(candidate):
+                return
+            self._journal = candidate
 
-            if apply_result is not AccountUsagePresenceApplyResult.APPLIED:
-                if pending_entry is not None:
-                    candidate = dict(self._journal)
-                    if prior_owned_entry is None:
-                        candidate.pop(state_key, None)
-                    else:
-                        candidate[state_key] = prior_owned_entry
-                    if self._persist_journal(candidate):
-                        self._journal = candidate
-                continue
+        apply = getattr(adapter, "apply_account_usage_presence", None)
+        if not callable(apply):
+            return
+        try:
+            if baseline is not None:
+                assert guarded_apply is not None
+                expected_owned = (
+                    prior_owned_entry.owned
+                    if prior_owned_entry is not None
+                    else baseline
+                )
+                raw_apply_result = await self._await_adapter(
+                    cast(
+                        Awaitable[Any],
+                        guarded_apply(payload, baseline, expected_owned),
+                    )
+                )
+                try:
+                    apply_result = AccountUsagePresenceApplyResult(raw_apply_result)
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "Ignoring invalid guarded account-usage apply result from %s",
+                        platform,
+                    )
+                    apply_result = AccountUsagePresenceApplyResult.RETRY
+            else:
+                changed = await self._await_adapter(
+                    cast(Awaitable[Any], apply(payload, baseline))
+                )
+                apply_result = (
+                    AccountUsagePresenceApplyResult.APPLIED
+                    if changed
+                    else AccountUsagePresenceApplyResult.RETRY
+                )
+        except Exception as exc:
+            retry_after = retry_after_seconds(exc)
+            if retry_after is not None:
+                self._adapter_retry_until[state_key] = now + retry_after
+                logger.warning(
+                    "Account-usage presence rate-limited by %s; retrying in %.0fs",
+                    platform,
+                    retry_after,
+                )
+            else:
+                logger.warning(
+                    "Account-usage presence update failed for %s",
+                    platform,
+                    exc_info=True,
+                )
+            return
 
+        if apply_result is AccountUsagePresenceApplyResult.EXTERNAL:
+            candidate = dict(self._journal)
+            candidate.pop(state_key, None)
+            if self._persist_journal(candidate):
+                self._journal = candidate
+                self._owned_in_process.discard(state_key)
+                self._last_applied.pop(state_key, None)
+            logger.info(
+                "Account-usage presence no longer owns %s; preserving external value",
+                state_key,
+            )
+            return
+
+        if apply_result is not AccountUsagePresenceApplyResult.APPLIED:
             if pending_entry is not None:
-                self._owned_in_process.add(state_key)
                 candidate = dict(self._journal)
-                candidate[state_key] = replace(
-                    pending_entry,
-                    phase="owned",
-                    previous_owned=None,
-                )
+                if prior_owned_entry is None:
+                    candidate.pop(state_key, None)
+                else:
+                    candidate[state_key] = prior_owned_entry
                 if self._persist_journal(candidate):
                     self._journal = candidate
-            self._last_applied[state_key] = (id(adapter), payload)
+            return
+
+        if pending_entry is not None:
+            self._owned_in_process.add(state_key)
+            candidate = dict(self._journal)
+            candidate[state_key] = replace(
+                pending_entry,
+                phase="owned",
+                previous_owned=None,
+            )
+            if self._persist_journal(candidate):
+                self._journal = candidate
+        self._last_applied[state_key] = (id(adapter), payload)
 
     async def _restore_one(
+        self,
+        state_key: str,
+        platform: str,
+        adapter: Any,
+        entry: _JournalEntry,
+    ) -> AccountUsagePresenceRestoreResult:
+        async with self._state_lock(state_key):
+            current = self._journal.get(state_key)
+            if current != entry:
+                return AccountUsagePresenceRestoreResult.RETRY
+
+            result = await self._restore_remote_one(platform, adapter, current)
+            if not result.can_retire:
+                return result
+
+            if self._journal.get(state_key) != current:
+                return AccountUsagePresenceRestoreResult.RETRY
+            candidate = dict(self._journal)
+            candidate.pop(state_key, None)
+            if not self._persist_journal(candidate):
+                return AccountUsagePresenceRestoreResult.RETRY
+            self._journal = candidate
+            self._owned_in_process.discard(state_key)
+            self._last_applied.pop(state_key, None)
+            self._adapter_retry_until.pop(state_key, None)
+            return result
+
+    async def _restore_remote_one(
         self,
         platform: str,
         adapter: Any,
@@ -817,36 +865,18 @@ class AccountUsagePresenceController:
                 continue
             platform, adapter = connected_entry
             jobs[state_key] = asyncio.create_task(
-                self._restore_one(platform, adapter, entry)
+                self._restore_one(state_key, platform, adapter, entry)
             )
         if not jobs:
             return
 
         results = await asyncio.gather(*jobs.values())
-        retired = {
-            state_key
-            for state_key, result in zip(jobs, results)
-            if result.can_retire
-        }
         for state_key, result in zip(jobs, results):
             if result is AccountUsagePresenceRestoreResult.EXTERNAL:
                 logger.info(
                     "Account-usage presence no longer owns %s; preserving external value",
                     state_key,
                 )
-        if not retired:
-            return
-
-        candidate = {
-            key: value for key, value in self._journal.items() if key not in retired
-        }
-        if not self._persist_journal(candidate):
-            return
-        self._journal = candidate
-        self._owned_in_process.difference_update(retired)
-        for key in retired:
-            self._last_applied.pop(key, None)
-            self._adapter_retry_until.pop(key, None)
 
     def _load_state(self) -> None:
         if self._state_loaded:

--- a/gateway/account_usage_presence.py
+++ b/gateway/account_usage_presence.py
@@ -553,6 +553,9 @@ class AccountUsagePresenceController:
                 continue
 
             entry = self._journal.get(state_key)
+            prior_owned_entry = (
+                entry if entry is not None and entry.phase == "owned" else None
+            )
             baseline = entry.baseline if entry is not None else None
             if entry is None:
                 capture = getattr(adapter, "capture_account_usage_presence_baseline", None)
@@ -641,7 +644,10 @@ class AccountUsagePresenceController:
             if not changed:
                 if pending_entry is not None:
                     candidate = dict(self._journal)
-                    candidate.pop(state_key, None)
+                    if prior_owned_entry is None:
+                        candidate.pop(state_key, None)
+                    else:
+                        candidate[state_key] = prior_owned_entry
                     if self._persist_journal(candidate):
                         self._journal = candidate
                 continue

--- a/gateway/account_usage_presence.py
+++ b/gateway/account_usage_presence.py
@@ -1,0 +1,772 @@
+"""Provider account usage rendered through messaging identity/presence surfaces.
+
+Provider collection remains in :mod:`agent.account_usage`; this module owns only
+poll scheduling, a crash-safe ownership journal, and platform fan-out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+from dataclasses import dataclass, replace
+from enum import Enum
+import json
+import logging
+import math
+import os
+from pathlib import Path
+import stat
+import tempfile
+import threading
+import time
+from typing import Any, Awaitable, Callable, Mapping, Optional, cast
+
+from agent.account_usage import (
+    AccountUsageFetchOutcome,
+    AccountUsageSnapshot,
+    fetch_account_usage_outcome,
+    retry_after_seconds,
+)
+from gateway.config import AccountUsagePresenceConfig
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_STATE_VERSION = 2
+_MAX_STATE_BYTES = 64 * 1024
+_MAX_STATE_ENTRIES = 32
+_STATE_PHASES = frozenset({"pending", "owned"})
+
+
+@dataclass(frozen=True)
+class AccountUsagePresenceCapabilities:
+    """Identity surfaces an adapter can mutate at runtime."""
+
+    display_name: bool = False
+    activity: bool = False
+
+    @property
+    def any(self) -> bool:
+        return bool(self.display_name or self.activity)
+
+
+@dataclass(frozen=True)
+class AccountUsagePresencePayload:
+    """Provider-neutral value passed from the controller to platform adapters."""
+
+    label: str
+    remaining_percent: Optional[int]
+    cached: bool = False
+
+    @classmethod
+    def unknown(cls) -> "AccountUsagePresencePayload":
+        return cls(label="Usage", remaining_percent=None)
+
+
+class AccountUsagePresenceRestoreResult(str, Enum):
+    """Result of comparing a remote identity with one journaled ownership value."""
+
+    RESTORED = "restored"
+    ALREADY_BASELINE = "already_baseline"
+    EXTERNAL = "external"
+    RETRY = "retry"
+
+    @property
+    def can_retire(self) -> bool:
+        return self is not AccountUsagePresenceRestoreResult.RETRY
+
+
+@dataclass(frozen=True)
+class _JournalEntry:
+    baseline: dict[str, Any]
+    owned: dict[str, Any]
+    phase: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "baseline": self.baseline,
+            "owned": self.owned,
+            "phase": self.phase,
+        }
+
+
+def account_usage_presence_state_path(home: Optional[Path] = None) -> Path:
+    """Return the private journal path for one Hermes profile."""
+
+    root = Path(home) if home is not None else get_hermes_home()
+    return root / "state" / "account-usage-presence" / "journal.json"
+
+
+def account_usage_presence_payload_from_snapshot(
+    snapshot: AccountUsageSnapshot,
+    *,
+    window_label: Optional[str] = None,
+) -> Optional[AccountUsagePresencePayload]:
+    """Select one percentage window and convert it to a compact payload."""
+
+    selected = None
+    requested = str(window_label or "").strip().casefold()
+    for window in snapshot.windows:
+        if window.used_percent is None:
+            continue
+        if requested and str(window.label).strip().casefold() != requested:
+            continue
+        selected = window
+        break
+
+    if selected is None or selected.used_percent is None:
+        return None
+    used_value = float(selected.used_percent)
+    if not math.isfinite(used_value):
+        return None
+    used_percent = max(0.0, min(100.0, used_value))
+    return AccountUsagePresencePayload(
+        label=selected.label,
+        remaining_percent=int(round(100.0 - used_percent)),
+    )
+
+
+def _platform_name(value: Any) -> str:
+    raw = getattr(value, "value", value)
+    return str(raw or "").strip().lower()
+
+
+def _valid_state_mapping(value: Any) -> bool:
+    if not isinstance(value, dict) or not value or len(value) > 16:
+        return False
+    for key, item in value.items():
+        if not isinstance(key, str) or not key or len(key) > 128:
+            return False
+        if isinstance(item, str):
+            if len(item) > 1024:
+                return False
+        elif item is None or isinstance(item, (bool, int)):
+            pass
+        elif isinstance(item, float):
+            if not math.isfinite(item):
+                return False
+        else:
+            return False
+    return True
+
+
+def _parse_journal(raw: Any) -> dict[str, _JournalEntry]:
+    if not isinstance(raw, dict) or set(raw) != {"version", "entries"}:
+        raise ValueError("journal must contain exactly version and entries")
+    if raw["version"] != _STATE_VERSION:
+        raise ValueError("unsupported journal version")
+    entries = raw["entries"]
+    if not isinstance(entries, dict) or len(entries) > _MAX_STATE_ENTRIES:
+        raise ValueError("journal entries must be a bounded object")
+
+    parsed: dict[str, _JournalEntry] = {}
+    for key, value in entries.items():
+        if not isinstance(key, str) or not key or len(key) > 256:
+            raise ValueError("invalid journal state key")
+        if not isinstance(value, dict) or set(value) != {"baseline", "owned", "phase"}:
+            raise ValueError("invalid journal entry schema")
+        if not _valid_state_mapping(value["baseline"]):
+            raise ValueError("invalid journal baseline")
+        if not _valid_state_mapping(value["owned"]):
+            raise ValueError("invalid journal owned state")
+        phase = value["phase"]
+        if phase not in _STATE_PHASES:
+            raise ValueError("invalid journal phase")
+        parsed[key] = _JournalEntry(
+            baseline=dict(value["baseline"]),
+            owned=dict(value["owned"]),
+            phase=phase,
+        )
+    return parsed
+
+
+def _safe_regular_identity(path: Path) -> Optional[tuple[int, int]]:
+    """Return a regular file identity, None if absent, and reject link tricks."""
+
+    try:
+        info = os.lstat(path)
+    except FileNotFoundError:
+        return None
+    if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+        raise ValueError("journal path is not a single-link regular file")
+    if info.st_size > _MAX_STATE_BYTES:
+        raise ValueError("journal exceeds size limit")
+    return (info.st_dev, info.st_ino)
+
+
+def _read_state_no_follow(path: Path) -> bytes:
+    expected = _safe_regular_identity(path)
+    if expected is None:
+        raise FileNotFoundError(path)
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags)
+    try:
+        opened = os.fstat(fd)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or (opened.st_dev, opened.st_ino) != expected
+            or opened.st_size > _MAX_STATE_BYTES
+        ):
+            raise ValueError("journal changed or is unsafe while opening")
+        with os.fdopen(fd, "rb", closefd=False) as handle:
+            data = handle.read(_MAX_STATE_BYTES + 1)
+        if len(data) > _MAX_STATE_BYTES:
+            raise ValueError("journal exceeds size limit")
+        return data
+    finally:
+        os.close(fd)
+
+
+def _write_state_atomically(path: Path, value: dict[str, Any]) -> None:
+    """Atomically replace a private journal without following its target."""
+
+    parent = path.parent
+    parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+    parent_info = os.lstat(parent)
+    if not stat.S_ISDIR(parent_info.st_mode) or stat.S_ISLNK(parent_info.st_mode):
+        raise ValueError("journal directory is not a real directory")
+    os.chmod(parent, 0o700)
+
+    encoded = (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    if len(encoded) > _MAX_STATE_BYTES:
+        raise ValueError("journal exceeds size limit")
+
+    initial_identity = _safe_regular_identity(path)
+    fd, temporary_name = tempfile.mkstemp(prefix=".journal-", dir=parent)
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb", closefd=False) as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.close(fd)
+        fd = -1
+
+        if _safe_regular_identity(path) != initial_identity:
+            raise RuntimeError("journal target changed during atomic write")
+        os.replace(temporary, path)
+        os.chmod(path, 0o600)
+        try:
+            directory_fd = os.open(parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError:
+            pass
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+class AccountUsagePresenceController:
+    """Fetch one provider snapshot and fan it out to selected adapters."""
+
+    def __init__(
+        self,
+        config: AccountUsagePresenceConfig,
+        adapters: Callable[[], Mapping[Any, Any]],
+        *,
+        fetcher: Optional[Callable[[str], Any]] = None,
+        state_path: Optional[Path] = None,
+        monotonic: Callable[[], float] = time.monotonic,
+        fetch_timeout_seconds: float = 20.0,
+        adapter_timeout_seconds: float = 15.0,
+        recovery_interval_seconds: float = 30.0,
+    ) -> None:
+        self.config = config
+        self._adapters = adapters
+        self._fetcher = fetcher or fetch_account_usage_outcome
+        self._state_path = state_path or account_usage_presence_state_path()
+        self._monotonic = monotonic
+        self._fetch_timeout_seconds = max(0.01, float(fetch_timeout_seconds))
+        self._adapter_timeout_seconds = max(0.01, float(adapter_timeout_seconds))
+        self._recovery_interval_seconds = max(0.01, float(recovery_interval_seconds))
+        self._task: Optional[asyncio.Task] = None
+        self._fetch_thread: Optional[threading.Thread] = None
+        self._state_loaded = False
+        self._journal_blocked = False
+        self._journal: dict[str, _JournalEntry] = {}
+        self._owned_in_process: set[str] = set()
+        self._last_payload: Optional[AccountUsagePresencePayload] = None
+        self._last_success_at: Optional[float] = None
+        self._last_applied: dict[str, tuple[int, AccountUsagePresencePayload]] = {}
+        self._adapter_retry_until: dict[str, float] = {}
+        self._provider_retry_until = 0.0
+
+    @property
+    def task(self) -> Optional[asyncio.Task]:
+        return self._task
+
+    @property
+    def recovery_pending(self) -> bool:
+        self._load_state()
+        return bool(self._journal) or self._journal_blocked
+
+    async def start(self) -> None:
+        """Recover prior ownership, then poll only when explicitly configured."""
+
+        self._load_state()
+        if self._journal_blocked:
+            return
+        if self._journal:
+            await self.recover_saved_baselines()
+
+        if not self.config.is_configured:
+            if self._journal and (self._task is None or self._task.done()):
+                self._task = asyncio.create_task(
+                    self._run_recovery(),
+                    name="account-usage-presence-recovery",
+                )
+            return
+
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(
+                self._run(),
+                name="account-usage-presence",
+            )
+
+    async def stop(self) -> None:
+        """Cancel refreshes and CAS-restore persistent identity surfaces."""
+
+        task = self._task
+        self._task = None
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        await self.recover_saved_baselines()
+
+    async def recover_saved_baselines(self) -> None:
+        """Retry pending recovery; safe to call after an adapter reconnect."""
+
+        await self._restore_saved_baselines()
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                await self.refresh_once()
+                await asyncio.sleep(self.config.update_interval_seconds)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Account-usage presence loop stopped unexpectedly", exc_info=True)
+
+    async def _run_recovery(self) -> None:
+        try:
+            while self._journal and not self._journal_blocked:
+                await self._restore_saved_baselines()
+                if not self._journal:
+                    return
+                await asyncio.sleep(self._recovery_interval_seconds)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Account-usage presence recovery loop stopped", exc_info=True)
+
+    @staticmethod
+    def _publish_fetch_outcome(
+        future: asyncio.Future,
+        outcome: tuple[bool, Any],
+    ) -> None:
+        if not future.done():
+            future.set_result(outcome)
+
+    async def _fetch_outcome(self, provider: str) -> AccountUsageFetchOutcome:
+        """Run the synchronous collector in one abandonable daemon worker."""
+
+        running = self._fetch_thread
+        if running is not None and running.is_alive():
+            raise TimeoutError("previous provider account-usage fetch is still running")
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future = loop.create_future()
+        context = contextvars.copy_context()
+
+        def collect() -> None:
+            try:
+                outcome: tuple[bool, Any] = (
+                    True,
+                    context.run(self._fetcher, provider),
+                )
+            except Exception as exc:
+                outcome = (False, exc)
+            try:
+                loop.call_soon_threadsafe(self._publish_fetch_outcome, future, outcome)
+            except RuntimeError:
+                pass
+
+        worker = threading.Thread(
+            target=collect,
+            name="hermes-account-usage-presence-fetch",
+            daemon=True,
+        )
+        self._fetch_thread = worker
+        try:
+            worker.start()
+        except Exception:
+            self._fetch_thread = None
+            raise
+
+        try:
+            succeeded, value = await asyncio.wait_for(
+                asyncio.shield(future),
+                timeout=self._fetch_timeout_seconds,
+            )
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError("provider account-usage fetch timed out") from exc
+
+        if not succeeded:
+            if isinstance(value, BaseException):
+                return AccountUsageFetchOutcome(
+                    retry_after_seconds=retry_after_seconds(value),
+                    failed=True,
+                )
+            return AccountUsageFetchOutcome(failed=True)
+        if isinstance(value, AccountUsageFetchOutcome):
+            return value
+        if value is None or isinstance(value, AccountUsageSnapshot):
+            return AccountUsageFetchOutcome(snapshot=value)
+        raise TypeError("account-usage fetcher returned an unsupported value")
+
+    async def refresh_once(self) -> None:
+        """Fetch and apply one snapshot; public for lifecycle tests."""
+
+        if not self.config.is_configured:
+            return
+        self._load_state()
+        if self._journal_blocked:
+            return
+
+        provider = self.config.provider
+        if not provider:
+            return
+        now = self._monotonic()
+        if now < self._provider_retry_until:
+            outcome = AccountUsageFetchOutcome(failed=True)
+        else:
+            try:
+                outcome = await self._fetch_outcome(provider)
+            except Exception:
+                logger.warning(
+                    "Account-usage presence fetch failed for provider %s",
+                    provider,
+                    exc_info=True,
+                )
+                outcome = AccountUsageFetchOutcome(failed=True)
+            if outcome.retry_after_seconds is not None:
+                self._provider_retry_until = now + outcome.retry_after_seconds
+                logger.warning(
+                    "Account-usage provider %s rate-limited; retrying in %.0fs",
+                    provider,
+                    outcome.retry_after_seconds,
+                )
+
+        live_payload = (
+            account_usage_presence_payload_from_snapshot(
+                outcome.snapshot,
+                window_label=self.config.window_label,
+            )
+            if outcome.snapshot is not None
+            else None
+        )
+        if live_payload is not None:
+            self._last_payload = live_payload
+            self._last_success_at = now
+            payload = live_payload
+        elif (
+            self._last_payload is not None
+            and self._last_success_at is not None
+            and now - self._last_success_at < self.config.stale_after_seconds
+        ):
+            payload = replace(self._last_payload, cached=True)
+        else:
+            payload = AccountUsagePresencePayload.unknown()
+
+        await self._apply_to_selected_adapters(payload, now=now)
+
+    def _iter_adapters(self):
+        for key, adapter in list(self._adapters().items()):
+            yield _platform_name(key), adapter
+
+    @staticmethod
+    def _state_key(platform: str, adapter: Any) -> str:
+        method = getattr(adapter, "account_usage_presence_state_key", None)
+        if callable(method):
+            try:
+                value = str(method() or "").strip()
+                if value:
+                    return value
+            except Exception:
+                logger.debug(
+                    "Account-usage presence state-key lookup failed for %s",
+                    platform,
+                    exc_info=True,
+                )
+        return platform
+
+    async def _await_adapter(self, result: Awaitable[Any]) -> Any:
+        return await asyncio.wait_for(result, timeout=self._adapter_timeout_seconds)
+
+    async def _apply_to_selected_adapters(
+        self,
+        payload: AccountUsagePresencePayload,
+        *,
+        now: float,
+    ) -> None:
+        selected = set(self.config.platforms)
+        for platform, adapter in self._iter_adapters():
+            if platform not in selected:
+                continue
+            capabilities = getattr(
+                adapter,
+                "account_usage_presence_capabilities",
+                AccountUsagePresenceCapabilities(),
+            )
+            if not isinstance(capabilities, AccountUsagePresenceCapabilities):
+                logger.warning(
+                    "Ignoring invalid account-usage presence capabilities from %s",
+                    platform,
+                )
+                continue
+            if not capabilities.any:
+                logger.info(
+                    "Account-usage presence unsupported by platform %s; skipping",
+                    platform,
+                )
+                continue
+
+            state_key = self._state_key(platform, adapter)
+            if now < self._adapter_retry_until.get(state_key, 0.0):
+                continue
+            if self._last_applied.get(state_key) == (id(adapter), payload):
+                continue
+            if state_key in self._journal and state_key not in self._owned_in_process:
+                continue
+
+            entry = self._journal.get(state_key)
+            baseline = entry.baseline if entry is not None else None
+            if entry is None:
+                capture = getattr(adapter, "capture_account_usage_presence_baseline", None)
+                if callable(capture):
+                    try:
+                        captured = await self._await_adapter(cast(Awaitable[Any], capture()))
+                    except Exception:
+                        logger.warning(
+                            "Could not capture %s account-usage presence baseline",
+                            platform,
+                            exc_info=True,
+                        )
+                        continue
+                    if captured is not None:
+                        if not _valid_state_mapping(captured):
+                            logger.warning(
+                                "Ignoring invalid %s account-usage presence baseline",
+                                platform,
+                            )
+                            continue
+                        baseline = dict(captured)
+
+            pending_entry: Optional[_JournalEntry] = None
+            if baseline is not None:
+                build_owned = getattr(
+                    adapter,
+                    "build_account_usage_presence_owned_state",
+                    None,
+                )
+                if not callable(build_owned):
+                    logger.warning(
+                        "Persistent account-usage surface %s has no ownership renderer",
+                        platform,
+                    )
+                    continue
+                try:
+                    owned = build_owned(payload, baseline)
+                except Exception:
+                    logger.warning(
+                        "Could not render %s account-usage ownership state",
+                        platform,
+                        exc_info=True,
+                    )
+                    continue
+                if not _valid_state_mapping(owned):
+                    logger.warning(
+                        "Ignoring invalid %s account-usage ownership state",
+                        platform,
+                    )
+                    continue
+                pending_entry = _JournalEntry(
+                    baseline=dict(baseline),
+                    owned=dict(owned),
+                    phase="pending",
+                )
+                candidate = dict(self._journal)
+                candidate[state_key] = pending_entry
+                if not self._persist_journal(candidate):
+                    continue
+                self._journal = candidate
+
+            apply = getattr(adapter, "apply_account_usage_presence", None)
+            if not callable(apply):
+                continue
+            try:
+                changed = await self._await_adapter(
+                    cast(Awaitable[Any], apply(payload, baseline))
+                )
+            except Exception as exc:
+                retry_after = retry_after_seconds(exc)
+                if retry_after is not None:
+                    self._adapter_retry_until[state_key] = now + retry_after
+                    logger.warning(
+                        "Account-usage presence rate-limited by %s; retrying in %.0fs",
+                        platform,
+                        retry_after,
+                    )
+                else:
+                    logger.warning(
+                        "Account-usage presence update failed for %s",
+                        platform,
+                        exc_info=True,
+                    )
+                continue
+
+            if not changed:
+                if pending_entry is not None:
+                    candidate = dict(self._journal)
+                    candidate.pop(state_key, None)
+                    if self._persist_journal(candidate):
+                        self._journal = candidate
+                continue
+
+            if pending_entry is not None:
+                self._owned_in_process.add(state_key)
+                candidate = dict(self._journal)
+                candidate[state_key] = replace(pending_entry, phase="owned")
+                if self._persist_journal(candidate):
+                    self._journal = candidate
+            self._last_applied[state_key] = (id(adapter), payload)
+
+    async def _restore_one(
+        self,
+        platform: str,
+        adapter: Any,
+        entry: _JournalEntry,
+    ) -> AccountUsagePresenceRestoreResult:
+        restore = getattr(adapter, "restore_account_usage_presence", None)
+        if not callable(restore):
+            return AccountUsagePresenceRestoreResult.RETRY
+        try:
+            value = await self._await_adapter(
+                cast(Awaitable[Any], restore(entry.baseline, entry.owned))
+            )
+        except Exception:
+            logger.warning(
+                "Account-usage presence restore failed for %s",
+                platform,
+                exc_info=True,
+            )
+            return AccountUsagePresenceRestoreResult.RETRY
+        try:
+            return AccountUsagePresenceRestoreResult(value)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Ignoring invalid account-usage restore result from %s",
+                platform,
+            )
+            return AccountUsagePresenceRestoreResult.RETRY
+
+    async def _restore_saved_baselines(self) -> None:
+        self._load_state()
+        if self._journal_blocked or not self._journal:
+            return
+
+        connected: dict[str, tuple[str, Any]] = {}
+        for platform, adapter in self._iter_adapters():
+            connected[self._state_key(platform, adapter)] = (platform, adapter)
+
+        jobs: dict[str, asyncio.Task] = {}
+        for state_key, entry in self._journal.items():
+            connected_entry = connected.get(state_key)
+            if connected_entry is None:
+                continue
+            platform, adapter = connected_entry
+            jobs[state_key] = asyncio.create_task(
+                self._restore_one(platform, adapter, entry)
+            )
+        if not jobs:
+            return
+
+        results = await asyncio.gather(*jobs.values())
+        retired = {
+            state_key
+            for state_key, result in zip(jobs, results)
+            if result.can_retire
+        }
+        for state_key, result in zip(jobs, results):
+            if result is AccountUsagePresenceRestoreResult.EXTERNAL:
+                logger.info(
+                    "Account-usage presence no longer owns %s; preserving external value",
+                    state_key,
+                )
+        if not retired:
+            return
+
+        candidate = {
+            key: value for key, value in self._journal.items() if key not in retired
+        }
+        if not self._persist_journal(candidate):
+            return
+        self._journal = candidate
+        self._owned_in_process.difference_update(retired)
+        for key in retired:
+            self._last_applied.pop(key, None)
+            self._adapter_retry_until.pop(key, None)
+
+    def _load_state(self) -> None:
+        if self._state_loaded:
+            return
+        self._state_loaded = True
+        try:
+            data = _read_state_no_follow(self._state_path)
+            raw = json.loads(data.decode("utf-8"))
+            self._journal = _parse_journal(raw)
+        except FileNotFoundError:
+            return
+        except Exception:
+            self._journal_blocked = True
+            logger.error(
+                "Unsafe or invalid account-usage presence journal at %s; "
+                "all identity mutation is disabled until an operator inspects it",
+                self._state_path,
+                exc_info=True,
+            )
+
+    def _persist_journal(self, entries: Mapping[str, _JournalEntry]) -> bool:
+        if self._journal_blocked:
+            return False
+        value = {
+            "version": _STATE_VERSION,
+            "entries": {
+                key: entry.to_dict() for key, entry in sorted(entries.items())
+            },
+        }
+        try:
+            _write_state_atomically(self._state_path, value)
+            return True
+        except Exception:
+            self._journal_blocked = True
+            logger.error(
+                "Could not safely persist account-usage presence journal at %s; "
+                "further identity mutation is disabled",
+                self._state_path,
+                exc_info=True,
+            )
+            return False

--- a/gateway/account_usage_presence.py
+++ b/gateway/account_usage_presence.py
@@ -76,6 +76,14 @@ class AccountUsagePresenceRestoreResult(str, Enum):
         return self is not AccountUsagePresenceRestoreResult.RETRY
 
 
+class AccountUsagePresenceApplyResult(str, Enum):
+    """CAS result for a persistent identity-surface generation update."""
+
+    APPLIED = "applied"
+    EXTERNAL = "external"
+    RETRY = "retry"
+
+
 @dataclass(frozen=True)
 class _JournalEntry:
     baseline: dict[str, Any]
@@ -563,10 +571,15 @@ class AccountUsagePresenceController:
                 continue
             if self._last_applied.get(state_key) == (id(adapter), payload):
                 continue
-            if state_key in self._journal and state_key not in self._owned_in_process:
+            entry = self._journal.get(state_key)
+            if entry is not None and entry.phase == "pending":
+                # A pending transition may have changed the remote value even
+                # when its API call raised. Fail closed until stop/restart
+                # recovery reconciles the journaled generations.
+                continue
+            if entry is not None and state_key not in self._owned_in_process:
                 continue
 
-            entry = self._journal.get(state_key)
             prior_owned_entry = (
                 entry if entry is not None and entry.phase == "owned" else None
             )
@@ -593,6 +606,7 @@ class AccountUsagePresenceController:
                         baseline = dict(captured)
 
             pending_entry: Optional[_JournalEntry] = None
+            guarded_apply: Optional[Callable[..., Awaitable[Any]]] = None
             if baseline is not None:
                 build_owned = getattr(
                     adapter,
@@ -602,6 +616,17 @@ class AccountUsagePresenceController:
                 if not callable(build_owned):
                     logger.warning(
                         "Persistent account-usage surface %s has no ownership renderer",
+                        platform,
+                    )
+                    continue
+                guarded_apply = getattr(
+                    adapter,
+                    "apply_account_usage_presence_if_owned",
+                    None,
+                )
+                if not callable(guarded_apply):
+                    logger.warning(
+                        "Persistent account-usage surface %s has no guarded ownership updater",
                         platform,
                     )
                     continue
@@ -640,9 +665,38 @@ class AccountUsagePresenceController:
             if not callable(apply):
                 continue
             try:
-                changed = await self._await_adapter(
-                    cast(Awaitable[Any], apply(payload, baseline))
-                )
+                if baseline is not None:
+                    assert guarded_apply is not None
+                    expected_owned = (
+                        prior_owned_entry.owned
+                        if prior_owned_entry is not None
+                        else baseline
+                    )
+                    raw_apply_result = await self._await_adapter(
+                        cast(
+                            Awaitable[Any],
+                            guarded_apply(payload, baseline, expected_owned),
+                        )
+                    )
+                    try:
+                        apply_result = AccountUsagePresenceApplyResult(
+                            raw_apply_result
+                        )
+                    except (TypeError, ValueError):
+                        logger.warning(
+                            "Ignoring invalid guarded account-usage apply result from %s",
+                            platform,
+                        )
+                        apply_result = AccountUsagePresenceApplyResult.RETRY
+                else:
+                    changed = await self._await_adapter(
+                        cast(Awaitable[Any], apply(payload, baseline))
+                    )
+                    apply_result = (
+                        AccountUsagePresenceApplyResult.APPLIED
+                        if changed
+                        else AccountUsagePresenceApplyResult.RETRY
+                    )
             except Exception as exc:
                 retry_after = retry_after_seconds(exc)
                 if retry_after is not None:
@@ -660,7 +714,20 @@ class AccountUsagePresenceController:
                     )
                 continue
 
-            if not changed:
+            if apply_result is AccountUsagePresenceApplyResult.EXTERNAL:
+                candidate = dict(self._journal)
+                candidate.pop(state_key, None)
+                if self._persist_journal(candidate):
+                    self._journal = candidate
+                    self._owned_in_process.discard(state_key)
+                    self._last_applied.pop(state_key, None)
+                logger.info(
+                    "Account-usage presence no longer owns %s; preserving external value",
+                    state_key,
+                )
+                continue
+
+            if apply_result is not AccountUsagePresenceApplyResult.APPLIED:
                 if pending_entry is not None:
                     candidate = dict(self._journal)
                     if prior_owned_entry is None:

--- a/gateway/account_usage_presence.py
+++ b/gateway/account_usage_presence.py
@@ -422,6 +422,12 @@ class AccountUsagePresenceController:
                 )
             except Exception as exc:
                 outcome = (False, exc)
+            # Publish only after clearing the completed worker reference. The
+            # loop callback can run before the OS reports this thread stopped;
+            # retaining the stale reference would turn a completed fetch into
+            # a false "previous fetch is still running" failure.
+            if self._fetch_thread is threading.current_thread():
+                self._fetch_thread = None
             try:
                 loop.call_soon_threadsafe(self._publish_fetch_outcome, future, outcome)
             except RuntimeError:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -822,7 +822,7 @@ class AccountUsagePresenceConfig:
     """
 
     SUPPORTED_PROVIDERS = frozenset({"openai-codex", "anthropic", "openrouter"})
-    SUPPORTED_PLATFORMS = frozenset({"telegram", "discord"})
+    SUPPORTED_PLATFORMS = frozenset({"telegram", "discord", "matrix"})
 
     enabled: bool = False
     provider: Optional[str] = None

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -812,6 +812,98 @@ class StreamingConfig:
         )
 
 
+@dataclass(frozen=True)
+class AccountUsagePresenceConfig:
+    """Opt-in provider account usage shown on supported messaging identities.
+
+    The provider is intentionally explicit instead of following whichever
+    model a conversation used most recently. That keeps one global bot
+    identity stable when chats route to different providers.
+    """
+
+    SUPPORTED_PROVIDERS = frozenset({"openai-codex", "anthropic", "openrouter"})
+    SUPPORTED_PLATFORMS = frozenset({"telegram", "discord"})
+
+    enabled: bool = False
+    provider: Optional[str] = None
+    platforms: tuple[str, ...] = ()
+    update_interval_seconds: int = 300
+    stale_after_seconds: int = 900
+    window_label: Optional[str] = None
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.enabled and self.provider and self.platforms)
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "enabled": self.enabled,
+            "platforms": list(self.platforms),
+            "update_interval_seconds": self.update_interval_seconds,
+            "stale_after_seconds": self.stale_after_seconds,
+        }
+        if self.provider:
+            result["provider"] = self.provider
+        if self.window_label:
+            result["window_label"] = self.window_label
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Any) -> "AccountUsagePresenceConfig":
+        data = _coerce_dict(data)
+        provider = str(data.get("provider") or "").strip().lower() or None
+        if provider in {"auto", "main"}:
+            provider = None
+        if provider is not None and provider not in cls.SUPPORTED_PROVIDERS:
+            logger.warning(
+                "Ignoring unsupported account_usage_presence.provider=%r "
+                "(supported: %s)",
+                provider,
+                ", ".join(sorted(cls.SUPPORTED_PROVIDERS)),
+            )
+            provider = None
+
+        raw_platforms = data.get("platforms")
+        if not isinstance(raw_platforms, (list, tuple, set)):
+            raw_platforms = ()
+        platforms: list[str] = []
+        for value in raw_platforms:
+            normalized = str(value or "").strip().lower()
+            if not normalized:
+                continue
+            if normalized not in cls.SUPPORTED_PLATFORMS:
+                logger.warning(
+                    "Ignoring unsupported account_usage_presence platform %r "
+                    "(supported: %s)",
+                    normalized,
+                    ", ".join(sorted(cls.SUPPORTED_PLATFORMS)),
+                )
+                continue
+            if normalized not in platforms:
+                platforms.append(normalized)
+
+        # Profile mutations are deliberately slow. Five minutes is both the
+        # default and the floor, so a typo cannot create a rate-limit loop.
+        update_interval = max(
+            300,
+            _coerce_int(data.get("update_interval_seconds"), 300),
+        )
+        stale_after = max(
+            update_interval,
+            _coerce_int(data.get("stale_after_seconds"), 900),
+        )
+        window_label = str(data.get("window_label") or "").strip() or None
+
+        return cls(
+            enabled=_coerce_bool(data.get("enabled"), False),
+            provider=provider,
+            platforms=tuple(platforms),
+            update_interval_seconds=update_interval,
+            stale_after_seconds=stale_after,
+            window_label=window_label,
+        )
+
+
 # -----------------------------------------------------------------------------
 # Built-in platform connection checkers
 # -----------------------------------------------------------------------------
@@ -942,6 +1034,12 @@ class GatewayConfig:
 
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
+
+    # EXPERIMENTAL: provider account usage surfaced through messaging identity /
+    # presence APIs. Off by default because these are global profile writes.
+    account_usage_presence: AccountUsagePresenceConfig = field(
+        default_factory=AccountUsagePresenceConfig
+    )
 
     # Session store pruning: drop SessionEntry records older than this many
     # days from the in-memory dict and sessions.json.  Keeps the store from
@@ -1074,6 +1172,7 @@ class GatewayConfig:
             "loop_watchdog": self.loop_watchdog,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
+            "account_usage_presence": self.account_usage_presence.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
             "profile_routes": [
                 asdict(r) if is_dataclass(r) and not isinstance(r, type) else r
@@ -1212,6 +1311,9 @@ class GatewayConfig:
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+            account_usage_presence=AccountUsagePresenceConfig.from_dict(
+                data.get("account_usage_presence", {})
+            ),
             session_store_max_age_days=session_store_max_age_days,
             profile_routes=profile_routes,
         )
@@ -1368,6 +1470,10 @@ def load_gateway_config() -> GatewayConfig:
                 if "systemd_watchdog_seconds" in gateway_section:
                     gw_data["systemd_watchdog_seconds"] = gateway_section[
                         "systemd_watchdog_seconds"
+                    ]
+                if "account_usage_presence" in gateway_section:
+                    gw_data["account_usage_presence"] = gateway_section[
+                        "account_usage_presence"
                     ]
 
             if "max_concurrent_sessions" in yaml_cfg:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -548,6 +548,11 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
+from gateway.account_usage_presence import (
+    AccountUsagePresenceCapabilities,
+    AccountUsagePresencePayload,
+    AccountUsagePresenceRestoreResult,
+)
 from gateway.session import SessionSource, build_session_key
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home
 
@@ -3393,6 +3398,51 @@ class BasePlatformAdapter(ABC):
         thread replies without explicit mentions).
         """
         self._session_store = session_store
+
+    @property
+    def account_usage_presence_capabilities(self) -> AccountUsagePresenceCapabilities:
+        """Runtime identity/presence surfaces supported by this adapter."""
+
+        return AccountUsagePresenceCapabilities()
+
+    def account_usage_presence_state_key(self) -> str:
+        """Stable key for crash-safe identity baseline state."""
+
+        return self.platform.value
+
+    async def capture_account_usage_presence_baseline(
+        self,
+    ) -> Optional[Dict[str, Any]]:
+        """Capture identity values needed to undo a later mutation."""
+
+        return None
+
+    def build_account_usage_presence_owned_state(
+        self,
+        payload: AccountUsagePresencePayload,
+        baseline: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """Render the exact persistent value the adapter intends to own."""
+
+        return None
+
+    async def apply_account_usage_presence(
+        self,
+        payload: AccountUsagePresencePayload,
+        baseline: Optional[Dict[str, Any]],
+    ) -> bool:
+        """Apply a provider account usage payload. Unsupported by default."""
+
+        return False
+
+    async def restore_account_usage_presence(
+        self,
+        baseline: Dict[str, Any],
+        owned: Dict[str, Any],
+    ) -> AccountUsagePresenceRestoreResult:
+        """CAS-restore persistent identity state. Unsupported by default."""
+
+        return AccountUsagePresenceRestoreResult.RETRY
     
     def _history_media_paths_for_session(self, session_key: str) -> Optional[set]:
         """Return media paths already delivered in prior turns of this session.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2173,11 +2173,13 @@ from gateway.config import (
     ChannelOverride,
     Platform,
     _BUILTIN_PLATFORM_VALUES,
+    AccountUsagePresenceConfig,
     GatewayConfig,
     HomeChannel,
     PlatformConfig,
     load_gateway_config,
 )
+from gateway.account_usage_presence import AccountUsagePresenceController
 from gateway.session import (
     AsyncSessionStore,
     SessionEntry,
@@ -3399,6 +3401,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("could not set multiplex-active flag", exc_info=True)
         self.adapters: Dict[Platform, BasePlatformAdapter] = {}
+        self._account_usage_presence_controller: Optional[
+            AccountUsagePresenceController
+        ] = None
         # Multi-profile multiplexing: adapters for NON-default profiles live
         # here, keyed by profile name then Platform. self.adapters stays the
         # default/active profile's map so the ~93 existing self.adapters[...]
@@ -8029,6 +8034,108 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 floor_timer.cancel()
             except Exception:
                 logger.debug("Failed to cancel gateway loop floor timer", exc_info=True)
+    async def _start_account_usage_presence(self) -> None:
+        if getattr(self, "_account_usage_presence_controller", None) is not None:
+            return
+
+        # Secondary multiplex profiles never poll; they only CAS-restore any
+        # journal left behind when the feature was previously enabled there.
+        await self._recover_secondary_profile_account_usage_presence()
+
+        config = self.config.account_usage_presence
+        if config.enabled and not config.is_configured:
+            logger.warning(
+                "Account-usage presence requires an explicit provider and at "
+                "least one platform; restoring prior identity state without "
+                "starting updates"
+            )
+        if self.config.multiplex_profiles and config.is_configured:
+            logger.warning(
+                "Account-usage presence is not supported with "
+                "gateway.multiplex_profiles; restoring prior identity state "
+                "without starting updates"
+            )
+            config = AccountUsagePresenceConfig()
+
+        controller = AccountUsagePresenceController(config, lambda: self.adapters)
+        self._account_usage_presence_controller = controller
+        try:
+            await controller.start()
+        except Exception:
+            logger.warning(
+                "Account-usage presence startup failed; gateway will continue",
+                exc_info=True,
+            )
+            self._account_usage_presence_controller = None
+            try:
+                await controller.stop()
+            except Exception:
+                logger.debug(
+                    "Account-usage presence cleanup after startup failure failed",
+                    exc_info=True,
+                )
+
+    async def _recover_secondary_profile_account_usage_presence(self) -> None:
+        """Fetchless CAS recovery for each secondary multiplex profile journal."""
+
+        profile_adapters = getattr(self, "_profile_adapters", None) or {}
+        if not profile_adapters:
+            return
+
+        from gateway.account_usage_presence import account_usage_presence_state_path
+
+        for profile_name, adapters in list(profile_adapters.items()):
+            if not adapters:
+                continue
+            try:
+                with self._profile_runtime_scope(profile_name):
+                    controller = AccountUsagePresenceController(
+                        AccountUsagePresenceConfig(),
+                        lambda adapters=adapters: adapters,
+                        state_path=account_usage_presence_state_path(),
+                    )
+                    await controller.recover_saved_baselines()
+            except Exception:
+                logger.warning(
+                    "Account-usage presence recovery failed for profile %s",
+                    profile_name,
+                    exc_info=True,
+                )
+
+    async def _notify_account_usage_presence_adapters_changed(self) -> None:
+        controller = getattr(self, "_account_usage_presence_controller", None)
+        if controller is None:
+            return
+        try:
+            await controller.recover_saved_baselines()
+        except Exception:
+            logger.debug(
+                "Account-usage presence recovery after adapter change failed",
+                exc_info=True,
+            )
+
+    async def _stop_account_usage_presence(self) -> None:
+        controller = getattr(self, "_account_usage_presence_controller", None)
+        self._account_usage_presence_controller = None
+        if controller is not None:
+            try:
+                await controller.stop()
+            except Exception:
+                logger.warning(
+                    "Account-usage presence restore failed during shutdown; "
+                    "adapter teardown will continue",
+                    exc_info=True,
+                )
+        # Secondary profiles keep their own journals; restore them while their
+        # adapters are still connected.
+        try:
+            await self._recover_secondary_profile_account_usage_presence()
+        except Exception:
+            logger.warning(
+                "Secondary-profile account-usage presence recovery failed "
+                "during shutdown",
+                exc_info=True,
+            )
 
     async def start(self) -> bool:
         """
@@ -8702,7 +8809,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._running = True
         self._update_runtime_status("running")
-
         # Loop-liveness heartbeat (#66892): an asyncio task so a frozen loop
         # stops refreshing ``state/gateway.heartbeat``. Cancelled with the
         # other background tasks during stop(). Best-effort — a liveness probe
@@ -8722,6 +8828,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     self._loop_heartbeat_task.add_done_callback(_bg.discard)
         except Exception:
             logger.debug("Failed to start gateway loop heartbeat", exc_info=True)
+
+        await self._start_account_usage_presence()
 
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)
@@ -9596,6 +9704,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 platform.value,
                                 exc_info=True,
                             )
+                        try:
+                            await self._notify_account_usage_presence_adapters_changed()
+                        except Exception:
+                            logger.debug(
+                                "account-usage presence recovery after %s reconnect failed",
+                                platform.value,
+                                exc_info=True,
+                            )
                     # Check if the failure is non-retryable
                     elif adapter.has_fatal_error and not adapter.fatal_error_retryable:
                         self._update_platform_runtime_status(
@@ -10043,6 +10159,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await self._cleanup_agent_resources_off_loop(
                         _agent, context="shutdown idle-cache"
                     )
+
+            # Restore any global profile identity/activity while adapters are
+            # still connected. This runs before teardown so Telegram can put
+            # the saved default name back after a clean stop or feature disable.
+            stop_account_usage_presence = getattr(
+                self,
+                "_stop_account_usage_presence",
+                None,
+            )
+            if callable(stop_account_usage_presence):
+                await stop_account_usage_presence()
 
             for platform, adapter in list(self.adapters.items()):
                 await self._bounded_adapter_teardown(adapter, platform)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8075,20 +8075,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     exc_info=True,
                 )
 
-    async def _recover_secondary_profile_account_usage_presence(self) -> None:
+    async def _recover_secondary_profile_account_usage_presence(
+        self, profile_name: Optional[str] = None
+    ) -> None:
         """Fetchless CAS recovery for each secondary multiplex profile journal."""
 
         profile_adapters = getattr(self, "_profile_adapters", None) or {}
-        if not profile_adapters:
+        if profile_name is not None:
+            adapters = profile_adapters.get(profile_name)
+            profile_items = [(profile_name, adapters)] if adapters else []
+        else:
+            profile_items = list(profile_adapters.items())
+        if not profile_items:
             return
 
         from gateway.account_usage_presence import account_usage_presence_state_path
+        from hermes_cli.profiles import get_profile_dir
 
-        for profile_name, adapters in list(profile_adapters.items()):
+        for profile_name, adapters in profile_items:
             if not adapters:
                 continue
             try:
-                with self._profile_runtime_scope(profile_name):
+                profile_home = get_profile_dir(profile_name)
+                with _profile_runtime_scope(profile_home):
                     controller = AccountUsagePresenceController(
                         AccountUsagePresenceConfig(),
                         lambda adapters=adapters: adapters,
@@ -10657,6 +10666,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "✓ %s reconnected (profile: %s)",
                                 platform.value,
                                 profile_name,
+                            )
+                            await self._recover_secondary_profile_account_usage_presence(
+                                profile_name
                             )
                             return
                         # A newer reconnect already won the slot while this

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8817,6 +8817,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._wire_teams_pipeline_runtime()
 
         self._running = True
+        self._schedule_pending_secondary_profile_reconnects()
         self._update_runtime_status("running")
         # Loop-liveness heartbeat (#66892): an asyncio task so a frozen loop
         # stops refreshing ``state/gateway.heartbeat``. Cancelled with the
@@ -10597,9 +10598,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     logger.warning("✗ %s failed to connect (profile: %s)", platform.value, profile_name)
                     await self._safe_adapter_disconnect(adapter, platform)
+                    self._remember_secondary_profile_startup_failure(
+                        profile_name, platform, adapter
+                    )
             except Exception as e:
                 logger.error("✗ %s error (profile: %s): %s", platform.value, profile_name, e)
                 await self._safe_adapter_disconnect(adapter, platform)
+                self._remember_secondary_profile_startup_failure(
+                    profile_name, platform, adapter
+                )
         return connected
 
     def _configure_profile_adapter(
@@ -10749,6 +10756,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._background_tasks = background_tasks
         background_tasks.add(task)
         task.add_done_callback(background_tasks.discard)
+
+    def _remember_secondary_profile_startup_failure(
+        self,
+        profile_name: str,
+        platform: Platform,
+        adapter: BasePlatformAdapter,
+    ) -> None:
+        """Retain retryable secondary startup failures until the runner is live."""
+        if (
+            getattr(adapter, "has_fatal_error", False)
+            and not getattr(adapter, "fatal_error_retryable", True)
+        ):
+            return
+        pending = getattr(self, "_pending_secondary_profile_reconnects", None)
+        if not isinstance(pending, dict):
+            pending = {}
+            self._pending_secondary_profile_reconnects = pending
+        pending[(profile_name, platform)] = adapter
+
+    def _schedule_pending_secondary_profile_reconnects(self) -> None:
+        """Publish startup failures after ``_running`` enables reconnect loops."""
+        pending = getattr(self, "_pending_secondary_profile_reconnects", None)
+        if not isinstance(pending, dict) or not pending:
+            return
+        self._pending_secondary_profile_reconnects = {}
+        for (profile_name, platform), adapter in pending.items():
+            self._schedule_secondary_profile_reconnect(
+                profile_name,
+                platform,
+                adapter,
+            )
 
     def _make_profile_fatal_error_handler(
         self, profile_name: str, platform: Platform

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3309,6 +3309,19 @@ DEFAULT_CONFIG = {
         # adapter. ``0`` disables the cap. Default 128 MiB.
         "max_inbound_media_bytes": 134217728,
 
+        # Opt-in provider account usage rendered on messaging bot identity
+        # surfaces (Telegram display name, Discord activity). Disabled by
+        # default. When enabled, provider must be an explicit quota source
+        # (openai-codex / anthropic / openrouter) and platforms must list
+        # supported adapters only (telegram / discord). Not supported with
+        # gateway.multiplex_profiles.
+        "account_usage_presence": {
+            "enabled": False,
+            "platforms": [],
+            "update_interval_seconds": 300,
+            "stale_after_seconds": 900,
+        },
+
         # When false (default), any file path the agent emits is delivered
         # as a native attachment as long as it isn't under the credential /
         # system-path denylist (/etc, /proc, ~/.ssh, ~/.aws, ~/.hermes/.env,

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1999,6 +1999,92 @@ def _setup_webhooks():
     print_info("   Open config in your editor:  hermes config edit")
 
 
+def _setup_account_usage_presence(config: dict) -> None:
+    """Optional opt-in for provider account usage on bot identity surfaces."""
+
+    from hermes_cli.config import save_config
+
+    print()
+    print_info("Account Usage Presence (optional)")
+    print_info(
+        "Show remaining provider usage on supported bot identity surfaces "
+        "(Telegram display name, Discord activity)."
+    )
+    print_info(
+        "Requires an explicit provider (openai-codex / anthropic / openrouter) "
+        "and is not supported with gateway.multiplex_profiles."
+    )
+    if not prompt_yes_no("Enable account usage presence?", default=False):
+        gateway = config.setdefault("gateway", {})
+        gateway["account_usage_presence"] = {
+            "enabled": False,
+            "platforms": [],
+            "update_interval_seconds": 300,
+            "stale_after_seconds": 900,
+        }
+        save_config(config)
+        return
+
+    provider_choices = [
+        "openai-codex",
+        "anthropic",
+        "openrouter",
+        "Skip / leave disabled",
+    ]
+    provider_idx = prompt_choice(
+        "Which provider account should be shown?",
+        provider_choices,
+        0,
+    )
+    if provider_idx >= len(provider_choices) - 1:
+        gateway = config.setdefault("gateway", {})
+        gateway["account_usage_presence"] = {
+            "enabled": False,
+            "platforms": [],
+            "update_interval_seconds": 300,
+            "stale_after_seconds": 900,
+        }
+        save_config(config)
+        return
+
+    platform_items = [
+        "Telegram display name",
+        "Discord activity",
+    ]
+    selected = prompt_checklist(
+        "Which platforms should show account usage?",
+        platform_items,
+        [0, 1],
+    )
+    platform_map = {0: "telegram", 1: "discord"}
+    platforms = [platform_map[idx] for idx in selected if idx in platform_map]
+    if not platforms:
+        print_warning("No platforms selected; leaving account usage presence disabled.")
+        gateway = config.setdefault("gateway", {})
+        gateway["account_usage_presence"] = {
+            "enabled": False,
+            "platforms": [],
+            "update_interval_seconds": 300,
+            "stale_after_seconds": 900,
+        }
+        save_config(config)
+        return
+
+    gateway = config.setdefault("gateway", {})
+    gateway["account_usage_presence"] = {
+        "enabled": True,
+        "provider": provider_choices[provider_idx],
+        "platforms": platforms,
+        "update_interval_seconds": 300,
+        "stale_after_seconds": 900,
+    }
+    save_config(config)
+    print_success(
+        "Account usage presence enabled for "
+        f"{provider_choices[provider_idx]} on {', '.join(platforms)}."
+    )
+
+
 def setup_gateway(config: dict):
     """Configure messaging platform integrations."""
     from hermes_cli.gateway import _all_platforms, _platform_status, _configure_platform
@@ -2047,6 +2133,7 @@ def setup_gateway(config: dict):
         print()
         print_info("━" * 50)
         print_success("Messaging platforms configured!")
+        _setup_account_usage_presence(config)
 
         # Check if any home channels are missing
         missing_home = []

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2014,15 +2014,26 @@ def _setup_account_usage_presence(config: dict) -> None:
         "Requires an explicit provider (openai-codex / anthropic / openrouter) "
         "and is not supported with gateway.multiplex_profiles."
     )
-    if not prompt_yes_no("Enable account usage presence?", default=False):
-        gateway = config.setdefault("gateway", {})
-        gateway["account_usage_presence"] = {
-            "enabled": False,
-            "platforms": [],
-            "update_interval_seconds": 300,
-            "stale_after_seconds": 900,
-        }
-        save_config(config)
+    gateway = config.setdefault("gateway", {})
+    if not isinstance(gateway, dict):
+        gateway = {}
+        config["gateway"] = gateway
+    raw_presence = gateway.get("account_usage_presence")
+    existing = dict(raw_presence) if isinstance(raw_presence, dict) else {}
+    presence = {
+        "enabled": bool(existing.get("enabled", False)),
+        "platforms": list(existing.get("platforms") or []),
+        "update_interval_seconds": existing.get("update_interval_seconds", 300),
+        "stale_after_seconds": existing.get("stale_after_seconds", 900),
+    }
+    presence.update(existing)
+
+    if not prompt_yes_no(
+        "Enable account usage presence?",
+        default=bool(presence["enabled"]),
+    ):
+        # Declining this optional section means "leave it alone" on reruns.
+        # An explicit disable remains available in the provider choices below.
         return
 
     provider_choices = [
@@ -2031,19 +2042,20 @@ def _setup_account_usage_presence(config: dict) -> None:
         "openrouter",
         "Skip / leave disabled",
     ]
+    current_provider = str(presence.get("provider") or "").strip().lower()
+    provider_default = (
+        provider_choices.index(current_provider)
+        if current_provider in provider_choices[:-1]
+        else 0
+    )
     provider_idx = prompt_choice(
         "Which provider account should be shown?",
         provider_choices,
-        0,
+        provider_default,
     )
     if provider_idx >= len(provider_choices) - 1:
-        gateway = config.setdefault("gateway", {})
-        gateway["account_usage_presence"] = {
-            "enabled": False,
-            "platforms": [],
-            "update_interval_seconds": 300,
-            "stale_after_seconds": 900,
-        }
+        presence["enabled"] = False
+        gateway["account_usage_presence"] = presence
         save_config(config)
         return
 
@@ -2051,33 +2063,33 @@ def _setup_account_usage_presence(config: dict) -> None:
         "Telegram display name",
         "Discord activity",
     ]
+    platform_map = {0: "telegram", 1: "discord"}
+    current_platforms = {
+        str(value).strip().lower()
+        for value in presence.get("platforms", [])
+        if str(value).strip().lower() in platform_map.values()
+    }
+    pre_selected = [
+        index
+        for index, platform in platform_map.items()
+        if platform in current_platforms
+    ]
     selected = prompt_checklist(
         "Which platforms should show account usage?",
         platform_items,
-        [0, 1],
+        pre_selected,
     )
-    platform_map = {0: "telegram", 1: "discord"}
     platforms = [platform_map[idx] for idx in selected if idx in platform_map]
     if not platforms:
-        print_warning("No platforms selected; leaving account usage presence disabled.")
-        gateway = config.setdefault("gateway", {})
-        gateway["account_usage_presence"] = {
-            "enabled": False,
-            "platforms": [],
-            "update_interval_seconds": 300,
-            "stale_after_seconds": 900,
-        }
-        save_config(config)
+        print_warning(
+            "No platforms selected; leaving account usage presence unchanged."
+        )
         return
 
-    gateway = config.setdefault("gateway", {})
-    gateway["account_usage_presence"] = {
-        "enabled": True,
-        "provider": provider_choices[provider_idx],
-        "platforms": platforms,
-        "update_interval_seconds": 300,
-        "stale_after_seconds": 900,
-    }
+    presence["enabled"] = True
+    presence["provider"] = provider_choices[provider_idx]
+    presence["platforms"] = platforms
+    gateway["account_usage_presence"] = presence
     save_config(config)
     print_success(
         "Account usage presence enabled for "

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2008,7 +2008,7 @@ def _setup_account_usage_presence(config: dict) -> None:
     print_info("Account Usage Presence (optional)")
     print_info(
         "Show remaining provider usage on supported bot identity surfaces "
-        "(Telegram display name, Discord activity)."
+        "(Telegram display name, Discord activity, Matrix presence status)."
     )
     print_info(
         "Requires an explicit provider (openai-codex / anthropic / openrouter) "
@@ -2062,8 +2062,9 @@ def _setup_account_usage_presence(config: dict) -> None:
     platform_items = [
         "Telegram display name",
         "Discord activity",
+        "Matrix presence status",
     ]
-    platform_map = {0: "telegram", 1: "discord"}
+    platform_map = {0: "telegram", 1: "discord", 2: "matrix"}
     current_platforms = {
         str(value).strip().lower()
         for value in presence.get("platforms", [])

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -120,6 +120,10 @@ except ImportError:
     from ffmpeg_utils import resolve_ffmpeg_executable
 
 from gateway.config import Platform, PlatformConfig
+from gateway.account_usage_presence import (
+    AccountUsagePresenceCapabilities,
+    AccountUsagePresencePayload,
+)
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker, convert_table_to_bullets
 from utils import atomic_json_write, env_float, env_int
@@ -1670,6 +1674,32 @@ class DiscordAdapter(BasePlatformAdapter):
         headroom = max(0.5, budget * 0.2)
         deadline = max(1.0, budget - headroom)
         return min(deadline, budget * 0.9)
+
+    @property
+    def account_usage_presence_capabilities(self) -> AccountUsagePresenceCapabilities:
+        return AccountUsagePresenceCapabilities(activity=True)
+
+    async def apply_account_usage_presence(
+        self,
+        payload: AccountUsagePresencePayload,
+        baseline: Optional[Dict[str, Any]],
+    ) -> bool:
+        client = self._client
+        if client is None:
+            return False
+        if payload.remaining_percent is None:
+            text = "Usage unavailable"
+        else:
+            label = " ".join(str(payload.label or "Usage").split())
+            text = f"{label} {payload.remaining_percent}% remaining"
+            if payload.cached:
+                text += " (cached)"
+        activity = discord.Activity(
+            type=discord.ActivityType.watching,
+            name=text[:128],
+        )
+        await client.change_presence(activity=activity)
+        return True
 
     async def disconnect(self) -> None:
         """Disconnect from Discord."""

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -125,6 +125,12 @@ except ImportError:
     TrustState = _TrustStateStub  # type: ignore[misc,assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.account_usage_presence import (
+    AccountUsagePresenceApplyResult,
+    AccountUsagePresenceCapabilities,
+    AccountUsagePresencePayload,
+    AccountUsagePresenceRestoreResult,
+)
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -4058,6 +4064,127 @@ class MatrixAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     _VALID_PRESENCE_STATES = frozenset(("online", "offline", "unavailable"))
+
+    @property
+    def account_usage_presence_capabilities(self) -> AccountUsagePresenceCapabilities:
+        """Expose Matrix user presence status as an account-usage surface."""
+
+        return AccountUsagePresenceCapabilities(activity=True)
+
+    def account_usage_presence_state_key(self) -> str:
+        """Keep the journal isolated per Matrix bot identity."""
+
+        user_id = self._user_id or getattr(self._client, "mxid", "")
+        return f"matrix:{user_id}" if user_id else super().account_usage_presence_state_key()
+
+    @classmethod
+    def _normalize_account_usage_presence_state(
+        cls,
+        value: Any,
+    ) -> Optional[Dict[str, str]]:
+        if not isinstance(value, dict):
+            return None
+        raw_presence = value.get("presence", "online")
+        presence = str(getattr(raw_presence, "value", raw_presence) or "").strip().lower()
+        if presence not in cls._VALID_PRESENCE_STATES:
+            return None
+        status_msg = str(value.get("status_msg") or "")[:255]
+        return {"presence": presence, "status_msg": status_msg}
+
+    async def _read_account_usage_presence(self) -> Optional[Dict[str, str]]:
+        client = self._client
+        user_id = self._user_id or getattr(client, "mxid", "")
+        if client is None or not user_id or not hasattr(client, "get_presence"):
+            return None
+        current = await client.get_presence(UserID(user_id))
+        return self._normalize_account_usage_presence_state(
+            {
+                "presence": getattr(current, "presence", "online"),
+                "status_msg": getattr(current, "status_msg", ""),
+            }
+        )
+
+    @staticmethod
+    def _account_usage_presence_status(payload: AccountUsagePresencePayload) -> str:
+        label = " ".join(str(payload.label or "Usage").split()) or "Usage"
+        if payload.remaining_percent is None:
+            status = f"{label}: usage unavailable"
+        else:
+            status = f"{label}: {payload.remaining_percent}% remaining"
+        if payload.cached:
+            status += " (cached)"
+        return status[:255]
+
+    def build_account_usage_presence_owned_state(
+        self,
+        payload: AccountUsagePresencePayload,
+        baseline: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        state = self._normalize_account_usage_presence_state(baseline)
+        if state is None:
+            return None
+        return {
+            "presence": state["presence"],
+            "status_msg": self._account_usage_presence_status(payload),
+        }
+
+    async def capture_account_usage_presence_baseline(
+        self,
+    ) -> Optional[Dict[str, Any]]:
+        return await self._read_account_usage_presence()
+
+    async def apply_account_usage_presence(
+        self,
+        payload: AccountUsagePresencePayload,
+        baseline: Optional[Dict[str, Any]],
+    ) -> bool:
+        if baseline is None:
+            return False
+        owned = self.build_account_usage_presence_owned_state(payload, baseline)
+        if owned is None:
+            return False
+        return await self.set_presence(owned["presence"], owned["status_msg"])
+
+    async def apply_account_usage_presence_if_owned(
+        self,
+        payload: AccountUsagePresencePayload,
+        baseline: Dict[str, Any],
+        expected_owned: Dict[str, Any],
+    ) -> AccountUsagePresenceApplyResult:
+        current = await self._read_account_usage_presence()
+        expected = self._normalize_account_usage_presence_state(expected_owned)
+        if current is None or expected is None:
+            return AccountUsagePresenceApplyResult.RETRY
+        if current != expected:
+            return AccountUsagePresenceApplyResult.EXTERNAL
+        owned = self.build_account_usage_presence_owned_state(payload, baseline)
+        if owned is None:
+            return AccountUsagePresenceApplyResult.RETRY
+        changed = await self.set_presence(owned["presence"], owned["status_msg"])
+        return (
+            AccountUsagePresenceApplyResult.APPLIED
+            if changed
+            else AccountUsagePresenceApplyResult.RETRY
+        )
+
+    async def restore_account_usage_presence(
+        self,
+        baseline: Dict[str, Any],
+        owned: Dict[str, Any],
+    ) -> AccountUsagePresenceRestoreResult:
+        current = await self._read_account_usage_presence()
+        expected_owned = self._normalize_account_usage_presence_state(owned)
+        target = self._normalize_account_usage_presence_state(baseline)
+        if current is None or expected_owned is None or target is None:
+            return AccountUsagePresenceRestoreResult.RETRY
+        if current != expected_owned:
+            return AccountUsagePresenceRestoreResult.EXTERNAL
+        restored = await self.set_presence(target["presence"], target["status_msg"])
+        return (
+            AccountUsagePresenceRestoreResult.RESTORED
+            if restored
+            else AccountUsagePresenceRestoreResult.RETRY
+        )
 
     async def set_presence(self, state: str = "online", status_msg: str = "") -> bool:
         """Set the bot's presence status."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -262,6 +262,11 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.authz_mixin import _coerce_allow_set
 from gateway.config import Platform, PlatformConfig
+from gateway.account_usage_presence import (
+    AccountUsagePresenceCapabilities,
+    AccountUsagePresencePayload,
+    AccountUsagePresenceRestoreResult,
+)
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -4100,6 +4105,92 @@ class TelegramAdapter(BasePlatformAdapter):
             self._set_fatal_error("telegram_connect_error", message, retryable=True)
             logger.error("[%s] Failed to connect to Telegram: %s", self.name, safe_error)
             return False
+
+    @property
+    def account_usage_presence_capabilities(self) -> AccountUsagePresenceCapabilities:
+        return AccountUsagePresenceCapabilities(display_name=True)
+
+    def account_usage_presence_state_key(self) -> str:
+        bot = self._bot
+        if bot is None:
+            return super().account_usage_presence_state_key()
+        return f"telegram:{bot.id}"
+
+    async def capture_account_usage_presence_baseline(
+        self,
+    ) -> Optional[Dict[str, Any]]:
+        bot = self._bot
+        if bot is None:
+            return None
+        current = await bot.get_my_name()
+        name = str(getattr(current, "name", "") or "").strip()
+        if not name:
+            return None
+        return {"display_name": name}
+
+    @staticmethod
+    def _account_usage_presence_name(
+        payload: AccountUsagePresencePayload,
+        baseline: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        if not baseline:
+            return None
+        base_name = str(baseline.get("display_name") or "").strip()
+        if not base_name:
+            return None
+        if payload.remaining_percent is None:
+            suffix = " · usage unavailable"
+        else:
+            label = " ".join(str(payload.label or "Usage").split())
+            suffix = f" · {label} {payload.remaining_percent}%"
+            if payload.cached:
+                suffix += " (cached)"
+        available = 64 - len(suffix)
+        if available <= 0:
+            return suffix[-64:]
+        return f"{base_name[:available].rstrip()}{suffix}"
+
+    def build_account_usage_presence_owned_state(
+        self,
+        payload: AccountUsagePresencePayload,
+        baseline: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        name = self._account_usage_presence_name(payload, baseline)
+        return {"display_name": name} if name is not None else None
+
+    async def apply_account_usage_presence(
+        self,
+        payload: AccountUsagePresencePayload,
+        baseline: Optional[Dict[str, Any]],
+    ) -> bool:
+        bot = self._bot
+        name = self._account_usage_presence_name(payload, baseline)
+        if bot is None or name is None:
+            return False
+        await bot.set_my_name(name=name)
+        return True
+
+    async def restore_account_usage_presence(
+        self,
+        baseline: Dict[str, Any],
+        owned: Dict[str, Any],
+    ) -> AccountUsagePresenceRestoreResult:
+        bot = self._bot
+        if bot is None:
+            return AccountUsagePresenceRestoreResult.RETRY
+        baseline_name = str(baseline.get("display_name") or "").strip()
+        owned_name = str(owned.get("display_name") or "").strip()
+        if not baseline_name or not owned_name:
+            return AccountUsagePresenceRestoreResult.RETRY
+
+        current = await bot.get_my_name()
+        current_name = str(getattr(current, "name", "") or "").strip()
+        if current_name == baseline_name:
+            return AccountUsagePresenceRestoreResult.ALREADY_BASELINE
+        if current_name != owned_name:
+            return AccountUsagePresenceRestoreResult.EXTERNAL
+        await bot.set_my_name(name=baseline_name)
+        return AccountUsagePresenceRestoreResult.RESTORED
 
     async def _set_status_indicator(self, online: bool) -> None:
         """Set the bot's short description to the online/offline status text.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -263,6 +263,7 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 from gateway.authz_mixin import _coerce_allow_set
 from gateway.config import Platform, PlatformConfig
 from gateway.account_usage_presence import (
+    AccountUsagePresenceApplyResult,
     AccountUsagePresenceCapabilities,
     AccountUsagePresencePayload,
     AccountUsagePresenceRestoreResult,
@@ -4169,6 +4170,27 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         await bot.set_my_name(name=name)
         return True
+
+    async def apply_account_usage_presence_if_owned(
+        self,
+        payload: AccountUsagePresencePayload,
+        baseline: Dict[str, Any],
+        expected_owned: Dict[str, Any],
+    ) -> AccountUsagePresenceApplyResult:
+        """Apply one name generation only while the prior generation is live."""
+
+        bot = self._bot
+        name = self._account_usage_presence_name(payload, baseline)
+        expected_name = str(expected_owned.get("display_name") or "").strip()
+        if bot is None or name is None or not expected_name:
+            return AccountUsagePresenceApplyResult.RETRY
+
+        current = await bot.get_my_name()
+        current_name = str(getattr(current, "name", "") or "").strip()
+        if current_name != expected_name:
+            return AccountUsagePresenceApplyResult.EXTERNAL
+        await bot.set_my_name(name=name)
+        return AccountUsagePresenceApplyResult.APPLIED
 
     async def restore_account_usage_presence(
         self,

--- a/tests/agent/test_account_usage_outcome.py
+++ b/tests/agent/test_account_usage_outcome.py
@@ -45,3 +45,125 @@ def test_fetch_outcome_preserves_provider_retry_after(monkeypatch):
     assert outcome.retry_after_seconds == 600.0
     assert outcome.failed is True
     assert account_usage.fetch_account_usage("anthropic") is None
+
+
+def test_openrouter_credits_success_key_rate_limit_preserves_partial_snapshot(monkeypatch):
+    class _Client:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def get(self, url, *, headers):
+            request = account_usage.httpx.Request("GET", url)
+            if url.endswith("/credits"):
+                return account_usage.httpx.Response(
+                    200,
+                    json={"data": {"total_credits": 10, "total_usage": 3}},
+                    request=request,
+                )
+            return account_usage.httpx.Response(
+                429,
+                headers={"Retry-After": "120"},
+                request=request,
+            )
+
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "or-key",
+            "base_url": "https://openrouter.example/api/v1",
+        },
+    )
+    monkeypatch.setattr(account_usage.httpx, "Client", lambda **kwargs: _Client())
+
+    outcome = account_usage.fetch_account_usage_outcome("openrouter")
+
+    assert outcome.failed is True
+    assert outcome.retry_after_seconds == 120.0
+    assert outcome.snapshot is not None
+    assert outcome.snapshot.details == ("Credits balance: $7.00",)
+    assert outcome.snapshot.windows == ()
+
+
+@pytest.mark.asyncio
+async def test_openrouter_rate_limit_outcome_is_used_by_controller_before_deadline(
+    tmp_path,
+):
+    from gateway.account_usage_presence import (
+        AccountUsagePresenceCapabilities,
+        AccountUsagePresenceController,
+    )
+    from gateway.config import AccountUsagePresenceConfig
+
+    class _Clock:
+        now = 0.0
+
+        def __call__(self):
+            return self.now
+
+    clock = _Clock()
+    calls = []
+
+    def fetch(provider):
+        calls.append(provider)
+        if len(calls) == 1:
+            return account_usage.AccountUsageFetchOutcome(
+                snapshot=account_usage.AccountUsageSnapshot(
+                    provider="openrouter",
+                    source="credits_api",
+                    fetched_at=datetime.now(timezone.utc),
+                    windows=(
+                        account_usage.AccountUsageWindow(
+                            label="API key quota", used_percent=25
+                        ),
+                    ),
+                    details=("Credits balance: $7.00",),
+                ),
+                retry_after_seconds=120.0,
+                failed=True,
+            )
+        return account_usage.AccountUsageSnapshot(
+            provider="openrouter",
+            source="credits_api",
+            fetched_at=datetime.now(timezone.utc),
+            windows=(
+                account_usage.AccountUsageWindow(label="API key quota", used_percent=30),
+            ),
+        )
+
+    class _Adapter:
+        def __init__(self):
+            self.account_usage_presence_capabilities = AccountUsagePresenceCapabilities(
+                activity=True
+            )
+            self.applied = []
+
+        async def apply_account_usage_presence(self, payload, baseline):
+            self.applied.append(payload)
+            return True
+
+    adapter = _Adapter()
+    controller = AccountUsagePresenceController(
+        AccountUsagePresenceConfig.from_dict(
+            {
+                "enabled": True,
+                "provider": "openrouter",
+                "platforms": ["discord"],
+            }
+        ),
+        lambda: {"discord": adapter},
+        fetcher=fetch,
+        state_path=tmp_path / "journal.json",
+        monotonic=clock,
+    )
+
+    await controller.refresh_once()
+    clock.now = 119
+    await controller.refresh_once()
+
+    assert calls == ["openrouter"]
+    assert len(adapter.applied) == 2
+    assert adapter.applied[-1].cached is True

--- a/tests/agent/test_account_usage_outcome.py
+++ b/tests/agent/test_account_usage_outcome.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from agent import account_usage
+
+
+class _RateLimited(RuntimeError):
+    def __init__(self, retry_after=None, *, header=None):
+        super().__init__("rate limited")
+        self.retry_after = retry_after
+        self.response = SimpleNamespace(headers={"Retry-After": header} if header else {})
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (120, 120.0),
+        ("45", 45.0),
+        (timedelta(seconds=30), 30.0),
+    ],
+)
+def test_retry_after_seconds_supports_numeric_and_timedelta(value, expected):
+    assert account_usage.retry_after_seconds(_RateLimited(value)) == expected
+
+
+def test_retry_after_seconds_supports_http_date():
+    now = datetime(2030, 1, 2, 3, 4, tzinfo=timezone.utc)
+    exc = _RateLimited(header="Wed, 02 Jan 2030 03:06:00 GMT")
+
+    assert account_usage.retry_after_seconds(exc, now=now) == 120.0
+
+
+def test_fetch_outcome_preserves_provider_retry_after(monkeypatch):
+    monkeypatch.setattr(
+        account_usage,
+        "_fetch_anthropic_account_usage",
+        lambda: (_ for _ in ()).throw(_RateLimited(timedelta(minutes=10))),
+    )
+
+    outcome = account_usage.fetch_account_usage_outcome("anthropic")
+
+    assert outcome.snapshot is None
+    assert outcome.retry_after_seconds == 600.0
+    assert outcome.failed is True
+    assert account_usage.fetch_account_usage("anthropic") is None

--- a/tests/gateway/test_account_usage_presence.py
+++ b/tests/gateway/test_account_usage_presence.py
@@ -8,6 +8,7 @@ import pytest
 
 from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
 from gateway.account_usage_presence import (
+    AccountUsagePresenceApplyResult,
     AccountUsagePresenceCapabilities,
     AccountUsagePresenceController,
     AccountUsagePresenceRestoreResult,
@@ -87,6 +88,19 @@ class _Adapter:
             raise self.apply_error
         self.applied.append((payload, baseline))
         return True
+
+    async def apply_account_usage_presence_if_owned(
+        self,
+        payload,
+        baseline,
+        expected_owned,
+    ) -> AccountUsagePresenceApplyResult:
+        changed = await self.apply_account_usage_presence(payload, baseline)
+        return (
+            AccountUsagePresenceApplyResult.APPLIED
+            if changed
+            else AccountUsagePresenceApplyResult.RETRY
+        )
 
     async def restore_account_usage_presence(self, baseline, owned):
         self.restored.append((baseline, owned))
@@ -526,6 +540,131 @@ async def test_later_false_apply_recovers_prior_owned_after_rollback_write_failu
     ]
     assert telegram.remote_state == baseline
     assert not state_path.exists() or json.loads(state_path.read_text())["entries"] == {}
+
+
+@pytest.mark.asyncio
+async def test_pending_transition_blocks_reapply_until_restart_recovery(tmp_path):
+    class AmbiguousAdapter(_Adapter):
+        def __init__(self, *args, remote_state, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.remote_state = dict(remote_state)
+            self.guarded_calls = 0
+
+        async def apply_account_usage_presence_if_owned(
+            self,
+            payload,
+            baseline,
+            expected_owned,
+        ) -> AccountUsagePresenceApplyResult:
+            self.guarded_calls += 1
+            if self.remote_state != expected_owned:
+                return AccountUsagePresenceApplyResult.EXTERNAL
+            if self.guarded_calls == 2:
+                raise TimeoutError("ambiguous provider timeout")
+            desired = self.build_account_usage_presence_owned_state(payload, baseline)
+            assert desired is not None
+            self.remote_state = dict(desired)
+            self.applied.append((payload, baseline))
+            return AccountUsagePresenceApplyResult.APPLIED
+
+        async def restore_account_usage_presence(self, baseline, owned):
+            self.restored.append((baseline, owned))
+            if self.remote_state == owned:
+                self.remote_state = dict(baseline)
+                return AccountUsagePresenceRestoreResult.RESTORED
+            return AccountUsagePresenceRestoreResult.EXTERNAL
+
+    state_path = tmp_path / "journal.json"
+    baseline = {"display_name": "Hermes"}
+    telegram = AmbiguousAdapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline=baseline,
+        remote_state=baseline,
+    )
+    snapshots = iter(
+        (
+            _snapshot(used_percent=25),
+            _snapshot(used_percent=26),
+            _snapshot(used_percent=27),
+        )
+    )
+    controller = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: next(snapshots),
+        state_path=state_path,
+    )
+
+    await controller.refresh_once()
+    await controller.refresh_once()
+    await controller.refresh_once()
+
+    assert telegram.guarded_calls == 2
+    pending = json.loads(state_path.read_text())["entries"]["telegram"]
+    assert pending["phase"] == "pending"
+    assert pending["owned"] == {"display_name": "owned-74"}
+    assert pending["previous_owned"] == {"display_name": "owned-75"}
+
+    restarted = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: None,
+        state_path=state_path,
+    )
+    await restarted.stop()
+
+    assert telegram.restored == [
+        (baseline, {"display_name": "owned-74"}),
+        (baseline, {"display_name": "owned-75"}),
+    ]
+    assert telegram.remote_state == baseline
+
+
+@pytest.mark.asyncio
+async def test_external_identity_change_is_not_overwritten_by_next_generation(tmp_path):
+    class GuardedAdapter(_Adapter):
+        def __init__(self, *args, remote_state, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.remote_state = dict(remote_state)
+
+        async def apply_account_usage_presence_if_owned(
+            self,
+            payload,
+            baseline,
+            expected_owned,
+        ) -> AccountUsagePresenceApplyResult:
+            if self.remote_state != expected_owned:
+                return AccountUsagePresenceApplyResult.EXTERNAL
+            desired = self.build_account_usage_presence_owned_state(payload, baseline)
+            assert desired is not None
+            self.remote_state = dict(desired)
+            self.applied.append((payload, baseline))
+            return AccountUsagePresenceApplyResult.APPLIED
+
+    state_path = tmp_path / "journal.json"
+    baseline = {"display_name": "Hermes"}
+    telegram = GuardedAdapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline=baseline,
+        remote_state=baseline,
+    )
+    snapshots = iter((_snapshot(used_percent=25), _snapshot(used_percent=26)))
+    controller = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: next(snapshots),
+        state_path=state_path,
+    )
+
+    await controller.refresh_once()
+    telegram.remote_state = {"display_name": "Operator override"}
+    await controller.refresh_once()
+
+    assert telegram.remote_state == {"display_name": "Operator override"}
+    assert len(telegram.applied) == 1
+    assert json.loads(state_path.read_text())["entries"] == {}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_account_usage_presence.py
+++ b/tests/gateway/test_account_usage_presence.py
@@ -93,6 +93,16 @@ class _Adapter:
         return self.restore_result
 
 
+class _ApplyResultAdapter(_Adapter):
+    def __init__(self, *args, apply_results, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._apply_results = iter(apply_results)
+
+    async def apply_account_usage_presence(self, payload, baseline):
+        self.applied.append((payload, baseline))
+        return next(self._apply_results)
+
+
 def _config(**overrides) -> AccountUsagePresenceConfig:
     data = {
         "enabled": True,
@@ -390,6 +400,59 @@ async def test_baseline_is_persisted_before_mutation_and_restored_on_stop(tmp_pa
         ({"display_name": "Hermes"}, {"display_name": "owned-75"})
     ]
     assert not state_path.exists() or json.loads(state_path.read_text())["entries"] == {}
+
+
+@pytest.mark.asyncio
+async def test_later_false_apply_keeps_prior_owned_journal_for_stop(tmp_path):
+    state_path = tmp_path / "journal.json"
+    telegram = _ApplyResultAdapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline={"display_name": "Hermes"},
+        apply_results=(True, False),
+    )
+    snapshots = iter((_snapshot(used_percent=25), _snapshot(used_percent=26)))
+    controller = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: next(snapshots),
+        state_path=state_path,
+    )
+
+    await controller.refresh_once()
+    await controller.refresh_once()
+
+    entry = json.loads(state_path.read_text(encoding="utf-8"))["entries"]["telegram"]
+    assert entry["phase"] == "owned"
+    assert entry["baseline"] == {"display_name": "Hermes"}
+    assert entry["owned"] == {"display_name": "owned-75"}
+
+    await controller.stop()
+
+    assert telegram.restored == [
+        ({"display_name": "Hermes"}, {"display_name": "owned-75"})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_initial_false_apply_discards_never_owned_pending_journal(tmp_path):
+    state_path = tmp_path / "journal.json"
+    telegram = _ApplyResultAdapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline={"display_name": "Hermes"},
+        apply_results=(False,),
+    )
+    controller = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: _snapshot(),
+        state_path=state_path,
+    )
+
+    await controller.refresh_once()
+
+    assert json.loads(state_path.read_text(encoding="utf-8"))["entries"] == {}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_account_usage_presence.py
+++ b/tests/gateway/test_account_usage_presence.py
@@ -831,6 +831,83 @@ async def test_disabled_recovery_retries_after_late_adapter_connect(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_restore_and_apply_are_serialized_per_state_key(tmp_path):
+    class RacingAdapter(_Adapter):
+        def __init__(self, *args, remote_state, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.remote_state = dict(remote_state)
+            self.restore_started = asyncio.Event()
+            self.release_restore = asyncio.Event()
+            self.apply_b_started = asyncio.Event()
+
+        async def apply_account_usage_presence_if_owned(
+            self,
+            payload,
+            baseline,
+            expected_owned,
+        ) -> AccountUsagePresenceApplyResult:
+            if payload.remaining_percent == 74:
+                self.apply_b_started.set()
+            if self.remote_state != expected_owned:
+                return AccountUsagePresenceApplyResult.EXTERNAL
+            owned = self.build_account_usage_presence_owned_state(payload, baseline)
+            assert owned is not None
+            self.remote_state = dict(owned)
+            self.applied.append((payload, baseline))
+            return AccountUsagePresenceApplyResult.APPLIED
+
+        async def restore_account_usage_presence(self, baseline, owned):
+            self.restored.append((baseline, owned))
+            self.restore_started.set()
+            await self.release_restore.wait()
+            if self.remote_state == owned:
+                self.remote_state = dict(baseline)
+                return AccountUsagePresenceRestoreResult.RESTORED
+            if self.remote_state == baseline:
+                return AccountUsagePresenceRestoreResult.ALREADY_BASELINE
+            return AccountUsagePresenceRestoreResult.EXTERNAL
+
+    state_path = tmp_path / "journal.json"
+    baseline = {"display_name": "Hermes"}
+    adapter = RacingAdapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline=baseline,
+        remote_state=baseline,
+    )
+    snapshots = iter((_snapshot(used_percent=25), _snapshot(used_percent=26)))
+
+    def fetch(_provider):
+        return next(snapshots)
+
+    controller = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": adapter},
+        fetcher=fetch,
+        state_path=state_path,
+    )
+
+    await controller.refresh_once()
+    restore_task = asyncio.create_task(controller.recover_saved_baselines())
+    await asyncio.wait_for(adapter.restore_started.wait(), timeout=1)
+
+    apply_task = asyncio.create_task(controller.refresh_once())
+    await asyncio.sleep(0.01)
+    assert not adapter.apply_b_started.is_set()
+    assert not apply_task.done()
+
+    adapter.release_restore.set()
+    await restore_task
+    await apply_task
+
+    assert adapter.remote_state == {"display_name": "owned-74"}
+    journal = json.loads(state_path.read_text(encoding="utf-8"))
+    assert journal["entries"]["telegram"]["owned"] == {
+        "display_name": "owned-74"
+    }
+
+
+@pytest.mark.asyncio
 async def test_malformed_journal_blocks_identity_mutation(tmp_path):
     state_path = tmp_path / "journal.json"
     state_path.write_text("{not-json", encoding="utf-8")

--- a/tests/gateway/test_account_usage_presence.py
+++ b/tests/gateway/test_account_usage_presence.py
@@ -1,0 +1,698 @@
+from datetime import datetime, timezone
+import asyncio
+import json
+import threading
+import time
+
+import pytest
+
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+from gateway.account_usage_presence import (
+    AccountUsagePresenceCapabilities,
+    AccountUsagePresenceController,
+    AccountUsagePresenceRestoreResult,
+    account_usage_presence_payload_from_snapshot,
+)
+from gateway.config import AccountUsagePresenceConfig
+
+
+RESET_AT = datetime(2030, 1, 2, 3, 4, tzinfo=timezone.utc)
+
+
+def _snapshot(
+    *,
+    used_percent: float = 25,
+    label: str = "Session",
+    source: str = "usage_api",
+    reset_at: datetime | None = RESET_AT,
+) -> AccountUsageSnapshot:
+    return AccountUsageSnapshot(
+        provider="openai-codex",
+        source=source,
+        fetched_at=datetime.now(timezone.utc),
+        plan="Pro",
+        windows=(
+            AccountUsageWindow(
+                label=label,
+                used_percent=used_percent,
+                reset_at=reset_at,
+            ),
+        ),
+    )
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+class _RateLimited(RuntimeError):
+    def __init__(self, retry_after: float) -> None:
+        super().__init__("rate limited")
+        self.retry_after = retry_after
+
+
+class _Adapter:
+    def __init__(
+        self,
+        platform: str,
+        *,
+        capabilities: AccountUsagePresenceCapabilities,
+        baseline: dict | None = None,
+    ) -> None:
+        self.platform = platform
+        self.account_usage_presence_capabilities = capabilities
+        self._baseline = baseline
+        self.applied = []
+        self.restored = []
+        self.apply_error: Exception | None = None
+        self.restore_result = AccountUsagePresenceRestoreResult.RESTORED
+
+    def account_usage_presence_state_key(self) -> str:
+        return self.platform
+
+    async def capture_account_usage_presence_baseline(self):
+        return self._baseline
+
+    def build_account_usage_presence_owned_state(self, payload, baseline):
+        if baseline is None:
+            return None
+        return {"display_name": f"owned-{payload.remaining_percent}"}
+
+    async def apply_account_usage_presence(self, payload, baseline):
+        if self.apply_error is not None:
+            raise self.apply_error
+        self.applied.append((payload, baseline))
+        return True
+
+    async def restore_account_usage_presence(self, baseline, owned):
+        self.restored.append((baseline, owned))
+        return self.restore_result
+
+
+def _config(**overrides) -> AccountUsagePresenceConfig:
+    data = {
+        "enabled": True,
+        "provider": "openai-codex",
+        "platforms": ["telegram", "discord"],
+        "update_interval_seconds": 300,
+        "stale_after_seconds": 900,
+    }
+    data.update(overrides)
+    return AccountUsagePresenceConfig.from_dict(data)
+
+
+def test_snapshot_uses_first_percentage_window():
+    payload = account_usage_presence_payload_from_snapshot(_snapshot(used_percent=12.4))
+
+    assert payload is not None
+    assert payload.label == "Session"
+    assert payload.remaining_percent == 88
+
+
+def test_payload_equality_ignores_unrendered_snapshot_metadata():
+    first = account_usage_presence_payload_from_snapshot(
+        _snapshot(source="usage_api", reset_at=RESET_AT)
+    )
+    second = account_usage_presence_payload_from_snapshot(
+        _snapshot(
+            source="different_endpoint",
+            reset_at=datetime(2031, 5, 6, tzinfo=timezone.utc),
+        )
+    )
+
+    assert first is not None
+    assert first == second
+
+
+def test_snapshot_can_select_a_named_window_case_insensitively():
+    snapshot = AccountUsageSnapshot(
+        provider="anthropic",
+        source="oauth_usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(label="Five hour", used_percent=10),
+            AccountUsageWindow(label="Seven day", used_percent=82),
+        ),
+    )
+
+    payload = account_usage_presence_payload_from_snapshot(snapshot, window_label="seven DAY")
+
+    assert payload is not None
+    assert payload.label == "Seven day"
+    assert payload.remaining_percent == 18
+
+
+def test_snapshot_without_matching_percentage_window_is_unsupported():
+    snapshot = AccountUsageSnapshot(
+        provider="openrouter",
+        source="credits_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(AccountUsageWindow(label="Credits", detail="$5 remaining"),),
+    )
+
+    assert account_usage_presence_payload_from_snapshot(snapshot) is None
+    assert account_usage_presence_payload_from_snapshot(snapshot, window_label="missing") is None
+
+
+@pytest.mark.parametrize("used_percent", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_percentage_is_unsupported(used_percent):
+    assert account_usage_presence_payload_from_snapshot(_snapshot(used_percent=used_percent)) is None
+
+
+@pytest.mark.parametrize(
+    ("used_percent", "remaining_percent"),
+    [
+        (0, 100),
+        (50, 50),
+        (51, 49),
+        (80, 20),
+        (81, 19),
+        (99, 1),
+        (100, 0),
+        (150, 0),
+    ],
+)
+def test_percent_clamping(used_percent, remaining_percent):
+    payload = account_usage_presence_payload_from_snapshot(_snapshot(used_percent=used_percent))
+
+    assert payload is not None
+    assert payload.remaining_percent == remaining_percent
+
+
+@pytest.mark.asyncio
+async def test_one_provider_fetch_fans_out_to_two_platforms(tmp_path):
+    telegram = _Adapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline={"display_name": "Hermes"},
+    )
+    discord = _Adapter(
+        "discord",
+        capabilities=AccountUsagePresenceCapabilities(activity=True),
+    )
+    calls = []
+
+    def fetch(provider):
+        calls.append(provider)
+        return _snapshot()
+
+    controller = AccountUsagePresenceController(
+        _config(),
+        lambda: {"telegram": telegram, "discord": discord},
+        fetcher=fetch,
+        state_path=tmp_path / "account-usage-presence.json",
+    )
+
+    await controller.refresh_once()
+
+    assert calls == ["openai-codex"]
+    assert len(telegram.applied) == 1
+    assert len(discord.applied) == 1
+    assert telegram.applied[0][1] == {"display_name": "Hermes"}
+
+
+@pytest.mark.asyncio
+async def test_unchanged_payload_skips_api_but_replacement_adapter_reapplies(tmp_path):
+    current = _Adapter(
+        "discord",
+        capabilities=AccountUsagePresenceCapabilities(activity=True),
+    )
+    adapters = {"discord": current}
+    controller = AccountUsagePresenceController(
+        _config(platforms=["discord"]),
+        lambda: adapters,
+        fetcher=lambda provider: _snapshot(),
+        state_path=tmp_path / "state.json",
+    )
+
+    await controller.refresh_once()
+    await controller.refresh_once()
+    assert len(current.applied) == 1
+
+    replacement = _Adapter(
+        "discord",
+        capabilities=AccountUsagePresenceCapabilities(activity=True),
+    )
+    adapters["discord"] = replacement
+    await controller.refresh_once()
+
+    assert len(replacement.applied) == 1
+
+
+@pytest.mark.asyncio
+async def test_transient_fetch_failure_keeps_value_only_until_stale_ttl(tmp_path):
+    adapter = _Adapter(
+        "discord",
+        capabilities=AccountUsagePresenceCapabilities(activity=True),
+    )
+    snapshots = [_snapshot(), None, None]
+    clock = _Clock()
+    controller = AccountUsagePresenceController(
+        _config(platforms=["discord"], stale_after_seconds=600),
+        lambda: {"discord": adapter},
+        fetcher=lambda provider: snapshots.pop(0),
+        state_path=tmp_path / "state.json",
+        monotonic=clock,
+    )
+
+    await controller.refresh_once()
+    clock.now = 599
+    await controller.refresh_once()
+    assert len(adapter.applied) == 2
+    assert adapter.applied[-1][0].cached is True
+
+    clock.now = 601
+    await controller.refresh_once()
+    assert len(adapter.applied) == 3
+    unknown = adapter.applied[-1][0]
+    assert unknown.label == "Usage"
+    assert unknown.remaining_percent is None
+    assert unknown.cached is False
+
+
+@pytest.mark.asyncio
+async def test_first_fetch_failure_surfaces_unknown_instead_of_stale_value(tmp_path):
+    adapter = _Adapter(
+        "discord",
+        capabilities=AccountUsagePresenceCapabilities(activity=True),
+    )
+    controller = AccountUsagePresenceController(
+        _config(platforms=["discord"]),
+        lambda: {"discord": adapter},
+        fetcher=lambda provider: None,
+        state_path=tmp_path / "state.json",
+    )
+
+    await controller.refresh_once()
+
+    assert len(adapter.applied) == 1
+    assert adapter.applied[0][0].label == "Usage"
+    assert adapter.applied[0][0].remaining_percent is None
+
+
+@pytest.mark.asyncio
+async def test_adapter_retry_after_is_respected_without_blocking_other_platforms(tmp_path):
+    telegram = _Adapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+    )
+    telegram.apply_error = _RateLimited(120)
+    discord = _Adapter(
+        "discord",
+        capabilities=AccountUsagePresenceCapabilities(activity=True),
+    )
+    clock = _Clock()
+    controller = AccountUsagePresenceController(
+        _config(),
+        lambda: {"telegram": telegram, "discord": discord},
+        fetcher=lambda provider: _snapshot(),
+        state_path=tmp_path / "state.json",
+        monotonic=clock,
+    )
+
+    await controller.refresh_once()
+    telegram.apply_error = None
+    clock.now = 119
+    await controller.refresh_once()
+
+    assert telegram.applied == []
+    assert len(discord.applied) == 1
+
+    clock.now = 121
+    await controller.refresh_once()
+    assert len(telegram.applied) == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_retry_after_suppresses_fetch_until_deadline(tmp_path):
+    clock = _Clock()
+    calls = []
+
+    def fetch(provider):
+        calls.append(provider)
+        if len(calls) == 1:
+            raise _RateLimited(120)
+        return _snapshot()
+
+    adapter = _Adapter(
+        "discord",
+        capabilities=AccountUsagePresenceCapabilities(activity=True),
+    )
+    controller = AccountUsagePresenceController(
+        _config(platforms=["discord"]),
+        lambda: {"discord": adapter},
+        fetcher=fetch,
+        state_path=tmp_path / "state.json",
+        monotonic=clock,
+    )
+
+    await controller.refresh_once()
+    clock.now = 119
+    await controller.refresh_once()
+    assert calls == ["openai-codex"]
+
+    clock.now = 121
+    await controller.refresh_once()
+    assert calls == ["openai-codex", "openai-codex"]
+    assert adapter.applied[-1][0].remaining_percent == 75
+
+
+@pytest.mark.asyncio
+async def test_baseline_is_persisted_before_mutation_and_restored_on_stop(tmp_path):
+    state_path = tmp_path / "account-usage-presence" / "journal.json"
+    telegram = _Adapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline={"display_name": "Hermes"},
+    )
+    controller = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: _snapshot(),
+        state_path=state_path,
+    )
+
+    await controller.refresh_once()
+
+    saved = json.loads(state_path.read_text(encoding="utf-8"))
+    entry = saved["entries"]["telegram"]
+    assert entry["baseline"]["display_name"] == "Hermes"
+    assert entry["owned"]["display_name"] == "owned-75"
+    assert entry["phase"] == "owned"
+
+    await controller.stop()
+
+    assert telegram.restored == [
+        ({"display_name": "Hermes"}, {"display_name": "owned-75"})
+    ]
+    assert not state_path.exists() or json.loads(state_path.read_text())["entries"] == {}
+
+
+@pytest.mark.asyncio
+async def test_external_identity_change_is_preserved_on_restore(tmp_path):
+    state_path = tmp_path / "journal.json"
+    telegram = _Adapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline={"display_name": "Hermes"},
+    )
+    telegram.restore_result = AccountUsagePresenceRestoreResult.EXTERNAL
+    controller = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: _snapshot(),
+        state_path=state_path,
+    )
+
+    await controller.refresh_once()
+    await controller.stop()
+
+    assert telegram.restored
+    assert not json.loads(state_path.read_text(encoding="utf-8"))["entries"]
+
+
+@pytest.mark.asyncio
+async def test_disabled_controller_recovers_saved_identity_without_fetching(tmp_path):
+    state_path = tmp_path / "account-usage-presence" / "journal.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "entries": {
+                    "telegram": {
+                        "baseline": {"display_name": "Hermes"},
+                        "owned": {"display_name": "Hermes · Session 75%"},
+                        "phase": "owned",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    telegram = _Adapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+    )
+    controller = AccountUsagePresenceController(
+        AccountUsagePresenceConfig(),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: pytest.fail("disabled controller must not fetch"),
+        state_path=state_path,
+    )
+
+    await controller.start()
+
+    assert telegram.restored == [
+        ({"display_name": "Hermes"}, {"display_name": "Hermes · Session 75%"})
+    ]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["entries"] == {}
+    assert controller.task is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_recovery_retries_after_late_adapter_connect(tmp_path):
+    state_path = tmp_path / "journal.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "entries": {
+                    "telegram": {
+                        "baseline": {"display_name": "Hermes"},
+                        "owned": {"display_name": "Hermes · Session 75%"},
+                        "phase": "owned",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    adapters: dict = {}
+    telegram = _Adapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+    )
+    controller = AccountUsagePresenceController(
+        AccountUsagePresenceConfig(),
+        lambda: adapters,
+        fetcher=lambda provider: pytest.fail("disabled controller must not fetch"),
+        state_path=state_path,
+        recovery_interval_seconds=0.01,
+    )
+
+    await controller.start()
+    assert telegram.restored == []
+    assert controller.task is not None
+
+    adapters["telegram"] = telegram
+    for _ in range(100):
+        if telegram.restored:
+            break
+        await asyncio.sleep(0.01)
+
+    assert telegram.restored
+    assert json.loads(state_path.read_text(encoding="utf-8"))["entries"] == {}
+    await controller.stop()
+
+
+@pytest.mark.asyncio
+async def test_malformed_journal_blocks_identity_mutation(tmp_path):
+    state_path = tmp_path / "journal.json"
+    state_path.write_text("{not-json", encoding="utf-8")
+    telegram = _Adapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline={"display_name": "Hermes"},
+    )
+    controller = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: _snapshot(),
+        state_path=state_path,
+    )
+
+    await controller.refresh_once()
+
+    assert telegram.applied == []
+    assert state_path.read_text(encoding="utf-8") == "{not-json"
+
+
+@pytest.mark.asyncio
+async def test_symlink_journal_blocks_identity_mutation(tmp_path):
+    target = tmp_path / "victim.txt"
+    target.write_text("do-not-clobber", encoding="utf-8")
+    state_path = tmp_path / "journal.json"
+    state_path.symlink_to(target)
+    telegram = _Adapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline={"display_name": "Hermes"},
+    )
+    controller = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: _snapshot(),
+        state_path=state_path,
+    )
+
+    await controller.refresh_once()
+
+    assert telegram.applied == []
+    assert target.read_text(encoding="utf-8") == "do-not-clobber"
+
+
+@pytest.mark.asyncio
+async def test_baseline_persistence_failure_blocks_identity_mutation(
+    tmp_path, monkeypatch
+):
+    telegram = _Adapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline={"display_name": "Hermes"},
+    )
+
+    def fail_write(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "gateway.account_usage_presence._write_state_atomically",
+        fail_write,
+    )
+    controller = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: _snapshot(),
+        state_path=tmp_path / "state.json",
+    )
+
+    await controller.refresh_once()
+
+    assert telegram.applied == []
+
+
+@pytest.mark.asyncio
+async def test_stop_does_not_wait_for_blocked_sync_fetch(tmp_path):
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_fetch(provider):
+        started.set()
+        release.wait(timeout=5)
+        return _snapshot()
+
+    controller = AccountUsagePresenceController(
+        _config(platforms=["discord"]),
+        lambda: {},
+        fetcher=blocking_fetch,
+        state_path=tmp_path / "state.json",
+        fetch_timeout_seconds=30,
+    )
+
+    try:
+        await controller.start()
+        for _ in range(100):
+            if started.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert started.is_set()
+
+        before = time.monotonic()
+        await controller.stop()
+        elapsed = time.monotonic() - before
+
+        worker = controller._fetch_thread
+        assert elapsed < 0.5
+        assert worker is not None
+        assert worker.daemon
+        assert worker.is_alive()
+    finally:
+        release.set()
+        worker = controller._fetch_thread
+        if worker is not None:
+            worker.join(timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_hung_adapter_times_out_without_blocking_other_platform(tmp_path):
+    class HangingAdapter(_Adapter):
+        async def apply_account_usage_presence(self, payload, baseline):
+            await asyncio.Event().wait()
+
+    telegram = HangingAdapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+    )
+    discord = _Adapter(
+        "discord",
+        capabilities=AccountUsagePresenceCapabilities(activity=True),
+    )
+    controller = AccountUsagePresenceController(
+        _config(),
+        lambda: {"telegram": telegram, "discord": discord},
+        fetcher=lambda provider: _snapshot(),
+        state_path=tmp_path / "state.json",
+        adapter_timeout_seconds=0.01,
+    )
+
+    await controller.refresh_once()
+
+    assert len(discord.applied) == 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_restore_runs_in_parallel_within_one_timeout(tmp_path):
+    class SlowRestore(_Adapter):
+        async def restore_account_usage_presence(self, baseline, owned):
+            await asyncio.sleep(0.15)
+            return await super().restore_account_usage_presence(baseline, owned)
+
+    state_path = tmp_path / "journal.json"
+    telegram = SlowRestore(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline={"display_name": "Hermes"},
+    )
+    discord = SlowRestore(
+        "discord",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline={"display_name": "Bot"},
+    )
+    controller = AccountUsagePresenceController(
+        _config(),
+        lambda: {"telegram": telegram, "discord": discord},
+        fetcher=lambda provider: _snapshot(),
+        state_path=state_path,
+        adapter_timeout_seconds=1.0,
+    )
+
+    await controller.refresh_once()
+    before = time.monotonic()
+    await controller.stop()
+    elapsed = time.monotonic() - before
+
+    assert len(telegram.restored) == 1
+    assert len(discord.restored) == 1
+    assert elapsed < 0.28
+
+
+@pytest.mark.asyncio
+async def test_unsupported_adapter_is_explicit_noop(tmp_path):
+    adapter = _Adapter(
+        "matrix",
+        capabilities=AccountUsagePresenceCapabilities(),
+    )
+    controller = AccountUsagePresenceController(
+        _config(platforms=["matrix"]),
+        lambda: {"matrix": adapter},
+        fetcher=lambda provider: _snapshot(),
+        state_path=tmp_path / "state.json",
+    )
+
+    await controller.refresh_once()
+
+    assert adapter.applied == []

--- a/tests/gateway/test_account_usage_presence.py
+++ b/tests/gateway/test_account_usage_presence.py
@@ -435,6 +435,100 @@ async def test_later_false_apply_keeps_prior_owned_journal_for_stop(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_later_false_apply_recovers_prior_owned_after_rollback_write_failure(
+    tmp_path,
+    monkeypatch,
+):
+    import gateway.account_usage_presence as presence_module
+
+    class StatefulAdapter(_ApplyResultAdapter):
+        def __init__(self, *args, remote_state, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.remote_state = dict(remote_state)
+
+        async def apply_account_usage_presence(self, payload, baseline):
+            changed = await super().apply_account_usage_presence(payload, baseline)
+            if changed:
+                self.remote_state = self.build_account_usage_presence_owned_state(
+                    payload,
+                    baseline,
+                )
+            return changed
+
+        async def restore_account_usage_presence(self, baseline, owned):
+            self.restored.append((baseline, owned))
+            if self.remote_state == owned:
+                self.remote_state = dict(baseline)
+                return AccountUsagePresenceRestoreResult.RESTORED
+            if self.remote_state == baseline:
+                return AccountUsagePresenceRestoreResult.ALREADY_BASELINE
+            return AccountUsagePresenceRestoreResult.EXTERNAL
+
+    state_path = tmp_path / "journal.json"
+    baseline = {"display_name": "Hermes"}
+    telegram = StatefulAdapter(
+        "telegram",
+        capabilities=AccountUsagePresenceCapabilities(display_name=True),
+        baseline=baseline,
+        apply_results=(True, False),
+        remote_state=baseline,
+    )
+    snapshots = iter((_snapshot(used_percent=25), _snapshot(used_percent=26)))
+    controller = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: next(snapshots),
+        state_path=state_path,
+    )
+
+    real_write = presence_module._write_state_atomically
+    write_count = 0
+
+    def fail_rollback_write(path, value):
+        nonlocal write_count
+        write_count += 1
+        if write_count == 4:
+            raise OSError("simulated rollback journal failure")
+        real_write(path, value)
+
+    monkeypatch.setattr(
+        presence_module,
+        "_write_state_atomically",
+        fail_rollback_write,
+    )
+    await controller.refresh_once()
+    await controller.refresh_once()
+
+    pending = json.loads(state_path.read_text(encoding="utf-8"))["entries"][
+        "telegram"
+    ]
+    assert pending["phase"] == "pending"
+    assert pending["owned"] == {"display_name": "owned-74"}
+    assert pending["previous_owned"] == {"display_name": "owned-75"}
+    assert telegram.remote_state == {"display_name": "owned-75"}
+
+    monkeypatch.setattr(
+        presence_module,
+        "_write_state_atomically",
+        real_write,
+    )
+    restarted = AccountUsagePresenceController(
+        _config(platforms=["telegram"]),
+        lambda: {"telegram": telegram},
+        fetcher=lambda provider: None,
+        state_path=state_path,
+    )
+    await restarted.stop()
+
+    assert telegram.restored == [
+        (baseline, {"display_name": "owned-74"}),
+        (baseline, {"display_name": "owned-75"}),
+    ]
+    assert telegram.remote_state == baseline
+    assert not state_path.exists() or json.loads(state_path.read_text())["entries"] == {}
+
+
+@pytest.mark.asyncio
 async def test_initial_false_apply_discards_never_owned_pending_journal(tmp_path):
     state_path = tmp_path / "journal.json"
     telegram = _ApplyResultAdapter(

--- a/tests/gateway/test_account_usage_presence.py
+++ b/tests/gateway/test_account_usage_presence.py
@@ -386,6 +386,40 @@ async def test_provider_retry_after_suppresses_fetch_until_deadline(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_provider_retry_after_starts_when_slow_fetch_completes(tmp_path):
+    clock = _Clock()
+    calls = []
+
+    def fetch(provider):
+        calls.append((provider, clock.now))
+        if len(calls) == 1:
+            clock.now = 20
+            raise _RateLimited(610)
+        return _snapshot()
+
+    adapter = _Adapter(
+        "discord",
+        capabilities=AccountUsagePresenceCapabilities(activity=True),
+    )
+    controller = AccountUsagePresenceController(
+        _config(platforms=["discord"]),
+        lambda: {"discord": adapter},
+        fetcher=fetch,
+        state_path=tmp_path / "state.json",
+        monotonic=clock,
+    )
+
+    await controller.refresh_once()
+    clock.now = 620
+    await controller.refresh_once()
+    assert calls == [("openai-codex", 0.0)]
+
+    clock.now = 630
+    await controller.refresh_once()
+    assert calls == [("openai-codex", 0.0), ("openai-codex", 630)]
+
+
+@pytest.mark.asyncio
 async def test_baseline_is_persisted_before_mutation_and_restored_on_stop(tmp_path):
     state_path = tmp_path / "account-usage-presence" / "journal.json"
     telegram = _Adapter(

--- a/tests/gateway/test_account_usage_presence_config.py
+++ b/tests/gateway/test_account_usage_presence_config.py
@@ -1,0 +1,125 @@
+from pathlib import Path
+
+from gateway.config import AccountUsagePresenceConfig, GatewayConfig, load_gateway_config
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def test_account_usage_presence_defaults_off_and_unconfigured():
+    config = AccountUsagePresenceConfig()
+
+    assert config.enabled is False
+    assert config.provider is None
+    assert config.platforms == ()
+    assert config.update_interval_seconds == 300
+    assert config.stale_after_seconds == 900
+    assert config.is_configured is False
+
+
+def test_account_usage_presence_config_roundtrip_normalizes_values():
+    parsed = AccountUsagePresenceConfig.from_dict(
+        {
+            "enabled": "true",
+            "provider": " Anthropic ",
+            "platforms": ["Telegram", "discord", "telegram", ""],
+            "update_interval_seconds": 10,
+            "stale_after_seconds": 20,
+            "window_label": " Seven day ",
+        }
+    )
+
+    assert parsed.enabled is True
+    assert parsed.provider == "anthropic"
+    assert parsed.platforms == ("telegram", "discord")
+    assert parsed.update_interval_seconds == 300
+    assert parsed.stale_after_seconds == 300
+    assert parsed.window_label == "Seven day"
+    assert parsed.is_configured is True
+    assert AccountUsagePresenceConfig.from_dict(parsed.to_dict()) == parsed
+
+
+def test_enabled_config_requires_explicit_provider_and_platforms():
+    assert AccountUsagePresenceConfig.from_dict({"enabled": True}).is_configured is False
+    assert (
+        AccountUsagePresenceConfig.from_dict(
+            {"enabled": True, "provider": "openai-codex"}
+        ).is_configured
+        is False
+    )
+    assert (
+        AccountUsagePresenceConfig.from_dict(
+            {"enabled": True, "platforms": ["telegram"]}
+        ).is_configured
+        is False
+    )
+
+
+def test_ambiguous_provider_aliases_are_not_explicit_accounts():
+    for provider in ("auto", "main"):
+        parsed = AccountUsagePresenceConfig.from_dict(
+            {
+                "enabled": True,
+                "provider": provider,
+                "platforms": ["telegram"],
+            }
+        )
+        assert parsed.provider is None
+        assert parsed.is_configured is False
+
+
+def test_unsupported_provider_and_platform_values_are_ignored():
+    parsed = AccountUsagePresenceConfig.from_dict(
+        {
+            "enabled": True,
+            "provider": "not-a-real-provider",
+            "platforms": ["telegram", "matrix", "discord"],
+        }
+    )
+
+    assert parsed.provider is None
+    assert parsed.platforms == ("telegram", "discord")
+    assert parsed.is_configured is False
+
+
+def test_gateway_config_roundtrip_includes_account_usage_presence():
+    original = GatewayConfig(
+        account_usage_presence=AccountUsagePresenceConfig.from_dict(
+            {
+                "enabled": True,
+                "provider": "openrouter",
+                "platforms": ["discord"],
+            }
+        )
+    )
+
+    restored = GatewayConfig.from_dict(original.to_dict())
+
+    assert restored.account_usage_presence == original.account_usage_presence
+
+
+def test_load_gateway_config_reads_nested_gateway_account_usage_presence(tmp_path: Path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        (tmp_path / "config.yaml").write_text(
+            """
+gateway:
+  account_usage_presence:
+    enabled: true
+    provider: openai-codex
+    platforms: [telegram, discord]
+    update_interval_seconds: 600
+    stale_after_seconds: 1800
+    window_label: Session
+""".lstrip(),
+            encoding="utf-8",
+        )
+
+        loaded = load_gateway_config()
+    finally:
+        reset_hermes_home_override(token)
+
+    assert loaded.account_usage_presence.enabled is True
+    assert loaded.account_usage_presence.provider == "openai-codex"
+    assert loaded.account_usage_presence.platforms == ("telegram", "discord")
+    assert loaded.account_usage_presence.update_interval_seconds == 600
+    assert loaded.account_usage_presence.stale_after_seconds == 1800
+    assert loaded.account_usage_presence.window_label == "Session"

--- a/tests/gateway/test_account_usage_presence_config.py
+++ b/tests/gateway/test_account_usage_presence_config.py
@@ -76,7 +76,7 @@ def test_unsupported_provider_and_platform_values_are_ignored():
     )
 
     assert parsed.provider is None
-    assert parsed.platforms == ("telegram", "discord")
+    assert parsed.platforms == ("telegram", "matrix", "discord")
     assert parsed.is_configured is False
 
 

--- a/tests/gateway/test_account_usage_presence_runner.py
+++ b/tests/gateway/test_account_usage_presence_runner.py
@@ -1,9 +1,14 @@
-from contextlib import nullcontext
+import json
 from unittest.mock import AsyncMock
 
 import pytest
 
-from gateway.config import AccountUsagePresenceConfig, GatewayConfig
+from gateway.config import (
+    AccountUsagePresenceConfig,
+    GatewayConfig,
+    Platform,
+    PlatformConfig,
+)
 from gateway.run import GatewayRunner
 
 
@@ -30,7 +35,6 @@ def _runner(config):
     runner.config = config
     runner.adapters = {"telegram": object()}
     runner._profile_adapters = {}
-    runner._profile_runtime_scope = lambda profile: nullcontext()
     runner._account_usage_presence_controller = None
     return runner
 
@@ -59,8 +63,10 @@ async def test_runner_starts_account_usage_presence_with_live_adapter_getter(mon
 
 
 @pytest.mark.asyncio
-async def test_runner_multiplex_mode_only_runs_disabled_recovery(monkeypatch):
+async def test_runner_multiplex_mode_only_runs_disabled_recovery(monkeypatch, tmp_path):
     monkeypatch.setattr("gateway.run.AccountUsagePresenceController", _Controller)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "profiles" / "work").mkdir(parents=True)
     config = GatewayConfig(
         multiplex_profiles=True,
         account_usage_presence=AccountUsagePresenceConfig.from_dict(
@@ -81,9 +87,94 @@ async def test_runner_multiplex_mode_only_runs_disabled_recovery(monkeypatch):
     secondary_controller, controller = _Controller.instances
     assert secondary_controller.config.enabled is False
     secondary_controller.recover_saved_baselines.assert_awaited_once_with()
+    assert secondary_controller.kwargs["state_path"] == (
+        tmp_path
+        / "profiles"
+        / "work"
+        / "state"
+        / "account-usage-presence"
+        / "journal.json"
+    )
     assert controller.config.enabled is False
     assert controller.config.is_configured is False
     controller.start.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_secondary_reconnect_recovers_profile_journal_after_startup_offline(
+    monkeypatch, tmp_path
+):
+    from gateway.account_usage_presence import (
+        AccountUsagePresenceCapabilities,
+        AccountUsagePresenceRestoreResult,
+    )
+    from hermes_cli.profiles import get_profile_dir
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    profile_home = get_profile_dir("work")
+    profile_home.mkdir(parents=True)
+    state_path = profile_home / "state" / "account-usage-presence" / "journal.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "entries": {
+                    "telegram": {
+                        "baseline": {"display_name": "Hermes"},
+                        "owned": {"display_name": "Hermes · Session 75%"},
+                        "phase": "owned",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class RecoveringAdapter:
+        platform = Platform.TELEGRAM
+        account_usage_presence_capabilities = AccountUsagePresenceCapabilities(
+            display_name=True
+        )
+
+        def __init__(self):
+            self.remote_state = {"display_name": "Hermes · Session 75%"}
+
+        def account_usage_presence_state_key(self):
+            return "telegram"
+
+        async def restore_account_usage_presence(self, baseline, owned):
+            if self.remote_state == owned:
+                self.remote_state = dict(baseline)
+                return AccountUsagePresenceRestoreResult.RESTORED
+            if self.remote_state == baseline:
+                return AccountUsagePresenceRestoreResult.ALREADY_BASELINE
+            return AccountUsagePresenceRestoreResult.EXTERNAL
+
+    adapter = RecoveringAdapter()
+    runner = _runner(GatewayConfig(multiplex_profiles=True))
+    runner._profile_adapters = {}
+    runner._profile_failed_platforms = {}
+    runner._running = True
+    runner._create_adapter = lambda platform, config: adapter
+    runner._configure_profile_adapter = lambda adapter, profile, platform: None
+    runner._connect_adapter_with_timeout = AsyncMock(return_value=True)
+    runner._sync_voice_mode_state_to_adapter = lambda adapter: None
+    monkeypatch.setattr(
+        "gateway.config.load_gateway_config",
+        lambda: GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True)}
+        ),
+    )
+
+    await runner._recover_secondary_profile_account_usage_presence()
+    assert json.loads(state_path.read_text(encoding="utf-8"))["entries"]
+
+    await runner._run_secondary_profile_reconnect("work", Platform.TELEGRAM)
+
+    assert runner._profile_adapters["work"][Platform.TELEGRAM] is adapter
+    assert adapter.remote_state == {"display_name": "Hermes"}
+    assert json.loads(state_path.read_text(encoding="utf-8"))["entries"] == {}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_account_usage_presence_runner.py
+++ b/tests/gateway/test_account_usage_presence_runner.py
@@ -133,6 +133,8 @@ async def test_secondary_reconnect_recovers_profile_journal_after_startup_offlin
 
     class RecoveringAdapter:
         platform = Platform.TELEGRAM
+        has_fatal_error = False
+        fatal_error_retryable = True
         account_usage_presence_capabilities = AccountUsagePresenceCapabilities(
             display_name=True
         )
@@ -155,10 +157,13 @@ async def test_secondary_reconnect_recovers_profile_journal_after_startup_offlin
     runner = _runner(GatewayConfig(multiplex_profiles=True))
     runner._profile_adapters = {}
     runner._profile_failed_platforms = {}
-    runner._running = True
+    runner._pending_secondary_profile_reconnects = {}
+    runner._background_tasks = set()
+    runner._running = False
     runner._create_adapter = lambda platform, config: adapter
     runner._configure_profile_adapter = lambda adapter, profile, platform: None
-    runner._connect_adapter_with_timeout = AsyncMock(return_value=True)
+    runner._connect_adapter_with_timeout = AsyncMock(side_effect=[False, True])
+    runner._safe_adapter_disconnect = AsyncMock()
     runner._sync_voice_mode_state_to_adapter = lambda adapter: None
     monkeypatch.setattr(
         "gateway.config.load_gateway_config",
@@ -167,10 +172,20 @@ async def test_secondary_reconnect_recovers_profile_journal_after_startup_offlin
         ),
     )
 
-    await runner._recover_secondary_profile_account_usage_presence()
+    connected = await runner._start_one_profile_adapters(
+        "work",
+        profile_home,
+        {},
+    )
+
+    assert connected == 0
+    assert ("work", Platform.TELEGRAM) in runner._pending_secondary_profile_reconnects
     assert json.loads(state_path.read_text(encoding="utf-8"))["entries"]
 
-    await runner._run_secondary_profile_reconnect("work", Platform.TELEGRAM)
+    runner._running = True
+    runner._schedule_pending_secondary_profile_reconnects()
+    reconnect_task = runner._profile_failed_platforms["work"][Platform.TELEGRAM]
+    await reconnect_task
 
     assert runner._profile_adapters["work"][Platform.TELEGRAM] is adapter
     assert adapter.remote_state == {"display_name": "Hermes"}

--- a/tests/gateway/test_account_usage_presence_runner.py
+++ b/tests/gateway/test_account_usage_presence_runner.py
@@ -129,6 +129,7 @@ async def test_runner_real_controller_lifecycle_with_journal(tmp_path):
 
     from agent.account_usage import AccountUsageFetchOutcome, AccountUsageSnapshot, AccountUsageWindow
     from gateway.account_usage_presence import (
+        AccountUsagePresenceApplyResult,
         AccountUsagePresenceCapabilities,
         AccountUsagePresenceController,
         AccountUsagePresenceRestoreResult,
@@ -162,6 +163,17 @@ async def test_runner_real_controller_lifecycle_with_journal(tmp_path):
             owned = self.build_account_usage_presence_owned_state(payload, baseline)
             self.current_name = owned["display_name"]
             return True
+
+        async def apply_account_usage_presence_if_owned(
+            self,
+            payload,
+            baseline,
+            expected_owned,
+        ):
+            if self.current_name != expected_owned["display_name"]:
+                return AccountUsagePresenceApplyResult.EXTERNAL
+            await self.apply_account_usage_presence(payload, baseline)
+            return AccountUsagePresenceApplyResult.APPLIED
 
         async def restore_account_usage_presence(self, baseline, owned):
             if self.current_name == baseline["display_name"]:

--- a/tests/gateway/test_account_usage_presence_runner.py
+++ b/tests/gateway/test_account_usage_presence_runner.py
@@ -1,0 +1,213 @@
+from contextlib import nullcontext
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import AccountUsagePresenceConfig, GatewayConfig
+from gateway.run import GatewayRunner
+
+
+class _Controller:
+    instances = []
+
+    def __init__(self, config, adapters, **kwargs):
+        self.config = config
+        self.adapters = adapters
+        self.kwargs = kwargs
+        self.start = AsyncMock()
+        self.stop = AsyncMock()
+        self.recover_saved_baselines = AsyncMock()
+        self.__class__.instances.append(self)
+
+
+@pytest.fixture(autouse=True)
+def _reset_instances():
+    _Controller.instances.clear()
+
+
+def _runner(config):
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner.adapters = {"telegram": object()}
+    runner._profile_adapters = {}
+    runner._profile_runtime_scope = lambda profile: nullcontext()
+    runner._account_usage_presence_controller = None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_runner_starts_account_usage_presence_with_live_adapter_getter(monkeypatch):
+    monkeypatch.setattr("gateway.run.AccountUsagePresenceController", _Controller)
+    config = GatewayConfig(
+        account_usage_presence=AccountUsagePresenceConfig.from_dict(
+            {
+                "enabled": True,
+                "provider": "anthropic",
+                "platforms": ["telegram"],
+            }
+        )
+    )
+    runner = _runner(config)
+
+    await runner._start_account_usage_presence()
+
+    controller = _Controller.instances[0]
+    assert controller.config == config.account_usage_presence
+    assert controller.adapters() is runner.adapters
+    controller.start.assert_awaited_once_with()
+    assert runner._account_usage_presence_controller is controller
+
+
+@pytest.mark.asyncio
+async def test_runner_multiplex_mode_only_runs_disabled_recovery(monkeypatch):
+    monkeypatch.setattr("gateway.run.AccountUsagePresenceController", _Controller)
+    config = GatewayConfig(
+        multiplex_profiles=True,
+        account_usage_presence=AccountUsagePresenceConfig.from_dict(
+            {
+                "enabled": True,
+                "provider": "openai-codex",
+                "platforms": ["telegram", "discord"],
+            }
+        ),
+    )
+    runner = _runner(config)
+    secondary = {"telegram": object()}
+    runner._profile_adapters = {"work": secondary}
+
+    await runner._start_account_usage_presence()
+
+    assert len(_Controller.instances) == 2
+    secondary_controller, controller = _Controller.instances
+    assert secondary_controller.config.enabled is False
+    secondary_controller.recover_saved_baselines.assert_awaited_once_with()
+    assert controller.config.enabled is False
+    assert controller.config.is_configured is False
+    controller.start.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_runner_notifies_presence_controller_after_adapter_reconnect():
+    config = GatewayConfig()
+    runner = _runner(config)
+    controller = _Controller(config.account_usage_presence, lambda: runner.adapters)
+    runner._account_usage_presence_controller = controller
+
+    await runner._notify_account_usage_presence_adapters_changed()
+
+    controller.recover_saved_baselines.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_runner_stops_and_drops_account_usage_presence_controller():
+    config = GatewayConfig()
+    runner = _runner(config)
+    controller = _Controller(config.account_usage_presence, lambda: runner.adapters)
+    runner._account_usage_presence_controller = controller
+
+    await runner._stop_account_usage_presence()
+
+    controller.stop.assert_awaited_once_with()
+    assert runner._account_usage_presence_controller is None
+
+
+@pytest.mark.asyncio
+async def test_runner_capacity_stop_is_idempotent():
+    runner = _runner(GatewayConfig())
+
+    await runner._stop_account_usage_presence()
+
+    assert runner._account_usage_presence_controller is None
+
+
+@pytest.mark.asyncio
+async def test_runner_real_controller_lifecycle_with_journal(tmp_path):
+    """Exercise real controller wiring through GatewayRunner stop path."""
+
+    import json
+    from datetime import datetime, timezone
+
+    from agent.account_usage import AccountUsageFetchOutcome, AccountUsageSnapshot, AccountUsageWindow
+    from gateway.account_usage_presence import (
+        AccountUsagePresenceCapabilities,
+        AccountUsagePresenceController,
+        AccountUsagePresenceRestoreResult,
+        account_usage_presence_state_path,
+    )
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    class _LiveAdapter:
+        def __init__(self):
+            self.current_name = "Hermes"
+
+        @property
+        def account_usage_presence_capabilities(self):
+            return AccountUsagePresenceCapabilities(display_name=True)
+
+        def account_usage_presence_state_key(self):
+            return "telegram:1"
+
+        async def capture_account_usage_presence_baseline(self):
+            return {"display_name": self.current_name}
+
+        def build_account_usage_presence_owned_state(self, payload, baseline):
+            return {
+                "display_name": (
+                    f"{baseline['display_name']} · {payload.label} "
+                    f"{payload.remaining_percent}%"
+                )
+            }
+
+        async def apply_account_usage_presence(self, payload, baseline):
+            owned = self.build_account_usage_presence_owned_state(payload, baseline)
+            self.current_name = owned["display_name"]
+            return True
+
+        async def restore_account_usage_presence(self, baseline, owned):
+            if self.current_name == baseline["display_name"]:
+                return AccountUsagePresenceRestoreResult.ALREADY_BASELINE
+            if self.current_name != owned["display_name"]:
+                return AccountUsagePresenceRestoreResult.EXTERNAL
+            self.current_name = baseline["display_name"]
+            return AccountUsagePresenceRestoreResult.RESTORED
+
+    token = set_hermes_home_override(tmp_path)
+    try:
+        snapshot = AccountUsageSnapshot(
+            provider="openai-codex",
+            source="test",
+            fetched_at=datetime.now(timezone.utc),
+            windows=(AccountUsageWindow(label="Session", used_percent=25.0),),
+        )
+        config = GatewayConfig(
+            account_usage_presence=AccountUsagePresenceConfig.from_dict(
+                {
+                    "enabled": True,
+                    "provider": "openai-codex",
+                    "platforms": ["telegram"],
+                }
+            )
+        )
+        runner = _runner(config)
+        adapter = _LiveAdapter()
+        runner.adapters = {"telegram": adapter}
+        controller = AccountUsagePresenceController(
+            config.account_usage_presence,
+            lambda: runner.adapters,
+            fetcher=lambda provider: AccountUsageFetchOutcome(snapshot=snapshot),
+            state_path=account_usage_presence_state_path(),
+        )
+        runner._account_usage_presence_controller = controller
+
+        await controller.refresh_once()
+        assert adapter.current_name == "Hermes · Session 75%"
+        journal = tmp_path / "state" / "account-usage-presence" / "journal.json"
+        assert journal.is_file()
+
+        await runner._stop_account_usage_presence()
+        assert adapter.current_name == "Hermes"
+        assert runner._account_usage_presence_controller is None
+        assert journal.exists()
+        assert json.loads(journal.read_text(encoding="utf-8"))["entries"] == {}
+    finally:
+        reset_hermes_home_override(token)

--- a/tests/gateway/test_discord_account_usage_presence.py
+++ b/tests/gateway/test_discord_account_usage_presence.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.account_usage_presence import (
+    AccountUsagePresenceCapabilities,
+    AccountUsagePresencePayload,
+    AccountUsagePresenceRestoreResult,
+)
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter, discord
+
+
+def _payload(percent=75, *, cached=False):
+    return AccountUsagePresencePayload(
+        label="Five hour",
+        remaining_percent=percent,
+        cached=cached,
+    )
+
+
+def _adapter():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = MagicMock()
+    adapter._client.change_presence = AsyncMock()
+    return adapter
+
+
+def _install_activity_double(monkeypatch):
+    factory = MagicMock(
+        side_effect=lambda **kwargs: SimpleNamespace(**kwargs)
+    )
+    monkeypatch.setattr(discord, "Activity", factory)
+    monkeypatch.setattr(
+        discord,
+        "ActivityType",
+        SimpleNamespace(watching="watching"),
+    )
+    return factory
+
+
+def test_discord_advertises_activity_capacity():
+    adapter = _adapter()
+
+    assert adapter.account_usage_presence_capabilities == AccountUsagePresenceCapabilities(
+        activity=True
+    )
+    assert adapter.account_usage_presence_state_key() == "discord"
+
+
+@pytest.mark.asyncio
+async def test_discord_sets_watching_activity(monkeypatch):
+    factory = _install_activity_double(monkeypatch)
+    adapter = _adapter()
+
+    changed = await adapter.apply_account_usage_presence(_payload(75), None)
+
+    assert changed is True
+    factory.assert_called_once_with(
+        type="watching",
+        name="Five hour 75% remaining",
+    )
+    activity = adapter._client.change_presence.await_args.kwargs["activity"]
+    assert activity.type == "watching"
+    assert activity.name == "Five hour 75% remaining"
+
+
+@pytest.mark.asyncio
+async def test_discord_unknown_usage_is_truthful(monkeypatch):
+    _install_activity_double(monkeypatch)
+    adapter = _adapter()
+
+    await adapter.apply_account_usage_presence(
+        AccountUsagePresencePayload.unknown(), None
+    )
+
+    activity = adapter._client.change_presence.await_args.kwargs["activity"]
+    assert activity.name == "Usage unavailable"
+
+
+@pytest.mark.asyncio
+async def test_discord_cached_usage_is_visible(monkeypatch):
+    _install_activity_double(monkeypatch)
+    adapter = _adapter()
+
+    await adapter.apply_account_usage_presence(_payload(75, cached=True), None)
+
+    activity = adapter._client.change_presence.await_args.kwargs["activity"]
+    assert activity.name == "Five hour 75% remaining (cached)"
+
+
+@pytest.mark.asyncio
+async def test_discord_does_not_clear_activity_on_restore():
+    adapter = _adapter()
+
+    restored = await adapter.restore_account_usage_presence({}, {})
+
+    assert restored is AccountUsagePresenceRestoreResult.RETRY
+    adapter._client.change_presence.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_capacity_is_noop_before_client_initializes():
+    adapter = _adapter()
+    adapter._client = None
+
+    assert await adapter.apply_account_usage_presence(_payload(), None) is False

--- a/tests/gateway/test_matrix_account_usage_presence.py
+++ b/tests/gateway/test_matrix_account_usage_presence.py
@@ -1,0 +1,113 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.account_usage_presence import (
+    AccountUsagePresenceApplyResult,
+    AccountUsagePresencePayload,
+    AccountUsagePresenceRestoreResult,
+)
+from gateway.config import PlatformConfig
+from plugins.platforms.matrix.adapter import MatrixAdapter, PresenceState
+
+
+@pytest.fixture
+def adapter():
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@bot:example.org",
+        },
+    )
+    result = MatrixAdapter(config)
+    result._client = MagicMock()
+    result._client.mxid = "@bot:example.org"
+    result._client.get_presence = AsyncMock(
+        return_value=SimpleNamespace(presence="online", status_msg="Idle")
+    )
+    result._client.set_presence = AsyncMock()
+    return result
+
+
+def test_matrix_exposes_account_usage_activity_and_identity_key(adapter):
+    assert adapter.account_usage_presence_capabilities.activity is True
+    assert adapter.account_usage_presence_capabilities.display_name is False
+    assert adapter.account_usage_presence_state_key() == "matrix:@bot:example.org"
+
+
+@pytest.mark.asyncio
+async def test_matrix_captures_baseline_and_renders_status(adapter):
+    baseline = await adapter.capture_account_usage_presence_baseline()
+    assert baseline == {"presence": "online", "status_msg": "Idle"}
+
+    payload = AccountUsagePresencePayload(label="Session", remaining_percent=75)
+    owned = adapter.build_account_usage_presence_owned_state(payload, baseline)
+    assert owned == {
+        "presence": "online",
+        "status_msg": "Session: 75% remaining",
+    }
+
+    cached = adapter.build_account_usage_presence_owned_state(
+        AccountUsagePresencePayload(
+            label="Session", remaining_percent=75, cached=True
+        ),
+        baseline,
+    )
+    assert cached is not None
+    assert cached["status_msg"].endswith("(cached)")
+
+
+@pytest.mark.asyncio
+async def test_matrix_guarded_apply_preserves_external_status(adapter):
+    baseline = {"presence": "online", "status_msg": "Idle"}
+    payload = AccountUsagePresencePayload(label="Session", remaining_percent=75)
+    owned = adapter.build_account_usage_presence_owned_state(payload, baseline)
+    assert owned is not None
+
+    result = await adapter.apply_account_usage_presence_if_owned(
+        payload, baseline, owned
+    )
+    assert result is AccountUsagePresenceApplyResult.EXTERNAL
+    adapter._client.set_presence.assert_not_awaited()
+
+    adapter._client.get_presence = AsyncMock(
+        return_value=SimpleNamespace(
+            presence="online", status_msg="Session: 75% remaining"
+        )
+    )
+    result = await adapter.apply_account_usage_presence_if_owned(
+        AccountUsagePresencePayload(label="Session", remaining_percent=70),
+        baseline,
+        owned,
+    )
+    assert result is AccountUsagePresenceApplyResult.APPLIED
+    adapter._client.set_presence.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_matrix_restore_uses_compare_and_swap(adapter):
+    baseline = {"presence": "online", "status_msg": "Idle"}
+    owned = {"presence": "online", "status_msg": "Session: 75% remaining"}
+    adapter._client.get_presence = AsyncMock(
+        return_value=SimpleNamespace(
+            presence="online", status_msg="Session: 75% remaining"
+        )
+    )
+
+    result = await adapter.restore_account_usage_presence(baseline, owned)
+    assert result is AccountUsagePresenceRestoreResult.RESTORED
+    adapter._client.set_presence.assert_awaited_once_with(
+        presence=PresenceState.ONLINE,
+        status="Idle",
+    )
+
+    adapter._client.set_presence.reset_mock()
+    adapter._client.get_presence = AsyncMock(
+        return_value=SimpleNamespace(presence="online", status_msg="Manual status")
+    )
+    result = await adapter.restore_account_usage_presence(baseline, owned)
+    assert result is AccountUsagePresenceRestoreResult.EXTERNAL
+    adapter._client.set_presence.assert_not_awaited()

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -1,5 +1,8 @@
-import pytest
+import asyncio
+import json
 from unittest.mock import AsyncMock
+
+import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
@@ -62,6 +65,160 @@ class _SuccessfulAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id):
         return {"id": chat_id}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("first_outcome", "expect_reconnect"),
+    [
+        ("false", True),
+        ("exception", True),
+        ("nonretryable", False),
+    ],
+)
+async def test_running_transition_reconnects_retryable_secondary_startup_failure(
+    monkeypatch,
+    tmp_path,
+    first_outcome,
+    expect_reconnect,
+):
+    from gateway.account_usage_presence import (
+        AccountUsagePresenceCapabilities,
+        AccountUsagePresenceRestoreResult,
+    )
+    from hermes_cli.profiles import get_profile_dir
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    profile_home = get_profile_dir("work")
+    profile_home.mkdir(parents=True)
+    state_path = (
+        profile_home
+        / "state"
+        / "account-usage-presence"
+        / "journal.json"
+    )
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "entries": {
+                    "telegram": {
+                        "baseline": {"display_name": "Hermes"},
+                        "owned": {"display_name": "Hermes · Session 75%"},
+                        "phase": "owned",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    reconnect_gate = asyncio.Event()
+
+    class _SecondaryAdapter(BasePlatformAdapter):
+        def __init__(self):
+            super().__init__(
+                PlatformConfig(enabled=True, token="secondary-token"),
+                Platform.TELEGRAM,
+            )
+            self.connect_calls = 0
+            self.remote_state = {"display_name": "Hermes · Session 75%"}
+
+        @property
+        def account_usage_presence_capabilities(self):
+            return AccountUsagePresenceCapabilities(display_name=True)
+
+        async def connect(self, *, is_reconnect: bool = False) -> bool:
+            self.connect_calls += 1
+            if self.connect_calls == 1:
+                if first_outcome == "exception":
+                    raise OSError("temporary startup exception")
+                self._set_fatal_error(
+                    "telegram_connect_error",
+                    "temporary startup failure",
+                    retryable=first_outcome != "nonretryable",
+                )
+                return False
+            await reconnect_gate.wait()
+            self._mark_connected()
+            return True
+
+        async def disconnect(self) -> None:
+            self._mark_disconnected()
+
+        async def send(self, chat_id, content, reply_to=None, metadata=None):
+            raise NotImplementedError
+
+        async def get_chat_info(self, chat_id):
+            return {"id": chat_id}
+
+        def account_usage_presence_state_key(self):
+            return "telegram"
+
+        async def restore_account_usage_presence(self, baseline, owned):
+            if self.remote_state == owned:
+                self.remote_state = dict(baseline)
+                return AccountUsagePresenceRestoreResult.RESTORED
+            if self.remote_state == baseline:
+                return AccountUsagePresenceRestoreResult.ALREADY_BASELINE
+            return AccountUsagePresenceRestoreResult.EXTERNAL
+
+    adapter = _SecondaryAdapter()
+    runner = GatewayRunner(
+        GatewayConfig(
+            multiplex_profiles=True,
+            platforms={},
+            sessions_dir=tmp_path / "sessions",
+        )
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name",
+        lambda: "default",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex: [("default", tmp_path), ("work", profile_home)],
+    )
+    monkeypatch.setattr(
+        "gateway.config.load_gateway_config",
+        lambda: GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(
+                    enabled=True,
+                    token="secondary-token",
+                )
+            }
+        ),
+    )
+    monkeypatch.setattr(runner, "_create_adapter", lambda platform, cfg: adapter)
+    monkeypatch.setattr(
+        runner,
+        "_configure_profile_adapter",
+        lambda adapter, profile, platform: None,
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    if not expect_reconnect:
+        assert not getattr(runner, "_pending_secondary_profile_reconnects", {})
+        assert "work" not in runner._profile_failed_platforms
+        assert adapter.connect_calls == 1
+        assert json.loads(state_path.read_text(encoding="utf-8"))["entries"]
+        await runner.stop()
+        return
+
+    reconnect_task = runner._profile_failed_platforms["work"][Platform.TELEGRAM]
+    assert not reconnect_task.done()
+    assert json.loads(state_path.read_text(encoding="utf-8"))["entries"]
+
+    reconnect_gate.set()
+    await asyncio.wait_for(reconnect_task, timeout=2)
+
+    assert runner._profile_adapters["work"][Platform.TELEGRAM] is adapter
+    assert adapter.remote_state == {"display_name": "Hermes"}
+    assert json.loads(state_path.read_text(encoding="utf-8"))["entries"] == {}
+    await runner.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_account_usage_presence.py
+++ b/tests/gateway/test_telegram_account_usage_presence.py
@@ -1,0 +1,189 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.account_usage_presence import (
+    AccountUsagePresenceCapabilities,
+    AccountUsagePresencePayload,
+    AccountUsagePresenceRestoreResult,
+)
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+def _payload(percent=75, *, cached=False):
+    return AccountUsagePresencePayload(
+        label="Session",
+        remaining_percent=percent,
+        cached=cached,
+    )
+
+
+def _adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._bot = MagicMock()
+    adapter._bot.id = 12345
+    adapter._bot.get_my_name = AsyncMock(return_value=SimpleNamespace(name="Hermes"))
+    adapter._bot.set_my_name = AsyncMock(return_value=True)
+    return adapter
+
+
+def test_telegram_advertises_display_name_capacity():
+    adapter = _adapter()
+
+    assert adapter.account_usage_presence_capabilities == AccountUsagePresenceCapabilities(
+        display_name=True
+    )
+    assert adapter.account_usage_presence_state_key() == "telegram:12345"
+
+
+@pytest.mark.asyncio
+async def test_telegram_captures_default_language_name():
+    adapter = _adapter()
+
+    baseline = await adapter.capture_account_usage_presence_baseline()
+
+    assert baseline == {"display_name": "Hermes"}
+    adapter._bot.get_my_name.assert_awaited_once_with()
+
+
+def test_telegram_builds_owned_name_from_baseline():
+    adapter = _adapter()
+
+    owned = adapter.build_account_usage_presence_owned_state(
+        _payload(75), {"display_name": "Hermes"}
+    )
+
+    assert owned == {"display_name": "Hermes · Session 75%"}
+
+
+@pytest.mark.asyncio
+async def test_telegram_sets_capacity_name_from_saved_baseline():
+    adapter = _adapter()
+
+    changed = await adapter.apply_account_usage_presence(
+        _payload(75), {"display_name": "Hermes"}
+    )
+
+    assert changed is True
+    adapter._bot.set_my_name.assert_awaited_once_with(name="Hermes · Session 75%")
+
+
+@pytest.mark.asyncio
+async def test_telegram_capacity_name_preserves_suffix_with_64_char_limit():
+    adapter = _adapter()
+
+    await adapter.apply_account_usage_presence(
+        _payload(5), {"display_name": "H" * 80}
+    )
+
+    name = adapter._bot.set_my_name.await_args.kwargs["name"]
+    assert len(name) == 64
+    assert name.endswith(" · Session 5%")
+
+
+@pytest.mark.asyncio
+async def test_telegram_unknown_usage_is_truthful():
+    adapter = _adapter()
+    payload = AccountUsagePresencePayload.unknown()
+
+    await adapter.apply_account_usage_presence(payload, {"display_name": "Hermes"})
+
+    adapter._bot.set_my_name.assert_awaited_once_with(
+        name="Hermes · usage unavailable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_telegram_cached_usage_is_visible_in_name():
+    adapter = _adapter()
+
+    await adapter.apply_account_usage_presence(
+        _payload(75, cached=True), {"display_name": "Hermes"}
+    )
+
+    adapter._bot.set_my_name.assert_awaited_once_with(
+        name="Hermes · Session 75% (cached)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_telegram_restore_cas_writes_baseline_only_when_owned():
+    adapter = _adapter()
+    adapter._bot.get_my_name = AsyncMock(
+        return_value=SimpleNamespace(name="Hermes · Session 75%")
+    )
+
+    restored = await adapter.restore_account_usage_presence(
+        {"display_name": "Hermes"},
+        {"display_name": "Hermes · Session 75%"},
+    )
+
+    assert restored is AccountUsagePresenceRestoreResult.RESTORED
+    adapter._bot.set_my_name.assert_awaited_once_with(name="Hermes")
+
+
+@pytest.mark.asyncio
+async def test_telegram_restore_preserves_external_rename():
+    adapter = _adapter()
+    adapter._bot.get_my_name = AsyncMock(return_value=SimpleNamespace(name="Support"))
+
+    restored = await adapter.restore_account_usage_presence(
+        {"display_name": "Hermes"},
+        {"display_name": "Hermes · Session 75%"},
+    )
+
+    assert restored is AccountUsagePresenceRestoreResult.EXTERNAL
+    adapter._bot.set_my_name.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_telegram_restore_skips_write_when_already_baseline():
+    adapter = _adapter()
+    adapter._bot.get_my_name = AsyncMock(return_value=SimpleNamespace(name="Hermes"))
+
+    restored = await adapter.restore_account_usage_presence(
+        {"display_name": "Hermes"},
+        {"display_name": "Hermes · Session 75%"},
+    )
+
+    assert restored is AccountUsagePresenceRestoreResult.ALREADY_BASELINE
+    adapter._bot.set_my_name.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_telegram_capacity_is_noop_before_bot_initializes():
+    adapter = _adapter()
+    adapter._bot = None
+
+    assert await adapter.capture_account_usage_presence_baseline() is None
+    assert await adapter.apply_account_usage_presence(_payload(), None) is False
+    assert (
+        await adapter.restore_account_usage_presence(
+            {"display_name": "Hermes"},
+            {"display_name": "Hermes · Session 75%"},
+        )
+        is AccountUsagePresenceRestoreResult.RETRY
+    )

--- a/tests/gateway/test_telegram_account_usage_presence.py
+++ b/tests/gateway/test_telegram_account_usage_presence.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.account_usage_presence import (
+    AccountUsagePresenceApplyResult,
     AccountUsagePresenceCapabilities,
     AccountUsagePresencePayload,
     AccountUsagePresenceRestoreResult,
@@ -89,6 +90,44 @@ async def test_telegram_sets_capacity_name_from_saved_baseline():
 
     assert changed is True
     adapter._bot.set_my_name.assert_awaited_once_with(name="Hermes · Session 75%")
+
+
+@pytest.mark.asyncio
+async def test_telegram_guarded_apply_requires_the_expected_owned_generation():
+    adapter = _adapter()
+    bot = adapter._bot
+    assert bot is not None
+    bot.get_my_name.return_value = SimpleNamespace(
+        name="Hermes · Session 75%"
+    )
+
+    result = await adapter.apply_account_usage_presence_if_owned(
+        _payload(74),
+        {"display_name": "Hermes"},
+        {"display_name": "Hermes · Session 75%"},
+    )
+
+    assert result is AccountUsagePresenceApplyResult.APPLIED
+    bot.set_my_name.assert_awaited_once_with(
+        name="Hermes · Session 74%"
+    )
+
+
+@pytest.mark.asyncio
+async def test_telegram_guarded_apply_preserves_external_name():
+    adapter = _adapter()
+    bot = adapter._bot
+    assert bot is not None
+    bot.get_my_name.return_value = SimpleNamespace(name="Operator override")
+
+    result = await adapter.apply_account_usage_presence_if_owned(
+        _payload(74),
+        {"display_name": "Hermes"},
+        {"display_name": "Hermes · Session 75%"},
+    )
+
+    assert result is AccountUsagePresenceApplyResult.EXTERNAL
+    bot.set_my_name.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -540,3 +540,98 @@ def test_prompt_yes_no_keyboard_interrupt_still_exits(monkeypatch):
     with pytest.raises(SystemExit):
         setup_mod.prompt_yes_no("Install it now?", True)
 
+
+def _presence_config():
+    return {
+        "enabled": True,
+        "provider": "anthropic",
+        "platforms": ["telegram"],
+        "update_interval_seconds": 600,
+        "stale_after_seconds": 1800,
+        "window_label": "Seven day",
+    }
+
+
+def test_account_usage_presence_rerun_decline_preserves_existing_config(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = {"gateway": {"account_usage_presence": _presence_config()}}
+    save_config(config)
+
+    rerun_config = load_config()
+    monkeypatch.setattr(
+        setup_mod,
+        "prompt_yes_no",
+        lambda question, default=False: False,
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "prompt_choice",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("declining the optional section must not prompt again")
+        ),
+    )
+
+    setup_mod._setup_account_usage_presence(rerun_config)
+
+    assert load_config()["gateway"]["account_usage_presence"] == _presence_config()
+
+
+def test_account_usage_presence_rerun_uses_existing_defaults_and_merges_edits(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = {"gateway": {"account_usage_presence": _presence_config()}}
+    save_config(config)
+    rerun_config = load_config()
+
+    def choose_provider(question, choices, default=0):
+        assert default == choices.index("anthropic")
+        return choices.index("openrouter")
+
+    def choose_platforms(question, items, pre_selected):
+        assert pre_selected == [0]
+        return [1]
+
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda question, default=False: True)
+    monkeypatch.setattr(setup_mod, "prompt_choice", choose_provider)
+    monkeypatch.setattr(setup_mod, "prompt_checklist", choose_platforms)
+
+    setup_mod._setup_account_usage_presence(rerun_config)
+
+    assert load_config()["gateway"]["account_usage_presence"] == {
+        "enabled": True,
+        "provider": "openrouter",
+        "platforms": ["discord"],
+        "update_interval_seconds": 600,
+        "stale_after_seconds": 1800,
+        "window_label": "Seven day",
+    }
+
+
+def test_account_usage_presence_only_disables_on_explicit_skip(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = {"gateway": {"account_usage_presence": _presence_config()}}
+    save_config(config)
+    rerun_config = load_config()
+
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda question, default=False: True)
+    monkeypatch.setattr(
+        setup_mod,
+        "prompt_choice",
+        lambda question, choices, default=0: len(choices) - 1,
+    )
+
+    setup_mod._setup_account_usage_presence(rerun_config)
+
+    assert load_config()["gateway"]["account_usage_presence"] == {
+        "enabled": False,
+        "provider": "anthropic",
+        "platforms": ["telegram"],
+        "update_interval_seconds": 600,
+        "stale_after_seconds": 1800,
+        "window_label": "Seven day",
+    }

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -635,3 +635,16 @@ def test_account_usage_presence_only_disables_on_explicit_skip(
         "stale_after_seconds": 1800,
         "window_label": "Seven day",
     }
+
+
+def test_account_usage_presence_setup_accepts_matrix(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = {"gateway": {}}
+
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda question, default=False: True)
+    monkeypatch.setattr(setup_mod, "prompt_choice", lambda *args, **kwargs: 0)
+    monkeypatch.setattr(setup_mod, "prompt_checklist", lambda *args, **kwargs: [2])
+
+    setup_mod._setup_account_usage_presence(config)
+
+    assert load_config()["gateway"]["account_usage_presence"]["platforms"] == ["matrix"]

--- a/website/docs/user-guide/messaging/account-usage-presence.md
+++ b/website/docs/user-guide/messaging/account-usage-presence.md
@@ -1,0 +1,88 @@
+---
+sidebar_position: 1
+title: "Account Usage Presence"
+description: "Show one provider account's remaining usage on Telegram and Discord bot identity surfaces"
+---
+
+# Account Usage Presence (Experimental)
+
+Account-usage presence exposes one provider account's remaining usage on messaging
+surfaces without sending a chat message. Hermes fetches the same
+provider-neutral account usage data used by `/usage`, then fans one snapshot
+out to every selected platform.
+
+| Platform | Surface |
+|---|---|
+| Telegram | Default-language bot display name, for example `Hermes · Session 75%` |
+| Discord | Bot activity, for example `Watching Five hour 75% remaining` |
+
+The feature is **off by default** because these are global bot identity writes,
+visible to every user of that bot rather than one conversation.
+
+## Configure
+
+You can enable it from `hermes setup gateway` (after selecting messaging
+platforms), or add an explicit provider and platform allowlist to
+`~/.hermes/config.yaml`:
+
+```yaml
+gateway:
+  account_usage_presence:
+    enabled: true
+    provider: openai-codex
+    platforms:
+      - telegram
+      - discord
+    update_interval_seconds: 300
+    stale_after_seconds: 900
+    # Optional: select a provider window by its displayed label.
+    # Without this, Hermes uses the first window with a percentage.
+    window_label: Session
+```
+
+`provider` is fixed for the global identity. It does not follow whichever model
+a conversation used most recently, so separate chats cannot make the bot name
+or activity oscillate between providers. Aliases such as `auto` and `main` do
+not select an explicit account and therefore leave the feature disabled. Only
+`openai-codex`, `anthropic`, and `openrouter` are accepted; the configured
+account must already be authenticated for `/usage` to return a percentage
+window. Only `telegram` and `discord` are accepted platforms in this version.
+
+The minimum update interval is five minutes. Hermes also performs change-only
+writes: an unchanged rendered identity does not call the platform API again.
+When a stale cached value is still within `stale_after_seconds`, platforms show
+an explicit `(cached)` marker instead of presenting it as live.
+
+## Failure and restoration behavior
+
+- Provider and platform failures are **fail-open for messaging**: chat delivery
+  continues even if account usage cannot be fetched or displayed.
+- A transient fetch failure keeps the last live value only until
+  `stale_after_seconds`. After that, the surface says usage is unavailable
+  instead of presenting a stale percentage as live.
+- Provider `Retry-After` metadata is honored separately from platform write
+  backoff.
+- Telegram ownership uses a private journal at
+  `~/.hermes/state/account-usage-presence/journal.json`. Before each mutation
+  Hermes records both the original baseline and the feature-owned value. On
+  restore it re-reads the remote name and only writes the baseline when the
+  current remote value still matches the owned value (CAS). External renames
+  are preserved and the journal entry is retired.
+- Unsafe or malformed journals fail closed for identity mutation until an
+  operator inspects the file. Symlinks and non-regular files are rejected.
+- If Telegram was offline when the feature was disabled, recovery retries after
+  adapter reconnect instead of running only once at startup.
+- Discord activity is connection-scoped and is not journaled. Hermes does not
+  clear an activity it does not own; normal disconnect drops the presence.
+- Telegram's optional `status_indicator` uses the short description, so it can
+  run at the same time as account-usage presence without competing for the name.
+- `gateway.multiplex_profiles` is not supported for live updates in this
+  experimental version. Hermes logs a warning, performs only saved-identity
+  recovery for each profile journal, and does not start account-usage updates.
+
+## Disable
+
+Set `enabled: false` (or remove the section) and restart the gateway. If a
+Telegram ownership journal still exists, Hermes restores the original name after
+the adapter reconnects. Do not delete the journal while a mutated Telegram name
+still needs restoration.

--- a/website/docs/user-guide/messaging/account-usage-presence.md
+++ b/website/docs/user-guide/messaging/account-usage-presence.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: "Account Usage Presence"
-description: "Show one provider account's remaining usage on Telegram and Discord bot identity surfaces"
+description: "Show one provider account's remaining usage on Telegram, Discord, and Matrix bot identity surfaces"
 ---
 
 # Account Usage Presence (Experimental)
@@ -15,6 +15,7 @@ out to every selected platform.
 |---|---|
 | Telegram | Default-language bot display name, for example `Hermes · Session 75%` |
 | Discord | Bot activity, for example `Watching Five hour 75% remaining` |
+| Matrix | Bot presence status, for example `Session: 75% remaining` |
 
 The feature is **off by default** because these are global bot identity writes,
 visible to every user of that bot rather than one conversation.
@@ -33,6 +34,7 @@ gateway:
     platforms:
       - telegram
       - discord
+      - matrix
     update_interval_seconds: 300
     stale_after_seconds: 900
     # Optional: select a provider window by its displayed label.
@@ -42,11 +44,12 @@ gateway:
 
 `provider` is fixed for the global identity. It does not follow whichever model
 a conversation used most recently, so separate chats cannot make the bot name
-or activity oscillate between providers. Aliases such as `auto` and `main` do
+aliases such as `auto` and `main` do
 not select an explicit account and therefore leave the feature disabled. Only
 `openai-codex`, `anthropic`, and `openrouter` are accepted; the configured
 account must already be authenticated for `/usage` to return a percentage
-window. Only `telegram` and `discord` are accepted platforms in this version.
+window. `telegram`, `discord`, and `matrix` are accepted platforms in this
+version.
 
 The minimum update interval is five minutes. Hermes also performs change-only
 writes: an unchanged rendered identity does not call the platform API again.
@@ -74,6 +77,8 @@ an explicit `(cached)` marker instead of presenting it as live.
   adapter reconnect instead of running only once at startup.
 - Discord activity is connection-scoped and is not journaled. Hermes does not
   clear an activity it does not own; normal disconnect drops the presence.
+- Matrix presence status is journaled with the same CAS ownership checks as
+  Telegram. External status changes are preserved rather than overwritten.
 - Telegram's optional `status_indicator` uses the short description, so it can
   run at the same time as account-usage presence without competing for the name.
 - `gateway.multiplex_profiles` is not supported for live updates in this

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -613,6 +613,7 @@ const sidebars: SidebarsConfig = {
       collapsed: true,
       items: [
         'user-guide/messaging/index',
+        'user-guide/messaging/account-usage-presence',
         {
           type: 'category',
           label: 'Popular',


### PR DESCRIPTION
## Summary

- add the provider account-usage presence lifecycle and CAS ownership journal
- retain the existing Telegram display-name and Discord activity surfaces
- expose Matrix bot presence status as an account-usage surface
- preserve externally changed Matrix status instead of overwriting it
- add Matrix configuration/setup/docs and adapter/CAS regression coverage

Matrix renders the selected usage window as a status message such as `Session: 75% remaining`, while preserving the prior presence state. Updates and restoration use the same compare-and-swap ownership checks as the other journaled surface.

## Verification

- `python3 -m pytest tests/gateway/test_matrix_account_usage_presence.py tests/gateway/test_account_usage_presence_config.py tests/gateway/test_account_usage_presence.py -q` — 50 passed
- `python3 -m pytest tests/agent/test_account_usage_outcome.py tests/gateway/test_account_usage_presence.py tests/gateway/test_account_usage_presence_config.py tests/gateway/test_account_usage_presence_runner.py tests/gateway/test_discord_account_usage_presence.py tests/gateway/test_telegram_account_usage_presence.py -q` — 76 passed
- `python3 -m pytest tests/hermes_cli/test_setup.py -k 'account_usage_presence' -q` — 4 passed, 18 deselected
- `python3 -m pytest tests/gateway/test_account_usage_presence.py -q` — 39 passed; repeated five times after the fetch-worker race fix
- `uvx --from ruff ruff check ...` — passed
- `python3 -m compileall` and `git diff --check` — passed

The repository-wide suite was attempted separately but did not complete within 600 seconds; the environment then reached a no-space condition from the existing large local Hermes state database and test logging. No Gateway restart was performed.
