### PR TITLE
fix(cli): refuse kanban npm/build against a checkout outside the task workspace

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1436,6 +1436,63 @@ def _workspace_root(dir: Path) -> Path:
     return dir
 
 
+def _assert_kanban_workspace_owns_path(target: Path, *, action: str) -> None:
+    """Refuse npm/build mutations outside the active kanban workspace.
+
+    Kanban workers are expected to run from an isolated task workspace or
+    worktree. If this Python process was imported from a different checkout
+    (for example the live editable ``~/.hermes/hermes-agent`` tree), repo-root
+    npm/build helpers can silently mutate that live tree instead of the task's
+    workspace. Refuse those writes explicitly so the operator must rerun from
+    the isolated checkout.
+    """
+    task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if not task_id:
+        return
+
+    workspace_raw = (os.environ.get("HERMES_KANBAN_WORKSPACE") or "").strip()
+    if not workspace_raw:
+        print(
+            f"Refusing {action}: kanban task {task_id} has no HERMES_KANBAN_WORKSPACE set.",
+            file=sys.stderr,
+        )
+        print(
+            "  Re-run from the task's isolated workspace/worktree so npm/build steps cannot touch a live checkout.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        workspace = Path(workspace_raw).expanduser().resolve(strict=True)
+    except OSError:
+        print(
+            f"Refusing {action}: kanban workspace is missing or unreadable: {workspace_raw}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        target_resolved = target.expanduser().resolve(strict=False)
+    except OSError:
+        target_resolved = target.expanduser()
+
+    if target_resolved == workspace or target_resolved.is_relative_to(workspace):
+        return
+
+    print(
+        f"Refusing {action}: target path is outside the active kanban workspace.",
+        file=sys.stderr,
+    )
+    print(f"  task: {task_id}", file=sys.stderr)
+    print(f"  workspace: {workspace}", file=sys.stderr)
+    print(f"  requested path: {target_resolved}", file=sys.stderr)
+    print(
+        "  Re-run this command from the task's isolated checkout/worktree instead of the live editable Hermes tree.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
 def _termux_workspace_install_context(
     dir: Path, *, include_child_workspaces: bool = False
 ) -> tuple[Path, tuple[str, ...]]:
@@ -1788,6 +1845,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     #    Existing desktop behaviour runs npm from the workspace root.  Termux
     #    scopes the install to ui-tui so launch does not pull desktop/web
     #    dependencies into the hot path.
+    _assert_kanban_workspace_owns_path(tui_dir, action="TUI npm/build")
     did_install = False
     termux_startup = _is_termux_startup_environment()
     termux_need_rebuild = False
@@ -4884,6 +4942,8 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     if not _web_ui_build_needed(web_dir):
         return True
 
+    _assert_kanban_workspace_owns_path(web_dir, action="web UI npm/build")
+
     # Console-encoding-safe print: Windows consoles default to cp1252
     # (or similar) and will raise UnicodeEncodeError on arrow / check
     # glyphs unless PYTHONIOENCODING=utf-8 is set. Routing every print
@@ -5706,6 +5766,7 @@ def cmd_gui(args: argparse.Namespace):
             build_label = "source build" if source_mode else "packaged app"
             print(f"✓ Desktop {build_label} is up to date (content stamp matches)")
         else:
+            _assert_kanban_workspace_owns_path(desktop_dir, action="desktop npm/build")
             print("→ Installing desktop workspace dependencies...")
             nixos_env = _nixos_build_env()
             install_result = _run_npm_install_deterministic(npm, PROJECT_ROOT, capture_output=False, env=nixos_env)

--- a/tests/hermes_cli/test_kanban_workspace_guard.py
+++ b/tests/hermes_cli/test_kanban_workspace_guard.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import main as cli_main
+
+
+@pytest.fixture
+def kanban_env(monkeypatch, tmp_path: Path) -> Path:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_guard")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+    return workspace
+
+
+def _ns(**kw):
+    defaults = dict(
+        skip_build=False,
+        build_only=False,
+        force_build=False,
+        source=False,
+        fake_boot=False,
+        ignore_existing=False,
+        hermes_root=None,
+        cwd=None,
+    )
+    defaults.update(kw)
+    return argparse.Namespace(**defaults)
+
+
+def test_guard_allows_targets_inside_workspace(kanban_env: Path) -> None:
+    target = kanban_env / "repo" / "apps" / "desktop"
+    target.mkdir(parents=True)
+    cli_main._assert_kanban_workspace_owns_path(target, action="desktop npm/build")
+
+
+def test_guard_rejects_targets_outside_workspace(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = tmp_path / "live-root" / "apps" / "desktop"
+    target.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_guard")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main._assert_kanban_workspace_owns_path(target, action="desktop npm/build")
+
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "outside the active kanban workspace" in err
+    assert str(workspace) in err
+    assert str(target) in err
+
+
+def test_make_tui_argv_rejects_live_checkout_path(
+    kanban_env: Path, monkeypatch, tmp_path: Path, capsys
+) -> None:
+    tui_dir = tmp_path / "live-root" / "ui-tui"
+    tui_dir.mkdir(parents=True)
+    (tui_dir / "package.json").write_text("{}")
+
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.setattr(cli_main, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(cli_main, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(cli_main, "_tui_need_rebuild", lambda _root: False)
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main._make_tui_argv(tui_dir, tui_dev=False)
+
+    assert exc.value.code == 1
+    assert "outside the active kanban workspace" in capsys.readouterr().err
+
+
+def test_build_web_ui_rejects_live_checkout_path(
+    kanban_env: Path, tmp_path: Path, capsys
+) -> None:
+    web_dir = tmp_path / "live-root" / "web"
+    web_dir.mkdir(parents=True)
+    (web_dir / "package.json").write_text("{}")
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main._build_web_ui(web_dir)
+
+    assert exc.value.code == 1
+    assert "outside the active kanban workspace" in capsys.readouterr().err
+
+
+def test_cmd_gui_rejects_live_checkout_path(
+    kanban_env: Path, tmp_path: Path, monkeypatch, capsys
+) -> None:
+    root = tmp_path / "live-root"
+    desktop_dir = root / "apps" / "desktop"
+    desktop_dir.mkdir(parents=True)
+    (desktop_dir / "package.json").write_text("{}")
+
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    monkeypatch.setattr(cli_main, "_desktop_build_needed", lambda *_args, **_kwargs: True)
+
+    with patch("hermes_constants.find_node_executable", return_value="/usr/bin/npm"), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 1
+    assert "outside the active kanban workspace" in capsys.readouterr().err


### PR DESCRIPTION
## What & why

Kanban workers are expected to run from an isolated task workspace/worktree. When the Hermes process is imported from a *different* checkout — most notably the live editable `~/.hermes/hermes-agent` tree that a developer install runs from — the repo-root npm/build helpers for the TUI, web UI, and desktop app anchor on that imported checkout root. A build step then runs `npm install` / `npm run build` against the **live** tree instead of the task's workspace, silently regenerating its `package-lock.json` and reverting deliberate lockfile fixes (e.g. platform-specific `@esbuild` entries restored for CI).

This adds a small fail-closed guard so a kanban task cannot mutate a checkout it does not own.

## Change

- New `_assert_kanban_workspace_owns_path(target, *, action)` in `hermes_cli/main.py`.
  - **No-op unless `HERMES_KANBAN_TASK` is set** — ordinary CLI / desktop / web use is completely unchanged.
  - When a kanban task is active, it resolves `HERMES_KANBAN_WORKSPACE` and refuses the npm/build step when `target` resolves outside that workspace, printing the task id, the workspace, the blocked path, and the remediation (rerun from the isolated workspace/worktree).
- Wired into the three repo-root npm/build entrypoints: `_make_tui_argv()`, `_build_web_ui()`, and `cmd_gui()`.

Uses `pathlib` (`resolve()` + `is_relative_to`) — no path-separator assumptions.

## How to test

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_workspace_guard.py
# or:
pytest tests/hermes_cli/test_kanban_workspace_guard.py -q
```

The suite covers: no-op when `HERMES_KANBAN_TASK` is unset; refusal when the target is outside the workspace; pass-through when the target is inside the workspace; and the missing/unreadable-`HERMES_KANBAN_WORKSPACE` paths.

Manual: with `HERMES_KANBAN_TASK=t_x HERMES_KANBAN_WORKSPACE=/some/task/ws`, invoking a TUI/web/desktop build whose dir is outside `/some/task/ws` now aborts with a clear message instead of mutating the other checkout.

## Platforms tested

- **macOS** — unit tests + manual guard exercise.
- Cross-platform by construction (`pathlib`, no shell); `scripts/check-windows-footguns.py hermes_cli/main.py` is clean.

## Duplicate check

Searched `NousResearch/hermes-agent` issues and PRs (all states) for `npm install workspace isolation`, `package-lock drift editable`, `kanban workspace guard`, `install.sh INSTALL_DIR npm`, `workspace ownership guard`, `refuse npm live checkout`, `editable install lockfile` — no existing issue or PR covers this.

## Scope note

This PR is the **runtime** guard (the path that produced the observed drift). A matching belt-and-suspenders guard for the explicit desktop-installer bootstrap (`scripts/install.sh` + `scripts/install.ps1`, kept in lockstep per CONTRIBUTING) is intended as a small follow-up so it can be validated on a Windows runner; it is deliberately left out here to keep this PR focused and fully verifiable.
