### PR TITLE
fix(webhook): scope reuse_address=False to macOS only

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -39,6 +39,7 @@ import json
 import logging
 import re
 import subprocess
+import sys
 import time
 from collections import deque
 from typing import Any, Deque, Dict, List, Optional
@@ -251,14 +252,21 @@ class WebhookAdapter(BasePlatformAdapter):
         await self._runner.setup()
         # Do not probe only one address family before binding. With the
         # dual-stack default, an IPv6-only listener can already own this port
-        # while 127.0.0.1 still looks free. Also disable SO_REUSEADDR for the
-        # listener: on macOS, two wildcard/specific sockets with SO_REUSEADDR
-        # can silently split traffic while both servers report success.
+        # while 127.0.0.1 still looks free.
+        #
+        # SO_REUSEADDR is platform-dependent:
+        #   - macOS (BSD semantics): two wildcard/specific sockets with
+        #     SO_REUSEADDR can silently split traffic while both servers
+        #     report success — so disable it there.
+        #   - Linux: SO_REUSEADDR only permits rebinding past TIME_WAIT
+        #     (a second live listener needs SO_REUSEPORT, which we never
+        #     set). Disabling it would make a quick gateway restart fail
+        #     to bind for up to ~60s — so keep the default (enabled).
         site = web.TCPSite(
             self._runner,
             self._host,
             self._port,
-            reuse_address=False,
+            reuse_address=False if sys.platform == "darwin" else None,
         )
         try:
             await site.start()


### PR DESCRIPTION
## Infographic

![webhook-reuse-address-darwin](https://v3b.fal.media/files/b/0aa274e6/hvu6H4IO74oMhSeTCltVz_qkbHTLdz.png)

## Summary

Quick gateway restarts on Linux can rebind the webhook port immediately again — `reuse_address=False` is now scoped to macOS only.

Follow-up to #63711 (dual-stack bind). That PR disabled SO_REUSEADDR unconditionally to guard against macOS's BSD semantics, where two wildcard/specific sockets with SO_REUSEADDR can silently split traffic while both servers report success. But that hazard doesn't exist on Linux: SO_REUSEADDR there only permits rebinding past TIME_WAIT (a second live listener would additionally need SO_REUSEPORT, which we never set). Disabling it on Linux bought no protection while making a fast gateway restart fail to bind for up to ~60s with "Could not bind."

## Changes

- `gateway/platforms/webhook.py`: `reuse_address=False if sys.platform == "darwin" else None` on the TCPSite — split-guard kept on macOS, default (enabled) semantics elsewhere.

## Validation

| Check | Result |
|---|---|
| Dual-stack v4+v6 bind on one port (real sockets, E2E) | pass |
| Immediate rebind after disconnect on same port (Linux) | pass |
| Second live listener on same port still rejected, runner cleaned | pass |
| `tests/gateway/test_webhook_adapter.py` | 91/91 |
