### PR TITLE
fix(gateway): deliver voice clips from every assistant segment of a turn

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17259,8 +17259,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if response:
                     _media_adapter = self._adapter_for_source(source)
                     if _media_adapter:
+                        # Deliver media from EVERY assistant segment of this
+                        # turn, not just the final response. A turn that voices
+                        # an answer reveal and then the next question emits two
+                        # [[audio_as_voice]] clips across a tool call boundary;
+                        # scanning only the final segment silently dropped all
+                        # but the last clip.
+                        # select_turn_messages refuses the slice when the
+                        # reported turn boundary is ambiguous (compaction
+                        # re-baselines history_offset to 0), in which case
+                        # collect_turn_media_text falls back to the final
+                        # response and behaviour is unchanged.
+                        from gateway.turn_media import (
+                            collect_turn_media_text,
+                            select_turn_messages,
+                        )
+                        _turn_msgs = select_turn_messages(
+                            agent_messages,
+                            agent_result.get("history_offset"),
+                            history,
+                        )
+                        _media_text = collect_turn_media_text(_turn_msgs, response)
                         await self._deliver_media_from_response(
-                            response, event, _media_adapter,
+                            _media_text, event, _media_adapter,
                         )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1708,7 +1708,7 @@ class GatewayTurnMixin:
 
     async def _hmwa_deliver_turn_response(
         self, event, source, session_entry, session_key, run_generation,
-        agent_result, agent_messages, response, _footer_line, _intentional_silence,
+        agent_result, agent_messages, response, _footer_line, _intentional_silence, media_history,
     ):
         """Final delivery decisions: intentional silence, voice reply, streamed-turn media/footer.
         Returns the text for the adapter to send, or ``None`` when already delivered."""
@@ -1731,7 +1731,15 @@ class GatewayTurnMixin:
         # skip when the agent failed: the error text is new content streaming didn't show.
         if agent_result.get("already_sent") and not agent_result.get("failed"):
             if response and adapter:
-                await self._deliver_media_from_response(response, event, adapter)
+                from gateway.turn_media import collect_turn_media_text, select_turn_messages
+                # Collect every assistant segment only when the turn boundary is
+                # trustworthy. Compaction can rebase it to zero while retaining
+                # prior-turn clips; that case keeps final-response-only delivery.
+                turn_messages = select_turn_messages(
+                    agent_messages, agent_result.get("history_offset"), media_history,
+                )
+                media_text = collect_turn_media_text(turn_messages, response)
+                await self._deliver_media_from_response(media_text, event, adapter)
             # Streaming delivered the body, but the footer was held back (`not already_sent` gate).
             if _footer_line and adapter:
                 try:
@@ -1960,6 +1968,9 @@ class GatewayTurnMixin:
             # Admission/typing is not execution. All routing, authorization and
             # turn preparation gates have passed when the agent runner is entered.
             event._heartbeat_execution_started = True
+            # Preserve the incoming boundary even if the run or persistence mutates
+            # history in place. Only its pre-turn emptiness decides whether zero is safe.
+            media_history = list(history)
             agent_result = await self._run_agent(
                 message=message_text, context_prompt=prepared.context_prompt, history=history, source=source,
                 session_id=_run_start_session_id, session_key=session_key,
@@ -2015,7 +2026,7 @@ class GatewayTurnMixin:
             )
             return await self._hmwa_deliver_turn_response(
                 event, source, session_entry, session_key, run_generation,
-                agent_result, agent_messages, response, _footer_line, _intentional_silence,
+                agent_result, agent_messages, response, _footer_line, _intentional_silence, media_history,
             )
 
         except Exception as e:

