### PR TITLE
fix(cli): don't replay transcript on the session's first benign SIGWINCH

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4350,9 +4350,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             new_width = None
         prev_width = getattr(self, "_last_resize_width", None)
-        # First resize of the session has no prior width to compare against;
-        # treat it as a change so an initial maximize/restore is covered too.
-        width_changed = new_width is not None and new_width != prev_width
+        # Replay only on an OBSERVED width change.  The first signal of a
+        # session must not count as one (#65293): GNOME Terminal and friends
+        # deliver benign SIGWINCHes (tab bar appearing, monitor-scale change,
+        # focus events), and a 2J+replay against preserved scrollback
+        # duplicates everything ``_OUTPUT_HISTORY`` holds — after a resume
+        # that is the entire "Previous Conversation" recap plus the first
+        # live exchange.  ``_install_resize_recovery`` seeds the baseline at
+        # startup, so an initial maximize/restore still differs from it and
+        # is still recovered; with no baseline (width probe failed) this
+        # signal just records one for the next comparison.
+        width_changed = (
+            new_width is not None
+            and prev_width is not None
+            and new_width != prev_width
+        )
         if width_changed:
             try:
                 self._clear_prompt_toolkit_screen(app, rebuild_scrollback=False)
@@ -4450,6 +4462,45 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             self._resize_recovery_pending = False
             self._recover_after_resize(app, original_on_resize)
+
+    def _install_resize_recovery(self, app) -> None:
+        """Route prompt_toolkit's ``_on_resize`` through the debounced
+        ghost-clearing recovery (#5474/#49120) and record the current terminal
+        width as the baseline for width-change detection.
+
+        Seeding the baseline here is what keeps the session's FIRST SIGWINCH
+        honest (#65293): ``_recover_after_resize`` replays the transcript only
+        on an observed width change, and without a startup baseline it could
+        not tell a benign signal (GNOME Terminal tab bar, monitor-scale
+        change) from a real one.  An initial maximize/restore still differs
+        from the seeded width, so it is still recovered.
+
+        The probe reads ``app.output`` directly — NOT
+        ``_get_tui_terminal_width`` — because this runs before ``app.run()``,
+        when ``get_app()`` still returns prompt_toolkit's DummyApplication
+        whose DummyOutput reports a hardcoded 80 columns; seeding that fake
+        width would make the first real signal look like a width change and
+        resurrect the duplicate-replay bug this exists to fix.
+        ``app.output`` is the same object the running app's resize handler
+        measures, so install-time and signal-time widths are comparable.
+        """
+        width = None
+        try:
+            width = app.output.get_size().columns
+        except Exception:
+            width = None
+        if not width or width <= 0:
+            try:
+                width = shutil.get_terminal_size((80, 24)).columns
+            except Exception:
+                width = None
+        self._last_resize_width = width
+        original_on_resize = app._on_resize
+
+        def _resize_clear_ghosts():
+            self._schedule_resize_recovery(app, original_on_resize)
+
+        app._on_resize = _resize_clear_ghosts
 
     def _status_bar_context_style(self, percent_used: Optional[int]) -> str:
         if percent_used is None:
@@ -15310,12 +15361,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # don't permanently freeze the input (issue #16263). Idempotent.
         _apply_bracketed_paste_timeout_patch()
 
-        _original_on_resize = app._on_resize
-
-        def _resize_clear_ghosts():
-            self._schedule_resize_recovery(app, _original_on_resize)
-
-        app._on_resize = _resize_clear_ghosts
+        self._install_resize_recovery(app)
 
         def spinner_loop():
             while not self._should_exit:

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -223,3 +223,119 @@ class TestForceFullRedraw:
         bare_cli._app = app
 
         bare_cli._force_full_redraw()  # must not raise
