### PR TITLE
fix(tui): sweep orphaned TUI/subagent session rows at gateway startup

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2356,6 +2356,79 @@ class SessionDB:
             ).fetchone()
         return dict(row) if row else None
 
+    def sweep_orphaned_sessions(
+        self,
+        *,
+        sources: List[str],
+        idle_seconds: float,
+        end_reason: str,
+        exclude_ids: List[str] = (),
+    ) -> List[str]:
+        """End open session rows whose owning process is provably gone.
+
+        Startup-sweep companion to the TUI gateway's in-process WS-orphan
+        reaper (#65194): that reaper is a ``threading.Timer``, so a gateway
+        restart kills it before it fires and the row stays ``ended_at IS
+        NULL`` forever — no later code path revisits it. This ends rows in
+        ``sources`` that have been quiet for at least ``idle_seconds``,
+        stamping ``end_reason`` so swept rows stay distinguishable from live
+        reaps.
+
+        Staleness requires BOTH clocks to be past the cutoff: the row's own
+        ``started_at`` AND its newest message timestamp (falling back to
+        ``started_at`` for message-less rows). Message recency alone would
+        sweep a freshly created row that carries older *copied* history
+        (branch/compression children copy a parent transcript), and
+        ``started_at`` alone would sweep a long-lived session that is still
+        actively talking. This mirrors the in-memory idle reaper's
+        ``last_active AND created_at`` contract in ``tui_gateway.server``.
+
+        state.db is shared by sibling processes on the same profile
+        (messaging gateway, CLI, worktree agents), so callers must pass a
+        conservative ``idle_seconds`` (hours-scale): a row a sibling is
+        actively using always has recent messages. ``exclude_ids`` spares
+        rows the calling process itself still references.
+
+        Returns the swept session ids.
+        """
+        srcs = [s for s in sources if s]
+        if not srcs or idle_seconds < 0:
+            return []
+        cutoff = time.time() - idle_seconds
+        marks = ",".join("?" for _ in srcs)
+        staleness = (
+            "started_at < ? AND COALESCE((SELECT MAX(m.timestamp) FROM messages m"
+            " WHERE m.session_id = sessions.id), started_at) < ?"
+        )
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT id FROM sessions WHERE ended_at IS NULL"
+                f" AND source IN ({marks}) AND {staleness}",
+                (*srcs, cutoff, cutoff),
+            ).fetchall()
+        excluded = {str(x) for x in exclude_ids if x}
+        victims = [str(r["id"]) for r in rows if str(r["id"]) not in excluded]
+        if not victims:
+            return []
+
+        def _do(conn):
+            now = time.time()
+            swept = []
+            for sid in victims:
+                # Re-check liveness inside the write transaction: a sibling
+                # may have ended/resumed the row or appended a message since
+                # the SELECT above.
+                cur = conn.execute(
+                    f"UPDATE sessions SET ended_at = ?, end_reason = ?"
+                    f" WHERE id = ? AND ended_at IS NULL AND {staleness}",
+                    (now, end_reason, sid, cutoff, cutoff),
+                )
+                if cur.rowcount:
+                    swept.append(sid)
+            return swept
+
+        return self._execute_write(_do)
+
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session as ended.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2487,6 +2487,181 @@ def test_ws_orphan_reap_disabled_when_grace_zero(monkeypatch):
     assert fired["timer"] is False
 
 
