### PR TITLE
fix: replace assert with RuntimeError in Google Meet realtime WebSocket client

### DIFF
--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -221,12 +221,14 @@ class RealtimeSession:
             return False
 
     def _send_json(self, payload: dict) -> None:
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket is not connected")
         with self._send_lock:
             self._ws.send(json.dumps(payload))
 
     def _recv(self, timeout: Optional[float] = None):
-        assert self._ws is not None
+        if self._ws is None:
+            raise RuntimeError("WebSocket is not connected")
         try:
             if timeout is None:
                 return self._ws.recv()


### PR DESCRIPTION
## Problem

2 `assert self._ws is not None` statements in `plugins/google_meet/realtime/openai_client.py` are stripped under `python -O`. If the WebSocket is None (disconnected or never opened), these methods crash with `AttributeError: NoneType object has no attribute send` instead of raising a clear error.

## Fix

Replace each `assert self._ws is not None` with:
```python
if self._ws is None:
    raise RuntimeError("WebSocket is not connected")
```

This is consistent with the sibling method `cancel_response()` which already handles `self._ws is None` gracefully (returns False).

## Lines Changed

| Line | Method | Issue |
|------|--------|-------|
| 224 | `_send_json()` | `assert self._ws is not None` before `self._ws.send()` |
| 229 | `_recv()` | `assert self._ws is not None` before `self._ws.recv()` |