--- a/gateway/turn_media.py
+++ b/gateway/turn_media.py
@@ -1,0 +1,64 @@
+"""Collect every MEDIA:/[[audio_as_voice]] tag emitted across one agent turn.
+
+The gateway streams an agent turn as several assistant segments split by
+tool calls. Post-stream media delivery historically scanned only the final
+response segment, so when a turn emitted more than one audio clip (for
+example, an answer reveal voiced just before the next question), only the
+last clip was delivered and the earlier ones were silently dropped.
+
+``collect_turn_media_text`` joins the content of every assistant segment in
+the turn so all clips are delivered, falling back to the final response when
+no assistant segments are available.
+"""
+
+
+def select_turn_messages(agent_messages, history_offset, history):
+    """Return this turn's messages, or ``[]`` when the boundary is ambiguous.
+
+    ``history_offset`` is normally a real slice point into ``agent_messages``.
+    It is not trustworthy on its own: split and in-place compaction
+    deliberately re-baseline it to 0 while ``agent_messages`` holds the whole
+    compacted transcript, and the compressor retains copied tail messages. A 0
+    offset next to a non-empty incoming ``history`` is therefore
+    indistinguishable from a genuine first turn, and slicing from it would
+    rescan retained prior-turn segments and replay their attachments.
+
+    Refusing the slice in that case is deliberately conservative: the caller
+    falls back to the final response alone, which is the behaviour that
+    shipped before multi-segment collection existed.
+    """
+    if not isinstance(agent_messages, list):
+        return []
+    if not isinstance(history_offset, int) or isinstance(history_offset, bool):
+        return []
+    if not 0 <= history_offset <= len(agent_messages):
+        return []
+    if history_offset == 0 and history:
+        return []
+    return agent_messages[history_offset:]
+
+
+def collect_turn_media_text(turn_messages, fallback_response=""):
+    """Join every assistant segment of the turn (or fall back to the final).
+
+    Callers pass this turn's messages (``agent_messages`` sliced from
+    ``history_offset``). That slice is only turn-local when the offset is
+    trustworthy: after split or in-place compaction the gateway deliberately
+    reports ``history_offset=0`` while ``messages`` holds the compacted
+    transcript, so the slice can still contain retained prior-turn segments.
+    Replay is prevented by the caller, which passes an empty ``turn_messages``
+    whenever the boundary is ambiguous (offset 0 with a non-empty incoming
+    history); this function then falls back to the final response alone.
+    """
+    parts = []
+    for message in turn_messages or []:
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") != "assistant":
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and content.strip():
+            parts.append(content)
+    if not parts:
+        return fallback_response or ""
+    return "\n".join(parts)

