### PR TITLE
fix(desktop): resolve model switches against live session

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -227,7 +227,6 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   })
 
   const { refreshCurrentModel, selectModel, updateModelOptionsCache } = useModelControls({
-    activeSessionId,
     queryClient,
     requestGateway
   })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -31,18 +31,13 @@ vi.mock('@/store/notifications', () => ({
 
 type Controls = ReturnType<typeof useModelControls>
 
-function Harness({
-  activeSessionId,
-  onReady,
-  requestGateway
-}: {
-  activeSessionId: string | null
+function Harness({ onReady, queryClient = new QueryClient(), requestGateway }: {
   onReady: (controls: Controls) => void
+  queryClient?: QueryClient
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }) {
   const controls = useModelControls({
-    activeSessionId,
-    queryClient: new QueryClient(),
+    queryClient,
     requestGateway
   })
 
@@ -74,7 +69,6 @@ describe('useModelControls', () => {
 
     const { result } = renderHook(() =>
       useModelControls({
-        activeSessionId: null,
         queryClient: new QueryClient(),
         requestGateway: vi.fn()
       })
@@ -97,7 +91,6 @@ describe('useModelControls', () => {
 
     const { result } = renderHook(() =>
       useModelControls({
-        activeSessionId: 'runtime-1',
         queryClient: new QueryClient(),
         requestGateway: vi.fn()
       })
@@ -112,10 +105,9 @@ describe('useModelControls', () => {
   it('routes active-session picker changes through config.set with an explicit session-scoped provider', async () => {
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'claude-sonnet-4.6' }) as never)
     let controls!: Controls
+    $activeSessionId.set('session-1')
 
-    render(
-      <Harness activeSessionId="session-1" onReady={value => (controls = value)} requestGateway={requestGateway} />
-    )
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
 
     await expect(
       controls.selectModel({
@@ -135,10 +127,9 @@ describe('useModelControls', () => {
   it('session-scopes MoA preset selections so they cannot persist as the global gateway default', async () => {
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'BeastMode' }) as never)
     let controls!: Controls
+    $activeSessionId.set('session-1')
 
-    render(
-      <Harness activeSessionId="session-1" onReady={value => (controls = value)} requestGateway={requestGateway} />
-    )
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
 
     await expect(
       controls.selectModel({
@@ -158,7 +149,7 @@ describe('useModelControls', () => {
     const requestGateway = vi.fn()
     let controls!: Controls
 
-    render(<Harness activeSessionId={null} onReady={value => (controls = value)} requestGateway={requestGateway} />)
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
 
     await expect(
       controls.selectModel({
@@ -175,12 +166,69 @@ describe('useModelControls', () => {
     expect(setGlobalModel).not.toHaveBeenCalled()
   })
 
+  it('routes a stale pre-session picker callback to the current runtime session', async () => {
+    const requestGateway = vi.fn(async () => ({ key: 'model', value: 'claude-sonnet-4.6' }) as never)
+    const queryClient = new QueryClient()
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} queryClient={queryClient} requestGateway={requestGateway} />)
+    $activeSessionId.set('session-1')
+
+    await expect(
+      controls.selectModel({
+        model: 'claude-sonnet-4.6',
+        provider: 'anthropic'
+      })
+    ).resolves.toBe(true)
+
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      session_id: 'session-1',
+      key: 'model',
+      value: 'claude-sonnet-4.6 --provider anthropic --session'
+    })
+    expect(queryClient.getQueryData(['model-options', 'session-1'])).toEqual({
+      model: 'claude-sonnet-4.6',
+      provider: 'anthropic'
+    })
+    expect(queryClient.getQueryData(['model-options', 'global'])).toBeUndefined()
+  })
+
+  it('rolls back a stale picker callback against the same live session cache', async () => {
+    const requestGateway = vi.fn(async () => {
+      throw new Error('switch failed')
+    })
+
+    const queryClient = new QueryClient()
+    let controls!: Controls
+
+    setCurrentModel('deepseek/deepseek-v4-pro')
+    setCurrentProvider('deepseek')
+
+    render(<Harness onReady={value => (controls = value)} queryClient={queryClient} requestGateway={requestGateway} />)
+    $activeSessionId.set('session-1')
+
+    await expect(
+      controls.selectModel({
+        model: 'claude-sonnet-4.6',
+        provider: 'anthropic'
+      })
+    ).resolves.toBe(false)
+
+    expect($currentModel.get()).toBe('deepseek/deepseek-v4-pro')
+    expect($currentProvider.get()).toBe('deepseek')
+    expect(queryClient.getQueryData(['model-options', 'session-1'])).toEqual({
+      model: 'deepseek/deepseek-v4-pro',
+      provider: 'deepseek'
+    })
+    expect(queryClient.getQueryData(['model-options', 'global'])).toBeUndefined()
+    expect(notifyError).toHaveBeenCalledWith(expect.any(Error), 'Model switch failed')
+  })
+
   it('seeds an empty composer model from global but never clobbers a pick', async () => {
     vi.mocked(getGlobalModelInfo).mockResolvedValue({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
 
     const { result } = renderHook(() =>
       useModelControls({
-        activeSessionId: null,
         queryClient: new QueryClient(),
         requestGateway: vi.fn()
       })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -13,17 +13,17 @@ interface ModelSelection {
 }
 
 interface ModelControlsOptions {
-  activeSessionId: string | null
   queryClient: QueryClient
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
 
-export function useModelControls({ activeSessionId, queryClient, requestGateway }: ModelControlsOptions) {
+export function useModelControls({ queryClient, requestGateway }: ModelControlsOptions) {
   const { t } = useI18n()
   const copy = t.desktop
 
   const updateModelOptionsCache = useCallback(
     (provider: string, model: string, includeGlobal: boolean) => {
+      const activeSessionId = $activeSessionId.get()
       const patch = (prev: ModelOptionsResponse | undefined) => ({ ...(prev ?? {}), provider, model })
 
       queryClient.setQueryData<ModelOptionsResponse>(['model-options', activeSessionId || 'global'], patch)
@@ -32,7 +32,7 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
         queryClient.setQueryData<ModelOptionsResponse>(['model-options', 'global'], patch)
       }
     },
-    [activeSessionId, queryClient]
+    [queryClient]
   )
 
   // Seed the composer's model state from the profile default. `force` reseeds
@@ -76,6 +76,11 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
   // silently mutate global config.
   const selectModel = useCallback(
     async (selection: ModelSelection): Promise<boolean> => {
+      // The contribution shell keeps a stable action bag so memoized surfaces
+      // can hold this callback across session creation/resume. Read the runtime
+      // id at invocation time rather than trusting the render that created the
+      // callback, or a pre-session picker silently stays UI-only forever.
+      const liveSessionId = $activeSessionId.get()
       // Snapshot for rollback: the switch is applied optimistically, so a
       // failure must restore the prior model/provider (store + query cache)
       // rather than leave the UI showing a model the backend never selected.
@@ -84,34 +89,34 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
 
       setCurrentModel(selection.model)
       setCurrentProvider(selection.provider)
-      updateModelOptionsCache(selection.provider, selection.model, !activeSessionId)
+      updateModelOptionsCache(selection.provider, selection.model, !liveSessionId)
 
       // No live session yet: the pick is pure UI state. session.create reads
       // $currentModel/$currentProvider and applies it as that session's override.
-      if (!activeSessionId) {
+      if (!liveSessionId) {
         return true
       }
 
       try {
         await requestGateway('config.set', {
-          session_id: activeSessionId,
+          session_id: liveSessionId,
           key: 'model',
           value: `${selection.model} --provider ${selection.provider} --session`
         })
 
-        void queryClient.invalidateQueries({ queryKey: ['model-options', activeSessionId] })
+        void queryClient.invalidateQueries({ queryKey: ['model-options', liveSessionId] })
 
         return true
       } catch (err) {
         setCurrentModel(prevModel)
         setCurrentProvider(prevProvider)
-        updateModelOptionsCache(prevProvider, prevModel, !activeSessionId)
+        updateModelOptionsCache(prevProvider, prevModel, !liveSessionId)
         notifyError(err, copy.modelSwitchFailed)
 
         return false
       }
     },
-    [activeSessionId, copy.modelSwitchFailed, queryClient, requestGateway, updateModelOptionsCache]
+    [copy.modelSwitchFailed, queryClient, requestGateway, updateModelOptionsCache]
   )
 
   return { refreshCurrentModel, selectModel, updateModelOptionsCache }


### PR DESCRIPTION
## Bug Description

Desktop model picker silently fails to switch models after session creation or reopen: clicking a different model updates the UI label locally but never reaches `config.set` on the Gateway, and after the next interaction the model snaps back to the pre-session default.

## Root Cause

**Commit `0f922002e` (`feat(desktop): contribution controller, surfaces, and wiring`)** introduced a `ContribWiring` layer that memoizes the full action bag inside a stable `actionsRef`. The `selectModel` callback entered that bag at render time, capturing `activeSessionId` from its `useModelControls` props. Since the contribution shell is created before any session exists, that captured value is `null` — and stays `null` even after session creation, because the action reference never changes.

The callback's no-session branch treated the pick as UI-only state, so `$currentModel` / `$currentProvider` were set correctly and the menu label updated — but no `config.set` RPC was ever fired. The next state refresh (seeding, inventory, etc.) would then overwrite the session cache back to the global default — hence the "snap back" behavior.

## Fix

3-file change:

- **`use-model-controls.ts`**: Drop the `activeSessionId` prop. Read `$activeSessionId.get()` at invocation time inside `selectModel` and `updateModelOptionsCache` instead of binding to the render-time prop. This way the stale callback from `actionsRef` always resolves to the current runtime session.
- **`wiring.tsx`**: Stop threading `activeSessionId` into `useModelControls`. The hook now derives it from the Nano Stores atom on its own.
- **`use-model-controls.test.tsx`**: Remove `activeSessionId` from all test harnesses; read/write `$activeSessionId` store directly. Add two new tests:
  1. A stale pre-session callback correctly routes selection to the runtime session.
  2. A failed stale-callback switch correctly rolls back both store and query cache.

## How to Verify

1. Open Desktop, click a historical session tile to resume it.
2. Click the model picker in the composer area, select a different model.
3. Observe that the model label updates **and** the model change takes effect on the next message — it should NOT snap back to the original model.

## Test Plan

- [x] Added regression test for stale callback routing to live session
- [x] Added regression test for stale callback error rollback
- [ ] Existing tests pass (CI will confirm)
- [ ] Manual verification with Desktop build

## Risk Assessment

**Low** — the fix is localized to the model-controls hook. It changes *when* the session ID is read (render time → invocation time) without changing the overall logic. No-session paths are unaffected; the former `activeSessionId: null` blocks are now `$activeSessionId.get() === null`, which is semantically identical. The wiring change is a single deleted prop from a call site that already has the store available.
