### PR TITLE
fix(status): parse Linux proc stat after the final comm delimiter

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -136,6 +136,36 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
     return _get_lock_dir() / f"{scope}-{_scope_hash(identity)}.lock"
 
 
+def _parse_linux_proc_stat_suffix(raw: str) -> list[str]:
+    """Return fields 3 onward from a Linux ``/proc/<pid>/stat`` row.
+
+    Field 2 is a parenthesized process name that may contain spaces and right
+    parentheses, so fixed-position whitespace splitting is unsafe. Kernel
+    fields resume after the final ``)`` delimiter.
+    """
+    open_paren = raw.find("(")
+    close_paren = raw.rfind(")")
+    if open_paren <= 0 or close_paren <= open_paren:
+        raise ValueError("malformed /proc stat comm field")
+
+    suffix_fields = raw[close_paren + 1:].split()
+    if not suffix_fields:
+        raise ValueError("truncated /proc stat row")
+
+    state = suffix_fields[0]
+    if len(state) != 1 or not state.isascii() or not state.isalpha():
+        raise ValueError("invalid /proc stat state field")
+    return suffix_fields
+
+
+def _parse_linux_proc_stat_start_time(raw: str) -> int:
+    """Parse field 22 (``starttime``) from a Linux proc stat row."""
+    suffix_fields = _parse_linux_proc_stat_suffix(raw)
+    if len(suffix_fields) <= 19:
+        raise ValueError("truncated /proc stat row")
+    return int(suffix_fields[19])
+
+
 def _get_process_start_time(pid: int) -> Optional[int]:
     """Return a stable per-process start-time fingerprint, or None.
 
@@ -157,7 +187,9 @@ def _get_process_start_time(pid: int) -> Optional[int]:
     stat_path = Path(f"/proc/{pid}/stat")
     try:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
-        return int(stat_path.read_text(encoding="utf-8").split()[21])
+        return _parse_linux_proc_stat_start_time(
+            stat_path.read_text(encoding="utf-8")
+        )
     except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
         pass
 
@@ -664,10 +696,10 @@ def _pid_exists(pid: int) -> bool:
         # answers os.kill(pid, 0) successfully, so without this check
         # ``--replace`` would wait on a dead PID and abort with exit 1.
         try:
-            stat_fields = (
-                Path(f"/proc/{int(pid)}/stat").read_text(encoding="utf-8").split()
+            stat_suffix = _parse_linux_proc_stat_suffix(
+                Path(f"/proc/{int(pid)}/stat").read_text(encoding="utf-8")
             )
-            if len(stat_fields) > 2 and stat_fields[2] == "Z":
+            if stat_suffix[0] == "Z":
                 return False
         except FileNotFoundError:
             # No /proc (macOS/BSD) — fall back to ps state.
@@ -682,7 +714,7 @@ def _pid_exists(pid: int) -> bool:
                     return False
             except Exception:
                 pass
-        except (IndexError, PermissionError, OSError):
+        except (IndexError, PermissionError, ValueError, OSError):
             pass
         try:
             os.kill(int(pid), 0)  # windows-footgun: ok — POSIX-only branch (the whole point of _pid_exists)

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -265,12 +265,44 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
     return _get_lock_dir() / f"{scope}-{_scope_hash(identity)}.lock"
 
 
+def _parse_linux_proc_stat_suffix(raw: str) -> list[str]:
+    """Return fields 3 onward from a Linux ``/proc/<pid>/stat`` row.
+
+    Field 2 is a parenthesized process name that may contain spaces and right
+    parentheses, so fixed-position whitespace splitting is unsafe. Kernel
+    fields resume after the final ``)`` delimiter.
+    """
+    open_paren = raw.find("(")
+    close_paren = raw.rfind(")")
+    if open_paren <= 0 or close_paren <= open_paren:
+        raise ValueError("malformed /proc stat comm field")
+
+    suffix_fields = raw[close_paren + 1:].split()
+    if not suffix_fields:
+        raise ValueError("truncated /proc stat row")
+
+    state = suffix_fields[0]
+    if len(state) != 1 or not state.isascii() or not state.isalpha():
+        raise ValueError("invalid /proc stat state field")
+    return suffix_fields
+
+
+def _parse_linux_proc_stat_start_time(raw: str) -> int:
+    """Parse field 22 (``starttime``) from a Linux proc stat row."""
+    suffix_fields = _parse_linux_proc_stat_suffix(raw)
+    if len(suffix_fields) <= 19:
+        raise ValueError("truncated /proc stat row")
+    return int(suffix_fields[19])
+
+
 def _get_process_start_time(pid: int) -> Optional[int]:
     """Per-process start-time fingerprint (PID-reuse guard), or None: ``/proc/<pid>/stat`` field 22
     on Linux, else psutil ``create_time()`` in centiseconds. Units differ per platform; the guard
     only compares same-host values."""
     with contextlib.suppress(IndexError, ValueError, OSError):
-        return int(Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").split()[21])
+        return _parse_linux_proc_stat_start_time(
+            Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+        )
     try:
         import psutil  # type: ignore
         return int(round(psutil.Process(pid).create_time() * 100))
@@ -601,8 +633,10 @@ def _pid_exists(pid: int) -> bool:
 def _posix_is_zombie(pid: int) -> bool:
     """Zombie via ``/proc/<pid>/stat`` field 3, or ``ps -o state=`` without /proc (macOS/BSD)."""
     try:
-        stat_fields = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").split()
-        return len(stat_fields) > 2 and stat_fields[2] == "Z"
+        stat_suffix = _parse_linux_proc_stat_suffix(
+            Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+        )
+        return stat_suffix[0] == "Z"
     except FileNotFoundError:
         with contextlib.suppress(Exception):
             # --compile-bytecode: uv does NOT write __pycache__ by default (pip does), so without it the
@@ -617,7 +651,7 @@ def _posix_is_zombie(pid: int) -> bool:
                 capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5,
             )
             return r.returncode == 0 and r.stdout.strip().startswith("Z")
-    except (IndexError, PermissionError, OSError):
+    except (IndexError, PermissionError, ValueError, OSError):
         pass
     return False
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -6,7 +6,50 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from gateway import status
+
+
+def _proc_stat_row(
+    comm: str, *, state: str = "S", start_time: int | str = 987654
+) -> str:
+    fields_4_through_21 = [str(value) for value in range(1, 19)]
+    return " ".join(
+        [f"123 ({comm})", state, *fields_4_through_21, str(start_time)]
+    )
+
+
+class TestLinuxProcStatParsing:
+    @pytest.mark.parametrize(
+        "comm",
+        [
+            "python",
+            "process with spaces",
+            "worker) with right paren",
+            "nested (worker)) name",
+        ],
+    )
+    def test_state_and_start_time_follow_final_comm_parenthesis(self, comm):
+        raw = _proc_stat_row(comm, state="Z", start_time=424242)
+
+        assert status._parse_linux_proc_stat_suffix(raw)[0] == "Z"
+        assert status._parse_linux_proc_stat_start_time(raw) == 424242
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "123 python S 1 2 3",
+            "123 ()",
+            "123 (truncated) S 1 2",
+            _proc_stat_row("bad start", start_time="not-an-integer"),
+            _proc_stat_row("bad state", state="99"),
+            _proc_stat_row("missing state", state=""),
+        ],
+    )
+    def test_malformed_or_truncated_records_raise_value_error(self, raw):
+        with pytest.raises(ValueError):
+            status._parse_linux_proc_stat_start_time(raw)
 
 
 class TestGatewayPidState:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -12,13 +12,54 @@ import pytest
 from gateway import status
 
 
+def _proc_stat_row(
+    comm: str, *, state: str = "S", start_time: int | str = 987654
+) -> str:
+    fields_4_through_21 = [str(value) for value in range(1, 19)]
+    return " ".join(
+        [f"123 ({comm})", state, *fields_4_through_21, str(start_time)]
+    )
+
+
+class TestLinuxProcStatParsing:
+    @pytest.mark.parametrize(
+        "comm",
+        [
+            "python",
+            "process with spaces",
+            "worker) with right paren",
+            "nested (worker)) name",
+        ],
+    )
+    def test_state_and_start_time_follow_final_comm_parenthesis(self, comm):
+        raw = _proc_stat_row(comm, state="Z", start_time=424242)
+
+        assert status._parse_linux_proc_stat_suffix(raw)[0] == "Z"
+        assert status._parse_linux_proc_stat_start_time(raw) == 424242
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "123 python S 1 2 3",
+            "123 ()",
+            "123 (truncated) S 1 2",
+            _proc_stat_row("bad start", start_time="not-an-integer"),
+            _proc_stat_row("bad state", state="99"),
+            _proc_stat_row("missing state", state=""),
+        ],
+    )
+    def test_malformed_or_truncated_records_raise_value_error(self, raw):
+        with pytest.raises(ValueError):
+            status._parse_linux_proc_stat_start_time(raw)
+
+
 class TestGatewayPidState:
     def test_write_pid_file_records_gateway_metadata(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
         status.write_pid_file()
 
-        payload = json.loads((tmp_path / "gateway.pid").read_text())
+        payload = json.loads((tmp_path / "gateway.pid").read_text(encoding="utf-8"))
         assert payload["pid"] == os.getpid()
         assert payload["kind"] == "hermes-gateway"
         assert isinstance(payload["argv"], list)
@@ -45,7 +86,7 @@ class TestGatewayPidState:
             status.write_pid_file()
 
         # Original record is preserved.
-        payload = json.loads((tmp_path / "gateway.pid").read_text())
+        payload = json.loads((tmp_path / "gateway.pid").read_text(encoding="utf-8"))
         assert payload["pid"] == os.getpid()
 
 
@@ -74,9 +115,8 @@ class TestGatewayPidState:
                 "argv": ["python", "-m", "hermes_cli.main", "gateway"],
                 "start_time": start_time,
             }
-            pid_path.write_text(json.dumps(record))
-            (tmp_path / "gateway.lock").write_text(json.dumps(record))
-
+            pid_path.write_text(json.dumps(record), encoding="utf-8")
+            (tmp_path / "gateway.lock").write_text(json.dumps(record), encoding="utf-8")
         _write_record(111, 123)
 
         calls = {"lock_active": 0}
@@ -162,7 +202,7 @@ class TestGatewayPidState:
         assert (process_home / "gateway.pid").exists()
         assert not (profile_home / "gateway.pid").exists()
 
-        payload = json.loads((process_home / "gateway.pid").read_text())
+        payload = json.loads((process_home / "gateway.pid").read_text(encoding="utf-8"))
         assert payload["pid"] == os.getpid()
 
         # Cleanup for atexit hooks.
@@ -521,7 +561,7 @@ class TestScopedLocks:
         acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
 
         assert acquired is True
-        payload = json.loads(lock_path.read_text())
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
@@ -560,7 +600,7 @@ class TestScopedLocks:
 
         assert acquired is True
         assert existing["pid"] == os.getpid()
-        payload = json.loads(lock_path.read_text())
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
         assert payload["pid"] == os.getpid()
         assert payload["start_time"] == 987654321
         assert payload["metadata"]["platform"] == "discord"
@@ -609,7 +649,7 @@ class TestScopedLocks:
 
         assert acquired is True
         assert existing["pid"] == os.getpid()
-        payload = json.loads(lock_path.read_text())
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
         assert payload["pid"] == os.getpid()
         assert payload["start_time"] == 987654321
 
@@ -626,7 +666,7 @@ class TestScopedLocks:
             "start_time": 123,
             "kind": "hermes-gateway",
         }
-        lock_path.write_text(json.dumps(stale_record))
+        lock_path.write_text(json.dumps(stale_record), encoding="utf-8")
         monkeypatch.setattr(status, "_pid_exists", lambda pid: False)
 
         winner_record = {
@@ -641,7 +681,7 @@ class TestScopedLocks:
             if str(src) == str(lock_path):
                 # Simulate the winner completing removal + O_EXCL create
                 # between our staleness check and our removal attempt.
-                lock_path.write_text(json.dumps(winner_record))
+                lock_path.write_text(json.dumps(winner_record), encoding="utf-8")
                 raise FileNotFoundError(2, "No such file or directory", str(src))
             return real_replace(src, dst, *args, **kwargs)
 
@@ -653,7 +693,7 @@ class TestScopedLocks:
         assert existing is not None
         assert existing["pid"] == 424242
         # The winner's fresh lock must be untouched on disk.
-        assert json.loads(lock_path.read_text())["pid"] == 424242
+        assert json.loads(lock_path.read_text(encoding="utf-8"))["pid"] == 424242
 
 
     def test_acquire_scoped_lock_replaces_stale_record(self, tmp_path, monkeypatch):
@@ -672,7 +712,7 @@ class TestScopedLocks:
         acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
 
         assert acquired is True
-        payload = json.loads(lock_path.read_text())
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
@@ -717,7 +757,7 @@ class TestScopedLocks:
         lock_path = tmp_path / "locks" / (
             "telegram-bot-token-" + status._scope_hash("secret") + ".lock"
         )
-        payload = json.loads(lock_path.read_text())
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
         assert payload["profile"] == "lead-gen-outreach"
 
     def test_acquire_scoped_lock_omits_profile_when_not_inferable(self, tmp_path, monkeypatch):
@@ -732,7 +772,7 @@ class TestScopedLocks:
         lock_path = tmp_path / "locks" / (
             "telegram-bot-token-" + status._scope_hash("secret") + ".lock"
         )
-        payload = json.loads(lock_path.read_text())
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
         assert "profile" not in payload
 
 
@@ -812,7 +852,7 @@ class TestTakeoverMarker:
         assert ok is True
         marker = tmp_path / ".gateway-takeover.json"
         assert marker.exists()
-        payload = json.loads(marker.read_text())
+        payload = json.loads(marker.read_text(encoding="utf-8"))
         assert payload["target_pid"] == 12345
         assert payload["target_start_time"] == 42
         assert payload["replacer_pid"] == os.getpid()
@@ -838,7 +878,7 @@ class TestTakeoverMarker:
 
         ok = status.write_takeover_marker(target_pid=os.getpid())
         assert ok is True
-        payload = json.loads((tmp_path / ".gateway-takeover.json").read_text())
+        payload = json.loads((tmp_path / ".gateway-takeover.json").read_text(encoding="utf-8"))
         assert payload["target_start_time"] is None
 
         result = status.consume_takeover_marker_for_self()
@@ -854,7 +894,7 @@ class TestTakeoverMarker:
 
         status.write_takeover_marker(target_pid=12345)
 
-        payload = json.loads((tmp_path / ".gateway-takeover.json").read_text())
+        payload = json.loads((tmp_path / ".gateway-takeover.json").read_text(encoding="utf-8"))
         assert payload["replacer_hermes_home"] == str(tmp_path)
 
     def test_consume_rejects_marker_from_different_profile(self, tmp_path, monkeypatch):
@@ -919,7 +959,7 @@ class TestScopedLockTakeover:
             "start_time": start_time,
             "hermes_home": str(target_home),
         }
-        (target_home / "gateway.pid").write_text(json.dumps(record))
+        (target_home / "gateway.pid").write_text(json.dumps(record), encoding="utf-8")
         return record
 
     def test_verified_distinct_home_handoff_marks_target_before_sigterm(
@@ -944,7 +984,7 @@ class TestScopedLockTakeover:
         def terminate(pid, *, force=False):
             marker_path = target_home / ".gateway-takeover.json"
             assert marker_path.exists()
-            payload = json.loads(marker_path.read_text())
+            payload = json.loads(marker_path.read_text(encoding="utf-8"))
             assert payload["target_hermes_home"] == str(target_home)
             assert payload["replacer_hermes_home"] == str(replacer_home)
             calls.append((pid, force))
@@ -966,8 +1006,7 @@ class TestScopedLockTakeover:
         # The lock claims target_home, but that home's PID record names a
         # different process identity.
         bad_pid_record = dict(record, pid=9999)
-        (target_home / "gateway.pid").write_text(json.dumps(bad_pid_record))
-
+        (target_home / "gateway.pid").write_text(json.dumps(bad_pid_record), encoding="utf-8")
         monkeypatch.setattr(status, "_pid_exists", lambda _pid: True)
         monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 123)
         monkeypatch.setattr(
@@ -997,7 +1036,7 @@ class TestPlannedStopMarker:
         assert ok is True
         marker = tmp_path / ".gateway-planned-stop.json"
         assert marker.exists()
-        payload = json.loads(marker.read_text())
+        payload = json.loads(marker.read_text(encoding="utf-8"))
         assert payload["target_pid"] == 12345
         assert payload["target_start_time"] == 42
         assert payload["stopper_pid"] == os.getpid()
@@ -1026,7 +1065,7 @@ class TestPlannedStopMarker:
         ok = status.write_planned_stop_marker(target_pid=os.getpid())
         assert ok is True
         # Marker carries a null start_time, exactly as written on Windows.
-        payload = json.loads((tmp_path / ".gateway-planned-stop.json").read_text())
+        payload = json.loads((tmp_path / ".gateway-planned-stop.json").read_text(encoding="utf-8"))
         assert payload["target_start_time"] is None
 
         result = status.consume_planned_stop_marker_for_self()


### PR DESCRIPTION
## What does this PR do?

Linux `/proc/<pid>/stat` stores the process name in a parenthesized `comm` field. That name may contain spaces and right parentheses, so splitting the entire row on whitespace can shift the field indexes and misread both process state and start time.

This change:

- parses fields 3 onward only after the final `)` delimiter;
- shares the parser between process start-time and zombie-state checks;
- rejects malformed or truncated rows and preserves the existing safe fallback behavior;
- adds synthetic regression coverage for spaces, embedded `)`, truncation, invalid state, and invalid start time.

## Verification

- [x] Tested on Ubuntu 26.04 / Linux x86_64
- [x] `pytest tests/gateway/test_status.py -q` — 104 passed
- [x] `ruff check gateway/status.py tests/gateway/test_status.py`
- [x] `python -m py_compile gateway/status.py tests/gateway/test_status.py`
- [x] `git diff --check`

No live `/proc` data, credentials, or environment-specific paths are used by the tests.