### PR TITLE
fix(cron): support durable cron state store

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1,8 +1,9 @@
 """
 Cron job storage and management.
 
-Jobs are stored in ~/.hermes/cron/jobs.json
-Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
+Jobs are stored in ``<HERMES_HOME>/cron/jobs.json`` by default.
+When ``cron.store_dir`` is configured, jobs, locks, ticker state, and output
+are stored together under that absolute directory instead.
 """
 
 import contextlib
@@ -115,11 +116,46 @@ _cron_store_override: ContextVar[Optional[_CronStorePaths]] = ContextVar(
 )
 
 
+def _configured_cron_store() -> Optional[_CronStorePaths]:
+    """Return the configured durable cron store, if one is requested.
+
+    ``cron.store_dir`` keeps the definition file, locks, run state, and output
+    in one coherent store. It is intended for a single profile gateway whose
+    normal ``HERMES_HOME`` is ephemeral (for example, a container with SQLite
+    on local disk). A profile-scoped ``use_cron_store()`` context takes
+    precedence in ``_current_cron_store`` below, preserving profile isolation
+    for callers which intentionally execute work for another profile.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cron_config = (load_config() or {}).get("cron") or {}
+    except Exception:
+        # A missing/unreadable config retains the historical default store.
+        return None
+    raw = cron_config.get("store_dir")
+    if raw is None or not str(raw).strip():
+        return None
+    if not isinstance(raw, str):
+        raise ValueError("cron.store_dir must be an absolute path string")
+    cron_dir = Path(raw).expanduser()
+    if not cron_dir.is_absolute():
+        raise ValueError("cron.store_dir must be an absolute path")
+    cron_dir = cron_dir.resolve()
+    return _CronStorePaths(
+        cron_dir=cron_dir,
+        jobs_file=cron_dir / "jobs.json",
+        output_dir=cron_dir / "output",
+    )
+
+
 def _current_cron_store() -> _CronStorePaths:
     """Return paths pinned to this execution context's profile."""
     override = _cron_store_override.get()
     if override is not None:
         return override
+    configured = _configured_cron_store()
+    if configured is not None:
+        return configured
     return _CronStorePaths(CRON_DIR, JOBS_FILE, OUTPUT_DIR)
 
 
@@ -138,6 +174,11 @@ def use_cron_store(home: Union[str, Path]):
         yield
     finally:
         _cron_store_override.reset(token)
+
+
+def get_cron_store_dir() -> Path:
+    """Return the current store directory for jobs, locks, and ticker state."""
+    return _current_cron_store().cron_dir
 
 
 def get_cron_output_dir() -> Path:
@@ -789,12 +830,12 @@ def record_ticker_heartbeat(success: bool = False) -> None:
     Best-effort: a write failure must never disrupt the tick loop.
     """
     try:
-        _atomic_write_epoch(TICKER_HEARTBEAT_FILE)
+        _atomic_write_epoch(_current_cron_store().cron_dir / "ticker_heartbeat")
     except Exception:
         pass
     if success:
         try:
-            _atomic_write_epoch(TICKER_SUCCESS_FILE)
+            _atomic_write_epoch(_current_cron_store().cron_dir / "ticker_last_success")
         except Exception:
             pass
 
@@ -813,12 +854,12 @@ def get_ticker_heartbeat_age() -> Optional[float]:
     None = heartbeat file missing/unreadable (older build, never ran, or a
     torn read). Callers treat None as "cannot determine", not "dead".
     """
-    return _epoch_file_age(TICKER_HEARTBEAT_FILE)
+    return _epoch_file_age(_current_cron_store().cron_dir / "ticker_heartbeat")
 
 
 def get_ticker_success_age() -> Optional[float]:
     """Seconds since the ticker last completed a tick WITHOUT raising, or None."""
-    return _epoch_file_age(TICKER_SUCCESS_FILE)
+    return _epoch_file_age(_current_cron_store().cron_dir / "ticker_last_success")
 
 
 # =============================================================================

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -553,9 +553,13 @@ def _get_hermes_home() -> Path:
 
 
 def _get_lock_paths() -> tuple[Path, Path]:
