### PR TITLE
fix: replace bare asserts with runtime guards in skill_manager_tool.py

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -945,7 +945,8 @@ def _patch_skill(
         target, err = _resolve_skill_target(skill_dir, file_path)
         if err:
             return {"success": False, "error": err}
-        assert target is not None
+        if target is None:
+            return {"success": False, "error": "Failed to resolve skill target path"}
     else:
         # Patching SKILL.md
         target = skill_dir / "SKILL.md"
@@ -1163,7 +1164,8 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
-    assert target is not None
+    if target is None:
+        return {"success": False, "error": "Failed to resolve skill target path"}
     if target.exists():
         read_guard = _background_review_read_before_write_guard(
             name, target, "write_file", file_path
@@ -1209,7 +1211,8 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     target, err = _resolve_skill_target(skill_dir, file_path)
     if err:
         return {"success": False, "error": err}
-    assert target is not None
+    if target is None:
+        return {"success": False, "error": "Failed to resolve skill target path"}
     if not target.exists():
         # List what's actually there for the model to see
         available = []


### PR DESCRIPTION
## Problem

3 `assert target is not None` statements in `tools/skill_manager_tool.py` are stripped under `python -O` (optimized mode). If `_resolve_skill_target` ever returns `(None, "")` with an empty error string, the code silently continues to `target.exists()` which raises `AttributeError` on `None`, crashing the skill management operation with an unhandled exception instead of a clean error response.

## Fix

Replace each `assert target is not None` with:
```python
if target is None:
    return {"success": False, "error": "Failed to resolve skill target path"}
```

This matches the existing error-handling pattern already used in these functions (the `if err: return {...}` checks immediately above).

## Lines Changed

| Line | Function | Context |
|------|----------|---------|
| 948 | `skill_patch` | After `_resolve_skill_target(skill_dir, file_path)` |
| 1166 | `skill_write_file` | After `_resolve_skill_target(existing["path"], file_path)` |
| 1212 | `skill_remove_file` | After `_resolve_skill_target(skill_dir, file_path)`