### PR TITLE
fix(session): prefer ContextVar over process env for session identity

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -28,6 +28,16 @@ from agent.thread_scoped_output import thread_scoped_silence
 logger = logging.getLogger(__name__)
 
 
+def _session_source_hint(default: str = "cli") -> str:
+    """Task-local HERMES_SESSION_SOURCE first; process env only if unbound."""
+    try:
+        from gateway.session_context import resolve_session_source_hint
+
+        return resolve_session_source_hint(default)
+    except Exception:
+        return os.environ.get("HERMES_SESSION_SOURCE") or default
+
+
 # ---------------------------------------------------------------------------
 # Background-review aux-model selector + routed digest.
 #
@@ -604,7 +614,7 @@ def build_memory_write_metadata(
         ),
         "session_id": agent.session_id or "",
         "parent_session_id": agent._parent_session_id or "",
-        "platform": agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+        "platform": agent.platform or _session_source_hint(),
         "tool_name": "memory",
     }
     if task_id:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -42,6 +42,17 @@ from agent.model_metadata import estimate_request_tokens_rough
 
 logger = logging.getLogger(__name__)
 
+
+def _session_source_hint(default: str = "cli") -> str:
+    """Task-local HERMES_SESSION_SOURCE first; process env only if unbound."""
+    try:
+        from gateway.session_context import resolve_session_source_hint
+
+        return resolve_session_source_hint(default)
+    except Exception:
+        return os.environ.get("HERMES_SESSION_SOURCE") or default
+
+
 # Stable marker the gateway matches on to re-tag the auto-compaction lifecycle
 # status as ``kind="compacting"`` (tui_gateway/server.py::_status_update), so
 # drivers like the desktop app can show an explicit "Summarizing…" indicator
