### PR TITLE
fix(gateway): show effective channel route on /new banner

### DIFF
--- a/contributors/emails/andrew@chalkley.org
+++ b/contributors/emails/andrew@chalkley.org
@@ -1,0 +1,1 @@
+chalkers

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18146,15 +18146,55 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
-                return self._format_session_info()
-        return self._format_session_info()
+                return self._format_session_info(source)
+        return self._format_session_info(source)
 
-    def _format_session_info(self) -> str:
-        """Resolve current model config and return a formatted info block.
+    def _describe_model_route_source(self, source: SessionSource) -> Optional[str]:
+        """Return the user-facing source of a non-global model route."""
+        try:
+            session_key = self._session_key_for_source(source)
+            state = self._peek_session_state(session_key)
+            if state and state.conversation.model_override:
+                return "session override"
+        except Exception:
+            pass
 
-        Surfaces model, provider, context length, and endpoint so gateway
-        users can immediately see if context detection went wrong (e.g.
-        local models falling to the 128K default).
+        try:
+            config = getattr(self, "config", None)
+            if config is None:
+                return None
+            channel_override = _get_channel_override(
+                config,
+                source.platform,
+                str(source.chat_id) if source.chat_id else "",
+                thread_id=(
+                    str(source.thread_id)
+                    if getattr(source, "thread_id", None)
+                    else None
+                ),
+                parent_id=(
+                    str(source.parent_chat_id)
+                    if getattr(source, "parent_chat_id", None)
+                    else None
+                ),
+            )
+            if channel_override and (
+                channel_override.model or channel_override.provider
+            ):
+                return "channel override"
+        except Exception:
+            pass
+        return None
+
+    def _format_session_info(
+        self, source: Optional[SessionSource] = None
+    ) -> str:
+        """Resolve the effective model route and return a formatted info block.
+
+        When ``source`` is provided, use the same session → channel → global
+        precedence as a real turn. The resolved model/runtime tuple is consumed
+        as one atomic snapshot so empty route fields never inherit unrelated
+        global credentials or endpoints.
         """
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
 
@@ -18168,6 +18208,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         configured_model = None
         configured_provider = None
         configured_base_url = None
+        route_source = None
 
         try:
             data = _load_gateway_config()
@@ -18193,14 +18234,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
-        # Resolve runtime credentials for probing
-        try:
-            runtime = _resolve_runtime_agent_kwargs()
-            provider = runtime.get("provider") or provider
-            base_url = runtime.get("base_url") or base_url
+        # Resolve the effective route once. A successful source-aware
+        # resolution is authoritative even when provider fields are empty;
+        # filling falsey values from a second global resolution can mix a
+        # routed model with unrelated credentials or an unrelated endpoint.
+        runtime = None
+        if source is not None:
+            try:
+                model, runtime = self._resolve_session_agent_runtime(source=source)
+                route_source = self._describe_model_route_source(source)
+            except Exception:
+                logger.debug(
+                    "Source-aware session-info route resolution failed; "
+                    "falling back to the global route",
+                    exc_info=True,
+                )
+
+        if runtime is None:
+            try:
+                runtime = _resolve_runtime_agent_kwargs()
+                runtime_model = runtime.get("model")
+                if runtime_model:
+                    model = runtime_model
+            except Exception:
+                runtime = None
+
+        if runtime is not None:
+            provider = runtime.get("provider")
+            base_url = runtime.get("base_url")
             api_key = runtime.get("api_key")
-        except Exception:
-            pass
 
         if config_context_length is not None:
             try:
@@ -18262,6 +18324,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             f"◆ Provider: {provider or 'openrouter'}",
             f"◆ Context: {ctx_display} tokens ({ctx_source})",
         ]
+
+        if route_source:
+            lines.append(f"◆ Route: {route_source}")
 
         # Show endpoint for local/custom setups
         if base_url and ("localhost" in base_url or "127.0.0.1" in base_url or "0.0.0.0" in base_url):
@@ -22452,7 +22517,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Failed to read persisted session model override", exc_info=True
             )
             return
-        if not persisted:
+        if not isinstance(persisted, dict) or not persisted:
             return
         override: Dict[str, Any] = {
             "model": persisted.get("model"),
@@ -22463,8 +22528,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if provider:
             # Re-resolve credentials for the persisted provider. On failure
             # (e.g. credentials were removed since the switch) keep the
-            # credential-less override — _resolve_session_agent_runtime falls
-            # back to env-based resolution and applies model/provider on top.
+            # credential-less override. Applying that route clears credentials
+            # inherited from another provider rather than mixing route state.
             try:
                 runtime = _resolve_runtime_agent_kwargs_for_provider(provider)
                 override["api_key"] = runtime.get("api_key")
@@ -22492,17 +22557,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         The gateway /model command stores per-session overrides in
         ``_session_model_overrides``.  These must take precedence over
         config.yaml defaults so the switched model is actually used for
-        subsequent messages.  Fields with ``None`` values are skipped so
-        partial overrides don't clobber valid config defaults.
+        subsequent messages. Model-only overrides inherit the active route,
+        but once provider or endpoint identity changes its credential-bearing
+        fields are replaced as one unit. This prevents a credential-less
+        override from inheriting an unrelated global API key or pool.
         """
         _apply_state = self._peek_session_state(session_key)
         override = _apply_state.conversation.model_override if _apply_state else None
         if not override:
             return model, runtime_kwargs
         model = override.get("model", model)
-        for key in ("provider", "api_key", "base_url", "api_mode", "credential_pool"):
+
+        provider_changed = bool(override.get("provider"))
+        endpoint_changed = bool(override.get("base_url"))
+        route_identity_changed = provider_changed or endpoint_changed
+        if provider_changed:
+            runtime_kwargs["provider"] = override.get("provider")
+            # Provider endpoints are route-owned too. If credential
+            # re-resolution failed to supply one, fail closed rather than
+            # retaining another provider's global endpoint.
+            runtime_kwargs["base_url"] = override.get("base_url")
+        elif endpoint_changed:
+            runtime_kwargs["base_url"] = override.get("base_url")
+        for key in ("api_key", "api_mode", "credential_pool"):
             val = override.get(key)
-            if val is not None:
+            if route_identity_changed or val is not None:
                 runtime_kwargs[key] = val
         if (
             runtime_kwargs.get("api_key")

--- a/tests/gateway/test_35994_reset_button_deadlock.py
+++ b/tests/gateway/test_35994_reset_button_deadlock.py
@@ -78,7 +78,7 @@ def _make_runner_with_cached_agent(close_fn):
     runner._pending_approvals = {}
     runner._session_db = None
     runner._is_user_authorized = lambda _source: True
-    runner._format_session_info = lambda: ""
+    runner._format_session_info = lambda *_args, **_kwargs: ""
 
     # Enable the cache-lock path (this is what the button callback exercises)
     runner._agent_cache_lock = threading.RLock()

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -68,7 +68,7 @@ def _make_runner():
     runner._session_db = None
     runner._agent_cache_lock = None
     runner._is_user_authorized = lambda _source: True
-    runner._format_session_info = lambda: ""
+    runner._format_session_info = lambda *_args, **_kwargs: ""
 
     return runner
 

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -1,15 +1,21 @@
 """Tests for GatewayRunner._format_session_info — session config surfacing."""
 
-import pytest
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
+from gateway.config import ChannelOverride, GatewayConfig, Platform, PlatformConfig
 from gateway.run import GatewayRunner
+from gateway.session import SessionSource
 
 
 @pytest.fixture()
 def runner():
     """Create a bare GatewayRunner without __init__."""
-    return GatewayRunner.__new__(GatewayRunner)
+    gr = GatewayRunner.__new__(GatewayRunner)
+    gr._sessions = {}
+    return gr
 
 
 def _patch_info(tmp_path, config_yaml, model, runtime):
@@ -24,30 +30,61 @@ def _patch_info(tmp_path, config_yaml, model, runtime):
     )
 
 
-class TestFormatSessionInfo:
+def _source(room_id="!room:example.org"):
+    return SessionSource(
+        platform=Platform.MATRIX,
+        chat_id=room_id,
+        user_id="u1",
+    )
 
