### PR TITLE
fix(gateway): prune stale disabled platform states

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6917,7 +6917,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(gateway_state="starting", exit_reason=None)
+            active_platforms = {
+                platform.value
+                for platform, platform_config in self.config.platforms.items()
+                if platform_config.enabled
+            }
+            write_runtime_status(
+                gateway_state="starting",
+                exit_reason=None,
+                active_platforms=active_platforms,
+            )
         except Exception:
             pass
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -805,8 +805,15 @@ def write_runtime_status(
     error_code: Any = _UNSET,
     error_message: Any = _UNSET,
     served_profiles: Any = _UNSET,
+    active_platforms: Any = _UNSET,
 ) -> None:
-    """Persist gateway runtime health information for diagnostics/status."""
+    """Persist gateway runtime health information for diagnostics/status.
+
+    ``active_platforms`` is a startup/reconfiguration boundary. When supplied,
+    entries not present in that iterable are removed before the record is
+    written, so failures from platforms disabled since the previous run cannot
+    survive in runtime state.
+    """
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
     current_record = _build_pid_record()
@@ -816,6 +823,17 @@ def write_runtime_status(
     payload["argv"] = current_record["argv"]
     payload["start_time"] = current_record["start_time"]
     payload["updated_at"] = _utc_now_iso()
+
+    if active_platforms is not _UNSET:
+        active_names = {
+            str(getattr(active_platform, "value", active_platform))
+            for active_platform in active_platforms
+        }
+        payload["platforms"] = {
+            name: platform_payload
+            for name, platform_payload in payload["platforms"].items()
+            if name in active_names
+        }
 
     if gateway_state is not _UNSET:
         payload["gateway_state"] = gateway_state

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from unittest.mock import AsyncMock
 
@@ -140,6 +142,45 @@ async def test_runner_records_connected_platform_state_on_success(monkeypatch, t
     assert state["platforms"]["discord"]["state"] == "connected"
     assert state["platforms"]["discord"]["error_code"] is None
     assert state["platforms"]["discord"]["error_message"] is None
+
+
+@pytest.mark.asyncio
+async def test_restart_prunes_disabled_platform_state(monkeypatch, tmp_path):
+    """Startup state reflects this config, not failures from a prior run."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "gateway_state.json").write_text(json.dumps({
+        "gateway_state": "degraded",
+        "platforms": {
+            "discord": {"state": "connected"},
+            "telegram": {
+                "state": "fatal",
+                "error_code": "old_failure",
+                "error_message": "failure from the previous configuration",
+            },
+        },
+    }))
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(enabled=True, token="***"),
+            Platform.TELEGRAM: PlatformConfig(enabled=False, token="***"),
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    monkeypatch.setattr(
+        runner,
+        "_create_adapter",
+        lambda platform, platform_config: _SuccessfulAdapter(),
+    )
+    monkeypatch.setattr(runner.hooks, "discover_and_load", lambda: None)
+    monkeypatch.setattr(runner.hooks, "emit", AsyncMock())
+
+    assert await runner.start() is True
+
+    state = read_runtime_status()
+    assert state["gateway_state"] == "running"
+    assert set(state["platforms"]) == {"discord"}
+    assert state["platforms"]["discord"]["state"] == "connected"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -416,6 +416,41 @@ class TestGatewayRuntimeStatus:
             )
         ]
 
+    def test_write_runtime_status_prunes_inactive_platforms_on_restart(self, tmp_path, monkeypatch):
+        """A restarted gateway must not retain failures for now-disabled platforms."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "gateway_state": "running",
+            "platforms": {
+                "telegram": {
+                    "state": "connected",
+                    "updated_at": "2025-01-01T00:00:00Z",
+                },
+                "whatsapp": {
+                    "state": "fatal",
+                    "error_code": "not_paired",
+                    "error_message": "WhatsApp is not paired",
+                    "updated_at": "2025-01-01T00:00:00Z",
+                },
+            },
+        }))
+
+        status.write_runtime_status(
+            gateway_state="starting",
+            exit_reason=None,
+            active_platforms={"telegram"},
+        )
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_state"] == "starting"
+        assert payload["platforms"] == {
+            "telegram": {
+                "state": "connected",
+                "updated_at": "2025-01-01T00:00:00Z",
+            }
+        }
+
     def test_write_runtime_status_overwrites_stale_pid_on_restart(self, tmp_path, monkeypatch):
         """Regression: setdefault() preserved stale PID from previous process (#1631)."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary
- treat the enabled platform set as a gateway runtime-state lifecycle boundary at startup
- prune persisted platform entries that are disabled or removed while preserving active platform state
- add unit and real `GatewayRunner.start()` regressions for config-change/restart behavior

## Tests
- `scripts/run_tests.sh tests/gateway/test_status.py tests/gateway/test_runner_startup_failures.py -q` (108 passed)