### PR TITLE
test(voice): drive silence detection tests with an explicit clock

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -68,6 +68,54 @@ def mock_sd(monkeypatch):
     return mock
 
 
+class _FakeTime:
+    """Stand-in for the ``time`` module with a monotonic clock the test drives.
+
+    Silence detection compares ``time.monotonic()`` deltas against thresholds
+    of a few dozen milliseconds.  Driving those deltas with real ``sleep()``
+    calls only works when the platform clock is finer-grained than the margin
+    the test leaves: ``time.monotonic()`` is ``GetTickCount64()`` (15.625 ms
+    resolution) on Windows until CPython 3.13 moved it to
+    ``QueryPerformanceCounter()``, so a 60 ms sleep can legitimately measure
+    as 46 ms and land under a 50 ms threshold.  Advancing an explicit clock
+    keeps the arithmetic exact on every platform.
+
+    Everything other than ``monotonic`` delegates to the real module, so
+    ``time.sleep``/``time.strftime`` in the code under test keep working.
+    """
+
+    def __init__(self, real_time, start: float = 1000.0) -> None:
+        self._real = real_time
+        self._now = start
+
+    def monotonic(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+@pytest.fixture
+def fake_clock(monkeypatch):
+    """Give voice_mode a hand-driven clock.
+
+    Patches the name ``time`` inside ``tools.voice_mode`` rather than
+    ``time.monotonic`` itself -- ``voice_mode.time`` *is* the stdlib module,
+    so setting the attribute on it would swap the clock out from under every
+    other importer for the duration of the test.
+    """
+    import time as real_time
+
+    import tools.voice_mode as voice_mode
+
+    clock = _FakeTime(real_time)
+    monkeypatch.setattr(voice_mode, "time", clock)
+    return clock
+
+
 # ============================================================================
 # detect_audio_environment — WSL / SSH / Docker detection
 # ============================================================================
@@ -1032,7 +1080,7 @@ class TestPlayBeep:
 # ============================================================================
 
 class TestSilenceDetection:
-    def test_silence_callback_fires_after_speech_then_silence(self, mock_sd):
+    def test_silence_callback_fires_after_speech_then_silence(self, mock_sd, fake_clock):
         np = pytest.importorskip("numpy")
         import threading
 
@@ -1061,7 +1109,7 @@ class TestSilenceDetection:
         # Simulate sustained speech (multiple loud chunks to exceed min_speech_duration)
         loud_frame = np.full((1600, 1), 5000, dtype="int16")
         callback(loud_frame, 1600, None, None)
-        time.sleep(0.06)
+        fake_clock.advance(0.06)
         callback(loud_frame, 1600, None, None)
         assert recorder._has_spoken is True
 
@@ -1069,12 +1117,13 @@ class TestSilenceDetection:
         silent_frame = np.zeros((1600, 1), dtype="int16")
         callback(silent_frame, 1600, None, None)
 
-        # Wait a bit past the silence duration, then send another silent frame
-        time.sleep(0.06)
+        # Move past the silence duration, then send another silent frame
+        fake_clock.advance(0.06)
         callback(silent_frame, 1600, None, None)
 
-        # The callback should have been fired
-        assert fired.wait(timeout=1.0) is True
+        # The callback should have been fired (it runs on a real thread, so
+        # this wait is the one place real time is still involved)
+        assert fired.wait(timeout=5.0) is True
 
         recorder.cancel()
 
@@ -1369,7 +1418,7 @@ class TestAudioLevelIndicator:
 class TestConfigurableSilenceParams:
     """Verify that silence detection params can be configured."""
 
-    def test_custom_threshold_and_duration(self, mock_sd):
+    def test_custom_threshold_and_duration(self, mock_sd, fake_clock):
         np = pytest.importorskip("numpy")
 
         mock_stream = MagicMock()
@@ -1393,7 +1442,7 @@ class TestConfigurableSilenceParams:
         moderate = np.full((1600, 1), 1000, dtype="int16")
         for _ in range(5):
             callback(moderate, 1600, None, None)
-            time.sleep(0.02)
+            fake_clock.advance(0.02)
 
         assert recorder._has_spoken is False
         assert fired.wait(timeout=0.2) is False
@@ -1401,7 +1450,7 @@ class TestConfigurableSilenceParams:
         # Now send really loud audio (above 5000 threshold)
         very_loud = np.full((1600, 1), 8000, dtype="int16")
         callback(very_loud, 1600, None, None)
-        time.sleep(0.06)
+        fake_clock.advance(0.06)
         callback(very_loud, 1600, None, None)
         assert recorder._has_spoken is True
 

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1156,7 +1156,7 @@ class TestSilenceDetection:
 
         recorder.cancel()
 
-    def test_micro_pause_tolerance_during_speech(self, mock_sd):
+    def test_micro_pause_tolerance_during_speech(self, mock_sd, fake_clock):
         """Brief dips below threshold during speech should NOT reset speech tracking."""
         np = pytest.importorskip("numpy")
         import threading
@@ -1183,14 +1183,14 @@ class TestSilenceDetection:
 
         # Speech chunk 1
         callback(loud_frame, 1600, None, None)
-        time.sleep(0.05)
+        fake_clock.advance(0.05)
         # Brief micro-pause (dip < max_dip_tolerance)
         callback(quiet_frame, 1600, None, None)
-        time.sleep(0.05)
+        fake_clock.advance(0.05)
         # Speech resumes -- speech_start should NOT have been reset
         callback(loud_frame, 1600, None, None)
         assert recorder._speech_start > 0, "Speech start should be preserved across brief dips"
-        time.sleep(0.06)
+        fake_clock.advance(0.06)
         # Another speech chunk to exceed min_speech_duration
         callback(loud_frame, 1600, None, None)
         assert recorder._has_spoken is True, "Speech should be confirmed after tolerating micro-pause"


### PR DESCRIPTION
## What does this PR do?

Two tests in `tests/tools/test_voice_mode.py` fail on Windows about a third of the time on clean `main`, landing on a different assert depending on the run:

- `TestSilenceDetection::test_silence_callback_fires_after_speech_then_silence` — either `assert recorder._has_spoken is True` or `assert fired.wait(timeout=1.0) is True`
- `TestConfigurableSilenceParams::test_custom_threshold_and_duration` — `assert recorder._has_spoken is True`

Both space their audio frames with `time.sleep(0.06)` and check the result against 50 ms thresholds (`_min_speech_duration` / `_silence_duration`), leaving a 10 ms margin. That margin only holds if the clock is finer-grained than the margin — and on Windows it isn't. `time.monotonic()` there is `GetTickCount64()` with 15.625 ms resolution, until CPython 3.13 moved it to `QueryPerformanceCounter()`:

```text
Python 3.11.9   namespace(implementation='GetTickCount64()', resolution=0.015625)
Python 3.13.1   namespace(implementation='QueryPerformanceCounter()', resolution=1e-07)
```

So a sleep that really lasts 62.5 ms measures as 46.9 ms whenever it straddles a tick boundary — under the 50 ms threshold. Measured directly on the same box, 30 samples:

```text
sleep(0.06) measured, ms: [46.0, 47.0, 62.0, 63.0]   -> under 50 ms in 4/30
```

Each test has two such gates (confirm speech, then mature the silence timer), which is why the same root cause surfaces on two different asserts.

The clock is the whole story — same machine, same commit, same tests, only the interpreter differs:

| Python | `monotonic()` | Resolution | 20 runs of the two tests |
|---|---|---|---|
| 3.11.9 | `GetTickCount64()` | 15.625 ms | **9 failures** (6 + 3) |
| 3.13.1 | `QueryPerformanceCounter()` | 0.0001 ms | **0 failures** |

Rather than widen the margins — which would leave the tests hostage to the platform clock and just make the flake rarer — this drives an explicit clock, so the timing arithmetic is exact everywhere and the tests stop waiting on real time.

CI doesn't see any of this: it runs on `ubuntu-latest`, where `clock_gettime` is nanosecond-resolution. But `requires-python = ">=3.11,<3.14"`, so Windows on 3.11/3.12 is a supported configuration where the suite is flaky today.

## Related Issue

No issue — this wasn't filed; I hit it running the suite on Windows and chased it down. Happy to open one first if you'd prefer that order.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/tools/test_voice_mode.py` — added `_FakeTime`, a stand-in for the `time` module with a monotonic clock the test advances by hand. Everything except `monotonic` delegates to the real module, so `time.sleep` / `time.strftime` in the code under test keep working.
- `tests/tools/test_voice_mode.py` — added the `fake_clock` fixture. It patches the **name** `time` inside `tools.voice_mode` rather than `time.monotonic` itself: `voice_mode.time` *is* the stdlib module, so patching through it would swap the clock out from under every other importer for the duration of the test.
- `tests/tools/test_voice_mode.py` — `test_silence_callback_fires_after_speech_then_silence` and `test_custom_threshold_and_duration` now advance `fake_clock` instead of sleeping. The one real wait left is `fired.wait(...)`, since the callback genuinely runs on another thread; its timeout went 1.0 → 5.0 so a loaded box isn't the thing that fails it.

No production code is touched.

## How to Test

1. On Windows with Python 3.11 or 3.12, on `main`, run the two tests ~20 times:

   ```bash
   pytest tests/tools/test_voice_mode.py::TestSilenceDetection::test_silence_callback_fires_after_speech_then_silence \
          tests/tools/test_voice_mode.py::TestConfigurableSilenceParams::test_custom_threshold_and_duration -q
   ```

   They fail intermittently — measured 6/20 and 3/20 on `569b912d7`, Windows 11 / Python 3.11.9.

2. Same command on this branch: 0/30 failures. On Python 3.13, 10/10 pass both before and after — that contrast is what pins the clock as the cause rather than the detection logic.

3. No Windows box handy? The root cause is checkable from anywhere:

   ```bash
   python -c "import time; print(time.get_clock_info('monotonic'))"
   ```

   On Windows ≤ 3.12 that prints `GetTickCount64()` / `resolution=0.015625`, which is larger than the 10 ms margin the tests leave.

4. The tests still have teeth — break the production gates they cover and they fail:

   - `tools/voice_mode.py:561` (`>= self._min_speech_duration` → `+ 999`) fails both tests
   - `tools/voice_mode.py:612` (`>= self._silence_duration` → `+ 999`) fails the first

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11.9 (and Python 3.13.1 for the clock comparison)

On the unchecked test box: `tests/tools/test_voice_mode.py` is fully green here (70 passed, stable across 5 runs) except for three failures that predate this branch and are unrelated — `TestPulseSocketReachable` uses `socket.AF_UNIX`, which doesn't exist on Windows. I left those alone rather than mix concerns into a deflake PR; happy to send a `skipif` for them separately. The wider suite has other pre-existing Windows failures too, so I can't honestly claim a clean `pytest tests/ -q` from this box.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — N/A, test-only change; the reasoning lives in the fixture docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change removes a platform dependency rather than adding one: the tests no longer care about clock resolution, so they behave identically on Linux, macOS and Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — N/A, no behavior change

## Screenshots / Logs

Before, on `main` @ `569b912d7` (Windows 11, Python 3.11.9) — same test, two different runs, two different asserts:

```text
FAILED tests/tools/test_voice_mode.py::TestSilenceDetection::test_silence_callback_fires_after_speech_then_silence
E       assert False is True
E        +  where False = wait(timeout=1.0)
E        +    where wait = <threading.Event at 0x242e1045290: unset>.wait
```

```text
FAILED tests/tools/test_voice_mode.py::TestSilenceDetection::test_silence_callback_fires_after_speech_then_silence
>       assert recorder._has_spoken is True
E       assert False is True
```

After, 30 consecutive runs of both tests: `2 passed in 1.00s`, every time.