### PR TITLE
fix(gateway): skip raw text notification when agent already consumed completion (#65379)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16001,6 +16001,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         continue
                     break
 
+                if agent_notify:
+                    # Completion was already consumed by the agent's own
+                    # wait()/log() call before this watcher tick ran. The
+                    # agent will surface the result to the user itself on
+                    # its next turn -- don't also send the raw text
+                    # notification below, or the user gets the same
+                    # completion twice (once from the agent, once raw).
+                    break
+
                 # --- Normal text-only notification ---
                 # Decide whether to notify based on mode
                 should_notify = (

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -358,6 +358,46 @@ async def test_agent_notification_no_message_id_is_tolerated(monkeypatch, tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_agent_notify_consumed_completion_sends_no_raw_duplicate(monkeypatch, tmp_path):
+    """When the agent already consumed the completion via process(wait),
+    the watcher must not also push the raw text-only notification.
+
+    Reproduces #65379: agent_notify=True + is_completion_consumed()==True
+    used to fall through the synthetic-injection guard straight into the
+    plain-text branch below, which only checked notify_mode and ignored
+    agent_notify entirely -- sending the same completion twice."""
+    import tools.process_registry as pr_module
+
+    class _ConsumedRegistry(_FakeRegistry):
+        def is_completion_consumed(self, session_id):
+            return True
+
+    sessions = [SimpleNamespace(
+        output_buffer="done\n", exited=True, exit_code=0, command="sleep 1",
+    )]
+    monkeypatch.setattr(pr_module, "process_registry", _ConsumedRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    watcher = {
+        "session_id": "proc_already_consumed",
+        "check_interval": 0,
+        "platform": "telegram",
+        "chat_id": "123",
+        "notify_on_complete": True,
+    }
+    await runner._run_process_watcher(watcher)
+
+    adapter.send.assert_not_awaited()
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_inject_watch_notification_carries_message_id_reply_anchor(monkeypatch, tmp_path):
     from gateway.session import SessionSource
 


### PR DESCRIPTION
## What does this PR do?

Fixes a duplicate-completion-notification bug: when a background process was started with `notify_on_complete=true` and the agent later called `process(action="wait")` for it, the gateway's watcher would send **both** the agent-mediated reply **and** a separate raw text notification with the same completion info to the same chat.

Root cause in `gateway/run.py::_run_process_watcher`: when the watcher tick observes `session.exited` and `agent_notify=True`, it checks `is_completion_consumed(session_id)` to decide whether to inject the synthetic agent-notification event. If the completion was already consumed (because `process(wait)` marked it consumed in `tools/process_registry.py` lines 1433-1448 before this tick ran), that `if agent_notify and not consumed:` block is skipped — but execution then falls straight through into the "Normal text-only notification" branch a few lines below, which only gates on `notify_mode` (`all`/`result`/`error`) and never checks `agent_notify` at all. So a consumed, agent-notified completion still gets a second raw message pushed to the platform.

## Related Issue

Fixes #65379

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: after the agent-notify synthetic-injection branch (which `break`s on success), added an explicit `if agent_notify: break` before the plain-text branch. If `agent_notify` is set at all, the completion is the agent's responsibility to relay — whether or not it was already consumed by the time this tick observed the exit — so the raw duplicate must never fire.
- `tests/gateway/test_background_process_notifications.py`: added `test_agent_notify_consumed_completion_sends_no_raw_duplicate`, which drives `GatewayRunner._run_process_watcher()` end-to-end with a fake registry whose `is_completion_consumed()` returns `True` (simulating the agent having already called `wait()`), and asserts neither `adapter.send` nor `adapter.handle_message` is ever awaited.

## How to Test

1. Set `display.background_process_notifications: all`.
2. Start a background command with `notify_on_complete=true`.
3. Call `process(action="wait")` for it so the completion is marked consumed.
4. Let the watcher's next tick observe `session.exited`.
5. Before this fix: a raw `[Background process ... finished with exit code ...]` message is still sent to the chat, duplicating what the agent already relayed via `wait()`'s return value. After this fix: no raw message is sent.

Fail-before / pass-after (this repo, this branch):

```
$ git stash push -- gateway/run.py   # revert only the fix
$ python -m pytest tests/gateway/test_background_process_notifications.py::test_agent_notify_consumed_completion_sends_no_raw_duplicate -q
FAILED ... AssertionError: Expected mock to not have been awaited. Awaited 1 times.
1 failed in 1.41s
$ git stash pop
$ python -m pytest tests/gateway/test_background_process_notifications.py::test_agent_notify_consumed_completion_sends_no_raw_duplicate -q
1 passed in 5.67s
$ python -m pytest tests/gateway/test_background_process_notifications.py -q
32 passed in 2.03s
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the full `tests/gateway/test_background_process_notifications.py` file — 32/32)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed.

## Screenshots / Logs

See the fail-before/pass-after transcript above under "How to Test".