+
+def _matrix_config(room_id=None, override=None):
+    overrides = {room_id: override} if room_id and override else {}
+    return GatewayConfig(
+        platforms={
+            Platform.MATRIX: PlatformConfig(
+                enabled=True,
+                channel_overrides=overrides,
+            )
+        }
+    )
+
+
+class TestFormatSessionInfo:
     def test_includes_model_name(self, runner, tmp_path):
-        p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: anthropic/claude-opus-4.6\n  provider: openrouter\n",
-                                  "anthropic/claude-opus-4.6",
-                                  {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_key": "k"})
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: anthropic/claude-opus-4.6\n  provider: openrouter\n",
+            "anthropic/claude-opus-4.6",
+            {
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "k",
+            },
+        )
         with p1, p2, p3:
             info = runner._format_session_info()
         assert "claude-opus-4.6" in info
 
-
     def test_config_context_length(self, runner, tmp_path):
-        p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: test-model\n  context_length: 32768\n",
-                                  "test-model",
-                                  {"provider": "custom", "base_url": "", "api_key": ""})
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: test-model\n  context_length: 32768\n",
+            "test-model",
+            {"provider": "custom", "base_url": "", "api_key": ""},
+        )
         with p1, p2, p3:
             info = runner._format_session_info()
         assert "32K" in info
         assert "config" in info
 
     def test_default_fallback_hint(self, runner, tmp_path):
-        p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: unknown-model-xyz\n",
-                                  "unknown-model-xyz",
-                                  {"provider": "", "base_url": "", "api_key": ""})
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: unknown-model-xyz\n",
+            "unknown-model-xyz",
+            {"provider": "", "base_url": "", "api_key": ""},
+        )
         with p1, p2, p3:
             info = runner._format_session_info()
         assert "256K" in info
@@ -56,9 +93,18 @@ class TestFormatSessionInfo:
     def test_local_endpoint_shown(self, runner, tmp_path):
         p1, p2, p3 = _patch_info(
             tmp_path,
-            "model:\n  default: qwen3:8b\n  provider: custom\n  base_url: http://localhost:11434/v1\n  context_length: 8192\n",
+            "model:\n"
+            "  default: qwen3:8b\n"
+            "  provider: custom\n"
+            "  base_url: http://localhost:11434/v1\n"
+            "  context_length: 8192\n",
             "qwen3:8b",
-            {"provider": "custom", "base_url": "http://localhost:11434/v1", "api_key": ""})
+            {
+                "provider": "custom",
+                "base_url": "http://localhost:11434/v1",
+                "api_key": "",
+            },
+        )
         with p1, p2, p3:
             info = runner._format_session_info()
         assert "localhost:11434" in info
@@ -67,12 +113,7 @@ class TestFormatSessionInfo:
     def test_named_custom_provider_keeps_context_pin_without_model_base_url(
         self, runner, tmp_path
     ):
-        """Session-reset banner must honor model.context_length for named custom providers.
-
-        Repro: /status shows 262144 from config while the reset banner said
-        ``131K tokens (detected)`` because empty model.base_url + runtime URL
-        falsely cleared the pin and fell through to the Qwen family default.
-        """
+        """Session-reset banner must honor model.context_length for named custom providers."""
         model = "custom-local-agentw/Qwen-AgentWorld-35B-A3B-Q5_K_XL"
         config_yaml = (
             "model:\n"
@@ -94,21 +135,25 @@ class TestFormatSessionInfo:
                 "api_key": "",
             },
         )
