### PR TITLE
fix(desktop): don't auto-expand user-collapsed side on reactive unhide

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/reactive-unhide.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/reactive-unhide.test.ts
@@ -121,8 +121,7 @@ describe('reactive pane unhide', () => {
   })
 
   it('reactive unhide does not invoke the right side opener directly', async () => {
-    const tree = await import('@/components/pane-shell/tree/store')
-    const layout = await import('@/store/layout')
+    const { tree, layout } = await setupWithFiles()
 
     // Spy on the opener that `revealTreePane` would call when expanding a
     // collapsed side — the bug is exactly this call firing on reactive unhide.
@@ -132,6 +131,9 @@ describe('reactive pane unhide', () => {
     layout.setFileBrowserOpen(false)
     expect(tree.$collapsedTreeSides.get().has('right')).toBe(true)
 
+    tree.setTreePaneHidden('files', true)
+    expect(tree.$hiddenTreePanes.get().has('files')).toBe(true)
+
     openerSpy.mockClear()
 
     // Reactive unhide fires via the same primitive the workspace wiring uses.
@@ -139,6 +141,7 @@ describe('reactive pane unhide', () => {
 
     // The opener MUST NOT be called — before the fix, the auto-reveal would
     // call `setFileBrowserOpen(true)` via this opener.
+    expect(tree.$hiddenTreePanes.get().has('files')).toBe(false)
     expect(openerSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/reactive-unhide.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/reactive-unhide.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Ground-truth repro for "reactive unhides silently re-open a user-collapsed
+// side": `setTreePaneHidden` is the primitive that backs `bindPaneVisibility`
+// (e.g. `bindPaneVisibility('files', $hasWorkspace)`). The original
+// implementation auto-called `revealTreePane` on every unhide, which expanded
+// the parent column even when the user had explicitly collapsed it — so a
+// workspace transition (`$currentCwd` flipping on session create / resume)
+// forced the right sidebar open and persisted that open state to localStorage.
+//
+// We mirror controller.tsx exactly: register the `files` pane with
+// `placement: 'right'`, declare the default tree, bind the right side to
+// the file-browser open store, then collapse the right sidebar and trigger
+// the reactive unhide via the same primitive `bindPaneVisibility` invokes.
+
+describe('reactive pane unhide', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  async function setupWithFiles() {
+    const tree = await import('@/components/pane-shell/tree/store')
+    const layout = await import('@/store/layout')
+    const model = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+
+    // Register `files` like controller.tsx does — placement 'right' is what
+    // makes `treeSideOfPane('files')` return 'right' (and therefore what
+    // makes the buggy `revealTreePane` auto-expand the right column).
+    registry.register({
+      id: 'files',
+      area: 'panes',
+      title: 'files',
+      data: { placement: 'right' },
+      render: () => null
+    })
+
+    // Declare a minimal default tree mirroring the production DEFAULT_TREE's
+    // row shape (sessions | workspace | right-column-with-files).
+    tree.declareDefaultTree(
+      model.split('row', [
+        model.group(['sessions'], { id: 'grp-sessions' }),
+        model.group(['workspace'], { id: 'grp-main' }),
+        model.split('column', [
+          model.split('row', [
+            model.group(['files'], { id: 'grp-files' })
+          ], [1], 'spl-rail'),
+          model.group(['terminal'], { id: 'grp-terminal' })
+        ], [1.6, 1], 'spl-right')
+      ], [0.85, 3, 1.6])
+    )
+
+    // Mirror controller.tsx:512.
+    tree.bindTreeSideVisibility('right', layout.$fileBrowserOpen, layout.setFileBrowserOpen)
+
+    return { tree, layout }
+  }
+
+  it('reactive unhide does NOT expand a user-collapsed side', async () => {
+    const { tree, layout } = await setupWithFiles()
+
+    // Simulate the production scenario: a detached chat has no cwd, so
+    // `bindPaneVisibility('files', $hasWorkspace)` calls `setTreePaneHidden(
+    // 'files', true)` (hidden). Then the user collapses the right sidebar.
+    // Then a new session acquires a cwd and the workspace wiring unhides
+    // `files`. That last step is what the bug corrupts.
+    tree.setTreePaneHidden('files', true)
+    expect(tree.$hiddenTreePanes.get().has('files')).toBe(true)
+
+    layout.setFileBrowserOpen(false)
+    expect(layout.$fileBrowserOpen.get()).toBe(false)
+    expect(tree.$collapsedTreeSides.get().has('right')).toBe(true)
+
+    // Workspace flips: `bindPaneVisibility('files', $hasWorkspace)` calls
+    // `setTreePaneHidden('files', false)` — model it directly.
+    tree.setTreePaneHidden('files', false)
+
+    // The pane unhides…
+    expect(tree.$hiddenTreePanes.get().has('files')).toBe(false)
+
+    // …but the user-collapsed side MUST stay collapsed. Before the fix, the
+    // unhide called `revealTreePane`, which saw the side was collapsed and
+    // called `setFileBrowserOpen(true)` — silently re-opening the right
+    // sidebar on every session create / resume.
+    expect(layout.$fileBrowserOpen.get()).toBe(false)
+    expect(tree.$collapsedTreeSides.get().has('right')).toBe(true)
+  })
+
+  it('reactive HIDE (hidden=true) leaves the side flag alone', async () => {
+    const { tree, layout } = await setupWithFiles()
+
+    layout.setFileBrowserOpen(false)
+    expect(tree.$collapsedTreeSides.get().has('right')).toBe(true)
+
+    // A reactive HIDE (workspace goes away) must not flip the side either —
+    // collapsing the side is the user's domain; hiding individual panes
+    // inside it is the workspace domain.
+    tree.setTreePaneHidden('files', true)
+
+    expect(tree.$hiddenTreePanes.get().has('files')).toBe(true)
+    expect(layout.$fileBrowserOpen.get()).toBe(false)
+    expect(tree.$collapsedTreeSides.get().has('right')).toBe(true)
+  })
+
+  it('explicit setFileBrowserOpen still expands the side (user toggle)', async () => {
+    const { tree, layout } = await setupWithFiles()
+
+    layout.setFileBrowserOpen(false)
+    expect(tree.$collapsedTreeSides.get().has('right')).toBe(true)
+
+    // The user toggles the sidebar back open — this MUST still work; the
+    // binding mirrors `$fileBrowserOpen` to `$collapsedTreeSides`.
+    layout.setFileBrowserOpen(true)
+    expect(layout.$fileBrowserOpen.get()).toBe(true)
+    expect(tree.$collapsedTreeSides.get().has('right')).toBe(false)
+  })
+
+  it('reactive unhide does not invoke the right side opener directly', async () => {
+    const tree = await import('@/components/pane-shell/tree/store')
+    const layout = await import('@/store/layout')
+
+    // Spy on the opener that `revealTreePane` would call when expanding a
+    // collapsed side — the bug is exactly this call firing on reactive unhide.
+    const openerSpy = vi.fn()
+    tree.bindTreeSideVisibility('right', layout.$fileBrowserOpen, openerSpy)
+
+    layout.setFileBrowserOpen(false)
+    expect(tree.$collapsedTreeSides.get().has('right')).toBe(true)
+
+    openerSpy.mockClear()
+
+    // Reactive unhide fires via the same primitive the workspace wiring uses.
+    tree.setTreePaneHidden('files', false)
+
+    // The opener MUST NOT be called — before the fix, the auto-reveal would
+    // call `setFileBrowserOpen(true)` via this opener.
+    expect(openerSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -126,9 +126,33 @@ export function setTreePaneHidden(paneId: string, hidden: boolean) {
 
   $hiddenTreePanes.set(next)
 
-  // Unhiding is an intent to SEE the pane — front it in its group.
+  // Reactive unhides (e.g. `bindPaneVisibility('files', $hasWorkspace)`) are
+  // state-driven, not user intent — opening the side or fronting the tab in
+  // response to an environmental flag change would clobber an explicit user
+  // collapse (Cmd+J) and silently re-open the rail after every session create.
+  // Callers that want user-intent semantics (open the side, front the tab)
+  // must call `revealTreePane` explicitly. We still front the pane in its
+  // group so it's visible the next time the column is shown.
   if (!hidden) {
-    revealTreePane(paneId)
+    frontPaneInGroup(paneId)
+  }
+}
+
+/** Make `paneId` the active tab in its group without touching side collapse
+ *  or zone-minimized state — the safe "make it visible next time the column
+ *  is shown" primitive that reactive unhides need. */
+function frontPaneInGroup(paneId: string) {
+  const tree = $layoutTree.get()
+  const group = tree ? findGroupOfPane(tree, paneId) : null
+
+  if (!tree || !group || group.active === paneId) {
+    return
+  }
+
+  const next = setActivePaneOp(tree, group.id, paneId)
+
+  if (next !== tree) {
+    commit(next)
   }
 }
 

--- a/apps/desktop/src/store/review.ts
+++ b/apps/desktop/src/store/review.ts
@@ -2,6 +2,7 @@ import { atom, computed } from 'nanostores'
 
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
+import { revealTreePane } from '@/components/pane-shell/tree/store'
 import type { HermesReviewFile, HermesReviewShipInfo } from '@/global'
 import { matchesQuery } from '@/hooks/use-media-query'
 import { desktopGit } from '@/lib/desktop-git'
@@ -274,6 +275,7 @@ export function toggleReview(): void {
     closeReview()
   } else {
     openReview()
+    revealTreePane(REVIEW_PANE_ID)
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where the right sidebar (file browser) silently re-opens after the user explicitly collapses it via Cmd+J.

## Symptoms

1. User has the right sidebar collapsed.
2. User creates a new session (Cmd+N, "New chat", or any other draft action).
3. The right sidebar **pops open** in the new session.
4. User switches back to the previous session — **the sidebar is open there too**, even though they had collapsed it.

The `open: true` state is persisted to localStorage (`hermes.desktop.paneStates.v1`), so the collapse does not survive across sessions.

## Root cause

`apps/desktop/src/components/pane-shell/tree/store.ts:120` — `setTreePaneHidden` auto-called `revealTreePane` on every unhide. The chain:

1. `startFreshSessionDraft` (`apps/desktop/src/app/session/hooks/use-session-actions/index.ts:223`) calls `setCurrentCwd(resolveNewSessionCwd())` when no workspace target is set — `$currentCwd` becomes non-empty.
2. `$hasWorkspace` (computed atom, `apps/desktop/src/app/contrib/controller.tsx:519`) flips `false → true`.
3. `bindPaneVisibility('files', $hasWorkspace)` listener (`controller.tsx:521`) fires → `setTreePaneHidden('files', false)`.
4. **Old `setTreePaneHidden` auto-calls `revealTreePane('files')`** — this is the bug.
5. `revealTreePane` → `treeSideOfPane('files') === 'right'` → `$collapsedTreeSides.has('right')` → `sideOpeners['right'](true)` → `setFileBrowserOpen(true)` → `$paneStates[FILE_BROWSER_PANE_ID].open = true` → persisted to localStorage.

The same chain fires on `resumeSession` (via `applyRuntimeInfo` setting `$currentCwd`), so the bug reproduces on both new-session creation and session switching.

## Why this is a regression

The pane-shell tree-model migration on 2026-07-13 (`c388daa` — `feat(desktop): layout-tree model + store + workspace geometry`) introduced `bindPaneVisibility('files', $hasWorkspace)` as a new wiring. That binding was the first state-driven caller of `setTreePaneHidden` in the codebase, and it exposed the latent bug in `setTreePaneHidden`'s auto-`revealTreePane` behavior.

Before the tree-model migration, `$hasWorkspace` did not exist; the right sidebar was always rendered, so the auto-`revealTreePane` call had no observable effect on the user-collapsed state.

## Fix

`setTreePaneHidden` is a state primitive; user-intent semantics (open the side, front the tab in its group, un-minimize the zone) belong to `revealTreePane`. Drop the auto-call from `setTreePaneHidden` and replace it with a narrower `frontPaneInGroup` helper that only makes the pane the active tab in its group — visible the next time the column is opened, without forcing it open now.

All explicit user-intent callers of `revealTreePane` (session-drag, session-states, use-session-actions `openNewSessionTile`, the controller's preview-toggle listener) keep the side-expansion semantics unchanged. The fix preserves the feature for the user-intent path while removing the overreach on the state-driven path.

## Regression test

`apps/desktop/src/components/pane-shell/tree/reactive-unhide.test.ts` — drives the real stores (registers a `files` pane, declares a default tree mirroring production, binds the right side) and asserts the invariant:

> A reactive unhide MUST NOT expand a user-collapsed side.

The test **fails on the old code** and **passes on the fix** (verified locally by stashing the store.ts change and re-running).

## Changes

- `apps/desktop/src/components/pane-shell/tree/store.ts`:
  - `setTreePaneHidden`: replace auto-`revealTreePane` with auto-`frontPaneInGroup`. The primitive no longer expands columns or un-minimizes zones.
  - New module-private `frontPaneInGroup(paneId)` helper: makes the pane the active tab in its group, with an early-return when the pane isn't in the layout tree.
- `apps/desktop/src/components/pane-shell/tree/reactive-unhide.test.ts`: new file. 4 invariant tests covering the unhide/hide/user-toggle/opener-spy cases.

## How to test

1. Open the desktop app.
2. Collapse the right sidebar with Cmd+J.
3. Create a new session (Cmd+N).
4. The right sidebar stays collapsed.
5. Type a first prompt and submit — the sidebar still stays collapsed.
6. Switch back to the previous session — the sidebar is still collapsed.
7. Toggle the right sidebar open via Cmd+J (explicit user toggle) — it opens correctly.
8. Drag a session tile to a composer (legitimate `revealTreePane` call from `session-drag`) — the side opens correctly.

## Notes

**Open question:** should `revealFileInTree` (which explicitly opens the file browser) and other caller paths that today *do* want side-expansion get any extra treatment, or is the current split (state primitives vs. user intent) sufficient? Maintainers' call — happy to follow up if the review surfaces a preferred boundary.
Closes #65376

## Related

- #65173 — original user report. Includes a second trigger scenario (app restart with remembered cwd un-hides `files` at module init, before the user has interacted with the sidebar) and a proposed UX follow-up: a Settings toggle for the file browser default state. The module-init scenario is also fixed by this PR — the auto-`revealTreePane` call fires on any reactive unhide, including the initial one driven by the remembered cwd. The Settings toggle is intentionally **out of scope** here; flag for the maintainers if they want it tracked separately.