+
+
+class TestFirstSigwinchBaseline:
+    """Bug #65293: the session's FIRST SIGWINCH used to be force-treated as a
+    width change (no prior width to compare against), so a benign resize
+    signal — GNOME Terminal tab bar appearing, monitor-scale change, focus
+    events — cleared the viewport and replayed ``_OUTPUT_HISTORY``.  After a
+    resume that deque holds the whole "Previous Conversation" recap plus the
+    first live exchange, so everything reprinted as a duplicate.  A replay
+    must require an OBSERVED width change against a recorded baseline.
+    """
+
+    def test_first_sigwinch_with_unchanged_width_does_not_replay(
+        self, bare_cli, monkeypatch
+    ):
+        app = MagicMock()
+        events = []
+        app.renderer.output.erase_screen.side_effect = lambda: events.append("erase")
+        original_on_resize = lambda: events.append("original_resize")
+
+        bare_cli._status_bar_suppressed_after_resize = False
+        # No baseline recorded yet — the pre-fix code forced width_changed=True.
+        assert getattr(bare_cli, "_last_resize_width", None) is None
+        monkeypatch.setattr(bare_cli, "_get_tui_terminal_width", lambda: 120)
+        monkeypatch.setattr(bare_cli, "_schedule_status_bar_unsuppress", lambda *_: None)
+        monkeypatch.setattr(
+            cli_mod, "_replay_output_history", lambda: events.append("replay")
+        )
+
+        bare_cli._recover_after_resize(app, original_on_resize)
+
+        # Width did not change — no clear, no replay, straight to prompt_toolkit.
+        assert events == ["original_resize"]
+        app.renderer.output.erase_screen.assert_not_called()
+        # The signal still records the baseline for the next comparison.
+        assert bare_cli._last_resize_width == 120
+
+    def test_real_width_change_after_baseline_still_replays(
+        self, bare_cli, monkeypatch
+    ):
+        """The #49120 recovery (2J + replay) must still fire on a real change."""
+        app = MagicMock()
+        events = []
+        app.renderer.output.erase_screen.side_effect = lambda: events.append("erase")
+        original_on_resize = lambda: events.append("original_resize")
+
+        bare_cli._status_bar_suppressed_after_resize = False
+        bare_cli._last_resize_width = 120
+        monkeypatch.setattr(bare_cli, "_get_tui_terminal_width", lambda: 90)
+        monkeypatch.setattr(bare_cli, "_schedule_status_bar_unsuppress", lambda *_: None)
+        monkeypatch.setattr(
+            cli_mod, "_replay_output_history", lambda: events.append("replay")
+        )
+
+        bare_cli._recover_after_resize(app, original_on_resize)
+
+        assert "erase" in events and "replay" in events
+        assert bare_cli._last_resize_width == 90
+
+    def test_install_resize_recovery_seeds_width_baseline(self, bare_cli):
+        """Hook installation records the CURRENT width as the baseline, so an
+        initial maximize/restore (a real change vs that baseline) is still
+        recovered while a same-size first signal is not.
+
+        The baseline must come from ``app.output`` — the same object the
+        running app measures on SIGWINCH — not from ``get_app()``, which
+        before ``app.run()`` is a DummyApplication reporting a fake 80 cols.
+        """
+        app = MagicMock()
+        app.output.get_size.return_value.columns = 132
+        scheduled = []
+        bare_cli._schedule_resize_recovery = lambda *a, **k: scheduled.append(a)
+
+        original = app._on_resize
+        bare_cli._install_resize_recovery(app)
+
+        assert bare_cli._last_resize_width == 132
+        assert app._on_resize is not original  # hook installed
+        app._on_resize()  # simulated SIGWINCH → routes to the debouncer
+        assert len(scheduled) == 1
+        assert scheduled[0][0] is app
+        assert scheduled[0][1] is original
+
+    def test_install_resize_recovery_falls_back_to_shutil(
+        self, bare_cli, monkeypatch
+    ):
+        """A dead app.output probe falls back to shutil, never to the
+        DummyApplication's fake width."""
+        import os as os_mod
+
+        app = MagicMock()
+        app.output.get_size.side_effect = RuntimeError("not attached")
+        monkeypatch.setattr(
+            cli_mod.shutil,
+            "get_terminal_size",
+            lambda _default: os_mod.terminal_size((97, 40)),
+        )
+
+        bare_cli._install_resize_recovery(app)
+
+        assert bare_cli._last_resize_width == 97
+
+    def test_install_resize_recovery_survives_width_probe_failure(
+        self, bare_cli, monkeypatch
+    ):
+        app = MagicMock()
+        app.output.get_size.side_effect = RuntimeError("not attached")
+
+        def _boom(_default):
+            raise RuntimeError("no tty")
+
+        monkeypatch.setattr(cli_mod.shutil, "get_terminal_size", _boom)
+
+        bare_cli._install_resize_recovery(app)  # must not raise
+
+        assert getattr(bare_cli, "_last_resize_width", None) is None