-        with p1, p2, p3, patch(
-            "hermes_cli.config.get_compatible_custom_providers",
-            return_value=[
-                {
-                    "name": "custom-local-agentw",
-                    "base_url": "http://127.0.0.1:8080/v1",
-                    "models": {},
-                }
-            ],
-        ), patch(
-            "agent.model_metadata.get_model_context_length",
-            side_effect=lambda *args, **kwargs: (
-                kwargs.get("config_context_length")
-                if kwargs.get("config_context_length")
-                else 131072
+        with (
+            p1,
+            p2,
+            p3,
+            patch(
+                "hermes_cli.config.get_compatible_custom_providers",
+                return_value=[
+                    {
+                        "name": "custom-local-agentw",
+                        "base_url": "http://127.0.0.1:8080/v1",
+                        "models": {},
+                    }
+                ],
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                side_effect=lambda *args, **kwargs: (
+                    kwargs.get("config_context_length") or 131072
+                ),
             ),
         ):
             info = runner._format_session_info()
@@ -116,18 +161,295 @@ class TestFormatSessionInfo:
         assert "config" in info
         assert "131K" not in info
 
+    def test_channel_override_uses_effective_route(self, runner, tmp_path):
+        room_id = "!channel-route:example.org"
+        runner.config = _matrix_config(
+            room_id,
+            ChannelOverride(model="routed-model", provider="routed-provider"),
+        )
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n"
+            "  default: global-model\n"
+            "  provider: global-provider\n"
+            "  context_length: 128000\n",
+            "global-model",
+            {
+                "provider": "global-provider",
+                "base_url": "https://global.example/v1",
+                "api_key": "global-key",
+            },
+        )
+        with (
+            p1,
+            p2,
+            p3,
+            patch(
+                "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+                return_value={
+                    "provider": "routed-provider",
+                    "base_url": "https://routed.example/v1",
+                    "api_key": "routed-key",
+                },
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=65536,
+            ),
+        ):
+            info = runner._format_session_info(_source(room_id))
+
+        assert "routed-model" in info
+        assert "routed-provider" in info
+        assert "channel override" in info
+        assert "global-model" not in info
+        assert "global-provider" not in info
+
+    def test_effective_global_route_is_one_atomic_snapshot(self, runner, tmp_path):
+        runner.config = _matrix_config()
+        first = {
+            "model": "model-r1",
+            "provider": "provider-r1",
+            "base_url": "",
+            "api_key": None,
+        }
+        second = {
+            "model": "model-r2",
+            "provider": "provider-r2",
+            "base_url": "https://second.example/v1",
+            "api_key": "key-r2",
+        }
+        p1, p2, _p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: configured-model\n",
+            "configured-model",
+            first,
+        )
+        with (
+            p1,
+            p2,
+            patch(
+                "gateway.run._resolve_runtime_agent_kwargs",
+                side_effect=[first, second],
+            ) as resolve_runtime,
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=32768,
+            ) as detect_context,
+        ):
+            info = runner._format_session_info(_source())
+
+        assert "model-r1" in info
+        assert resolve_runtime.call_count == 1
+        assert detect_context.call_args.kwargs["provider"] == "provider-r1"
+        assert detect_context.call_args.kwargs["base_url"] == ""
+        assert detect_context.call_args.kwargs["api_key"] == ""
+
+    def test_falsey_routed_fields_do_not_inherit_global_values(
+        self, runner, tmp_path
+    ):
+        room_id = "!routed-empty:example.org"
+        runner.config = _matrix_config(
+            room_id,
+            ChannelOverride(model="routed-model", provider="routed-provider"),
+        )
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n"
+            "  default: global-model\n"
+            "  provider: global-provider\n"
+            "  base_url: http://localhost:9999/v1\n",
+            "global-model",
+            {
+                "provider": "global-provider",
+                "base_url": "http://localhost:9999/v1",
+                "api_key": "global-key",
+            },
+        )
+        with (
+            p1,
+            p2,
+            p3,
+            patch(
+                "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+                return_value={
+                    "provider": "routed-provider",
+                    "base_url": "",
+                    "api_key": None,
+                },
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=32768,
+            ) as detect_context,
+        ):
+            info = runner._format_session_info(_source(room_id))
+
+        assert "routed-model" in info
+        assert "routed-provider" in info
+        assert "localhost:9999" not in info
+        assert detect_context.call_args.kwargs["provider"] == "routed-provider"
+        assert detect_context.call_args.kwargs["base_url"] == ""
+        assert detect_context.call_args.kwargs["api_key"] == ""
+
+    def test_same_model_different_provider_discards_global_context_pin(
+        self, runner, tmp_path
+    ):
+        room_id = "!same-model-route:example.org"
+        runner.config = _matrix_config(
+            room_id,
+            ChannelOverride(model="shared-model", provider="routed-provider"),
+        )
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n"
+            "  default: shared-model\n"
+            "  provider: global-provider\n"
+            "  context_length: 128000\n"
+            "custom_providers:\n"
+            "  - name: routed-provider\n"
+            "    base_url: https://routed.example/v1\n"
+            "    models:\n"
+            "      shared-model:\n"
+            "        context_length: 65536\n",
+            "shared-model",
+            {
+                "provider": "global-provider",
+                "base_url": "",
+                "api_key": "global-key",
+            },
+        )
+
+        def detected(_model, **kwargs):
+            return kwargs.get("config_context_length") or 262144
+
+        with (
+            p1,
+            p2,
+            p3,
+            patch(
+                "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+                return_value={
+                    "provider": "routed-provider",
+                    "base_url": "https://routed.example/v1",
+                    "api_key": "routed-key",
+                },
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                side_effect=detected,
+            ) as detect_context,
+        ):
+            info = runner._format_session_info(_source(room_id))
+
+        assert "routed-provider" in info
+        assert "65K" in info
+        assert "128K" not in info
+        assert detect_context.call_args.kwargs["config_context_length"] == 65536
+
+    def test_session_override_takes_priority_over_channel(self, runner, tmp_path):
+        room_id = "!session-route:example.org"
+        runner.config = _matrix_config(
+            room_id,
+            ChannelOverride(model="room-model", provider="room-provider"),
+        )
+        source = _source(room_id)
+        session_key = runner._session_key_for_source(source)
+        runner._session_state(session_key).conversation.model_override = {
+            "model": "session-model",
+            "provider": "session-provider",
+            "api_key": "session-key",
+            "base_url": "https://session.example/v1",
+            "api_mode": None,
+        }
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: global-model\n  provider: global-provider\n",
+            "global-model",
+            {
+                "provider": "global-provider",
+                "base_url": "",
+                "api_key": "global-key",
+            },
+        )
+        with (
+            p1,
+            p2,
+            p3,
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=32768,
+            ),
+        ):
+            info = runner._format_session_info(source)
+
+        assert "session-model" in info
+        assert "session-provider" in info
+        assert "session override" in info
+        assert "room-model" not in info
+        assert "global-model" not in info
+
+    def test_source_without_override_stays_global(self, runner, tmp_path):
+        runner.config = _matrix_config()
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: global-model\n  provider: global-provider\n",
+            "global-model",
+            {
+                "provider": "global-provider",
+                "base_url": "",
+                "api_key": "global-key",
+            },
+        )
+        with p1, p2, p3:
+            info = runner._format_session_info(_source())
+        assert "global-model" in info
+        assert "global-provider" in info
+        assert "Route:" not in info
+
+    def test_source_resolution_failure_uses_global_fallback(self, runner, tmp_path):
+        runner.config = _matrix_config()
+        p1, p2, _p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: configured-model\n",
+            "configured-model",
+            {},
+        )
+        with (
+            p1,
+            p2,
+            patch.object(
+                GatewayRunner,
+                "_resolve_session_agent_runtime",
+                side_effect=RuntimeError("route unavailable"),
+            ),
+            patch(
+                "gateway.run._resolve_runtime_agent_kwargs",
+                return_value={
+                    "model": "fallback-model",
+                    "provider": "fallback-provider",
+                    "base_url": "",
+                    "api_key": "fallback-key",
+                },
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=32768,
+            ),
+        ):
+            info = runner._format_session_info(_source())
+        assert "fallback-model" in info
+        assert "fallback-provider" in info
+
 
 class TestResetNoticeSessionInfo:
