### PR TITLE
feat(pricing): Fireworks cost estimation + cached picker price columns

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -609,6 +609,43 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source="official_docs_snapshot",
         pricing_version="minimax-pricing-2026-04",
     ),
+    # Fireworks AI — serverless pricing for the models hermes typically routes
+    # through when configured with provider="fireworks". Fireworks publishes a
+    # cached_input rate per model alongside input/output, which maps to
+    # cache_read_cost_per_million. No separately published cache_write rate.
+    (
+        "fireworks",
+        "kimi-k2p6",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.95"),
+        output_cost_per_million=Decimal("4.00"),
+        cache_read_cost_per_million=Decimal("0.16"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-05",
+    ),
+    (
+        "fireworks",
+        "deepseek-v4-pro",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.74"),
+        output_cost_per_million=Decimal("3.48"),
+        cache_read_cost_per_million=Decimal("0.145"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-05",
+    ),
+    (
+        "fireworks",
+        "qwen3p6-plus",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.50"),
+        output_cost_per_million=Decimal("3.00"),
+        cache_read_cost_per_million=Decimal("0.10"),
+        source="official_docs_snapshot",
+        source_url="https://fireworks.ai/models/fireworks/qwen3p6-plus",
+        pricing_version="fireworks-pricing-2026-05",
+    ),
 }
 
 # GPT-5.6 "-pro" high-effort variants bill at the same per-token rates as
@@ -672,6 +709,10 @@ def resolve_billing_route(
     # the OpenAI-compat endpoint requires so the pricing key matches.
     if provider_name == "vertex" or base_url_host_matches(base_url or "", "aiplatform.googleapis.com"):
         return BillingRoute(provider="gemini", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name == "fireworks" or base_url_host_matches(base_url or "", "api.fireworks.ai"):
+        # Fireworks model ids look like accounts/fireworks/models/<name>;
+        # rsplit("/", 1)[-1] yields just <name> which is what the dict keys on.
+        return BillingRoute(provider="fireworks", model=model.rsplit("/", 1)[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"custom", "local"} or (base and "localhost" in base):
         return BillingRoute(provider=provider_name or "custom", model=model, base_url=base_url or "", billing_mode="unknown")
     return BillingRoute(provider=provider_name or "unknown", model=model.split("/")[-1] if model else "", base_url=base_url or "", billing_mode="unknown")

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -613,6 +613,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     # through when configured with provider="fireworks". Fireworks publishes a
     # cached_input rate per model alongside input/output, which maps to
     # cache_read_cost_per_million. No separately published cache_write rate.
+    # Snapshot of https://docs.fireworks.ai/serverless/pricing (Standard tier).
     (
         "fireworks",
         "kimi-k2p6",
@@ -622,7 +623,29 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         cache_read_cost_per_million=Decimal("0.16"),
         source="official_docs_snapshot",
         source_url="https://docs.fireworks.ai/serverless/pricing",
-        pricing_version="fireworks-pricing-2026-05",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    (
+        "fireworks",
+        "kimi-k2p7-code",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.95"),
+        output_cost_per_million=Decimal("4.00"),
+        cache_read_cost_per_million=Decimal("0.19"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    (
+        "fireworks",
+        "glm-5p2",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.40"),
+        output_cost_per_million=Decimal("4.40"),
+        cache_read_cost_per_million=Decimal("0.14"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
     ),
     (
         "fireworks",
@@ -633,18 +656,141 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         cache_read_cost_per_million=Decimal("0.145"),
         source="official_docs_snapshot",
         source_url="https://docs.fireworks.ai/serverless/pricing",
-        pricing_version="fireworks-pricing-2026-05",
+        pricing_version="fireworks-pricing-2026-07",
     ),
     (
         "fireworks",
-        "qwen3p6-plus",
+        "deepseek-v4-flash",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.50"),
-        output_cost_per_million=Decimal("3.00"),
-        cache_read_cost_per_million=Decimal("0.10"),
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.028"),
         source="official_docs_snapshot",
-        source_url="https://fireworks.ai/models/fireworks/qwen3p6-plus",
-        pricing_version="fireworks-pricing-2026-05",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    (
+        "fireworks",
+        "qwen3p7-plus",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.40"),
+        output_cost_per_million=Decimal("1.60"),
+        cache_read_cost_per_million=Decimal("0.08"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    (
+        "fireworks",
+        "minimax-m3",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.30"),
+        output_cost_per_million=Decimal("1.20"),
+        cache_read_cost_per_million=Decimal("0.06"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    (
+        "fireworks",
+        "gpt-oss-120b",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.15"),
+        output_cost_per_million=Decimal("0.60"),
+        cache_read_cost_per_million=Decimal("0.015"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    (
+        "fireworks",
+        "gpt-oss-20b",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.07"),
+        output_cost_per_million=Decimal("0.30"),
+        cache_read_cost_per_million=Decimal("0.035"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    (
+        "fireworks",
+        "glm-5p1",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.40"),
+        output_cost_per_million=Decimal("4.40"),
+        cache_read_cost_per_million=Decimal("0.26"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    (
+        "fireworks",
+        "minimax-m2p7",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.30"),
+        output_cost_per_million=Decimal("1.20"),
+        cache_read_cost_per_million=Decimal("0.06"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    # Fast/turbo serving tiers — exposed as accounts/fireworks/routers/<name>,
+    # so rsplit("/", 1) yields these distinct ids with their own (higher) rates.
+    (
+        "fireworks",
+        "kimi-k2p6-fast",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.00"),
+        output_cost_per_million=Decimal("8.00"),
+        cache_read_cost_per_million=Decimal("0.30"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    (
+        "fireworks",
+        "kimi-k2p6-turbo",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.00"),
+        output_cost_per_million=Decimal("8.00"),
+        cache_read_cost_per_million=Decimal("0.30"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    (
+        "fireworks",
+        "kimi-k2p7-code-fast",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.90"),
+        output_cost_per_million=Decimal("8.00"),
+        cache_read_cost_per_million=Decimal("0.38"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    (
+        "fireworks",
+        "glm-5p2-fast",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.10"),
+        output_cost_per_million=Decimal("6.60"),
+        cache_read_cost_per_million=Decimal("0.21"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
+    ),
+    (
+        "fireworks",
+        "glm-5p1-fast",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.80"),
+        output_cost_per_million=Decimal("8.80"),
+        cache_read_cost_per_million=Decimal("0.52"),
+        source="official_docs_snapshot",
+        source_url="https://docs.fireworks.ai/serverless/pricing",
+        pricing_version="fireworks-pricing-2026-07",
     ),
 }
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2857,9 +2857,22 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         model_list = list(dict.fromkeys(mid for mid in model_list if mid))
 
     if model_list:
+        # Per-model pricing, when the provider supports it (fireworks via the
+        # models.dev disk cache, novita/deepinfra via their cached /models
+        # endpoints). get_pricing_for_provider() is memoized in-process and
+        # returns {} for providers without pricing — never a blocking fetch
+        # beyond the catalog lookup that already happened above.
+        pricing: dict = {}
+        try:
+            from hermes_cli.models import get_pricing_for_provider
+
+            pricing = get_pricing_for_provider(provider_id) or {}
+        except Exception:
+            pricing = {}
         selected = _prompt_model_selection(
             model_list,
             current_model=current_model,
+            pricing=pricing,
             confirm_provider=provider_id,
             confirm_base_url=effective_base,
             confirm_api_key=existing_key,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1654,6 +1654,8 @@ def get_pricing_for_provider(provider: str, *, force_refresh: bool = False) -> d
         return _fetch_novita_pricing(force_refresh=force_refresh)
     if normalized == "deepinfra":
         return _fetch_deepinfra_pricing(force_refresh=force_refresh)
+    if normalized == "fireworks":
+        return _fireworks_pricing_from_models_dev(force_refresh=force_refresh)
     if normalized == "nous":
         api_key, base_url = _resolve_nous_pricing_credentials()
         if base_url:
@@ -1668,6 +1670,55 @@ def get_pricing_for_provider(provider: str, *, force_refresh: bool = False) -> d
                 force_refresh=force_refresh,
             )
     return {}
+
+
+def _fireworks_pricing_from_models_dev(
+    *,
+    force_refresh: bool = False,
+) -> dict[str, dict[str, str]]:
+    """Derive Fireworks picker pricing from the models.dev registry cache.
+
+    No dedicated network fetch: ``fetch_models_dev()`` already maintains an
+    in-memory + disk cache (1h TTL) that every picker surface shares, so this
+    is a pure dict transform on the picker path — no added latency and no
+    per-render network call. Results are additionally memoized in
+    ``_pricing_cache`` so repeated menu renders within a process are free.
+
+    models.dev publishes Fireworks costs in USD per 1M tokens; the shared
+    pricing formatter expects per-token strings, so divide by 1M.
+    """
+    cache_key = "models.dev/fireworks"
+    if not force_refresh and cache_key in _pricing_cache:
+        return _pricing_cache[cache_key]
+
+    result: dict[str, dict[str, str]] = {}
+    try:
+        from agent.models_dev import _get_provider_models
+
+        models = _get_provider_models("fireworks") or {}
+        for mid, entry in models.items():
+            if not isinstance(entry, dict):
+                continue
+            cost = entry.get("cost")
+            if not isinstance(cost, dict):
+                continue
+            inp = cost.get("input")
+            out = cost.get("output")
+            if inp is None and out is None:
+                continue
+            row: dict[str, str] = {
+                "prompt": str(float(inp or 0) / 1_000_000),
+                "completion": str(float(out or 0) / 1_000_000),
+            }
+            cache_read = cost.get("cache_read")
+            if cache_read:
+                row["input_cache_read"] = str(float(cache_read) / 1_000_000)
+            result[str(mid)] = row
+    except Exception:
+        result = {}
+
+    _pricing_cache[cache_key] = result
+    return result
 
 
 def _fetch_novita_pricing(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -338,6 +338,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "hi@neueway.com": "brendandebeasi",
     "dorokuma@users.noreply.github.com": "dorokuma",
     "liuwei666888@users.noreply.github.com": "liuwei666888",
     "527711370@qq.com": "liuwei666888",

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -322,3 +322,45 @@ def test_bedrock_claude_cached_session_estimates_cost_not_unknown():
     )
     assert result.status == "estimated"
     assert result.amount_usd is not None
+
+def test_fireworks_kimi_k2p6_resolves_with_full_model_path():
+    """Fireworks model ids look like accounts/fireworks/models/<name>;
+    the routing layer must strip the prefix so the dict lookup succeeds."""
+    entry = get_pricing_entry(
+        "accounts/fireworks/models/kimi-k2p6",
+        provider="fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.95
+    assert float(entry.output_cost_per_million) == 4.00
+    assert float(entry.cache_read_cost_per_million) == 0.16
+    assert entry.source == "official_docs_snapshot"
+
+
+def test_fireworks_base_url_host_match_alone_routes_to_pricing():
+    """Provider not explicitly passed; routing infers fireworks from the host."""
+    entry = get_pricing_entry(
+        "accounts/fireworks/models/deepseek-v4-pro",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 1.74
+    assert float(entry.output_cost_per_million) == 3.48
+
+
+def test_fireworks_qwen3p6_plus_estimate_usage_cost():
+    """End-to-end: Fireworks Qwen3.6-Plus sessions report a dollar estimate."""
+    result = estimate_usage_cost(
+        "accounts/fireworks/models/qwen3p6-plus",
+        CanonicalUsage(input_tokens=1_000_000, output_tokens=500_000),
+        provider="fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 1M input × $0.50/M + 500K output × $3.00/M = $0.50 + $1.50 = $2.00
+    assert float(result.amount_usd) == 2.00

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -351,10 +351,10 @@ def test_fireworks_base_url_host_match_alone_routes_to_pricing():
     assert float(entry.output_cost_per_million) == 3.48
 
 
-def test_fireworks_qwen3p6_plus_estimate_usage_cost():
-    """End-to-end: Fireworks Qwen3.6-Plus sessions report a dollar estimate."""
+def test_fireworks_qwen3p7_plus_estimate_usage_cost():
+    """End-to-end: Fireworks Qwen3.7-Plus sessions report a dollar estimate."""
     result = estimate_usage_cost(
-        "accounts/fireworks/models/qwen3p6-plus",
+        "accounts/fireworks/models/qwen3p7-plus",
         CanonicalUsage(input_tokens=1_000_000, output_tokens=500_000),
         provider="fireworks",
         base_url="https://api.fireworks.ai/inference/v1",
@@ -362,5 +362,56 @@ def test_fireworks_qwen3p6_plus_estimate_usage_cost():
 
     assert result.status == "estimated"
     assert result.amount_usd is not None
-    # 1M input × $0.50/M + 500K output × $3.00/M = $0.50 + $1.50 = $2.00
-    assert float(result.amount_usd) == 2.00
+    # 1M input × $0.40/M + 500K output × $1.60/M = $0.40 + $0.80 = $1.20
+    assert float(result.amount_usd) == 1.20
+
+
+def test_fireworks_router_fast_tier_prices_distinctly():
+    """Fast serving tiers live under accounts/fireworks/routers/<name>-fast and
+    bill at higher rates than the standard model — the routing layer's
+    rsplit("/", 1) must land on the distinct fast-tier entry."""
+    standard = get_pricing_entry(
+        "accounts/fireworks/models/kimi-k2p6",
+        provider="fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+    fast = get_pricing_entry(
+        "accounts/fireworks/routers/kimi-k2p6-fast",
+        provider="fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+    assert standard is not None and fast is not None
+    assert fast.input_cost_per_million > standard.input_cost_per_million
+    assert fast.output_cost_per_million > standard.output_cost_per_million
+
+
+def test_fireworks_plugin_fallback_models_all_have_pricing():
+    """Invariant: every model in the Fireworks provider plugin's
+    fallback_models (the picker's curated safety net) must resolve to a
+    pricing entry — otherwise the default picker choices bill as unknown."""
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("fireworks")
+    assert profile is not None
+    for mid in profile.fallback_models:
+        entry = get_pricing_entry(
+            mid,
+            provider="fireworks",
+            base_url="https://api.fireworks.ai/inference/v1",
+        )
+        assert entry is not None, f"no pricing entry for fallback model {mid}"
+        assert entry.input_cost_per_million is not None, mid
+
+
+def test_fireworks_rows_all_carry_cache_read_pricing():
+    """Invariant: Fireworks publishes cached-input rates for every serverless
+    model, and Hermes prompt caching is active on Fireworks sessions — every
+    snapshot row must carry a cache_read rate cheaper than fresh input."""
+    from agent.usage_pricing import _OFFICIAL_DOCS_PRICING
+
+    fw_rows = [k for k in _OFFICIAL_DOCS_PRICING if k[0] == "fireworks"]
+    assert fw_rows, "expected at least one fireworks pricing row"
+    for key in fw_rows:
+        entry = _OFFICIAL_DOCS_PRICING[key]
+        assert entry.cache_read_cost_per_million is not None, key
+        assert entry.cache_read_cost_per_million < entry.input_cost_per_million, key


### PR DESCRIPTION
## Summary
Fireworks sessions now report real dollar cost estimates instead of `Estimated Cost: N/A`, and the Fireworks model picker shows per-model $/M price columns — with zero added latency on the picker path.

Salvages #29860 by @brendandebeasi (cherry-picked, authorship preserved), refreshed and extended on top.

## Changes
- `agent/usage_pricing.py` (from #29860 + refresh): `fireworks` branch in `resolve_billing_route()` (explicit provider OR `api.fireworks.ai` host match; `rsplit("/")` strips the `accounts/fireworks/models/` prefix). Snapshot refreshed from `fireworks-pricing-2026-05` (3 entries, one for a delisted model) to `fireworks-pricing-2026-07`: 17 entries covering the full serverless catalog including the `routers/*-fast` tiers at their distinct higher rates.
- `hermes_cli/models.py`: `get_pricing_for_provider("fireworks")` derives picker pricing from the shared models.dev registry cache (in-memory → disk, 1h TTL) — a pure dict transform, **no network call on the picker path**, additionally memoized in `_pricing_cache` so repeated renders are free.
- `hermes_cli/model_setup_flows.py`: the generic api-key-provider setup flow now passes pricing into `_prompt_model_selection`, so Fireworks (and novita/deepinfra) get the same aligned $/M columns OpenRouter and Nous pickers already show. Providers without pricing get `{}` — unchanged rendering.
- Tests: contributor's 3 tests (one updated to `qwen3p7-plus` after Fireworks delisted `qwen3p6-plus`) + invariants: plugin `fallback_models` all priced, fast tiers price strictly higher than standard, every row carries `cache_read < input`.

## Latency validation (offline E2E, network fully blocked at socket level)
| Path | Result |
|---|---|
| Cold picker pricing (disk cache, zero network) | 37 ms, 16 models |
| Warm (in-process memo) | 0.006 ms |
| Billing estimate (1M in / 100K out / 500K cache-read on glm-5p2) | `estimated · $1.91 · fireworks-pricing-2026-07` |
| Targeted tests (pricing, models, setup flows, inventory, fireworks plugin) | 353/353 passed |

## Infographic

![fireworks-pricing](https://v3b.fal.media/files/b/0aa274cb/rJfrlW7VU-Is6yYjOYody_DmTSiNkH.png)
