### PR TITLE
fix(agent): improve Codex OAuth 401 error message to cover server-side token invalidation (#65346)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3891,10 +3891,11 @@ def run_conversation(
                             pass
                         elif _provider in {"openai-codex", "xai-oauth", "nous"} and status_code == 401:
                             if _provider == "openai-codex":
-                                agent._vprint(f"{agent.log_prefix}   💡 Codex OAuth token was rejected (HTTP 401). Your token may have been", force=True)
-                                agent._vprint(f"{agent.log_prefix}      refreshed by another client (Codex CLI, VS Code). To fix:", force=True)
+                                agent._vprint(f"{agent.log_prefix}   💡 Codex OAuth token was rejected (HTTP 401). The token may have been", force=True)
+                                agent._vprint(f"{agent.log_prefix}      invalidated by the server or refreshed by another client.", force=True)
+                                agent._vprint(f"{agent.log_prefix}      To fix:", force=True)
                                 agent._vprint(f"{agent.log_prefix}      1. Run `codex` in your terminal to generate fresh tokens.", force=True)
-                                agent._vprint(f"{agent.log_prefix}      2. Then run `hermes auth` to re-authenticate.", force=True)
+                                agent._vprint(f"{agent.log_prefix}      2. Then run `hermes auth openai-codex` to re-authenticate.", force=True)
                             elif _provider == "xai-oauth":
                                 agent._vprint(f"{agent.log_prefix}   💡 xAI OAuth token was rejected (HTTP 401). To fix:", force=True)
                                 agent._vprint(f"{agent.log_prefix}      re-authenticate with xAI Grok OAuth (SuperGrok / Premium+) from `hermes model`.", force=True)


### PR DESCRIPTION
## Problem
OpenAI Codex OAuth tokens are invalidated server-side after ~2.5 days despite a 10-day declared expiration. When Hermes receives HTTP 401 `token_invalidated`, the error message only says the token 'may have been refreshed by another client (Codex CLI, VS Code)' — this is misleading when the actual cause is server-side invalidation.

## Root Cause
The Codex OAuth provider revokes access tokens before their natural expiration. Hermes correctly attempts a credential refresh but the refresh token is also invalidated, making recovery impossible without manual re-authentication. The existing error message did not mention server-side invalidation as a possibility.

## Fix
Improved the HTTP 401 error message for Codex OAuth to:
1. Mention both possible causes (server-side invalidation \**or*\* another client consuming the token)
2. Add an explicit `To fix:` label
3. Use the more targeted `hermes auth openai-codex` re-auth command

Closes #65346

## Testing
- Syntax check of changed file passed (`python -m py_compile agent/conversation_loop.py`)
- Change is error-message-only, no logic change