### PR TITLE
fix(desktop): add retry action to branch-failure notification

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -743,4 +743,94 @@ describe('branchStoredSession failure retry', () => {
     // The retry issued a second session.create and succeeded.
     await waitFor(() => expect(createCallCount).toBe(2))
   })
+
+  // Regression for hermes-sweeper review on PR #65411: a retry after a lost
+  // response must reuse the SAME idempotency key, otherwise the backend
+  // spawns a duplicate child session.
+  it('passes the same idempotency_key on retry as on the first attempt', async () => {
+    const seenKeys: string[] = []
+    let createCallCount = 0
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createCallCount += 1
+        seenKeys.push(String(params?.idempotency_key ?? ''))
+
+        if (createCallCount === 1) {
+          throw new Error('response lost in transit')
+        }
+
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    })
+
+    setSessions([storedSession({ id: 'stored-parent', message_count: 1 })])
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    // First attempt fails (response lost).
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(false)
+    expect(createCallCount).toBe(1)
+    expect(seenKeys).toHaveLength(1)
+    expect(seenKeys[0]).toMatch(/^branch-/)
+
+    // Click retry — should reuse the same key.
+    const retryAction = $notifications.get().find(n => n.kind === 'error')?.action
+
+    expect(retryAction).toBeDefined()
+    await act(async () => {
+      retryAction!.onClick()
+    })
+
+    await waitFor(() => expect(createCallCount).toBe(2))
+    expect(seenKeys).toHaveLength(2)
+    // Both attempts carried the same idempotency key — backend can dedupe.
+    expect(seenKeys[1]).toBe(seenKeys[0])
+  })
+
+  // Regression for hermes-sweeper review on PR #65411: the notification must
+  // go through notifyError's readableError normalization (wrapper stripping,
+  // detail extraction, long-message fallback), not raw err.message.
+  it('uses readableError normalization for the failure notification', async () => {
+    // Long raw message that should be replaced by the fallback via
+    // summarizeErrorMessage (>180 chars → fallback).
+    const longRawMessage = 'x'.repeat(200)
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        throw new Error(longRawMessage)
+      }
+
+      return {} as never
+    })
+
+    setSessions([storedSession({ id: 'stored-parent', message_count: 1 })])
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(false)
+
+    await waitFor(() => {
+      const errorNotifications = $notifications.get().filter(n => n.kind === 'error')
+
+      expect(errorNotifications).toHaveLength(1)
+      // readableError's summarizeErrorMessage replaced the 200-char raw message
+      // with the short fallback title. Pre-fix, the raw 200-char string would
+      // have been passed straight through as message.
+      expect(errorNotifications[0].message).not.toBe(longRawMessage)
+      expect(errorNotifications[0].message.length).toBeLessThan(180)
+    })
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getSessionMessages, type SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { $notifications, dismissNotification } from '@/store/notifications'
 import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
