### PR TITLE
fix(usage): label Codex usage windows by duration, not response position (#65387)

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -525,11 +525,30 @@ def _fetch_codex_account_usage(
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
-    for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
+    # The Codex usage API keys these "primary_window"/"secondary_window" by
+    # response position, not by which duration each one is — it does not
+    # guarantee primary_window is always the short (session) window. When
+    # only one window is returned it can be the weekly one occupying
+    # primary_window, which the old position-based mapping mislabeled as
+    # "Session" and reported Weekly as unavailable (#65387). Prefer each
+    # window's OWN limit_window_seconds when the API provides it: anything
+    # over a day is the weekly window, everything else (ChatGPT's session
+    # window is documented at 5 hours = 18000s) is the session window. Fall
+    # back to the position default (primary=Session, secondary=Weekly) only
+    # when limit_window_seconds is absent — some callers/pool credentials
+    # never receive it, and position is still the best signal available then.
+    _WEEKLY_WINDOW_THRESHOLD_SECONDS = 86400
+    _POSITION_DEFAULT_LABEL = {"primary_window": "Session", "secondary_window": "Weekly"}
+    for key in ("primary_window", "secondary_window"):
         window = rate_limit.get(key) or {}
         used = window.get("used_percent")
         if used is None:
             continue
+        limit_seconds = window.get("limit_window_seconds")
+        if isinstance(limit_seconds, (int, float)):
+            label = "Weekly" if limit_seconds > _WEEKLY_WINDOW_THRESHOLD_SECONDS else "Session"
+        else:
+            label = _POSITION_DEFAULT_LABEL[key]
         windows.append(
             AccountUsageWindow(
                 label=label,

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -124,8 +124,8 @@ def test_fetch_account_usage_codex_weekly_only_response_is_not_mislabeled_sessio
                     "primary_window": {
                         "used_percent": 1,
                         "limit_window_seconds": 604800,
-                        "secondary_window": None,
                     },
+                    "secondary_window": None,
                 },
             }
         ),

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -95,6 +95,53 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert "Credits balance: $12.50" in snapshot.details
 
 
+def test_fetch_account_usage_codex_weekly_only_response_is_not_mislabeled_session(monkeypatch):
+    """Regression for #65387: the Codex usage API keys windows by response
+    position, not by duration — primary_window is not guaranteed to be the
+    short (session) window. A response with only the 7-day/weekly window
+    occupying primary_window must be labeled "Weekly", not "Session", and
+    must not silently drop to a fabricated "Session" reading."""
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "access-token",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage._read_codex_tokens",
+        lambda: {"tokens": {"account_id": "acct_123"}},
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "plan_type": "pro",
+                # Live sanitized reproduction from the issue: only the weekly
+                # window is present, and it occupies primary_window.
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 1,
+                        "limit_window_seconds": 604800,
+                        "secondary_window": None,
+                    },
+                },
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert len(snapshot.windows) == 1
+    assert snapshot.windows[0].label == "Weekly", (
+        "A primary_window with limit_window_seconds=604800 (7 days) is the "
+        "weekly window regardless of its response-position key — see #65387."
+    )
+    assert snapshot.windows[0].used_percent == 1.0
+
+
 def test_render_account_usage_lines_includes_reset_and_provider():
     snapshot = AccountUsageSnapshot(
         provider="openai-codex",


### PR DESCRIPTION
## What does this PR do?

`agent/account_usage.py::_fetch_codex_account_usage()` assigned Codex usage window labels by dict key position — `primary_window` always got `Session`, `secondary_window` always got `Weekly`. The live Codex usage API does not guarantee that ordering: when only one window is returned, it can be the 7-day/weekly window occupying `primary_window`. Hermes then reports the weekly quota as `Session` and Weekly as unavailable downstream.

## Related Issue

Closes #65387

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/account_usage.py`: label each window from its own `limit_window_seconds` when the API provides it (over a day = Weekly, else Session — ChatGPT's session window is documented at 5 hours = 18000s). Falls back to the existing position-based default (`primary_window`→Session, `secondary_window`→Weekly) only when `limit_window_seconds` is absent, since some callers/pool-credential paths never receive it and position is still the best signal available then.
- `tests/test_account_usage.py`: added `test_fetch_account_usage_codex_weekly_only_response_is_not_mislabeled_session`, reproducing the issue's exact payload shape (one window, 604800s duration, occupying `primary_window`) and asserting the label is `Weekly`.

## Validation

| Check | Command | Result |
|---|---|---|
| New test | `uv run --extra dev pytest tests/test_account_usage.py -q` | 5 passed |
| Fail-before | Reverted only the labeling logic to the old position-based version | The new test failed exactly as reported in the issue: `windows[0].label == 'Session'` instead of `'Weekly'` |
| Broader suite | `uv run --extra dev pytest tests/agent/test_account_usage.py tests/test_account_usage.py -q` | 18 passed — including two pre-existing tests whose fixture payload has no `limit_window_seconds` and asserts the position-based labels; the fallback path was added specifically so those keep passing unchanged |
| Lint | `ruff check agent/account_usage.py tests/test_account_usage.py` | Clean |

## How to Test

1. Call the Codex usage endpoint with a response where only `primary_window` is present and its `limit_window_seconds` is `604800` (7 days).
2. Before this fix: `/usage` reports `Session: X% used`, `Weekly: unavailable`.
3. After this fix: `/usage` reports `Weekly: X% used` (no fabricated Session reading).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` (scoped: `tests/test_account_usage.py` + `tests/agent/test_account_usage.py`) and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed