### PR TITLE
fix(bedrock): preserve regional runtime on model switch

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1838,6 +1838,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             "_anthropic_base_url",
             "_is_anthropic_oauth",
             "_config_context_length",
+            "_bedrock_region",
         )
     }
     # _client_kwargs is a dict — snapshot a shallow copy so mutating the
@@ -1932,6 +1933,30 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent.base_url = "moa://local"
             agent._client_kwargs = {}
             agent.client = MoAClient(agent.model or "default")
+        elif (new_provider or "").strip().lower() == "bedrock" and api_mode in {
+            "anthropic_messages",
+            "bedrock_converse",
+        }:
+            _br_match = re.search(
+                r"bedrock-runtime\.([a-z0-9-]+)\.",
+                (base_url or agent.base_url or ""),
+            )
+            _br_region = _br_match.group(1) if _br_match else "us-east-1"
+            agent._bedrock_region = _br_region
+            agent.api_key = "aws-sdk"
+            agent.client = None
+            agent._client_kwargs = {}
+            if api_mode == "anthropic_messages":
+                from agent.anthropic_adapter import build_anthropic_bedrock_client
+                agent._anthropic_client = build_anthropic_bedrock_client(_br_region)
+                agent._anthropic_api_key = "aws-sdk"
+                agent._anthropic_base_url = base_url or agent.base_url
+                agent._is_anthropic_oauth = False
+            else:
+                agent._anthropic_client = None
+                agent._anthropic_api_key = None
+                agent._anthropic_base_url = None
+                agent._is_anthropic_oauth = False
         elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -73,3 +73,50 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+def test_switch_model_builds_bedrock_anthropic_client_with_resolved_region():
+    agent = _make_agent_with_compressor(config_context_length=None)
+    built = object()
+
+    with patch("agent.anthropic_adapter.build_anthropic_bedrock_client", return_value=built) as mock_build:
+        with patch("agent.model_metadata.get_model_context_length", return_value=200_000):
+            agent.switch_model(
+                "jp.anthropic.claude-opus-4-8",
+                "bedrock",
+                api_key="aws-sdk",
+                base_url="https://bedrock-runtime.ap-northeast-1.amazonaws.com",
+                api_mode="anthropic_messages",
+            )
+
+    mock_build.assert_called_once_with("ap-northeast-1")
+    assert agent.provider == "bedrock"
+    assert agent.api_mode == "anthropic_messages"
+    assert agent.api_key == "aws-sdk"
+    assert agent._bedrock_region == "ap-northeast-1"
+    assert agent._anthropic_client is built
+    assert agent._anthropic_api_key == "aws-sdk"
+    assert agent.client is None
+    assert agent._client_kwargs == {}
+
+
+def test_switch_model_builds_bedrock_converse_without_openai_client():
+    agent = _make_agent_with_compressor(config_context_length=None)
+    agent._create_openai_client = MagicMock(side_effect=AssertionError("bedrock should not build OpenAI client"))
+
+    with patch("agent.model_metadata.get_model_context_length", return_value=128_000):
+        agent.switch_model(
+            "amazon.nova-pro-v1:0",
+            "bedrock",
+            api_key="aws-sdk",
+            base_url="https://bedrock-runtime.eu-west-1.amazonaws.com",
+            api_mode="bedrock_converse",
+        )
+
+    assert agent.provider == "bedrock"
+    assert agent.api_mode == "bedrock_converse"
+    assert agent.api_key == "aws-sdk"
+    assert agent._bedrock_region == "eu-west-1"
+    assert agent.client is None
+    assert agent._anthropic_client is None
+    assert agent._client_kwargs == {}

--- a/tests/run_agent/test_switch_model_rollback.py
+++ b/tests/run_agent/test_switch_model_rollback.py
@@ -202,3 +202,36 @@ def test_successful_switch_still_works_after_rollback_refactor():
     assert agent.provider == "openrouter"
     assert agent.api_key == "or-key-new"
     assert agent.client is new_client
