### PR TITLE
fix(dashboard): don't let a provider-name query hide the selected provider's models (#65374)

### DIFF
--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { cn, themedBody } from "@/lib/utils";
 import { fuzzyRank } from "@/lib/fuzzy";
+import { queryMatchesProviderOnly } from "@/lib/model-picker-filter";
 
 /**
  * Two-stage model picker modal.
@@ -226,15 +227,30 @@ export function ModelPickerDialog(props: Props) {
     [providers, trimmedQuery],
   );
 
+  // A query that matched the SELECTED provider by name/slug (not its models)
+  // located that provider — it shouldn't also hide that provider's models
+  // just because their ids don't share a substring with the provider name
+  // (e.g. typing "aws" to find "AWS Build" then finding zero of its Claude
+  // model ids contain "aws"). Fall back to an unfiltered model list in that
+  // case; a query that also matches a model id keeps filtering normally.
+  const queryMatchesSelectedProviderOnly = useMemo(
+    () => queryMatchesProviderOnly(selectedProvider, models, trimmedQuery),
+    [trimmedQuery, selectedProvider, models],
+  );
+
   // Fuzzy-ranked models carrying the matched character positions so the model
   // list can highlight why each entry matched.
   const filteredModels = useMemo(
     () =>
-      fuzzyRank(models, trimmedQuery, (m) => m).map((r) => ({
+      fuzzyRank(
+        models,
+        queryMatchesSelectedProviderOnly ? "" : trimmedQuery,
+        (m) => m,
+      ).map((r) => ({
         model: r.item,
         positions: r.positions,
       })),
-    [models, trimmedQuery],
+    [models, trimmedQuery, queryMatchesSelectedProviderOnly],
   );
 
   const canConfirm = !!selectedProvider && !!selectedModel && !applying;

--- a/web/src/lib/model-picker-filter.test.ts
+++ b/web/src/lib/model-picker-filter.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { queryMatchesProviderOnly } from "./model-picker-filter";
+
+describe("queryMatchesProviderOnly", () => {
+  it("returns true when the query finds the provider but no model id (issue #65374)", () => {
+    // Reproduces the exact case from the issue: typing "aws" locates the
+    // "AWS Build" provider, but none of its Claude model ids contain "aws".
+    const provider = { name: "AWS Build", slug: "aws-build" };
+    const models = ["claude-sonnet-4.5", "claude-sonnet-4", "claude-haiku-4.5"];
+
+    expect(queryMatchesProviderOnly(provider, models, "aws")).toBe(true);
+  });
+
+  it("returns false when the query also matches a model id — keeps normal filtering", () => {
+    const provider = { name: "AWS Build", slug: "aws-build" };
+    const models = ["claude-sonnet-4.5", "claude-sonnet-4", "claude-haiku-4.5"];
+
+    expect(queryMatchesProviderOnly(provider, models, "sonnet")).toBe(false);
+  });
+
+  it("returns false when the query does not match the provider at all", () => {
+    const provider = { name: "AWS Build", slug: "aws-build" };
+    const models = ["claude-sonnet-4.5"];
+
+    expect(queryMatchesProviderOnly(provider, models, "openrouter")).toBe(false);
+  });
+
+  it("returns false for an empty query", () => {
+    const provider = { name: "AWS Build", slug: "aws-build" };
+    const models = ["claude-sonnet-4.5"];
+
+    expect(queryMatchesProviderOnly(provider, models, "")).toBe(false);
+  });
+
+  it("returns false when there is no selected provider", () => {
+    expect(queryMatchesProviderOnly(null, ["claude-sonnet-4.5"], "aws")).toBe(false);
+  });
+});

--- a/web/src/lib/model-picker-filter.ts
+++ b/web/src/lib/model-picker-filter.ts
@@ -1,0 +1,23 @@
+import { fuzzyScoreMulti } from "@/lib/fuzzy";
+
+/**
+ * True when `trimmedQuery` located the selected provider by name/slug but
+ * matches none of its models by id — the case where a single search box
+ * filtering both the provider and model columns would otherwise leave the
+ * model pane empty even though the user just successfully found the
+ * provider they were looking for.
+ */
+export function queryMatchesProviderOnly(
+  selectedProvider: { name: string; slug: string } | null,
+  models: readonly string[],
+  trimmedQuery: string,
+): boolean {
+  if (!trimmedQuery || !selectedProvider) return false;
+
+  const matchesProvider =
+    fuzzyScoreMulti(`${selectedProvider.name} ${selectedProvider.slug}`, trimmedQuery) !=
+    null;
+  const matchesAnyModel = models.some((m) => fuzzyScoreMulti(m, trimmedQuery) != null);
+
+  return matchesProvider && !matchesAnyModel;
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a UX trap in the dashboard model picker: `web/src/components/ModelPickerDialog.tsx` uses a single `query` state to filter both the provider column and the model column. Typing a provider name (e.g. "aws") to find a provider also filters the model column by that same text — if the provider's model ids don't share a substring with the provider name (e.g. `AWS Build`'s models are `claude-sonnet-4.5`, `claude-sonnet-4`, `claude-haiku-4.5`), the model pane shows "no models match your filter" even though the provider row correctly reports "3 models". The user has to clear the search box to actually pick a model.

Root cause: `filteredModels` (line ~231 on `main`) always fuzzy-filters `models` by the raw `trimmedQuery`, with no awareness that the query may have already done its job by locating the selected provider.

## Related Issue

Fixes #65374

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/lib/model-picker-filter.ts` (new): exported pure function `queryMatchesProviderOnly(selectedProvider, models, trimmedQuery)` — true when the query fuzzy-matches the selected provider's name/slug but matches none of its model ids.
- `web/src/components/ModelPickerDialog.tsx`: computes `queryMatchesSelectedProviderOnly` via that helper, and when true, filters the model column with an empty query (`fuzzyRank` returns every item unfiltered on an empty query) instead of `trimmedQuery` — so the model pane shows all of the selected provider's models instead of an empty list. A query that also matches a model id (e.g. "sonnet") keeps filtering normally — this only changes behavior for the provider-name-only case the issue describes.
- `web/src/lib/model-picker-filter.test.ts` (new): 5 unit tests covering the issue's exact repro (provider match + no model match → bypass), the case that must keep filtering (query also matches a model id), no-match, empty-query, and no-selected-provider.

## How to Test

1. Open the dashboard → Chat → click the model button (SWITCH MODEL dialog).
2. Configure a custom OpenAI-compatible provider whose model ids don't share a substring with the provider name (issue's repro: `aws-build` with `claude-*` models).
3. Type `aws` in the filter box, select the "AWS Build" provider.
4. Before this fix: model pane shows "no models match your filter" despite the provider reporting "3 models". After this fix: all 3 models are shown and selectable.
5. Typing "sonnet" still filters the model list to only sonnet models (unchanged behavior) — the fix only kicks in when the query matches the provider but zero models.

Fail-before / pass-after (this repo, this branch):

```
$ cd web
# replaced queryMatchesProviderOnly's body with `return false;` (the effective pre-fix behavior)
$ npx vitest run src/lib/model-picker-filter.test.ts
 FAIL  ... > returns true when the query finds the provider but no model id (issue #65374)
 AssertionError: expected false to be true
 Tests  1 failed | 4 passed (5)

# restored the fix
$ npx vitest run src/lib/model-picker-filter.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ npx tsc --noEmit -p .
EXIT:0
```

Full `web` suite (`npx vitest run`): 81/81 tests pass across the 13 test files that resolve cleanly in this environment. One pre-existing, unrelated file (`src/lib/chat-sidebar-session-params.test.ts`) fails to even import in this local dev environment because it transitively imports `@nous-research/ui`, a workspace package not resolvable outside the full monorepo install — reproduced this same failure by running that file alone on a clean checkout of `main` before making any change, so it's environmental, not caused by this diff.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the relevant test suite and all resolvable tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed.

## Screenshots / Logs

See the fail-before/pass-after transcript above under "How to Test".