-    """#59003: the auto-reset banner must report the serving profile's config,
-    not the multiplexer's base config."""
-
-    _RUNTIME = {"provider": "", "base_url": "", "api_key": ""}
+    """Auto-reset banners must use both profile and channel/session routing."""
 
     def _source(self):
-        from gateway.config import Platform
-        from gateway.session import SessionSource
         return SessionSource(
-            platform=Platform.TELEGRAM, chat_id="123", user_id="u1",
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            user_id="u1",
             profile="planner",
         )
 
@@ -137,20 +459,69 @@ class TestResetNoticeSessionInfo:
         profile.mkdir(parents=True)
         base.mkdir()
         base.joinpath("config.yaml").write_text(
-            "model:\n  default: base-model\n  provider: custom\n  context_length: 1000\n")
+            "model:\n"
+            "  default: base-model\n"
+            "  provider: custom\n"
+            "  context_length: 1000\n"
+        )
         profile.joinpath("config.yaml").write_text(
-            "model:\n  default: profile-model\n  provider: anthropic\n  context_length: 2000\n")
+            "model:\n"
+            "  default: profile-model\n"
+            "  provider: anthropic\n"
+            "  context_length: 2000\n"
+        )
         return base, profile
 
     def test_multiplex_uses_profile_config(self, runner, tmp_path):
