### PR TITLE
fix(execute-code): resolve project-mode cwd from the session's own directory

### DIFF
--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -220,6 +220,17 @@ class TestResolveChildCwd(unittest.TestCase):
         with patch.dict(os.environ, {"TERMINAL_CWD": "~"}):
             self.assertEqual(_resolve_child_cwd("project", "/tmp/staging"), home)
 
+    def test_project_prefers_registered_task_cwd_override(self):
+        import tempfile
+        import tools.terminal_tool as terminal_tool
+
+        with tempfile.TemporaryDirectory() as td:
+            task_id = "session-cwd-test"
+            with patch.dict(os.environ, {"TERMINAL_CWD": "/does/not/exist"}):
+                with patch.object(terminal_tool, "_task_env_overrides", {}, create=False):
+                    terminal_tool.register_task_env_overrides(task_id, {"cwd": td})
+                    self.assertEqual(_resolve_child_cwd("project", "/tmp/staging", task_id=task_id), td)
+
 
 # ---------------------------------------------------------------------------
 # Schema description
@@ -315,6 +326,28 @@ class TestExecuteCodeModeIntegration(unittest.TestCase):
                 os.path.realpath(result["output"].strip()),
                 os.path.realpath(td),
             )
+
+    def test_project_mode_uses_registered_session_cwd_override(self):
+        """Project mode must honor session.cwd.set-style overrides even when
+        TERMINAL_CWD is absent or points elsewhere."""
+        import tempfile
+        import tools.terminal_tool as terminal_tool
+
+        with tempfile.TemporaryDirectory() as td:
+            task_id = "session-cwd-test"
+            with patch.dict(os.environ, {"TERMINAL_CWD": "/does/not/exist"}):
+                with patch.object(terminal_tool, "_task_env_overrides", {}, create=False):
+                    terminal_tool.register_task_env_overrides(task_id, {"cwd": td})
+                    with _mock_mode("project"):
+                        with patch("model_tools.handle_function_call", side_effect=_mock_handle_function_call):
+                            raw = execute_code(
+                                code="import os; print(os.getcwd())",
+                                task_id=task_id,
+                                enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
+                            )
+            result = json.loads(raw)
+            self.assertEqual(result["status"], "success")
+            self.assertEqual(os.path.realpath(result["output"].strip()), os.path.realpath(td))
 
     def test_project_mode_interpreter_is_venv_python(self):
         """Project mode: sys.executable inside the child is the venv's python

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -231,6 +231,58 @@ class TestResolveChildCwd(unittest.TestCase):
                     terminal_tool.register_task_env_overrides(task_id, {"cwd": td})
                     self.assertEqual(_resolve_child_cwd("project", "/tmp/staging", task_id=task_id), td)
 
+    def test_project_prefers_session_cwd_record_over_override(self):
+        """The session's cwd RECORD (its live `cd` state) outranks the
+        registration-time workspace override — same ladder as file tools
+        and the terminal, so a `cd` before execute_code is honored."""
+        import tempfile
+        import tools.terminal_tool as terminal_tool
+
+        with tempfile.TemporaryDirectory() as reg, tempfile.TemporaryDirectory() as cded:
+            task_id = "session-record-test"
+            with patch.dict(os.environ, {"TERMINAL_CWD": "/does/not/exist"}):
+                with patch.object(terminal_tool, "_task_env_overrides", {}, create=False), \
+                     patch.object(terminal_tool, "_session_cwd", {}, create=False):
+                    terminal_tool.register_task_env_overrides(task_id, {"cwd": reg})
+                    # Simulate a later `cd`: post-command tracking rewrites the record.
+                    terminal_tool.record_session_cwd(task_id, cded)
+                    self.assertEqual(
+                        _resolve_child_cwd("project", "/tmp/staging", task_id=task_id), cded
+                    )
+
+    def test_project_uses_session_cwd_record_without_any_override(self):
+        """A session that only `cd`'d (no session.cwd.set registration) still
+        resolves to its recorded directory."""
+        import tempfile
+        import tools.terminal_tool as terminal_tool
+
+        with tempfile.TemporaryDirectory() as cded:
+            task_id = "record-only-test"
+            with patch.dict(os.environ, {"TERMINAL_CWD": "/does/not/exist"}):
+                with patch.object(terminal_tool, "_task_env_overrides", {}, create=False), \
+                     patch.object(terminal_tool, "_session_cwd", {}, create=False):
+                    terminal_tool.record_session_cwd(task_id, cded)
+                    self.assertEqual(
+                        _resolve_child_cwd("project", "/tmp/staging", task_id=task_id), cded
+                    )
+
+    def test_project_stale_record_falls_through_to_override(self):
+        """A recorded directory that no longer exists is skipped; the
+        registered override is the next rung."""
+        import tempfile
+        import tools.terminal_tool as terminal_tool
+
+        with tempfile.TemporaryDirectory() as reg:
+            task_id = "stale-record-test"
+            with patch.dict(os.environ, {"TERMINAL_CWD": "/does/not/exist"}):
+                with patch.object(terminal_tool, "_task_env_overrides", {}, create=False), \
+                     patch.object(terminal_tool, "_session_cwd", {}, create=False):
+                    terminal_tool.register_task_env_overrides(task_id, {"cwd": reg})
+                    terminal_tool.record_session_cwd(task_id, "/deleted/dir/gone")
+                    self.assertEqual(
+                        _resolve_child_cwd("project", "/tmp/staging", task_id=task_id), reg
+                    )
+
 
 # ---------------------------------------------------------------------------
 # Schema description

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1339,7 +1339,7 @@ def execute_code(
         # Env scrubbing and tool whitelist apply identically in both modes.
         _mode = _get_execution_mode()
         _child_python = _resolve_child_python(_mode)
-        _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id)
+        _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id or "")
         _script_path = os.path.join(tmpdir, "script.py")
 
         proc = subprocess.Popen(
@@ -1745,29 +1745,43 @@ def _resolve_child_python(mode: str) -> str:
     return sys.executable
 
 
-def _resolve_child_cwd(mode: str, staging_dir: str, task_id: Optional[str] = None) -> str:
+def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
     """Resolve the working directory for the execute_code subprocess.
 
     - ``strict``: the staging tmpdir (today's behavior).
-    - ``project``: the session's registered cwd override (from
-      ``session.cwd.set``), then ``TERMINAL_CWD``, then ``os.getcwd()``.
-      Falls back to the staging tmpdir as a last resort so we never invoke
-      Popen with a nonexistent cwd.
+    - ``project``: the session's own cwd — its per-session cwd record
+      (written after every completed terminal command), then the raw
+      per-session cwd override registered via ``session.cwd.set`` /
+      ``register_task_env_overrides``, then the session's TERMINAL_CWD
+      (same as the terminal tool), or ``os.getcwd()`` if none points at a
+      real dir. Falls back to the staging tmpdir as a last resort so we
+      never invoke Popen with a nonexistent cwd.
+
+    This mirrors the resolution ladder file tools and the terminal use
+    (record → registered override → TERMINAL_CWD), so all file-writing
+    paths within a session agree on the working directory. (#56047)
     """
     if mode != "project":
         return staging_dir
-    # Check per-session cwd override first (registered via session.cwd.set
-    # → register_task_env_overrides).  This is the same lookup used by
-    # write_file/read_file/patch/terminal so all tool paths agree on the
-    # working directory within a session.  (#56047)
     if task_id:
+        # 1. The session's cwd record — IS the session's `cd` state.
+        try:
+            from tools.terminal_tool import get_session_cwd
+
+            recorded = get_session_cwd(task_id)
+        except Exception:
+            recorded = None
+        if recorded and os.path.isdir(recorded):
+            return recorded
+        # 2. Registered workspace override (session.cwd.set → gateway/TUI/ACP).
         try:
             from tools.file_tools import _registered_task_cwd_override
-            override = _registered_task_cwd_override(task_id)
-            if override and os.path.isdir(override):
-                return override
+
+            session_cwd = _registered_task_cwd_override(task_id)
         except Exception:
-            pass
+            session_cwd = None
+        if session_cwd and os.path.isdir(session_cwd):
+            return session_cwd
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         expanded = os.path.expanduser(raw)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1339,7 +1339,7 @@ def execute_code(
         # Env scrubbing and tool whitelist apply identically in both modes.
         _mode = _get_execution_mode()
         _child_python = _resolve_child_python(_mode)
-        _child_cwd = _resolve_child_cwd(_mode, tmpdir)
+        _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id)
         _script_path = os.path.join(tmpdir, "script.py")
 
         proc = subprocess.Popen(
@@ -1745,17 +1745,29 @@ def _resolve_child_python(mode: str) -> str:
     return sys.executable
 
 
-def _resolve_child_cwd(mode: str, staging_dir: str) -> str:
+def _resolve_child_cwd(mode: str, staging_dir: str, task_id: Optional[str] = None) -> str:
     """Resolve the working directory for the execute_code subprocess.
 
     - ``strict``: the staging tmpdir (today's behavior).
-    - ``project``: the session's TERMINAL_CWD (same as the terminal tool), or
-      ``os.getcwd()`` if TERMINAL_CWD is unset or doesn't point at a real dir.
+    - ``project``: the session's registered cwd override (from
+      ``session.cwd.set``), then ``TERMINAL_CWD``, then ``os.getcwd()``.
       Falls back to the staging tmpdir as a last resort so we never invoke
       Popen with a nonexistent cwd.
     """
     if mode != "project":
         return staging_dir
+    # Check per-session cwd override first (registered via session.cwd.set
+    # → register_task_env_overrides).  This is the same lookup used by
+    # write_file/read_file/patch/terminal so all tool paths agree on the
+    # working directory within a session.  (#56047)
+    if task_id:
+        try:
+            from tools.file_tools import _registered_task_cwd_override
+            override = _registered_task_cwd_override(task_id)
+            if override and os.path.isdir(override):
+                return override
+        except Exception:
+            pass
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         expanded = os.path.expanduser(raw)


### PR DESCRIPTION
## Summary

`execute_code` project mode now resolves the child's working directory from the session's own cwd — closing the divergence where `write_file`/`patch`/`terminal` used the session workspace while `execute_code` silently ran in the process launch directory. Fixes #56047.

Consolidated salvage of #56055 (@AlexFucuson9, first submitter) and #56803 (@gauravsaxena1997, richer tests) — both contributor commits cherry-picked with authorship preserved, then adapted to the per-session cwd record store from #65213: the record (live `cd` state) is rung 1, the `session.cwd.set` registered override rung 2, `TERMINAL_CWD` rung 3, process cwd last — the same ladder file tools and the terminal resolve against.

## Changes
- `tools/code_execution_tool.py`: `_resolve_child_cwd()` takes `task_id`; project mode resolves record → registered override → TERMINAL_CWD → getcwd → staging dir (contributor commits + record-store adaptation)
- `tests/tools/test_code_execution_modes.py`: contributor tests (override precedence + full `execute_code` integration test) plus follow-up coverage: record-over-override, record-only, stale-record fall-through

## Validation
| | Before | After |
|---|---|---|
| `_resolve_child_cwd("project", ..., task_id)` with session cwd set | process launch dir | session dir |
| after a real `cd` through `terminal_tool` | ignored | followed (live E2E) |
| `test_code_execution_modes` + `test_session_cwd_store` | — | 59/59 green |

## Credits

@AlexFucuson9 submitted the fix first (#56055); @gauravsaxena1997 submitted the same fix with an integration test suite (#56803). Both are in the commit history.

## Infographic

![execcode-session-cwd](https://v3b.fal.media/files/b/0aa2752c/o3NFBFmPmhLFhYGqFMbTR_VBxiA1ET.png)
