### PR TITLE
fix(web): prefer ~/.hermes/.env over stale process env for provider keys

### DIFF
--- a/agent/web_search_provider.py
+++ b/agent/web_search_provider.py
@@ -59,16 +59,37 @@ from typing import Any, Dict, List, Optional
 def get_provider_env(name: str) -> str:
     """Config-aware env lookup for web providers.
 
-    Resolves *name* via :func:`hermes_cli.config.get_env_value` (checks
-    ``os.environ`` first, then ``~/.hermes/.env``) so credentials set
-    through Hermes' config layer are visible even when they were never
-    exported into the process environment — gateway sessions, delegate
-    children, and subprocess agent runs (issue #40190). Falls back to a
-    bare ``os.getenv`` when the config module is unavailable (stripped
-    installs, early import contexts).
+    Prefers a deliberate ``~/.hermes/.env`` value over a stale/empty value
+    already present in ``os.environ`` (via
+    :func:`hermes_cli.config.get_env_value_prefer_dotenv`). That matches how
+    Hermes-managed provider credentials are rotated: editing ``.env`` must
+    take effect even when a parent shell, TUI host, or multiplexedTimeout
+    process still transports an outdated export — which otherwise surfaces
+    as persistent 401s (Tavily, Firecrawl, Exa, …; issue #65459).
+
+    Falls back to :func:`hermes_cli.config.get_env_value` (process env first)
+    and finally a bare ``os.getenv`` when the prefer-dotenv helper is
+    unavailable (older installs / early import contexts). Still covers the
+    original gateway / delegate / subprocess path (issue #40190).
 
     Returns the stripped value, or ``""`` when unset.
     """
+    # Preferred path: ~/.hermes/.env wins over stale/empty process env.
+    # An empty result here is authoritative — in an active profile scope an
+    # absent key is intentional (secret_scope), so we must NOT re-resolve it
+    # through the environment-first helpers, which could select an unrelated
+    # process-global key. Fallbacks apply only when the prefer-dotenv helper
+    # is genuinely unavailable (older installs / early import contexts).
+    try:
+        from hermes_cli.config import get_env_value_prefer_dotenv
+    except Exception:  # noqa: BLE001 — prefer-dotenv optional on older trees
+        get_env_value_prefer_dotenv = None  # type: ignore[assignment]
+
+    if get_env_value_prefer_dotenv is not None:
+        return (get_env_value_prefer_dotenv(name) or "").strip()
+
+    # Helper unavailable: fall back to the legacy env-first resolver, then a
+    # bare os.getenv (original gateway / delegate / subprocess path, #40190).
     val: Optional[str] = None
     try:
         from hermes_cli.config import get_env_value
@@ -76,7 +97,7 @@ def get_provider_env(name: str) -> str:
         val = get_env_value(name)
     except Exception:  # noqa: BLE001 — config layer optional here
         val = None
-    if val is None:
+    if not val:
         val = os.getenv(name, "")
     return (val or "").strip()
 

--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -122,10 +122,10 @@ Firecrawl = _FirecrawlProxy()
 
 def _get_direct_firecrawl_config() -> Optional[tuple]:
     """Return explicit direct Firecrawl kwargs + cache key, or None when unset."""
-    from hermes_cli.config import get_env_value
+    from agent.web_search_provider import get_provider_env
 
-    api_key = (get_env_value("FIRECRAWL_API_KEY") or "").strip()
-    api_url = (get_env_value("FIRECRAWL_API_URL") or "").strip().rstrip("/")
+    api_key = get_provider_env("FIRECRAWL_API_KEY")
+    api_url = get_provider_env("FIRECRAWL_API_URL").rstrip("/")
 
     if not api_key and not api_url:
         return None

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -564,37 +564,36 @@ class TestNonBuiltinProviderAvailability:
 
 
 class TestFirecrawlEnvResolution:
-    """Verify Firecrawl reads env values from hermes_cli.config.get_env_value,
-    not just os.getenv.  This catches the regression reported in #40190 where
-    values stored in ~/.hermes/.env were invisible to the provider."""
+    """Verify Firecrawl reads env values through get_provider_env
+    (prefer-dotenv), not bare os.getenv / env-first get_env_value alone.
+    Covers #40190 + #65459 credential rotation."""
 
-    def test_direct_config_reads_via_get_env_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """_get_direct_firecrawl_config() must use get_env_value, not os.getenv."""
-        # Ensure os.environ does NOT carry the key
+    def test_direct_config_reads_via_get_provider_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """_get_direct_firecrawl_config() must use get_provider_env."""
         monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
         monkeypatch.delenv("FIRECRAWL_API_URL", raising=False)
 
         fake_key = "fc-test-key-from-dotenv"
         with patch(
-            "hermes_cli.config.get_env_value",
-            side_effect=lambda k: fake_key if k == "FIRECRAWL_API_KEY" else None,
+            "agent.web_search_provider.get_provider_env",
+            side_effect=lambda k: fake_key if k == "FIRECRAWL_API_KEY" else "",
         ):
             from plugins.web.firecrawl.provider import _get_direct_firecrawl_config
 
             result = _get_direct_firecrawl_config()
-            assert result is not None, "get_env_value fallback should find the key"
+            assert result is not None, "get_provider_env should find the key"
             kwargs, _cache_key = result
             assert kwargs["api_key"] == fake_key
 