-        from types import SimpleNamespace
         base, profile = self._homes(tmp_path)
-        runner.config = SimpleNamespace(multiplex_profiles=True)
-        with patch("gateway.run._hermes_home", base), \
-             patch.object(GatewayRunner, "_resolve_profile_home_for_source", return_value=profile), \
-             patch("gateway.run._resolve_runtime_agent_kwargs", return_value=self._RUNTIME):
+        runner.config = SimpleNamespace(multiplex_profiles=True, platforms={})
+        with (
+            patch("gateway.run._hermes_home", base),
+            patch.object(
+                GatewayRunner,
+                "_resolve_profile_home_for_source",
+                return_value=profile,
+            ),
+            patch(
+                "gateway.run._resolve_runtime_agent_kwargs",
+                return_value={
+                    "provider": "anthropic",
+                    "base_url": "",
+                    "api_key": "profile-key",
+                },
+            ),
+        ):
             info = runner._reset_notice_session_info(self._source())
         assert "profile-model" in info
         assert "anthropic" in info
         assert "base-model" not in info
 
+    def test_single_profile_uses_base_config(self, runner, tmp_path):
+        base, _profile = self._homes(tmp_path)
+        runner.config = SimpleNamespace(multiplex_profiles=False, platforms={})
+        with (
+            patch("gateway.run._hermes_home", base),
+            patch(
+                "gateway.run._resolve_runtime_agent_kwargs",
+                return_value={
+                    "provider": "custom",
+                    "base_url": "",
+                    "api_key": "base-key",
+                },
+            ),
+        ):
+            info = runner._reset_notice_session_info(self._source())
+        assert "base-model" in info
+        assert "custom" in info
+        assert "profile-model" not in info
+
+    def test_reset_notice_passes_source_to_formatter(self, runner):
+        runner.config = SimpleNamespace(multiplex_profiles=False)
+        source = self._source()
+        with patch.object(
+            GatewayRunner,
+            "_format_session_info",
+            return_value="info",
+        ) as format_info:
+            assert runner._reset_notice_session_info(source) == "info"
+        format_info.assert_called_once_with(source)

--- a/tests/gateway/test_session_model_override_credential_pool.py
+++ b/tests/gateway/test_session_model_override_credential_pool.py
@@ -35,3 +35,88 @@ def test_fast_session_override_includes_credential_pool(monkeypatch):
     assert runtime.get("credential_pool") is fake_pool
 
 