@@ -895,7 +906,7 @@ def compress_context(
                     try:
                         agent._session_db.create_session(
                             session_id=agent.session_id,
-                            source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                            source=agent.platform or _session_source_hint(),
                             model=agent.model,
                             model_config=agent._session_init_model_config,
                             parent_session_id=old_session_id,

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1436,19 +1436,29 @@ def _skill_should_show(
 
 
 def _current_session_platform_hint() -> str:
-    """Return the active platform without importing the gateway package on CLI startup."""
-    platform = os.environ.get("HERMES_PLATFORM") or os.environ.get("HERMES_SESSION_PLATFORM")
-    if platform:
-        return platform
+    """Return the active platform without importing the gateway package on CLI startup.
 
+    Prefer the task-local session ContextVar when gateway.session_context is
+    already loaded. Process env is only a fallback for cold CLI start; reading
+    env first lets a concurrent gateway sibling's stale HERMES_SESSION_PLATFORM
+    win over this task's binding.
+    """
     session_context = sys.modules.get("gateway.session_context")
-    get_session_env = getattr(session_context, "get_session_env", None) if session_context else None
-    if get_session_env is None:
-        return ""
-    try:
-        return get_session_env("HERMES_SESSION_PLATFORM") or ""
-    except Exception:
-        return ""
+    resolve = (
+        getattr(session_context, "resolve_session_platform_hint", None)
+        if session_context
+        else None
+    )
+    if resolve is not None:
+        try:
+            return resolve() or ""
+        except Exception:
+            pass
+    return (
+        os.environ.get("HERMES_PLATFORM")
+        or os.environ.get("HERMES_SESSION_PLATFORM")
+        or ""
+    )
 
 
 def build_skills_system_prompt(

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -125,12 +125,9 @@ def _resolve_skill_commands_platform() -> Optional[str]:
     rollouts, standalone scripts).
     """
     try:
-        from gateway.session_context import get_session_env
+        from gateway.session_context import resolve_session_platform_hint
 
-        resolved_platform = (
-            os.getenv("HERMES_PLATFORM")
-            or get_session_env("HERMES_SESSION_PLATFORM")
-        )
+        resolved_platform = resolve_session_platform_hint()
     except Exception:
         resolved_platform = os.getenv("HERMES_PLATFORM")
     return resolved_platform or None

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -376,12 +376,8 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
     if not isinstance(skills_cfg, dict):
         return set()
 
-    from gateway.session_context import get_session_env
-    resolved_platform = (
-        platform
-        or os.getenv("HERMES_PLATFORM")
-        or get_session_env("HERMES_SESSION_PLATFORM")
-    )
+    from gateway.session_context import resolve_session_platform_hint
+    resolved_platform = platform or resolve_session_platform_hint()
     global_disabled = _normalize_string_set(skills_cfg.get("disabled"))
     if resolved_platform:
         platform_disabled = (skills_cfg.get("platform_disabled") or {}).get(

--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -113,16 +113,17 @@ def _session_is_messaging_surface() -> bool:
     non-messaging surface.
     """
     try:
-        from gateway.session_context import get_session_env
-
-        platform = (
-            os.getenv("HERMES_PLATFORM")
-            or get_session_env("HERMES_SESSION_PLATFORM", "")
+        from gateway.session_context import (
+            resolve_session_platform_hint,
+            resolve_session_source_hint,
         )
-        source = get_session_env("HERMES_SESSION_SOURCE", "")
+
+        platform = resolve_session_platform_hint()
+        source = resolve_session_source_hint(default="")
     except Exception:
-        platform = os.getenv("HERMES_PLATFORM", "") or os.environ.get(
-            "HERMES_SESSION_PLATFORM", ""
+        platform = (
+            os.getenv("HERMES_PLATFORM", "")
+            or os.environ.get("HERMES_SESSION_PLATFORM", "")
         )
         source = os.environ.get("HERMES_SESSION_SOURCE", "")
     for identity in (platform, source):

--- a/cli.py
+++ b/cli.py
@@ -7069,9 +7069,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if self._session_db:
                 try:
                     self.agent._session_db_created = False
+                    try:
+                        from gateway.session_context import resolve_session_source_hint
+
+                        _session_source = resolve_session_source_hint()
+                    except Exception:
+                        _session_source = os.environ.get("HERMES_SESSION_SOURCE", "cli")
                     self._session_db.create_session(
                         session_id=self.session_id,
-                        source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                        source=_session_source,
                         model=self.model,
                         model_config={
                             "max_iterations": self.max_turns,

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -327,6 +327,55 @@ def get_session_env(name: str, default: str = "") -> str:
     return os.getenv(name, default)
 
 
+def resolve_session_platform_hint() -> str:
+    """Active platform for this task, ContextVar-first.
+
+    Concurrent gateway turns bind ``HERMES_SESSION_PLATFORM`` only in a
+    task-local ContextVar (``set_session_vars`` does not mirror it into
+    ``os.environ``). Call sites that read process env first pick up a
+    sibling session's stale value and mis-tag skills / provenance.
+
+    Resolution:
+    1. Task-local ``HERMES_SESSION_PLATFORM`` when bound (including empty
+       after ``clear_session_vars`` — no env fallback for SESSION_PLATFORM).
+    2. When never bound in this task: ``HERMES_PLATFORM`` then process
+       ``HERMES_SESSION_PLATFORM`` (CLI / cold start).
+    """
+    import os
+
+    var = _VAR_MAP.get("HERMES_SESSION_PLATFORM")
+    if var is not None:
+        value = var.get()
+        if value is not _UNSET:
+            if value:
+                return value
+            # Explicitly cleared for this task — do not resurrect a sibling
+            # session's process-global SESSION_PLATFORM.
+            return os.environ.get("HERMES_PLATFORM") or ""
+    return (
+        os.environ.get("HERMES_PLATFORM")
+        or os.environ.get("HERMES_SESSION_PLATFORM")
+        or ""
+    )
+
+
+def resolve_session_source_hint(default: str = "cli") -> str:
+    """Active session source for this task, ContextVar-first.
+
+    Same concurrency rule as :func:`resolve_session_platform_hint`: a
+    task-local binding wins over process env so concurrent turns cannot
+    stamp memory / session rows with a sibling source.
+    """
+    import os
+
+    var = _VAR_MAP.get("HERMES_SESSION_SOURCE")
+    if var is not None:
+        value = var.get()
+        if value is not _UNSET:
+            return value or default
+    return os.environ.get("HERMES_SESSION_SOURCE") or default
+
+
 def async_delivery_supported() -> bool:
     """Whether the current session can deliver a background completion later.
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -918,9 +918,15 @@ class CLICommandsMixin:
         # /sessions even after the parent is reopened and re-ended with a
         # different end_reason (e.g. tui_shutdown overwriting 'branched').
         try:
+            try:
+                from gateway.session_context import resolve_session_source_hint
+
+                _session_source = resolve_session_source_hint()
+            except Exception:
+                _session_source = os.environ.get("HERMES_SESSION_SOURCE", "cli")
             self._session_db.create_session(
                 session_id=new_session_id,
-                source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                source=_session_source,
                 model=self.model,
                 model_config={
                     "max_iterations": self.max_turns,

--- a/run_agent.py
+++ b/run_agent.py
@@ -91,9 +91,9 @@ def _launch_cwd_for_session(source: str) -> Optional[str]:
 
 def _session_source_for_agent(platform: Optional[str]) -> str:
     try:
-        from gateway.session_context import get_session_env
+        from gateway.session_context import resolve_session_source_hint
 
-        source = get_session_env("HERMES_SESSION_SOURCE", "")
+        source = resolve_session_source_hint(default="")
     except Exception:
         source = os.environ.get("HERMES_SESSION_SOURCE", "")
     source = str(source or "").strip()

--- a/tests/gateway/test_session_env_contextvar_priority.py
+++ b/tests/gateway/test_session_env_contextvar_priority.py
@@ -1,0 +1,204 @@
+"""Residual HERMES_SESSION_* readers must prefer task-local ContextVars.
+
+set_session_vars binds platform/source only in ContextVars (not os.environ).
+Call sites that read process env first pick up a sibling session's stale
+value under concurrent gateway turns.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from gateway.session_context import (
+    _UNSET,
+    _VAR_MAP,
+    clear_session_vars,
+    get_session_env,
+    reset_session_vars,
+    resolve_session_platform_hint,
+    resolve_session_source_hint,
+    set_session_vars,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_contextvars_and_env(monkeypatch):
+    # Setup and teardown: leave no bound ContextVars for later modules that
+    # share this thread (e.g. skill_commands tests in the same pytest process).
+    for var in _VAR_MAP.values():
+        var.set(_UNSET)
+    for key in (
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_SOURCE",
+        "HERMES_PLATFORM",
+        "HERMES_SESSION_ID",
+        "HERMES_SESSION_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    yield
+    for var in _VAR_MAP.values():
+        var.set(_UNSET)
+    for key in (
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_SOURCE",
+        "HERMES_PLATFORM",
+        "HERMES_SESSION_ID",
+        "HERMES_SESSION_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_resolve_platform_prefers_contextvar_over_polluted_env(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+    tokens = set_session_vars(
+        platform="discord",
+        source="discord",
+        chat_id="1",
+        session_key="discord:1",
+    )
+    try:
+        assert get_session_env("HERMES_SESSION_PLATFORM") == "discord"
+        # Process env still holds the sibling/stale value.
+        assert os.environ.get("HERMES_SESSION_PLATFORM") == "telegram"
+        assert resolve_session_platform_hint() == "discord"
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_resolve_source_prefers_contextvar_over_polluted_env(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "cli")
+    tokens = set_session_vars(source="telegram", chat_id="9", session_key="t:9")
+    try:
+        assert resolve_session_source_hint() == "telegram"
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_prompt_builder_platform_hint_prefers_contextvar(monkeypatch):
+    """Regression: prompt_builder used to read os.environ before ContextVar."""
+    import agent.prompt_builder as pb
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    # Ensure the gateway module is importable so the lazy path can resolve.
+    import gateway.session_context  # noqa: F401
+
+    tokens = set_session_vars(
+        platform="discord",
+        source="discord",
+        chat_id="2",
+        session_key="discord:2",
+    )
+    try:
+        assert pb._current_session_platform_hint() == "discord"
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_background_review_metadata_uses_task_local_source(monkeypatch):
+    from agent.background_review import build_memory_write_metadata
+
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "cli")
+    tokens = set_session_vars(source="slack", chat_id="c", session_key="slack:c")
+    try:
+
+        class _Agent:
+            session_id = "s1"
+            _parent_session_id = ""
+            platform = None
+            _memory_write_origin = "assistant_tool"
+            _memory_write_context = "foreground"
+
+        meta = build_memory_write_metadata(_Agent())
+        assert meta["platform"] == "slack"
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_explicit_clear_does_not_resurrect_session_platform_env(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    tokens = set_session_vars(platform="discord", chat_id="1", session_key="k")
+    clear_session_vars(tokens)
+    # Cleared task must not fall back to the stale SESSION_PLATFORM env value.
+    assert resolve_session_platform_hint() == ""
+    # Operator-wide HERMES_PLATFORM pin still works after clear.
+    monkeypatch.setenv("HERMES_PLATFORM", "api")
+    assert resolve_session_platform_hint() == "api"
+
+
+def test_unbound_task_still_reads_process_env_for_cli(monkeypatch):
+    reset_session_vars()
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    assert resolve_session_platform_hint() == "telegram"
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "cron")
+    assert resolve_session_source_hint() == "cron"
+
+
+def test_skill_disabled_platform_resolution_uses_contextvar(monkeypatch):
+    from tools.skills_tool import _is_skill_disabled
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+
+    class _Cfg(dict):
+        pass
+
+    def _fake_load():
+        return {
+            "skills": {
+                "disabled": [],
+                "platform_disabled": {
+                    "discord": ["secret-skill"],
+                    "telegram": [],
+                },
+            }
+        }
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _fake_load)
+    tokens = set_session_vars(platform="discord", chat_id="1", session_key="d:1")
+    try:
+        assert _is_skill_disabled("secret-skill") is True
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_kanban_stamp_does_not_resurrect_session_id_after_clear(monkeypatch):
+    """After clear_session_vars, kanban must not re-read process HERMES_SESSION_ID."""
+    from tools.kanban_tools import _stamp_worker_session_metadata
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+    monkeypatch.setenv("HERMES_SESSION_ID", "stale-sibling-session")
+    tokens = set_session_vars(
+        platform="telegram",
+        chat_id="1",
+        session_key="t:1",
+        session_id="live-session",
+    )
+    try:
+        stamped = _stamp_worker_session_metadata("task-1", {})
+        assert stamped is not None
+        assert stamped["worker_session_id"] == "live-session"
+    finally:
+        clear_session_vars(tokens)
+
+    # Cleared ContextVar returns "" and must not fall back to stale env.
+    assert _stamp_worker_session_metadata("task-1", {"x": 1}) == {"x": 1}
+
+
+def test_kanban_create_session_id_respects_cleared_contextvar(monkeypatch):
+    """create_task path: get_session_env after clear must not resurrect env."""
+    from gateway.session_context import get_session_env
+
+    monkeypatch.setenv("HERMES_SESSION_ID", "stale-from-env")
+    tokens = set_session_vars(session_id="live-create", chat_id="1", session_key="k")
+    try:
+        assert get_session_env("HERMES_SESSION_ID", "") == "live-create"
+    finally:
+        clear_session_vars(tokens)
+    assert get_session_env("HERMES_SESSION_ID", "") == ""
+    # Simulate the fixed create_task resolution (no raw env after get_session_env).
+    resolved = get_session_env("HERMES_SESSION_ID", "")
+    assert resolved == ""
+    assert resolved or None is None

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -124,7 +124,16 @@ def _stamp_worker_session_metadata(
     """Add trusted worker session id metadata for this worker's own task."""
     if os.environ.get("HERMES_KANBAN_TASK") != task_id:
         return metadata
-    session_id = os.environ.get("HERMES_SESSION_ID")
+    try:
+        from gateway.session_context import get_session_env
+
+        # get_session_env already falls back to process env when the
+        # ContextVar is unbound. After clear_session_vars it returns ""
+        # on purpose; do not re-read os.environ here or a stale sibling
+        # HERMES_SESSION_ID resurrects after clear.
+        session_id = get_session_env("HERMES_SESSION_ID", "")
+    except Exception:
+        session_id = os.environ.get("HERMES_SESSION_ID")
     if not session_id:
         return metadata
     stamped = dict(metadata or {})
@@ -857,9 +866,17 @@ def _handle_create(args: dict, **kw) -> str:
     parents = args.get("parents") or []
     tenant = args.get("tenant") or os.environ.get("HERMES_TENANT")
     # Stamp the originating session id when the agent loop runs under
-    # ACP (which sets HERMES_SESSION_ID before invoking tools). NULL on
-    # CLI / dashboard paths and on legacy hosts that don't set the env.
-    session_id = args.get("session_id") or os.environ.get("HERMES_SESSION_ID")
+    # ACP / gateway. Prefer task-local session context (get_session_env
+    # falls back to process env only when unbound; after clear it stays "").
+    if args.get("session_id"):
+        session_id = args.get("session_id")
+    else:
+        try:
+            from gateway.session_context import get_session_env
+
+            session_id = get_session_env("HERMES_SESSION_ID", "")
+        except Exception:
+            session_id = os.environ.get("HERMES_SESSION_ID")
     priority = args.get("priority")
     # Resolve workspace. If the caller passed one explicitly, honor it.
     # Otherwise, a dispatcher-spawned worker (HERMES_KANBAN_TASK set)

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -652,7 +652,10 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         from hermes_cli.config import load_config
         config = load_config()
         skills_cfg = config.get("skills", {})
-        resolved_platform = platform or os.getenv("HERMES_PLATFORM") or _get_session_platform()
+        # Task-local session platform first (via _get_session_platform), then
+        # process HERMES_PLATFORM. Do not read process HERMES_SESSION_PLATFORM
+        # ahead of the ContextVar — concurrent gateway turns would cross-wire.
+        resolved_platform = platform or _get_session_platform() or os.getenv("HERMES_PLATFORM")
         global_disabled = skills_cfg.get("disabled", [])
         if resolved_platform:
             platform_disabled = cfg_get(skills_cfg, "platform_disabled", resolved_platform)


### PR DESCRIPTION
Prefer task-local session platform and source over stale process environment values when filtering skills and recording provenance. Shared resolvers retain cold CLI fallback and respect explicitly cleared session values. Current CLI session handlers and shared messaging-surface policy use the same precedence.

Kanban keeps trusted durable origin precedence, then uses the task-local session ID. A missing or cleared ID is stored as NULL rather than an empty string or a stale sibling ID. Worker metadata retains its own-task restriction.

Fixes #65407

Validation: 48 focused tests passed, including a real kanban database regression. Broader related suites passed 182 tests with 2 skips; their 6 failures reproduce unchanged against the pinned main code and concern existing Windows path/shell assumptions. Both review passes found no remaining issue in this repair.

Updated on the refactored main at 1ab32b212b, with the repair folded into one commit.
