### PR TITLE
fix(mcp_catalog): add timeout and stdin=DEVNULL to _run_bootstrap subprocess.run

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -380,7 +380,7 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        proc = subprocess.run(cmd, cwd=str(cwd), shell=True, timeout=300, stdin=subprocess.DEVNULL)
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"


### PR DESCRIPTION
## Summary

Add `timeout=300` and `stdin=subprocess.DEVNULL` to the `subprocess.run()` call in `_run_bootstrap()` that was missing them entirely.

## Problem

`_run_bootstrap()` in `hermes_cli/mcp_catalog.py:383` calls `subprocess.run(cmd, shell=True)` with no `timeout` and no `stdin` redirect. If any bootstrap command (e.g. `npm install`, `pip install`) hangs due to network issues, interactive prompts, or a stalled process, the entire CLI blocks indefinitely — with no way to recover.

Additionally, without `stdin=DEVNULL\>, a bootstrap command can silently consume stdin from the parent process, potentially stealing input intended for the CLI.

## Fix

Added `timeout=300` (5 minutes, consistent with other install-time subprocess calls in the codebase) and `stdin=subprocess.DEVNULL` to the single `subprocess.run` call in `_run_bootstrap`.

## Testing
- Syntax check passed (py_compile)
- Behavior verified