### PR TITLE
feat(browser): add browser.min_available_mb cold start memory guard

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -383,6 +383,14 @@ browser:
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120
 
+  # Refuse a COLD browser start (spawning a new Chromium, ~300-400MB) when host
+  # MemAvailable is below this many MB; the agent is steered to web_extract or
+  # web_search instead. 0 disables the guard (default). Reusing an already-open
+  # browser session is never blocked, and the check fails open on hosts without
+  # /proc/meminfo. Recommended on small single-box hosts (e.g. a 1 GB VPS)
+  # where the Chromium launch spike can OOM-kill the gateway: 350
+  min_available_mb: 0
+
 # =============================================================================
 # Tool Loop Guardrails
 # =============================================================================

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -383,12 +383,12 @@ browser:
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120
 
-  # Refuse a COLD browser start (spawning a new Chromium, ~300-400MB) when host
+  # Refuse a cold local Chromium start (roughly 300 to 400 MB) when host
   # MemAvailable is below this many MB; the agent is steered to web_extract or
   # web_search instead. 0 disables the guard (default). Reusing an already-open
-  # browser session is never blocked, and the check fails open on hosts without
-  # /proc/meminfo. Recommended on small single-box hosts (e.g. a 1 GB VPS)
-  # where the Chromium launch spike can OOM-kill the gateway: 350
+  # local session is never blocked. Cloud browsers and CDP overrides are not
+  # checked. The check fails open on hosts without /proc/meminfo. Recommended
+  # on small single-box hosts (for example, a 1 GB VPS): 350
   min_available_mb: 0
 
 # =============================================================================

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -537,6 +537,14 @@ browser:
   # (same per-page budget as web_extract).
   # snapshot_threshold: 15000
 
