### PR TITLE
fix(local): normalize relative initial cwd to an absolute host path

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1990,6 +1990,7 @@ AUTHOR_MAP = {
     "i@dex.moe": "dexhunter",  # PR #60339 salvage (skills snapshot manifest speedup)
     "1torhan@protonmail.com": "uzaylisak",  # PR #29988 salvage (detect_local_server_type process-lifetime cache)
     "zhchl@hermes-agent.local": "8294",  # PR #50572 salvage (honor config context_length on banner)
+    "yansh2017@gmail.com": "ya-nsh",  # PR #26790 salvage (normalize local terminal relative cwd; #26783)
 }
 
 

--- a/tests/tools/test_local_env_relative_cwd.py
+++ b/tests/tools/test_local_env_relative_cwd.py
@@ -1,0 +1,52 @@
+"""Regression tests for local terminal initial cwd normalization."""
+
+from pathlib import Path
+
+from tools.environments.local import LocalEnvironment, _resolve_local_initial_cwd
+
+
+def test_relative_initial_cwd_resolves_from_parent(tmp_path, monkeypatch):
+    project = tmp_path / "hermes-agent"
+    project.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    assert _resolve_local_initial_cwd("hermes-agent") == str(project)
+
+
+def test_relative_initial_cwd_matching_current_dir_uses_current_dir(tmp_path, monkeypatch):
+    project = tmp_path / "hermes-agent"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    assert _resolve_local_initial_cwd("hermes-agent") == str(project)
+
+
+def test_local_environment_does_not_cd_into_nested_matching_relative_cwd(tmp_path, monkeypatch):
+    project = tmp_path / "hermes-agent"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    env = LocalEnvironment(cwd="hermes-agent", timeout=5)
+    try:
+        result = env.execute("pwd", timeout=5)
+    finally:
+        env.cleanup()
+
+    assert result["returncode"] == 0
+    assert result["output"].strip() == str(project)
+    assert "cd: hermes-agent" not in result["output"]
+
+
+def test_local_environment_keeps_existing_relative_child_cwd(tmp_path, monkeypatch):
+    project = tmp_path / "hermes-agent"
+    project.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    env = LocalEnvironment(cwd="hermes-agent", timeout=5)
+    try:
+        result = env.execute("pwd", timeout=5)
+    finally:
+        env.cleanup()
+
+    assert result["returncode"] == 0
+    assert result["output"].strip() == str(project)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -63,6 +63,12 @@ def _resolve_local_initial_cwd(cwd: str) -> str:
     expanded = os.path.expanduser(cwd) if cwd else os.getcwd()
     if _IS_WINDOWS:
         expanded = _msys_to_windows_path(expanded)
+        # Use the Windows-aware check explicitly: when _IS_WINDOWS is
+        # patched in tests on a POSIX host, os.path.isabs would reject
+        # ``C:\Users\x`` and mangle it through the relative branch.
+        import ntpath
+        if ntpath.isabs(expanded):
+            return expanded
     if os.path.isabs(expanded):
         return expanded
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -48,6 +48,40 @@ def _msys_to_windows_path(cwd: str) -> str:
     return f"{drive}:{tail or chr(92)}"  # chr(92) = backslash, avoid raw-string escape
 
 
+def _resolve_local_initial_cwd(cwd: str) -> str:
+    """Resolve the local backend's initial cwd to an absolute host path.
+
+    ``TERMINAL_CWD`` can be populated from config.yaml before the terminal
+    backend is created.  If that value is relative and happens to match the
+    directory Hermes was already launched from (for example ``hermes-agent``
+    while the process cwd is ``~/.hermes/hermes-agent``), passing it through
+    unchanged makes the wrapper run ``cd hermes-agent`` *inside* the project
+    and fail with a confusing nested-path error.  Anchor relative local cwd
+    values once, up front, so both ``subprocess.Popen(cwd=...)`` and the
+    in-shell ``cd`` use the same absolute directory.
+    """
+    expanded = os.path.expanduser(cwd) if cwd else os.getcwd()
+    if _IS_WINDOWS:
+        expanded = _msys_to_windows_path(expanded)
+    if os.path.isabs(expanded):
+        return expanded
+
+    candidate = os.path.abspath(expanded)
+    current = os.getcwd()
+
+    # Common recovery for config values like ``hermes-agent`` when Hermes was
+    # launched from that directory already.  ``os.path.abspath`` would point at
+    # a nonexistent nested ``./hermes-agent``; use the current directory instead.
+    if not os.path.isdir(candidate):
+        wanted_parts = Path(expanded).parts
+        current_parts = Path(current).parts
+        if wanted_parts and len(wanted_parts) <= len(current_parts):
+            if current_parts[-len(wanted_parts):] == wanted_parts:
+                return current
+
+    return candidate
+
+
 def _windows_to_msys_path(cwd: str) -> str:
     """Translate a native Windows path (``C:\\Users\\x``) to Git Bash /
     MSYS form (``/c/Users/x``) so ``builtin cd`` resolves it reliably.
@@ -1102,9 +1136,8 @@ class LocalEnvironment(BaseEnvironment):
     """
 
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
-        if cwd:
-            cwd = os.path.expanduser(cwd)
-        super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        cwd = _resolve_local_initial_cwd(cwd)
+        super().__init__(cwd=cwd, timeout=timeout, env=env)
         self.init_session()
 
     def get_temp_dir(self) -> str:


### PR DESCRIPTION
## Summary

Salvage of #26790 by @ya-nsh: the local terminal backend now resolves a relative initial cwd to an absolute host path before creating the session, instead of passing it into the wrapper where `cd hermes-agent` runs *inside* the project, fails, and silently falls back to `/tmp`.

Root cause: `terminal.cwd` / `TERMINAL_CWD` can hold a relative directory name (e.g. `hermes-agent`) matching the directory Hermes was launched from. `LocalEnvironment.__init__` passed it through unchanged; both `subprocess.Popen(cwd=...)` and the in-shell `cd` then resolved it as a nested `./hermes-agent`, which doesn't exist. Fixes #26783 (bug reproduced live on current main — commands ran in `/tmp`).

## Changes
- `tools/environments/local.py`: new `_resolve_local_initial_cwd()` — expanduser, keep absolute paths, anchor relative values to the launch dir, tail-match recovery when the process is already inside the target directory; `__init__` uses it (contributor commit, authorship preserved)
- `tools/environments/local.py`: follow-up — check `ntpath.isabs` on the Windows branch so native `C:\...` paths aren't mangled through the relative branch when `_IS_WINDOWS` is patched on a POSIX host (caught by the existing MSYS bootstrap test)
- `tests/tools/test_local_env_relative_cwd.py`: 4 regression tests incl. real `LocalEnvironment.execute()` round-trips
- `scripts/release.py`: AUTHOR_MAP entry for @ya-nsh

## Validation
| | Before | After |
|---|---|---|
| `LocalEnvironment(cwd="hermes-agent")` from inside that dir | falls back to `/tmp` | runs in the project dir |
| same relative cwd from the parent dir | nested-path failure risk | resolves to the child dir |
| targeted suites (relative-cwd, msys, cwd-recovery, task-cwd, base-env) | — | 98/98 green |
| live E2E (real `execute("pwd")` both cases) | BUG PRESENT | resolves correctly |

## Infographic

![local-relative-cwd](https://v3b.fal.media/files/b/0aa274ca/F7Ukw9LOj53FzC_j8vF2b_lMQjB3NO.png)
