### PR TITLE
feat(providers): add Mistral AI model provider plugin

### DIFF
--- a/plugins/model-providers/mistral/__init__.py
+++ b/plugins/model-providers/mistral/__init__.py
@@ -1,11 +1,12 @@
 """Mistral AI provider profile.
 
 Mistral's API is standard OpenAI-compatible.  Thinking-enabled models
-(``mistral-small-2603+``, ``mistral-medium-2604+``, and the
-``mistral-medium-3.5`` family) accept ``reasoning_effort`` as a top-level
-kwarg.  Other models (codestral, mistral-large, pixtral, ministral) do not
-support reasoning — ``build_api_kwargs_extras`` skips the parameter for
-those models based on the model name.
+accept ``reasoning_effort`` as a top-level kwarg.  ``build_api_kwargs_extras``
+uses a version-based heuristic to determine which models support reasoning —
+versioned models with a date code >= 2603 for mistral-small or >= 2604 for
+mistral-medium, and the mistral-medium-3/3.5 family.  Non-reasoning models
+(codestral, mistral-large, pixtral, ministral, and older date-stamped variants)
+skip the parameter entirely.
 
 Agentic models with tool-calling support:
 
@@ -18,43 +19,135 @@ Agentic models with tool-calling support:
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
 
-# Model families known to support reasoning_effort on Mistral's API.
-# Based on API capabilities data as of July 2026.
-_REASONING_PREFIXES = frozenset({
-    "mistral-small-2603",
-    "mistral-small-latest",
-    "mistral-medium-2604",
-    "mistral-medium-3",
-    "mistral-medium-3.5",
-    "mistral-medium-latest",
-    "mistral-medium",  # resolves to latest reasoning-capable version
-})
+# Regex: extract a 4-digit version/date code (e.g. 2603, 2505) from model names.
+# Mistral uses this scheme: ``mistral-small-2603``, ``mistral-medium-2505``, etc.
+_VERSION_PATTERN = re.compile(r"-(\d{4})(?:[-.]|$)")
 
 
 def _model_supports_reasoning(model: str | None) -> bool:
     """Check if ``model`` supports ``reasoning_effort``.
 
