### PR TITLE
fix(desktop): preserve streamed reasoning on late fallback

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -161,6 +161,25 @@ def _ra():
     return run_agent
 
 
+def _relay_available_reasoning(agent, assistant_content: str) -> None:
+    """Relay completed inline reasoning without truncating the live fallback."""
+    think_text = re.sub(
+        r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', assistant_content.strip()
+    ).strip()
+    first_line = think_text.split('\n')[0][:80] if think_text else ""
+
+    if first_line and getattr(agent, '_delegate_depth', 0) > 0:
+        try:
+            agent.tool_progress_callback("_thinking", first_line)
+        except Exception:
+            pass
+    elif think_text:
+        try:
+            agent.tool_progress_callback("reasoning.available", "_thinking", think_text, None)
+        except Exception:
+            pass
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (
@@ -4422,24 +4441,7 @@ def run_conversation(
             # Notify progress callback of model's thinking (used by subagent
             # delegation to relay the child's reasoning to the parent display).
             if (assistant_message.content and agent.tool_progress_callback):
-                _think_text = assistant_message.content.strip()
-                # Strip reasoning XML tags that shouldn't leak to parent display
-                _think_text = re.sub(
-                    r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
-                ).strip()
-                # For subagents: relay first line to parent display (existing behaviour).
-                # For all agents with a structured callback: emit reasoning.available event.
-                first_line = _think_text.split('\n')[0][:80] if _think_text else ""
-                if first_line and getattr(agent, '_delegate_depth', 0) > 0:
-                    try:
-                        agent.tool_progress_callback("_thinking", first_line)
-                    except Exception:
-                        pass
-                elif _think_text:
-                    try:
-                        agent.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
-                    except Exception:
-                        pass
+                _relay_available_reasoning(agent, assistant_message.content)
             
             # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
             # This means the model ran out of output tokens mid-reasoning — retry up to 2 times

--- a/apps/desktop/src/app/session/hooks/use-message-stream.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { reasoningPart, textPart } from '@/lib/chat-messages'
+
+import { applyReasoningAvailable } from './use-message-stream'
+
+describe('applyReasoningAvailable', () => {
+  it('inserts available reasoning before existing assistant text', () => {
+    const parts = applyReasoningAvailable([textPart('Final answer.')], 'Late reasoning.')
+
+    expect(parts.map(part => part.type)).toEqual(['reasoning', 'text'])
+    expect(parts[0]).toEqual(reasoningPart('Late reasoning.'))
+    expect(parts[1]).toEqual(textPart('Final answer.'))
+  })
+
+  it('keeps the current reasoning part when one already exists', () => {
+    const existing = [reasoningPart('Streaming reasoning.'), textPart('Final answer.')]
+    const parts = applyReasoningAvailable(existing, 'Late reasoning.')
+
+    expect(parts).toBe(existing)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -53,6 +53,20 @@ interface QueuedStreamDeltas {
   reasoning: string
 }
 
+export function applyReasoningAvailable(parts: ChatMessagePart[], text: string): ChatMessagePart[] {
+  if (parts.some(part => part.type === 'reasoning')) {
+    return parts
+  }
+
+  const textIndex = parts.findIndex(part => part.type === 'text')
+
+  if (textIndex < 0) {
+    return [...parts, reasoningPart(text)]
+  }
+
+  return [...parts.slice(0, textIndex), reasoningPart(text), ...parts.slice(textIndex)]
+}
+
 export function useMessageStream({
   activeSessionIdRef,
   hydrateFromStoredSession,
@@ -267,17 +281,7 @@ export function useMessageStream({
 
       mutateStream(
         sessionId,
-        (parts, message) => {
-          if (replace && chatMessageText(message).trim()) {
-            return parts
-          }
-
-          if (replace) {
-            return [...parts.filter(part => part.type !== 'reasoning'), reasoningPart(delta)]
-          }
-
-          return appendReasoningPart(parts, delta)
-        },
+        parts => (replace ? applyReasoningAvailable(parts, delta) : appendReasoningPart(parts, delta)),
         () => [reasoningPart(delta)]
       )
     },

--- a/apps/desktop/src/app/session/hooks/use-message-stream/reasoning-available-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/reasoning-available-event.test.tsx
@@ -1,0 +1,106 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import type { ChatMessagePart } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let sessionStateByRuntimeId: Map<string, ClientSessionState>
+let reasoningSnapshots: ChatMessagePart[]
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(sessionStateByRuntimeId)
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+
+      const message = next.messages.find(item => item.id === next.streamId)
+      const reasoning = message?.parts.find(part => part.type === 'reasoning')
+
+      if (reasoning) {
+        reasoningSnapshots.push(reasoning)
+      }
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}) {
+  act(() => handleEvent!({ payload, session_id: SID, type }))
+}
+
+function streamedParts(): ChatMessagePart[] {
+  const state = sessionStateByRuntimeId.get(SID)
+  const message = state?.messages.find(item => item.id === state.streamId)
+
+  return message?.parts ?? []
+}
+
+describe('useMessageStream reasoning.available fallback', () => {
+  beforeEach(() => {
+    handleEvent = null
+    sessionStateByRuntimeId = new Map()
+    reasoningSnapshots = []
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('preserves streamed reasoning when the late available fallback arrives', async () => {
+    await mountStream()
+    const streamedReasoning = 'streamed reasoning '.repeat(40)
+
+    emit('reasoning.delta', { text: streamedReasoning })
+    emit('reasoning.available', { text: streamedReasoning.slice(0, 500) })
+
+    const reasoningParts = streamedParts().filter(part => part.type === 'reasoning')
+
+    expect(reasoningParts).toHaveLength(1)
+    expect(reasoningParts[0]).toMatchObject({ text: streamedReasoning })
+    expect(reasoningSnapshots.at(-1)).toBe(reasoningSnapshots.at(-2))
+  })
+
+  it('inserts late available reasoning before assistant text when no delta streamed', async () => {
+    await mountStream()
+
+    emit('message.delta', { text: 'Final answer.' })
+    emit('reasoning.available', { text: 'Late reasoning.' })
+
+    expect(streamedParts()).toMatchObject([
+      { text: 'Late reasoning.', type: 'reasoning' },
+      { text: 'Final answer.', type: 'text' }
+    ])
+  })
+})

--- a/tests/agent/test_reasoning_available.py
+++ b/tests/agent/test_reasoning_available.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+from agent.conversation_loop import _relay_available_reasoning
+
+
+def test_available_reasoning_relay_preserves_full_content():
+    events = []
+    reasoning = "reasoning " * 80
+    agent = SimpleNamespace(
+        _delegate_depth=0,
+        tool_progress_callback=lambda *args: events.append(args),
+    )
+
+    _relay_available_reasoning(
+        agent,
+        f"<REASONING_SCRATCHPAD>{reasoning}</REASONING_SCRATCHPAD>",
+    )
+
+    assert events == [("reasoning.available", "_thinking", reasoning.strip(), None)]
+    assert len(events[0][2]) > 500
+
+
+def test_available_reasoning_relay_keeps_subagent_preview_bounded():
+    events = []
+    agent = SimpleNamespace(
+        _delegate_depth=1,
+        tool_progress_callback=lambda *args: events.append(args),
+    )
+
+    _relay_available_reasoning(agent, "first line " * 20 + "\nsecond line")
+
+    assert events == [("_thinking", ("first line " * 20)[:80])]


### PR DESCRIPTION
## What does this PR do?

Prevents a late `reasoning.available` fallback from replacing reasoning that already streamed through `reasoning.delta`. When no reasoning delta was received, the fallback is still inserted before assistant text. The backend now sends the complete inline reasoning fallback instead of truncating it to 500 characters.

The frontend portion mechanically salvages #47183 onto the current split hook layout while preserving skyc1e's original commit authorship. The additional backend and end-to-end event coverage address #64995's truncation/remount case.

## Related Issue

Fixes #64995

Salvages and extends #47183 with original author credit preserved. #64689 remains a separate MoA-reference accumulation fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/index.ts`: adds an idempotent late-reasoning fallback reducer, preserves the existing reasoning part object, and inserts a fallback before assistant text when no delta arrived.
- `agent/conversation_loop.py`: relays complete available reasoning without the 500-character truncation while preserving bounded subagent previews.
- Desktop and Python regressions cover streamed preservation, no-delta fallback, full payload relay, and subagent preview bounds.

## How to Test

1. Stream more than 500 characters through `reasoning.delta`, then emit `reasoning.available`; verify the displayed reasoning text and part identity remain unchanged.
2. Emit assistant text followed by `reasoning.available` without prior reasoning deltas; verify reasoning appears before the text.
3. Run:

       scripts/run_tests.sh tests/run_agent/ tests/agent/test_reasoning_available.py tests/tools/test_delegate.py -q
       PATH=/opt/homebrew/opt/node@22/bin:$PATH npx vitest run --maxWorkers=1
       PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run typecheck

Results:

- Python conversation/delegation coverage: 2,202 passed
- Desktop Vitest suite on supported Node 22: 1,724 passed, 1 skipped
- focused desktop event/reducer tests after final rebase: 4 passed
- desktop TypeScript typecheck passed
- ESLint, Prettier, Ruff, and `git diff --check` passed

A parallel full-desktop run exposed an existing cross-file isolation race in `src/app/skills/index.test.tsx`; the same file passed 3/3 in isolation, and the serial supported-Node run passed the complete suite.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commits follow Conventional Commits.
- [x] I searched existing PRs; #47183 is explicitly salvaged with original author credit, and #64689 covers a separate MoA path.
- [x] My PR contains only changes related to this fix.
- [ ] The complete local Python repository suite is green; the affected Python groups are green and the known same-base environment failures are documented separately.
- [x] I've added tests for my changes.
- [x] Tested on macOS 26.5.2 with Python 3.11 and Node 22.22.3.

### Documentation and Housekeeping

- [x] Documentation update: N/A; no user-facing configuration changed.
- [x] `cli-config.yaml.example`: N/A.
- [x] Architecture/workflow docs: N/A.
- [x] Cross-platform impact considered; no platform-specific I/O changed.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

No UI layout changes; regression tests exercise the gateway-event timeline and reasoning-part identity directly.