### PR TITLE
fix: replace assert with RuntimeError in codex_app_server_session.py (2 sites)

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -397,7 +397,8 @@ class CodexAppServerSession:
             # turn re-spawns cleanly.
             result.should_retire = True
             return result
-        assert self._client is not None and self._thread_id is not None
+        if self._client is None or self._thread_id is None:
+            raise RuntimeError("Codex app-server client or thread_id not initialized")
         result.thread_id = self._thread_id
 
         self._interrupt_event.clear()
@@ -658,7 +659,8 @@ class CodexAppServerSession:
             result.should_retire = True
             return result
 
-        assert self._client is not None and self._thread_id is not None
+        if self._client is None or self._thread_id is None:
+            raise RuntimeError("Codex app-server client or thread_id not initialized")
         result.thread_id = self._thread_id
         self._interrupt_event.clear()
         projector = CodexEventProjector()


### PR DESCRIPTION
## Problem

2 `assert self._client is not None and self._thread_id is not None` statements in `agent/transports/codex_app_server_session.py` are stripped under `python -O`. If the startup error path somehow fails to return, the code proceeds with `self._client = None`, causing `AttributeError` on `self._client.request()`.

## Fix

Replace each assert with:
```python
if self._client is None or self._thread_id is None:
    raise RuntimeError("Codex app-server client or thread_id not initialized")
```

## Lines Changed

| Line | Method | Context |
|------|--------|---------|
| 400 | `_run_turn()` | After startup error handling, before `self._client.request()` |
| 661 | `_compact_thread()` | After startup error handling, before `self._client.request()` |