+  # Refuse a cold local Chromium start (roughly 300 to 400 MB) when host
+  # MemAvailable is below this many MB; the agent is steered to web_extract or
+  # web_search instead. 0 disables the guard (default). Reusing an already-open
+  # local session is never blocked. Cloud browsers and CDP overrides are not
+  # checked. The check fails open on hosts without /proc/meminfo. Recommended
+  # on small single-box hosts (for example, a 1 GB VPS): 350
+  min_available_mb: 0
+
 # =============================================================================
 # Tool Loop Guardrails
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -345,6 +345,11 @@ DEFAULT_CONFIG = {
     "browser": {
         "inactivity_timeout": 120,
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
+        # Refuse a cold local Chromium start (roughly 300 to 400 MB) when host
+        # MemAvailable is below this many MB. 0 disables the guard (default).
+        # Reuse, cloud browsers, and CDP overrides are not blocked. The check
+        # fails open where /proc/meminfo is unavailable.
+        "min_available_mb": 0,
         "record_sessions": False,  # Auto-record browser sessions as WebM videos
         "headed": False,  # Local mode: launch Chromium with a visible window (also skips per-turn cleanup so the window persists between turns; idle reaper still applies)
         "allow_private_urls": False,  # Allow navigating to private/internal IPs (localhost, 192.168.x.x, etc.)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -383,6 +383,10 @@ DEFAULT_CONFIG = {
         "inactivity_timeout": 120,
         "command_timeout": 30,  # seconds per browser command (screenshot, navigate, etc.)
         "snapshot_threshold": 15000,  # max chars before snapshot truncate-and-store (min 1000)
+        # Refuse cold local Chromium starts below this MemAvailable floor in MB.
+        # Zero disables it; reuse and CDP sessions are exempt, and missing
+        # /proc/meminfo fails open.
+        "min_available_mb": 0,
         "record_sessions": False,  # auto-record browser sessions as WebM videos
         # headed: visible Chromium window (local); skips per-turn cleanup, idle reaper still applies
         "headed": False,

--- a/tests/tools/test_browser_lowmem_guard.py
+++ b/tests/tools/test_browser_lowmem_guard.py
@@ -1,0 +1,107 @@
+"""Tests for the browser.min_available_mb cold-start low-memory guard."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from tools.browser_tool import (
+    _available_memory_mb,
+    _cold_start_lowmem_error,
+    _get_min_available_mb,
+)
+
+
+class TestAvailableMemoryParsing:
+    def test_parses_memavailable_from_meminfo(self, tmp_path):
+        meminfo = tmp_path / "meminfo"
+        meminfo.write_text(
+            "MemTotal:        1024000 kB\n"
+            "MemFree:          102400 kB\n"
+            "MemAvailable:     204800 kB\n",
+            encoding="utf-8",
+        )
+        assert _available_memory_mb(str(meminfo)) == 200
+
+    def test_returns_none_when_memavailable_missing(self, tmp_path):
+        meminfo = tmp_path / "meminfo"
+        meminfo.write_text("MemTotal: 1024000 kB\n", encoding="utf-8")
+        assert _available_memory_mb(str(meminfo)) is None
+
+    def test_returns_none_when_unreadable(self, tmp_path):
+        assert _available_memory_mb(str(tmp_path / "does-not-exist")) is None
+
+
+class TestMinAvailableConfig:
+    def test_defaults_to_disabled(self):
+        with patch("hermes_cli.config.read_raw_config", return_value={}):
+            assert _get_min_available_mb() == 0
+
+    def test_reads_threshold_from_config(self):
+        cfg = {"browser": {"min_available_mb": 350}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert _get_min_available_mb() == 350
+
+    def test_negative_values_clamp_to_disabled(self):
+        cfg = {"browser": {"min_available_mb": -5}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert _get_min_available_mb() == 0
+
+    def test_config_error_fails_open(self):
+        with patch("hermes_cli.config.read_raw_config", side_effect=RuntimeError("boom")):
+            assert _get_min_available_mb() == 0
+
+
+class TestColdStartGuard:
+    def test_disabled_guard_allows_cold_start(self):
+        with patch("tools.browser_tool._get_min_available_mb", return_value=0), \
+             patch("tools.browser_tool._available_memory_mb", return_value=10), \
+             patch.dict("tools.browser_tool._active_sessions", {}, clear=True):
+            assert _cold_start_lowmem_error("default", "default") is None
+
+    def test_cold_start_refused_below_threshold(self):
+        with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
+             patch("tools.browser_tool._available_memory_mb", return_value=120), \
+             patch.dict("tools.browser_tool._active_sessions", {}, clear=True):
+            error = _cold_start_lowmem_error("default", "default")
+        assert error is not None
+        assert "web_extract" in error
+        assert "min_available_mb" in error
+        assert "120MB" in error
+        assert "350MB" in error
+
+    def test_cold_start_allowed_with_enough_memory(self):
+        with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
+             patch("tools.browser_tool._available_memory_mb", return_value=800), \
+             patch.dict("tools.browser_tool._active_sessions", {}, clear=True):
+            assert _cold_start_lowmem_error("default", "default") is None
+
+    def test_session_reuse_never_blocked(self):
+        with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
+             patch("tools.browser_tool._available_memory_mb", return_value=10), \
+             patch.dict("tools.browser_tool._active_sessions", {"default": object()}, clear=True):
+            assert _cold_start_lowmem_error("default", "default") is None
+
+    def test_unreadable_memory_fails_open(self):
+        with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
+             patch("tools.browser_tool._available_memory_mb", return_value=None), \
+             patch.dict("tools.browser_tool._active_sessions", {}, clear=True):
+            assert _cold_start_lowmem_error("default", "default") is None
+
+
+class TestBrowserNavigateWiring:
+    def test_navigate_refuses_cold_start_before_creating_session(self):
+        from tools.browser_tool import browser_navigate
+
+        session_info = MagicMock(side_effect=AssertionError("session must not be created"))
+        with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
+             patch("tools.browser_tool._available_memory_mb", return_value=120), \
+             patch.dict("tools.browser_tool._active_sessions", {}, clear=True), \
+             patch("tools.browser_tool._is_local_backend", return_value=True), \
+             patch("tools.browser_tool._is_camofox_mode", return_value=False), \
+             patch("tools.browser_tool.check_website_access", return_value=None), \
+             patch("tools.browser_tool._get_session_info", session_info):
+            result = browser_navigate("https://example.com")
+
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "web_extract" in parsed["error"]
+        session_info.assert_not_called()

--- a/tests/tools/test_browser_lowmem_guard.py
+++ b/tests/tools/test_browser_lowmem_guard.py
@@ -1,8 +1,9 @@
 """Tests for the browser.min_available_mb cold-start low-memory guard."""
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
+import tools.browser_tool as browser_tool
 from tools.browser_tool import (
     _available_memory_mb,
     _cold_start_lowmem_error,
@@ -53,15 +54,17 @@ class TestMinAvailableConfig:
 class TestColdStartGuard:
     def test_disabled_guard_allows_cold_start(self):
         with patch("tools.browser_tool._get_min_available_mb", return_value=0), \
-             patch("tools.browser_tool._available_memory_mb", return_value=10), \
-             patch.dict("tools.browser_tool._active_sessions", {}, clear=True):
-            assert _cold_start_lowmem_error("default", "default") is None
+             patch("tools.browser_tool._available_memory_mb", return_value=10):
+            assert _cold_start_lowmem_error(
+                {"cdp_url": None}, session_was_active=False
+            ) is None
 
     def test_cold_start_refused_below_threshold(self):
         with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
-             patch("tools.browser_tool._available_memory_mb", return_value=120), \
-             patch.dict("tools.browser_tool._active_sessions", {}, clear=True):
-            error = _cold_start_lowmem_error("default", "default")
+             patch("tools.browser_tool._available_memory_mb", return_value=120):
+            error = _cold_start_lowmem_error(
+                {"cdp_url": None}, session_was_active=False
+            )
         assert error is not None
         assert "web_extract" in error
         assert "min_available_mb" in error
@@ -70,38 +73,156 @@ class TestColdStartGuard:
 
     def test_cold_start_allowed_with_enough_memory(self):
         with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
-             patch("tools.browser_tool._available_memory_mb", return_value=800), \
-             patch.dict("tools.browser_tool._active_sessions", {}, clear=True):
-            assert _cold_start_lowmem_error("default", "default") is None
+             patch("tools.browser_tool._available_memory_mb", return_value=800):
+            assert _cold_start_lowmem_error(
+                {"cdp_url": None}, session_was_active=False
+            ) is None
 
     def test_session_reuse_never_blocked(self):
         with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
-             patch("tools.browser_tool._available_memory_mb", return_value=10), \
-             patch.dict("tools.browser_tool._active_sessions", {"default": object()}, clear=True):
-            assert _cold_start_lowmem_error("default", "default") is None
+             patch("tools.browser_tool._available_memory_mb", return_value=10):
+            assert _cold_start_lowmem_error(
+                {"cdp_url": None}, session_was_active=True
+            ) is None
 
     def test_unreadable_memory_fails_open(self):
         with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
-             patch("tools.browser_tool._available_memory_mb", return_value=None), \
-             patch.dict("tools.browser_tool._active_sessions", {}, clear=True):
-            assert _cold_start_lowmem_error("default", "default") is None
+             patch("tools.browser_tool._available_memory_mb", return_value=None):
+            assert _cold_start_lowmem_error(
+                {"cdp_url": None}, session_was_active=False
+            ) is None
 
 
 class TestBrowserNavigateWiring:
-    def test_navigate_refuses_cold_start_before_creating_session(self):
-        from tools.browser_tool import browser_navigate
+    @staticmethod
+    def _patch_navigation_dependencies(monkeypatch):
+        runner = MagicMock(
+            return_value={
+                "success": True,
+                "data": {"title": "Example", "url": "https://example.com"},
+            }
+        )
+        memory_probe = MagicMock(return_value=120)
+        monkeypatch.setattr(browser_tool, "_active_sessions", {})
+        monkeypatch.setattr(browser_tool, "_session_last_activity", {})
+        monkeypatch.setattr(browser_tool, "_last_active_session_key", {})
+        monkeypatch.setattr(browser_tool, "_start_browser_cleanup_thread", lambda: None)
+        monkeypatch.setattr(browser_tool, "_update_session_activity", lambda task_id: None)
+        monkeypatch.setattr(browser_tool, "_ensure_cdp_supervisor", lambda task_id: None)
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(browser_tool, "_auto_local_for_private_urls", lambda: True)
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: True)
+        monkeypatch.setattr(browser_tool, "check_website_access", lambda url: None)
+        monkeypatch.setattr(browser_tool, "_maybe_start_recording", lambda task_id: None)
+        monkeypatch.setattr(browser_tool, "_run_browser_command", runner)
+        monkeypatch.setattr(browser_tool, "_get_min_available_mb", lambda: 350)
+        monkeypatch.setattr(browser_tool, "_available_memory_mb", memory_probe)
+        return runner, memory_probe
 
-        session_info = MagicMock(side_effect=AssertionError("session must not be created"))
-        with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
-             patch("tools.browser_tool._available_memory_mb", return_value=120), \
-             patch.dict("tools.browser_tool._active_sessions", {}, clear=True), \
-             patch("tools.browser_tool._is_local_backend", return_value=True), \
-             patch("tools.browser_tool._is_camofox_mode", return_value=False), \
-             patch("tools.browser_tool.check_website_access", return_value=None), \
-             patch("tools.browser_tool._get_session_info", session_info):
-            result = browser_navigate("https://example.com")
+    def test_local_cold_start_blocked_at_low_memory(self, monkeypatch):
+        runner, memory_probe = self._patch_navigation_dependencies(monkeypatch)
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: None)
+
+        result = browser_tool.browser_navigate(
+            "https://example.com", task_id="local-task"
+        )
 
         parsed = json.loads(result)
         assert parsed["success"] is False
         assert "web_extract" in parsed["error"]
-        session_info.assert_not_called()
+        memory_probe.assert_called_once_with()
+        runner.assert_not_called()
+        assert "local-task" not in browser_tool._active_sessions
+
+    def test_cloud_session_not_blocked_at_low_memory(self, monkeypatch):
+        runner, memory_probe = self._patch_navigation_dependencies(monkeypatch)
+        provider = MagicMock()
+        provider.create_session.return_value = {
+            "session_name": "cloud-session",
+            "bb_session_id": "cloud-123",
+            "cdp_url": "wss://cloud.example/devtools/browser/abc",
+            "features": {"cloud": True},
+        }
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: provider)
+        monkeypatch.setattr(browser_tool, "_url_is_private", lambda url: False)
+
+        result = browser_tool.browser_navigate(
+            "https://example.com", task_id="cloud-task"
+        )
+
+        assert json.loads(result)["success"] is True
+        provider.create_session.assert_called_once_with("cloud-task")
+        memory_probe.assert_not_called()
+        runner.assert_any_call(
+            "cloud-task", "open", ["https://example.com"], timeout=ANY
+        )
+
+    def test_explicit_cdp_override_not_blocked_at_low_memory(self, monkeypatch):
+        runner, memory_probe = self._patch_navigation_dependencies(monkeypatch)
+        provider = MagicMock()
+        cdp_url = "ws://cdp.example/devtools/browser/abc"
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: cdp_url)
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: provider)
+
+        result = browser_tool.browser_navigate(
+            "https://example.com", task_id="cdp-task"
+        )
+
+        assert json.loads(result)["success"] is True
+        provider.create_session.assert_not_called()
+        assert browser_tool._active_sessions["cdp-task"]["cdp_url"] == cdp_url
+        memory_probe.assert_not_called()
+        runner.assert_any_call(
+            "cdp-task", "open", ["https://example.com"], timeout=ANY
+        )
+
+    def test_hybrid_local_sidecar_blocked_at_low_memory(self, monkeypatch):
+        runner, memory_probe = self._patch_navigation_dependencies(monkeypatch)
+        provider = MagicMock()
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: provider)
+        monkeypatch.setattr(browser_tool, "_url_is_private", lambda url: True)
+        browser_tool._active_sessions["hybrid-task"] = {
+            "session_name": "cloud-session",
+            "bb_session_id": "cloud-123",
+            "cdp_url": "wss://cloud.example/devtools/browser/abc",
+            "features": {"cloud": True},
+        }
+
+        result = browser_tool.browser_navigate(
+            "http://localhost:3000", task_id="hybrid-task"
+        )
+
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "web_extract" in parsed["error"]
+        provider.create_session.assert_not_called()
+        memory_probe.assert_called_once_with()
+        runner.assert_not_called()
+        assert "hybrid-task" in browser_tool._active_sessions
+        assert "hybrid-task::local" not in browser_tool._active_sessions
+
+    def test_existing_local_session_reuse_allowed_at_low_memory(self, monkeypatch):
+        runner, memory_probe = self._patch_navigation_dependencies(monkeypatch)
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: None)
+        browser_tool._active_sessions["reuse-task"] = {
+            "session_name": "local-session",
+            "bb_session_id": None,
+            "cdp_url": None,
+            "features": {"local": True},
+            "_first_nav": False,
+        }
+
+        result = browser_tool.browser_navigate(
+            "https://example.com", task_id="reuse-task"
+        )
+
+        assert json.loads(result)["success"] is True
+        memory_probe.assert_not_called()
+        runner.assert_any_call(
+            "reuse-task", "open", ["https://example.com"], timeout=ANY
+        )

--- a/tests/tools/test_browser_lowmem_guard.py
+++ b/tests/tools/test_browser_lowmem_guard.py
@@ -1,0 +1,229 @@
+"""Tests for the browser.min_available_mb cold-start low-memory guard."""
+
+import json
+from unittest.mock import ANY, MagicMock, patch
+
+import tools.browser_tool as browser_tool
+from tools import browser_tool_cdp as cdp
+from tools import browser_tool_cloud as cloud
+from tools import browser_tool_lifecycle as lifecycle
+from tools import browser_tool_session as session
+
+
+
+class TestAvailableMemoryParsing:
+    def test_parses_memavailable_from_meminfo(self, tmp_path):
+        meminfo = tmp_path / "meminfo"
+        meminfo.write_text(
+            "MemTotal:        1024000 kB\n"
+            "MemFree:          102400 kB\n"
+            "MemAvailable:     204800 kB\n",
+            encoding="utf-8",
+        )
+        assert browser_tool._available_memory_mb(str(meminfo)) == 200
+
+    def test_returns_none_when_memavailable_missing(self, tmp_path):
+        meminfo = tmp_path / "meminfo"
+        meminfo.write_text("MemTotal: 1024000 kB\n", encoding="utf-8")
+        assert browser_tool._available_memory_mb(str(meminfo)) is None
+
+    def test_returns_none_when_unreadable(self, tmp_path):
+        assert browser_tool._available_memory_mb(str(tmp_path / "does-not-exist")) is None
+
+
+class TestMinAvailableConfig:
+    def test_defaults_to_disabled(self):
+        with patch("hermes_cli.config.read_raw_config", return_value={}):
+            assert browser_tool._get_min_available_mb() == 0
+
+    def test_reads_threshold_from_config(self):
+        cfg = {"browser": {"min_available_mb": 350}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert browser_tool._get_min_available_mb() == 350
+
+    def test_negative_values_clamp_to_disabled(self):
+        cfg = {"browser": {"min_available_mb": -5}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert browser_tool._get_min_available_mb() == 0
+
+    def test_config_error_fails_open(self):
+        with patch("hermes_cli.config.read_raw_config", side_effect=RuntimeError("boom")):
+            assert browser_tool._get_min_available_mb() == 0
+
+
+class TestColdStartGuard:
+    def test_disabled_guard_allows_cold_start(self):
+        with patch("tools.browser_tool._get_min_available_mb", return_value=0), \
+             patch("tools.browser_tool._available_memory_mb", return_value=10):
+            assert browser_tool._cold_start_lowmem_error(
+                {"cdp_url": None}, session_was_active=False
+            ) is None
+
+    def test_cold_start_refused_below_threshold(self):
+        with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
+             patch("tools.browser_tool._available_memory_mb", return_value=120):
+            error = browser_tool._cold_start_lowmem_error(
+                {"cdp_url": None}, session_was_active=False
+            )
+        assert error is not None
+        assert "web_extract" in error
+        assert "min_available_mb" in error
+        assert "120MB" in error
+        assert "350MB" in error
+
+    def test_cold_start_allowed_with_enough_memory(self):
+        with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
+             patch("tools.browser_tool._available_memory_mb", return_value=800):
+            assert browser_tool._cold_start_lowmem_error(
+                {"cdp_url": None}, session_was_active=False
+            ) is None
+
+    def test_session_reuse_never_blocked(self):
+        with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
+             patch("tools.browser_tool._available_memory_mb", return_value=10):
+            assert browser_tool._cold_start_lowmem_error(
+                {"cdp_url": None}, session_was_active=True
+            ) is None
+
+    def test_unreadable_memory_fails_open(self):
+        with patch("tools.browser_tool._get_min_available_mb", return_value=350), \
+             patch("tools.browser_tool._available_memory_mb", return_value=None):
+            assert browser_tool._cold_start_lowmem_error(
+                {"cdp_url": None}, session_was_active=False
+            ) is None
+
+
+class TestBrowserNavigateWiring:
+    @staticmethod
+    def _patch_navigation_dependencies(monkeypatch):
+        runner = MagicMock(
+            return_value={
+                "success": True,
+                "data": {"title": "Example", "url": "https://example.com"},
+            }
+        )
+        memory_probe = MagicMock(return_value=120)
+        monkeypatch.setattr(browser_tool, "_active_sessions", {})
+        monkeypatch.setattr(browser_tool, "_session_last_activity", {})
+        monkeypatch.setattr(browser_tool, "_last_active_session_key", {})
+        monkeypatch.setattr(lifecycle, "_start_browser_cleanup_thread", lambda: None)
+        monkeypatch.setattr(lifecycle, "_update_session_activity", lambda task_id: None)
+        monkeypatch.setattr(cdp, "_ensure_cdp_supervisor", lambda task_id: None)
+        monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+        monkeypatch.setattr(cloud, "_auto_local_for_private_urls", lambda: True)
+        monkeypatch.setattr(cloud, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: True)
+        monkeypatch.setattr(browser_tool, "check_website_access", lambda url: None)
+        monkeypatch.setattr(browser_tool, "_maybe_start_recording", lambda task_id: None)
+        monkeypatch.setattr(session, "_run_browser_command", runner)
+        monkeypatch.setattr(browser_tool, "_get_min_available_mb", lambda: 350, raising=False)
+        monkeypatch.setattr(browser_tool, "_available_memory_mb", memory_probe, raising=False)
+        monkeypatch.setattr(cdp, "_get_cdp_override_raw", lambda: cdp._get_cdp_override())
+        return runner, memory_probe
+
+    def test_local_cold_start_blocked_at_low_memory(self, monkeypatch):
+        runner, memory_probe = self._patch_navigation_dependencies(monkeypatch)
+        monkeypatch.setattr(cdp, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(cloud, "_get_cloud_provider", lambda: None)
+
+        result = browser_tool.browser_navigate(
+            "https://example.com", task_id="local-task"
+        )
+
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "web_extract" in parsed["error"]
+        memory_probe.assert_called_once_with()
+        runner.assert_not_called()
+        assert "local-task" not in browser_tool._active_sessions
+
+    def test_cloud_session_not_blocked_at_low_memory(self, monkeypatch):
+        runner, memory_probe = self._patch_navigation_dependencies(monkeypatch)
+        provider = MagicMock()
+        provider.create_session.return_value = {
+            "session_name": "cloud-session",
+            "bb_session_id": "cloud-123",
+            "cdp_url": "wss://cloud.example/devtools/browser/abc",
+            "features": {"cloud": True},
+        }
+        monkeypatch.setattr(cdp, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(cloud, "_get_cloud_provider", lambda: provider)
+        monkeypatch.setattr(browser_tool, "_url_is_private", lambda url: False)
+
+        result = browser_tool.browser_navigate(
+            "https://example.com", task_id="cloud-task"
+        )
+
+        assert json.loads(result)["success"] is True
+        provider.create_session.assert_called_once_with("cloud-task")
+        memory_probe.assert_not_called()
+        runner.assert_any_call(
+            "cloud-task", "open", ["https://example.com"], timeout=ANY
+        )
+
+    def test_explicit_cdp_override_not_blocked_at_low_memory(self, monkeypatch):
+        runner, memory_probe = self._patch_navigation_dependencies(monkeypatch)
+        provider = MagicMock()
+        cdp_url = "ws://cdp.example/devtools/browser/abc"
+        monkeypatch.setattr(cdp, "_get_cdp_override", lambda: cdp_url)
+        monkeypatch.setattr(cloud, "_get_cloud_provider", lambda: provider)
+
+        result = browser_tool.browser_navigate(
+            "https://example.com", task_id="cdp-task"
+        )
+
+        assert json.loads(result)["success"] is True
+        provider.create_session.assert_not_called()
+        assert browser_tool._active_sessions["cdp-task"]["cdp_url"] == cdp_url
+        memory_probe.assert_not_called()
+        runner.assert_any_call(
+            "cdp-task", "open", ["https://example.com"], timeout=ANY
+        )
+
+    def test_hybrid_local_sidecar_blocked_at_low_memory(self, monkeypatch):
+        runner, memory_probe = self._patch_navigation_dependencies(monkeypatch)
+        provider = MagicMock()
+        monkeypatch.setattr(cdp, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(cloud, "_get_cloud_provider", lambda: provider)
+        monkeypatch.setattr(browser_tool, "_url_is_private", lambda url: True)
+        browser_tool._active_sessions["hybrid-task"] = {
+            "session_name": "cloud-session",
+            "bb_session_id": "cloud-123",
+            "cdp_url": "wss://cloud.example/devtools/browser/abc",
+            "features": {"cloud": True},
+        }
+
+        result = browser_tool.browser_navigate(
+            "http://localhost:3000", task_id="hybrid-task"
+        )
+
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "web_extract" in parsed["error"]
+        provider.create_session.assert_not_called()
+        memory_probe.assert_called_once_with()
+        runner.assert_not_called()
+        assert "hybrid-task" in browser_tool._active_sessions
+        assert "hybrid-task::local" not in browser_tool._active_sessions
+
+    def test_existing_local_session_reuse_allowed_at_low_memory(self, monkeypatch):
+        runner, memory_probe = self._patch_navigation_dependencies(monkeypatch)
+        monkeypatch.setattr(cdp, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(cloud, "_get_cloud_provider", lambda: None)
+        browser_tool._active_sessions["reuse-task"] = {
+            "session_name": "local-session",
+            "bb_session_id": None,
+            "cdp_url": None,
+            "features": {"local": True},
+            "_first_nav": False,
+        }
+
+        result = browser_tool.browser_navigate(
+            "https://example.com", task_id="reuse-task"
+        )
+
+        assert json.loads(result)["success"] is True
+        memory_probe.assert_not_called()
+        runner.assert_any_call(
+            "reuse-task", "open", ["https://example.com"], timeout=ANY
+        )

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2884,6 +2884,78 @@ def _redact_browser_output(value: Any) -> Any:
 # Browser Tool Functions
 # ============================================================================
 
+def _available_memory_mb(meminfo_path: str = "/proc/meminfo") -> Optional[int]:
+    """Best-effort MemAvailable (MB) from /proc/meminfo.
+
+    Returns None when unavailable (non-Linux hosts or any read error) so
+    callers fail open and browser behavior stays unchanged.
+    """
+    try:
+        with open(meminfo_path, "r", encoding="utf-8") as meminfo:
+            for line in meminfo:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) // 1024
+    except Exception:
+        return None
+    return None
+
+
+def _get_min_available_mb() -> int:
+    """Return ``browser.min_available_mb`` from config.yaml (0 = disabled).
+
+    Read on demand rather than cached: it is only consulted on a cold
+    browser start, and reading each time lets config edits take effect
+    without a gateway restart (read_raw_config is mtime-memoised).
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        val = cfg_get(cfg, "browser", "min_available_mb")
+        if val is not None:
+            return max(int(val), 0)
+    except Exception as e:
+        logger.debug("Could not read browser.min_available_mb from config: %s", e)
+    return 0
+
+
+def _cold_start_lowmem_error(nav_session_key: str, effective_task_id: str) -> Optional[str]:
+    """Return a refusal message when a COLD browser start should be blocked.
+
+    A cold start spawns Chromium, which needs roughly 300 to 400 MB. On a
+    small host (for example a 1 GB single-box VPS) that spike can OOM-kill
+    the gateway mid-task. When ``browser.min_available_mb`` is set above 0
+    and available memory is below it, refuse only the cold start and steer
+    the agent to the lighter fetch tools. Reusing an already-open session is
+    always allowed, and everything fails open (None) on any error.
+    """
+    try:
+        min_avail_mb = _get_min_available_mb()
+        if min_avail_mb <= 0:
+            return None
+        is_cold_start = (
+            nav_session_key not in _active_sessions
+            and effective_task_id not in _active_sessions
+        )
+        if not is_cold_start:
+            return None
+        avail_mb = _available_memory_mb()
+        if avail_mb is None or avail_mb >= min_avail_mb:
+            return None
+        logger.warning(
+            "browser_navigate: refusing cold browser start, %sMB free < %sMB "
+            "browser.min_available_mb",
+            avail_mb, min_avail_mb,
+        )
+        return (
+            f"Browser unavailable: only {avail_mb}MB RAM free (below the "
+            f"{min_avail_mb}MB browser.min_available_mb floor for launching "
+            f"Chromium safely on this host). Use web_extract to read this "
+            f"page's content, or web_search, instead of the browser."
+        )
+    except Exception:
+        return None
+
+
 def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     """
     Navigate to a URL in the browser.
@@ -2989,6 +3061,14 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             url,
             type(_get_cloud_provider()).__name__ if _get_cloud_provider() else "none",
         )
+
+    # Low-memory guard (``browser.min_available_mb`` in config.yaml, 0 =
+    # disabled): refuse a cold Chromium start on a memory-starved host so
+    # the launch spike cannot OOM-kill the gateway; session reuse is never
+    # blocked and any read error fails open.
+    _lowmem_error = _cold_start_lowmem_error(nav_session_key, effective_task_id)
+    if _lowmem_error is not None:
+        return json.dumps({"success": False, "error": _lowmem_error})
 
     # Get session info to check if this is a new session
     # (will create one with features logged if not exists)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2918,7 +2918,9 @@ def _get_min_available_mb() -> int:
     return 0
 
 
-def _cold_start_lowmem_error(nav_session_key: str, effective_task_id: str) -> Optional[str]:
+def _cold_start_lowmem_error(
+    session_info: Dict[str, Any], *, session_was_active: bool
+) -> Optional[str]:
     """Return a refusal message when a COLD browser start should be blocked.
 
     A cold start spawns Chromium, which needs roughly 300 to 400 MB. On a
@@ -2929,14 +2931,10 @@ def _cold_start_lowmem_error(nav_session_key: str, effective_task_id: str) -> Op
     always allowed, and everything fails open (None) on any error.
     """
     try:
+        if session_was_active or session_info.get("cdp_url"):
+            return None
         min_avail_mb = _get_min_available_mb()
         if min_avail_mb <= 0:
-            return None
-        is_cold_start = (
-            nav_session_key not in _active_sessions
-            and effective_task_id not in _active_sessions
-        )
-        if not is_cold_start:
             return None
         avail_mb = _available_memory_mb()
         if avail_mb is None or avail_mb >= min_avail_mb:
@@ -3062,17 +3060,26 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             type(_get_cloud_provider()).__name__ if _get_cloud_provider() else "none",
         )
 
-    # Low-memory guard (``browser.min_available_mb`` in config.yaml, 0 =
-    # disabled): refuse a cold Chromium start on a memory-starved host so
-    # the launch spike cannot OOM-kill the gateway; session reuse is never
-    # blocked and any read error fails open.
-    _lowmem_error = _cold_start_lowmem_error(nav_session_key, effective_task_id)
-    if _lowmem_error is not None:
-        return json.dumps({"success": False, "error": _lowmem_error})
-
     # Get session info to check if this is a new session
     # (will create one with features logged if not exists)
+    with _cleanup_lock:
+        session_was_active = nav_session_key in _active_sessions
     session_info = _get_session_info(nav_session_key)
+
+    # Apply the memory guard after session creation selects the actual backend.
+    # A CDP URL runs Chromium remotely, while a new session without one will
+    # launch local Chromium when the first browser command runs.
+    _lowmem_error = _cold_start_lowmem_error(
+        session_info, session_was_active=session_was_active
+    )
+    if _lowmem_error is not None:
+        if not session_was_active:
+            with _cleanup_lock:
+                if _active_sessions.get(nav_session_key) is session_info:
+                    _active_sessions.pop(nav_session_key, None)
+                    _session_last_activity.pop(nav_session_key, None)
+        return json.dumps({"success": False, "error": _lowmem_error})
+
     is_first_nav = session_info.get("_first_nav", True)
 
     # Auto-start recording if configured and this is first navigation

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -700,6 +700,76 @@ def _attach_auto_snapshot(response: Dict[str, Any], nav_session_key: str) -> Non
         logger.debug("Auto-snapshot after navigate failed: %s", e)
 
 
+def _available_memory_mb(meminfo_path: str = "/proc/meminfo") -> Optional[int]:
+    """Best-effort MemAvailable (MB) from /proc/meminfo.
+
+    Returns None when unavailable (non-Linux hosts or any read error) so
+    callers fail open and browser behavior stays unchanged.
+    """
+    try:
+        with open(meminfo_path, "r", encoding="utf-8") as meminfo:
+            for line in meminfo:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) // 1024
+    except Exception:
+        return None
+    return None
+
+
+def _get_min_available_mb() -> int:
+    """Return ``browser.min_available_mb`` from config.yaml (0 = disabled).
+
+    Read on demand rather than cached: it is only consulted on a cold
+    browser start, and reading each time lets config edits take effect
+    without a gateway restart (read_raw_config is mtime-memoised).
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        val = cfg_get(cfg, "browser", "min_available_mb")
+        if val is not None:
+            return max(int(val), 0)
+    except Exception as e:
+        logger.debug("Could not read browser.min_available_mb from config: %s", e)
+    return 0
+
+
+def _cold_start_lowmem_error(
+    session_info: Dict[str, Any], *, session_was_active: bool
+) -> Optional[str]:
+    """Return a refusal message when a COLD browser start should be blocked.
+
+    A cold start spawns Chromium, which needs roughly 300 to 400 MB. On a
+    small host (for example a 1 GB single-box VPS) that spike can OOM-kill
+    the gateway mid-task. When ``browser.min_available_mb`` is set above 0
+    and available memory is below it, refuse only the cold start and steer
+    the agent to the lighter fetch tools. Reusing an already-open session is
+    always allowed, and everything fails open (None) on any error.
+    """
+    try:
+        if session_was_active or session_info.get("cdp_url"):
+            return None
+        min_avail_mb = _get_min_available_mb()
+        if min_avail_mb <= 0:
+            return None
+        avail_mb = _available_memory_mb()
+        if avail_mb is None or avail_mb >= min_avail_mb:
+            return None
+        logger.warning(
+            "browser_navigate: refusing cold browser start, %sMB free < %sMB "
+            "browser.min_available_mb",
+            avail_mb, min_avail_mb,
+        )
+        return (
+            f"Browser unavailable: only {avail_mb}MB RAM free (below the "
+            f"{min_avail_mb}MB browser.min_available_mb floor for launching "
+            f"Chromium safely on this host). Use web_extract to read this "
+            f"page's content, or web_search, instead of the browser."
+        )
+    except Exception:
+        return None
+
+
 def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     """Navigate to ``url``; JSON with title, compact snapshot and, on first nav, stealth features.
     Hybrid routing decides BEFORE the safety checks whether this URL goes to a local sidecar
@@ -724,7 +794,23 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
                     "cloud for public URLs; set browser.auto_local_for_private_urls: false to disable)",
                     url, type(_cloud._get_cloud_provider()).__name__ if _cloud._get_cloud_provider() else "none")
 
+    with _cleanup_lock:
+        session_was_active = nav_session_key in _active_sessions
     session_info = _session._get_session_info(nav_session_key)
+
+    # Select the actual backend first: only a new session without CDP launches
+    # local Chromium, including a hybrid local sidecar beside a cloud session.
+    lowmem_error = _cold_start_lowmem_error(
+        session_info, session_was_active=session_was_active,
+    )
+    if lowmem_error is not None:
+        if not session_was_active:
+            with _cleanup_lock:
+                if _active_sessions.get(nav_session_key) is session_info:
+                    _active_sessions.pop(nav_session_key, None)
+                    _session_last_activity.pop(nav_session_key, None)
+        return json.dumps({"success": False, "error": lowmem_error})
+
     is_first_nav = session_info.get("_first_nav", True)
     if is_first_nav:
         session_info["_first_nav"] = False

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2017,6 +2017,7 @@ Configure browser automation behavior:
 browser:
   inactivity_timeout: 120        # Seconds before auto-closing idle sessions
   command_timeout: 30             # Timeout in seconds for browser commands (screenshot, navigate, etc.)
+  min_available_mb: 0            # Minimum available host RAM for a new local Chromium start (0 disables)
   record_sessions: false         # Auto-record browser sessions as WebM videos to ~/.hermes/browser_recordings/
   # Optional CDP override — when set, Hermes attaches directly to your own
   # Chromium-family browser (via /browser connect) rather than starting a headless browser.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2486,6 +2486,7 @@ Configure browser automation behavior:
 browser:
   inactivity_timeout: 120        # Seconds before auto-closing idle sessions
   command_timeout: 30             # Timeout in seconds for browser commands (screenshot, navigate, etc.)
+  min_available_mb: 0            # Minimum available host RAM for a new local Chromium start (0 disables)
   record_sessions: false         # Auto-record browser sessions as WebM videos to ~/.hermes/browser_recordings/
   # Optional CDP override — when set, Hermes attaches directly to your own
   # Chromium-family browser (via /browser connect) rather than starting a headless browser.


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in low memory guard for cold browser starts, configured in `config.yaml` as `browser.min_available_mb` (default 0 = disabled).

A cold `browser_navigate` spawns Chromium, which needs roughly 300 to 400 MB. On a small host (for example a 1 GB single-box VPS) that spike can OOM-kill the gateway in the middle of a task. With the guard enabled, a cold start below the floor is refused with a clear error that steers the agent to `web_extract` or `web_search`. Reusing an already-open browser session is never blocked.

This is a re-scope of #46494, which was closed per the standing `env-var-for-config` policy: the threshold now lives in `config.yaml` per the Contribution Rubric (behavioral settings belong in `config.yaml`, not new `HERMES_*` env vars), and the guard defaults to off so existing installs see no behavior change.

Cross-platform: available memory is read best-effort from `/proc/meminfo`. The helper returns `None` on non-Linux hosts or any read error, and the guard is skipped in that case (fail open), so the browser behaves exactly as before everywhere else.

## Related Issue

Re-scope of #46494 (closed per standing maintainer policy) onto the supported config surface.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/browser_tool.py`: `_available_memory_mb()` (best-effort MemAvailable read), `_get_min_available_mb()` (config read following the `_get_command_timeout` idiom), `_cold_start_lowmem_error()` (the guard decision, fail open on any error), and the guard call in `browser_navigate` just before session creation.
- `hermes_cli/config.py`: new `browser.min_available_mb` default (0 = disabled) with inline docs.
- `cli-config.yaml.example`: documented the new key in the browser section.
- `tests/tools/test_browser_lowmem_guard.py` (new, 13 tests): meminfo parsing, config read and negative-value clamping, the guard decision matrix (disabled / refused below floor / allowed with headroom / session reuse never blocked / unreadable memory fails open), and a `browser_navigate` wiring test asserting the refusal returns before any session is created.

## How to Test

1. `python -m pytest tests/tools/test_browser_lowmem_guard.py -q -o addopts=` (13 passed).
2. On a small Linux host, set `browser.min_available_mb: 350` in `config.yaml` and issue a cold `browser_navigate` while available memory is low: it returns the guard error and the agent falls back to the lighter fetch tools instead of OOM-killing the gateway.
3. With the key unset or 0, behavior is unchanged.

The guard logic itself has been running in production on a 1 GB single-box deployment since June (as a local patch): cold starts under memory pressure return the guard message and the agent completes the task with `web_extract`; with adequate memory the browser behaves normally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(browser):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (predecessor #46494 was mine and was closed for the env var surface this PR replaces)
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the targeted tests and they pass (13 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04 (1 GB OpenVZ VPS), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (inline config docs + `cli-config.yaml.example`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS): guard is skipped (fail open) where `/proc/meminfo` is unavailable
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A (refusal is an in-band tool error that already steers the agent)