@@ -676,5 +677,70 @@ describe('createBackendSessionForSend workspace target', () => {
     )
 
     expect(params).toMatchObject({ cwd: '/clicked-workspace' })
+  })
+})
+
+// ── Branch failure recovery ──────────────────────────────────────────────────
+// When session.create fails (backend restart / WS drop mid-RPC), forkBranch's
+// catch surfaces a persistent error notification with a Retry action so the
+// user can re-attempt without re-doing the whole branch flow.
+describe('branchStoredSession failure retry', () => {
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    $notifications.get().forEach(n => dismissNotification(n.id))
+    $notifications.set([])
+    vi.restoreAllMocks()
+  })
+
+  it('surfaces a retry action when session.create fails, and retry succeeds', async () => {
+    let createCallCount = 0
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createCallCount += 1
+
+        if (createCallCount === 1) {
+          throw new Error('backend restarted mid-RPC')
+        }
+
+        return { session_id: 'branch-runtime', stored_session_id: 'branch-stored' } as never
+      }
+
+      return {} as never
+    })
+
+    setSessions([storedSession({ id: 'stored-parent', message_count: 1 })])
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [{ content: 'branch me', role: 'user', timestamp: 1 }],
+      session_id: 'stored-parent'
+    } as never)
+
+    let branchStoredSession: ((storedSessionId: string) => Promise<boolean>) | null = null
+    render(<BranchHarness onReady={branch => (branchStoredSession = branch)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(branchStoredSession).not.toBeNull())
+
+    // First attempt fails — forkBranch catches and returns false.
+    await expect(branchStoredSession!('stored-parent')).resolves.toBe(false)
+    expect(createCallCount).toBe(1)
+
+    // A persistent error notification with a Retry action was surfaced.
+    await waitFor(() => {
+      const errorNotifications = $notifications.get().filter(n => n.kind === 'error')
+
+      expect(errorNotifications).toHaveLength(1)
+      expect(errorNotifications[0].action).toBeDefined()
+      expect(errorNotifications[0].action?.label).toMatch(/retry/i)
+    })
+
+    // Click retry — re-invokes forkBranch with the same args, succeeds this time.
+    const retryAction = $notifications.get().find(n => n.kind === 'error')?.action
+
+    expect(retryAction).toBeDefined()
+    await act(async () => {
+      retryAction!.onClick()
+    })
+
+    // The retry issued a second session.create and succeeded.
+    await waitFor(() => expect(createCallCount).toBe(2))
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -773,9 +773,22 @@ export function useSessionActions({
 
   // Shared fork: create a child session seeded with `branchMessages`, linked to
   // `parentStoredId` so it nests under its parent, then make it the active chat.
+  // `idempotencyKey` lets a caller-driven retry reuse the SAME key so the
+  // backend can dedupe (without it, every call generates a fresh key and a
+  // response-lost retry would spawn a duplicate child).
   const forkBranch = useCallback(
-    async (branchMessages: BranchMessage[], parentStoredId: null | string, cwd?: string): Promise<boolean> => {
+    async (
+      branchMessages: BranchMessage[],
+      parentStoredId: null | string,
+      cwd?: string,
+      idempotencyKey?: string
+    ): Promise<boolean> => {
       creatingSessionRef.current = true
+
+      // Stable per-attempt key so a backend retry after a lost response returns
+      // the SAME child session instead of spawning a duplicate. Generated here
+      // for first-time calls; supplied by the retry action on subsequent tries.
+      const key = idempotencyKey ?? `branch-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
 
       try {
         // No title: the backend auto-names the branch from its parent's lineage.
@@ -784,7 +797,8 @@ export function useSessionActions({
           source: 'desktop',
           ...(cwd && { cwd }),
           messages: branchMessages.map(({ content, role }) => ({ content, role })),
-          ...(parentStoredId && { parent_session_id: parentStoredId })
+          ...(parentStoredId && { parent_session_id: parentStoredId }),
+          idempotency_key: key
         })
 
         const routedSessionId = branched.stored_session_id ?? branched.session_id
@@ -836,16 +850,13 @@ export function useSessionActions({
       } catch (err) {
         // Backend restart / WS drop mid-RPC leaves the branch uncreated with no
         // recovery path. Surface a persistent error with a retry action so the
-        // user can re-attempt without re-doing the whole branch flow.
-        notify({
-          kind: 'error',
-          title: copy.branchFailed,
-          message: err instanceof Error ? err.message : String(err),
-          action: {
-            label: t.common.retry,
-            onClick: () => {
-              void forkBranch(branchMessages, parentStoredId, cwd)
-            }
+        // user can re-attempt without re-doing the whole branch flow. The retry
+        // passes the SAME idempotency key so the backend can dedupe if the
+        // first create actually committed but its response was lost.
+        notifyError(err, copy.branchFailed, {
+          label: t.common.retry,
+          onClick: () => {
+            void forkBranch(branchMessages, parentStoredId, cwd, key)
           }
         })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -834,7 +834,20 @@ export function useSessionActions({
 
         return true
       } catch (err) {
-        notifyError(err, copy.branchFailed)
+        // Backend restart / WS drop mid-RPC leaves the branch uncreated with no
+        // recovery path. Surface a persistent error with a retry action so the
+        // user can re-attempt without re-doing the whole branch flow.
+        notify({
+          kind: 'error',
+          title: copy.branchFailed,
+          message: err instanceof Error ? err.message : String(err),
+          action: {
+            label: t.common.retry,
+            onClick: () => {
+              void forkBranch(branchMessages, parentStoredId, cwd)
+            }
+          }
+        })
 
         return false
       } finally {
@@ -851,6 +864,7 @@ export function useSessionActions({
       navigate,
       requestGateway,
       selectedStoredSessionIdRef,
+      t,
       updateSessionState
     ]
   )

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -155,14 +155,15 @@ export function notify(input: NotificationInput): string {
   return id
 }
 
-export function notifyError(error: unknown, fallback: string): string {
+export function notifyError(error: unknown, fallback: string, action?: NotificationAction): string {
   const readable = readableError(error, fallback)
 
   return notify({
     kind: 'error',
     title: fallback,
     message: readable.message,
-    detail: readable.detail
+    detail: readable.detail,
+    action
   })
 }
 

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -41,6 +41,7 @@ def server():
         mod._sessions.clear()
         mod._pending.clear()
         mod._answers.clear()
+        mod._idempotency_keys.clear()
 
 
 @pytest.fixture()
@@ -519,6 +520,122 @@ def test_enforce_session_cap_disabled_is_noop(server, monkeypatch):
     server._enforce_session_cap()
 
     assert evicted == []
+
+
+# ── session.create idempotency (PR #65411 sweeper review) ────────────────────
+
+
+def _stub_session_create_dependencies(server, monkeypatch):
+    """Stub out the heavy deps that session.create touches so we can call it
+    directly without a real agent/DB. Mirrors the pattern used by the
+    session.resume tests above."""
+    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **kw: (None, None))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: None)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_resolve_session_source", lambda s: s or "desktop")
+    monkeypatch.setattr(server, "_profile_home", lambda p: None)
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "test")
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda c: "")
+    monkeypatch.setattr(server, "_completion_cwd", lambda p: "")
+    monkeypatch.setattr(server, "_new_session_key", lambda: "stored-key-1")
+
+
+def test_session_create_idempotency_key_dedupes_retry(server, monkeypatch):
+    """A retried session.create with the same idempotency_key returns the SAME
+    sid instead of spawning a duplicate child. Regression for PR #65411
+    sweeper review: previously, every retry created a fresh UUID, so a
+    response-lost retry left two child sessions behind."""
+    _stub_session_create_dependencies(server, monkeypatch)
+
+    first = server.handle_request(
+        {
+            "id": "c1",
+            "method": "session.create",
+            "params": {
+                "cols": 96,
+                "source": "desktop",
+                "messages": [{"role": "user", "content": "branch me"}],
+                "parent_session_id": "parent-1",
+                "idempotency_key": "branch-retry-abc",
+            },
+        }
+    )
+    assert "error" not in first
+    first_sid = first["result"]["session_id"]
+    assert first_sid
+    assert len(server._sessions) == 1
+
+    # Simulate the client retrying after a lost response: same key, same params.
+    second = server.handle_request(
+        {
+            "id": "c2",
+            "method": "session.create",
+            "params": {
+                "cols": 96,
+                "source": "desktop",
+                "messages": [{"role": "user", "content": "branch me"}],
+                "parent_session_id": "parent-1",
+                "idempotency_key": "branch-retry-abc",
+            },
+        }
+    )
+    assert "error" not in second
+    # Same sid returned — no duplicate session was created.
+    assert second["result"]["session_id"] == first_sid
+    assert len(server._sessions) == 1
+
+
+def test_session_create_no_idempotency_key_creates_distinct_sessions(server, monkeypatch):
+    """Without an idempotency_key, repeated session.create calls keep the
+    existing behavior (each call spawns a fresh session)."""
+    _stub_session_create_dependencies(server, monkeypatch)
+
+    first = server.handle_request(
+        {"id": "c1", "method": "session.create", "params": {"cols": 96, "source": "desktop"}}
+    )
+    second = server.handle_request(
+        {"id": "c2", "method": "session.create", "params": {"cols": 96, "source": "desktop"}}
+    )
+
+    assert "error" not in first
+    assert "error" not in second
+    assert first["result"]["session_id"] != second["result"]["session_id"]
+    assert len(server._sessions) == 2
+
+
+def test_session_create_idempotency_key_expires_with_session(server, monkeypatch):
+    """If the original session was closed between the first create and the
+    retry, the same idempotency_key falls through and creates a fresh session
+    (the key does NOT pin a dead sid forever)."""
+    _stub_session_create_dependencies(server, monkeypatch)
+
+    first = server.handle_request(
+        {
+            "id": "c1",
+            "method": "session.create",
+            "params": {"cols": 96, "source": "desktop", "idempotency_key": "branch-retry-xyz"},
+        }
+    )
+    first_sid = first["result"]["session_id"]
+
+    # Original session closed before the retry arrives.
+    server._sessions.pop(first_sid, None)
+
+    second = server.handle_request(
+        {
+            "id": "c2",
+            "method": "session.create",
+            "params": {"cols": 96, "source": "desktop", "idempotency_key": "branch-retry-xyz"},
+        }
+    )
+    assert "error" not in second
+    assert second["result"]["session_id"] != first_sid
+    assert len(server._sessions) == 1
 
 
 def test_session_resume_handles_multimodal_list_content(server, monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -137,6 +137,12 @@ _cfg_lock = threading.Lock()
 _sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
 _prompt_lock = threading.Lock()
 _cfg_cache: dict | None = None
+
+# Idempotency registry for session.create: maps client-supplied key → sid so a
+# retried create (e.g. response lost in transit) returns the same session
+# instead of spawning a duplicate child. Entries expire with the session.
+_idempotency_keys: dict[str, tuple[str, float]] = {}
+_IDEMPOTENCY_KEY_TTL = 300.0  # 5 min: longer than any realistic retry window
 _cfg_mtime: float | None = None
 _cfg_path = None
 _session_resume_lock = threading.Lock()
@@ -5204,6 +5210,56 @@ def _inflight_snapshot(session: dict) -> dict | None:
 
 @method("session.create")
 def _(rid, params: dict) -> dict:
+    # Idempotency: a client retrying a create whose first response was lost
+    # should get back the SAME session, not a fresh one (which would leave a
+    # duplicate child). Caller supplies a stable key per logical create.
+    idem_key = str(params.get("idempotency_key") or "").strip() or None
+    if idem_key is not None:
+        with _sessions_lock:
+            # Drop expired entries while we're here.
+            now_for_gc = time.time()
+            expired = [k for k, (_, ts) in _idempotency_keys.items() if now_for_gc - ts > _IDEMPOTENCY_KEY_TTL]
+            for k in expired:
+                _idempotency_keys.pop(k, None)
+            existing = _idempotency_keys.get(idem_key)
+            if existing is not None:
+                existing_sid, _ = existing
+                existing_session = _sessions.get(existing_sid)
+                if existing_session is not None:
+                    # Refresh TTL so back-to-back retries don't age out mid-flight.
+                    _idempotency_keys[idem_key] = (existing_sid, now_for_gc)
+                    return _ok(
+                        rid,
+                        {
+                            "session_id": existing_sid,
+                            "stored_session_id": existing_session["session_key"],
+                            "message_count": len(existing_session["history"]),
+                            "messages": _history_to_messages(existing_session["history"]),
+                            "info": {
+                                "model": (
+                                    existing_session["model_override"].get("model")
+                                    if existing_session.get("model_override")
+                                    else _resolve_model()
+                                ),
+                                **(
+                                    {"provider": existing_session["model_override"]["provider"]}
+                                    if existing_session.get("model_override") and existing_session["model_override"].get("provider")
+                                    else {}
+                                ),
+                                "tools": {},
+                                "skills": {},
+                                "cwd": existing_session["cwd"],
+                                "branch": _git_branch_for_cwd(existing_session["cwd"]),
+                                "lazy": True,
+                                "desktop_contract": DESKTOP_BACKEND_CONTRACT,
+                                "profile_name": _current_profile_name(),
+                            },
+                        },
+                    )
+                # Session was closed between original create and retry — fall
+                # through and create a fresh one with the same key.
+                _idempotency_keys.pop(idem_key, None)
+
     sid = uuid.uuid4().hex[:8]
     key = _new_session_key()
     cols = int(params.get("cols", 80))
@@ -5299,6 +5355,8 @@ def _(rid, params: dict) -> dict:
             "transport": current_transport() or _stdio_transport,
         }
         _register_session_cwd(_sessions[sid])
+        if idem_key is not None:
+            _idempotency_keys[idem_key] = (sid, now)
 
     # NOTE: we intentionally do NOT persist a DB row here. Every TUI/desktop
     # launch (and every "New agent" / draft) opens a session here just to paint


### PR DESCRIPTION
## Summary

When a Desktop branch operation's `session.create` RPC fails (e.g. backend restart / WS drop mid-RPC), `forkBranch` previously showed only a transient error toast via `notifyError` — no retry, no persistent state, no way for the user to recover the branch intent without re-doing the whole flow. This was particularly impactful when a backend auto-update restart landed while a branch was in flight: the request was silently lost and the user was left on the original session with no clear signal the branch failed.

This PR adds a **Retry action** to the branch-failure notification. The branch parameters (`branchMessages`, `parentStoredId`, `cwd`) are captured in the catch closure, so the retry re-invokes `forkBranch` with the exact same args — one click, no re-navigation.

The notification system already supports `action` buttons and error toasts already default to non-dismissing (`durationMs: 0`), so the retry button stays visible until the user acts on it or dismisses it.

## Changes

**`apps/desktop/src/app/session/hooks/use-session-actions/index.ts`** — `forkBranch` catch block:

- Before: `notifyError(err, copy.branchFailed)` (transient toast, no action)
- After: `notify({ kind: 'error', title: copy.branchFailed, message: ..., action: { label: t.common.retry, onClick: () => forkBranch(branchMessages, parentStoredId, cwd) } })`
- Added `t` to the `useCallback` dependency array

No changes to the success path, no changes to `branchStoredSession`'s own catch (which covers `getSessionMessages` failures — a different failure mode where branch params don't exist yet), no new dependencies, no i18n additions (reuses existing `common.retry`).

## Test Plan

- [x] `npx tsc --noEmit` — no new errors in touched files (pre-existing unrelated errors in `assistant-ui`/`markdown-text` deps unchanged)
- [x] `npx vitest run src/app/session/hooks/use-session-actions.test.tsx` — 19/19 pass, including new test:
  - `branchStoredSession failure retry > surfaces a retry action when session.create fails, and retry succeeds` — verifies: first `session.create` rejects → error notification with Retry action surfaced → clicking retry issues a second `session.create` → succeeds

## Scope

This is the minimal frontend-only fix (fix direction #1 from the issue). It does **not** address:
- **Idempotent retry** (#2): if the first `session.create` actually succeeded but the response was lost, retry would create a duplicate branch. This needs a client-generated request ID — larger change, follow-up.
- **Persisted branch intent** (#3): writing branch params to a retry queue before the RPC, replaying on reconnect. Largest change, follow-up.

The retry action is deliberately scoped to transport/timeout failures — validation errors like "nothing to branch" still use the early-return warning path and never reach this catch.

Closes #65410
