### PR TITLE
fix(toolsets): coerce string-typed toolset lists instead of iterating characters

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -170,9 +170,13 @@ def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     ordinary agent runs (#25752 — LLM-supplied enabled_toolsets was widening
     past config.yaml's denylist).
     """
+    from toolsets import normalize_toolset_spec
+
     disabled = ["cronjob", "messaging", "clarify"]
     agent_cfg = (cfg or {}).get("agent") or {}
-    user_disabled = agent_cfg.get("disabled_toolsets") or []
+    # normalize_toolset_spec repairs a string-typed config value that would
+    # otherwise be iterated per character here (#61264, #61265).
+    user_disabled = normalize_toolset_spec(agent_cfg.get("disabled_toolsets")) or []
     for name in user_disabled:
         name = str(name).strip()
         if name and name not in disabled:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2456,8 +2456,16 @@ def _get_platform_tools(
     # globally suppress specific toolsets (e.g. "memory") across all
     # platforms without per-platform toolset configuration.  This runs
     # last so it overrides everything above.
+    # A string value here must be repaired rather than iterated: `hermes config
+    # set agent.disabled_toolsets web` writes the bare scalar `web` (the setter
+    # only auto-coerces bool/int/float), and iterating that subtracts
+    # {'w','e','b'} — matching no toolset, so the globally disabled toolset
+    # stays enabled. That is the same denylist bypass #25752 closed, arriving
+    # through the CLI instead of a per-job override (#61264, #61265).
+    from toolsets import normalize_toolset_spec
+
     agent_cfg = config.get("agent") or {}
-    disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
+    disabled_toolsets = normalize_toolset_spec(agent_cfg.get("disabled_toolsets")) or []
     if disabled_toolsets:
         disabled_set = {str(ts) for ts in disabled_toolsets}
         enabled_toolsets -= disabled_set

--- a/model_tools.py
+++ b/model_tools.py
@@ -30,7 +30,7 @@ import time
 from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import discover_builtin_tools, registry, tool_error
-from toolsets import resolve_toolset, validate_toolset
+from toolsets import normalize_toolset_spec, resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
 
@@ -309,6 +309,12 @@ def get_tool_definitions(
     Returns:
         Filtered list of OpenAI-format tool definitions.
     """
+    # Repair string-typed toolset lists before anything (including the cache
+    # key) sees them: a YAML-quoted `disabled_toolsets: '["web"]'` otherwise
+    # iterates per character, silently disabling nothing (#61264, #61265).
+    enabled_toolsets = normalize_toolset_spec(enabled_toolsets)
+    disabled_toolsets = normalize_toolset_spec(disabled_toolsets)
+
     # Fast path: memoized result when the caller doesn't need stdout prints.
     # The cache key captures every argument-level input; the registry
     # generation captures registry mutations (MCP refresh, plugin load).

--- a/tests/test_toolset_spec_coercion.py
+++ b/tests/test_toolset_spec_coercion.py
@@ -1,0 +1,96 @@
+"""String-typed toolset lists must be coerced, not iterated per character.
+
+A YAML-quoted string (``disabled_toolsets: '["web", "browser"]'``) or bare
+scalar (``disabled_toolsets: web``) in config.yaml reaches consumers as a
+Python string. Iterating it yields characters, matches no toolset, and the
+denylist is silently ignored — the full tool schema set is then sent on every
+model call (#61264, #61265).
+"""
+
+import logging
+
+import model_tools
+from cron.scheduler import _resolve_cron_disabled_toolsets
+from toolsets import normalize_toolset_spec
+
+
+class TestNormalizeToolsetSpec:
+    def test_none_passthrough(self):
+        assert normalize_toolset_spec(None) is None
+
+    def test_list_passthrough(self):
+        assert normalize_toolset_spec(["web", "browser"]) == ["web", "browser"]
+
+    def test_tuple_becomes_list(self):
+        assert normalize_toolset_spec(("web",)) == ["web"]
+
+    def test_json_string_decodes(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="toolsets"):
+            assert normalize_toolset_spec('["web", "browser"]') == ["web", "browser"]
+        assert "configured as the string" in caplog.text
+
+    def test_bare_scalar_string(self):
+        assert normalize_toolset_spec("web") == ["web"]
+
+    def test_comma_separated_string(self):
+        assert normalize_toolset_spec("web, browser") == ["web", "browser"]
+
+    def test_malformed_json_falls_back_to_comma_split(self):
+        # Unbalanced bracket: json.loads fails; names are still recovered.
+        assert normalize_toolset_spec('["web", "browser"') == ["web", "browser"]
+
+    def test_quoted_names_in_comma_form(self):
+        assert normalize_toolset_spec("'web', \"browser\"") == ["web", "browser"]
+
+
+class TestModelToolsStringCoercion:
+    def test_string_disabled_toolsets_equals_list_form(self):
+        as_list = {
+            t["function"]["name"]
+            for t in model_tools.get_tool_definitions(
+                disabled_toolsets=["terminal", "file"], quiet_mode=True
+            )
+        }
+        as_yaml_string = {
+            t["function"]["name"]
+            for t in model_tools.get_tool_definitions(
+                disabled_toolsets='["terminal", "file"]', quiet_mode=True
+            )
+        }
+        assert as_yaml_string == as_list
+        # And the disable actually took: unfiltered catalog is strictly larger.
+        everything = {
+            t["function"]["name"]
+            for t in model_tools.get_tool_definitions(quiet_mode=True)
+        }
+        assert as_yaml_string < everything
+
+    def test_string_enabled_toolsets_equals_list_form(self):
+        as_list = {
+            t["function"]["name"]
+            for t in model_tools.get_tool_definitions(
+                enabled_toolsets=["terminal"], quiet_mode=True
+            )
+        }
+        as_string = {
+            t["function"]["name"]
+            for t in model_tools.get_tool_definitions(
+                enabled_toolsets="terminal", quiet_mode=True
+            )
+        }
+        assert as_string == as_list
+
+
+class TestCronDisabledToolsetsStringCoercion:
+    def test_string_config_yields_names_not_characters(self):
+        cfg = {"agent": {"disabled_toolsets": '["web", "browser"]'}}
+        disabled = _resolve_cron_disabled_toolsets(cfg)
+        assert "web" in disabled
+        assert "browser" in disabled
+        # No single-character garbage from per-char iteration.
+        assert not any(len(name) == 1 for name in disabled)
+
+    def test_list_config_unchanged(self):
+        cfg = {"agent": {"disabled_toolsets": ["web"]}}
+        disabled = _resolve_cron_disabled_toolsets(cfg)
+        assert disabled == ["cronjob", "messaging", "clarify", "web"]

--- a/tests/test_toolset_spec_coercion.py
+++ b/tests/test_toolset_spec_coercion.py
@@ -94,3 +94,46 @@ class TestCronDisabledToolsetsStringCoercion:
         cfg = {"agent": {"disabled_toolsets": ["web"]}}
         disabled = _resolve_cron_disabled_toolsets(cfg)
         assert disabled == ["cronjob", "messaging", "clarify", "web"]
+
+
+class TestPlatformToolsDisabledToolsetsStringCoercion:
+    """The global denylist must hold for the shape `hermes config set` writes.
+
+    ``hermes config set agent.disabled_toolsets web`` stores the bare scalar
+    ``web``: the setter only auto-coerces bool/int/float, so a name stays a
+    string. ``_get_platform_tools`` then subtracted ``{'w','e','b'}``, which
+    matches no toolset, and the disabled toolset stayed enabled — the same
+    denylist bypass #25752 closed, reached through the CLI rather than a
+    per-job override. This resolver feeds gateway setup and prompt-size.
+    """
+
+    BASE = {"platform_toolsets": {"cli": ["web", "file"]}}
+
+    def _resolve(self, disabled):
+        from hermes_cli.tools_config import _get_platform_tools
+
+        cfg = dict(self.BASE, agent={"disabled_toolsets": disabled})
+        return _get_platform_tools(cfg, "cli")
+
+    def test_bare_string_disables_the_toolset(self):
+        """The `hermes config set` shape — regression for the bypass."""
+        assert "web" not in self._resolve("web")
+
+    def test_json_string_disables_the_toolset(self):
+        assert "web" not in self._resolve('["web"]')
+
+    def test_string_and_list_agree(self):
+        """String input must resolve identically to the equivalent list."""
+        assert self._resolve("web") == self._resolve(["web"])
+
+    def test_list_config_unchanged(self):
+        """The documented shape keeps working — no behaviour change for it."""
+        resolved = self._resolve(["web"])
+        assert "web" not in resolved
+        assert "file" in resolved
+
+    def test_absent_key_leaves_toolsets_enabled(self):
+        from hermes_cli.tools_config import _get_platform_tools
+
+        resolved = _get_platform_tools(dict(self.BASE), "cli")
+        assert {"web", "file"} <= resolved

--- a/toolsets.py
+++ b/toolsets.py
@@ -889,6 +889,54 @@ def get_toolset_names() -> List[str]:
     return sorted(names)
 
 
+def normalize_toolset_spec(value) -> Optional[List[str]]:
+    """Coerce a toolset list that arrived as a string back into a list.
+
+    ``agent.enabled_toolsets`` / ``agent.disabled_toolsets`` written as a
+    YAML-quoted string (``disabled_toolsets: '["web", "browser"]'``) or a
+    bare scalar (``disabled_toolsets: web``) parse as a Python *string*.
+    Every consumer then iterates it character by character, matching no
+    toolset — the denylist is silently ignored and the full tool schema set
+    is sent on every model call (#61264, #61265).
+
+    Returns ``None`` for ``None``, a list of names for list/tuple/set input,
+    and for a string input: the JSON-decoded list when the string looks like
+    one, otherwise the comma-split names. String coercion logs a warning so
+    the config mistake is visible instead of silent.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple, set)):
+        return [str(name) for name in value]
+    if isinstance(value, str):
+        import json
+        import logging
+
+        stripped = value.strip()
+        parsed = None
+        if stripped.startswith("["):
+            try:
+                decoded = json.loads(stripped)
+                if isinstance(decoded, list):
+                    parsed = [str(name) for name in decoded]
+            except ValueError:
+                parsed = None
+        if parsed is None:
+            # Comma-split fallback also covers near-JSON like '[web, browser]'
+            # (unquoted names) and malformed JSON — strip brackets and quotes
+            # per part so the intended names are still recovered.
+            parsed = [
+                part.strip().strip("[]").strip("'\"")
+                for part in stripped.split(",")
+                if part.strip().strip("[]").strip("'\"")
+            ]
+        logging.getLogger(__name__).warning(
+            "Toolset list was configured as the string %r — interpreting it as %s. "
+            "Use a YAML list instead, e.g. disabled_toolsets: [web, browser].",
+            value, parsed,
+        )
+        return parsed
+    return [str(name) for name in value]
 
 
 def validate_toolset(name: str) -> bool:


### PR DESCRIPTION
## What does this PR do?

Repairs string-typed `enabled_toolsets` / `disabled_toolsets` config values instead of silently iterating them character by character.

When `agent.disabled_toolsets` in `config.yaml` is written as a YAML-quoted string:

```yaml
disabled_toolsets: '["web", "browser"]'   # or:  disabled_toolsets: web
```

it parses as a Python **string**, every consumer iterates it per character (`[`, `"`, `w`, `e`, …), no character matches a toolset, and the denylist is **silently ignored** — the full tool schema set is sent on every model call. That's the request-size blowup reported against NVIDIA NIM (#61264) and a contributor to the multi-minute local-model prefill stalls in #61265.

Reproduced on current `main` (306e2d231, Linux, minimal env):

```
no disable         : 35 tools
proper list        : 24 tools
YAML-quoted string : 35 tools   ← denylist silently ignored
plain string "web" : 35 tools   ← same
```

**Approach.** One shared helper, `toolsets.normalize_toolset_spec()`, applied at the two places every consumer flows through, rather than guards at each config read site:

1. **`model_tools.get_tool_definitions()`** — the funnel all tool-schema construction passes through (CLI, gateway, desktop, prompt_size, ACP). Normalization happens **before** the memo cache key is built; the cache key was also being poisoned with `frozenset('["web"...')` character sets.
2. **`cron/scheduler._resolve_cron_disabled_toolsets()`** — merges the raw config value into the cron policy denylist *before* the funnel, so it needs its own repair (per-char iteration there appends character garbage to the policy list).

The helper JSON-decodes strings that look like lists, falls back to comma-splitting (also recovering near-JSON like `'[web, browser]'`), and **logs a warning** naming the misconfiguration — silence was the sting here.

Credit: @kyssta-exe diagnosed the type confusion in #61324 (closed as stale). This PR takes a different implementation route — funnel + cron choke points instead of per-call-site guards — so gateway/desktop/cron paths and the memo cache are covered too.

## Related Issue

Fixes #61264. Addresses the tool-schema-blowup contributor to #61265.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `toolsets.py` — new `normalize_toolset_spec()` helper (JSON decode → comma-split fallback → warning log)
- `model_tools.py` — normalize both toolset args at the top of `get_tool_definitions()`, before the memo cache key
- `cron/scheduler.py` — normalize `agent.disabled_toolsets` in `_resolve_cron_disabled_toolsets()` before merging into the policy denylist
- `tests/test_toolset_spec_coercion.py` — 12 regression tests: helper unit tests (None/list/tuple/JSON-string/bare/comma/malformed/quoted forms), `get_tool_definitions` string≡list equivalence for both args, cron policy-list repair

## How to Test

1. `pytest tests/test_toolset_spec_coercion.py -q` — 12 passed
2. `pytest tests/test_toolsets.py tests/test_model_tools.py tests/cron/ -q` — all pass
3. Manual repro: `get_tool_definitions(disabled_toolsets='["web", "browser"]', quiet_mode=True)` now returns the same 24-tool set as the proper list form (was 35), with a warning naming the bad config value.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — the closed #61324 addressed the same confusion at three call sites; no open PR covers it
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CachyOS Linux (Arch), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings; N/A otherwise
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python string handling, no platform surface
