### PR TITLE
fix(agent): refresh MCP tool manifest mid-turn after tool execution

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5712,6 +5712,49 @@ def run_conversation(
                 # entire conversation.
                 truncated_tool_call_retries = 0
 
+                # Mid-turn MCP tool refresh: when an MCP server changes its
+                # tool set while handling a call (e.g. a server that swaps
+                # between a minimal and a full toolset when a mode-change
+                # tool is called), the registry updates via ToolListChanged
+                # but agent.tools still holds the stale snapshot from the
+                # start of this run_conversation() call.  Worse, the
+                # notification races
+                # the tool-call response it follows and often lands AFTER
+                # this checkpoint, so a snapshot rebuild alone still misses
+                # the change and the next API request advertises tools that
+                # no longer exist (issue #65428).  The helper closes both
+                # gaps: it re-polls tools/list on the just-called servers
+                # whose lists are known dynamic (deterministic — the poll is
+                # processed after the tool handler finished), then rebuilds
+                # agent.tools from the registry.  No-op for static servers
+                # and unchanged tool sets, preserving the prompt-cache
+                # prefix in the common case.
+                try:
+                    if not getattr(agent, "_skip_mcp_refresh", False):
+                        # Import-cost gate: avoid pulling in the mcp package
+                        # (~0.4s) when no MCP servers are configured.  See
+                        # turn_context.py for the full rationale.  Especially
+                        # important here since this runs on every tool-loop
+                        # iteration, not just once per turn.
+                        import sys as _sys
+                        if "tools.mcp_tool" in _sys.modules:
+                            from tools.mcp_tool import (
+                                has_registered_mcp_tools,
+                                refresh_agent_tools_after_mcp_calls,
+                            )
+                            if has_registered_mcp_tools():
+                                _called_names = {
+                                    tc.function.name
+                                    for tc in assistant_message.tool_calls
+                                }
+                                _mcp_added = refresh_agent_tools_after_mcp_calls(
+                                    agent, _called_names, quiet_mode=True
+                                )
+                                if _mcp_added:
+                                    logger.info("Mid-turn MCP tool refresh: added %s", _mcp_added)
+                except Exception:
+                    logger.debug("mid-turn MCP tool refresh failed", exc_info=True)
+
                 # Signal that a paragraph break is needed before the next
                 # streamed text.  We don't emit it immediately because
                 # multiple consecutive tool iterations would stack up

--- a/tests/agent/test_mid_turn_mcp_refresh.py
+++ b/tests/agent/test_mid_turn_mcp_refresh.py
@@ -1,0 +1,482 @@
+"""Tests for mid-turn MCP tool refresh in the conversation loop.
+
+When an MCP server changes its tool set while handling a call (e.g. a server
+that swaps between a minimal and a full toolset when a mode-change tool is
+called), the registry updates via ``ToolListChanged`` but ``agent.tools``
+still holds the stale snapshot.  Worse, the notification races the tool-call
+response it follows and can land *after* the post-execution checkpoint, so a
+snapshot rebuild alone still misses the change (issue #65428).
+
+The mid-turn sync after ``_execute_tool_calls()`` closes both gaps:
+``refresh_agent_tools_after_mcp_calls`` re-polls ``tools/list`` on the
+just-called servers whose lists are known dynamic, then rebuilds
+``agent.tools`` from the registry.
+
+These test the *contract*: after tool execution, the manifest presented to
+the next API call reflects the server's post-call tool list — without
+depending on notification arrival order.
+
+The scenario used throughout is a fictitious dynamic server exposing
+``swap_in_full_toolset`` in its minimal mode; calling it replaces the tool
+set with the full toolset (``probe_state``, ``poke_state``,
+``swap_in_minimal_toolset``), and ``swap_in_minimal_toolset`` swaps back.
+"""
+
+import asyncio
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+
+def _tool(name):
+    return {"type": "function", "function": {"name": name, "description": "", "parameters": {}}}
+
+
+def _make_agent(tool_names):
+    """Minimal agent with the attributes the mid-turn refresh touches."""
+    a = types.SimpleNamespace()
+    a.tools = [_tool(n) for n in tool_names]
+    a.valid_tool_names = set(tool_names)
+    a.enabled_toolsets = None
+    a.disabled_toolsets = None
+    a._skip_mcp_refresh = False
+    a._tool_snapshot_generation = 0
+    return a
+
+
+def _simulate_mid_turn_refresh(agent, called_tool_names=()):
+    """Run the mid-turn MCP refresh code path extracted from conversation_loop.py.
+
+    This executes the same logic as the inline block after
+    ``_execute_tool_calls()`` in the conversation loop — the try/except
+    with the three guards (_skip_mcp_refresh, sys.modules, has_registered).
+    """
+    try:
+        if not getattr(agent, "_skip_mcp_refresh", False):
+            if "tools.mcp_tool" in sys.modules:
+                from tools.mcp_tool import (
+                    has_registered_mcp_tools,
+                    refresh_agent_tools_after_mcp_calls,
+                )
+                if has_registered_mcp_tools():
+                    _mcp_added = refresh_agent_tools_after_mcp_calls(
+                        agent, set(called_tool_names), quiet_mode=True
+                    )
+                    return _mcp_added
+    except Exception:
+        pass
+    return set()
+
+
+class TestMidTurnMcpRefresh:
+    """Mid-turn MCP tool refresh contracts (mirrors between-turns tests)."""
+
+    def test_adds_dynamically_registered_tool(self, monkeypatch):
+        """After tool execution, a newly registered MCP tool appears in agent.tools."""
+        agent = _make_agent(["swap_in_full_toolset"])
+
+        # Simulate: the server swapped its minimal toolset for the full one.
+        new_defs = [
+            _tool(n)
+            for n in ("probe_state", "poke_state", "swap_in_minimal_toolset")
+        ]
+        import model_tools
+        monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: list(new_defs))
+
+        with patch("tools.mcp_tool.has_registered_mcp_tools", return_value=True):
+            added = _simulate_mid_turn_refresh(agent)
+
+        assert "probe_state" in added
+        assert "poke_state" in added
+        assert "swap_in_minimal_toolset" in added
+        assert "swap_in_full_toolset" not in agent.valid_tool_names
+        assert "probe_state" in agent.valid_tool_names
+
+    def test_no_change_returns_empty(self, monkeypatch):
+        """Unchanged tool set → empty set, snapshot not swapped."""
+        agent = _make_agent(["read_file", "terminal"])
+        original_tools = agent.tools
+
+        import model_tools
+        monkeypatch.setattr(
+            model_tools, "get_tool_definitions",
+            lambda **kw: [_tool("read_file"), _tool("terminal")],
+        )
+
+        with patch("tools.mcp_tool.has_registered_mcp_tools", return_value=True):
+            added = _simulate_mid_turn_refresh(agent)
+
+        assert added == set()
+        assert agent.tools is original_tools  # no churn
+
+    def test_skipped_when_no_mcp_servers(self, monkeypatch):
+        """No MCP servers registered → refresh never walks the registry."""
+        agent = _make_agent(["read_file"])
+
+        import model_tools
+        gtd = MagicMock()
+        monkeypatch.setattr(model_tools, "get_tool_definitions", gtd)
+
+        with patch("tools.mcp_tool.has_registered_mcp_tools", return_value=False):
+            added = _simulate_mid_turn_refresh(agent)
+
+        assert added == set()
+        gtd.assert_not_called()
+
+    def test_skipped_when_skip_flag_set(self, monkeypatch):
+        """_skip_mcp_refresh=True → refresh bypassed even with MCP servers."""
+        agent = _make_agent(["read_file"])
+        agent._skip_mcp_refresh = True
+
+        import model_tools
+        gtd = MagicMock()
+        monkeypatch.setattr(model_tools, "get_tool_definitions", gtd)
+
+        with patch("tools.mcp_tool.has_registered_mcp_tools", return_value=True):
+            added = _simulate_mid_turn_refresh(agent)
+
+        assert added == set()
+        gtd.assert_not_called()
+
+    def test_detects_tool_swap_same_count(self, monkeypatch):
+        """Name-based diff catches add+remove of equal count (a one-for-one swap)."""
+        agent = _make_agent(["swap_in_full_toolset"])
+
+        import model_tools
+        monkeypatch.setattr(
+            model_tools, "get_tool_definitions",
+            lambda **kw: [_tool("swap_in_minimal_toolset")],
+        )
+
+        with patch("tools.mcp_tool.has_registered_mcp_tools", return_value=True):
+            added = _simulate_mid_turn_refresh(agent)
+
+        assert added == {"swap_in_minimal_toolset"}
+        assert "swap_in_full_toolset" not in agent.valid_tool_names
+        assert "swap_in_minimal_toolset" in agent.valid_tool_names
+
+    def test_exception_is_swallowed(self, monkeypatch):
+        """Refresh failure must not crash the tool loop."""
+        agent = _make_agent(["read_file"])
+
+        with patch("tools.mcp_tool.has_registered_mcp_tools", side_effect=RuntimeError("boom")):
+            # Should not raise
+            added = _simulate_mid_turn_refresh(agent)
+
+        assert added == set()
+        # Agent tools unchanged
+        assert agent.valid_tool_names == {"read_file"}
+
+
+class _FakeServer:
+    """Stand-in for MCPServerTask exposing what the post-call sync touches."""
+
+    def __init__(self, name, *, dynamic=True, has_session=True):
+        self.name = name
+        self.session = object() if has_session else None
+        self._dynamic = dynamic
+        self.poll_count = 0
+
+    def _has_dynamic_tool_list(self):
+        return self._dynamic
+
+    async def _refresh_tools(self):
+        self.poll_count += 1
+
+
+def _install_servers(monkeypatch, tool_to_server, servers):
+    """Point the module-level server maps at fakes for the duration of a test."""
+    import tools.mcp_tool as mcp_tool
+    monkeypatch.setattr(mcp_tool, "_mcp_tool_server_names", dict(tool_to_server))
+    monkeypatch.setattr(mcp_tool, "_servers", {s.name: s for s in servers})
+
+
+def _run_coro_inline(coro_or_factory, timeout=30):
+    """Test double for _run_on_mcp_loop: run the coroutine synchronously."""
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+    return asyncio.run(coro)
+
+
+class TestNotificationOrderingPoll:
+    """The tools/list re-poll that defeats the response/notification race.
+
+    The race being simulated: the server already swapped its tool set while
+    handling the call, but the ToolListChanged notification hasn't arrived,
+    so the registry (here: get_tool_definitions) still serves the OLD list
+    until the server is explicitly re-polled.
+    """
+
+    def _race_gtd(self, server, old_defs, new_defs):
+        """get_tool_definitions that stays stale until the server was polled."""
+        return lambda **kw: list(new_defs) if server.poll_count else list(old_defs)
+
+    def test_poll_freshens_manifest_before_next_api_call(self, monkeypatch):
+        """Swap-back direction: registry is stale at the checkpoint; the re-poll fixes it."""
+        agent = _make_agent([
+            "mcp__dyn_server__probe_state",
+            "mcp__dyn_server__swap_in_minimal_toolset",
+        ])
+        server = _FakeServer("dyn_server", dynamic=True)
+        _install_servers(
+            monkeypatch,
+            {
+                "mcp__dyn_server__probe_state": "dyn_server",
+                "mcp__dyn_server__swap_in_minimal_toolset": "dyn_server",
+            },
+            [server],
+        )
+
+        import model_tools
+        old_defs = [
+            _tool("mcp__dyn_server__probe_state"),
+            _tool("mcp__dyn_server__swap_in_minimal_toolset"),
+        ]
+        new_defs = [_tool("mcp__dyn_server__swap_in_full_toolset")]
+        monkeypatch.setattr(
+            model_tools, "get_tool_definitions",
+            self._race_gtd(server, old_defs, new_defs),
+        )
+
+        import tools.mcp_tool as mcp_tool
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _run_coro_inline)
+
+        added = mcp_tool.refresh_agent_tools_after_mcp_calls(
+            agent, {"mcp__dyn_server__swap_in_minimal_toolset"}
+        )
+
+        assert server.poll_count == 1
+        assert added == {"mcp__dyn_server__swap_in_full_toolset"}
+        assert "mcp__dyn_server__swap_in_full_toolset" in agent.valid_tool_names
+        assert "mcp__dyn_server__probe_state" not in agent.valid_tool_names
+
+    def test_sanitized_server_name_still_polls(self, monkeypatch):
+        """Hyphenated config name vs sanitized mapping value must still match.
+
+        ``_mcp_tool_server_names`` stores sanitized names (``dyn_server``)
+        while ``_servers`` is keyed by the config name (``dyn-server``).
+        A naive key lookup silently skips the poll for every such server —
+        the exact gap found in live testing of PR #65436.
+        """
+        agent = _make_agent([
+            "mcp__dyn_server__probe_state",
+            "mcp__dyn_server__swap_in_minimal_toolset",
+        ])
+        server = _FakeServer("dyn-server", dynamic=True)
+        import tools.mcp_tool as mcp_tool
+        monkeypatch.setattr(
+            mcp_tool, "_mcp_tool_server_names",
+            {"mcp__dyn_server__swap_in_minimal_toolset": "dyn_server"},
+        )
+        monkeypatch.setattr(mcp_tool, "_servers", {"dyn-server": server})
+
+        import model_tools
+        old_defs = [
+            _tool("mcp__dyn_server__probe_state"),
+            _tool("mcp__dyn_server__swap_in_minimal_toolset"),
+        ]
+        new_defs = [_tool("mcp__dyn_server__swap_in_full_toolset")]
+        monkeypatch.setattr(
+            model_tools, "get_tool_definitions",
+            self._race_gtd(server, old_defs, new_defs),
+        )
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _run_coro_inline)
+
+        added = mcp_tool.refresh_agent_tools_after_mcp_calls(
+            agent, {"mcp__dyn_server__swap_in_minimal_toolset"}
+        )
+
+        assert server.poll_count == 1
+        assert added == {"mcp__dyn_server__swap_in_full_toolset"}
+
+    def test_static_server_is_not_polled(self, monkeypatch):
+        """No listChanged capability and never notified → no extra RPC."""
+        agent = _make_agent(["mcp__files__read"])
+        server = _FakeServer("files", dynamic=False)
+        _install_servers(monkeypatch, {"mcp__files__read": "files"}, [server])
+
+        import model_tools
+        monkeypatch.setattr(
+            model_tools, "get_tool_definitions",
+            lambda **kw: [_tool("mcp__files__read")],
+        )
+
+        import tools.mcp_tool as mcp_tool
+        run_loop = MagicMock(side_effect=_run_coro_inline)
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", run_loop)
+
+        added = mcp_tool.refresh_agent_tools_after_mcp_calls(agent, {"mcp__files__read"})
+
+        run_loop.assert_not_called()
+        assert server.poll_count == 0
+        assert added == set()
+
+    def test_non_mcp_tools_do_not_poll(self, monkeypatch):
+        """Built-in tool names map to no server → no poll, plain refresh only."""
+        agent = _make_agent(["terminal"])
+        server = _FakeServer("dyn_server", dynamic=True)
+        _install_servers(
+            monkeypatch,
+            {"mcp__dyn_server__swap_in_minimal_toolset": "dyn_server"},
+            [server],
+        )
+
+        import model_tools
+        monkeypatch.setattr(
+            model_tools, "get_tool_definitions",
+            lambda **kw: [_tool("terminal")],
+        )
+
+        import tools.mcp_tool as mcp_tool
+        run_loop = MagicMock(side_effect=_run_coro_inline)
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", run_loop)
+
+        added = mcp_tool.refresh_agent_tools_after_mcp_calls(agent, {"terminal"})
+
+        run_loop.assert_not_called()
+        assert added == set()
+
+    def test_server_without_session_is_skipped(self, monkeypatch):
+        """A recycled/disconnected server (session=None) is not polled."""
+        agent = _make_agent(["mcp__dyn_server__swap_in_minimal_toolset"])
+        server = _FakeServer("dyn_server", dynamic=True, has_session=False)
+        _install_servers(
+            monkeypatch,
+            {"mcp__dyn_server__swap_in_minimal_toolset": "dyn_server"},
+            [server],
+        )
+
+        import model_tools
+        monkeypatch.setattr(
+            model_tools, "get_tool_definitions",
+            lambda **kw: [_tool("mcp__dyn_server__swap_in_minimal_toolset")],
+        )
+
+        import tools.mcp_tool as mcp_tool
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _run_coro_inline)
+
+        mcp_tool.refresh_agent_tools_after_mcp_calls(
+            agent, {"mcp__dyn_server__swap_in_minimal_toolset"}
+        )
+
+        assert server.poll_count == 0
+
+    def test_poll_failure_fails_soft(self, monkeypatch):
+        """A timed-out poll is swallowed; the snapshot rebuild still runs."""
+        agent = _make_agent(["mcp__dyn_server__swap_in_minimal_toolset"])
+        server = _FakeServer("dyn_server", dynamic=True)
+        _install_servers(
+            monkeypatch,
+            {"mcp__dyn_server__swap_in_minimal_toolset": "dyn_server"},
+            [server],
+        )
+
+        import model_tools
+        # Registry happens to be fresh despite the failed poll (notification
+        # won the race after all) — the rebuild must still pick it up.
+        monkeypatch.setattr(
+            model_tools, "get_tool_definitions",
+            lambda **kw: [_tool("mcp__dyn_server__swap_in_full_toolset")],
+        )
+
+        import tools.mcp_tool as mcp_tool
+
+        def _boom(coro_or_factory, timeout=30):
+            if callable(coro_or_factory):
+                coro_or_factory().close()
+            raise TimeoutError("MCP call timed out")
+
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _boom)
+
+        added = mcp_tool.refresh_agent_tools_after_mcp_calls(
+            agent, {"mcp__dyn_server__swap_in_minimal_toolset"}
+        )
+
+        assert added == {"mcp__dyn_server__swap_in_full_toolset"}
+
+    def test_interrupt_aborts_remaining_polls(self, monkeypatch):
+        """InterruptedError stops polling other servers but still rebuilds."""
+        agent = _make_agent(["mcp__srv_a__x", "mcp__srv_b__y"])
+        server_a = _FakeServer("srv_a", dynamic=True)
+        server_b = _FakeServer("srv_b", dynamic=True)
+        _install_servers(
+            monkeypatch,
+            {"mcp__srv_a__x": "srv_a", "mcp__srv_b__y": "srv_b"},
+            [server_a, server_b],
+        )
+
+        import model_tools
+        monkeypatch.setattr(
+            model_tools, "get_tool_definitions",
+            lambda **kw: [_tool("mcp__srv_a__x"), _tool("mcp__srv_b__y")],
+        )
+
+        import tools.mcp_tool as mcp_tool
+        calls = []
+
+        def _interrupt(coro_or_factory, timeout=30):
+            if callable(coro_or_factory):
+                coro_or_factory().close()
+            calls.append(1)
+            raise InterruptedError("User sent a new message")
+
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _interrupt)
+
+        added = mcp_tool.refresh_agent_tools_after_mcp_calls(
+            agent, {"mcp__srv_a__x", "mcp__srv_b__y"}
+        )
+
+        # Servers are polled in sorted-name order; the first raises and the
+        # second must not be attempted.
+        assert len(calls) == 1
+        assert added == set()
+
+
+class TestDynamicToolListGates:
+    """Capability/latch gates deciding which servers get the re-poll."""
+
+    @staticmethod
+    def _fake_task(init_result, seen=False):
+        """Host object carrying the real gate methods over fake attributes.
+
+        MCPServerTask.__init__ spins up asyncio primitives, so instead of
+        instantiating one we borrow the (attribute-only) gate methods onto a
+        plain class.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        class _Host:
+            _advertises_tool_list_changed = MCPServerTask._advertises_tool_list_changed
+            _has_dynamic_tool_list = MCPServerTask._has_dynamic_tool_list
+
+        host = _Host()
+        host.initialize_result = init_result
+        host._tool_list_changed_seen = seen
+        return host
+
+    @staticmethod
+    def _init_result(list_changed):
+        return types.SimpleNamespace(
+            capabilities=types.SimpleNamespace(
+                tools=types.SimpleNamespace(listChanged=list_changed)
+            )
+        )
+
+    def test_declared_listchanged_true(self):
+        fake = self._fake_task(self._init_result(True))
+        assert fake._advertises_tool_list_changed() is True
+        assert fake._has_dynamic_tool_list() is True
+
+    def test_declared_listchanged_false(self):
+        fake = self._fake_task(self._init_result(False))
+        assert fake._advertises_tool_list_changed() is False
+        assert fake._has_dynamic_tool_list() is False
+
+    def test_no_capability_info_defaults_to_static(self):
+        """Unlike _advertises_tools, missing init info must NOT add RPCs."""
+        fake = self._fake_task(None)
+        assert fake._advertises_tool_list_changed() is False
+
+    def test_seen_notification_latch_wins(self):
+        """A server that notified without declaring listChanged is dynamic."""
+        fake = self._fake_task(self._init_result(False), seen=True)
+        assert fake._has_dynamic_tool_list() is True

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1832,6 +1832,7 @@ class MCPServerTask:
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
         "_reconnect_retries", "_session_proven", "_was_parked",
+        "_tool_list_changed_seen",
     )
 
     def __init__(self, name: str):
@@ -1904,6 +1905,14 @@ class MCPServerTask:
         # back to ``list_tools`` (the pre-ping probe) so we neither spam pings
         # nor reconnect-loop. Reset on each fresh transport connection.
         self._ping_unsupported: bool = False
+        # Latched True the first time this server sends a
+        # ``notifications/tools/list_changed``. Together with the
+        # ``tools.listChanged`` capability it decides whether the mid-turn
+        # manifest sync re-polls this server after a tool call (see
+        # ``refresh_agent_tools_after_mcp_calls``). Never reset: once a server
+        # has proven its tool list is dynamic, it stays on the re-poll path
+        # even across reconnects.
+        self._tool_list_changed_seen: bool = False
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
@@ -1928,6 +1937,35 @@ class MCPServerTask:
         if caps is None:
             return True
         return getattr(caps, "tools", None) is not None
+
+    def _advertises_tool_list_changed(self) -> bool:
+        """Whether the server declares the ``tools.listChanged`` capability.
+
+        Per the MCP spec, a server that may change its tool list at runtime
+        (and emit ``notifications/tools/list_changed``) declares
+        ``capabilities.tools.listChanged: true`` at initialize.
+
+        Unlike ``_advertises_tools`` this defaults to **False** when no
+        capability info was captured: that gate *skips* an RPC that legacy
+        behavior always made, so defaulting True preserves compatibility —
+        this gate *adds* a ``tools/list`` re-poll per tool call, so an
+        unknown server must not silently pay for it. Servers that emit
+        list_changed without declaring the capability are still caught by
+        the ``_tool_list_changed_seen`` latch.
+        """
+        init_result = self.initialize_result
+        caps = getattr(init_result, "capabilities", None) if init_result is not None else None
+        tools_cap = getattr(caps, "tools", None) if caps is not None else None
+        return bool(getattr(tools_cap, "listChanged", False))
+
+    def _has_dynamic_tool_list(self) -> bool:
+        """Whether this server's tool list is known to change at runtime.
+
+        True when the server either declared ``tools.listChanged`` at
+        initialize or has actually sent a list_changed notification on this
+        process's watch (noncompliant servers that notify without declaring).
+        """
+        return self._tool_list_changed_seen or self._advertises_tool_list_changed()
 
     def _is_recycled_stdio(self) -> bool:
         """Return True when a stdio server was intentionally recycled."""
@@ -2056,6 +2094,7 @@ class MCPServerTask:
                             # subsequent tool calls time out. Do the refresh in
                             # a separate task and let the handler return
                             # promptly.
+                            self._tool_list_changed_seen = True
                             self._schedule_tools_refresh()
                             # Yield one loop tick so tests and short-lived
                             # notification contexts can observe the scheduled
@@ -6104,6 +6143,93 @@ def refresh_agent_mcp_tools(
             engine_names.update(staged_engine_names)
         agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
         return new_names - current
+
+
+def refresh_agent_tools_after_mcp_calls(
+    agent,
+    called_tool_names,
+    *,
+    quiet_mode: bool = True,
+    poll_timeout: float = 10.0,
+) -> set:
+    """Mid-turn tool-manifest sync after a batch of tool calls.
+
+    ``ToolListChanged`` notifications race the tool-call response they follow:
+    a server that swaps its tool set while handling a call (e.g. one that
+    replaces its full toolset with a minimal one when a mode-change tool is
+    called) may send the response first and the notification milliseconds
+    later. At the conversation loop's post-execution checkpoint the
+    notification often hasn't even been READ off the transport yet, so a
+    registry-snapshot rebuild alone sees no change and the next API request
+    advertises a stale manifest — every model then calls a tool that no
+    longer exists (see issue #65428).
+
+    Waiting on pending notification tasks can't close that window (there is
+    nothing pending until the notification arrives). What IS deterministic is
+    re-polling: a ``tools/list`` request sent after the tool-call response was
+    received is necessarily processed by the server after its tool handler
+    finished mutating the tool set. So for each *just-called* server whose
+    tool list is known to be dynamic (``_has_dynamic_tool_list``), run its
+    ``_refresh_tools`` — the same fetch-diff-register used by the notification
+    path, sharing ``_refresh_lock`` so a concurrently arriving notification
+    refresh serializes instead of duplicating — and then rebuild the agent
+    snapshot from the registry.
+
+    Static servers (no ``listChanged``, never notified) are never re-polled,
+    so the common case costs nothing beyond the generation-cached
+    ``refresh_agent_mcp_tools`` no-op and their conversations keep a stable
+    ``tools=`` prefix (the prompt-cache invariant). A dynamic server that
+    actually changed its list invalidates the cached prefix by definition —
+    refreshing mid-turn spends the invalidation the next turn would pay
+    anyway, instead of buying a guaranteed unknown-tool failure round first.
+
+    Fail-soft: a poll error (timeout, dead session) is logged and skipped —
+    the snapshot rebuild still runs against whatever the registry holds. A
+    user interrupt aborts remaining polls; the interrupt flag stays set for
+    the conversation loop's own checkpoint.
+
+    Returns the set of newly-added tool names, like
+    ``refresh_agent_mcp_tools``.
+    """
+    # ``_mcp_tool_server_names`` stores SANITIZED server names (see
+    # ``_track_mcp_tool_server``) while ``_servers`` is keyed by the original
+    # config name — e.g. a server configured as ``my-server`` registers tools
+    # mapped to ``my_server``, but its task lives under ``my-server``.  Match
+    # through the sanitizer, or any server whose name needs sanitizing
+    # silently never gets polled.
+    with _lock:
+        called_server_names = {
+            _mcp_tool_server_names[name]
+            for name in called_tool_names
+            if name in _mcp_tool_server_names
+        }
+        servers = [
+            srv
+            for srv_name, srv in sorted(_servers.items())
+            if sanitize_mcp_name_component(srv_name) in called_server_names
+        ]
+
+    for server in servers:
+        if server.session is None or not server._has_dynamic_tool_list():
+            continue
+        try:
+            logger.debug(
+                "MCP server '%s': post-call tools/list re-poll", server.name
+            )
+            _run_on_mcp_loop(server._refresh_tools, timeout=poll_timeout)
+        except InterruptedError:
+            logger.debug(
+                "MCP server '%s': post-call tools/list re-poll interrupted",
+                server.name,
+            )
+            break
+        except Exception:
+            logger.debug(
+                "MCP server '%s': post-call tools/list re-poll failed",
+                server.name, exc_info=True,
+            )
+
+    return refresh_agent_mcp_tools(agent, quiet_mode=quiet_mode)
 
 
 def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:


### PR DESCRIPTION
## What does this PR do?

When an MCP server changes its tool set while handling a tool call (e.g.
[mcp-dap-server](https://github.com/go-delve/mcp-dap-server) swaps
`debug`→session tools on `debug`, and session→`debug` on `stop`), the agent
keeps presenting a stale tool manifest to the model, which then deterministically
calls a tool that no longer exists. This PR fixes both defects behind that
symptom:

**1. Snapshot staleness.** `agent.tools` is set once in `agent_init` and
refreshed only in `build_turn_context()` at the start of each user message.
Even after the registry updates via `ToolListChanged`, dynamically registered
tools stay invisible until the *next user message*. Fix: Add a mid-turn refresh
after `_execute_tool_calls()` in the conversation loop, mirroring the
between-turns refresh in `turn_context.py` behind the same guards
(`_skip_mcp_refresh`, `sys.modules` import-cost gate,
`has_registered_mcp_tools`).

**2. Notification-ordering race.** `ToolListChanged` races the tool-call
response it follows: a server that swaps its tool set inside a tool handler
sends the response first and the notification milliseconds later. At the
post-execution checkpoint the notification often hasn't even been read off the
transport yet, so the *registry itself* is still stale and a snapshot rebuild
alone sees no change. The next API request then advertises tools that no
longer exist. Tested across 11 models from multiple providers
(Claude Opus 4.6/4.8/Fable 5, GPT-5.6, Qwen 27B/35B/122B, GLM-5.2, Gemma 31B, …)
with 100% reproduction: every model picks a now-unregistered tool and burns a
failure round before the notification lands. This is not a model defect — it
is Hermes presenting a stale tool list.

### Why re-polling is the right approach

Waiting on pending notification-refresh tasks **cannot** close the race window:
nothing is pending until the notification arrives, and at the checkpoint it
usually hasn't. A fixed delay is a timing guess. What *is* deterministic is
re-polling: a `tools/list` request sent after the tool-call response was
received is necessarily processed by the server **after** its tool handler
finished mutating the tool set — regardless of when the notification shows up.

So the new `refresh_agent_tools_after_mcp_calls()` runs `_refresh_tools()` —
the exact fetch-diff-register path the notification handler already uses,
sharing `_refresh_lock` so a concurrently arriving notification refresh
serializes instead of duplicating — on each **just-called** server whose tool
list is **known dynamic**, then rebuilds the agent snapshot from the registry.

"Known dynamic" means the server declared the `tools.listChanged` capability at
initialize, or has actually sent a `list_changed` notification on this
process's watch (new `_tool_list_changed_seen` latch, covering noncompliant
servers). Unlike `_advertises_tools`, missing capability info defaults to
**not** dynamic: this gate *adds* an RPC rather than skipping one, so unknown
servers must not silently pay for it.

### Prompt-caching invariant (the `sweeper:risk-caching` flag)

Addressing the review concern that this violates the cache invariant in
`AGENTS.md` ("do not change toolsets mid-conversation"):

- **Static servers are never re-polled**, and unchanged tool sets never swap
  the snapshot (`refresh_agent_mcp_tools` diffs by name and is a
  generation-cached no-op). Conversations keep a byte-stable `tools=` prefix in
  the common case — i.e. for every MCP server that exists today except
  dynamic-toolset ones, and for all built-in tools.
- When a dynamic server **actually changed** its list, the cached prefix
  already describes tools that no longer exist. Refreshing mid-turn spends the
  cache invalidation the next turn would pay anyway — it just spends it before
  the model burns a guaranteed unknown-tool failure round (which itself costs
  tokens *and* still invalidates the cache next turn).
- The exception is opt-in by the server: only servers declaring
  `tools.listChanged` (or observed notifying) get the new behavior.

**This PR deliberately does NOT edit `AGENTS.md`** — documenting an exception
to a project-wide policy is the maintainers' call, not a contributor's. If you
agree the exception is justified, here is proposed wording for the
"Prompt Caching Must Not Break" section, to adopt, reword, or reject:

> Narrow exception — dynamic MCP toolsets: an MCP server that declares the
> `tools.listChanged` capability may change its tool list while handling a
> tool call. When that happens the cached `tools=` prefix already describes
> tools that no longer exist, so the mid-turn refresh in
> `conversation_loop.py` (via `refresh_agent_tools_after_mcp_calls`)
> rebuilds the manifest immediately rather than serving a known-invalid
> prefix that makes the model call unregistered tools. The refresh is a
> no-op — and the cache prefix stays byte-stable — for static servers and
> whenever the tool set is unchanged.

**Maintainers: this policy question is the explicit decision being
requested** (the `needs-decision` label from the earlier review). The code
change stands on its own regardless of the wording you choose.

## Related Issue

Fixes #65428

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`
  - New `refresh_agent_tools_after_mcp_calls(agent, called_tool_names, ...)`:
    maps the just-called tool names to their server tasks, re-polls
    `tools/list` (via the existing `_refresh_tools()`) on those that are known
    dynamic, then rebuilds the agent snapshot via `refresh_agent_mcp_tools()`.
    Fail-soft on poll errors; aborts remaining polls on user interrupt.
    The tool→server match goes through `sanitize_mcp_name_component()`:
    `_mcp_tool_server_names` stores sanitized names (`mcp_dap_server`) while
    `_servers` is keyed by the config name (`mcp-dap-server`), so a naive key
    lookup silently skips the poll for any server whose name needs
    sanitizing — found by live-gateway testing, pinned by a regression test.
  - New `MCPServerTask._advertises_tool_list_changed()` /
    `_has_dynamic_tool_list()` capability gates, and a
    `_tool_list_changed_seen` latch set by the `ToolListChanged` handler.
- `agent/conversation_loop.py`
  - Mid-turn refresh block after `_execute_tool_calls()`, calling the helper
    above with the executed tool-call names, behind the same guards as the
    between-turns refresh.
- `tests/agent/test_mid_turn_mcp_refresh.py` (new, 17 tests)
  - Conversation-loop refresh contracts: dynamic addition, no-change no-op,
    skip guards, equal-count swap detection, exception swallowing.
  - The ordering race itself: registry stays stale until the server is polled;
    the helper produces the fresh manifest.
  - The sanitized-server-name mapping (hyphenated config name still polls).
  - No-poll gates: static server, no session, non-MCP tool names.
  - Poll failure fail-soft; interrupt aborts remaining polls.
  - Capability gates: declared `listChanged` true/false, missing capability
    info defaults static, seen-notification latch wins.

## How to Test

1. Unit tests:
   `pytest tests/agent/test_mid_turn_mcp_refresh.py tests/tools/test_refresh_agent_mcp_tools.py tests/agent/test_turn_context.py -q`
   → 48 passed.
2. End-to-end (no LLM required — drives the real machinery): with a dynamic
   MCP server configured (e.g. mcp-dap-server + GDB 14+), the script in the
   collapsed section below connects through `register_mcp_servers()`, calls
   `debug` then `stop` via the registry handlers, and at each boundary compares
   the old behavior (`refresh_agent_mcp_tools` alone) against the new helper.
   Observed result: old behavior shows a stale manifest at **both** boundaries;
   the new helper shows the post-call tool list at both. (The `debug` direction
   only *appeared* fixed in the previous revision of this PR because GDB's
   multi-second startup usually lets the notification win the race.)
3. Live agent: run Hermes with mcp-dap-server, ask for a debug session, then
   ask it to stop and start a new one. Before this fix every tested model calls
   `step` (stale manifest) and errors; with it, the model sees `debug`
   immediately.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — #65568 (closed) attempted a
      generation-stamp variant of this; see "Why re-polling" above for why
      that class of fix can't close the race
- [x] My PR contains only changes related to this fix
- [x] I've run the test suite — `tests/agent` + `tests/tools`: identical
      pass/fail set with and without this change (the failures are
      pre-existing/flaky: `test_execute_code_approval_cluster`,
      `test_models.py`, `test_cmd_update.py`, and xdist-interference flakes)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Fedora 44 (Linux 6.19)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `AGENTS.md` — deliberately NOT edited; proposed wording for the
      prompt-caching policy exception is in the PR description above for
      maintainers to adopt, reword, or reject
- [x] Cross-platform impact — N/A (no platform-specific code; pure
      Python threading/asyncio paths already in use)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

End-to-end run against mcp-dap-server + GDB (script below):

```
initial manifest: ['mcp__mcp_dap_server__debug', 'mcp__mcp_dap_server__get_prompt', 'mcp__mcp_dap_server__list_prompts']

--- calling mcp__mcp_dap_server__debug ---
debug result: {"result": "Debug session started for .../gdb.base/break/break. ..."}
old behavior manifest after debug: ['mcp__mcp_dap_server__debug', 'mcp__mcp_dap_server__get_prompt', 'mcp__mcp_dap_server__list_prompts']
fixed behavior manifest after debug: ['mcp__mcp_dap_server__breakpoint', 'mcp__mcp_dap_server__clear_breakpoints',
 'mcp__mcp_dap_server__context', 'mcp__mcp_dap_server__continue', 'mcp__mcp_dap_server__disassemble',
 'mcp__mcp_dap_server__evaluate', 'mcp__mcp_dap_server__get_prompt', 'mcp__mcp_dap_server__info',
 'mcp__mcp_dap_server__list_prompts', 'mcp__mcp_dap_server__pause', 'mcp__mcp_dap_server__set_variable',
 'mcp__mcp_dap_server__step', 'mcp__mcp_dap_server__stop']

--- calling mcp__mcp_dap_server__stop ---
stop result: {"result": "Debug session stopped"}

old behavior manifest: [...session tools, no debug...]
fixed behavior manifest: ['mcp__mcp_dap_server__debug', 'mcp__mcp_dap_server__disassemble',
 'mcp__mcp_dap_server__get_prompt', 'mcp__mcp_dap_server__list_prompts', 'mcp__mcp_dap_server__set_variable']

old behavior saw post-stop manifest: False
fixed behavior saw post-stop manifest: True
```

<details>
<summary>E2E reproduction script (run with the project venv from the repo root)</summary>

```python
"""End-to-end reproduction of the stop-direction notification race.

