### PR TITLE
fix(memory/mem0): resolve api_key_env in OSS config before Memory.from_config

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -160,13 +160,40 @@ class OSSBackend(Mem0Backend):
         import os
         from mem0 import Memory
 
+        def _resolve_api_key_env(section: dict) -> dict:
+            """Translate ``api_key_env`` (name of an env var holding the key)
+            into the ``api_key`` field mem0's provider configs actually accept.
+
+            Keeps secrets in the environment/.env instead of mem0.json. An
+            unknown key would otherwise be passed through to mem0's config
+            classes, which reject unexpected kwargs at init time.
+            """
+            section = dict(section)
+            cfg = dict(section.get("config", {}))
+            env_name = cfg.pop("api_key_env", None)
+            if env_name:
+                value = os.environ.get(env_name, "")
+                if not value:
+                    raise ValueError(
+                        f"mem0 config references api_key_env={env_name!r} but "
+                        f"that environment variable is not set. Add it to "
+                        f"~/.hermes/.env or replace api_key_env with api_key "
+                        f"in mem0.json."
+                    )
+                cfg.setdefault("api_key", value)
+            section["config"] = cfg
+            return section
+
+        llm = _resolve_api_key_env(oss_config["llm"])
+        embedder = _resolve_api_key_env(oss_config["embedder"])
+
         vector_store = dict(oss_config["vector_store"])
         vs_config = dict(vector_store.get("config", {}))
 
         if "path" in vs_config:
             vs_config["path"] = os.path.expanduser(vs_config["path"])
 
-        embedder_config = oss_config.get("embedder", {}).get("config", {})
+        embedder_config = embedder.get("config", {})
         dims = embedder_config.get("embedding_dims")
         if not dims:
             from ._oss_providers import KNOWN_DIMS
@@ -182,8 +209,8 @@ class OSSBackend(Mem0Backend):
 
         config = {
             "vector_store": vector_store,
-            "llm": oss_config["llm"],
-            "embedder": oss_config["embedder"],
+            "llm": llm,
+            "embedder": embedder,
             "version": "v1.1",
         }
         self._memory = Memory.from_config(config)

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -192,6 +192,70 @@ class TestOSSBackend:
         assert result == {"result": "Memory deleted.", "memory_id": "m1"}
 
 
+class TestOSSBackendApiKeyEnv:
+    """__init__ must translate api_key_env into api_key — mem0's provider
+    config classes reject unexpected kwargs, so passing api_key_env through
+    raises at init (the 'OpenAIConfig got unexpected keyword api_key_env' bug)."""
+
+    def _init_with(self, monkeypatch, oss_config):
+        import sys
+        import types
+
+        captured = {}
+
+        class _FakeMemory:
+            @classmethod
+            def from_config(cls, config):
+                captured["config"] = config
+                return FakeOSSMemory()
+
+        fake_mem0 = types.ModuleType("mem0")
+        fake_mem0.Memory = _FakeMemory
+        monkeypatch.setitem(sys.modules, "mem0", fake_mem0)
+        OSSBackend(oss_config)
+        return captured["config"]
+
+    def _oss_config(self):
+        return {
+            "llm": {
+                "provider": "openai",
+                "config": {"model": "m", "api_key_env": "FAKE_LLM_KEY"},
+            },
+            "embedder": {
+                "provider": "ollama",
+                "config": {"model": "e", "embedding_dims": 8},
+            },
+            "vector_store": {"provider": "pgvector", "config": {}},
+        }
+
+    def test_api_key_env_resolved_to_api_key(self, monkeypatch):
+        monkeypatch.setenv("FAKE_LLM_KEY", "sk-test-123")
+        config = self._init_with(monkeypatch, self._oss_config())
+        llm_cfg = config["llm"]["config"]
+        assert "api_key_env" not in llm_cfg
+        assert llm_cfg["api_key"] == "sk-test-123"
+
+    def test_explicit_api_key_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("FAKE_LLM_KEY", "sk-from-env")
+        oss = self._oss_config()
+        oss["llm"]["config"]["api_key"] = "sk-explicit"
+        config = self._init_with(monkeypatch, oss)
+        assert config["llm"]["config"]["api_key"] == "sk-explicit"
+        assert "api_key_env" not in config["llm"]["config"]
+
+    def test_missing_env_var_raises_actionable_error(self, monkeypatch):
+        monkeypatch.delenv("FAKE_LLM_KEY", raising=False)
+        with pytest.raises(ValueError, match="FAKE_LLM_KEY"):
+            self._init_with(monkeypatch, self._oss_config())
+
+    def test_original_config_not_mutated(self, monkeypatch):
+        monkeypatch.setenv("FAKE_LLM_KEY", "sk-test-123")
+        oss = self._oss_config()
+        self._init_with(monkeypatch, oss)
+        assert oss["llm"]["config"]["api_key_env"] == "FAKE_LLM_KEY"
+        assert "api_key" not in oss["llm"]["config"]
+
+
 httpx = pytest.importorskip("httpx")
 
 


### PR DESCRIPTION
## Symptom

With a self-hosted (OSS) mem0 config that uses `api_key_env` in the LLM section of `mem0.json`:

```json
"llm": {
  "provider": "openai",
  "config": { "model": "...", "openai_base_url": "...", "api_key_env": "GLM_API_KEY" }
}
```

every memory tool call fails at backend init:

```
Mem0 backend not initialized: OpenAIConfig.__init__() got an unexpected keyword argument 'api_key_env'.
```

`OSSBackend.__init__` passed the config sections straight through to `mem0.Memory.from_config()`, and mem0's provider config classes (e.g. `OpenAIConfig`) reject unknown kwargs. The error message misleadingly points at the vector store; pgvector was healthy.

## Fix

`OSSBackend.__init__` now resolves `api_key_env` (the name of an env var holding the key) into the `api_key` field mem0 actually accepts, for **both** the `llm` and `embedder` sections (whole bug class, not just the reported site). This keeps secrets in the environment/.env instead of persisted in `mem0.json`.

- An explicit `api_key` in the config wins over the env var (`setdefault`).
- If the named env var is unset, init raises an actionable `ValueError` naming the variable and both remediation paths, instead of mem0's opaque unexpected-kwarg TypeError.
- Input config dicts are copied, not mutated.

## Validation

- Reproduced the symptom on current main with a real `mem0.json`, then verified a cold `OSSBackend` init + live `search()` against a real pgvector store succeeds with the fix (`INIT OK, search returned 5 results`).
- 4 new regression tests (`TestOSSBackendApiKeyEnv`): env resolution, explicit-key precedence, missing-env-var error, no input mutation.
- Full memory plugin suite: 454 passed, 1 skipped.