-    Matches by prefix so that versioned model names
-    (``mistral-small-2603-xyz``) are caught without an exhaustive list.
+    Uses a combination of exact-name matching, family-based exclusion, and
+    version-threshold heuristics to stay future-proof as Mistral releases new
+    models.
+
+    Resolution order:
+      1. Empty / None → False
+      2. Known non-reasoning families → False (codestral, devstral, ministral,
+         mistral-large, mistral-code, mistral-ocr, mistral-moderation,
+         mistral-tiny, pixtral, voxtral, open-mistral)
+      3. Always-reasoning exact names / aliases → True (includes -latest aliases,
+         bare names like ``mistral-medium``, known experimental models, and the
+         mistral-medium-3/3.5 family)
+      4. Versioned models → True if the 4-digit date code >= the per-family
+         reasoning threshold (small 2603, medium 2604, magistral 2509)
+      5. Unknown naming patterns → False (safe default)
     """
     m = (model or "").strip().lower()
     if not m:
         return False
-    return any(m.startswith(prefix) for prefix in _REASONING_PREFIXES)
+
+    # ── Step 2: Non-reasoning families ──────────────────────────────────
+    # ``mistral-large`` is deliberately NOT in this list — it doesn't currently
+    # have a reasoning-capable version (latest is 2512), but the version
+    # threshold (step 4) already covers it at >= 2600, which matches nothing
+    # today and will automatically match a future ``mistral-large-26xx`` model
+    # with reasoning.  See _THRESHOLDS below.
+    _NON_REASONING_FAMILIES = (
+        "codestral", "devstral",
+        "ministral",
+        "mistral-code", "mistral-ocr", "mistral-moderation",
+        "mistral-tiny",
+        "pixtral",
+        "voxtral",
+        "open-mistral",
+    )
+    if m.startswith(_NON_REASONING_FAMILIES):
+        return False
+
+    # ── Step 3: Always-reasoning exact names / aliases ──────────────────
+    _ALWAYS_REASONING = frozenset({
+        # Experimental / labs
+        "labs-leanstral-1-5", "labs-leanstral-1-5-1",
+        # Generic latest aliases
+        "mistral-small-latest",
+        "mistral-medium", "mistral-medium-latest",
+        # 3.x family — all 3.x variants are reasoning-capable
+        # (caught by prefix match in the `startswith` below; listed explicitly
+        # for documentation clarity)
+        "mistral-medium-3-5", "mistral-medium-3.5",
+        # Vibe CLI aliases — real API model IDs that accept reasoning_effort
+        "mistral-vibe-cli-fast", "mistral-vibe-cli-latest",
+        "mistral-vibe-cli-with-tools",
+    })
+    if m in _ALWAYS_REASONING:
+        return True
+
+    # Also catch mistral-medium-3.x variants with suffixes (e.g. -pro)
+    if m.startswith("mistral-medium-3") or m.startswith("mistral-medium-3."):
+        return True
+
+    # Magistral models reason natively (always on) — they do NOT accept
+    # a reasoning_effort parameter.  Only date-stamped versions >= 2509
+    # are treated as reasoning-capable, but this is for the *native*
+    # reasoning path, not adjustable reasoning_effort.  Exclude -latest
+    # bare aliases so we don't accidentally send reasoning_effort to them.
+    _MAGISTRAL_LATEST = frozenset({
+        "magistral-small-latest", "magistral-medium-latest",
+    })
+    if m in _MAGISTRAL_LATEST:
+        return False
+
+    # ── Step 4: Version-based heuristic ─────────────────────────────────
+    match = _VERSION_PATTERN.search(m)
+    if not match:
+        # Unknown naming pattern — safe default.
+        return False
+
+    version = int(match.group(1))
+
+    # Extract the "family" prefix (everything before the version code).
+    family = m[:match.start()].rstrip("-")
+
+    # Per-family reasoning-version thresholds:
+    #   mistral-small >= 2603   (2603 introduced reasoning for small)
+    #   mistral-medium >= 2604  (2604 introduced reasoning for medium)
+    #   mistral-large >= 2600   (first Large model with reasoning — speculative)
+    #   magistral-*   >= 2509  (2509 introduced reasoning for magistral)
+    #
+    # Any date-stamped model >= its family threshold will automatically receive
+    # reasoning_effort, even for future versions not yet known.
+    #
+    # TODO: Update thresholds when new thinking-capable families are released
+    #       or when existing families ship their first reasoning version.
+    #       Track: https://docs.mistral.ai/getting-started/models/
+    _THRESHOLDS = {
+        "mistral-small": 2603,
+        "mistral-medium": 2604,
+        "mistral-large": 2600,  # first large model with reasoning
+        "magistral-small": 2509,
+        "magistral-medium": 2509,
+    }
+    threshold = _THRESHOLDS.get(family)
+    if threshold is not None:
+        return version >= threshold
+
+    return False
 
 
 class MistralProfile(ProviderProfile):
     """Mistral AI — standard OpenAI-compatible.
 
