### PR TITLE
fix: hashlib FIPS crash in skills_sync, weixin, web_server (usedforsecurity=False)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1416,7 +1416,7 @@ class WeixinAdapter(BasePlatformAdapter):
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
         if text:
-            content_key = f"content:{sender_id}:{hashlib.md5(text.encode()).hexdigest()}"
+            content_key = f"content:{sender_id}:{hashlib.md5(text.encode(), usedforsecurity=False).hexdigest()}"
             if self._dedup.is_duplicate(content_key):
                 logger.debug("[%s] Content-dedup: skipping duplicate message from %s", self.name, sender_id)
                 return
@@ -2115,7 +2115,7 @@ class WeixinAdapter(BasePlatformAdapter):
         filekey = secrets.token_hex(16)
         aes_key = secrets.token_bytes(16)
         rawsize = len(plaintext)
-        rawfilemd5 = hashlib.md5(plaintext).hexdigest()
+        rawfilemd5 = hashlib.md5(plaintext, usedforsecurity=False).hexdigest()
         upload_response = await _get_upload_url(
             self._send_session,
             base_url=self._base_url,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11490,7 +11490,7 @@ def _mcp_install_action_name(name: str) -> str:
     re-click or a second catalog install doesn't overwrite the first's tracked
     process/log while its git clone is still running."""
     slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")[:48] or "server"
-    digest = hashlib.sha1(name.encode()).hexdigest()[:8]
+    digest = hashlib.sha1(name.encode(), usedforsecurity=False).hexdigest()[:8]
     action = f"mcp-install-{slug}-{digest}"
     _ACTION_LOG_FILES.setdefault(action, f"action-{action}.log")
     return action
@@ -12430,7 +12430,7 @@ def _hub_action_name(verb: str, key: str) -> str:
     (readable) + hash (collision-proof) keys each action to its own row.
     """
     slug = re.sub(r"[^a-z0-9]+", "-", key.lower()).strip("-")[:48] or "skill"
-    digest = hashlib.sha1(key.encode()).hexdigest()[:8]
+    digest = hashlib.sha1(key.encode(), usedforsecurity=False).hexdigest()[:8]
     name = f"skills-{verb}-{slug}-{digest}"
     _ACTION_LOG_FILES.setdefault(name, f"action-{name}.log")
     return name

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -231,7 +231,7 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
 
 def _dir_hash(directory: Path) -> str:
     """Compute a hash of all file contents in a directory for change detection."""
-    hasher = hashlib.md5()
+    hasher = hashlib.md5(usedforsecurity=False)
     try:
         for fpath in sorted(directory.rglob("*")):
             if fpath.is_file():


### PR DESCRIPTION
## Problem

3 files still call `hashlib.md5()` / `hashlib.sha1()` without `usedforsecurity=False`. On FIPS-enabled systems (RHEL 9, Ubuntu 22.04 FIPS, AWS AL2023 FIPS), these raise `ValueError: [digital envelope routines] unsupported`, crashing the affected code paths.

## Files Fixed

| File | Line | Usage |
|------|------|-------|
| `tools/skills_sync.py` | 234 | `_dir_hash()` content fingerprinting |
| `gateway/platforms/weixin.py` | 1419 | Text message dedup hash |
| `gateway/platforms/weixin.py` | 2118 | File upload checksum |
| `hermes_cli/web_server.py` | 11493 | MCP install action name |
| `hermes_cli/web_server.py` | 12433 | Skill action name |

All are **non-security** use cases (content hashing, dedup, naming).

## Not Changed (intentionally)

`plugins/platforms/sms/adapter.py:257` — HMAC-SHA1 for Twilio webhook signature verification. This is a **cryptographic security** use case and must NOT use `usedforsecurity=False`.

## Related

Follows pattern from PRs #56715, #64062, #64808 which fixed the same issue in other files.