### PR TITLE
fix(gateway): suppress consumed process completions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16855,7 +16855,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # poll() is read-only and intentionally does NOT mark consumed
                 # (#10156) — a status check must not suppress this delivery turn.
                 from tools.process_registry import format_process_notification, process_registry as _pr_check
-                if agent_notify and not _pr_check.is_completion_consumed(session_id):
+                if agent_notify:
+                    if _pr_check.is_completion_consumed(session_id):
+                        logger.debug(
+                            "Process watcher skipped consumed completion: %s",
+                            session_id,
+                        )
+                        break
                     from agent.redact import redact_terminal_output
                     from tools.ansi_strip import strip_ansi
                     _command = getattr(session, "command", "") or ""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -57,6 +57,7 @@ LEGACY_AUTHOR_MAP = {
     "bryan@users.noreply.github.com": "hydraxman",  # PR #62028 salvage (copilot xhigh) — regression-test commit authored under a bare-noreply local git identity; PR author is @hydraxman
     "antydizajn@gmail.com": "antydizajn",  # PR #36043 salvage (auxiliary: route custom:<name> through named-provider arm + Palantir Bearer auth)
     "252620095+briandevans@users.noreply.github.com": "briandevans",  # PR #64951 salvage (lmstudio: clamp max/ultra reasoning effort)
+    "reymondmeking@gmail.com": "reymondmeking-dot",  # First-time contributor mapping
     "kar.iskakov@gmail.com": "karfly",  # PR #64012 salvage (gateway: surface extended reasoning efforts)
     "enzo.eliott.adami@gmail.com": "enzo-adami",  # PR #66637 salvage (compression: preserve human intent and durable handoffs)
     "kimyeon30@naver.com": "rlaehddus302",  # PR #61985 salvage (gateway: secondary-adapter auth callback profile)

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -24,8 +24,9 @@ from gateway.run import GatewayRunner, _parse_session_key
 class _FakeRegistry:
     """Return pre-canned sessions, then None once exhausted."""
 
-    def __init__(self, sessions):
+    def __init__(self, sessions, *, completion_consumed=False):
         self._sessions = list(sessions)
+        self._completion_consumed = completion_consumed
 
     def get(self, session_id):
         if self._sessions:
@@ -33,7 +34,7 @@ class _FakeRegistry:
         return None
 
     def is_completion_consumed(self, session_id):
-        return False
+        return self._completion_consumed
 
 
 def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
@@ -355,6 +356,37 @@ async def test_agent_notification_no_message_id_is_tolerated(monkeypatch, tmp_pa
     adapter.handle_message.assert_awaited_once()
     synth_event = adapter.handle_message.await_args.args[0]
     assert synth_event.message_id is None
+
+
+@pytest.mark.asyncio
+async def test_consumed_agent_completion_skips_raw_platform_notification(monkeypatch, tmp_path):
+    """A result returned by process(wait) must not be sent again as raw text."""
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(
+        output_buffer="done\n", exited=True, exit_code=0, command="sleep 1",
+    )]
+    monkeypatch.setattr(
+        pr_module,
+        "process_registry",
+        _FakeRegistry(sessions, completion_consumed=True),
+    )
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    watcher = {
+        **_watcher_dict("proc_consumed"),
+        "notify_on_complete": True,
+    }
+
+    await runner._run_process_watcher(watcher)
+
+    adapter.handle_message.assert_not_awaited()
+    adapter.send.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- stop `notify_on_complete` gateway watchers after `process(wait)` or a full `process(log)` read has already consumed the completion
- prevent the consumed completion from falling through to the raw platform notification branch
- add a behavioral regression test that asserts neither agent injection nor direct adapter delivery occurs

## Root cause

The gateway watcher guarded only the synthetic agent-notification branch with `is_completion_consumed()`. When that guard was false because `process(wait)` had already consumed the result, control continued into the normal text-only notification branch. With `background_process_notifications: all` or `result`, the gateway then sent the same output directly through the platform adapter.

The fix treats a consumed `notify_on_complete` result as terminal for the watcher. Poll-only observations remain unaffected because `poll()` intentionally does not mark completions consumed.

## Validation

- `python -m pytest tests/gateway/test_background_process_notifications.py -q` (32 passed)
- `python -m pytest tests/gateway/test_completion_delivery.py tests/gateway/test_internal_event_bypass_pairing.py -q` (24 passed)
- `python -m pytest tests/tools/test_notify_on_complete.py -q` (35 passed; one pre-existing Windows subprocess decode warning)
- `python scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_background_process_notifications.py`

Fixes #65379