### PR TITLE
feat(providers): add tencent-tokenplan as a model-provider plugin

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1063,7 +1063,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("alibaba",        "Qwen Cloud",               "Qwen Cloud / DashScope (Qwen + multi-provider)"),
     ProviderEntry("xai-oauth",      "xAI Grok OAuth (SuperGrok / Premium+)", "xAI Grok OAuth (SuperGrok / Premium+ subscription)"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2.5 and V2 models: pro, omni, flash)"),
-    ProviderEntry("tencent-tokenhub", "Tencent TokenHub",       "Tencent TokenHub (Hy3 Preview via tokenhub.tencentmaas.com)"),
+    ProviderEntry("tencent-tokenhub", "Tencent TokenHub",       "Tencent TokenHub (Hy3 via tokenhub.tencentmaas.com)"),
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),

--- a/plugins/model-providers/tencent-tokenplan/README.md
+++ b/plugins/model-providers/tencent-tokenplan/README.md
@@ -1,0 +1,31 @@
+# Tencent TokenPlan
+
+Routes Hermes through Tencent's [LKEAP](https://cloud.tencent.com/product/lkeap)
+TokenPlan gateway to the **Hy3** (Hunyuan) model over an Anthropic
+Messages-compatible endpoint.
+
+## Setup
+
+Add your API key to `~/.hermes/.env`:
+
+```bash
+TOKENPLAN_API_KEY=your-api-key
+```
+
+Then run:
+
+```bash
+hermes chat --provider tencent-tokenplan --model hy3
+```
+
+Aliases: `tokenplan`, `tencent-lkeap`.
+
+## Configuration
+
+| Env var | Purpose |
+|---|---|
+| `TOKENPLAN_API_KEY` | API key for the LKEAP TokenPlan gateway |
+| `TOKENPLAN_BASE_URL` | Override the base URL (default: `https://api.lkeap.cloud.tencent.com/plan/anthropic`) |
+
+The base URL ends with `/anthropic`; the Anthropic SDK appends `/v1/messages`
+automatically, so do **not** include that suffix in overrides.

--- a/plugins/model-providers/tencent-tokenplan/__init__.py
+++ b/plugins/model-providers/tencent-tokenplan/__init__.py
@@ -1,0 +1,27 @@
+"""Tencent TokenPlan provider profile.
+
+Routes Hermes through Tencent's LKEAP TokenPlan gateway, which exposes the
+Hy3 (Hunyuan) model via an Anthropic Messages-compatible endpoint. The base
+URL ends with ``/anthropic`` so the Anthropic SDK appends ``/v1/messages``
+automatically — do not include the ``/v1/messages`` suffix here.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+tencent_tokenplan = ProviderProfile(
+    name="tencent-tokenplan",
+    aliases=("tokenplan", "tencent-lkeap"),
+    api_mode="anthropic_messages",
+    display_name="Tencent TokenPlan",
+    description="Tencent TokenPlan (Hy3 via api.lkeap.cloud.tencent.com)",
+    signup_url="https://cloud.tencent.com/product/lkeap",
+    env_vars=("TOKENPLAN_API_KEY", "TOKENPLAN_BASE_URL"),
+    base_url="https://api.lkeap.cloud.tencent.com/plan/anthropic",
+    auth_type="api_key",
+    default_aux_model="hy3",
+    fallback_models=("hy3",),
+)
+
+register_provider(tencent_tokenplan)

--- a/plugins/model-providers/tencent-tokenplan/plugin.yaml
+++ b/plugins/model-providers/tencent-tokenplan/plugin.yaml
@@ -1,0 +1,5 @@
+name: tencent-tokenplan-provider
+kind: model-provider
+version: 1.0.0
+description: Tencent TokenPlan (Hy3 via LKEAP Anthropic-compatible endpoint)
+author: Contentment003111

--- a/tests/hermes_cli/test_tencent_tokenhub_provider.py
+++ b/tests/hermes_cli/test_tencent_tokenhub_provider.py
@@ -182,7 +182,7 @@ class TestTencentTokenhubCanonicalProvider:
     def test_description_contains_hy3(self):
         from hermes_cli.models import CANONICAL_PROVIDERS
         entry = next(p for p in CANONICAL_PROVIDERS if p.slug == "tencent-tokenhub")
-        assert "Hy3 Preview" in entry.tui_desc
+        assert "Hy3" in entry.tui_desc
 
 
 # =============================================================================

--- a/tests/plugins/model_providers/test_tencent_tokenplan_profile.py
+++ b/tests/plugins/model_providers/test_tencent_tokenplan_profile.py
@@ -1,0 +1,89 @@
+"""Unit tests for the Tencent TokenPlan provider profile.
+
+Tencent TokenPlan is a drop-in model-provider plugin
+(``plugins/model-providers/tencent-tokenplan/``) that routes Hermes through
+Tencent's LKEAP gateway to the Hy3 (Hunyuan) model over an Anthropic
+Messages-compatible endpoint.
+
+These tests pin the profile's identity, aliases, transport mode, endpoint,
+and auxiliary model so any future drift shows up as a failing test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def tokenplan_profile():
+    """Resolve the registered tencent-tokenplan profile via the public API.
+
+    Importing ``model_tools`` triggers lazy plugin discovery so the plugin
+    directory is scanned before we look the profile up.
+    """
+    import model_tools  # noqa: F401  -- triggers plugin discovery
+    import providers
+
+    profile = providers.get_provider_profile("tencent-tokenplan")
+    assert profile is not None, "tencent-tokenplan provider profile must be registered"
+    return profile
+
+
+class TestTencentTokenplanIdentity:
+    """Canonical id, aliases, and human-readable metadata."""
+
+    def test_name(self, tokenplan_profile):
+        assert tokenplan_profile.name == "tencent-tokenplan"
+
+    def test_display_name(self, tokenplan_profile):
+        assert tokenplan_profile.display_name == "Tencent TokenPlan"
+
+    @pytest.mark.parametrize("alias", ["tokenplan", "tencent-lkeap"])
+    def test_alias_resolves(self, alias):
+        import model_tools  # noqa: F401
+        import providers
+
+        profile = providers.get_provider_profile(alias)
+        assert profile is not None
+        assert profile.name == "tencent-tokenplan"
+
+
+class TestTencentTokenplanTransport:
+    """TokenPlan uses the Anthropic Messages protocol over the LKEAP gateway."""
+
+    def test_api_mode_is_anthropic_messages(self, tokenplan_profile):
+        assert tokenplan_profile.api_mode == "anthropic_messages"
+
+    def test_base_url(self, tokenplan_profile):
+        # Must NOT include the /v1/messages suffix — the Anthropic SDK appends
+        # it. Including it would produce a doubled path and a 404.
+        assert (
+            tokenplan_profile.base_url
+            == "https://api.lkeap.cloud.tencent.com/plan/anthropic"
+        )
+
+    def test_base_url_has_no_messages_suffix(self, tokenplan_profile):
+        assert not tokenplan_profile.base_url.rstrip("/").endswith("/messages")
+
+    def test_auth_type_is_api_key(self, tokenplan_profile):
+        assert tokenplan_profile.auth_type == "api_key"
+
+    def test_env_vars(self, tokenplan_profile):
+        assert "TOKENPLAN_API_KEY" in tokenplan_profile.env_vars
+        assert "TOKENPLAN_BASE_URL" in tokenplan_profile.env_vars
+
+
+class TestTencentTokenplanModels:
+    """Aux model and fallback catalog advertise Hy3."""
+
+    def test_default_aux_model(self, tokenplan_profile):
+        assert tokenplan_profile.default_aux_model == "hy3"
+
+    def test_hy3_in_fallback_models(self, tokenplan_profile):
+        assert "hy3" in tokenplan_profile.fallback_models
+
+    def test_consumer_aux_api_returns_hy3(self, tokenplan_profile):
+        from agent.auxiliary_client import _get_aux_model_for_provider
+
+        resolved = _get_aux_model_for_provider("tencent-tokenplan")
+        assert resolved == tokenplan_profile.default_aux_model


