### PR TITLE
fix(agent): create built-in memory store when memory toolset is enabled despite skip_memory (#65429)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1374,7 +1374,14 @@ def init_agent(
     agent._memory_nudge_interval = 10
     agent._turns_since_memory = 0
     agent._iters_since_skill = 0
-    if not skip_memory:
+    # A flush/background agent may pass skip_memory=True to avoid spinning up an
+    # external memory *provider*, but if the caller also explicitly enables the
+    # "memory" toolset it still needs the built-in file-backed store — otherwise
+    # the memory tool dispatches with store=None and every call fails (#65429).
+    # So the built-in store is created unless memory is globally disabled, while
+    # the external-provider block below stays gated on skip_memory.
+    _memory_toolset_requested = "memory" in (agent.enabled_toolsets or [])
+    if not skip_memory or _memory_toolset_requested:
         try:
             mem_config = _agent_cfg.get("memory", {})
             agent._memory_enabled = mem_config.get("memory_enabled", False)

--- a/tests/agent/test_skip_memory_store_65429.py
+++ b/tests/agent/test_skip_memory_store_65429.py
@@ -1,0 +1,65 @@
+"""Regression test for issue #65429.
+
+An agent built with ``skip_memory=True`` AND ``enabled_toolsets=["memory"]``
+used to get a memory tool wired to ``store=None`` (the built-in
+``MemoryStore`` was skipped along with the external provider), so every
+memory call failed silently and the main auto-capture path was dead.
+
+The fix creates the built-in store whenever memory is enabled in config OR the
+memory toolset is explicitly enabled, while the external-provider block stays
+gated on ``skip_memory``.
+"""
+
+import pytest
+
+from run_agent import AIAgent
+
+
+class _FakeOpenAI:
+    def __init__(self, **kw):
+        self.api_key = kw.get("api_key", "test")
+        self.base_url = kw.get("base_url", "http://test")
+
+    def close(self):
+        pass
+
+
+def _make_agent(monkeypatch, enabled_toolsets=None, skip_memory=True):
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+    return AIAgent(
+        api_key="test-key",
+        base_url="http://test",
+        provider="openrouter",
+        api_mode="chat_completions",
+        max_iterations=1,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=skip_memory,
+        enabled_toolsets=enabled_toolsets,
+    )
+
+
+def test_skip_memory_with_memory_toolset_creates_store(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hm"))
+    agent = _make_agent(monkeypatch, enabled_toolsets=["memory"], skip_memory=True)
+    assert agent._memory_store is not None, (
+        "memory toolset enabled despite skip_memory=True must still build "
+        "the built-in store (#65429)"
+    )
+
+
+def test_skip_memory_without_memory_toolset_has_no_store(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hm"))
+    agent = _make_agent(monkeypatch, enabled_toolsets=None, skip_memory=True)
+    assert agent._memory_store is None, (
+        "flush/background agent with skip_memory and no memory toolset must "
+        "have no built-in store"
+    )
+
+
+def test_memory_toolset_without_skip_memory_creates_store(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hm"))
+    agent = _make_agent(monkeypatch, enabled_toolsets=["memory"], skip_memory=False)
+    assert agent._memory_store is not None


### PR DESCRIPTION
## Summary
Fixes #65429 — agents built with `skip_memory=True` **and** `enabled_toolsets=["memory"]` exposed a memory tool that always failed (`store=None`), silently disabling the main automatic memory-capture path.

## Root cause
`agent/agent_init.py` gated creation of the built-in file-backed `MemoryStore` on `if not skip_memory:`. The `skip_memory` flag was intended to skip the *external memory provider* for flush/background agents, but it also suppressed the built-in store. When the caller still enables the `memory` toolset, `agent/agent_runtime_helpers.py:2318` / `agent/tool_executor.py:1305` build the memory tool with `store=agent._memory_store` → `None`, and every call returns "Memory is not available."

## Fix
The built-in store is now created whenever memory is enabled in config **OR** the `memory` toolset is explicitly enabled. The external-provider block below stays gated on `skip_memory`, preserving the flush-agent's intent (no external provider).

## Test plan
- [ ] Construct an agent with `skip_memory=True, enabled_toolsets=["memory"]`; confirm `agent._memory_store` is a `MemoryStore`, not `None`.
- [ ] Flush/background agents without the memory toolset behave as before (no store, no external provider).
