### PR TITLE
fix(discord): log silent require_mention drops at INFO level

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5880,6 +5880,13 @@ class DiscordAdapter(BasePlatformAdapter):
 
             if require_mention and not is_free_channel and not in_bot_thread:
                 if not self._self_is_explicitly_mentioned(message) and not mention_prefix:
+                    logger.info(
+                        "[Discord] Silently dropping message in channel %s "
+                        "(require_mention=True, no @mention, not a free/thread channel). "
+                        "Set discord.require_mention: false in config.yaml to allow "
+                        "un-mentioned messages.",
+                        current_channel_id,
+                    )
                     return
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -1047,3 +1047,25 @@ def test_register_skill_command_autocomplete_filters_by_name_and_description(ada
     # via direct function call in the real-discord integration path.
     assert skill_cmd.callback is not None
 
+
+
+def test_require_mention_drop_logs_info_in_source():
+    """When require_mention drops a message, an INFO log must be emitted so
+    operators can diagnose silent drops (PR #33975).
+
+    Verifies the logger.info() call exists at the mention-gate return site
+    in plugins/platforms/discord/adapter.py.
+    """
+    src = open("plugins/platforms/discord/adapter.py").read()
+    # Find the require_mention gate
+    gate_idx = src.find("require_mention and not is_free_channel and not in_bot_thread")
+    assert gate_idx >= 0, "require_mention gate must exist in adapter.py"
+    # The INFO log must appear between the gate and the return statement
+    gate_section = src[gate_idx:gate_idx + 800]
+    assert "logger.info" in gate_section, (
+        "An INFO log must be emitted at the require_mention drop site so "
+        "operators can diagnose why the bot is silent in server channels."
+    )
+    assert "silently dropping" in gate_section.lower() or "require_mention" in gate_section.lower(), (
+        "The INFO log must mention the drop reason (require_mention or silently dropping)"
+    )


### PR DESCRIPTION
## Problem

When require_mention=True and a message has no @mention, the gateway silently drops it with a bare return. Operators cannot distinguish bot broken from require_mention blocking (issue #33947).

## Fix

Add logger.info() at the mention-gate return site with channel ID and config hint.

The auto_thread config.extra branch from PR #33975 is NOT included: current main already bridges discord.auto_thread to DISCORD_AUTO_THREAD at adapter.py:8288, and reading config.extra first would override DISCORD_AUTO_THREAD=false (wrong precedence per docs).

## Verification

1 source-level test verifies logger.info() exists at the require_mention gate. 1/1 pass.

Fixes #33947