+
+
+def test_bedrock_client_rebuild_failure_restores_previous_region_and_runtime():
+    """A failed regional Bedrock swap must keep the previous Bedrock runtime."""
+    agent = _make_agent_anthropic()
+    old_client = agent._anthropic_client
+    agent.model = "global.anthropic.claude-sonnet-4-6"
+    agent.provider = "bedrock"
+    agent.base_url = "https://bedrock-runtime.eu-west-1.amazonaws.com"
+    agent.api_key = "aws-sdk"
+    agent._anthropic_api_key = "aws-sdk"
+    agent._anthropic_base_url = agent.base_url
+    agent._bedrock_region = "eu-west-1"
+
+    with patch(
+        "agent.anthropic_adapter.build_anthropic_bedrock_client",
+        side_effect=RuntimeError("client rebuild failed"),
+    ):
+        with pytest.raises(RuntimeError, match="client rebuild failed"):
+            agent.switch_model(
+                "jp.anthropic.claude-opus-4-8",
+                "bedrock",
+                api_key="aws-sdk",
+                base_url="https://bedrock-runtime.ap-northeast-1.amazonaws.com",
+                api_mode="anthropic_messages",
+            )
+
+    assert agent.model == "global.anthropic.claude-sonnet-4-6"
+    assert agent.provider == "bedrock"
+    assert agent.base_url == "https://bedrock-runtime.eu-west-1.amazonaws.com"
+    assert agent.api_mode == "anthropic_messages"
+    assert agent._bedrock_region == "eu-west-1"
+    assert agent._anthropic_client is old_client


### PR DESCRIPTION
## What does this PR do?

Restores the Bedrock-specific runtime when `/model` switches into AWS Bedrock mid-session. Regional inference profiles now keep their resolved AWS region, Claude models rebuild through `AnthropicBedrock`, Converse models avoid constructing an OpenAI client, and a failed rebuild rolls the prior Bedrock region/runtime back atomically.

This salvages #41322 on current `main` while preserving BROCCOLO1D's commit authorship. The older PR's `runtime_provider.py` change is intentionally omitted because current `main` already routes Bedrock from `target_model`.

## Related Issue

Fixes #41296

Salvages #41322 with original author credit preserved.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)

## Changes Made

- `agent/agent_runtime_helpers.py`: snapshots `_bedrock_region`, rebuilds Bedrock Anthropic/Converse state from the resolved regional endpoint, and clears incompatible client state.
- `tests/run_agent/test_switch_model_context.py`: covers regional Claude/AnthropicBedrock and Nova/Converse switches.
- `tests/run_agent/test_switch_model_rollback.py`: covers failed regional client rebuild rollback.

## How to Test

1. Configure Bedrock for a non-`us-east-1` region and start Hermes on a non-Bedrock provider.
2. Switch to a regional Claude profile with `/model ... --provider bedrock`; verify the AnthropicBedrock client receives the resolved region.
3. Switch to a non-Claude Bedrock model; verify the Converse path does not build an OpenAI client.
4. Run:

       scripts/run_tests.sh -j 6 tests/run_agent/test_switch_model_*.py tests/hermes_cli/test_runtime_provider_resolution.py -q

Result after rebasing onto current `main`: 180 passed.

Additional validation:

- full repository Python suite: 41,370 passed, 28 failed in 14 unrelated environment/platform files
- changed test files: 9/9 passed
- model-switch group: 29/29 passed
- runtime-provider resolution: 151/151 passed
- relevant Bedrock adapter, transport, integration, picker, regional-picker, 1M-context, and interrupt-worker groups passed
- Ruff, Windows-footgun scan, and `git diff --check` passed

The 28 repository-wide failures are outside this diff and fall into existing macOS-vs-WSL/systemd assumptions, `/tmp` canonicalization/mode differences, shared import/mock isolation, and subprocess timing. No changed or Bedrock/model-switch test failed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched existing PRs and issues; this is an attributed salvage of closed #41322, not a duplicate of an active PR.
- [x] My PR contains only changes related to this fix.
- [ ] The complete local Python suite is green (see the 28 unrelated environment/platform failures above).
- [x] I've added tests for my changes.
- [x] Tested on macOS 26.5.2 with Python 3.11.

### Documentation and Housekeeping

- [x] Documentation update: N/A; no user-facing configuration changed.
- [x] `cli-config.yaml.example`: N/A.
- [x] Architecture/workflow docs: N/A.
- [x] Cross-platform impact considered; no platform-specific I/O changed.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

No UI changes. A live AWS Bedrock call was not made; region/client routing and rollback are covered with behavior tests.