### PR TITLE
fix: isolate Desktop project routing per session

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+
+import { ProjectOverviewRow } from './overview-row'
+import type { SidebarProjectTree } from './workspace-groups'
+
+vi.mock('./project-menu', () => ({ ProjectMenu: () => null }))
+
+const projectB: SidebarProjectTree = {
+  id: 'p_project_b',
+  label: 'Project B',
+  path: '/work/project-b',
+  repos: [],
+  sessionCount: 0
+}
+
+function renderRow(overrides: Partial<React.ComponentProps<typeof ProjectOverviewRow>> = {}) {
+  return render(
+    <I18nProvider configClient={null}>
+      <ProjectOverviewRow project={projectB} {...overrides} />
+    </I18nProvider>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('ProjectOverviewRow', () => {
+  it('enters the clicked project before starting its new session', () => {
+    const calls: string[] = []
+    const onEnter = vi.fn((id: string) => calls.push(`enter:${id}`))
+    const onNewSession = vi.fn((path: null | string) => calls.push(`new:${path}`))
+
+    renderRow({ activeProjectId: 'p_project_a', onEnter, onNewSession })
+    fireEvent.click(screen.getByRole('button', { name: 'New session in Project B' }))
+
+    expect(calls).toEqual(['enter:p_project_b', 'new:/work/project-b'])
+    expect(onEnter).toHaveBeenCalledWith(projectB.id)
+    expect(onNewSession).toHaveBeenCalledWith(projectB.path)
+  })
+
+  it('keeps ordinary project entry separate from session creation', () => {
+    const onEnter = vi.fn()
+    const onNewSession = vi.fn()
+
+    renderRow({ activeProjectId: 'p_project_a', onEnter, onNewSession })
+    fireEvent.click(screen.getByRole('button', { name: 'Open Project B' }))
+
+    expect(onEnter).toHaveBeenCalledWith(projectB.id)
+    expect(onNewSession).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -117,7 +117,13 @@ export function ProjectOverviewRow({
         actions={
           <>
             {onNewSession && (
-              <WorkspaceAddButton label={s.newSessionIn(project.label)} onClick={() => onNewSession(project.path)} />
+              <WorkspaceAddButton
+                label={s.newSessionIn(project.label)}
+                onClick={() => {
+                  onEnter?.(project.id)
+                  onNewSession(project.path)
+                }}
+              />
             )}
             <ProjectMenu anchorRef={rowRef} isActive={isActive} project={project} />
           </>

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -31,7 +31,7 @@ import { setCronFocusJobId } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { $filePreviewTarget, $previewTarget } from '@/store/preview'
 import { $activeGatewayProfile, $freshSessionRequest, $profileScope, refreshActiveProfile } from '@/store/profile'
-import { $startWorkSessionRequest, followActiveSessionCwd, resolveNewSessionCwd } from '@/store/projects'
+import { $startWorkSessionRequest } from '@/store/projects'
 import {
   $activeSessionId,
   $connection,
@@ -48,8 +48,6 @@ import {
   sessionPinId,
   setAwaitingResponse,
   setBusy,
-  setCurrentBranch,
-  setCurrentCwd,
   setCurrentModel,
   setCurrentProvider,
   setMessages
@@ -85,6 +83,7 @@ import { useRouteResume } from '../session/hooks/use-route-resume'
 import { useSessionActions } from '../session/hooks/use-session-actions'
 import { useSessionListActions } from '../session/hooks/use-session-list-actions'
 import { useSessionStateCache } from '../session/hooks/use-session-state-cache'
+import { startWorkspaceSession } from '../session/workspace-session-target'
 import { useOverlayRouting } from '../shell/hooks/use-overlay-routing'
 import { useWindowControlsOverlayWidth } from '../shell/hooks/use-window-controls-overlay-width'
 import { KeybindPanel } from '../shell/keybind-panel'
@@ -423,33 +422,15 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // also drills the sidebar into that project so the new lane is visible.
   const startSessionInWorkspace = useCallback(
     (path: null | string) => {
-      startFreshSessionDraft()
-
-      // A worktree lane carries its own path; the trunk "+" can be path-less
-      // (the main checkout is implicit), so fall back to the active project's
-      // root instead of no-op'ing on null.
-      const target = path?.trim() || resolveNewSessionCwd()
-
-      if (!target) {
-        return
-      }
-
-      setCurrentCwd(target)
-      void requestGateway<{ branch?: string; cwd?: string }>('config.get', { key: 'project', cwd: target })
-        .then(info => {
-          const resolved = info.cwd || target
-
-          setCurrentCwd(resolved)
-          setCurrentBranch(info.branch || '')
-
-          if (path?.trim()) {
-            restoreWorktree(resolved)
-            void followActiveSessionCwd(resolved)
-          }
-        })
-        .catch(() => undefined)
+      startWorkspaceSession({
+        activeSessionIdRef,
+        onExplicitWorkspace: restoreWorktree,
+        path,
+        requestGateway,
+        startFreshSessionDraft
+      })
     },
-    [requestGateway, startFreshSessionDraft]
+    [activeSessionIdRef, requestGateway, startFreshSessionDraft]
   )
 
   // Composer "branch off into a new worktree": open a fresh session anchored

--- a/tests/tools/test_project_tools.py
+++ b/tests/tools/test_project_tools.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+
+from hermes_cli import projects_db as pdb
+from tools import project_tools
+
+
+def _use_projects_db(monkeypatch, tmp_path):
+    db_path = tmp_path / "projects.db"
+    original_connect_closing = pdb.connect_closing
+    monkeypatch.setattr(pdb, "connect_closing", lambda: original_connect_closing(db_path=db_path))
+    return db_path, original_connect_closing
+
+
+def test_agent_session_project_create_keeps_profile_active_pointer_and_moves_session(monkeypatch, tmp_path):
+    db_path, connect_closing = _use_projects_db(monkeypatch, tmp_path)
+    with connect_closing(db_path=db_path) as conn:
+        active_id = pdb.create_project(conn, name="Foreground", folders=["/work/foreground"])
+        pdb.set_active(conn, active_id)
+
+    workspace_moves: list[tuple[str, str, str]] = []
+    project_tools.set_project_workspace_callback(lambda *args: workspace_moves.append(args))
+
+    try:
+        result = json.loads(
+            project_tools.project_create(
+                "Background", path="/work/background", task_id="session-background"
+            )
+        )
+    finally:
+        project_tools.set_project_workspace_callback(None)
+
+    with connect_closing(db_path=db_path) as conn:
+        assert pdb.get_active_id(conn) == active_id
+        created = pdb.get_project(conn, result["id"])
+
+    assert result["success"] is True
+    assert created is not None
+    assert created.name == "Background"
+    assert workspace_moves == [("session-background", "/work/background", "Background")]
+
+
+def test_legacy_project_create_sets_profile_active_pointer(monkeypatch, tmp_path):
+    db_path, connect_closing = _use_projects_db(monkeypatch, tmp_path)
+    with connect_closing(db_path=db_path) as conn:
+        previous_id = pdb.create_project(conn, name="Previous", folders=["/work/previous"])
+        pdb.set_active(conn, previous_id)
+
+    result = json.loads(project_tools.project_create("Created", path="/work/created"))
+
+    with connect_closing(db_path=db_path) as conn:
+        assert pdb.get_active_id(conn) == result["id"]
+
+    assert result["success"] is True
+
+
+def test_legacy_project_switch_sets_profile_active_pointer(monkeypatch, tmp_path):
+    db_path, connect_closing = _use_projects_db(monkeypatch, tmp_path)
+    with connect_closing(db_path=db_path) as conn:
+        active_id = pdb.create_project(conn, name="Active", folders=["/work/active"])
+        target_id = pdb.create_project(conn, name="Target", folders=["/work/target"])
+        pdb.set_active(conn, active_id)
+
+    result = json.loads(project_tools.project_switch(target_id))
+
+    with connect_closing(db_path=db_path) as conn:
+        assert pdb.get_active_id(conn) == target_id
+
+    assert result["success"] is True
+    assert result["id"] == target_id
+
+
+def test_agent_session_project_switch_keeps_profile_active_pointer(monkeypatch, tmp_path):
+    db_path = tmp_path / "projects.db"
+    original_connect_closing = pdb.connect_closing
+
+    with original_connect_closing(db_path=db_path) as conn:
+        active_id = pdb.create_project(conn, name="Foreground", folders=["/work/foreground"])
+        background_id = pdb.create_project(conn, name="Background", folders=["/work/background"])
+        pdb.set_active(conn, active_id)
+
+    monkeypatch.setattr(pdb, "connect_closing", lambda: original_connect_closing(db_path=db_path))
+    workspace_moves: list[tuple[str, str, str]] = []
+    project_tools.set_project_workspace_callback(lambda *args: workspace_moves.append(args))
+
+    try:
+        result = json.loads(project_tools.project_switch(background_id, task_id="session-background"))
+    finally:
+        project_tools.set_project_workspace_callback(None)
+
+    with original_connect_closing(db_path=db_path) as conn:
+        assert pdb.get_active_id(conn) == active_id
+
+    assert result["success"] is True
+    assert result["id"] == background_id
+    assert workspace_moves == [("session-background", "/work/background", "Background")]

--- a/tools/project_tools.py
+++ b/tools/project_tools.py
@@ -3,13 +3,16 @@
 
 Projects (per-profile ``projects.db``) are the named workspaces the desktop
 sidebar groups sessions into. Creating / switching a project is a deliberate act
-expressed as explicit tools — never a side effect of a terminal ``cd``.
+expressed as explicit tools — never a side effect of a terminal ``cd``. A live
+session create/switch re-anchors only that session; it must not move the
+profile-global Desktop selection shared by concurrent chats.
 
 Exposed only on GUI sessions: the tools live in the `project` toolset (kept off
 ``_HERMES_CORE_TOOLS``) which the desktop/TUI gateway folds into its resolved
 toolsets, so no CLI/messaging/cron schema carries them. The GUI also wires
 ``set_project_workspace_callback`` so a create/switch re-anchors the live
-session's cwd and the sidebar follows the move; the DB write is the durable part.
+session's cwd and the sidebar follows the move. Project creation remains durable;
+a create/switch without a live task id retains the legacy active-pointer behavior.
 """
 
 import json
@@ -20,8 +23,7 @@ from tools.registry import registry
 
 # Set by the GUI gateway (tui_gateway) at session wiring. Receives
 # ``(task_id, primary_path, project_name)`` and re-anchors that session's
-# workspace + refreshes the sidebar. ``None`` in CLI / messaging contexts — the
-# DB write still happens; there's just no live GUI session to move.
+# workspace + refreshes the sidebar. ``None`` in CLI / messaging contexts.
 _workspace_callback: Optional[Callable[[str, str, str], None]] = None
 
 
@@ -102,7 +104,11 @@ def project_create(name: str, path: Optional[str] = None, task_id: Optional[str]
     try:
         with pdb.connect_closing() as conn:
             pid = pdb.create_project(conn, name=name, folders=[folder] if folder else [], primary_path=folder or None)
-            pdb.set_active(conn, pid)
+            # A live agent session owns its workspace independently. Creating a
+            # project must not let a background chat redirect the profile-global
+            # Desktop selection used by unrelated and newly created sessions.
+            if not task_id:
+                pdb.set_active(conn, pid)
             proj = pdb.get_project(conn, pid)
     except ValueError as exc:
         return json.dumps({"success": False, "error": str(exc)})
@@ -123,7 +129,11 @@ def project_switch(project: str, task_id: Optional[str] = None) -> str:
         proj = _resolve(conn, project)
         if proj is None:
             return json.dumps({"success": False, "error": f"no project matching '{project}'"})
-        pdb.set_active(conn, proj.id)
+        # A live agent session owns its workspace independently. Mutating the
+        # profile-global pointer here lets a background chat redirect unrelated
+        # Desktop windows and newly created sessions into this project.
+        if not task_id:
+            pdb.set_active(conn, proj.id)
 
     primary = _primary_path(proj)
     _apply_workspace(task_id, primary, proj.name)


### PR DESCRIPTION
## Summary
- prevent task-scoped `project_create` and `project_switch` from mutating profile-global `active_id`
- enter the selected project before the sidebar `+` creates a session
- pin an explicit workspace target through async session creation
- add regressions for concurrent project routing and legacy no-task-id behavior

## Verification
- `scripts/run_tests.sh tests/tools/test_project_tools.py -q` (4 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_projects_db.py -q` (15 passed)
- focused Desktop UI regressions (3 passed; independent review suite 57 passed)
- Desktop typecheck, production build, Ruff, ESLint, and `git diff --check` passed

Independent ship review found no blocking issues.