+def _orphan_sweep_db(tmp_path):
+    from hermes_state import SessionDB
+
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+def _seed_session_row(db, session_id, *, source, last_active, started_at=None):
+    """Create an open session row whose last activity is ``last_active``.
+
+    ``started_at`` defaults to ``last_active``; pass it explicitly to model a
+    freshly created row that carries older copied history (branch child).
+    """
+    db.create_session(session_id, source=source)
+    db.append_message(session_id, role="user", content="hello")
+    with db._lock:
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = ?",
+            (last_active if started_at is None else started_at, session_id),
+        )
+        db._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE session_id = ?",
+            (last_active, session_id),
+        )
+
+
+def test_startup_orphan_sweep_ends_stale_rows(monkeypatch, tmp_path):
+    """Rows left ended_at IS NULL by a dead gateway get swept at startup with
+    a distinct end_reason (#65194: the ws_orphan_reap timer dies with the
+    process, so no live reap ever revisits them)."""
+    db = _orphan_sweep_db(tmp_path)
+    try:
+        stale = time.time() - 8 * 3600
+        _seed_session_row(db, "stale-tui", source="tui", last_active=stale)
+        _seed_session_row(db, "stale-sub", source="subagent", last_active=stale)
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        monkeypatch.setattr(server, "_SESSION_TTL_S", 6 * 3600.0)
+        monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 20.0)
+
+        swept = server._sweep_orphaned_session_rows()
+
+        assert sorted(swept) == ["stale-sub", "stale-tui"]
+        for sid in ("stale-tui", "stale-sub"):
+            row = db.get_session(sid)
+            assert row["ended_at"] is not None
+            assert row["end_reason"] == "orphan_startup_sweep"
+    finally:
+        db.close()
+
+
+def test_startup_orphan_sweep_spares_fresh_row_with_old_copied_history(
+    monkeypatch, tmp_path
+):
+    """A branch-style row created just now but seeded with the parent's older
+    transcript must never look orphaned: session.branch copies the parent's
+    messages onto a brand-new row, so message recency alone is not a safe
+    staleness clock. started_at must be stale too."""
+    db = _orphan_sweep_db(tmp_path)
+    try:
+        old_history = time.time() - 8 * 3600
+        _seed_session_row(
+            db,
+            "fresh-branch",
+            source="tui",
+            last_active=old_history,
+            started_at=time.time(),
+        )
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        monkeypatch.setattr(server, "_SESSION_TTL_S", 6 * 3600.0)
+        monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 20.0)
+
+        swept = server._sweep_orphaned_session_rows()
+
+        assert swept == []
+        row = db.get_session("fresh-branch")
+        assert row["ended_at"] is None
+        assert row["end_reason"] is None
+    finally:
+        db.close()
+
+
+def test_startup_orphan_sweep_spares_recent_and_live_rows(monkeypatch, tmp_path):
+    """A row inside the grace/TTL window or referenced by a live in-memory
+    session (mid-reconnect right after startup) is never swept."""
+    db = _orphan_sweep_db(tmp_path)
+    sid = "resumed-sid"
+    try:
+        _seed_session_row(db, "recent-tui", source="tui", last_active=time.time() - 30)
+        stale = time.time() - 120
+        _seed_session_row(db, "resumed-tui", source="tui", last_active=stale)
+        _seed_session_row(db, "gateway-row", source="telegram", last_active=stale)
+        # Simulate a session.resume that landed during the startup grace
+        # delay: the old row is stale but a live in-memory session owns it.
+        server._sessions[sid] = _session(
+            agent=types.SimpleNamespace(session_id="resumed-tui")
+        )
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        # TTL 0 + grace 60 exercises the grace floor: eligibility is
+        # max(TTL, grace) = 60s of inactivity.
+        monkeypatch.setattr(server, "_SESSION_TTL_S", 0.0)
+        monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 60.0)
+
+        swept = server._sweep_orphaned_session_rows()
+
+        assert swept == []
+        for row_id in ("recent-tui", "resumed-tui", "gateway-row"):
+            row = db.get_session(row_id)
+            assert row["ended_at"] is None
+            assert row["end_reason"] is None
+    finally:
+        server._sessions.pop(sid, None)
+        db.close()
+
+
+def test_startup_orphan_sweep_leaves_already_ended_rows_untouched(
+    monkeypatch, tmp_path
+):
+    """Already-ended rows keep their original end_reason/ended_at (first
+    reason wins — same contract as SessionDB.end_session)."""
+    db = _orphan_sweep_db(tmp_path)
+    try:
+        stale = time.time() - 8 * 3600
+        _seed_session_row(db, "reaped-tui", source="tui", last_active=stale)
+        db.end_session("reaped-tui", "ws_orphan_reap")
+        before = db.get_session("reaped-tui")
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        monkeypatch.setattr(server, "_SESSION_TTL_S", 6 * 3600.0)
+        monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 20.0)
+
+        swept = server._sweep_orphaned_session_rows()
+
+        assert swept == []
+        after = db.get_session("reaped-tui")
+        assert after["end_reason"] == "ws_orphan_reap"
+        assert after["ended_at"] == before["ended_at"]
+    finally:
+        db.close()
+
+
+def test_schedule_startup_orphan_sweep_gates(monkeypatch):
+    """Once-per-process guard, `session_orphan_reaper: false` opt-out, and
+    the grace=0 park-forever opt-out all suppress the sweep timer."""
+    started = {"count": 0}
+
+    class _Timer:
+        def __init__(self, *a, **k):
+            pass
+
+        def start(self):
+            started["count"] += 1
+
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 20.0)
+
+    # Config opt-out: no timer, and the once-guard stays unset so a later
+    # enabled call could still run.
+    monkeypatch.setattr(server, "_startup_orphan_sweep_ran", False)
+    monkeypatch.setattr(server, "_session_orphan_reaper_enabled", lambda: False)
+    server._schedule_startup_orphan_sweep()
+    assert started["count"] == 0
+    assert server._startup_orphan_sweep_ran is False
+
+    # Enabled: schedules exactly once; repeat calls are no-ops.
+    monkeypatch.setattr(server, "_session_orphan_reaper_enabled", lambda: True)
+    server._schedule_startup_orphan_sweep()
+    server._schedule_startup_orphan_sweep()
+    assert started["count"] == 1
+    assert server._startup_orphan_sweep_ran is True
+
+    # Grace 0 disables the sweep like it disables the live reaper.
+    monkeypatch.setattr(server, "_startup_orphan_sweep_ran", False)
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.0)
+    server._schedule_startup_orphan_sweep()
+    assert started["count"] == 1
+
+
 def test_init_session_fires_reset_hook(monkeypatch):
     hooks = []
 

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -293,6 +293,15 @@ def join_mcp_discovery(timeout: float | None = None) -> bool:
 def main():
     _install_sidecar_publisher()
 
+    # One-time sweep of session rows orphaned by a previous gateway process
+    # (#65194) — the in-process WS-orphan reap timer dies with the process,
+    # so leftovers must be revisited at startup like every other resource
+    # type. Config-gated + once-per-process guarded inside.
+    try:
+        server._schedule_startup_orphan_sweep()
+    except Exception:
+        logger.warning("startup orphan sweep scheduling failed", exc_info=True)
+
     # MCP tool discovery — runs in a background daemon thread so a slow or
     # unreachable MCP server can't freeze TUI startup.  Previously this ran
     # inline before ``gateway.ready``, which meant any configured-but-down

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1009,6 +1009,117 @@ def _start_idle_reaper() -> None:
     threading.Thread(target=_loop, daemon=True).start()
 
 
+# ── Startup sweep for orphaned session rows (#65194) ─────────────────────
+# The WS-orphan reaper above is an in-process threading.Timer: a gateway
+# restart (every `hermes update` / deploy) kills it before it fires, leaving
+# the session row `ended_at IS NULL` forever — no code path in the next
+# process ever revisits it. This is the "sweep leftovers at next startup"
+# pass every other resource type already has (docker_orphan_reaper,
+# terminal/browser orphan reaps, the MCP stdio watchdog). Scheduled once per
+# process from both gateway entry points; state.db is shared by sibling
+# processes on the same profile (messaging gateway, CLI, worktree agents),
+# so eligibility is deliberately conservative — see _sweep_orphaned_session_rows.
+# Disable via `session_orphan_reaper: false` in config.yaml (top-level or
+# under `gateway:`), mirroring `terminal.docker_orphan_reaper`.
+_ORPHAN_SWEEP_END_REASON = "orphan_startup_sweep"
+# Only sources this backend (or a subagent spawned by a dead sibling) owns.
+# Gateway-platform sources are never touched (#60609 doctrine: the messaging
+# gateway owns their lifecycle) and `cli` rows belong to interactive CLI
+# processes with their own exit-path finalize.
+_ORPHAN_SWEEP_SOURCES = ("tui", "desktop", "subagent")
+_startup_orphan_sweep_ran = False
+_startup_orphan_sweep_lock = threading.Lock()
+
+
+def _session_orphan_reaper_enabled() -> bool:
+    try:
+        cfg = _load_cfg() or {}
+        raw = cfg.get("session_orphan_reaper")
+        if raw is None:
+            gateway_cfg = cfg.get("gateway")
+            if isinstance(gateway_cfg, dict):
+                raw = gateway_cfg.get("session_orphan_reaper")
+        return is_truthy_value(raw, default=True)
+    except Exception:
+        return True
+
+
+def _sweep_orphaned_session_rows() -> list[str]:
+    """End orphaned tui/desktop/subagent session rows left by a dead process.
+
+    Every pre-restart session by definition has no live websocket in this
+    process, but state.db is per-profile, not per-process: a sibling process
+    on the same profile could legitimately own an open row. "Provably
+    orphaned" is therefore inferred conservatively from inactivity — the row
+    must have been *created* AND last *messaged* at least the session TTL ago
+    (``HERMES_TUI_SESSION_TTL_S``, hours-scale, the same knob the in-process
+    idle reaper uses) — since any row a live process is using keeps gaining
+    messages, and a freshly created row that copied an old transcript
+    (branch/compression child) is protected by its own ``started_at``. Rows
+    referenced by a live in-memory session here (e.g. a session.resume that
+    landed during the startup grace delay) are excluded, so the sweep never
+    races a mid-reconnect client.
+    """
+    db = _get_db()
+    if db is None:
+        return []
+    exclude: set[str] = set()
+    with _sessions_lock:
+        for session in _sessions.values():
+            agent = session.get("agent")
+            for sid in (getattr(agent, "session_id", None), session.get("session_key")):
+                if sid:
+                    exclude.add(str(sid))
+    swept = db.sweep_orphaned_sessions(
+        sources=list(_ORPHAN_SWEEP_SOURCES),
+        idle_seconds=max(_SESSION_TTL_S, _WS_ORPHAN_REAP_GRACE_S),
+        end_reason=_ORPHAN_SWEEP_END_REASON,
+        exclude_ids=sorted(exclude),
+    )
+    if swept:
+        logger.info(
+            "Startup orphan sweep ended %d session row(s) left open by a "
+            "previous process: %s",
+            len(swept),
+            ", ".join(swept),
+        )
+    return swept
+
+
+def _schedule_startup_orphan_sweep() -> None:
+    """Schedule the once-per-process startup orphan sweep (#65194).
+
+    Called from both gateway entry points (stdio ``entry.main`` and the WS
+    sidecar's connection handler) — the once-guard makes repeat calls no-ops,
+    mirroring the other idempotent startup passes. The sweep is delayed by the
+    WS-orphan grace window so a client reconnecting right after a restart can
+    ``session.resume`` its row before the sweep reads the DB — the same
+    grace semantics as ``_schedule_ws_orphan_reap``, whose 0 value also
+    disables this sweep (park forever, pre-fix behaviour).
+    """
+    global _startup_orphan_sweep_ran
+    if _WS_ORPHAN_REAP_GRACE_S <= 0:
+        return
+    if not _session_orphan_reaper_enabled():
+        return
+    if _startup_orphan_sweep_ran:
+        return
+    with _startup_orphan_sweep_lock:
+        if _startup_orphan_sweep_ran:
+            return
+        _startup_orphan_sweep_ran = True
+
+    def _run() -> None:
+        try:
+            _sweep_orphaned_session_rows()
+        except Exception:
+            logger.warning("startup orphan session sweep failed", exc_info=True)
+
+    timer = threading.Timer(_WS_ORPHAN_REAP_GRACE_S, _run)
+    timer.daemon = True
+    timer.start()
+
+
 atexit.register(_shutdown_sessions)
 _start_idle_reaper()
 

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -316,6 +316,15 @@ async def handle_ws(ws: Any) -> None:
             thread_name="tui-ws-mcp-discovery",
         )
 
