### PR TITLE
fix(container): keep named multiplex gateway slots down

### DIFF
--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -125,6 +125,16 @@ def reconcile_profile_gateways(
     """
     actions: list[ReconcileAction] = []
 
+    # A multiplexing root/default gateway owns inbound platform connections
+    # for every profile. Named slots must still be registered (so explicit
+    # lifecycle management remains available), but booting them from their
+    # persisted run intent would create additional multiplex owners.
+    from utils import is_truthy_value
+
+    multiplex_profiles = is_truthy_value(
+        os.environ.get("GATEWAY_MULTIPLEX_PROFILES"),
+    )
+
     # Default profile — always register, even if nothing has ever
     # populated the root profile dir. The slot exists so
     # ``hermes gateway start`` (no ``-p``) has somewhere to land;
@@ -173,7 +183,9 @@ def reconcile_profile_gateways(
                 continue
 
             prior_state = _read_desired_state(entry)
-            should_start = prior_state in _AUTOSTART_STATES
+            should_start = (
+                not multiplex_profiles and prior_state in _AUTOSTART_STATES
+            )
 
             if not dry_run:
                 _cleanup_stale_runtime_files(entry)

--- a/tests/hermes_cli/test_container_boot.py
+++ b/tests/hermes_cli/test_container_boot.py
@@ -195,6 +195,39 @@ def test_desired_state_running_autostarts_even_if_runtime_failed(tmp_path: Path)
     assert not (scandir / "gateway-resilient" / "down").exists()
 
 
+def test_multiplex_boot_keeps_named_running_profile_registered_down(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the root/default s6 slot may own a multiplex gateway process."""
+    monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "true")
+    scandir = tmp_path / "run-service"; scandir.mkdir()
+    _seed_default_root(tmp_path, state="running")
+    profile = _make_profile(
+        tmp_path,
+        "resilient",
+        state="running",
+        desired_state="running",
+    )
+    persisted_state = (profile / "gateway_state.json").read_text()
+
+    actions = reconcile_profile_gateways(
+        hermes_home=tmp_path, scandir=scandir, dry_run=False,
+    )
+
+    assert actions == [
+        ReconcileAction(
+            profile="default", prior_state="running", action="started",
+        ),
+        ReconcileAction(
+            profile="resilient", prior_state="running", action="registered",
+        ),
+    ]
+    assert not (scandir / "gateway-default" / "down").exists()
+    assert (scandir / "gateway-resilient" / "down").exists()
+    assert (profile / "gateway_state.json").read_text() == persisted_state
+
+
 def test_desired_state_stopped_blocks_legacy_running_runtime(tmp_path: Path) -> None:
     """Explicit stop must survive a stale legacy runtime state of running."""
     scandir = tmp_path / "run-service"; scandir.mkdir()


### PR DESCRIPTION
## Summary

- make container boot enforce one s6 gateway process owner when `GATEWAY_MULTIPLEX_PROFILES=true`
- keep the root/default gateway eligible for autostart while registering every named profile slot with an s6 `down` marker
- preserve each named profile's persisted `gateway_state.json` / desired run intent unchanged
- leave non-multiplex reconciliation behavior unchanged

## Live mechanism

The hosted container sets `GATEWAY_MULTIPLEX_PROFILES=true`. The root/default gateway then multiplexes every profile, but container boot previously also removed the `down` marker for each named profile whose persisted desired state was `running`. s6 consequently started `gateway-default` and each named `gateway-*` slot; every process multiplexed all profiles, multiplying relay sockets and platform ownership.

The reconciler now treats the env-backed multiplex mode as a startup-ownership constraint: only the root/default slot may autostart. Named slots are still rendered and their persisted desired state is still read and reported, but they are published down. This requires no new operational flags or deployment changes.

## Verification

- RED: `.venv/bin/python -m pytest tests/hermes_cli/test_container_boot.py::test_multiplex_boot_keeps_named_running_profile_registered_down -q` -> 1 failed (named `resilient` action was `started`, expected `registered`)
- GREEN targeted: same command -> 1 passed
- container boot + service manager: `.venv/bin/python -m pytest tests/hermes_cli/test_container_boot.py tests/hermes_cli/test_service_manager.py -q` -> 122 passed
- multiplex env precedence: `.venv/bin/python -m pytest tests/gateway/test_config.py::TestMultiplexProfilesEnvOverride -q` -> 9 passed

## Notes

A broader `tests/gateway/test_config.py` run in the minimal isolated venv produced 4 unrelated Telegram plugin failures because optional runtime dependencies (`requests` / `httpx`) were not installed; all 100 other tests in that file passed. The directly relevant multiplex config class passes.

![Single multiplex gateway owner](https://v3b.fal.media/files/b/0aa26efb/j0DIFy3iQ-Wph7mkqP2Cg_ftFw6kGW.png)