### PR DESCRIPTION
## What

Stops the classic CLI from duplicating the entire resumed conversation after the session's first benign SIGWINCH, fixing #65293.

- **`cli.py`** — `_recover_after_resize` now replays the transcript only on an **observed** width change (`prev_width is not None and new_width != prev_width`); the hook installation is extracted into `_install_resize_recovery(app)`, which seeds the width baseline at startup.
- **`tests/cli/test_cli_force_redraw.py`** — new `TestFirstSigwinchBaseline` class: first-signal-same-width does not replay; real change after baseline still replays; baseline seeding (incl. the DummyOutput trap below); probe-failure fallbacks.

## Why — the actual mechanism (differs from the issue's suspicion)

The reporter suspected prompt_toolkit's renderer buffer. The real chain is Hermes's own resize recovery:

1. `--continue`/`--resume` seeds the "Previous Conversation" panel into `_OUTPUT_HISTORY` (`cli_agent_setup_mixin.py:688`) — by design, it's what Ctrl+L replays. The first live exchange is appended too (`_cprint` → `_record_output_history`).
2. `_recover_after_resize` treated the session's **first SIGWINCH as a width change** ("no prior width to compare against; treat it as a change"), running the Ctrl+L-style recovery: CSI **2J** viewport clear + full `_replay_output_history()`.
3. 2J preserves scrollback (deliberately — CSI 3J would destroy the startup banner), so the replay paints a **second copy** of everything below the still-visible original: recap panel, user message, and response — the exact reported symptom. GNOME Terminal delivers benign SIGWINCHes routinely (tab bar appearing, monitor-scale changes, fullscreen/focus transitions, font zoom), which is why "just sending a message" appears to trigger it.

Reproduced deterministically in a pty harness (fixed-size pty, mock OpenAI endpoint, seeded 112-message session): a clean send produces **no** duplication; injecting one SIGWINCH with **unchanged dimensions** produced CSI 2J 4 bytes later and a byte-exact second copy of the recap + exchange.

### The fix — and a subtle trap

Seed `_last_resize_width` when the resize hook is installed, and require an observed change to replay. One trap made the obvious version of this fix silently wrong: the baseline must be read from **`app.output`**, not `_get_tui_terminal_width()` — at install time (before `app.run()`) `get_app()` still returns prompt_toolkit's `DummyApplication`, whose `DummyOutput.get_size()` reports a hardcoded **80 columns**. Seeding that fake width turns the first real signal back into a phantom "width change". `app.output` is the same object the running app's resize handler measures, so install-time and signal-time widths are comparable.

A genuine initial maximize/restore still differs from the seeded baseline and is still recovered — the #49120 duplicated-status-bar fix is fully preserved.

## How to test

Automated:

```bash
scripts/run_tests.sh tests/cli/
```

End-to-end (performed, pty harness with a mock model and a resumed 112-message session):

| scenario | before fix | after fix |
|---|---|---|
| clean send, no SIGWINCH | no duplication | no duplication |
| benign SIGWINCH, size unchanged | **recap + exchange all duplicated** (CSI 2J + full replay) | no clear, no replay, everything exactly once |
| real resize 120→100 cols | 2J + replay (intended #49120 recovery) | 2J + replay — unchanged |

Manual repro from the issue: resume a 50+ message session in GNOME Terminal, send a message, toggle fullscreen or open a second tab (any benign WINCH) — previously duplicated everything; now stays clean. `Ctrl+L` behavior is untouched.

Known remaining trade-off (pre-existing, out of scope): on a **real** width change the replay still re-paints content that survives in scrollback — that's the deliberate #49120 trade-off and matches Ctrl+L semantics.

## Platforms tested

Linux (x86_64), GNOME-class terminal semantics simulated via pty. Change is pure Python signal/width bookkeeping — no platform-specific I/O.

Fixes #65293