### PR TITLE
fix: propagate Docker policy to file tools

### DIFF
--- a/tests/tools/test_file_tools_container_config.py
+++ b/tests/tools/test_file_tools_container_config.py
@@ -21,6 +21,10 @@ def _make_env_config(**overrides):
         "docker_volumes": [],
         "docker_mount_cwd_to_workspace": True,
         "docker_forward_env": ["MY_SECRET", "API_KEY"],
+        "docker_env": {"APP_ENV": "test"},
+        "docker_extra_args": ["--cap-drop=ALL"],
+        "docker_persist_across_processes": False,
+        "docker_orphan_reaper": False,
     }
     base.update(overrides)
     return base
@@ -72,6 +76,33 @@ class TestFileToolsContainerConfig:
         del cfg["docker_forward_env"]
         cc = self._run(cfg, "t4").get("container_config", {})
         assert cc.get("docker_forward_env") == []
+
+    def test_docker_policy_fields_passed(self):
+        """Docker policy values are forwarded to container_config unchanged."""
+        cc = self._run(_make_env_config(), "t5").get("container_config", {})
+
+        assert cc["docker_env"] == {"APP_ENV": "test"}
+        assert cc["docker_extra_args"] == ["--cap-drop=ALL"]
+        assert cc["docker_persist_across_processes"] is False
+        assert cc["docker_orphan_reaper"] is False
+
+    def test_docker_policy_fields_use_terminal_defaults(self):
+        """Docker policy fields preserve terminal_tool defaults when absent."""
+        cfg = _make_env_config()
+        for key in (
+            "docker_env",
+            "docker_extra_args",
+            "docker_persist_across_processes",
+            "docker_orphan_reaper",
+        ):
+            del cfg[key]
+
+        cc = self._run(cfg, "t6").get("container_config", {})
+
+        assert cc["docker_env"] == {}
+        assert cc["docker_extra_args"] == []
+        assert cc["docker_persist_across_processes"] is True
+        assert cc["docker_orphan_reaper"] is True
 
     def test_cwd_only_raw_task_override_reaches_file_environment(self):
         """CWD-only task overrides collapse to default but must keep their cwd."""

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1146,8 +1146,12 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "docker_volumes": config.get("docker_volumes", []),
                     "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                     "docker_forward_env": config.get("docker_forward_env", []),
+                    "docker_env": config.get("docker_env", {}),
                     "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                     "docker_network": config.get("docker_network", True),
+                    "docker_extra_args": config.get("docker_extra_args", []),
+                    "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                    "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
                 }
 
             ssh_config = None


### PR DESCRIPTION
## Summary

Propagate Docker policy fields from `terminal_tool._get_env_config()` through the file-tool environment creation path.

When a file tool created the Docker environment first, `tools/file_tools.py` omitted policy fields that `terminal_tool._create_environment()` consumes. The consumer therefore fell back to its defaults, silently ignoring explicit configuration such as `docker_persist_across_processes: false`.

This forwards:

- `docker_env` (default `{}`)
- `docker_extra_args` (default `[]`)
- `docker_persist_across_processes` (default `true`)
- `docker_orphan_reaper` (default `true`)

The defaults match the terminal-tool path exactly, and `.get()` preserves explicit `false` and empty collection values.

## Tests

Added deterministic propagation/default tests, including the original `docker_persist_across_processes=False` failure mode.

CI-parity per-file runner:

```text
scripts/run_tests.sh \
  tests/tools/test_file_tools_container_config.py \
  tests/tools/test_container_cwd_sanitize.py \
  tests/tools/test_docker_orphan_reaper_integration.py \
  tests/tools/test_modal_sandbox_fixes.py \
  tests/tools/test_docker_environment.py \
  -q

5 files, 128 tests passed, 0 failed
```

Additional checks:

- `python3 -m py_compile tools/file_tools.py tests/tools/test_file_tools_container_config.py`
- `git diff --check`
- independent read-only review: **SHIP**, correctness 9/10, risk 2/10

No Docker daemon is required for these tests.