### PR DESCRIPTION
## What does this PR do?

Adds **Tencent TokenPlan** (Hy3 via Tencent's LKEAP Anthropic-compatible endpoint) as a drop-in **model-provider plugin** under `plugins/model-providers/tencent-tokenplan/`, with **no core file changes** for the new provider.

This is a re-do of the previously closed #57500, which was closed under the standing `in-tree-provider-integration` policy (that PR wired the provider directly into core files `hermes_cli/auth.py`, `hermes_cli/providers.py`, `hermes_cli/models.py`, etc.). Following the maintainer guidance in `website/docs/developer-guide/model-provider-plugin.md`, the provider is now shipped purely as a `ProviderProfile` plugin that auto-wires into auth, the `hermes model` picker, `doctor`, runtime resolution, and the auxiliary client — without touching any core provider/auth/runtime files.

Additionally, this PR drops the stale `Preview` label from the existing `tencent-tokenhub` picker description. Note: `tencent-tokenhub` is **pre-existing in-tree logic** (it predates the plugin architecture and still lives in `hermes_cli/models.py`), so this one-line description fix is a small edit to core rather than a plugin change.

## Related Issue

Supersedes #57500 (closed as not-planned under the `in-tree-provider-integration` policy). This PR reimplements the same capability as a standalone model-provider plugin per that policy.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

**New provider (plugin — no core changes):**
- `plugins/model-providers/tencent-tokenplan/__init__.py` — registers the `ProviderProfile` (`api_mode="anthropic_messages"`, base URL `https://api.lkeap.cloud.tencent.com/plan/anthropic`, env `TOKENPLAN_API_KEY` / `TOKENPLAN_BASE_URL`, aliases `tokenplan` / `tencent-lkeap`, aux model `hy3`)
- `plugins/model-providers/tencent-tokenplan/plugin.yaml` — plugin manifest (`kind: model-provider`)
- `plugins/model-providers/tencent-tokenplan/README.md` — setup instructions
- `tests/plugins/model_providers/test_tencent_tokenplan_profile.py` — profile identity / transport / endpoint / aux-model tests

**Existing provider (core — description only):**
- `hermes_cli/models.py` — drop `Preview` from the `tencent-tokenhub` picker description (`Hy3 Preview` → `Hy3`)
- `tests/hermes_cli/test_tencent_tokenhub_provider.py` — sync the description assertion

## How to Test

1. Set `TOKENPLAN_API_KEY` in `~/.hermes/.env`
2. Run `hermes chat --provider tencent-tokenplan --model hy3` (aliases `tokenplan` / `tencent-lkeap` also work)
3. Verify the model responds via the Anthropic Messages protocol
4. Run `hermes model` and confirm `Tencent TokenPlan (Hy3 via api.lkeap.cloud.tencent.com)` appears in the picker, and that `Tencent TokenHub` no longer shows `Preview`
5. `pytest tests/plugins/model_providers/test_tencent_tokenplan_profile.py tests/hermes_cli/test_tencent_tokenhub_provider.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (CentOS)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (plugin README) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure profile declaration)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