Drives the real mcp-dap-server through Hermes' real MCP machinery (no LLM):
  1. connect, snapshot the initial manifest (expect a debug-ish tool)
  2. call debug -> session tools appear (notification lands during the call)
  3. call stop, then IMMEDIATELY:
       a. plain refresh_agent_mcp_tools on agent_old  (old behavior)
       b. refresh_agent_tools_after_mcp_calls on agent_new (the fix)
  4. report whether each saw the post-stop manifest (debug back, session gone)

Adjust the three paths (mcp-dap-server binary, debuggee, gdb) for your setup.
"""
import sys
import time
import types

from tools.registry import registry
from tools.mcp_tool import (
    register_mcp_servers,
    refresh_agent_mcp_tools,
    refresh_agent_tools_after_mcp_calls,
)

MCP_DAP_SERVER = "/home/kevinb-claude/mcp-dap-server/mcp-dap-server"
DEBUGGEE = "/mesquite2/sourceware-git/f44-master/bld/gdb/testsuite/outputs/gdb.base/break/break"
GDB = "/mesquite2/sourceware-git/f44-master/bld/gdb/gdb"


def make_agent():
    a = types.SimpleNamespace()
    a.tools = []
    a.valid_tool_names = set()
    a.enabled_toolsets = None
    a.disabled_toolsets = None
    a._skip_mcp_refresh = False
    a._tool_snapshot_generation = 0
    refresh_agent_mcp_tools(a, quiet_mode=True)
    return a


def mcp_names(agent):
    return sorted(n for n in agent.valid_tool_names if n.startswith("mcp__mcp_dap_server"))


def call(name, **kwargs):
    entry = registry.get_entry(name)
    assert entry is not None, f"tool {name} not in registry"
    return entry.handler(kwargs)


register_mcp_servers({"mcp-dap-server": {"command": MCP_DAP_SERVER, "args": [], "enabled": True}})
agent_probe = make_agent()
print("initial manifest:", mcp_names(agent_probe))

debug_tool = next(n for n in mcp_names(agent_probe) if n.endswith("_debug"))
print(f"\n--- calling {debug_tool} ---")
out = call(debug_tool, mode="binary", path=DEBUGGEE, debugger="gdb",
           gdbPath=GDB, stopOnEntry=True)
print("debug result:", str(out)[:300])

agent_old = make_agent()  # plain snapshot rebuild == old behavior
agent_new = make_agent()
refresh_agent_tools_after_mcp_calls(agent_new, {debug_tool})  # the fix
print("old behavior manifest after debug:", mcp_names(agent_old))
print("fixed behavior manifest after debug:", mcp_names(agent_new))
stop_tool = next(n for n in mcp_names(agent_new) if n.endswith("_stop"))

print(f"\n--- calling {stop_tool} ---")
out = call(stop_tool)
print("stop result:", str(out)[:300])

# The critical instant: the stop response is in hand; the ToolListChanged
# notification is (typically) still in flight.
refresh_agent_mcp_tools(agent_old, quiet_mode=True)           # old behavior
refresh_agent_tools_after_mcp_calls(agent_new, {stop_tool})   # the fix
old_manifest = mcp_names(agent_old)
new_manifest = mcp_names(agent_new)

print("\nold behavior manifest:", old_manifest)
print("fixed behavior manifest:", new_manifest)

old_fresh = any(n.endswith("_debug") for n in old_manifest) and stop_tool not in old_manifest
new_fresh = any(n.endswith("_debug") for n in new_manifest) and stop_tool not in new_manifest
print(f"\nold behavior saw post-stop manifest: {old_fresh}")
print(f"fixed behavior saw post-stop manifest: {new_fresh}")

time.sleep(1)  # let the late notification drain before teardown
sys.exit(0 if new_fresh else 1)
```