+def test_credentialless_route_override_clears_global_credentials():
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {
+        "sess-1": {
+            "model": "routed-model",
+            "provider": "routed-provider",
+            "base_url": "https://routed.example/v1",
+        },
+    }
+    global_pool = object()
+
+    model, runtime = runner._apply_session_model_override(
+        "sess-1",
+        "global-model",
+        {
+            "provider": "global-provider",
+            "base_url": "https://global.example/v1",
+            "api_key": "global-key",
+            "api_mode": "global-mode",
+            "credential_pool": global_pool,
+        },
+    )
+
+    assert model == "routed-model"
+    assert runtime == {
+        "provider": "routed-provider",
+        "base_url": "https://routed.example/v1",
+        "api_key": None,
+        "api_mode": None,
+        "credential_pool": None,
+    }
+
+
+def test_model_only_override_keeps_active_route_credentials():
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {
+        "sess-1": {"model": "alternate-global-model"},
+    }
+    global_pool = object()
+    active_runtime = {
+        "provider": "global-provider",
+        "base_url": "https://global.example/v1",
+        "api_key": "global-key",
+        "api_mode": "global-mode",
+        "credential_pool": global_pool,
+    }
+
+    model, runtime = runner._apply_session_model_override(
+        "sess-1", "global-model", dict(active_runtime)
+    )
+
+    assert model == "alternate-global-model"
+    assert runtime == active_runtime
+
+
+def test_provider_override_without_endpoint_clears_global_endpoint():
+    runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {
+        "sess-1": {
+            "model": "routed-model",
+            "provider": "routed-provider",
+        },
+    }
+
+    _model, runtime = runner._apply_session_model_override(
+        "sess-1",
+        "global-model",
+        {
+            "provider": "global-provider",
+            "base_url": "https://global.example/v1",
+            "api_key": "global-key",
+            "api_mode": "global-mode",
+            "credential_pool": object(),
+        },
+    )
+
+    assert runtime == {
+        "provider": "routed-provider",
+        "base_url": None,
+        "api_key": None,
+        "api_mode": None,
+        "credential_pool": None,
+    }
+
+

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -61,7 +61,7 @@ def _make_runner():
     runner._session_db = None
     runner._agent_cache_lock = None  # disables _evict_cached_agent lock path
     runner._is_user_authorized = lambda _source: True
-    runner._format_session_info = lambda: ""
+    runner._format_session_info = lambda *_args, **_kwargs: ""
 
     return runner
 

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -207,7 +207,7 @@ class TestResetCommandWithTitle:
         runner._agent_cache = {}
         runner._agent_cache_lock = None
         runner._is_user_authorized = lambda _source: True
-        runner._format_session_info = lambda: ""
+        runner._format_session_info = lambda *_args, **_kwargs: ""
 
         event = _make_event(text="/new Dup")
         result = await runner._handle_reset_command(event)


### PR DESCRIPTION
## Problem

`/new` (and auto-reset notices) show a session-info banner with model/provider/context so users can confirm what the fresh session will run.

That banner only read **global** `model.default` / `model.provider`. It ignored the effective route for the current chat:

1. session `/model` override  
2. platform `channel_overrides` (Matrix rooms, Discord channels, etc.)  
3. global default  

On multi-room gateways this is actively misleading. Example:

- Room A (Matrix) → `xai-oauth` / `grok-4.5` via `channel_overrides`
- Global default → `openai-codex` / `gpt-5.6-sol`

After `/new` in Room A the banner said Codex, while the next real turn correctly ran Grok. The runtime path was already correct; only the banner lied.

## Expected ergonomics

`/new` is a conversation boundary. The banner should answer:

- I’m in a clean session
- **this chat’s effective model/provider** is what I think it is
- any session `/model` override is gone (after reset)
- context/tooling baseline matches the route that will actually run

It should report **what this room will run next**, not what the global default is.

## Fix

- `_reset_notice_session_info` now passes `source` into `_format_session_info`
- `_format_session_info(source=…)` resolves model/provider via `_resolve_session_agent_runtime` (same priority as a real agent turn)
- non-default routes get a compact `◆ Route: channel override` / `session override` line
- without `source`, behavior stays global-only for callers with no chat context
- failure to resolve the effective route falls back to the previous global banner (no crash)

## Tests

- channel override preferred over global when `source` is provided
- session override preferred over channel override
- source with no override stays global and omits Route line
- `_reset_notice_session_info` forwards source for channel routes
- existing multiplex profile + format tests still pass
- reset-path mocks updated to accept `source` kwargs

```bash
./venv/bin/python -m pytest tests/gateway/test_session_info.py \
  tests/gateway/test_session_model_reset.py \
  tests/gateway/test_session_boundary_hooks.py \
  tests/gateway/test_title_command.py \
  tests/gateway/test_35994_reset_button_deadlock.py \
  -o 'addopts=' -q
# 44 passed
```

## Notes

- Runtime routing was already correct; this is banner accuracy only.
- Adds `andrew@chalkley.org` to `AUTHOR_MAP` for attribution CI.