--- a/tests/gateway/test_turn_media.py
+++ b/tests/gateway/test_turn_media.py
@@ -1,0 +1,218 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from gateway.turn_media import collect_turn_media_text, select_turn_messages
+
+
+def _voiced(text):
+    media, _ = BasePlatformAdapter.extract_media(text)
+    return [p for p, is_voice in media if is_voice]
+
+
+def test_collects_every_voice_clip_emitted_across_a_turn():
+    # A quiz turn reveals the previous answer (clip 1) then asks the next
+    # question (clip 2). The two MEDIA tags live in separate assistant
+    # segments split by a tool call, so scanning only the final segment
+    # drops the reveal clip. collect_turn_media_text must surface BOTH.
+    turn_messages = [
+        {"role": "assistant", "content": "David goes with bronze censers. The answer is the mirrors of the women."},
+        {"role": "tool", "content": "tts ok reveal"},
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/reveal.ogg Yentl, your next question."},
+        {"role": "tool", "content": "tts ok question"},
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/question.ogg"},
+    ]
+    final_response = "[[audio_as_voice]] MEDIA:/cache/question.ogg"
+    voiced = _voiced(collect_turn_media_text(turn_messages, final_response))
+    assert "/cache/reveal.ogg" in voiced
+    assert "/cache/question.ogg" in voiced
+
+
+def test_does_not_duplicate_the_final_clip():
+    turn_messages = [
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/a.ogg next"},
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/b.ogg"},
+    ]
+    voiced = _voiced(collect_turn_media_text(turn_messages, "[[audio_as_voice]] MEDIA:/cache/b.ogg"))
+    assert voiced.count("/cache/a.ogg") == 1
+    assert voiced.count("/cache/b.ogg") == 1
+
+
+def test_falls_back_to_final_response_when_no_assistant_segments():
+    assert collect_turn_media_text([], "final text") == "final text"
+    assert collect_turn_media_text(None, "final text") == "final text"
+
+
+def test_selects_the_turn_local_slice_on_a_normal_continuing_turn():
+    messages = [
+        {"role": "assistant", "content": "older turn"},
+        {"role": "user", "content": "next question please"},
+        {"role": "assistant", "content": "current turn"},
+    ]
+    assert select_turn_messages(messages, 2, ["some", "history"]) == [
+        {"role": "assistant", "content": "current turn"}
+    ]
+
+
+def test_selects_everything_on_a_genuine_first_turn():
+    messages = [{"role": "assistant", "content": "first ever reply"}]
+    assert select_turn_messages(messages, 0, []) == messages
+    assert select_turn_messages(messages, 0, None) == messages
+
+
+def test_refuses_the_slice_when_compaction_rebaselined_the_offset():
+    # Split / in-place compaction reports history_offset=0 while the message
+    # list is the compacted transcript, so offset 0 next to a non-empty
+    # incoming history must NOT be treated as a start-of-turn boundary.
+    messages = [
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/old.ogg"},
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/new.ogg"},
+    ]
+    assert select_turn_messages(messages, 0, [{"role": "user", "content": "earlier"}]) == []
+
+
+def test_refuses_malformed_offsets():
+    messages = [{"role": "assistant", "content": "a"}]
+    assert select_turn_messages(messages, -1, []) == []
+    assert select_turn_messages(messages, 99, []) == []
+    assert select_turn_messages(messages, "2", []) == []
+    assert select_turn_messages(messages, None, []) == []
+    assert select_turn_messages("not a list", 0, []) == []
+
+
+def test_compacted_turn_does_not_replay_an_old_clip():
+    # End to end over both helpers: with an ambiguous boundary the caller gets
+    # the final response only, so the retained older clip is never delivered.
+    messages = [
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/old.ogg"},
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/new.ogg"},
+    ]
+    final_response = "[[audio_as_voice]] MEDIA:/cache/new.ogg"
+    turn_messages = select_turn_messages(messages, 0, [{"role": "user", "content": "earlier"}])
+    voiced = _voiced(collect_turn_media_text(turn_messages, final_response))
+    assert "/cache/old.ogg" not in voiced
+    assert voiced == ["/cache/new.ogg"]
+
+
+# The integration cases below run the same composition the gateway call site
+# uses (select_turn_messages -> collect_turn_media_text ->
+# _deliver_media_from_response) through the REAL delivery method, so they pin
+# the wiring rather than the helpers alone.
+
+
+def _event():
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123CHAN",
+        chat_type="group",
+        thread_id=None,
+    )
+    return MessageEvent(
+        text="hi",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="171.000001",
+    )
+
+
+def _fake_runner():
+    return SimpleNamespace(
+        _thread_metadata_for_source=lambda source, anchor=None: {},
+        _reply_anchor_for_event=lambda event: None,
+    )
+
+
+def _adapter():
+    return SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="imgs")),
+    )
+
+
+def _clips(tmp_path, monkeypatch, *names):
+    root = tmp_path / "media-cache"
+    root.mkdir(parents=True, exist_ok=True)
+    made = []
+    for name in names:
+        clip = root / name
+        clip.write_bytes(b"ogg")
+        made.append(clip.resolve())
+    monkeypatch.setattr(
+        "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+        (root,),
+    )
+    return made
+
+
+def _delivered_voice_paths(adapter):
+    return [call.kwargs["audio_path"] for call in adapter.send_voice.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_every_turn_clip_reaches_the_real_delivery_method(tmp_path, monkeypatch):
+    """The bug this PR fixes: a reveal clip and a next-question clip emitted in
+    separate assistant segments must BOTH be uploaded, not just the last."""
+    reveal, question = _clips(tmp_path, monkeypatch, "reveal.ogg", "question.ogg")
+    adapter = _adapter()
+    agent_messages = [
+        {"role": "user", "content": "next question"},
+        {"role": "assistant", "content": f"[[audio_as_voice]] MEDIA:{reveal}"},
+        {"role": "tool", "content": "tts ok"},
+        {"role": "assistant", "content": f"[[audio_as_voice]] MEDIA:{question}"},
+    ]
+    final_response = f"[[audio_as_voice]] MEDIA:{question}"
+
+    turn_messages = select_turn_messages(agent_messages, 0, [])
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(),
+        collect_turn_media_text(turn_messages, final_response),
+        _event(),
+        adapter,
+    )
+
+    delivered = _delivered_voice_paths(adapter)
+    assert str(reveal) in delivered
+    assert str(question) in delivered
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_boundary_delivers_only_the_final_clip(tmp_path, monkeypatch):
+    """With a compaction-rebaselined offset the retained older clip must not be
+    re-uploaded, so delivery falls back to the final response alone."""
+    old, new = _clips(tmp_path, monkeypatch, "old.ogg", "new.ogg")
+    adapter = _adapter()
+    agent_messages = [
+        {"role": "assistant", "content": f"[[audio_as_voice]] MEDIA:{old}"},
+        {"role": "assistant", "content": f"[[audio_as_voice]] MEDIA:{new}"},
+    ]
+    final_response = f"[[audio_as_voice]] MEDIA:{new}"
+
+    turn_messages = select_turn_messages(
+        agent_messages, 0, [{"role": "user", "content": "earlier"}]
+    )
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(),
+        collect_turn_media_text(turn_messages, final_response),
+        _event(),
+        adapter,
+    )
+
+    delivered = _delivered_voice_paths(adapter)
+    assert delivered == [str(new)]

