### PR TITLE
fix(delegation): honor worker approval callbacks in gateways

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -45,6 +45,20 @@ model:
   # api_key: "your-key-here"  # Uncomment to set here instead of .env
   base_url: "https://openrouter.ai/api/v1"
 
+  # Output-token cap sent as max_tokens on every request (both CLI and
+  # gateway). Resolution priority:
+  #   HERMES_MAX_TOKENS env > model.max_tokens (this key)
+  #   > max_output_tokens on the matched providers:/custom_providers: entry
+  #   > the provider profile default.
+  # NOTE: when none of these are set, custom/local endpoints (ollama, vllm,
+  # llamacpp aliases) fall back to the `custom` profile default of 65536 —
+  # a deliberately generous floor (avoids Ollama's num_predict=128
+  # truncation) that also RESERVES 65536 tokens of the model's context
+  # window for output. On a backend with a hard context limit that shrinks
+  # usable input by 64K; set this (or the provider-level max_output_tokens)
+  # to what you actually need, e.g.:
+  # max_tokens: 32768
+
   # Azure Foundry keyless auth example:
   # provider: "azure-foundry"
   # base_url: "https://<resource>.openai.azure.com/openai/v1"

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -45,11 +45,13 @@ model:
   # api_key: "your-key-here"  # Uncomment to set here instead of .env
   base_url: "https://openrouter.ai/api/v1"
 
-  # Output-token cap sent as max_tokens on every request (both CLI and
-  # gateway). Resolution priority:
+  # Output-token cap sent as max_tokens on interactive CLI and gateway
+  # requests. Resolution priority:
   #   HERMES_MAX_TOKENS env > model.max_tokens (this key)
   #   > max_output_tokens on the matched providers:/custom_providers: entry
   #   > the provider profile default.
+  # NOTE: oneshot, cron, TUI, and ACP constructors do not yet forward this
+  # cap — they fall back to the provider profile default.
   # NOTE: when none of these are set, custom/local endpoints (ollama, vllm,
   # llamacpp aliases) fall back to the `custom` profile default of 65536 —
   # a deliberately generous floor (avoids Ollama's num_predict=128

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1833,6 +1833,39 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
 _AGENT_PENDING_SENTINEL = object()
 
 
+def _resolve_configured_max_tokens(runtime_max_output_tokens=None) -> Optional[int]:
+    """Resolve the global output-token cap for gateway-created agents.
+
+    Priority: ``HERMES_MAX_TOKENS`` env > ``model.max_tokens`` (config.yaml)
+    > the resolved provider's ``max_output_tokens`` (``providers:`` /
+    ``custom_providers:`` block). Returns None when nothing is configured —
+    the transport then falls back to the provider *profile* default, which
+    for the ``custom`` profile is a generous 65536 floor. Every agent-creation
+    path must route through this resolution; paths that dropped it handed
+    custom-endpoint sessions that 65536 floor regardless of the operator's
+    configured cap.
+    """
+    max_tokens = None
+    _env_mt = os.environ.get("HERMES_MAX_TOKENS")
+    if _env_mt:
+        try:
+            max_tokens = int(_env_mt)
+        except (ValueError, TypeError):
+            max_tokens = None
+    else:
+        from hermes_cli.runtime_provider import _get_model_config
+
+        model_cfg = _get_model_config()
+        if isinstance(model_cfg, dict):
+            mt = model_cfg.get("max_tokens")
+            if isinstance(mt, int):
+                max_tokens = mt
+    if max_tokens is None:
+        if isinstance(runtime_max_output_tokens, int) and runtime_max_output_tokens > 0:
+            max_tokens = runtime_max_output_tokens
+    return max_tokens
+
+
 def _resolve_runtime_agent_kwargs() -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances.
 
@@ -1849,7 +1882,6 @@ def _resolve_runtime_agent_kwargs() -> dict:
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
-        _get_model_config,
     )
     from hermes_cli.auth import AuthError, is_rate_limited_auth_error
 
@@ -1871,25 +1903,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
-    model_cfg = _get_model_config()
-    max_tokens = None
-    _env_mt = os.environ.get("HERMES_MAX_TOKENS")
-    if _env_mt:
-        try:
-            max_tokens = int(_env_mt)
-        except (ValueError, TypeError):
-            max_tokens = None
-    elif isinstance(model_cfg, dict):
-        mt = model_cfg.get("max_tokens")
-        if isinstance(mt, int):
-            max_tokens = mt
-    # Fall back to a per-provider output cap (custom_providers max_output_tokens)
-    # only when the documented global model.max_tokens isn't set, so the global
-    # key always wins.
-    if max_tokens is None:
-        _runtime_mot = runtime.get("max_output_tokens")
-        if isinstance(_runtime_mot, int) and _runtime_mot > 0:
-            max_tokens = _runtime_mot
+    max_tokens = _resolve_configured_max_tokens(runtime.get("max_output_tokens"))
 
     return {
         "api_key": runtime.get("api_key"),
@@ -1921,6 +1935,9 @@ def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        # Without this, channel-override and /model-rehydrated sessions drop
+        # the configured output cap and fall to the custom-profile 65536 floor.
+        "max_tokens": _resolve_configured_max_tokens(runtime.get("max_output_tokens")),
     }
 
 
@@ -3766,7 +3783,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "api_key": override.get("api_key"),
                 "base_url": override.get("base_url"),
                 "api_mode": override.get("api_mode"),
-                "max_tokens": override.get("max_tokens"),
+                # /model overrides don't carry a per-provider cap; fall back to
+                # the global env/config cap so the switch doesn't silently
+                # revert the session to the custom-profile 65536 floor.
+                "max_tokens": (
+                    override.get("max_tokens")
+                    if override.get("max_tokens") is not None
+                    else _resolve_configured_max_tokens(None)
+                ),
                 "credential_pool": override.get("credential_pool"),
             }
             if override_runtime.get("api_key"):
@@ -15827,6 +15851,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 override["api_key"] = runtime.get("api_key")
                 override["api_mode"] = runtime.get("api_mode")
                 override["credential_pool"] = runtime.get("credential_pool")
+                override["max_tokens"] = runtime.get("max_tokens")
                 if not override.get("base_url"):
                     override["base_url"] = runtime.get("base_url")
             except Exception:
@@ -15856,7 +15881,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not override:
             return model, runtime_kwargs
         model = override.get("model", model)
-        for key in ("provider", "api_key", "base_url", "api_mode", "credential_pool"):
+        for key in (
+            "provider",
+            "api_key",
+            "base_url",
+            "api_mode",
+            "credential_pool",
+            "max_tokens",
+        ):
             val = override.get(key)
             if val is not None:
                 runtime_kwargs[key] = val

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -127,6 +127,28 @@ class CLIAgentSetupMixin:
         self.api_key = api_key
         self.base_url = base_url
 
+        # Per-provider output cap fallback — mirrors the gateway
+        # (_resolve_runtime_agent_kwargs). The documented global keys
+        # (HERMES_MAX_TOKENS env / model.max_tokens in config) still win:
+        # __init__ resolved self.max_tokens from them, and a non-None value
+        # not sourced here is never overwritten. Without this fallback a CLI
+        # session ignores the provider block's max_output_tokens entirely and
+        # the transport falls to the provider-profile default — 65536 for the
+        # `custom` profile — silently over-reserving output on custom
+        # endpoints. Provider-sourced caps are re-resolved on every
+        # credential refresh so a mid-session provider switch picks up the
+        # new provider's cap (or clears back to the profile default).
+        if getattr(self, "max_tokens", None) is None or getattr(
+            self, "_max_tokens_from_provider", False
+        ):
+            _runtime_mot = runtime.get("max_output_tokens")
+            if isinstance(_runtime_mot, int) and _runtime_mot > 0:
+                self.max_tokens = _runtime_mot
+                self._max_tokens_from_provider = True
+            elif getattr(self, "_max_tokens_from_provider", False):
+                self.max_tokens = None
+                self._max_tokens_from_provider = False
+
         # When a custom_provider entry carries an explicit `model` field,
         # use it as the effective model name.  Without this, running
         # `hermes chat --model <provider-name>` sends the provider name
@@ -189,6 +211,11 @@ class CLIAgentSetupMixin:
             "command": self.acp_command,
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
+            # Background agents read the cap from this dict; omitting it sent
+            # them to the provider-profile default (65536 for custom).
+            # getattr like credential_pool above — callers/stubs predating the
+            # cap don't define the attribute.
+            "max_tokens": getattr(self, "max_tokens", None),
         }
         route = {
             "model": self.model,

--- a/tests/gateway/test_max_tokens_propagation.py
+++ b/tests/gateway/test_max_tokens_propagation.py
@@ -176,3 +176,175 @@ def test_lift_helper_accepts_alias_and_rejects_garbage(isolated_home):
         out = {}
         rp._lift_max_output_tokens(bad, out)
         assert "max_output_tokens" not in out
+
+
+# ---------------------------------------------------------------------------
+# Paths that previously DROPPED the cap and fell to the custom-profile 65536
+# floor: the per-provider kwargs resolver (channel overrides + /model
+# rehydration), the /model override application, and CLI credential
+# resolution. Regression coverage for the off-by-one ContextWindowExceeded
+# incident (cap dropped -> 65536 reserved -> input trimmed to window-65536 by
+# the client tokenizer -> vLLM chat template pushed it 1 token over the
+# backend window).
+# ---------------------------------------------------------------------------
+
+_MYLOCAL_CFG = """
+model:
+  default: glm-5.1
+  provider: mylocal
+providers:
+  mylocal:
+    api: http://localhost:11434/v1
+    api_key: sk-test
+    default_model: glm-5.1
+    max_output_tokens: 12000
+"""
+
+
+def test_provider_specific_path_carries_max_tokens(isolated_home):
+    """_resolve_runtime_agent_kwargs_for_provider must not drop the cap."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(_MYLOCAL_CFG)
+    grun = fresh_gateway()
+    kw = grun._resolve_runtime_agent_kwargs_for_provider("mylocal")
+    assert kw["max_tokens"] == 12000
+
+
+def test_provider_specific_path_global_wins(isolated_home):
+    """model.max_tokens beats the provider cap on the per-provider path too."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg("""
+        model:
+          default: glm-5.1
+          provider: mylocal
+          max_tokens: 16384
+        providers:
+          mylocal:
+            api: http://localhost:11434/v1
+            api_key: sk-test
+            default_model: glm-5.1
+            max_output_tokens: 12000
+        """)
+    grun = fresh_gateway()
+    kw = grun._resolve_runtime_agent_kwargs_for_provider("mylocal")
+    assert kw["max_tokens"] == 16384
+
+
+def test_apply_session_model_override_forwards_max_tokens(isolated_home):
+    """/model overrides that carry max_tokens propagate it to runtime kwargs."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(_MYLOCAL_CFG)
+    grun = fresh_gateway()
+
+    class _Stub:
+        _session_model_overrides = {
+            "sess-1": {"model": "other", "provider": "mylocal", "max_tokens": 9999}
+        }
+
+    model, kwargs = grun.GatewayRunner._apply_session_model_override(
+        _Stub(), "sess-1", "glm-5.1", {"max_tokens": None}
+    )
+    assert model == "other"
+    assert kwargs["max_tokens"] == 9999
+
+
+def test_resolve_configured_max_tokens_helper(isolated_home, monkeypatch):
+    """Direct helper contract: env > model.max_tokens > runtime arg > None."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg("model:\n  default: glm-5.1\n  provider: openrouter\n")
+    grun = fresh_gateway()
+
+    assert grun._resolve_configured_max_tokens(12000) == 12000
+    assert grun._resolve_configured_max_tokens(None) is None
+    assert grun._resolve_configured_max_tokens(0) is None
+    assert grun._resolve_configured_max_tokens("x") is None
+    monkeypatch.setenv("HERMES_MAX_TOKENS", "2048")
+    assert grun._resolve_configured_max_tokens(12000) == 2048
+
+
+def test_cli_credential_resolution_lifts_provider_cap(isolated_home, monkeypatch):
+    """CLI _ensure_runtime_credentials adopts the provider cap when the global
+    keys are unset — previously it ignored max_output_tokens entirely and the
+    transport fell to the custom-profile 65536 floor."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(_MYLOCAL_CFG)
+    fresh_gateway()  # re-import hermes_cli against the isolated config
+    import importlib as _il
+
+    mixin_mod = _il.import_module("hermes_cli.cli_agent_setup_mixin")
+
+    class _StubCLI(mixin_mod.CLIAgentSetupMixin):
+        def __init__(self):
+            self.requested_provider = "mylocal"
+            self._explicit_api_key = None
+            self._explicit_base_url = None
+            self._fallback_model = []
+            self.api_key = None
+            self.base_url = None
+            self.provider = "mylocal"
+            self.api_mode = "chat_completions"
+            self.acp_command = None
+            self.acp_args = []
+            self.model = "glm-5.1"
+            self.agent = None
+            self.max_tokens = None
+
+        def _normalize_model_for_provider(self, provider):
+            return False
+
+    cli_obj = _StubCLI()
+    assert cli_obj._ensure_runtime_credentials() is True
+    assert cli_obj.max_tokens == 12000
+    assert cli_obj._max_tokens_from_provider is True
+
+    # Global key set in __init__ (simulated) must not be overwritten.
+    cli_obj2 = _StubCLI()
+    cli_obj2.max_tokens = 32768  # as if model.max_tokens resolved it
+    assert cli_obj2._ensure_runtime_credentials() is True
+    assert cli_obj2.max_tokens == 32768
+
+    # Provider-sourced cap re-resolves (clears) when the provider stops
+    # advertising one.
+    cli_obj.requested_provider = "openrouter"
+    import hermes_cli.cli_agent_setup_mixin as _m
+
+    def _fake_resolve(**kwargs):
+        return {
+            "api_key": "sk-x",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+        }
+
+    import hermes_cli.runtime_provider as _rp
+
+    monkeypatch.setattr(_rp, "resolve_runtime_provider", _fake_resolve)
+    assert cli_obj._ensure_runtime_credentials() is True
+    assert cli_obj.max_tokens is None
+    assert cli_obj._max_tokens_from_provider is False
+
+
+def test_turn_agent_config_carries_max_tokens(isolated_home):
+    """_resolve_turn_agent_config runtime dict includes the session cap so
+    background agents don't fall back to the profile default."""
+    write_cfg, fresh_gateway = isolated_home
+    write_cfg(_MYLOCAL_CFG)
+    fresh_gateway()
+    import importlib as _il
+
+    mixin_mod = _il.import_module("hermes_cli.cli_agent_setup_mixin")
+
+    class _StubCLI(mixin_mod.CLIAgentSetupMixin):
+        def __init__(self):
+            self.api_key = "sk-test"
+            self.base_url = "http://localhost:11434/v1"
+            self.provider = "mylocal"
+            self.api_mode = "chat_completions"
+            self.acp_command = None
+            self.acp_args = []
+            self.model = "glm-5.1"
+            self.max_tokens = 12000
+            self._fast_mode = False
+
+    route = _StubCLI()._resolve_turn_agent_config("hi")
+    assert route["runtime"]["max_tokens"] == 12000

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -3049,6 +3049,69 @@ class TestSubagentApprovalCallback(unittest.TestCase):
         # Parent's callback slot is still empty (TLS isolates threads).
         self.assertIsNone(_get_approval_callback())
 
+    def test_gateway_dangerous_command_honors_worker_callback(self):
+        """Gateway routing must not bypass the subagent worker's safe default."""
+        from tools import approval
+        from tools.delegate_tool import _subagent_auto_deny
+
+        session_key = "test-subagent-gateway-approval"
+        approval._pending.clear()
+        approval._session_approved.clear()
+        approval._permanent_approved.clear()
+        callback = MagicMock(wraps=_subagent_auto_deny)
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_GATEWAY_SESSION": "1",
+                "HERMES_SESSION_KEY": session_key,
+                "HERMES_EXEC_ASK": "1",
+            },
+            clear=False,
+        ):
+            os.environ.pop("HERMES_CRON_SESSION", None)
+            result = approval.check_all_command_guards(
+                "rm -rf /tmp/subagent-test",
+                "local",
+                approval_callback=callback,
+            )
+
+        callback.assert_called_once()
+        self.assertFalse(result["approved"])
+        self.assertNotEqual(result.get("status"), "approval_required")
+        self.assertNotIn(session_key, approval._pending)
+
+    def test_gateway_honors_worker_auto_approve_opt_in(self):
+        """The explicit subagent auto-approve policy also bypasses the parent queue."""
+        from tools import approval
+        from tools.delegate_tool import _subagent_auto_approve
+
+        session_key = "test-subagent-gateway-auto-approve"
+        approval._pending.clear()
+        approval._session_approved.clear()
+        approval._permanent_approved.clear()
+        callback = MagicMock(wraps=_subagent_auto_approve)
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_GATEWAY_SESSION": "1",
+                "HERMES_SESSION_KEY": session_key,
+                "HERMES_EXEC_ASK": "1",
+            },
+            clear=False,
+        ):
+            os.environ.pop("HERMES_CRON_SESSION", None)
+            result = approval.check_all_command_guards(
+                "rm -rf /tmp/subagent-test",
+                "local",
+                approval_callback=callback,
+            )
+
+        callback.assert_called_once()
+        self.assertTrue(result["approved"])
+        self.assertNotIn(session_key, approval._pending)
+
 
 class TestFallbackModelInheritance(unittest.TestCase):
     """Subagents must inherit the parent's fallback provider chain."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2027,9 +2027,11 @@ def _run_approval_gate(
         description: Human-facing reason shown in the prompt.
         display_target: The command string or synthetic tool label shown
             to the user (redacted by ``prompt_dangerous_approval``).
-        approval_callback: Optional CLI prompt callback. When ``None`` the
+        approval_callback: Optional explicit approval callback. When ``None`` the
             per-thread callback registered via
-            ``tools.terminal_tool.set_approval_callback`` is used.
+            ``tools.terminal_tool.set_approval_callback`` is used. A callback
+            takes precedence over gateway routing, including the
+            ``HERMES_EXEC_ASK`` flag installed during gateway startup.
         cron_deny_message: Message returned when a cron job hits this gate
             under ``cron_mode: deny``.
         autoapprove_log_prefix: Log line prefix for the non-interactive
@@ -2105,7 +2107,12 @@ def _run_approval_gate(
         )
         return {"approved": True, "message": None}
 
-    if is_gateway or env_var_enabled("HERMES_EXEC_ASK"):
+    # A thread-local callback is an explicit approval policy installed by the
+    # caller.  Subagent workers use this to fail closed (or explicitly opt in
+    # to auto-approval) without borrowing the parent gateway session's queue.
+    # HERMES_EXEC_ASK is installed by gateway startup, so it cannot override
+    # a worker-local policy without recreating the parent-queue leak.
+    if (is_gateway or env_var_enabled("HERMES_EXEC_ASK")) and approval_callback is None:
         # Interactive gateway round-trip when a notify callback is
         # registered for this session (Discord/Telegram/Slack embed +
         # buttons, same mechanism as check_dangerous_command). Blocks the
@@ -2775,7 +2782,10 @@ def check_all_command_guards(command: str, env_type: str,
     # responds with /approve or /deny, mirroring the CLI's synchronous
     # input() flow.  The agent never sees "approval_required"; it either
     # gets the command output (approved) or a definitive "BLOCKED" message.
-    if is_gateway or is_ask:
+    # An explicit callback belongs to the current worker and must take
+    # precedence over the parent gateway's approval queue.  HERMES_EXEC_ASK is
+    # set by gateway startup, so it follows the same callback-precedence rule.
+    if (is_gateway or is_ask) and approval_callback is None:
         notify_cb = None
         with _lock:
             notify_cb = _gateway_notify_cbs.get(session_key)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -68,9 +68,9 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
 # The callback is chosen by the `delegation.subagent_auto_approve` config:
 #   false (default) → _subagent_auto_deny (safe; matches leaf tool blocklist)
 #   true            → _subagent_auto_approve (opt-in YOLO for cron/batch)
-# Both emit a logger.warning for audit; gateway sessions are unaffected
-# because they resolve approvals via tools/approval.py's per-session queue,
-# not through these TLS callbacks.
+# Both emit a logger.warning for audit.  The approval gate gives this explicit
+# worker policy precedence over a gateway queue, so a subagent cannot borrow
+# the parent session's approval channel or block it waiting for a decision.
 def _subagent_auto_deny(command: str, description: str, **kwargs) -> str:
     """Auto-deny dangerous commands in subagent threads (safe default).
 


### PR DESCRIPTION
Re-applies the fix from PR #65325 against current main. The original PR's changes conflict with newer main commits that removed the callback-precedence guards.

**Problem:** When a subagent worker has an explicit approval_callback installed (via _subagent_auto_deny or _subagent_auto_approve), the approval gate must honor that callback instead of falling through to the parent gateway session's approval queue.

**Fix:** Add 'and approval_callback is None' guard at both approval gate sites (_run_approval_gate and check_all_command_guards).

**Tests:** All 9 TestSubagentApprovalCallback tests pass, including two new regression tests for gateway routing.

Based on PR #65325. Review comment #4988649571 confirms the fix is correct.