### PR TITLE
fix(desktop): route stale model callbacks to live session

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -132,6 +132,38 @@ describe('useModelControls', () => {
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
   })
 
+  it('routes a picker callback captured before resume to the current runtime session', async () => {
+    const requestGateway = vi.fn(async () => ({ key: 'model', value: 'claude-sonnet-4.6' }) as never)
+    let controls!: Controls
+
+    const view = render(
+      <Harness activeSessionId={null} onReady={value => (controls = value)} requestGateway={requestGateway} />
+    )
+    const capturedBeforeResume = controls.selectModel
+
+    $activeSessionId.set('session-resumed')
+    view.rerender(
+      <Harness
+        activeSessionId="session-resumed"
+        onReady={value => (controls = value)}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await expect(
+      capturedBeforeResume({
+        model: 'claude-sonnet-4.6',
+        provider: 'anthropic'
+      })
+    ).resolves.toBe(true)
+
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      session_id: 'session-resumed',
+      key: 'model',
+      value: 'claude-sonnet-4.6 --provider anthropic --session'
+    })
+  })
+
   it('session-scopes MoA preset selections so they cannot persist as the global gateway default', async () => {
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'BeastMode' }) as never)
     let controls!: Controls

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -25,8 +25,9 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
   const updateModelOptionsCache = useCallback(
     (provider: string, model: string, includeGlobal: boolean) => {
       const patch = (prev: ModelOptionsResponse | undefined) => ({ ...(prev ?? {}), provider, model })
+      const sessionId = $activeSessionId.get() || activeSessionId
 
-      queryClient.setQueryData<ModelOptionsResponse>(['model-options', activeSessionId || 'global'], patch)
+      queryClient.setQueryData<ModelOptionsResponse>(['model-options', sessionId || 'global'], patch)
 
       if (includeGlobal) {
         queryClient.setQueryData<ModelOptionsResponse>(['model-options', 'global'], patch)
@@ -81,31 +82,36 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
       // rather than leave the UI showing a model the backend never selected.
       const prevModel = $currentModel.get()
       const prevProvider = $currentProvider.get()
+      // ModelMenuPanel can retain this callback across a create/resume because
+      // its parent keeps a stable actions object. Read the authoritative store
+      // at click time so a callback captured before activation still targets
+      // the current runtime session.
+      const sessionId = $activeSessionId.get() || activeSessionId
 
       setCurrentModel(selection.model)
       setCurrentProvider(selection.provider)
-      updateModelOptionsCache(selection.provider, selection.model, !activeSessionId)
+      updateModelOptionsCache(selection.provider, selection.model, !sessionId)
 
       // No live session yet: the pick is pure UI state. session.create reads
       // $currentModel/$currentProvider and applies it as that session's override.
-      if (!activeSessionId) {
+      if (!sessionId) {
         return true
       }
 
       try {
         await requestGateway('config.set', {
-          session_id: activeSessionId,
+          session_id: sessionId,
           key: 'model',
           value: `${selection.model} --provider ${selection.provider} --session`
         })
 
-        void queryClient.invalidateQueries({ queryKey: ['model-options', activeSessionId] })
+        void queryClient.invalidateQueries({ queryKey: ['model-options', sessionId] })
 
         return true
       } catch (err) {
         setCurrentModel(prevModel)
         setCurrentProvider(prevProvider)
-        updateModelOptionsCache(prevProvider, prevModel, !activeSessionId)
+        updateModelOptionsCache(prevProvider, prevModel, !sessionId)
         notifyError(err, copy.modelSwitchFailed)
 
         return false

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "antydizajn@gmail.com": "antydizajn",  # PR #36043 salvage (auxiliary: route custom:<name> through named-provider arm + Palantir Bearer auth)
+    "reymondmeking@gmail.com": "reymondmeking-dot",  # First-time contributor mapping
     "kar.iskakov@gmail.com": "karfly",  # PR #64012 salvage (gateway: surface extended reasoning efforts)
     "kimyeon30@naver.com": "rlaehddus302",  # PR #61985 salvage (gateway: secondary-adapter auth callback profile)
     "agungsubastian1963@gmail.com": "aguung",  # PR #64461 salvage (gateway: multiplex secret_scope for authz/Slack/webhooks)


### PR DESCRIPTION
## Summary

- make Desktop model-picker callbacks resolve the current runtime session at click time
- keep optimistic model cache updates scoped to that same live session
- add a renderer lifecycle regression covering a callback captured before session resume

## Root cause

ContribWiring intentionally keeps its actions object at a stable identity and refreshes its fields with Object.assign. ChatRoutesSurface memoizes ModelMenuPanel and extracts actions.selectModel into the element props. If that element was created before a session was created or resumed, the retained callback closed over activeSessionId being null.

Selecting a model later therefore updated the local model/provider stores and returned success without sending config.set. The panel itself subscribes to the live session atom, so follow-up reasoning/fast preset writes could still target the session. This explains the reported split behavior where reasoning effort changes but the session model does not.

The hook now reads the active-session store when the user clicks, with the render prop retained as a transition/test fallback. A callback captured before activation therefore sends the session-scoped model change to the current runtime session.

## Reproduction proof

The new test mounts the hook with no active session, retains that initial picker callback, resumes a runtime session, and invokes the retained callback. On current main the callback returns true but sends zero gateway requests. With this fix it sends config.set with session_id=session-resumed and a session-scoped model/provider value.

## Validation

- npm test -- --run src/app/session/hooks/use-model-controls.test.tsx src/app/shell/model-menu-panel.test.tsx src/app/shell/model-edit-submenu.test.tsx (14 passed)
- npm run typecheck
- npx prettier --check on the two changed files
- git diff --check

Tested on Windows 11.

Follow-up to #65359. The issue was automatically closed as implemented on main, but the added renderer lifecycle test reproduces the remaining stale-callback failure on current main.