### PR TITLE
fix(gateway): reconcile flood-controlled partial stream instead of duplicating the final reply

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20614,6 +20614,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_key or "?", _edit_err,
                         )
 
+            elif not _is_empty_sentinel and not _transformed and _sc is not None:
+                # Streaming may have put a partial message on screen (e.g. Telegram
+                # flood control disabled progressive edits mid-answer) without ever
+                # confirming final delivery, so none of the flags above are set and
+                # the normal final send would duplicate that partial. Reconcile by
+                # editing the existing message to the final content (finalize=True
+                # splits on overflow). Fails safe: any error falls through to send.
+                from gateway.stream_reconcile import should_reconcile_partial
+                if should_reconcile_partial(
+                    _final,
+                    failed=bool(response.get("failed")),
+                    transformed=_transformed,
+                    streamed=_streamed,
+                    previewed=_previewed,
+                    content_delivered=_content_delivered,
+                    already_sent=bool(getattr(_sc, "already_sent", False)),
+                    message_id=getattr(_sc, "message_id", None),
+                ):
+                    _rec_msg_id = _sc.message_id
+                    try:
+                        await _sc.adapter.edit_message(
+                            chat_id=source.chat_id,
+                            message_id=_rec_msg_id,
+                            content=response["final_response"],
+                            finalize=True,
+                        )
+                        response["already_sent"] = True
+                        logger.info(
+                            "Reconciled partial streamed message %s for session %s "
+                            "(streaming left a partial without confirming final "
+                            "delivery) instead of sending a duplicate.",
+                            _rec_msg_id, session_key or "?",
+                        )
+                    except Exception as _rec_err:
+                        logger.warning(
+                            "Partial-stream reconcile failed for session %s: %s; "
+                            "falling through to normal send.",
+                            session_key or "?", _rec_err,
+                        )
+
         # Schedule deletion of tracked temporary progress bubbles after the
         # final response lands. Failed runs skip this so bubbles remain as
         # breadcrumbs for the user to see what work happened. Only fires on

--- a/gateway/stream_reconcile.py
+++ b/gateway/stream_reconcile.py
@@ -1,0 +1,43 @@
+"""Decide whether a streamed reply already covered the final response, or left a
+partial message on screen that should be reconciled (edited) rather than re-sent.
+
+Extracted from gateway/run.py's post-stream suppression block so the decision is
+unit-testable. It fixes the Telegram flood-control duplication: when flood
+control disables progressive edits mid-answer, the stream consumer leaves a
+partial message on screen but never confirms final delivery, so none of the
+suppression flags (streamed / previewed / content_delivered) are set and the
+normal final send re-delivers the whole answer on top of the partial (a
+duplicate). When this returns True, the caller edits the existing partial to the
+final content (finalize=True splits on overflow) instead of sending a duplicate.
+"""
+
+
+def should_reconcile_partial(
+    final_response,
+    *,
+    failed,
+    transformed,
+    streamed,
+    previewed,
+    content_delivered,
+    already_sent,
+    message_id,
+):
+    """True when streaming put a partial message on screen (``already_sent`` and a
+    ``message_id``) but never confirmed final delivery, so the final response
+    should be reconciled by editing that message rather than sent fresh.
+
+    Returns False for the normal cases so existing suppress/send behavior is
+    untouched:
+      - empty/"(empty)" final, or a failed run (the final must reach the user fresh);
+      - transformed responses (handled by the dedicated edit branch above it);
+      - deliveries already confirmed (streamed / previewed / content_delivered);
+      - nothing actually put on screen (no message to reconcile).
+    """
+    if not final_response or final_response == "(empty)" or failed:
+        return False
+    if transformed:
+        return False
+    if streamed or previewed or content_delivered:
+        return False
+    return bool(already_sent and message_id)

