### PR TITLE
feat(portal): conversation-scoped Nous Portal usage tags across aux/MoA/delegate calls

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -404,6 +404,12 @@ def _run_references_parallel(
     results: list[tuple[str, str, Any] | None] = [None] * len(reference_models)
     futures = {}
     workers = min(_MAX_REFERENCE_WORKERS, len(reference_models))
+    # Reference slots run on bare executor threads, which start with an empty
+    # contextvars.Context — propagate the parent turn's context (approval
+    # callbacks + the Nous Portal conversation tag) into each worker so
+    # advisor calls attribute to the same conversation as the acting turn.
+    from tools.thread_context import propagate_context_to_thread
+
     with ThreadPoolExecutor(max_workers=workers) as executor:
         for idx, slot in enumerate(reference_models):
             if slot.get("provider") == "moa":
@@ -415,7 +421,7 @@ def _run_references_parallel(
                 continue
             futures[
                 executor.submit(
-                    _run_reference,
+                    propagate_context_to_thread(_run_reference),
                     slot,
                     ref_messages,
                     temperature=temperature,

--- a/agent/portal_tags.py
+++ b/agent/portal_tags.py
@@ -31,7 +31,55 @@ version can change at runtime (editable installs, hot-reload tooling), and
 
 from __future__ import annotations
 
-from typing import List
+from contextvars import ContextVar
+from typing import List, Optional
+
+# ── Ambient conversation context ─────────────────────────────────────────────
+#
+# The main agent loop knows its ``session_id``; the dozens of auxiliary call
+# sites (compression, title generation, vision, web_extract, session_search,
+# MoA reference/aggregator slots, curator, kanban helpers, ...) do not — they
+# funnel through ``agent.auxiliary_client.call_llm`` which has no session
+# handle. Rather than threading a ``session_id`` parameter through every one
+# of those call sites (and every future one), the agent loop publishes the
+# active conversation id here and ``nous_portal_tags()`` picks it up as a
+# fallback whenever no explicit ``session_id`` is passed.
+#
+# ContextVar (not a module global) so concurrent agents in one process —
+# gateway sessions, delegate_task subagents, batch runners — never see each
+# other's conversation id. Worker threads spawned via
+# ``tools.thread_context.propagate_context_to_thread`` (background review,
+# MoA fan-out, tool executor) inherit it through the copied Context; bare
+# threads (title generator) capture it explicitly at spawn time.
+_conversation_id: ContextVar[Optional[str]] = ContextVar(
+    "nous_portal_conversation_id", default=None
+)
+
+
+def set_conversation_context(conversation_id: Optional[str]):
+    """Publish the active conversation id for ambient Portal tagging.
+
+    Called by the agent loop at turn entry with the conversation's stable
+    id (the session-lineage ROOT id, so the tag survives context-compression
+    session rotation). Pass ``None`` to clear. Returns the ContextVar token
+    so callers can ``reset_conversation_context(token)`` on turn exit.
+    """
+    return _conversation_id.set(conversation_id or None)
+
+
+def reset_conversation_context(token) -> None:
+    """Restore the previous conversation context (pair with ``set_...``)."""
+    try:
+        _conversation_id.reset(token)
+    except Exception:
+        # Token from another Context (e.g. reset on a different thread) —
+        # fall back to clearing rather than raising in cleanup paths.
+        _conversation_id.set(None)
+
+
+def get_conversation_context() -> Optional[str]:
+    """Return the ambient conversation id, or ``None`` when unset."""
+    return _conversation_id.get()
 
 
 def _hermes_version() -> str:
@@ -77,10 +125,20 @@ def nous_portal_tags(session_id: str | None = None) -> List[str]:
 
     When ``session_id`` is provided, a ``conversation=<session_id>`` tag is
     appended so Portal usage can be attributed to a specific Hermes
-    conversation. Callers without a session id (e.g. the auxiliary client's
-    always-on base tags) omit it and get the canonical two-tag set.
+    conversation. When it is omitted, the ambient conversation context
+    (``set_conversation_context``, published by the agent loop at turn
+    entry) is used instead — this is how auxiliary calls (compression,
+    titles, vision, MoA slots, ...) inherit the conversation tag without
+    per-call-site plumbing. Callers outside any conversation (e.g. the
+    auxiliary client's import-time base tags) get the canonical two-tag set.
     """
     tags = ["product=hermes-agent", hermes_client_tag()]
-    if session_id:
-        tags.append(conversation_tag(session_id))
+    # Ambient context first: the agent loop publishes the lineage ROOT id
+    # (stable across context-compression rotation and delegate subagent
+    # trees), which is the better conversation key than a per-segment
+    # session_id passed explicitly. The explicit argument remains as a
+    # fallback for callers running outside any agent turn.
+    effective = get_conversation_context() or session_id
+    if effective:
+        tags.append(conversation_tag(effective))
     return tags

--- a/agent/portal_tags.py
+++ b/agent/portal_tags.py
@@ -55,10 +55,32 @@ def hermes_client_tag() -> str:
     return f"client=hermes-client-v{_hermes_version()}"
 
 
-def nous_portal_tags() -> List[str]:
+def conversation_tag(session_id: str) -> str:
+    """Return the ``conversation=...`` tag for a Hermes session/conversation.
+
+    Format: ``conversation=<session_id>``. ``session_id`` is the canonical
+    Hermes conversation identifier (``AIAgent.session_id``) — the same value
+    used for ``~/.hermes/sessions/`` storage, session logs, and lineage.
+
+    Unlike the product/client tags this is high-cardinality (one value per
+    conversation), so it is only appended when a session id is actually
+    available — never as part of the always-on base tag set.
+    """
+    return f"conversation={session_id}"
+
+
+def nous_portal_tags(session_id: str | None = None) -> List[str]:
     """Return the canonical list of Nous Portal product tags.
 
     Always returns a fresh list so callers can mutate it freely
     (e.g. ``merged_extra.setdefault("tags", []).extend(nous_portal_tags())``).
+
+    When ``session_id`` is provided, a ``conversation=<session_id>`` tag is
+    appended so Portal usage can be attributed to a specific Hermes
+    conversation. Callers without a session id (e.g. the auxiliary client's
+    always-on base tags) omit it and get the canonical two-tag set.
     """
-    return ["product=hermes-agent", hermes_client_tag()]
+    tags = ["product=hermes-agent", hermes_client_tag()]
+    if session_id:
+        tags.append(conversation_tag(session_id))
+    return tags

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -145,6 +145,21 @@ def auto_title_session(
     except Exception:
         return
 
+    # This runs on a bare daemon thread spawned AFTER the turn's ambient
+    # conversation context was reset, so publish it here from the session id
+    # we already hold — the title-generation LLM call then carries the same
+    # ``conversation=`` Portal tag as the turn it titles. Root-of-lineage for
+    # consistency with the agent loop (a no-op on first exchange, where
+    # titling happens, but correct if this ever runs on a continuation).
+    from agent.portal_tags import set_conversation_context
+
+    conversation_id = session_id
+    try:
+        conversation_id = session_db.get_conversation_root(session_id) or session_id
+    except Exception:
+        pass
+    set_conversation_context(conversation_id)
+
     title = generate_title(
         user_message, assistant_response, failure_callback=failure_callback, main_runtime=main_runtime
     )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4544,6 +4544,20 @@ class SessionDB:
         messages = _strip_background_review_harness(messages)
         return messages
 
+    def get_conversation_root(self, session_id: str) -> str:
+        """Return the ROOT id of *session_id*'s lineage chain.
+
+        The root is the stable "conversation id": context compression
+        rotates ``session_id`` to a new segment linked via
+        ``parent_session_id``, and delegate subagents hang off their
+        parent the same way. Walking to the root gives every segment of
+        one user-facing conversation (and its delegation tree) a single
+        identifier — used for Nous Portal ``conversation=`` usage tagging.
+        Returns *session_id* unchanged when it has no recorded parent.
+        """
+        chain = self._session_lineage_root_to_tip(session_id)
+        return (chain[0] if chain and chain[0] else session_id)
+
     def _session_lineage_root_to_tip(self, session_id: str) -> List[str]:
         if not session_id:
             return [session_id]

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -13,7 +13,7 @@ class NousProfile(ProviderProfile):
     def build_extra_body(
         self, *, session_id: str | None = None, **context
     ) -> dict[str, Any]:
-        body: dict[str, Any] = {"tags": nous_portal_tags()}
+        body: dict[str, Any] = {"tags": nous_portal_tags(session_id=session_id)}
         provider_preferences = context.get("provider_preferences")
         if provider_preferences:
             body["provider"] = provider_preferences

--- a/run_agent.py
+++ b/run_agent.py
@@ -5876,6 +5876,35 @@ class AIAgent:
         from agent.chat_completion_helpers import handle_max_iterations
         return handle_max_iterations(self, messages, api_call_count)
 
+    def _conversation_root_id(self) -> Optional[str]:
+        """Resolve the stable conversation id for Portal usage attribution.
+
+        Returns the session-lineage ROOT id rather than the current segment
+        id, so one user-facing conversation keeps a single ``conversation=``
+        tag across context-compression rotation (`/new` starts a genuinely
+        new lineage). Delegate subagents resolve through their
+        ``_parent_session_id`` so an entire delegation tree tags as the
+        parent conversation.
+
+        Best-effort: falls back to the raw session id when the session DB
+        is unavailable or the lineage walk fails.
+        """
+        sid = getattr(self, "session_id", None)
+        if not sid:
+            return None
+        # Subagents may not have a DB row yet on their first turn; walking
+        # from the parent id still lands on the right root.
+        start = getattr(self, "_parent_session_id", None) or sid
+        db = getattr(self, "_session_db", None)
+        if db is not None:
+            try:
+                root = db.get_conversation_root(start)
+                if root:
+                    return root
+            except Exception:
+                logger.debug("Conversation root lineage walk failed", exc_info=True)
+        return start
+
     def run_conversation(
         self,
         user_message: Any,
@@ -5889,17 +5918,30 @@ class AIAgent:
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
-        return run_conversation(
-            self,
-            user_message,
-            system_message,
-            conversation_history,
-            task_id,
-            stream_callback,
-            persist_user_message,
-            persist_user_timestamp=persist_user_timestamp,
-            moa_config=moa_config,
+        from agent.portal_tags import (
+            reset_conversation_context,
+            set_conversation_context,
         )
+        # Publish the conversation id for ambient Nous Portal tagging. Every
+        # LLM call made inside this turn — main loop, compression, vision,
+        # web_extract, session_search, MoA slots, background-review forks
+        # (which copy this Context into their thread) — inherits the
+        # ``conversation=<root>`` tag with zero per-call-site plumbing.
+        token = set_conversation_context(self._conversation_root_id())
+        try:
+            return run_conversation(
+                self,
+                user_message,
+                system_message,
+                conversation_history,
+                task_id,
+                stream_callback,
+                persist_user_message,
+                persist_user_timestamp=persist_user_timestamp,
+                moa_config=moa_config,
+            )
+        finally:
+            reset_conversation_context(token)
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """

--- a/tests/agent/test_portal_tags.py
+++ b/tests/agent/test_portal_tags.py
@@ -69,6 +69,137 @@ def test_nous_portal_tags_omits_conversation_without_session_id():
         assert not any(t.startswith("conversation=") for t in tags)
 
 
+# ── Ambient conversation context (ContextVar) ────────────────────────────────
+
+
+def test_ambient_context_tags_calls_without_explicit_session_id():
+    """set_conversation_context makes bare nous_portal_tags() carry the tag.
+
+    This is the mechanism auxiliary calls (compression, titles, vision, MoA
+    slots) rely on — they call nous_portal_tags() with no argument.
+    """
+    from agent.portal_tags import (
+        conversation_tag,
+        nous_portal_tags,
+        reset_conversation_context,
+        set_conversation_context,
+    )
+
+    token = set_conversation_context("root-sess-1")
+    try:
+        tags = nous_portal_tags()
+        assert conversation_tag("root-sess-1") in tags
+        assert len(tags) == 3
+    finally:
+        reset_conversation_context(token)
+    # After reset the ambient tag is gone.
+    assert not any(t.startswith("conversation=") for t in nous_portal_tags())
+
+
+def test_ambient_context_wins_over_explicit_session_id():
+    """The lineage-root ambient id outranks a per-segment explicit id."""
+    from agent.portal_tags import (
+        conversation_tag,
+        nous_portal_tags,
+        reset_conversation_context,
+        set_conversation_context,
+    )
+
+    token = set_conversation_context("lineage-root")
+    try:
+        tags = nous_portal_tags(session_id="segment-2")
+        assert conversation_tag("lineage-root") in tags
+        assert conversation_tag("segment-2") not in tags
+    finally:
+        reset_conversation_context(token)
+
+
+def test_ambient_context_set_none_clears():
+    """set_conversation_context(None) publishes no tag (and coerces '')."""
+    from agent.portal_tags import (
+        get_conversation_context,
+        nous_portal_tags,
+        reset_conversation_context,
+        set_conversation_context,
+    )
+
+    for empty in (None, ""):
+        token = set_conversation_context(empty)
+        try:
+            assert get_conversation_context() is None
+            assert len(nous_portal_tags()) == 2
+        finally:
+            reset_conversation_context(token)
+
+
+def test_ambient_context_isolated_between_contexts():
+    """Two copied Contexts (≈ two concurrent agents) don't leak into each other."""
+    import contextvars
+
+    from agent.portal_tags import (
+        conversation_tag,
+        nous_portal_tags,
+        set_conversation_context,
+    )
+
+    def _in_conversation(cid):
+        set_conversation_context(cid)
+        return nous_portal_tags()
+
+    tags_a = contextvars.copy_context().run(_in_conversation, "agent-a")
+    tags_b = contextvars.copy_context().run(_in_conversation, "agent-b")
+    assert conversation_tag("agent-a") in tags_a
+    assert conversation_tag("agent-b") in tags_b
+    assert conversation_tag("agent-b") not in tags_a
+    # The outer (test) context stays clean.
+    assert not any(t.startswith("conversation=") for t in nous_portal_tags())
+
+
+def test_ambient_context_propagates_via_thread_context_helper():
+    """propagate_context_to_thread carries the tag onto executor workers (MoA path)."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    from agent.portal_tags import (
+        conversation_tag,
+        nous_portal_tags,
+        reset_conversation_context,
+        set_conversation_context,
+    )
+    from tools.thread_context import propagate_context_to_thread
+
+    token = set_conversation_context("moa-root")
+    try:
+        with ThreadPoolExecutor(max_workers=1) as ex:
+            plain = ex.submit(nous_portal_tags).result()
+            propagated = ex.submit(
+                propagate_context_to_thread(nous_portal_tags)
+            ).result()
+    finally:
+        reset_conversation_context(token)
+
+    # Bare submit loses the ContextVar; the propagation wrapper keeps it.
+    assert not any(t.startswith("conversation=") for t in plain)
+    assert conversation_tag("moa-root") in propagated
+
+
+def test_reset_with_foreign_token_clears_instead_of_raising():
+    """reset_conversation_context on another Context's token must not raise."""
+    import contextvars
+
+    from agent.portal_tags import (
+        get_conversation_context,
+        reset_conversation_context,
+        set_conversation_context,
+    )
+
+    foreign_token = contextvars.copy_context().run(
+        lambda: set_conversation_context("elsewhere")
+    )
+    set_conversation_context("here")
+    reset_conversation_context(foreign_token)  # must not raise
+    assert get_conversation_context() is None
+
+
 def test_auxiliary_client_nous_extra_body_uses_helper():
     """auxiliary_client.NOUS_EXTRA_BODY must match the canonical helper output."""
     from agent.auxiliary_client import NOUS_EXTRA_BODY

--- a/tests/agent/test_portal_tags.py
+++ b/tests/agent/test_portal_tags.py
@@ -42,6 +42,33 @@ def test_nous_portal_tags_returns_fresh_list():
     assert "client=test-mutation" not in b
 
 
+def test_conversation_tag_format():
+    """The conversation tag carries the session id verbatim."""
+    from agent.portal_tags import conversation_tag
+
+    assert conversation_tag("abc-123") == "conversation=abc-123"
+
+
+def test_nous_portal_tags_appends_conversation_when_session_id_given():
+    """A session id adds a third, high-cardinality conversation tag."""
+    from agent.portal_tags import conversation_tag, nous_portal_tags
+
+    tags = nous_portal_tags(session_id="sess-42")
+    assert "product=hermes-agent" in tags
+    assert conversation_tag("sess-42") in tags
+    assert len(tags) == 3
+
+
+def test_nous_portal_tags_omits_conversation_without_session_id():
+    """Base tag set stays at two tags when no session id is available."""
+    from agent.portal_tags import nous_portal_tags
+
+    for empty in (None, ""):
+        tags = nous_portal_tags(session_id=empty)
+        assert len(tags) == 2
+        assert not any(t.startswith("conversation=") for t in tags)
+
+
 def test_auxiliary_client_nous_extra_body_uses_helper():
     """auxiliary_client.NOUS_EXTRA_BODY must match the canonical helper output."""
     from agent.auxiliary_client import NOUS_EXTRA_BODY

--- a/tests/hermes_state/test_conversation_root.py
+++ b/tests/hermes_state/test_conversation_root.py
@@ -1,0 +1,57 @@
+"""Tests for SessionDB.get_conversation_root — stable conversation id resolution.
+
+The conversation root is the Nous Portal ``conversation=`` tag value: one
+stable id per user-facing conversation, surviving context-compression
+session rotation and covering delegate subagent trees.
+"""
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def test_root_of_standalone_session_is_itself(db):
+    db.create_session("solo", source="cli")
+    assert db.get_conversation_root("solo") == "solo"
+
+
+def test_root_of_unknown_session_is_itself(db):
+    # No DB row at all (e.g. subagent's first turn before create_session).
+    assert db.get_conversation_root("ghost") == "ghost"
+
+
+def test_root_follows_compression_rotation_chain(db):
+    # root -> seg2 -> seg3 (two compression rotations)
+    db.create_session("root", source="cli")
+    db.create_session("seg2", source="cli", parent_session_id="root")
+    db.create_session("seg3", source="cli", parent_session_id="seg2")
+    assert db.get_conversation_root("seg3") == "root"
+    assert db.get_conversation_root("seg2") == "root"
+    assert db.get_conversation_root("root") == "root"
+
+
+def test_root_covers_delegate_child_sessions(db):
+    db.create_session("parent", source="cli")
+    db.create_session("child", source="delegate", parent_session_id="parent")
+    assert db.get_conversation_root("child") == "parent"
+
+
+def test_root_handles_parent_cycle_without_hanging(db):
+    # Defensive: a corrupted parent chain with a cycle must terminate.
+    db.create_session("a", source="cli")
+    db.create_session("b", source="cli", parent_session_id="a")
+    with db._lock:
+        db._conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?", ("b", "a")
+        )
+        db._conn.commit()
+    root = db.get_conversation_root("b")
+    assert root in ("a", "b")  # terminated, returned a chain member
+
+
+def test_root_empty_session_id_passthrough(db):
+    assert db.get_conversation_root("") == ""

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -425,6 +425,12 @@ class TestNousProfile:
             "provider": preferences,
         }
 
+    def test_tags_include_conversation_when_session_id(self):
+        from agent.portal_tags import conversation_tag
+        p = get_provider_profile("nous")
+        body = p.build_extra_body(session_id="sess-99")
+        assert conversation_tag("sess-99") in body["tags"]
+
     def test_auth_type(self):
         p = get_provider_profile("nous")
         assert p.auth_type == "oauth_device_code"

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -429,7 +429,7 @@ class TestBuildApiKwargsNousPortal:
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         extra = kwargs.get("extra_body", {})
-        assert extra.get("tags") == nous_portal_tags()
+        assert extra.get("tags") == nous_portal_tags(session_id=agent.session_id)
 
     def test_uses_chat_completions_format(self, monkeypatch):
         agent = _make_agent(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3973,7 +3973,9 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         from agent.portal_tags import nous_portal_tags
 
-        assert kwargs["extra_body"]["tags"] == nous_portal_tags()
+        assert kwargs["extra_body"]["tags"] == nous_portal_tags(
+            session_id=agent.session_id
+        )
         assert kwargs["extra_body"]["provider"] == {
             "only": ["deepseek"],
             "ignore": ["deepinfra"],
@@ -3995,7 +3997,9 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         from agent.portal_tags import nous_portal_tags
 
-        assert kwargs["extra_body"] == {"tags": nous_portal_tags()}
+        assert kwargs["extra_body"] == {
+            "tags": nous_portal_tags(session_id=agent.session_id)
+        }
 
     def test_summary_drops_invalid_provider_sort(self, agent):
         agent.base_url = "https://openrouter.ai/api/v1"


### PR DESCRIPTION
## Summary

Every Nous Portal request in a conversation — main agent loop, compression, title generation, vision, web_extract, session_search, MoA reference/aggregator slots, and delegate subagent trees — now carries a `conversation=<id>` tag keyed to the conversation's stable lineage-root session id.

Salvages PR #65183 by @J-SUPHA (cherry-picked, authorship preserved), which added the `conversation=` tag to main-loop Nous requests, then extends it to the whole conversation:

## Changes

- `agent/portal_tags.py` (@J-SUPHA + follow-up): `conversation_tag()` + optional `session_id` on `nous_portal_tags()` (salvaged); ContextVar-based ambient conversation context (`set_conversation_context` / `reset_conversation_context` / `get_conversation_context`) as a fallback when no explicit id is passed — every existing aux tag site inherits the tag with zero per-call-site plumbing.
- `plugins/model-providers/nous/__init__.py` (@J-SUPHA): forward `session_id` into the tag list.
- `hermes_state.py`: `SessionDB.get_conversation_root()` — public lineage-root resolver. One user-facing conversation keeps a single `conversation=` value across context-compression session rotation; delegate subagents resolve to their parent conversation. (Addresses the per-segment fragmentation noted as a known limitation in #65183.)
- `run_agent.py`: `run_conversation()` publishes the root id for the turn, resets in `finally`; `_conversation_root_id()` walks via `_parent_session_id` for subagents.
- `agent/moa_loop.py`: MoA reference fan-out workers wrapped with `propagate_context_to_thread` — advisor calls attribute to the acting conversation (side benefit: approval/sudo callback propagation on that path, same wrapper used by the tool executor).
- `agent/title_generator.py`: title thread republishes the context from its own session id (it spawns after turn reset).

No cache impact (tags ride `extra_body`, never message content). Non-Nous providers unaffected. Outside any conversation, the tag set stays the canonical two tags.

## Validation

| | Before | After |
|---|---|---|
| Main-loop Nous request | 2 tags | 3 tags, `conversation=<lineage root>` |
| Aux calls (compression/titles/vision/...) | 2 tags | 3 tags, same conversation id |
| MoA advisor fan-out | 2 tags (ContextVar lost at thread hop) | 3 tags via context propagation |
| After compression rotation | would tag new segment id | same root id as before rotation |
| Outside a conversation | 2 tags | 2 tags (unchanged) |

- Targeted suites green: `test_portal_tags.py` (15), `test_conversation_root.py` (6), `test_provider_profiles.py` (58), `test_provider_parity.py` (93), `test_run_agent.py` (431), title/MoA suites.
- E2E (real imports, temp HERMES_HOME, real SessionDB): request `extra_body` captured on the wire carries `conversation=conv-root` (root, not the segment id the agent was constructed with); ambient context confirmed reset after both successful and failed turns; bare executor thread loses the tag, propagated worker keeps it.

## Infographic

![Conversation-scoped Portal attribution](https://v3b.fal.media/files/b/0aa2748d/Ba913jjUIOvqzJXsjt8bO_xT0OyQ7W.png)
