### PR TITLE
fix(anthropic): reorder tool_result blocks before text in user turns

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2706,7 +2706,7 @@ _RESPONSES_ONLY_KWARGS = frozenset(
 
 
 def sanitize_anthropic_kwargs(api_kwargs: Any, *, log_prefix: str = "") -> Any:
-    """Drop Responses-API-only keys before an Anthropic Messages SDK call.
+    """Repair the final payload before an Anthropic Messages SDK call.
 
     Defensive boundary guard for #31673: under rare api_mode-flip races
     (e.g. a concurrent auxiliary call mutating a shared agent between the
@@ -2733,6 +2733,47 @@ def sanitize_anthropic_kwargs(api_kwargs: Any, *, log_prefix: str = "") -> Any:
             "api_mode while dispatch ran under anthropic_messages.",
             log_prefix,
             sorted(leaked),
+        )
+
+    # Anthropic requires every tool_result block to come before any text or
+    # image blocks in the immediately following user message.  Compaction can
+    # preserve an assistant tool_use/result pair while injecting a
+    # system-reminder text block at the front of that user turn.  The IDs still
+    # match, but the API rejects the block order with a non-retryable HTTP 400.
+    # Repair at the final SDK boundary so later message decorators cannot leave
+    # an otherwise valid session permanently wedged.  Stable partitioning
+    # preserves the relative order within both block groups.
+    reordered_tool_result_turns = 0
+    messages = api_kwargs.get("messages")
+    if isinstance(messages, list):
+        for message in messages:
+            if not isinstance(message, dict) or message.get("role") != "user":
+                continue
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            tool_results = [
+                block
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "tool_result"
+            ]
+            if not tool_results:
+                continue
+            other_blocks = [
+                block
+                for block in content
+                if not (isinstance(block, dict) and block.get("type") == "tool_result")
+            ]
+            reordered = tool_results + other_blocks
+            if reordered != content:
+                message["content"] = reordered
+                reordered_tool_result_turns += 1
+    if reordered_tool_result_turns:
+        logger.warning(
+            "%sReordered tool_result blocks before other user content in %d "
+            "Anthropic message(s)",
+            log_prefix,
+            reordered_tool_result_turns,
         )
     return api_kwargs
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -25,6 +25,7 @@ from agent.anthropic_adapter import (
     read_claude_code_credentials,
     resolve_anthropic_token,
     run_oauth_setup_token,
+    sanitize_anthropic_kwargs,
 )
 from agent.transports import get_transport
 
@@ -826,6 +827,46 @@ class TestConvertTools:
 
 
 class TestConvertMessages:
+    def test_final_sanitizer_moves_tool_results_before_user_text(self):
+        """Anthropic requires tool_result blocks to lead the user turn.
+
+        Compaction can place an injected system-reminder text block before a
+        preserved tool result.  The final SDK boundary must repair that shape
+        instead of letting a non-retryable HTTP 400 kill the session.
+        """
+        api_kwargs = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call_compacted",
+                            "name": "execute_code",
+                            "input": {},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "<system-reminder>context</system-reminder>"},
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_compacted",
+                            "content": "ok",
+                        },
+                    ],
+                },
+            ]
+        }
+
+        sanitize_anthropic_kwargs(api_kwargs)
+
+        assert [
+            block["type"] for block in api_kwargs["messages"][1]["content"]
+        ] == ["tool_result", "text"]
+
     def test_extracts_system_prompt(self):
         messages = [
             {"role": "system", "content": "You are helpful."},


### PR DESCRIPTION
## Problem

A compacted conversation can retain an assistant `tool_use` plus its matching result while injecting a `<system-reminder>` text block at the **front** of the following user message. The `tool_use`/`tool_result` IDs still match, but Anthropic requires every `tool_result` block to precede any `text`/`image` blocks in that user turn.

The result is a **non-retryable** HTTP 400:

```
messages.N: `tool_use` ids were found without `tool_result` blocks immediately after: call_XXX.
Each `tool_use` block must have a corresponding `tool_result` block in the next message.
```

Because the persisted session is unchanged, every retry re-sends the same malformed order and 400s again — the session appears dead.

Observed shape in the failing request:

- assistant: `tool_use(call_X)`
- next user content: `[text(<system-reminder>...), tool_result(call_X)]`  ← invalid order

## Fix

At the final Anthropic Messages SDK boundary (`sanitize_anthropic_kwargs`), stable-partition each user content list so all `tool_result` blocks come first, preserving relative order within both groups. This repairs payloads that later message decorators (compaction / system-reminder injection) may have reordered, so a single serialization defect can no longer wedge an otherwise valid session.

## Test

Adds `test_final_sanitizer_moves_tool_results_before_user_text` using the real compacted shape; asserts the block order changes from `[text, tool_result]` to `[tool_result, text]`.

- `pytest tests/agent/test_anthropic_adapter.py` → 175 passed
- `ruff check` → clean
