### PR TITLE
feat: add Mistral AI model provider plugin

### DIFF
--- a/plugins/model-providers/mistral/__init__.py
+++ b/plugins/model-providers/mistral/__init__.py
@@ -1,0 +1,67 @@
+"""Mistral AI provider profile.
+
+Mistral's API is standard OpenAI-compatible with a ``reasoning_effort``
+top-level kwarg for thinking-enabled models (``mistral-small-2603+``).
+The ``reasoning_effort`` parameter is passed through transparently —
+this profile adds no special handling beyond registering the provider.
+
+Agentic models with tool-calling support:
+
+- ``mistral-large-latest`` — flagship, strong reasoning + tool use (128K ctx)
+- ``mistral-small-latest`` — fast, cost-effective, vision-capable (128K ctx)
+- ``ministral-8b-latest`` — edge-optimised, small (128K ctx)
+- ``ministral-14b-latest`` — edge-optimised, balanced (128K ctx)
+- ``codestral-latest`` — code generation (256K ctx)
+- ``pixtral-12b-latest`` — multimodal: text + image input (128K ctx)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class MistralProfile(ProviderProfile):
+    """Mistral AI — standard OpenAI-compatible, passes reasoning_effort through."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        # Mistral supports reasoning_effort as a top-level kwarg for thinking
+        # models. Pass through the Hermes reasoning config transparently.
+        if isinstance(reasoning_config, dict):
+            effort = (reasoning_config.get("effort") or "").strip().lower()
+            if effort:
+                top_level["reasoning_effort"] = effort
+
+        return extra_body, top_level
+
+
+mistral = MistralProfile(
+    name="mistral",
+    aliases=("mistral-ai", "mistralai", "mixtral"),
+    env_vars=("MISTRAL_API_KEY",),
+    display_name="Mistral AI",
+    description="Mistral AI — native Mistral API",
+    signup_url="https://console.mistral.ai/",
+    fallback_models=(
+        "mistral-large-latest",
+        "mistral-medium-latest",
+        "mistral-small-latest",
+        "codestral-latest",
+        "pixtral-12b-latest",
+    ),
+    base_url="https://api.mistral.ai/v1",
+    supports_vision=True,
+    default_aux_model="mistral-small-latest",
+)
+
+register_provider(mistral)

--- a/plugins/model-providers/mistral/plugin.yaml
+++ b/plugins/model-providers/mistral/plugin.yaml
@@ -1,0 +1,5 @@
+name: mistral-provider
+kind: model-provider
+version: 1.0.0
+description: Mistral AI
+author: Nous Research


### PR DESCRIPTION
## Summary

Adds a bundled model provider plugin for **Mistral AI** (`api.mistral.ai/v1`) — auto-discovered by the existing `providers/__init__.py` plugin system. No core changes needed.

## What it provides

- Standard OpenAI-compatible chat completions
- Tool/function calling (tested on Small, Medium, Large, Codestral, Ministral 3B/14B)
- Vision via base64 image input (tested on mistral-small-latest)
- `reasoning_effort` pass-through for thinking models
- Auto-registers with `hermes model` selector, `hermes status`, `hermes providers list`

## Models

- `mistral-large-latest` — flagship, tool calling + vision
- `mistral-medium-latest` — balanced, tool calling + vision
- `mistral-small-latest` — fast, tool calling + vision + reasoning
- `codestral-latest` — code generation specialist
- `pixtral-12b-latest` — vision-focused, cheap (128K ctx)

## Files

| File | Purpose |
|---|---|
| `plugins/model-providers/mistral/plugin.yaml` | Plugin manifest |
| `plugins/model-providers/mistral/__init__.py` | `MistralProfile` with `register_provider()` |

## Integration notes

- No core changes, no config schema bumps, no new dependencies
- Env var is `MISTRAL_API_KEY` — already auto-detectable via `runtime_provider.py`
- Mistral already has TTS/STT support in the codebase (136 refs); this fills the gap for LLM support
- Follows the exact same pattern as `plugins/model-providers/deepseek/`
- Also published as a [standalone plugin repo](https://github.com/luluthehungrycat/hermes-agent-mistral-provider) for users who prefer that

## Test plan

- [x] Provider auto-registers and appears in `hermes model` selector
- [x] Basic chat: mistral-small-latest
- [x] Tool calling: mistral-small-latest, ministral-8b-latest
- [x] Vision: mistral-small-latest (base64)
- [x] Reasoning effort: mistral-small-latest
- [x] Code generation: codestral-latest
- [x] Provider discovery works across profiles (coder, dr-k) via symlinks