### PR TITLE
fix(desktop): prove submit target belongs to selected session from both directions (#65328)

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -104,6 +104,11 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
   runtimeIdRef.current = runtimeId
   const storedIdRef = useRef(storedSessionId)
   storedIdRef.current = storedSessionId
+  // A tile IS its session (see the comment on the useSubmitPrompt call below)
+  // A tile owns one stable stored/runtime pair, so seed the shared ownership
+  // cache explicitly rather than relying on the primary route cache.
+  const runtimeIdByStoredSessionIdRef = useRef(new Map([[storedSessionId, runtimeId]]))
+  runtimeIdByStoredSessionIdRef.current.set(storedSessionId, runtimeId)
 
   // Tile busy tracks the SESSION state, never the global $busy — and it must
   // read LIVE. A render-time snapshot goes stale (this hook's host doesn't
@@ -216,6 +221,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
     // token is a stable constant (the guard never trips for a tile).
     getRouteToken: () => runtimeId,
     requestGateway,
+    runtimeIdByStoredSessionIdRef,
     // Tile ids are always bound before this hook mounts, so routed recovery is
     // unreachable here; keep the shared submit contract explicit.
     resumeStoredSession: () => undefined,

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -588,6 +588,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     refreshSessions,
     requestGateway,
     resumeStoredSession: resumeSession,
+    runtimeIdByStoredSessionIdRef,
     selectedStoredSessionIdRef,
     startFreshSessionDraft,
     sttEnabled,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -103,6 +103,7 @@ function Harness({
   refreshSessions,
   requestGateway,
   resumeStoredSession,
+  runtimeIdByStoredSessionIdRef: runtimeIdByStoredSessionIdRefProp,
   seedMessages,
   selectedStoredSessionIdRef: selectedStoredSessionIdRefProp,
   storedSessionId,
@@ -125,6 +126,7 @@ function Harness({
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
   resumeStoredSession?: (storedSessionId: string) => Promise<void> | void
+  runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
   seedMessages?: unknown[]
   selectedStoredSessionIdRef?: MutableRefObject<string | null>
   storedSessionId?: null | string
@@ -140,6 +142,16 @@ function Harness({
   const selectedStoredSessionIdRef: MutableRefObject<string | null> = selectedStoredSessionIdRefProp ?? {
     current: storedSessionId === undefined ? RUNTIME_SESSION_ID : storedSessionId
   }
+
+  const defaultStoredSessionId = storedSessionId === undefined ? RUNTIME_SESSION_ID : storedSessionId
+  const defaultRuntimeSessionId = activeSessionId === undefined ? RUNTIME_SESSION_ID : activeSessionId
+  const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> =
+    runtimeIdByStoredSessionIdRefProp ?? {
+      current:
+        defaultStoredSessionId && defaultRuntimeSessionId
+          ? new Map([[defaultStoredSessionId, defaultRuntimeSessionId]])
+          : new Map()
+    }
 
   const localBusyRef = busyRef ?? { current: false }
 
@@ -164,6 +176,7 @@ function Harness({
     refreshSessions,
     requestGateway,
     resumeStoredSession: resumeStoredSession ?? (() => undefined),
+    runtimeIdByStoredSessionIdRef,
     selectedStoredSessionIdRef,
     startFreshSessionDraft: () => undefined,
     sttEnabled: false,
@@ -3344,6 +3357,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
         refreshSessions={async () => undefined}
         requestGateway={requestGateway}
         resumeStoredSession={resumeStoredSession}
+        runtimeIdByStoredSessionIdRef={{ current: new Map([[STORED_SESSION_ID, RECOVERED_SESSION_ID]]) }}
         selectedStoredSessionIdRef={selectedStoredSessionIdRef}
         storedSessionId={STORED_SESSION_ID}
       />
@@ -3375,6 +3389,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
         refreshSessions={async () => undefined}
         requestGateway={requestGateway}
         resumeStoredSession={resumeStoredSession}
+        runtimeIdByStoredSessionIdRef={{ current: new Map([[STORED_SESSION_ID, RECOVERED_SESSION_ID]]) }}
         selectedStoredSessionIdRef={selectedStoredSessionIdRef}
         storedSessionId={STORED_SESSION_ID}
       />
@@ -4220,6 +4235,208 @@ describe('usePromptActions busy-gateway churn tolerance (#64327)', () => {
 
     expect(await submitting).toBe(false)
     expect(calls.some(c => c.method === 'prompt.submit')).toBe(false)
+  })
+})
+
+describe('usePromptActions submit entry-time runtime ownership proof (#64789/#65328)', () => {
+  const STORED_SESSION_B = 'stored-project-b'
+  const RUNTIME_SESSION_A = 'rt-session-a'
+  const RUNTIME_SESSION_B_RESUMED = 'rt-session-b-resumed'
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('does not submit to runtime A when the cache proves B is bound to a different runtime (forward mismatch)', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_B }
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_A }
+
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([[STORED_SESSION_B, 'rt-session-b-known']])
+    }
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.resume') {
+        return { session_id: RUNTIME_SESSION_B_RESUMED } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={RUNTIME_SESSION_A}
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={STORED_SESSION_B}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await handle!.submitText('ordinary text for the selected project B session')
+
+    expect(calls.find(c => c.method === 'session.resume')?.params).toEqual({
+      session_id: STORED_SESSION_B,
+      source: 'desktop'
+    })
+    expect(
+      calls.find(c => c.method === 'prompt.submit' && c.params?.session_id === RUNTIME_SESSION_A)
+    ).toBeUndefined()
+    expect(
+      calls.find(c => c.method === 'prompt.submit' && c.params?.session_id === RUNTIME_SESSION_B_RESUMED)
+    ).toBeDefined()
+  })
+
+  it('does not submit to runtime A when the cache proves A belongs to a DIFFERENT stored session (reverse proof, no forward entry for B)', async () => {
+    // The failure mode a one-directional (stored -> runtime) lookup misses:
+    // the cache has no entry for B at all (a forward miss looks like "no
+    // conflict"), but A is definitively known to belong to some OTHER
+    // stored session. A real-world trigger: the user is mid-conversation in
+    // an old session (whose runtime is A, cached under stored-project-old),
+    // then creates a fresh session B — if activeSessionIdRef hasn't been
+    // re-homed to B's own runtime yet by the time submit fires, A must not
+    // be accepted just because B itself was never cached.
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_B }
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_A }
+
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-project-old', RUNTIME_SESSION_A]])
+    }
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.resume') {
+        return { session_id: RUNTIME_SESSION_B_RESUMED } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={RUNTIME_SESSION_A}
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={STORED_SESSION_B}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await handle!.submitText('ordinary text for the freshly created project B session')
+
+    expect(calls.find(c => c.method === 'session.resume')?.params).toEqual({
+      session_id: STORED_SESSION_B,
+      source: 'desktop'
+    })
+    expect(
+      calls.find(c => c.method === 'prompt.submit' && c.params?.session_id === RUNTIME_SESSION_A)
+    ).toBeUndefined()
+    expect(
+      calls.find(c => c.method === 'prompt.submit' && c.params?.session_id === RUNTIME_SESSION_B_RESUMED)
+    ).toBeDefined()
+  })
+
+  it('still submits directly when the cache positively maps the selected session to the runtime', async () => {
+    // Direct submit is safe only when the cache explicitly proves the selected
+    // stored session owns the active runtime.
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_B }
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_A }
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([[STORED_SESSION_B, RUNTIME_SESSION_A]])
+    }
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={RUNTIME_SESSION_A}
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={STORED_SESSION_B}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await handle!.submitText('first message in a genuinely fresh session')
+
+    expect(calls.some(c => c.method === 'session.resume')).toBe(false)
+    expect(
+      calls.find(c => c.method === 'prompt.submit' && c.params?.session_id === RUNTIME_SESSION_A)
+    ).toBeDefined()
+  })
+
+  it('resumes the selected session when its ownership cache entry is missing', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_B }
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_A }
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = { current: new Map() }
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.resume') {
+        return { session_id: RUNTIME_SESSION_B_RESUMED } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={RUNTIME_SESSION_A}
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={STORED_SESSION_B}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await handle!.submitText('message after an ownership-cache miss')
+
+    expect(calls.find(c => c.method === 'session.resume')?.params).toEqual({
+      session_id: STORED_SESSION_B,
+      source: 'desktop'
+    })
+    expect(
+      calls.find(c => c.method === 'prompt.submit' && c.params?.session_id === RUNTIME_SESSION_A)
+    ).toBeUndefined()
+    expect(
+      calls.find(c => c.method === 'prompt.submit' && c.params?.session_id === RUNTIME_SESSION_B_RESUMED)
+    ).toBeDefined()
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -228,6 +228,7 @@ interface PromptActionsOptions {
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
+  runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   startFreshSessionDraft: () => void
   sttEnabled: boolean
@@ -259,6 +260,7 @@ export function usePromptActions({
   refreshSessions,
   requestGateway,
   resumeStoredSession,
+  runtimeIdByStoredSessionIdRef,
   selectedStoredSessionIdRef,
   startFreshSessionDraft,
   sttEnabled,
@@ -475,6 +477,7 @@ export function usePromptActions({
     getRuntimeIdForStoredSession,
     getRouteToken,
     requestGateway,
+    runtimeIdByStoredSessionIdRef,
     resumeStoredSession,
     selectedStoredSessionIdRef,
     syncAttachmentsForSubmit,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -59,6 +59,7 @@ interface SubmitPromptDeps {
   getRuntimeIdForStoredSession: (storedSessionId: string) => null | string
   getRouteToken: () => string
   requestGateway: GatewayRequest
+  runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   syncAttachmentsForSubmit: (
@@ -104,6 +105,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
     getRuntimeIdForStoredSession,
     getRouteToken,
     requestGateway,
+    runtimeIdByStoredSessionIdRef,
     resumeStoredSession,
     selectedStoredSessionIdRef,
     syncAttachmentsForSubmit,
@@ -429,6 +431,39 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         sessionId = null
       }
 
+      // Entry-time consistency check (#64789/#65328): activeSessionId is a
+      // render-closure value that can already be stale relative to the
+      // currently selected stored session by the time submit fires (e.g. a
+      // fast reselect, or a new-chat draft's active ref not yet re-homed).
+      // The #54527 drift guard only catches divergence that happens AFTER
+      // this point, so an already-diverged runtime/stored pair sails
+      // through it. Prove membership from BOTH directions against the same
+      // cache rather than trusting an absent forward entry as "no
+      // conflict" — a bare forward miss can't rule out the runtime being
+      // known to belong to a DIFFERENT stored session (the failure mode a
+      // one-directional check misses): if either direction disagrees,
+      // activeSessionId is not trustworthy and the resume-by-stored-id path
+      // below re-establishes the correct runtime id instead of silently
+      // sending to the wrong one.
+      const ownershipStoredSessionId = options?.sessionId ? null : targetStoredSessionId
+
+      if (sessionId && ownershipStoredSessionId) {
+        const provenRuntimeId = runtimeIdByStoredSessionIdRef.current.get(ownershipStoredSessionId)
+        // A selected stored session requires positive ownership proof. A cache
+        // miss is therefore unsafe too: the active runtime may belong to an
+        // entirely different stored session, so resume the selected id instead
+        // of sending to an unverified runtime.
+        const knownMismatch = provenRuntimeId !== sessionId
+
+        const runtimeOwnedByOtherStored = Array.from(runtimeIdByStoredSessionIdRef.current.entries()).some(
+          ([storedId, runtimeId]) => runtimeId === sessionId && storedId !== ownershipStoredSessionId
+        )
+
+        if (knownMismatch || runtimeOwnedByOtherStored) {
+          sessionId = null
+        }
+      }
+
       if (sessionId) {
         seedOptimistic(sessionId)
       } else if (targetIsCurrentView()) {
@@ -743,6 +778,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       getRuntimeIdForStoredSession,
       getRouteToken,
       requestGateway,
+      runtimeIdByStoredSessionIdRef,
       resumeStoredSession,
       scope,
       selectedStoredSessionIdRef,


### PR DESCRIPTION
## What does this PR do?

Fixes a race/entry-time condition in the Desktop app where `prompt.submit` can send a message to the wrong runtime session when the three session identities (runtime session, selected stored session, route token) are already split at submit entry — same bug class as #64789, reported again independently as #65328 ("New desktop session routes user input to existing old session instead").

## Related Issue

Closes #65328

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Background

A prior attempt at this exact fix (#64814, closed without merging) was reviewed by @Rika-xie, who confirmed the root-cause diagnosis but found the specific implementation's runtime-ownership check **failed open on a cache miss**: a reverse-lookup helper (`storedSessionIdForNotification`) returned the unverified input runtime id instead of `null` when it had no entry, so an unproven runtime could still slip through. Per that review: *"The current patch fixes the known cache-hit instance, but does not yet close the full #64789 bug class."*

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts` — before accepting `activeSessionId` as the submit target, prove runtime ownership from **both directions** against the existing `runtimeIdByStoredSessionIdRef` cache instead of trusting an absent forward entry as "no conflict":
  - forward: does the cache have a **different** runtime recorded for the selected stored session? (the original #64789 case)
  - reverse: is the current runtime recorded under a **different** stored session entirely? (the gap @Rika-xie found — a forward miss alone can't rule this out)
  
  If either check finds a conflict, `activeSessionId` is treated as untrustworthy and falls through to the existing `session.resume`-by-stored-id path, which re-establishes the correct runtime id instead of silently sending to the wrong one. A genuinely fresh session with no cache entries in either direction is correctly left alone — absence of proof is not proof of a conflict.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts` / `apps/desktop/src/app/contrib/wiring.tsx` — thread `runtimeIdByStoredSessionIdRef` (already maintained elsewhere in the codebase for the session-resume warm-cache path) through to the submit hook.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx` — 3 new regression tests: forward-mismatch (the #64789 case), reverse-only mismatch (the gap the prior review found — no forward entry for the target, proven only via the other direction), and a no-conflict control case (fresh session, no cache entries, must not be blocked).

## Validation

| Check | Command | Result |
|---|---|---|
| New tests | `npx vitest run src/app/session/hooks/use-prompt-actions/index.test.tsx` | 48 passed |
| Fail-before | Reverted only the new bidirectional check | The 2 new conflict-case tests fail exactly as expected (`session.resume` never called, `prompt.submit` still targets the wrong runtime); the no-conflict case keeps passing either way |
| Typecheck | `npx tsc --noEmit` | Clean |
| Lint | `npx eslint` on all 4 changed files | Clean (0 errors, 0 warnings — including fixing a real missing-dependency warning by adding `runtimeIdByStoredSessionIdRef` to the `useCallback` deps array) |
| Full suite | `npx vitest run` (apps/desktop) | 1680 passed, 25 failed — all 25 pre-existing and unrelated (electron packaging POSIX-path tests, markdown-text preprocessing, skills/messaging UI tests), confirmed by re-running the markdown-text suite with this diff stashed and getting the identical 17 failures |

## How to Test

1. Select an existing stored session B whose runtime id is cached as belonging to a *different* stored session in `runtimeIdByStoredSessionIdRef` (or is simply stale relative to `activeSessionId`).
2. Type and send a message immediately.
3. Before this fix: the message could be sent to the stale/wrong runtime (`activeSessionId`). After this fix: the mismatch is detected and the session is properly re-resumed via `session.resume` before the message is sent, landing in the correct conversation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (the only prior attempt, #64814, is closed/abandoned and explicitly confirmed incomplete by review)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` — N/A, this PR touches only `apps/desktop` (TypeScript); ran the equivalent `npx vitest run` instead (see Validation table)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed