### PR TITLE
fix(desktop): preserve unsafe config integers

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -804,6 +804,30 @@ def _infer_type(value: Any) -> str:
     return "string"
 
 
+_JS_MAX_SAFE_INTEGER = 9_007_199_254_740_991
+
+
+def _json_safe_config_value(value: Any) -> Any:
+    """Return a config value that can survive a JavaScript JSON round-trip.
+
+    The Desktop config editor receives `/api/config` as JSON and keeps a local
+    JavaScript object draft before autosaving it back. JSON itself permits
+    arbitrary-size integers, but JavaScript `Number` does not: Discord
+    snowflakes and similar IDs are rounded as soon as `JSON.parse()` sees them.
+    Stringify only integers outside JS's safe range so unchanged config values
+    preserve their exact scalar text across GET → PUT.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and abs(value) > _JS_MAX_SAFE_INTEGER:
+        return str(value)
+    if isinstance(value, list):
+        return [_json_safe_config_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _json_safe_config_value(item) for key, item in value.items()}
+    return value
+
+
 def _build_schema_from_config(
     config: Dict[str, Any],
     prefix: str = "",
@@ -4583,7 +4607,7 @@ def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
         config["model_context_length"] = ctx_len if isinstance(ctx_len, int) else 0
     else:
         config["model_context_length"] = 0
-    return config
+    return _json_safe_config_value(config)
 
 
 def _memory_provider_label(name: str) -> str:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5327,6 +5327,20 @@ class TestModelContextLength:
         result = _normalize_config_for_web(cfg)
         assert result["model_context_length"] == 0
 
+    def test_normalize_stringifies_json_unsafe_integers(self):
+        """Desktop must not receive Discord snowflakes as JS-rounded numbers."""
+        from hermes_cli.web_server import _normalize_config_for_web
+
+        snowflake = 1495601377412513923
+        result = _normalize_config_for_web({
+            "discord": {
+                "free_response_channels": [snowflake],
+                "allowed_channels": [42],
+            }
+        })
+        assert result["discord"]["free_response_channels"] == [str(snowflake)]
+        assert result["discord"]["allowed_channels"] == [42]
+
     def test_denormalize_writes_context_length_into_model_dict(self):
         """denormalize should write model_context_length back into model dict."""
         from hermes_cli.web_server import _denormalize_config_from_web

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3942,6 +3942,27 @@ class TestConfigRoundTrip:
         assert isinstance(config.get("model"), str), \
             f"model should be string, got {type(config.get('model'))}"
 
+    def test_round_trip_preserves_discord_snowflake_exactly(self):
+        """GET → unchanged PUT must not round a JavaScript-unsafe channel ID."""
+        from hermes_cli.config import read_raw_config, save_config
+
+        snowflake = 1495601377412513923
+        save_config({
+            "discord": {
+                "free_response_channels": [snowflake],
+            }
+        })
+
+        web_config = self.client.get("/api/config").json()
+        assert web_config["discord"]["free_response_channels"] == [str(snowflake)]
+
+        response = self.client.put("/api/config", json={"config": web_config})
+        assert response.status_code == 200
+
+        on_disk = read_raw_config()
+        saved = on_disk["discord"]["free_response_channels"][0]
+        assert str(saved) == str(snowflake)
+
     def test_round_trip_preserves_model_subkeys(self):
         """Save and reload should not lose model.provider, model.base_url, etc."""
         from hermes_cli.config import load_config, save_config


### PR DESCRIPTION
## Summary
- protect `/api/config` responses from JavaScript integer precision loss by stringifying integers outside `Number.MAX_SAFE_INTEGER`
- preserve ordinary safe integers as numbers so existing numeric settings still render/edit normally
- add a regression test for Discord snowflake-sized config values

## Why
The Desktop config editor receives `/api/config` as JSON, keeps a JavaScript object draft, and autosaves that draft back via `PUT /api/config`. Python can emit 19-digit Discord snowflake IDs as JSON numbers, but JavaScript parses them as IEEE-754 `Number`s and rounds them before the user changes anything. A later autosave can therefore rewrite exact channel IDs into rounded, invalid IDs.

## Tests
- `uv run --with pytest pytest tests/hermes_cli/test_web_server.py -k 'normalize_stringifies_json_unsafe_integers or normalize_extracts_context_length_from_dict'`
- `python3 -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check upstream/main...HEAD`
