### PR TITLE
fix(photon): launch the iMessage sidecar headless on Windows

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -174,6 +174,10 @@ def _reinstall_sidecar_deps() -> None:
     if not npm:
         logger.warning("[photon] cannot reinstall stale sidecar deps: npm not on PATH")
         return
+    # Windows: suppress the console flash these short-lived npm runs would
+    # otherwise pop (0 elsewhere). Same helper as the sidecar spawn below.
+    from hermes_cli._subprocess_compat import windows_hide_flags
+
     try:
         result = subprocess.run(  # noqa: S603
             [npm, "ci"],
@@ -182,6 +186,7 @@ def _reinstall_sidecar_deps() -> None:
             text=True,
             check=False,
             timeout=_NPM_REINSTALL_TIMEOUT,
+            creationflags=windows_hide_flags(),
         )
         if result.returncode != 0:
             logger.warning(
@@ -194,6 +199,7 @@ def _reinstall_sidecar_deps() -> None:
                 text=True,
                 check=False,
                 timeout=_NPM_REINSTALL_TIMEOUT,
+                creationflags=windows_hide_flags(),
             )
     except subprocess.TimeoutExpired:
         # A wedged npm (dead registry, network blackhole) must not stall the

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -944,6 +944,10 @@ class PhotonAdapter(BasePlatformAdapter):
         # never runs — can't leave it orphaned on the port.
         env["PHOTON_SIDECAR_WATCH_STDIN"] = "1"
 
+        # Windows: hide the child console (0 elsewhere). Same helper the
+        # discord/whatsapp adapters use for their sidecar spawns.
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
         try:
             patch = subprocess.run(  # noqa: S603
                 [
@@ -955,6 +959,9 @@ class PhotonAdapter(BasePlatformAdapter):
                 text=True,
                 timeout=10,
                 check=False,
+                # Windows: suppress the brief console flash this short-lived
+                # node patch run would otherwise pop on every sidecar start.
+                creationflags=windows_hide_flags(),
             )
             if patch.returncode != 0:
                 raise RuntimeError((patch.stderr or patch.stdout or "").strip())
@@ -973,6 +980,10 @@ class PhotonAdapter(BasePlatformAdapter):
             stderr=subprocess.STDOUT,
             env=env,
             start_new_session=(sys.platform != "win32"),
+            # Windows: run the persistent sidecar headless so it does not open
+            # (or leave) a visible console window. CREATE_NO_WINDOW only (no
+            # DETACHED_PROCESS) so the stdin/stdout pipes above stay usable.
+            creationflags=windows_hide_flags(),
         )
 
         # Pump sidecar stderr/stdout into our logger so users see crashes.

--- a/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
+++ b/tests/plugins/platforms/photon/test_sidecar_lifecycle.py
@@ -138,6 +138,23 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
     monkeypatch.setattr(photon_adapter, "_SIDECAR_DIR", tmp_path)
 
     spawned: Dict[str, Any] = {}
+    hidden_flags = 0x08000000
+    monkeypatch.setattr(
+        "hermes_cli._subprocess_compat.windows_hide_flags",
+        lambda: hidden_flags,
+    )
+
+    class _PatchResult:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _fake_run(cmd: List[str], **kwargs: Any) -> _PatchResult:
+        spawned["patch_cmd"] = cmd
+        spawned["patch_kwargs"] = kwargs
+        return _PatchResult()
+
+    monkeypatch.setattr(photon_adapter.subprocess, "run", _fake_run)
 
     class _FakeProc:
         pid = 999
@@ -169,3 +186,5 @@ async def test_start_sidecar_spawns_with_stdin_pipe(
     kwargs = spawned["kwargs"]
     assert kwargs["stdin"] is subprocess.PIPE
     assert kwargs["env"]["PHOTON_SIDECAR_WATCH_STDIN"] == "1"
+    assert spawned["patch_kwargs"]["creationflags"] == hidden_flags
+    assert kwargs["creationflags"] == hidden_flags


### PR DESCRIPTION
## Summary
The Photon (iMessage) sidecar no longer pops visible console windows on Windows. `start_new_session=True` is a silent no-op on Windows, so the long-lived Node sidecar spawned with an attached blank conhost window; the npm dep self-heal runs flashed one too.

## Changes
- `plugins/platforms/photon/adapter.py`: sidecar `Popen` and the short-lived node patch run now pass `creationflags=windows_hide_flags()` (the shared `hermes_cli/_subprocess_compat.py` helper — `CREATE_NO_WINDOW` only, no `DETACHED_PROCESS`, so the stdin/stdout pipes stay usable) — @lEWFkRAD's fix from #54565, cherry-picked with authorship preserved
- `plugins/platforms/photon/adapter.py`: follow-up widens the same flag to the sibling spawn sites in `_reinstall_sidecar_deps` (`npm ci` + `npm install` fallback)
- `tests/plugins/platforms/photon/test_sidecar_lifecycle.py`: regression coverage pinning the hidden-window spawn kwargs

## Validation
| | Before | After |
|---|---|---|
| Windows sidecar spawn | visible conhost window | `CREATE_NO_WINDOW`, pipes intact |
| npm self-heal runs | console flash per run | hidden |
| `scripts/run_tests.sh tests/plugins/platforms/photon/` | — | all pass |
| POSIX behavior | `start_new_session=True` | unchanged (helper returns 0) |

## Credit
Salvaged from #54565 by @lEWFkRAD (earliest submission, Jun 29). The same bug was independently fixed by @igparkernz-coder (#55554), @xIGBClutchIx (#56610), @ianarsenault-tn (#65083), and @smreed32 (#65299) — thanks to all five.

## Infographic
![PR infographic](https://v3b.fal.media/files/b/0aa273ff/AqP_PPU_Brj559grDMO0o_FKr2zEIW.png)