+        # Same once-per-process startup pass for session rows orphaned by a
+        # previous gateway process (#65194): the desktop/dashboard reach the
+        # agent through this WS sidecar, not entry.main(), so schedule it
+        # here too. Idempotent + config-gated inside.
+        try:
+            server._schedule_startup_orphan_sweep()
+        except Exception:
+            _log.warning("startup orphan sweep scheduling failed", exc_info=True)
+
         ready_ok = await transport.write_async(
             {
                 "jsonrpc": "2.0",


### PR DESCRIPTION
## What does this PR do?

Rebuilt on current `main` (`36f2a966c7`) and updated for the review feedback. The `ws_orphan_reap` timer is an in-process `threading.Timer` (`tui_gateway/server.py:810-840`), so a gateway restart (every `hermes update` / deploy, every crash) kills it before it fires and the session row stays `ended_at IS NULL` forever — no code path in the next process ever revisits it. Every other resource type Hermes manages already has a "sweep leftovers at next startup" pass (`docker_orphan_reaper`, terminal/browser orphan reaps, MCP stdio watchdog); TUI/desktop/subagent session rows do not. This adds it.

The gap is still present on current `main`: `_schedule_ws_orphan_reap` / `_reap_idle_sessions` / `_enforce_session_cap` all operate on the in-memory `_sessions` dict only, and `tui_gateway/entry.py:main()` has no startup pass over `sessions WHERE ended_at IS NULL`. The recently landed per-session turn lease work (#67401) touches `gateway/turn_lease.py` + `gateway/run.py` (turn serialization in the messaging gateway) and does not change session-row open/closed bookkeeping, so it neither overlaps nor invalidates this.

**Changed since the last push (review feedback):** staleness now requires **both** clocks to be past the cutoff — the row's own `started_at` **and** its newest `messages.timestamp` (falling back to `started_at` for message-less rows), including the same predicate in the write-transaction recheck. Message recency alone would have swept a freshly created row that carries older *copied* history: `session.branch` (`tui_gateway/server.py:8923+`) creates a new row and copies the parent transcript onto it. This mirrors the in-memory idle reaper's own `last_active AND created_at` contract (`tui_gateway/server.py:919`). A regression test for that fresh-row/old-history case is included.

**Note on duplication:** #65422 targets the same issue with a very similar design (opened ~1h before this one, currently mergeable, and it also documents the config key in `cli-config.yaml.example` / `configuration.md`). The two differ in coverage: this PR includes `source='desktop'` and hooks the WS sidecar entry point (`tui_gateway/ws.py`) that desktop/dashboard clients actually connect through, plus it excludes rows referenced by a live in-memory session. #65422 was asked in review to add desktop coverage; this one was asked to add the both-clocks predicate. Only one of the two should land — happy for that to be #65422 with the desktop/ws.py coverage ported over if maintainers prefer the more documented diff.

## Related Issue

Fixes #65194

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py` — new `SessionDB.sweep_orphaned_sessions()` next to `end_session`/`reopen_session`. SELECTs candidates, then re-verifies **inside the `BEGIN IMMEDIATE` write transaction** (`ended_at IS NULL AND still-stale`) so a sibling's concurrent end/resume/message can't be clobbered; `end_session`'s first-reason-wins contract preserved.
- `tui_gateway/server.py` — `_sweep_orphaned_session_rows()` + `_schedule_startup_orphan_sweep()`, scheduled once per process. Swept rows stamped `end_reason=orphan_startup_sweep` so they stay distinguishable from live `ws_orphan_reap`.
- `tui_gateway/entry.py` — schedules the sweep from the stdio TUI entry point.
- `tui_gateway/ws.py` — schedules the same sweep from the WS sidecar connection handler (desktop/dashboard never reach `entry.main()`). Idempotent + config-gated, so the double hook is safe.
- `tests/test_tui_gateway_server.py` — 5 tests (see below).

Eligibility (deliberately conservative): `ended_at IS NULL` **and** `source IN ('tui','desktop','subagent')` (gateway-platform sources never touched per the #60609 doctrine; `cli` rows have their own exit finalize) **and** both `started_at` and `MAX(messages.timestamp)` older than `max(SESSION_TTL, WS_ORPHAN_REAP_GRACE)` (default 6h, reusing `HERMES_TUI_SESSION_TTL_S`) **and** not referenced by a live in-memory session in this process. The timer is delayed by `_WS_ORPHAN_REAP_GRACE_S` after startup so an immediately reconnecting client can `session.resume` first. Opt-out: `session_orphan_reaper: false` (top-level or under `gateway:`), default on; grace `= 0` disables it exactly like the live reaper.

`state.db` is per-profile, but sibling processes on the same profile share it, so "no live websocket in this process" is not provable from the DB alone — hence inactivity-based eligibility at hours scale: any row a live sibling is using keeps gaining message rows.

## Open questions (still unresolved — this PR carries `needs-decision`)

1. **`desktop` in the swept source set.** The issue text says `('tui','subagent')`, but `_resolve_session_platform()` stamps the desktop chat panel — the primary `ws_orphan_reap` victim — as `desktop`, and the WS disconnect path schedules the orphan reaper without filtering source. Included here; trivial to narrow if maintainers prefer.
2. **Should `orphan_startup_sweep` join any recovery-eligible `end_reason` list?** The existing ones (`find_latest_gateway_session_for_peer`, `promote_to_session_reset`) only apply to gateway-platform sources, which this sweep never touches, so this PR leaves them alone.

Neither question has been answered on the issue or the PR, so `needs-decision` still applies — this push is the review-feedback fix, not a resolution of those two.

## How to Test

1. Start a TUI/desktop/subagent session, let its websocket drop, and kill the gateway before the ~20 s grace timer fires.
2. `sqlite3 ~/.hermes/state.db "SELECT id, source, end_reason FROM sessions WHERE ended_at IS NULL"` — the row is open, and before this change stayed open forever.
3. Once the row is TTL-stale (default 6 h; lower `HERMES_TUI_SESSION_TTL_S` to shorten), start the gateway again. After the grace delay the row is closed with `end_reason='orphan_startup_sweep'`. Rows that are fresh, still messaging, gateway-owned, or already ended are untouched; a second boot is a no-op.

Automated (5 tests in `tests/test_tui_gateway_server.py`):

- stale `tui` + `subagent` rows swept with the distinct reason
- **fresh row with old copied history is spared** (branch-child regression from review; verified to fail if the `started_at` predicate is removed)
- recent / grace-window, live-resumed, and gateway-source rows spared
- already-ended rows untouched (reason + timestamp preserved)
- scheduling gates (config off / once-guard / grace = 0)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #65422 overlaps; disclosed above rather than hidden
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not the full suite.** Ran, on `36f2a966c7`: `tests/test_tui_gateway_server.py` → **380 passed**; `tests/test_hermes_state.py tests/hermes_state/ tests/test_hermes_state_compression_locks.py tests/test_hermes_state_wal_fallback.py` → **480 passed**; `pytest tests/ -k "tui or session_sweep or orphan" --ignore=tests/acp --ignore=tests/acp_adapter` → **1142 passed, 7 failed**. All 7 failures are pre-existing: the identical 7 fail on a clean checkout of the same commit with these changes stashed (`test_async_delegation`, `test_delegation_session_lifecycle` ×2, `test_gateway_owned_session_reap` ×2, `test_projects_rpc`, `test_subagent_child_mirror`). `tests/acp*` is excluded because the module `acp` is not installed in this environment (collection error, unrelated). `ruff check hermes_state.py tui_gateway/ tests/test_tui_gateway_server.py` → clean.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.14. Pure Python/SQLite change.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module-level and function docstrings cover the sweep's contract and its concurrency reasoning; no user-guide page changed.
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — **not done, and this is a real gap.** `session_orphan_reaper` is documented only in the code comment. I kept this push to the five files the PR already touched; say the word (or prefer #65422's already-documented variant) and I'll add the example + `configuration.md` entry.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow change.
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A in the sense that nothing platform-specific is used: stdlib `threading` + SQLite only, no paths, no signals, no subprocesses.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool touched.

## Screenshots / Logs

```
$ python -m pytest tests/test_tui_gateway_server.py -q
380 passed in 9.67s

$ python -m pytest tests/test_hermes_state.py tests/hermes_state/ \
    tests/test_hermes_state_compression_locks.py tests/test_hermes_state_wal_fallback.py -q
480 passed in 17.62s

$ python -m ruff check hermes_state.py tui_gateway/ tests/test_tui_gateway_server.py
All checks passed!
```

On sweep, the gateway logs:

```
Startup orphan sweep ended 2 session row(s) left open by a previous process: stale-tui, stale-sub
```