-    """Resolve cron lock paths at call time so profile/env changes are honored."""
-    hermes_home = _get_hermes_home()
-    lock_dir = hermes_home / "cron"
+    """Resolve cron lock paths at call time so profile/config changes are honored."""
+    if _hermes_home is not None:
+        # Preserve the longstanding emergency/test override.
+        lock_dir = _hermes_home / "cron"
+    else:
+        from cron.jobs import get_cron_store_dir
+        lock_dir = get_cron_store_dir()
     return lock_dir, lock_dir / ".tick.lock"
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2671,6 +2671,12 @@ DEFAULT_CONFIG = {
     },
 
     "cron": {
+        # Optional absolute directory for the complete cron store (jobs,
+        # locks, ticker liveness markers, and output). Leave empty to keep the
+        # per-profile default at <HERMES_HOME>/cron. This is useful when a
+        # single-profile gateway has an ephemeral runtime home but a durable
+        # shared volume available for scheduling state.
+        "store_dir": "",
         # Active cron SCHEDULER provider (Axis B — the trigger that decides
         # WHEN a due job fires). Empty string = the built-in in-process 60s
         # ticker (default). Name an installed provider (plugins/cron_providers/<name>/ or

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -23,6 +23,10 @@ from cron.jobs import (
     heartbeat_run_claim,
     get_due_jobs,
     save_job_output,
+    use_cron_store,
+    record_ticker_heartbeat,
+    get_ticker_heartbeat_age,
+    get_ticker_success_age,
 )
 
 
@@ -237,6 +241,86 @@ def tmp_cron_dir(tmp_path, monkeypatch):
     monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
     monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
     return tmp_path
+
+
+def test_configured_cron_dir_survives_runtime_home_replacement(tmp_path, monkeypatch):
+    """A durable cron directory must not depend on a runtime HERMES_HOME sync.
+
+    This models a rolling replacement: the old gateway writes a job, then a
+    new gateway begins with a distinct empty local home. Both receive the same
+    persisted config, so the new process sees the job without waiting for the
+    old process's shutdown hook.
+    """
+    durable_cron = tmp_path / "durable" / "cron"
+    old_runtime = tmp_path / "old-runtime"
+    new_runtime = tmp_path / "new-runtime"
+    for runtime in (old_runtime, new_runtime):
+        runtime.mkdir()
+        (runtime / "config.yaml").write_text(
+            f"cron:\n  store_dir: {durable_cron}\n", encoding="utf-8"
+        )
+
+    monkeypatch.setenv("HERMES_HOME", str(old_runtime))
+    from cron.scheduler import _get_lock_paths
+    assert _get_lock_paths() == (durable_cron, durable_cron / ".tick.lock")
+    created = create_job(prompt="persist me", schedule="every 5m", deliver="local")
+    assert (durable_cron / "jobs.json").exists()
+    assert not (old_runtime / "cron" / "jobs.json").exists()
+
+    # A replacement receives the same durable cron-store configuration but no
+    # copied runtime state. Loading from it is the startup-side assertion.
+    monkeypatch.setenv("HERMES_HOME", str(new_runtime))
+    restored = load_jobs()
+    assert [job["id"] for job in restored] == [created["id"]]
+    assert not (new_runtime / "cron" / "jobs.json").exists()
+
+
+def test_configured_cron_dir_must_be_absolute(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "cron:\n  store_dir: relative-cron\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    with pytest.raises(ValueError, match="must be an absolute path"):
+        load_jobs()
+
+
+def test_profile_store_overrides_configured_cron_dir(tmp_path, monkeypatch):
+    """An explicit profile context must retain its isolated cron store."""
+    durable_cron = tmp_path / "durable" / "cron"
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        f"cron:\n  store_dir: {durable_cron}\n", encoding="utf-8"
+    )
+    profile_home = tmp_path / "profile"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    with use_cron_store(profile_home):
+        created = create_job(prompt="profile-only", schedule="every 5m", deliver="local")
+        assert [job["id"] for job in load_jobs()] == [created["id"]]
+
+    assert (profile_home / "cron" / "jobs.json").exists()
+    assert not (durable_cron / "jobs.json").exists()
+
+
+def test_ticker_liveness_uses_configured_cron_dir(tmp_path, monkeypatch):
+    durable_cron = tmp_path / "durable" / "cron"
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        f"cron:\n  store_dir: {durable_cron}\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    record_ticker_heartbeat(success=True)
+
+    assert (durable_cron / "ticker_heartbeat").exists()
+    assert (durable_cron / "ticker_last_success").exists()
+    assert get_ticker_heartbeat_age() is not None
+    assert get_ticker_success_age() is not None
+    assert not (home / "cron" / "ticker_heartbeat").exists()
 
 
 class TestJobCRUD:

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -390,7 +390,7 @@ not required (and is ignored) for DMs.
 
 ### Silent suppression
 
-If the agent's final response contains `[SILENT]`, delivery is suppressed entirely. The output is still saved locally for audit (in `~/.hermes/cron/output/`), but no message is sent to the delivery target.
+If the agent's final response contains `[SILENT]`, delivery is suppressed entirely. The output is still saved locally for audit (in `~/.hermes/cron/output/` by default), but no message is sent to the delivery target.
 
 This is useful for monitoring jobs that should only report when something is wrong:
 
@@ -400,6 +400,26 @@ Otherwise, report the issue.
 ```
 
 Failed jobs always deliver regardless of the `[SILENT]` marker — only successful runs can be silenced. For quiet monitoring jobs, prompt the agent to reply with only `[SILENT]` when there is nothing to report.
+
+### Durable cron storage
+
+By default, a profile stores cron state under `<HERMES_HOME>/cron`. If a
+single-profile gateway runs with an ephemeral home (for example, a container
+whose runtime filesystem is replaced during rollout), configure an absolute
+durable directory instead:
+
+```yaml
+# ~/.hermes/config.yaml
+cron:
+  store_dir: /mnt/hermes-cron
+```
+
+This moves the complete cron store together: `jobs.json`, scheduler and job
+locks, ticker liveness markers, and job output. All replicas that can run the
+same profile must use the same mounted path and filesystem with reliable file
+locking. Leave `store_dir` empty (the default) to retain the per-profile
+`<HERMES_HOME>/cron` store. It is intentionally for a single-profile gateway;
+profile-scoped operations continue to use their own isolated stores.
 
 ## Script timeout
 


### PR DESCRIPTION
## Summary
- add `cron.store_dir` for a durable, absolute cron state directory
- keep jobs, run/scheduler locks, ticker liveness markers, and output together
- retain explicit profile-scoped cron-store overrides
- document the deployment configuration and add rolling-replacement regression coverage

## Verification
- `git diff --check`
- `python -m compileall -q cron/jobs.py cron/scheduler.py hermes_cli/config.py`
- manual temp-home end-to-end smoke test for durable jobs, shared scheduler lock resolution, ticker liveness, and replacement-runtime reads

`pytest` could not run in the execution environment: it was not installed and the environment could not download it because PyPI TLS requests failed.