### PR TITLE
fix(windows): prevent Git Bash NUL redirect files

### DIFF
--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -72,6 +72,43 @@ class TestWindowsBashNulRedirections:
         for command in commands:
             assert _rewrite_windows_bash_nul_redirections(command) == command
 
+    def test_rewrites_executable_command_substitutions(self):
+        cases = {
+            "echo `git show missing 2>NUL || true`": (
+                "echo `git show missing 2>/dev/null || true`"
+            ),
+            'echo "`git show missing 2>NUL || true`"': (
+                'echo "`git show missing 2>/dev/null || true`"'
+            ),
+            "echo $(git show missing 2>NUL || true)": (
+                "echo $(git show missing 2>/dev/null || true)"
+            ),
+            'echo "$(git show missing 2>NUL || true)"': (
+                'echo "$(git show missing 2>/dev/null || true)"'
+            ),
+        }
+
+        for command, expected in cases.items():
+            assert _rewrite_windows_bash_nul_redirections(command) == expected
+
+    def test_preserves_quoted_and_unquoted_heredoc_payloads(self):
+        commands = (
+            "cat <<EOF\n2>NUL\nEOF",
+            "cat <<'EOF'\n2>NUL\nEOF",
+            'cat <<"EOF"\n2>NUL\nEOF',
+            "cat <<-EOF\n\t2>NUL\n\tEOF",
+        )
+
+        for command in commands:
+            assert _rewrite_windows_bash_nul_redirections(command) == command
+
+    def test_does_not_mistake_a_here_string_for_a_heredoc(self):
+        command = "cat <<< payload 2>NUL"
+        assert (
+            _rewrite_windows_bash_nul_redirections(command)
+            == "cat <<< payload 2>/dev/null"
+        )
+
     def test_preserves_non_redirect_nul_words(self):
         commands = (
             "echo NUL",

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -32,10 +32,70 @@ from tools.environments.local import (
     _prepend_git_bash_dirs,
     _quote_bash_path,
     _resolve_safe_cwd,
+    _rewrite_windows_bash_nul_redirections,
     _sanitize_subprocess_env,
     _windows_to_msys_path,
     hermes_subprocess_env,
 )
+
+
+# ---------------------------------------------------------------------------
+# CMD-style NUL redirections — Git Bash must use /dev/null
+# ---------------------------------------------------------------------------
+
+class TestWindowsBashNulRedirections:
+    def test_rewrites_common_cmd_null_device_spellings(self):
+        cases = {
+            "git show missing 2>NUL || true": "git show missing 2>/dev/null || true",
+            "tool 1>nul": "tool 1>/dev/null",
+            "tool 2>> Nul": "tool 2>> /dev/null",
+            "tool >NUL": "tool >/dev/null",
+            "tool > NUL": "tool > /dev/null",
+            "tool >>nul": "tool >>/dev/null",
+            "tool &>NUL": "tool &>/dev/null",
+            "tool &>> nul": "tool &>> /dev/null",
+        }
+
+        for command, expected in cases.items():
+            assert _rewrite_windows_bash_nul_redirections(command) == expected
+
+    def test_preserves_quoted_escaped_and_commented_text(self):
+        commands = (
+            "echo '2>NUL'",
+            'echo "2>NUL"',
+            "echo `printf '2>NUL'`",
+            r"echo 2\>NUL",
+            "cmd.exe /c \"tool 2>NUL\"",
+            "echo ok # tool 2>NUL",
+        )
+
+        for command in commands:
+            assert _rewrite_windows_bash_nul_redirections(command) == command
+
+    def test_preserves_non_redirect_nul_words(self):
+        commands = (
+            "echo NUL",
+            "echo ANNUL",
+            "tool >NUL.txt",
+            "tool 2>/dev/null",
+        )
+
+        for command in commands:
+            assert _rewrite_windows_bash_nul_redirections(command) == command
+
+    def test_local_environment_rewrites_only_on_windows(self, monkeypatch, tmp_path):
+        with patch.object(
+            LocalEnvironment, "init_session", autospec=True, return_value=None
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        command, _ = env._prepare_command("git show missing 2>NUL || true")
+        assert command == "git show missing 2>/dev/null || true"
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        command, _ = env._prepare_command("git show missing 2>NUL || true")
+        assert command == "git show missing 2>NUL || true"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -26,6 +26,121 @@ _WINDOWS_BASH_NUL_REDIRECTION_RE = re.compile(
 )
 
 
+def _mask_windows_bash_non_executable_text(command: str) -> tuple[str, bool]:
+    """Mask shell text that cannot contain an executable redirection.
+
+    Single-quoted text, literal double-quoted text, escaped characters, and
+    comments are data.  Command substitutions inside backticks or ``$(...)``
+    remain executable even when nested in double quotes, so their shell syntax
+    stays visible to the redirect matcher.
+
+    Heredocs require parsing delimiters and payload boundaries.  Report their
+    presence so the caller can conservatively leave the whole command alone
+    instead of rewriting redirect-looking payload data.
+    """
+    executable = [False] * len(command)
+    has_heredoc = False
+
+    def scan_double_quote(index: int) -> int:
+        index += 1
+        while index < len(command):
+            ch = command[index]
+            if ch == "\\":
+                index += 2
+                continue
+            if ch == '"':
+                return index + 1
+            if ch == "`":
+                index = scan_code(index + 1, closing="`")
+                if index < len(command) and command[index] == "`":
+                    index += 1
+                continue
+            if command.startswith("$(", index):
+                index = scan_code(index + 2, closing=")", paren_depth=1)
+                if index < len(command) and command[index] == ")":
+                    index += 1
+                continue
+            index += 1
+        return index
+
+    def scan_code(
+        index: int,
+        *,
+        closing: str | None = None,
+        paren_depth: int = 0,
+    ) -> int:
+        nonlocal has_heredoc
+
+        while index < len(command):
+            ch = command[index]
+
+            if closing == "`" and ch == "`":
+                return index
+            if closing == ")" and ch == ")":
+                paren_depth -= 1
+                if paren_depth == 0:
+                    return index
+                executable[index] = True
+                index += 1
+                continue
+            if closing == ")" and ch == "(":
+                paren_depth += 1
+                executable[index] = True
+                index += 1
+                continue
+
+            if ch == "'":
+                index += 1
+                while index < len(command) and command[index] != "'":
+                    index += 1
+                if index < len(command):
+                    index += 1
+                continue
+            if ch == '"':
+                index = scan_double_quote(index)
+                continue
+            if ch == "\\":
+                index += 2
+                continue
+            if ch == "#" and (
+                index == 0
+                or command[index - 1].isspace()
+                or command[index - 1] in ";|&(){}"
+            ):
+                while index < len(command) and command[index] != "\n":
+                    index += 1
+                continue
+            if (
+                command.startswith("<<", index)
+                and (index == 0 or command[index - 1] != "<")
+                and not command.startswith("<<<", index)
+            ):
+                has_heredoc = True
+                return len(command)
+            if ch == "`":
+                index = scan_code(index + 1, closing="`")
+                if index < len(command) and command[index] == "`":
+                    index += 1
+                continue
+            if command.startswith("$(", index):
+                index = scan_code(index + 2, closing=")", paren_depth=1)
+                if index < len(command) and command[index] == ")":
+                    index += 1
+                continue
+
+            executable[index] = True
+            index += 1
+
+        return index
+
+    scan_code(0)
+    masked = "".join(
+        ch if executable[index] else ("\n" if ch == "\n" else " ")
+        for index, ch in enumerate(command)
+    )
+    return masked, has_heredoc
+
+
 def _rewrite_windows_bash_nul_redirections(command: str) -> str:
     """Translate CMD-style ``NUL`` redirects for Windows Git Bash.
 
@@ -35,54 +150,19 @@ def _rewrite_windows_bash_nul_redirections(command: str) -> str:
     leave a Windows-reserved file in the working tree.  Rewrite the common
     CMD spellings to Bash's real null device before the command is wrapped.
 
-    Quoted strings, escaped characters, and shell comments are masked before
-    matching so examples such as ``echo '2>NUL'`` and nested
-    ``cmd.exe /c \"... 2>NUL\"`` commands keep their original text.
+    Non-executable strings, escaped characters, and shell comments are masked
+    before matching. Executable command substitutions remain visible. Commands
+    containing heredocs are left unchanged so payload data is never rewritten.
     """
     if not command or ">" not in command or "nul" not in command.lower():
         return command
 
-    masked = list(command)
-    quote: str | None = None
-    i = 0
-    while i < len(command):
-        ch = command[i]
-
-        if quote is not None:
-            masked[i] = "\n" if ch == "\n" else " "
-            if quote != "'" and ch == "\\" and i + 1 < len(command):
-                i += 1
-                masked[i] = "\n" if command[i] == "\n" else " "
-            elif ch == quote:
-                quote = None
-            i += 1
-            continue
-
-        if ch in {"'", '"', "`"}:
-            quote = ch
-            masked[i] = " "
-            i += 1
-            continue
-
-        if ch == "\\" and i + 1 < len(command):
-            masked[i] = " "
-            i += 1
-            masked[i] = "\n" if command[i] == "\n" else " "
-            i += 1
-            continue
-
-        if ch == "#" and (
-            i == 0 or command[i - 1].isspace() or command[i - 1] in ";|&(){}"
-        ):
-            while i < len(command) and command[i] != "\n":
-                masked[i] = " "
-                i += 1
-            continue
-
-        i += 1
+    masked, has_heredoc = _mask_windows_bash_non_executable_text(command)
+    if has_heredoc:
+        return command
 
     rewritten = command
-    matches = list(_WINDOWS_BASH_NUL_REDIRECTION_RE.finditer("".join(masked)))
+    matches = list(_WINDOWS_BASH_NUL_REDIRECTION_RE.finditer(masked))
     for match in reversed(matches):
         start, end = match.span("target")
         rewritten = rewritten[:start] + "/dev/null" + rewritten[end:]

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -20,6 +20,75 @@ _IS_WINDOWS = platform.system() == "Windows"
 logger = logging.getLogger(__name__)
 
 
+_WINDOWS_BASH_NUL_REDIRECTION_RE = re.compile(
+    r"(?i)(?:(?:\d+|&)>>?|>>?)[ \t]*"
+    r"(?P<target>nul)(?=$|[\s;&|(){}])"
+)
+
+
+def _rewrite_windows_bash_nul_redirections(command: str) -> str:
+    """Translate CMD-style ``NUL`` redirects for Windows Git Bash.
+
+    Hermes intentionally executes local Windows commands through Git Bash.
+    Unlike ``cmd.exe``, Bash treats a bare ``NUL`` redirect target as an
+    ordinary filename, so model-authored commands such as ``git ... 2>NUL``
+    leave a Windows-reserved file in the working tree.  Rewrite the common
+    CMD spellings to Bash's real null device before the command is wrapped.
+
+    Quoted strings, escaped characters, and shell comments are masked before
+    matching so examples such as ``echo '2>NUL'`` and nested
+    ``cmd.exe /c \"... 2>NUL\"`` commands keep their original text.
+    """
+    if not command or ">" not in command or "nul" not in command.lower():
+        return command
+
+    masked = list(command)
+    quote: str | None = None
+    i = 0
+    while i < len(command):
+        ch = command[i]
+
+        if quote is not None:
+            masked[i] = "\n" if ch == "\n" else " "
+            if quote != "'" and ch == "\\" and i + 1 < len(command):
+                i += 1
+                masked[i] = "\n" if command[i] == "\n" else " "
+            elif ch == quote:
+                quote = None
+            i += 1
+            continue
+
+        if ch in {"'", '"', "`"}:
+            quote = ch
+            masked[i] = " "
+            i += 1
+            continue
+
+        if ch == "\\" and i + 1 < len(command):
+            masked[i] = " "
+            i += 1
+            masked[i] = "\n" if command[i] == "\n" else " "
+            i += 1
+            continue
+
+        if ch == "#" and (
+            i == 0 or command[i - 1].isspace() or command[i - 1] in ";|&(){}"
+        ):
+            while i < len(command) and command[i] != "\n":
+                masked[i] = " "
+                i += 1
+            continue
+
+        i += 1
+
+    rewritten = command
+    matches = list(_WINDOWS_BASH_NUL_REDIRECTION_RE.finditer("".join(masked)))
+    for match in reversed(matches):
+        start, end = match.span("target")
+        rewritten = rewritten[:start] + "/dev/null" + rewritten[end:]
+    return rewritten
+
+
 def _msys_to_windows_path(cwd: str) -> str:
     """Translate a Git Bash / MSYS-style POSIX path (``/c/Users/x``) to the
     native Windows form (``C:\\Users\\x``) so ``os.path.isdir`` and
@@ -1106,6 +1175,11 @@ class LocalEnvironment(BaseEnvironment):
             cwd = os.path.expanduser(cwd)
         super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
         self.init_session()
+
+    def _prepare_command(self, command: str) -> tuple[str, str | None]:
+        if _IS_WINDOWS:
+            command = _rewrite_windows_bash_nul_redirections(command)
+        return super()._prepare_command(command)
 
     def get_temp_dir(self) -> str:
         """Return a shell-safe writable temp dir for local execution.


### PR DESCRIPTION
## What does this PR do?

On native Windows, `LocalEnvironment` intentionally executes commands through Git Bash. Git Bash treats a CMD-style `NUL` redirect target as a relative filename rather than the null device, so model-authored commands such as `git show missing 2>NUL || true` can leave a literal Windows-reserved `NUL` file in the working directory.

This PR normalizes common CMD-style `NUL` redirection targets to `/dev/null` before the Windows Git Bash command is prepared. Literal quoted text, escaped characters, and comments are left untouched; executable backtick and `$(...)` substitutions remain eligible for normalization, including inside double quotes. Commands containing heredocs are conservatively left unchanged so redirect-looking payload data is never modified. Non-Windows command handling is unchanged.

## Related Issue

Related to #57081. #57212 guards the downstream update/autostash path when a reserved file already exists; this PR prevents the local terminal path from creating one through CMD-style null redirection.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added Windows Git Bash `NUL` redirect normalization in `tools/environments/local.py`.
- Applied the normalization through `LocalEnvironment._prepare_command()` only on Windows.
- Kept executable backtick and `$(...)` command substitutions visible to the matcher while protecting literal shell text.
- Conservatively skipped commands containing heredocs so quoted and unquoted payloads cannot be rewritten; here-strings remain eligible for normal redirect handling.
- Added regression coverage in `tests/tools/test_local_env_windows_msys.py` for common redirect forms, executable command substitutions, protected quoted/escaped/commented text, quoted and unquoted heredocs, here-strings, non-redirect lookalikes, and the Windows-only environment path.

## How to Test

1. On native Windows, create a temporary Git repository and execute `git show missing 2>NUL || true` through `LocalEnvironment`.
2. Verify that the command completes and no literal `NUL` file exists in the working directory.
3. Run `scripts/run_tests.sh -j 4 tests/tools/test_local_env_windows_msys.py -k WindowsBashNulRedirections -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

Full-suite coverage is left to GitHub CI per the repository workflow.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings updated; no user-facing documentation change needed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (terminal schema is unchanged)

## Screenshots / Logs

- Focused regression selection: `7 tests passed, 0 failed` with 4 workers.
- Native Windows Git Bash checks in a temporary directory: executable backtick redirection was normalized without creating a literal `NUL` file, and quoted heredoc payload output remained exactly `2>NUL` without creating a file.
- Wrapper bytecode pre-compilation and `git diff --check` pass.
- A broader native-Windows run of `tests/tools/test_local_env_windows_msys.py` reached 42 passing tests and two pre-existing path-separator assertion failures outside this change; full-suite coverage is left to GitHub CI.