### PR TITLE
fix(dashboard): rotate PTY attach token when sidebar switches sessions

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -969,6 +969,17 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         clearTimeout(reconnectTimerRef.current);
         reconnectTimerRef.current = null;
       }
+      // Force one authoritative fit RIGHT NOW before we announce dims to
+      // Ink. On localhost the WS handshake completes in a few ms and can
+      // beat the double-rAF settle fit — without this, Ink boots against
+      // the pre-settle grid and the transcript renders at the wrong
+      // density until the user nudges the window/font, at which point
+      // ``syncTerminalMetrics`` finally sends a RESIZE. See #NS-XXX.
+      try {
+        syncTerminalMetrics();
+      } catch {
+        /* ignore — measurement code has its own try/catch */
+      }
       // Send the initial RESIZE immediately so Ink has *a* size to lay
       // out against on its first paint.  The double-rAF block above will
       // follow up with the authoritative measurement — at worst Ink

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -178,6 +178,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttemptRef = useRef(0);
   const forceFreshPtyRef = useRef(false);
+  // Tracks the resume target of the currently connected PTY. When ``resumeParam``
+  // changes to a different value at runtime (user picked a different history
+  // session in the sidebar), the old attach token would let the server hand back
+  // the still-alive PTY for the previous session — effectively "every sidebar
+  // pick reattaches to the same PTY". Force a fresh spawn so the new resume
+  // parameter actually reaches HERMES_TUI_RESUME and hydrates the new history.
+  const lastConnectedResumeRef = useRef<string | null>(null);
   const blockedInputNoticeRef = useRef(false);
   const lastResumeReconnectAtRef = useRef(0);
   // True from the moment the connect effect begins until the socket resolves
@@ -872,8 +879,24 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     let unmounting = false;
     let onDataDisposable: { dispose(): void } | null = null;
     let onResizeDisposable: { dispose(): void } | null = null;
+    // NS-XXX: sidebar picked a different session — the still-alive PTY for the
+    // previous session must NOT be reattached (that's the "every pick shows the
+    // same PTY" bug). Rotate the attach token so ``attach_or_spawn`` misses and
+    // spawns a fresh PTY with the new HERMES_TUI_RESUME. Do NOT also send
+    // ``fresh=1`` — the server treats that as "clear resume", which cancels the
+    // whole point (see hermes_cli/web_server.py:15716-15727).
+    const resumeChanged =
+      lastConnectedResumeRef.current !== null &&
+      (resumeParam ?? "") !== lastConnectedResumeRef.current;
+    if (resumeChanged) {
+      // Reserve a NEW attach token for this connect without touching the
+      // caller-driven `forceFreshPtyRef` flag (which controls the fresh=1
+      // query param and is meant for explicit "start new session" clicks).
+      ptyAttachToken(true);
+    }
     const forceFresh = forceFreshPtyRef.current;
     forceFreshPtyRef.current = false;
+    lastConnectedResumeRef.current = resumeParam ?? "";
     // A connect attempt is now in flight — set synchronously (before the async
     // socket-open IIFE below awaits its ticket URL) so a page-resume event in
     // that gap doesn't fire a redundant reconnect (wsRef isn't assigned yet).


### PR DESCRIPTION
## Summary

Every history-session pick in the dashboard sidebar reattached to the **same** PTY, showing the chat transcript of whichever session was opened first, not the one clicked. This makes the sidebar functionally broken for users with more than one saved session.

## Root cause

The connect effect in `ChatPage.tsx` calls `ptyAttachToken(forceFreshPtyRef.current)` where `forceFreshPtyRef` is only set to `true` on explicit user-driven "start fresh session" clicks. A URL change from the sidebar (`?resume=A` → `?resume=B`) does **not** touch that ref, so `ptyAttachToken(false)` returns the same token from localStorage.

Server-side, `PtySessionRegistry.attach_or_spawn` (`hermes_cli/pty_session.py:148`) keys purely on that token:

```py
existing = self._sessions.get(key)
if existing is not None and existing.alive:
    return existing, False   # ← returns the old PTY; _spawn() is never called
```

The `_spawn` closure carries the new `HERMES_TUI_RESUME` env var, but it's never executed. The old PTY (with the old session's history) is handed back.

## Fix

Track the last-connected `resumeParam` in a ref. When the effect fires with a different target, mint a new attach token so `attach_or_spawn` key-misses and the server spawns a fresh PTY with the new `HERMES_TUI_RESUME`.

Deliberately does **not** send `fresh=1` — `hermes_cli/web_server.py:15716-15727` treats `fresh=1` as "clear resume", which would null out the new resume parameter we're trying to activate.

## Verification

- `npm run check` — 80/80 tests pass, tsc clean
- `npx eslint src/pages/ChatPage.tsx` — 0 new errors (1 pre-existing warning on unrelated hook deps, untouched)
- End-to-end on a production dashboard with several hundred historical sessions:
  - Before: every sidebar pick lands on the same PTY / same transcript
  - After: each pick spawns a distinct PTY with the correct session hydrated (confirmed by inspecting `HERMES_TUI_RESUME` in `/proc/<pid>/environ` for freshly-spawned children)

## Files touched

- `web/src/pages/ChatPage.tsx` (+23 / -0)

Cache-, alternation-, and system-prompt invariants untouched. No new dependencies. No config surface added.
