### PR TITLE
fix(desktop): load history from older remote gateways

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -55,6 +55,7 @@ import {
   resolveTestWsUrl,
   tokenPreview
 } from './connection-config'
+import { fetchRemoteSessionListWithFallback } from './remote-session-compat'
 import { adoptServedDashboardToken } from './dashboard-token'
 import {
   buildPosixCleanupScript,
@@ -8075,12 +8076,24 @@ async function interceptSessionRequestForRemote(request) {
 
   if (method === 'GET' && pathname === '/api/profiles/sessions') {
     const remoteProfiles = configuredRemoteProfileNames()
+    const requested = (searchParams.get('profile') || 'all').trim() || 'all'
 
     if (remoteProfiles.length === 0) {
-      return undefined // no remote profiles → local fast path
-    }
+      if (!globalRemoteActive()) {
+        return undefined // no remote profiles → local fast path
+      }
 
-    const requested = (searchParams.get('profile') || 'all').trim() || 'all'
+      // Older remote backends expose the single-profile /api/sessions API but
+      // not Desktop's newer cross-profile aggregator. Try the aggregate path
+      // first and fall back only when that endpoint is explicitly missing.
+      const query = searchParams.toString()
+      return fetchRemoteSessionListWithFallback(
+        path => fetchJsonForProfile(null, path),
+        `${pathname}${query ? `?${query}` : ''}`,
+        `/api/sessions${query ? `?${query}` : ''}`,
+        requested
+      )
+    }
 
     if (requested !== 'all') {
       return profileHasRemoteOverride(requested) ? remoteSessionList(requested, searchParams) : undefined

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -55,7 +55,7 @@ import {
   resolveTestWsUrl,
   tokenPreview
 } from './connection-config'
-import { fetchRemoteSessionListWithFallback } from './remote-session-compat'
+import { fetchRemoteSessionListWithFallback, missingSessionListEndpoint } from './remote-session-compat'
 import { adoptServedDashboardToken } from './dashboard-token'
 import {
   buildPosixCleanupScript,
@@ -8110,9 +8110,20 @@ async function interceptSessionRequestForRemote(request) {
   // remote correctness is preserved.
   if (method === 'GET' && pathname === '/api/profiles/sessions/sidebar') {
     const remoteProfiles = configuredRemoteProfileNames()
+    const globalRemoteCompat = remoteProfiles.length === 0 && globalRemoteActive()
 
-    if (remoteProfiles.length === 0) {
+    if (remoteProfiles.length === 0 && !globalRemoteCompat) {
       return undefined // local fast path → batched endpoint's single DB open
+    }
+
+    if (globalRemoteCompat) {
+      try {
+        return await fetchJsonForProfile(null, request.path)
+      } catch (error) {
+        if (!missingSessionListEndpoint(error)) {
+          throw error
+        }
+      }
     }
 
     const recentsProfile = (searchParams.get('recents_profile') || 'all').trim() || 'all'
@@ -8146,16 +8157,27 @@ async function interceptSessionRequestForRemote(request) {
       messagingSp.set('exclude_sources', messagingExclude)
     }
 
+    const fetchSlice = (params: URLSearchParams) =>
+      globalRemoteCompat
+        ? fetchRemoteSessionListWithFallback(
+            path => fetchJsonForProfile(null, path),
+            `/api/profiles/sessions?${params}`,
+            `/api/sessions?${params}`,
+            (params.get('profile') || 'all').trim() || 'all'
+          )
+        : fetchProfilesSessionSlice(params, remoteProfiles)
+
     const [recents, cron, messaging] = await Promise.all([
-      fetchProfilesSessionSlice(recentsSp, remoteProfiles),
-      fetchProfilesSessionSlice(cronSp, remoteProfiles),
-      fetchProfilesSessionSlice(messagingSp, remoteProfiles)
+      fetchSlice(recentsSp),
+      fetchSlice(cronSp),
+      fetchSlice(messagingSp)
     ])
 
     return {
       recents: {
         sessions: rowsOf(recents),
         total: Number(recents?.total) || 0,
+        total_is_lower_bound: Boolean(recents?.total_is_lower_bound),
         profile_totals: recents?.profile_totals || {}
       },
       cron: { sessions: rowsOf(cron) },

--- a/apps/desktop/electron/remote-session-compat.test.ts
+++ b/apps/desktop/electron/remote-session-compat.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  fetchRemoteSessionListWithFallback,
+  missingSessionListEndpoint,
+  normalizeRemoteSessionList
+} from './remote-session-compat'
+
+test('recognizes only missing-endpoint failures as fallback candidates', () => {
+  assert.equal(missingSessionListEndpoint(new Error('404: Not Found')), true)
+  assert.equal(
+    missingSessionListEndpoint(
+      new Error(
+        'Expected JSON from https://host/api/profiles/sessions but got HTML. The endpoint is likely missing on the Hermes backend.'
+      )
+    ),
+    true
+  )
+  assert.equal(missingSessionListEndpoint(new Error('401: Unauthorized')), false)
+  assert.equal(missingSessionListEndpoint(new Error('connect ECONNREFUSED')), false)
+})
+
+test('normalizes the legacy gateway list shape for the desktop sidebar', () => {
+  const result = normalizeRemoteSessionList(
+    {
+      data: [{ id: 'remote-1', message_count: 2 }],
+      has_more: true,
+      limit: 40,
+      offset: 0
+    },
+    'health'
+  )
+
+  assert.deepEqual(result.sessions, [
+    {
+      id: 'remote-1',
+      is_default_profile: false,
+      message_count: 2,
+      profile: 'health'
+    }
+  ])
+  assert.equal(result.total, 2)
+  assert.deepEqual(result.profile_totals, { health: 2 })
+})
+
+test('falls back to /api/sessions only when the aggregate endpoint is missing', async () => {
+  const paths: string[] = []
+  const result = await fetchRemoteSessionListWithFallback(
+    async path => {
+      paths.push(path)
+
+      if (path.startsWith('/api/profiles/sessions')) {
+        throw new Error('404: Not Found')
+      }
+
+      return { sessions: [{ id: 'remote-1' }], total: 1 }
+    },
+    '/api/profiles/sessions?profile=health',
+    '/api/sessions?profile=health',
+    'health'
+  )
+
+  assert.deepEqual(paths, ['/api/profiles/sessions?profile=health', '/api/sessions?profile=health'])
+  assert.equal(result.sessions[0].id, 'remote-1')
+})
+
+test('does not hide authentication or connectivity failures behind the fallback', async () => {
+  let calls = 0
+
+  await assert.rejects(
+    fetchRemoteSessionListWithFallback(
+      async () => {
+        calls += 1
+        throw new Error('401: Unauthorized')
+      },
+      '/api/profiles/sessions',
+      '/api/sessions',
+      'default'
+    ),
+    /401/
+  )
+  assert.equal(calls, 1)
+})

--- a/apps/desktop/electron/remote-session-compat.test.ts
+++ b/apps/desktop/electron/remote-session-compat.test.ts
@@ -27,7 +27,7 @@ test('normalizes the legacy gateway list shape for the desktop sidebar', () => {
       data: [{ id: 'remote-1', message_count: 2 }],
       has_more: true,
       limit: 40,
-      offset: 0
+      offset: 40
     },
     'health'
   )
@@ -40,8 +40,9 @@ test('normalizes the legacy gateway list shape for the desktop sidebar', () => {
       profile: 'health'
     }
   ])
-  assert.equal(result.total, 2)
-  assert.deepEqual(result.profile_totals, { health: 2 })
+  assert.equal(result.total, 42)
+  assert.equal(result.total_is_lower_bound, true)
+  assert.deepEqual(result.profile_totals, { health: 42 })
 })
 
 test('falls back to /api/sessions only when the aggregate endpoint is missing', async () => {

--- a/apps/desktop/electron/remote-session-compat.ts
+++ b/apps/desktop/electron/remote-session-compat.ts
@@ -1,0 +1,55 @@
+/** Compatibility helpers for Desktop session lists served by older remote backends. */
+
+function missingSessionListEndpoint(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error || '')
+
+  return /(?:^|\s)404(?::|\s)/.test(message) || message.includes('endpoint is likely missing')
+}
+
+function normalizeRemoteSessionList(data: any, profile: string): any {
+  const rawRows = Array.isArray(data?.sessions) ? data.sessions : Array.isArray(data?.data) ? data.data : []
+  const rows = rawRows.map(row => {
+    if (!row || typeof row !== 'object' || row.profile || !profile || profile === 'all') {
+      return row
+    }
+
+    return {
+      ...row,
+      profile,
+      is_default_profile: profile === 'default'
+    }
+  })
+  const total = Number.isFinite(data?.total) ? Number(data.total) : rows.length + (data?.has_more ? 1 : 0)
+  const profileTotals =
+    data?.profile_totals && typeof data.profile_totals === 'object'
+      ? data.profile_totals
+      : profile && profile !== 'all'
+        ? { [profile]: total }
+        : {}
+
+  return {
+    ...data,
+    sessions: rows,
+    total,
+    profile_totals: profileTotals
+  }
+}
+
+async function fetchRemoteSessionListWithFallback(
+  fetchPath: (path: string) => Promise<any>,
+  aggregatePath: string,
+  legacyPath: string,
+  profile: string
+): Promise<any> {
+  try {
+    return await fetchPath(aggregatePath)
+  } catch (error) {
+    if (!missingSessionListEndpoint(error)) {
+      throw error
+    }
+  }
+
+  return normalizeRemoteSessionList(await fetchPath(legacyPath), profile)
+}
+
+export { fetchRemoteSessionListWithFallback, missingSessionListEndpoint, normalizeRemoteSessionList }

--- a/apps/desktop/electron/remote-session-compat.ts
+++ b/apps/desktop/electron/remote-session-compat.ts
@@ -19,7 +19,9 @@ function normalizeRemoteSessionList(data: any, profile: string): any {
       is_default_profile: profile === 'default'
     }
   })
-  const total = Number.isFinite(data?.total) ? Number(data.total) : rows.length + (data?.has_more ? 1 : 0)
+  const hasExactTotal = Number.isFinite(data?.total)
+  const offset = Number.isFinite(data?.offset) ? Math.max(0, Number(data.offset)) : 0
+  const total = hasExactTotal ? Number(data.total) : offset + rows.length + (data?.has_more ? 1 : 0)
   const profileTotals =
     data?.profile_totals && typeof data.profile_totals === 'object'
       ? data.profile_totals
@@ -31,6 +33,7 @@ function normalizeRemoteSessionList(data: any, profile: string): any {
     ...data,
     sessions: rows,
     total,
+    total_is_lower_bound: !hasExactTotal && Boolean(data?.has_more),
     profile_totals: profileTotals
   }
 }

--- a/apps/desktop/src/app/chat/sidebar/chrome.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/chrome.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { countLabel } from './chrome'
+
+describe('countLabel', () => {
+  it('marks pagination lower bounds without presenting them as exact totals', () => {
+    expect(countLabel(40, 41, true)).toBe('40+')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -8,9 +8,9 @@ import { cn } from '@/lib/utils'
 // sections and the project/workspace tree, so it lives outside either to keep
 // imports one-directional (no index <-> projects cycle).
 
-/** `loaded/total` when there's more on the server, else just the loaded count. */
-export const countLabel = (loaded: number, total: number): string =>
-  total > loaded ? `${loaded}/${total}` : String(loaded)
+/** `loaded/total` when exact, `loaded+` for a lower bound, else just loaded. */
+export const countLabel = (loaded: number, total: number, totalIsLowerBound = false): string =>
+  total > loaded ? (totalIsLowerBound ? `${loaded}+` : `${loaded}/${total}`) : String(loaded)
 
 /** The muted count chip next to a section/workspace label. */
 export function SidebarCount({ children }: { children: React.ReactNode }) {

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -93,6 +93,7 @@ import {
   $sessions,
   $sessionsLoading,
   $sessionsTotal,
+  $sessionsTotalIsLowerBound,
   sessionPinId,
   setCurrentCwd
 } from '@/store/session'
@@ -300,6 +301,7 @@ export function ChatSidebar({
   const messagingTruncated = useStore($messagingTruncated)
   const sessionsLoading = useStore($sessionsLoading)
   const sessionsTotal = useStore($sessionsTotal)
+  const sessionsTotalIsLowerBound = useStore($sessionsTotalIsLowerBound)
   const sessionProfileTotals = useStore($sessionProfileTotals)
   const workingSessionIds = useStore($workingSessionIds)
   const profiles = useStore($profiles)
@@ -967,7 +969,7 @@ export function ChatSidebar({
 
   const hasMoreSessions = knownSessionTotal > loadedSessionCount
 
-  const recentsMeta = countLabel(displayAgentSessions.length, knownSessionTotal)
+  const recentsMeta = countLabel(displayAgentSessions.length, knownSessionTotal, sessionsTotalIsLowerBound)
   const displayRecentsCountRef = useRef(0)
   const loadedRecentsCountRef = useRef(0)
   displayRecentsCountRef.current = displayAgentSessions.length

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -25,7 +25,8 @@ import {
   setSessionProfileTotals,
   setSessions,
   setSessionsLoading,
-  setSessionsTotal
+  setSessionsTotal,
+  setSessionsTotalIsLowerBound
 } from '@/store/session'
 import { $workingSessionIds, getRecentlySettledSessionIds } from '@/store/session-states'
 
@@ -186,6 +187,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
           return sameCronSignature(prev, next) ? prev : next
         })
+        setSessionsTotalIsLowerBound(Boolean(recents.total_is_lower_bound))
         setSessionsTotal(typeof recents.total === 'number' ? recents.total : recents.sessions.length)
         setSessionProfileTotals(prev => {
           const next = recents.profile_totals ?? {}

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -367,6 +367,8 @@ export async function listAllProfileSessions(
 export interface SidebarSessionSlice {
   sessions: SessionInfo[]
   total?: number
+  /** True when `total` is a pagination lower bound rather than an exact count. */
+  total_is_lower_bound?: boolean
   profile_totals?: Record<string, number>
 }
 

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -8,6 +8,7 @@ import {
   $sessions,
   $sessionsLoading,
   $sessionsTotal,
+  $sessionsTotalIsLowerBound,
   setCronSessions,
   setFreshDraftReady,
   setMessagingSessions,
@@ -40,6 +41,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     setCronSessions([])
     setMessagingSessions([])
     setSessionsLoading(true)
+    $sessionsTotalIsLowerBound.set(true)
     $gatewaySwitching.set(false)
   })
 
@@ -48,6 +50,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
 
     expect($sessions.get()).toEqual([])
     expect($sessionsTotal.get()).toBe(0)
+    expect($sessionsTotalIsLowerBound.get()).toBe(false)
     expect($cronSessions.get()).toEqual([])
     expect($messagingSessions.get()).toEqual([])
     expect($sessionsLoading.get()).toBe(true)

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -15,7 +15,8 @@ import {
   setSessionProfileTotals,
   setSessions,
   setSessionsLoading,
-  setSessionsTotal
+  setSessionsTotal,
+  setSessionsTotalIsLowerBound
 } from '@/store/session'
 import { clearAllSessionStates } from '@/store/session-states'
 
@@ -39,6 +40,7 @@ export const $gatewaySwitching = atom(false)
 export function wipeSessionListsForGatewaySwitch(): void {
   setSessions([])
   setSessionsTotal(0)
+  setSessionsTotalIsLowerBound(false)
   setSessionProfileTotals({})
   setCronSessions([])
   setMessagingSessions([])

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -216,6 +216,7 @@ export const $connection = atom<HermesConnection | null>(null)
 export const $gatewayState = atom('idle')
 export const $sessions = atom<SessionInfo[]>([])
 export const $sessionsTotal = atom<number>(0)
+export const $sessionsTotalIsLowerBound = atom<boolean>(false)
 // Cron-job sessions (source === 'cron') are fetched as their own list so the
 // scheduler's always-newest sessions never crowd recents out of the page
 // budget. Powers the collapsed "Cron jobs" sidebar section.
@@ -322,6 +323,7 @@ export const setConnection = (next: Updater<HermesConnection | null>) => updateA
 export const setGatewayState = (next: Updater<string>) => updateAtom($gatewayState, next)
 export const setSessions = (next: Updater<SessionInfo[]>) => updateAtom($sessions, next)
 export const setSessionsTotal = (next: Updater<number>) => updateAtom($sessionsTotal, next)
+export const setSessionsTotalIsLowerBound = (next: Updater<boolean>) => updateAtom($sessionsTotalIsLowerBound, next)
 export const setCronSessions = (next: Updater<SessionInfo[]>) => updateAtom($cronSessions, next)
 export const setMessagingSessions = (next: Updater<SessionInfo[]>) => updateAtom($messagingSessions, next)
 export const setMessagingPlatformTotals = (next: Updater<Record<string, number>>) =>

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -287,10 +287,14 @@ export interface ModelOptionsResponse {
 }
 
 export interface PaginatedSessions {
+  has_more?: boolean
   limit: number
   offset: number
   sessions: SessionInfo[]
   total: number
+  /** True when `total` is only a pagination lower bound because the backend
+   *  exposes `has_more` but not an exact count. */
+  total_is_lower_bound?: boolean
   /** Listable conversation count per profile (children excluded), keyed by
    *  profile name. Lets the sidebar scope its "Load more" footer to the active
    *  profile instead of the global total. Present only on

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -57,6 +57,7 @@ LEGACY_AUTHOR_MAP = {
     "bryan@users.noreply.github.com": "hydraxman",  # PR #62028 salvage (copilot xhigh) — regression-test commit authored under a bare-noreply local git identity; PR author is @hydraxman
     "antydizajn@gmail.com": "antydizajn",  # PR #36043 salvage (auxiliary: route custom:<name> through named-provider arm + Palantir Bearer auth)
     "252620095+briandevans@users.noreply.github.com": "briandevans",  # PR #64951 salvage (lmstudio: clamp max/ultra reasoning effort)
+    "reymondmeking@gmail.com": "reymondmeking-dot",  # First-time contributor mapping
     "kar.iskakov@gmail.com": "karfly",  # PR #64012 salvage (gateway: surface extended reasoning efforts)
     "enzo.eliott.adami@gmail.com": "enzo-adami",  # PR #66637 salvage (compression: preserve human intent and durable handoffs)
     "kimyeon30@naver.com": "rlaehddus302",  # PR #61985 salvage (gateway: secondary-adapter auth callback profile)


### PR DESCRIPTION
## Summary

- make Desktop global-remote session refresh try the current `/api/profiles/sessions` endpoint first
- fall back to `/api/sessions` only when the aggregate endpoint is explicitly missing on an older remote backend
- normalize both dashboard `{ sessions, total }` and thin gateway `{ data, has_more }` responses into the sidebar contract
- preserve authentication and connectivity errors instead of hiding them behind the compatibility path

## Root cause

The Desktop sidebar refreshes through `/api/profiles/sessions`. That endpoint exists on current Desktop/dashboard backends, but older remote Gateway installations expose only `/api/sessions`. In global remote mode Electron forwarded the aggregate request unchanged, so a reconnect could leave the sidebar empty even though the remote `state.db` still contained the conversations.

The compatibility path stays narrow: it retries `/api/sessions` only for a 404 or the existing missing-endpoint HTML diagnostic. A 401, timeout, or connection refusal is still surfaced normally.

## Validation

- `npx --yes tsx@4.22.4 --test electron/remote-session-compat.test.ts` (4 passed)
- `npx --yes prettier@3.8.3 --check electron/main.ts electron/remote-session-compat.ts electron/remote-session-compat.test.ts`
- `npx --yes esbuild@0.28.1 electron/main.ts --bundle --platform=node --format=esm --packages=external --outfile=<temp>/hermes-main-65351.mjs`
- `git diff --check`

Tested on Windows 11. The worktree did not have Desktop dependencies installed, so the focused pure-helper tests were run through the repository-pinned `tsx` version and the Electron entry point was bundled with the repository-pinned `esbuild` version.

Fixes #65351