### PR TITLE
fix: encoding round-trip write side in skills_hub.py (ensure_ascii=False without encoding)

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1144,7 +1144,7 @@ class GitHubSource(SkillSource):
         index_cache_dir.mkdir(parents=True, exist_ok=True)
         cache_file = index_cache_dir / f"{key}.json"
         try:
-            cache_file.write_text(json.dumps(data, ensure_ascii=False))
+            cache_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
         except OSError as e:
             logger.debug("Could not write cache: %s", e)
 
@@ -3363,7 +3363,7 @@ def _write_index_cache(key: str, data: Any) -> None:
             pass
     cache_file = index_cache_dir / f"{key}.json"
     try:
-        cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str))
+        cache_file.write_text(json.dumps(data, ensure_ascii=False, default=str), encoding="utf-8")
     except OSError as e:
         logger.debug("Could not write cache: %s", e)
 
@@ -3403,7 +3403,7 @@ class HubLockFile:
 
     def save(self, data: dict) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
     def record_install(
         self,


### PR DESCRIPTION
## Problem

3 `write_text()` calls in `tools/skills_hub.py` produce UTF-8 content via `ensure_ascii=False` but omit the `encoding="utf-8"` parameter. On Windows, `write_text()` defaults to the system codepage (cp1252), which corrupts non-ASCII characters in skill names, descriptions, and metadata.

PR #64822 already fixes the **read side** (`read_text()` → `read_text(encoding="utf-8")`). This PR fixes the **write side** to complete the encoding round-trip.

## Why This Matters

Without this fix, the write path produces cp1252-encoded JSON on Windows, while PR #64822 changes the read path to expect UTF-8. This mismatch causes `UnicodeDecodeError` or silent data corruption when reading back cached skill data with non-ASCII content.

## Files Changed

| Line | Function | Call |
|------|----------|------|
| 1147 | `_write_index_cache()` | `cache_file.write_text(json.dumps(..., ensure_ascii=False))` |
| 3366 | `_write_stale_index_cache()` | `cache_file.write_text(json.dumps(..., ensure_ascii=False, default=str))` |
| 3406 | `SkillLockStore.save()` | `self.path.write_text(json.dumps(..., ensure_ascii=False) + "\\n")`