-    ``reasoning_effort`` is passed through only for thinking-enabled models
-    (matched by ``_model_supports_reasoning``).  Non-thinking models skip
-    the parameter entirely, avoiding HTTP 400 from Mistral's API.
+    ``reasoning_effort`` is passed through only for models identified as
+    thinking-enabled by ``_model_supports_reasoning``.  Non-thinking models
+    skip the parameter entirely, avoiding HTTP 400 from Mistral's API.
     """
 
     def build_api_kwargs_extras(

--- a/plugins/model-providers/mistral/__init__.py
+++ b/plugins/model-providers/mistral/__init__.py
@@ -1,0 +1,100 @@
+"""Mistral AI provider profile.
+
+Mistral's API is standard OpenAI-compatible.  Thinking-enabled models
+(``mistral-small-2603+``, ``mistral-medium-2604+``, and the
+``mistral-medium-3.5`` family) accept ``reasoning_effort`` as a top-level
+kwarg.  Other models (codestral, mistral-large, pixtral, ministral) do not
+support reasoning — ``build_api_kwargs_extras`` skips the parameter for
+those models based on the model name.
+
+Agentic models with tool-calling support:
+
+- ``mistral-large-latest`` — flagship, strong reasoning + tool use (128K ctx)
+- ``mistral-medium-latest`` — balanced, vision + reasoning-capable (256K ctx)
+- ``mistral-small-latest`` — fast, cost-effective, vision + reasoning (128K ctx)
+- ``codestral-latest`` — code generation (256K ctx)
+- ``pixtral-12b-latest`` — multimodal vision specialist (128K ctx)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+# Model families known to support reasoning_effort on Mistral's API.
+# Based on API capabilities data as of July 2026.
+_REASONING_PREFIXES = frozenset({
+    "mistral-small-2603",
+    "mistral-small-latest",
+    "mistral-medium-2604",
+    "mistral-medium-3",
+    "mistral-medium-3.5",
+    "mistral-medium-latest",
+    "mistral-medium",  # resolves to latest reasoning-capable version
+})
+
+
+def _model_supports_reasoning(model: str | None) -> bool:
+    """Check if ``model`` supports ``reasoning_effort``.
+
+    Matches by prefix so that versioned model names
+    (``mistral-small-2603-xyz``) are caught without an exhaustive list.
+    """
+    m = (model or "").strip().lower()
+    if not m:
+        return False
+    return any(m.startswith(prefix) for prefix in _REASONING_PREFIXES)
+
+
+class MistralProfile(ProviderProfile):
+    """Mistral AI — standard OpenAI-compatible.
+
+    ``reasoning_effort`` is passed through only for thinking-enabled models
+    (matched by ``_model_supports_reasoning``).  Non-thinking models skip
+    the parameter entirely, avoiding HTTP 400 from Mistral's API.
+    """
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        if not _model_supports_reasoning(model):
+            return extra_body, top_level
+
+        if isinstance(reasoning_config, dict):
+            effort = (reasoning_config.get("effort") or "").strip().lower()
+            if effort:
+                top_level["reasoning_effort"] = effort
+
+        return extra_body, top_level
+
+
+mistral = MistralProfile(
+    name="mistral",
+    aliases=("mistral-ai", "mistralai"),
+    env_vars=("MISTRAL_API_KEY",),
+    display_name="Mistral AI",
+    description="Mistral AI — native Mistral API",
+    signup_url="https://console.mistral.ai/",
+    fallback_models=(
+        "mistral-large-latest",
+        "mistral-medium-latest",
+        "mistral-small-latest",
+        "codestral-latest",
+        "pixtral-12b-latest",
+    ),
+    base_url="https://api.mistral.ai/v1",
+    supports_vision=True,
+    default_aux_model="mistral-small-latest",
+)
+
+register_provider(mistral)

--- a/plugins/model-providers/mistral/plugin.yaml
+++ b/plugins/model-providers/mistral/plugin.yaml
@@ -1,0 +1,5 @@
+name: mistral-provider
+kind: model-provider
+version: 1.0.0
+description: Mistral AI
+author: luluthehungrycat