-    def test_direct_config_reads_url_via_get_env_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Self-hosted URL from .env must be picked up."""
+    def test_direct_config_reads_url_via_get_provider_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Self-hosted URL from provider env must be picked up."""
         monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
         monkeypatch.delenv("FIRECRAWL_API_URL", raising=False)
 
         fake_url = "https://firecrawl.internal.example.com"
         with patch(
-            "hermes_cli.config.get_env_value",
-            side_effect=lambda k: fake_url if k == "FIRECRAWL_API_URL" else None,
+            "agent.web_search_provider.get_provider_env",
+            side_effect=lambda k: fake_url if k == "FIRECRAWL_API_URL" else "",
         ):
             from plugins.web.firecrawl.provider import _get_direct_firecrawl_config
 
@@ -602,6 +601,63 @@ class TestFirecrawlEnvResolution:
             assert result is not None
             kwargs, _cache_key = result
             assert kwargs["api_url"] == fake_url.rstrip("/")
+
+
+class TestProviderEnvPreferDotenv:
+    """Regression coverage for #65459: dotenv-first provider keys + scoped empty.
+
+    Scope is stale/rotated process env vs ~/.hermes/.env — not cross-host
+    TUI/container credential plumbing.
+    """
+
+    def test_prefer_dotenv_over_stale_process_env(self, tmp_path, monkeypatch):
+        """Real temp HERMES_HOME .env must beat a stale process export."""
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / ".env").write_text("TAVILY_API_KEY=from-dotenv-rotated\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("TAVILY_API_KEY", "stale-process-export")
+
+        import hermes_cli.config as cfg
+        cfg.invalidate_env_cache()
+
+        from agent.web_search_provider import get_provider_env
+
+        assert get_provider_env("TAVILY_API_KEY") == "from-dotenv-rotated"
+
+    def test_empty_prefer_dotenv_is_authoritative(self, monkeypatch):
+        """Empty preferred result must NOT fall through to env-first get_env_value."""
+        monkeypatch.setenv("TAVILY_API_KEY", "process-global-should-not-win")
+        with patch(
+            "hermes_cli.config.get_env_value_prefer_dotenv",
+            return_value=None,
+        ), patch(
+            "hermes_cli.config.get_env_value",
+            return_value="must-not-be-used",
+        ) as env_first:
+            from agent.web_search_provider import get_provider_env
+
+            assert get_provider_env("TAVILY_API_KEY") == ""
+            env_first.assert_not_called()
+
+    def test_legacy_fallback_only_when_prefer_helper_missing(self, monkeypatch):
+        """When prefer-dotenv helper is unavailable, fall back to get_env_value."""
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+        import hermes_cli.config as cfg_mod
+        real_import = __import__
+
+        def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "hermes_cli.config" and fromlist and "get_env_value_prefer_dotenv" in fromlist:
+                raise ImportError("prefer helper unavailable")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with patch("builtins.__import__", side_effect=guarded_import), patch.object(
+            cfg_mod, "get_env_value", return_value="legacy-fallback-key"
+        ):
+            from agent.web_search_provider import get_provider_env
+
+            assert get_provider_env("TAVILY_API_KEY") == "legacy-fallback-key"
 
 
 class TestSiblingProvidersEnvResolution:
@@ -631,18 +687,21 @@ class TestSiblingProvidersEnvResolution:
         assert provider.is_available() is False
 
         with patch(
-            "hermes_cli.config.get_env_value",
-            side_effect=lambda k: "test-key-from-dotenv" if k == env_key else None,
+            "agent.web_search_provider.get_provider_env",
+            side_effect=lambda k: "test-key-from-dotenv" if k == env_key else "",
         ):
             assert provider.is_available() is True, (
                 f"{cls_name}.is_available() ignored {env_key} from the "
-                "config-aware env layer (get_env_value)"
+                "config-aware env layer (get_provider_env)"
             )
 
 
     def test_get_provider_env_unset_returns_empty(self, monkeypatch):
         monkeypatch.delenv("WSP_TEST_UNSET_KEY", raising=False)
-        with patch("hermes_cli.config.get_env_value", return_value=None):
+        with patch(
+            "hermes_cli.config.get_env_value_prefer_dotenv",
+            return_value=None,
+        ):
             from agent.web_search_provider import get_provider_env
 
             assert get_provider_env("WSP_TEST_UNSET_KEY") == ""


### PR DESCRIPTION
## Summary

- Web provider credential lookup (`get_provider_env`) prefers a deliberate `~/.hermes/.env` value over a stale/empty process-env export.
- Empty prefer-dotenv results are authoritative (no env-first fallthrough under profile scope).
- Firecrawl direct config uses the same resolver.
- Regression tests: real temp-`HERMES_HOME` dotenv-over-stale-process, scoped/empty authoritative, Firecrawl path, legacy helper-missing fallback.

## Scope (narrowed)

**In scope:** stale/rotated shell/`os.environ` masking a valid `~/.hermes/.env` key for web providers (Tavily et al.) — issue #65459's credential-rotation cause.

**Out of scope:** cross-host local-TUI ↔ remote-container credential plumbing / availability topology. That path is unchanged; this PR does not claim to fix host-boundary secret transport.

## Motivation

Closes the stale-key half of #65459.

`get_provider_env()` previously could re-resolve empty prefer-dotenv through environment-first helpers; under an active profile scope an absent key is intentional (`secret_scope`). Hermes already has `get_env_value_prefer_dotenv()` for this class of rotation; web providers now use it consistently, including Firecrawl.

## Verification

- `python3 -m pytest tests/tools/test_web_tools_config.py -k 'provider_env or is_available_reads or prefer_dotenv or process_only or unset_returns or FirecrawlEnv or empty_prefer or legacy_fallback or PreferDotenv' -q` — 10 passed