--- a/tests/gateway/test_turn_media.py
+++ b/tests/gateway/test_turn_media.py
@@ -1,0 +1,274 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+try:
+    from gateway.turn_media import collect_turn_media_text, select_turn_messages
+except ModuleNotFoundError:  # permits the real turn-path regression on upstream
+    collect_turn_media_text = select_turn_messages = None
+
+
+def _voiced(text):
+    media, _ = BasePlatformAdapter.extract_media(text)
+    return [p for p, is_voice in media if is_voice]
+
+
+def test_collects_every_voice_clip_emitted_across_a_turn():
+    # A quiz turn reveals the previous answer (clip 1) then asks the next
+    # question (clip 2). The two MEDIA tags live in separate assistant
+    # segments split by a tool call, so scanning only the final segment
+    # drops the reveal clip. collect_turn_media_text must surface BOTH.
+    turn_messages = [
+        {"role": "assistant", "content": "David goes with bronze censers. The answer is the mirrors of the women."},
+        {"role": "tool", "content": "tts ok reveal"},
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/reveal.ogg Yentl, your next question."},
+        {"role": "tool", "content": "tts ok question"},
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/question.ogg"},
+    ]
+    final_response = "[[audio_as_voice]] MEDIA:/cache/question.ogg"
+    voiced = _voiced(collect_turn_media_text(turn_messages, final_response))
+    assert "/cache/reveal.ogg" in voiced
+    assert "/cache/question.ogg" in voiced
+
+
+def test_does_not_duplicate_the_final_clip():
+    turn_messages = [
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/a.ogg next"},
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/b.ogg"},
+    ]
+    voiced = _voiced(collect_turn_media_text(turn_messages, "[[audio_as_voice]] MEDIA:/cache/b.ogg"))
+    assert voiced.count("/cache/a.ogg") == 1
+    assert voiced.count("/cache/b.ogg") == 1
+
+
+def test_falls_back_to_final_response_when_no_assistant_segments():
+    assert collect_turn_media_text([], "final text") == "final text"
+    assert collect_turn_media_text(None, "final text") == "final text"
+
+
+def test_selects_the_turn_local_slice_on_a_normal_continuing_turn():
+    messages = [
+        {"role": "assistant", "content": "older turn"},
+        {"role": "user", "content": "next question please"},
+        {"role": "assistant", "content": "current turn"},
+    ]
+    assert select_turn_messages(messages, 2, ["some", "history"]) == [
+        {"role": "assistant", "content": "current turn"}
+    ]
+
+
+def test_selects_everything_on_a_genuine_first_turn():
+    messages = [{"role": "assistant", "content": "first ever reply"}]
+    assert select_turn_messages(messages, 0, []) == messages
+    assert select_turn_messages(messages, 0, None) == messages
+
+
+def test_refuses_the_slice_when_compaction_rebaselined_the_offset():
+    # Split / in-place compaction reports history_offset=0 while the message
+    # list is the compacted transcript, so offset 0 next to a non-empty
+    # incoming history must NOT be treated as a start-of-turn boundary.
+    messages = [
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/old.ogg"},
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/new.ogg"},
+    ]
+    assert select_turn_messages(messages, 0, [{"role": "user", "content": "earlier"}]) == []
+
+
+def test_refuses_malformed_offsets():
+    messages = [{"role": "assistant", "content": "a"}]
+    assert select_turn_messages(messages, -1, []) == []
+    assert select_turn_messages(messages, 99, []) == []
+    assert select_turn_messages(messages, "2", []) == []
+    assert select_turn_messages(messages, None, []) == []
+    assert select_turn_messages("not a list", 0, []) == []
+
+
+def test_compacted_turn_does_not_replay_an_old_clip():
+    # End to end over both helpers: with an ambiguous boundary the caller gets
+    # the final response only, so the retained older clip is never delivered.
+    messages = [
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/old.ogg"},
+        {"role": "assistant", "content": "[[audio_as_voice]] MEDIA:/cache/new.ogg"},
+    ]
+    final_response = "[[audio_as_voice]] MEDIA:/cache/new.ogg"
+    turn_messages = select_turn_messages(messages, 0, [{"role": "user", "content": "earlier"}])
+    voiced = _voiced(collect_turn_media_text(turn_messages, final_response))
+    assert "/cache/old.ogg" not in voiced
+    assert voiced == ["/cache/new.ogg"]
+
+
+# The integration cases below run the same composition the gateway call site
+# uses (select_turn_messages -> collect_turn_media_text ->
+# _deliver_media_from_response) through the REAL delivery method, so they pin
+# the wiring rather than the helpers alone.
+
+
+def _event():
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123CHAN",
+        chat_type="group",
+        thread_id=None,
+    )
+    return MessageEvent(
+        text="hi",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="171.000001",
+    )
+
+
+def _fake_runner():
+    return SimpleNamespace(
+        _thread_metadata_for_source=lambda source, anchor=None: {},
+        _reply_anchor_for_event=lambda event: None,
+    )
+
+
+def _adapter():
+    return SimpleNamespace(
+        name="test",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=BasePlatformAdapter.extract_images,
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send_voice=AsyncMock(return_value=SendResult(success=True, message_id="voice")),
+        send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc")),
+        send_image_file=AsyncMock(return_value=SendResult(success=True, message_id="image")),
+        send_video=AsyncMock(return_value=SendResult(success=True, message_id="video")),
+        send_multiple_images=AsyncMock(return_value=SendResult(success=True, message_id="imgs")),
+    )
+
+
+def _clips(tmp_path, monkeypatch, *names):
+    root = tmp_path / "media-cache"
+    root.mkdir(parents=True, exist_ok=True)
+    made = []
+    for name in names:
+        clip = root / name
+        clip.write_bytes(b"ogg")
+        made.append(clip.resolve())
+    monkeypatch.setattr(
+        "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+        (root,),
+    )
+    return made
+
+
+def _delivered_voice_paths(adapter):
+    return [call.kwargs["audio_path"] for call in adapter.send_voice.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_every_turn_clip_reaches_the_real_delivery_method(tmp_path, monkeypatch):
+    """The bug this PR fixes: a reveal clip and a next-question clip emitted in
+    separate assistant segments must BOTH be uploaded, not just the last."""
+    reveal, question = _clips(tmp_path, monkeypatch, "reveal.ogg", "question.ogg")
+    adapter = _adapter()
+    agent_messages = [
+        {"role": "user", "content": "next question"},
+        {"role": "assistant", "content": f"[[audio_as_voice]] MEDIA:{reveal}"},
+        {"role": "tool", "content": "tts ok"},
+        {"role": "assistant", "content": f"[[audio_as_voice]] MEDIA:{question}"},
+    ]
+    final_response = f"[[audio_as_voice]] MEDIA:{question}"
+
+    turn_messages = select_turn_messages(agent_messages, 0, [])
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(),
+        collect_turn_media_text(turn_messages, final_response),
+        _event(),
+        adapter,
+    )
+
+    delivered = _delivered_voice_paths(adapter)
+    assert str(reveal) in delivered
+    assert str(question) in delivered
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_boundary_delivers_only_the_final_clip(tmp_path, monkeypatch):
+    """With a compaction-rebaselined offset the retained older clip must not be
+    re-uploaded, so delivery falls back to the final response alone."""
+    old, new = _clips(tmp_path, monkeypatch, "old.ogg", "new.ogg")
+    adapter = _adapter()
+    agent_messages = [
+        {"role": "assistant", "content": f"[[audio_as_voice]] MEDIA:{old}"},
+        {"role": "assistant", "content": f"[[audio_as_voice]] MEDIA:{new}"},
+    ]
+    final_response = f"[[audio_as_voice]] MEDIA:{new}"
+
+    turn_messages = select_turn_messages(
+        agent_messages, 0, [{"role": "user", "content": "earlier"}]
+    )
+    await GatewayRunner._deliver_media_from_response(
+        _fake_runner(),
+        collect_turn_media_text(turn_messages, final_response),
+        _event(),
+        adapter,
+    )
+
+    delivered = _delivered_voice_paths(adapter)
+    assert delivered == [str(new)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("had_history", [False, True])
+async def test_turn_delivery_uses_history_from_before_the_run(tmp_path, monkeypatch, had_history):
+    """Mutation during a run must not turn compaction into a fresh-turn boundary."""
+    old, reveal, question = _clips(tmp_path, monkeypatch, "old.ogg", "reveal.ogg", "question.ogg")
+    event, adapter = _event(), _adapter()
+    entry = SimpleNamespace(session_id="fixture-session")
+    history = [{"role": "user", "content": "earlier"}] if had_history else []
+    messages = [
+        {"role": "assistant", "content": f"[[audio_as_voice]] MEDIA:{path}"}
+        for path in ([old, reveal, question] if had_history else [reveal, question])
+    ]
+    response = messages[-1]["content"]
+    result = {"already_sent": True, "history_offset": 0, "messages": messages,
+              "final_response": response}
+    runner = object.__new__(GatewayRunner)
+    prepared = runner._PreparedTurn(history, "", "next question", None, None, None)
+    monkeypatch.setattr(runner, "_hmwa_resolve_session", AsyncMock(return_value=(event.source, entry, "fixture-key")))
+    monkeypatch.setattr(runner, "_hmwa_prepare_turn", AsyncMock(return_value=(prepared, None)))
+    runner.hooks = SimpleNamespace(emit=AsyncMock())
+
+    async def run_agent(**kwargs):
+        if had_history:
+            kwargs["history"].clear()
+        else:
+            kwargs["history"].append({"role": "user", "content": "current turn"})
+        return result
+
+    monkeypatch.setattr(runner, "_run_agent", run_agent)
+    monkeypatch.setattr(runner, "_hmwa_stop_typing_for_turn", AsyncMock())
+    monkeypatch.setattr(runner, "_is_session_run_current", lambda *a: True)
+    monkeypatch.setattr(runner, "_hmwa_shape_agent_response", AsyncMock(return_value=(response, False, messages)))
+    monkeypatch.setattr(runner, "_hmwa_prepend_reasoning", lambda result, response, *a: response)
+    monkeypatch.setattr(runner, "_hmwa_runtime_footer_line", lambda *a: "")
+    monkeypatch.setattr(runner, "_hmwa_post_turn_hooks", AsyncMock())
+    monkeypatch.setattr(runner, "_hmwa_classify_turn_failure", lambda *a: (False, False, False))
+    monkeypatch.setattr(runner, "_hmwa_compression_exhaustion_reset", AsyncMock(return_value=(response, entry)))
+    monkeypatch.setattr(runner, "_hmwa_persist_turn_transcript", AsyncMock())
+    monkeypatch.setattr(runner, "_clear_session_env", lambda *a: None)
+    monkeypatch.setattr(runner, "_adapter_for_source", lambda *a: adapter)
+    monkeypatch.setattr(runner, "_should_send_voice_reply", lambda *a, **k: False)
+    monkeypatch.setattr(runner, "_thread_metadata_for_source", lambda *a: {})
+    monkeypatch.setattr(runner, "_reply_anchor_for_event", lambda *a: None)
+    error_reply = AsyncMock()
+    monkeypatch.setattr(runner, "_hmwa_agent_error_reply", error_reply)
+
+    await runner._handle_message_with_agent(event, event.source, "fixture-key", 1)
+
+    error_reply.assert_not_awaited()
+    expected = [str(question)] if had_history else [str(reveal), str(question)]
+    assert _delivered_voice_paths(adapter) == expected


### PR DESCRIPTION
## What does this PR do?

Fixes silently dropped voice clips when one agent turn emits more than one `[[audio_as_voice]] MEDIA:` tag.

The gateway runs an agent turn as several assistant segments split by tool calls. The post-stream media delivery path (`_deliver_media_from_response`, called when streaming has `already_sent` the text) scans only the final `response` segment. So when a turn voices an answer and then a follow-up (for example a quiz host revealing the previous answer, then asking the next question, each as its own TTS clip across a tool call boundary), every clip except the last is dropped: the text streams live, but the earlier audio never reaches the chat.

The fix joins the content of every assistant segment of the current turn before extracting media, via a new adapter-agnostic helper, `gateway/turn_media.collect_turn_media_text`. The slice starts at `agent_result["history_offset"]` (the same boundary the surrounding code already uses for this turn's messages) and never reaches into prior-turn history, so media from earlier turns can never be replayed. When no assistant segments are available it falls back to the final response, which is exactly today's behavior.

Observed live: a group voice quiz where the host's answer-reveal clips repeatedly never arrived while the question clips did, because both were emitted in the same turn and only the final segment was scanned. With this change every clip in the turn is delivered, in order.

## Related Issue

None filed; root-caused from live gateway logs and session history. Happy to open one if useful.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/turn_media.py` (new): `collect_turn_media_text(turn_messages, fallback_response)`, joins this turn's assistant segment contents, ignores non-dict and non-assistant entries, falls back to the final response when the turn slice is empty or unavailable.
- `gateway/run.py`: the `already_sent` media-delivery call site now passes the joined turn text instead of only the final segment, guarded so any missing or malformed `history_offset` falls back to current behavior.
- `tests/gateway/test_turn_media.py` (new): multi-clip turn delivers BOTH clips (the reveal + question scenario, asserted through the real `extract_media`), the final clip is not duplicated, and the empty/None fallback returns the final response.

## How to Test

1. `python -m pytest tests/gateway/test_turn_media.py -q -o addopts=` (3 passed).
2. Live repro: in a voice-enabled chat, have the agent produce two TTS clips in one turn (one before and one after a tool call), with streaming delivering the text. On main only the second clip arrives; with this patch both arrive in order.

Running in production on a single-box deployment since late June; multi-clip turns (voice quiz sessions) deliver every clip.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the targeted tests and they pass (3 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04 (1 GB OpenVZ VPS), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation: N/A (internal delivery behavior, docstrings included)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS): platform-agnostic gateway logic, no OS-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A