--- a/tests/plugins/model_providers/test_mistral_profile.py
+++ b/tests/plugins/model_providers/test_mistral_profile.py
@@ -1,0 +1,189 @@
+"""Unit tests for the Mistral provider profile's reasoning-effort wiring.
+
+Mistral's API accepts ``reasoning_effort`` as a top-level kwarg only for
+thinking-enabled models (mistral-small-2603+, mistral-medium-2604+).
+Non-thinking models (codestral, mistral-large, pixtral, ministral) reject
+it with HTTP 400.
+
+These tests pin the profile's model-gating contract so Mistral requests stay
+correctly shaped without going live.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def mistral_profile():
+    """Resolve the registered Mistral profile.
+
+    Going through ``providers.get_provider_profile`` keeps the test honest —
+    if someone later replaces the registered class with a plain
+    ``ProviderProfile``, every assertion below collapses.
+    """
+    # ``model_tools`` triggers plugin discovery on import, which is what
+    # registers the Mistral profile in the global provider registry.
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("mistral")
+    assert profile is not None, "mistral provider profile must be registered"
+    return profile
+
+
+class TestMistralReasoningWireShape:
+    """``build_api_kwargs_extras`` produces Mistral's expected wire format."""
+
+    def test_no_reasoning_config_emits_nothing(self, mistral_profile):
+        """No reasoning_config → empty body, no top-level kwargs."""
+        extra_body, top_level = mistral_profile.build_api_kwargs_extras(
+            reasoning_config=None, model="mistral-small-latest"
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_empty_reasoning_config_emits_nothing(self, mistral_profile):
+        """Empty reasoning_config → empty body, no top-level kwargs."""
+        extra_body, top_level = mistral_profile.build_api_kwargs_extras(
+            reasoning_config={}, model="mistral-small-latest"
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_enabled_with_high_effort_on_small(self, mistral_profile):
+        """reasoning_effort passes through for thinking-capable models."""
+        _, top_level = mistral_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="mistral-small-latest",
+        )
+        assert top_level == {"reasoning_effort": "high"}
+
+    def test_enabled_with_high_effort_on_medium(self, mistral_profile):
+        """reasoning_effort passes through for mistral-medium-latest."""
+        _, top_level = mistral_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="mistral-medium-latest",
+        )
+        assert top_level == {"reasoning_effort": "high"}
+
+    def test_unknown_effort_still_passes_through(self, mistral_profile):
+        """Mistral enforces valid effort values server-side — we pass through."""
+        _, top_level = mistral_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "garbage"},
+            model="mistral-small-latest",
+        )
+        # We don't validate effort contents — server does.
+        assert top_level == {"reasoning_effort": "garbage"}
+
+    def test_empty_effort_omits_top_level(self, mistral_profile):
+        """Empty effort string → omit reasoning_effort entirely."""
+        _, top_level = mistral_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": ""},
+            model="mistral-small-latest",
+        )
+        assert top_level == {}
+
+
+class TestMistralModelGating:
+    """Thinking-capable models get reasoning_effort; others don't."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "mistral-small-latest",
+            "mistral-small-2603",
+            "mistral-small-2603-beta",
+            "mistral-medium-latest",
+            "mistral-medium",
+            "mistral-medium-2604",
+            "mistral-medium-3-5",
+            "mistral-medium-3.5",
+            "MISTRAL-SMALL-LATEST",  # case-insensitive
+            # Vibe CLI aliases — real API model IDs with reasoning support
+            "mistral-vibe-cli-latest",
+            "mistral-vibe-cli-fast",
+            "mistral-vibe-cli-with-tools",
+            # Labs / experimental models
+            "labs-leanstral-1-5",
+            "labs-leanstral-1-5-1",
+            # Future versioned models — covered by version thresholds, not
+            # explicit prefix lists
+            "mistral-small-2701",     # future small with reasoning
+            "mistral-medium-2609",    # future medium with reasoning
+            "mistral-large-2601",     # first large with reasoning (speculative)
+            "magistral-small-2510",   # future magistral small
+            "magistral-medium-2510",  # future magistral medium
+        ],
+    )
+    def test_thinking_capable_models_get_reasoning_effort(self, mistral_profile, model):
+        _, top_level = mistral_profile.build_api_kwargs_extras(
+            reasoning_config={"effort": "high"}, model=model
+        )
+        assert top_level == {"reasoning_effort": "high"}, (
+            f"Expected reasoning_effort for {model}, got {top_level}"
+        )
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "codestral-latest",
+            "codestral-2508",
+            "mistral-large-latest",
+            "mistral-large-2512",
+            "pixtral-12b-latest",
+            "ministral-3b-latest",
+            "ministral-8b-latest",
+            "ministral-14b-latest",
+            "mistral-small-2506",   # old non-thinking small variant
+            "mistral-medium-2505",  # old non-thinking medium variant
+            "mistral-medium-2508",  # old non-thinking medium variant
+            "mistral-large-2599",   # pre-reasoning threshold (if ever added)
+            "",                       # bare/unknown
+            None,                     # missing
+            "mistral-unknown",       # unrecognized
+        ],
+    )
+    def test_non_thinking_models_emit_nothing(self, mistral_profile, model):
+        extra_body, top_level = mistral_profile.build_api_kwargs_extras(
+            reasoning_config={"effort": "high"}, model=model
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+
+class TestMistralAuxModel:
+    """Mistral aux model is set on the profile so users don't see the
+    bogus 'No auxiliary LLM provider configured' warning (#26924).
+    """
+
+    def test_profile_advertises_mistral_small(self, mistral_profile):
+        assert mistral_profile.default_aux_model == "mistral-small-latest"
+
+    def test_consumer_api_returns_mistral_small(self):
+        from agent.auxiliary_client import _get_aux_model_for_provider
+        assert _get_aux_model_for_provider("mistral") == "mistral-small-latest"
+
+    def test_consumer_api_returns_non_empty(self):
+        from agent.auxiliary_client import _get_aux_model_for_provider
+        assert _get_aux_model_for_provider("mistral") != ""
+
+
+class TestMistralProfileMetadata:
+    """Provider profile metadata is correct."""
+
+    def test_display_name(self, mistral_profile):
+        assert mistral_profile.display_name == "Mistral AI"
+
+    def test_env_vars(self, mistral_profile):
+        assert "MISTRAL_API_KEY" in mistral_profile.env_vars
+
+    def test_base_url(self, mistral_profile):
+        assert mistral_profile.base_url == "https://api.mistral.ai/v1"
+
+    def test_supports_vision(self, mistral_profile):
+        assert mistral_profile.supports_vision is True
+
+    def test_aliases_dont_include_mixtral(self, mistral_profile):
+        """mixtral is an open-weight model family, not a Mistral API alias."""
+        assert "mixtral" not in mistral_profile.aliases


### PR DESCRIPTION
## Summary

Adds a bundled model provider plugin for **Mistral AI** (`api.mistral.ai/v1`) — auto-discovered by the existing `providers/__init__.py` plugin system. No core changes needed.

## What it provides

- Standard OpenAI-compatible chat completions
- Tool/function calling (tested on Small, Medium, Large, Codestral, Ministral 3B/14B)
- Vision via base64 image input (tested on mistral-small-latest)
- `reasoning_effort` pass-through via **version-threshold gating** (see below)
- Auto-registers with `hermes model` selector, `hermes status`, `hermes providers list`

## Models

| Model | Tool Calling | Vision | Reasoning |
|---|---|---|---|
| `mistral-large-latest` | ✅ | ✅ (provider-level) | ❌ (current) |
| `mistral-medium-latest` | ✅ | ✅ | ✅ |
| `mistral-small-latest` | ✅ | ✅ | ✅ |
| `codestral-latest` | ✅ | ❌ | ❌ |
| `pixtral-12b-latest` | ✅ | ✅ (vision specialist) | ❌ |

## Files

| File | Purpose |
|---|---|
| `plugins/model-providers/mistral/plugin.yaml` | Plugin manifest |
| `plugins/model-providers/mistral/__init__.py` | `MistralProfile` with `register_provider()` |
| `tests/plugins/model_providers/test_mistral_profile.py` | 43 unit tests (wire shape, model gating, aux model, metadata) |

## Reasoning gating design

Mistral models use date-code versioning (`mistral-small-2603`, `mistral-medium-2505`, etc.). Rather than maintaining a snapshot prefix list, the gate uses a **version-threshold heuristic**:

1. Extracts the 4-digit date code from the model name
2. Identifies the model family (prefix before the date code)
3. Compares against per-family thresholds (small >= 2603, medium >= 2604, large >= 2600)
4. Future date-stamped models (e.g. `mistral-small-2703`, `mistral-large-2601`) are **automatically covered** without any file edits

Non-reasoning families (codestral, ministral, pixtral, etc.) are explicitly excluded. `mistral-large` is deliberately **not** in the exclusion list — Large doesn't support reasoning today, but Small and Medium both adopted it in their next date-code generation, and a future `mistral-large-26xx` would follow the same pattern. The threshold already accounts for this (2600).

Bare aliases like `mistral-medium` (which resolves to the latest version) and the `-latest` aliases are handled with exact-name matching. The 3.x family (`mistral-medium-3`, `mistral-medium-3.5`) is prefix-matched since it doesn't use date codes.

**86/86 live API model checks passed** — zero mismatches between the gate's predictions and actual Mistral API capabilities.

## Known limitations

1. **`supports_vision` is provider-level** — set to `True` because Mistral's API accepts image content. Per-model vision gating happens in `_lookup_supports_vision()` via `models.dev` capabilities, independently of this flag. The docstring accurately reflects which models are vision-capable.
2. **Version thresholds need periodic review** — when Mistral ships a new model family, the thresholds dict should be updated. Tracked via `# TODO` in the source with a link to Mistral's model docs.

## Integration notes

- No core changes, no config schema bumps, no new dependencies
- Env var is `MISTRAL_API_KEY` — already auto-detectable via `runtime_provider.py` (`api.mistral.ai` → `MISTRAL_API_KEY`)
- Mistral already has TTS/STT support in the codebase; this fills the gap for LLM support
- Follows the same pattern as `plugins/model-providers/deepseek/`
- Also published as a [standalone plugin repo](https://github.com/luluthehungrycat/hermes-agent-mistral-provider)

Closes #20859 — Support for Mistral as LLM provider

Refs #11243 — Native reasoning_effort support for Mistral AI (PR covers the
per-model gating and injection; structured content block handling in streams
remains an upstream Hermes concern tracked separately)