--- a/tests/gateway/test_stream_reconcile.py
+++ b/tests/gateway/test_stream_reconcile.py
@@ -1,0 +1,44 @@
+from gateway.stream_reconcile import should_reconcile_partial
+
+# A partial is on screen (already_sent + message_id) and NO delivery flag is set:
+# the exact flood-control duplication scenario.
+BASE = dict(
+    failed=False,
+    transformed=False,
+    streamed=False,
+    previewed=False,
+    content_delivered=False,
+    already_sent=True,
+    message_id="123",
+)
+
+
+def test_reconcile_when_partial_on_screen_but_delivery_unconfirmed():
+    assert should_reconcile_partial("Full answer", **BASE) is True
+
+
+def test_no_reconcile_when_delivery_already_confirmed():
+    for flag in ("streamed", "previewed", "content_delivered"):
+        kw = dict(BASE)
+        kw[flag] = True
+        assert should_reconcile_partial("Full answer", **kw) is False, flag
+
+
+def test_no_reconcile_when_nothing_on_screen():
+    kw = dict(BASE)
+    kw["already_sent"] = False
+    assert should_reconcile_partial("Full answer", **kw) is False
+    kw = dict(BASE)
+    kw["message_id"] = None
+    assert should_reconcile_partial("Full answer", **kw) is False
+
+
+def test_no_reconcile_for_empty_failed_or_transformed():
+    assert should_reconcile_partial("", **BASE) is False
+    assert should_reconcile_partial("(empty)", **BASE) is False
+    kw = dict(BASE)
+    kw["failed"] = True
+    assert should_reconcile_partial("Full answer", **kw) is False
+    kw = dict(BASE)
+    kw["transformed"] = True
+    assert should_reconcile_partial("Full answer", **kw) is False


### PR DESCRIPTION
## What does this PR do?

Fixes a Telegram duplicate-delivery bug in the gateway's post-stream path.

When Telegram flood control disables progressive streaming edits mid answer (the stream consumer's flood-strike limit), the consumer leaves a partial message on screen but never confirms final delivery. None of the post-stream suppression flags (`streamed`, `previewed`, `content_delivered`) are set, so the normal final send re-delivers the entire answer on top of the visible partial. The user sees a truncated reply, then the whole reply again once the flood-control wait expires.

This PR reconciles instead of re-sending: when the final response is ready and a partial is on screen (`already_sent` with a `message_id`) but delivery was never confirmed, the gateway edits the existing streamed message to the final content (`finalize=True`, which splits on overflow) and marks the response delivered. The decision predicate lives in a new pure module, `gateway/stream_reconcile.should_reconcile_partial`, so it is unit-testable. Any edit failure logs a warning and falls through to the existing send path, so the worst case is exactly today's behavior.

Observed live on a production gateway: a 6,375 char reply had progressive edits disabled after repeated RetryAfter strikes, the partial stayed on screen, and the final send duplicated the full answer (split, plain) roughly 3 minutes later after an 82s flood wait. With this change the partial is edited into the final reply and no duplicate is sent.

## Relationship to existing work

- #48648 (merged) fixed the mid-stream overflow re-split flood, but not this path: it governs preview edits during streaming, while this bug is at the post-stream final send.
- #50965 and #55869 (open) improve Telegram adapter/consumer behavior under RetryAfter (cooldown honoring, tail-only fallback on finalized edits). This PR sits at a different layer: the platform-agnostic post-stream decision in `gateway/run.py`. It covers the case those paths cannot see, when edits were disabled mid-turn and no finalized edit is attempted at all. They compose: adapter-level improvements reduce how often the partial scenario arises, and this reconcile stops the duplication when it does.

## Related Issue

None filed; root-caused from live gateway logs. Happy to open one if that helps tracking.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/stream_reconcile.py` (new): `should_reconcile_partial(...)`, a pure predicate that returns True only when a partial is on screen and delivery was never confirmed. It returns False for empty, failed, transformed, and already-delivered cases so all existing suppress/send behavior is untouched.
- `gateway/run.py`: after the existing transformed-response edit branch, a guarded branch that edits the streamed partial into the final response and sets `already_sent`, with warning + fall-through to the normal send on any error.
- `tests/gateway/test_stream_reconcile.py` (new): the reconcile case plus the negative matrix (each delivery-confirmed flag, nothing on screen, empty/failed/transformed).

## How to Test

1. `python -m pytest tests/gateway/test_stream_reconcile.py -q -o addopts=` (4 passed).
2. Live repro: stream a long reply into a Telegram chat under flood control so progressive edits are disabled mid-turn (repeated RetryAfter until the consumer's strike limit). On main, the visible partial is followed by a full duplicate send after the flood wait; with this patch, the partial is edited into the final reply.

Running in production on a single-box deployment since late June; long flood-controlled replies no longer duplicate.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (closest are #50965 and #55869; see the relationship section above)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the targeted tests and they pass (4 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04 (1 GB OpenVZ VPS), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation: N/A (internal delivery behavior, docstrings included)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS): platform-agnostic gateway logic, no OS-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A