### PR TITLE
feat(delegation): per-task reasoning_effort in delegate_task

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5814,6 +5814,7 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            reasoning_effort=function_args.get("reasoning_effort"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2283,6 +2283,140 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "medium"})
 
 
+class TestPerTaskReasoningEffort(unittest.TestCase):
+    """Tests for the model-facing per-delegation reasoning_effort override."""
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_per_call_effort_beats_config_override(self, MockAgent, mock_cfg):
+        """Explicit per-call effort wins over delegation.reasoning_effort."""
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "low"}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "high"}
+
+        _build_child_agent(
+            task_index=0, goal="test", context=None, toolsets=None,
+            model=None, max_iterations=50, parent_agent=parent,
+            task_count=1, reasoning_effort="max",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "max"})
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_per_call_effort_beats_parent_inherit(self, MockAgent, mock_cfg):
+        """With no config override, per-call effort still beats the parent's."""
+        mock_cfg.return_value = {"max_iterations": 50}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "high"}
+
+        _build_child_agent(
+            task_index=0, goal="test", context=None, toolsets=None,
+            model=None, max_iterations=50, parent_agent=parent,
+            task_count=1, reasoning_effort="low",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "low"})
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_per_call_none_disables_thinking(self, MockAgent, mock_cfg):
+        """Per-call 'none' disables thinking for that child only."""
+        mock_cfg.return_value = {"max_iterations": 50}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "high"}
+
+        _build_child_agent(
+            task_index=0, goal="test", context=None, toolsets=None,
+            model=None, max_iterations=50, parent_agent=parent,
+            task_count=1, reasoning_effort="none",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": False})
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_invalid_per_call_effort_falls_back_to_config(self, MockAgent, mock_cfg):
+        """An unparseable per-call value falls through to the config level."""
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "low"}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "high"}
+
+        _build_child_agent(
+            task_index=0, goal="test", context=None, toolsets=None,
+            model=None, max_iterations=50, parent_agent=parent,
+            task_count=1, reasoning_effort="banana",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "low"})
+
+    def test_schema_exposes_reasoning_effort(self):
+        """reasoning_effort is model-facing at top level and per task."""
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("reasoning_effort", props)
+        enum = props["reasoning_effort"]["enum"]
+        for level in ("none", "low", "medium", "high", "max"):
+            self.assertIn(level, enum)
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("reasoning_effort", task_props)
+        self.assertEqual(task_props["reasoning_effort"]["enum"], enum)
+
+    def test_dispatch_forwards_reasoning_effort(self):
+        """The live model dispatch path forwards reasoning_effort."""
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {"goal": "test", "reasoning_effort": "low"},
+            )
+        self.assertEqual(captured["reasoning_effort"], "low")
+
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._load_config")
+    def test_delegate_task_rejects_unknown_effort(self, mock_cfg, mock_build):
+        """Unknown top-level effort errors out before any child is built."""
+        mock_cfg.return_value = {"max_iterations": 50}
+        parent = _make_mock_parent(depth=0)
+
+        result = delegate_task(
+            goal="test", reasoning_effort="banana", parent_agent=parent
+        )
+
+        payload = json.loads(result)
+        self.assertIn("reasoning_effort 'banana'", payload["error"])
+        self.assertIn("low", payload["error"])  # lists valid levels
+        mock_build.assert_not_called()
+
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._load_config")
+    def test_delegate_task_rejects_unknown_effort_in_batch(self, mock_cfg, mock_build):
+        """Top-level effort applies to batch tasks and is validated there too."""
+        mock_cfg.return_value = {"max_iterations": 50}
+        parent = _make_mock_parent(depth=0)
+
+        result = delegate_task(
+            tasks=[{"goal": "a"}, {"goal": "b", "reasoning_effort": "bogus"}],
+            parent_agent=parent,
+        )
+
+        payload = json.loads(result)
+        self.assertIn("Task 1", payload["error"])
+        self.assertIn("reasoning_effort 'bogus'", payload["error"])
+        mock_build.assert_not_called()
+
+
 # =========================================================================
 # Dispatch helper, progress events, concurrency
 # =========================================================================

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -36,9 +36,14 @@ from toolsets import TOOLSETS
 # not natively known (named custom providers, third-party aggregators, etc.).
 # Must match hermes_cli.runtime_provider.RUNTIME_PROVIDER_TYPE_CUSTOM.
 _RUNTIME_PROVIDER_CUSTOM = "custom"
+from hermes_constants import VALID_REASONING_EFFORTS
 from tools import file_state
 from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb
 from utils import base_url_hostname, is_truthy_value
+
+# Schema enum for per-delegation reasoning effort: every level
+# parse_reasoning_effort() accepts, plus 'none' to disable thinking.
+_REASONING_EFFORT_ENUM = ["none", *VALID_REASONING_EFFORTS]
 
 
 # Tools that children must never have access to
@@ -1041,6 +1046,50 @@ def _inherit_parent_base_url(parent_agent, fallback_base_url: Optional[str]) -> 
     return fallback_base_url or None
 
 
+def _resolve_child_reasoning(
+    parent_agent,
+    delegation_cfg: Dict[str, Any],
+    reasoning_effort: Optional[str] = None,
+):
+    """Resolve the reasoning config a child agent should run with.
+
+    Priority: per-call ``reasoning_effort`` (model-supplied, per task) >
+    ``delegation.reasoning_effort`` config > inherit the parent's config.
+    Invalid values at either level warn and fall through to the next one,
+    never fail the delegation.
+    """
+    from hermes_constants import parse_reasoning_effort
+
+    child_reasoning = getattr(parent_agent, "reasoning_config", None)
+    try:
+        # Keep the raw value — ``str(x or "")`` would coerce a YAML boolean
+        # False (``reasoning_effort: false``) to "" and inherit the parent
+        # instead of disabling thinking for children.
+        delegation_effort = delegation_cfg.get("reasoning_effort")
+        if delegation_effort or delegation_effort is False:
+            parsed = parse_reasoning_effort(delegation_effort)
+            if parsed is not None:
+                child_reasoning = parsed
+            else:
+                logger.warning(
+                    "Unknown delegation.reasoning_effort '%s', inheriting parent level",
+                    delegation_effort,
+                )
+    except Exception as exc:
+        logger.debug("Could not load delegation reasoning_effort: %s", exc)
+
+    if reasoning_effort is not None and str(reasoning_effort).strip():
+        parsed = parse_reasoning_effort(reasoning_effort)
+        if parsed is not None:
+            child_reasoning = parsed
+        else:
+            logger.warning(
+                "Unknown per-task reasoning_effort '%s', using fallback level",
+                reasoning_effort,
+            )
+    return child_reasoning
+
+
 def _build_child_agent(
     task_index: int,
     goal: str,
@@ -1064,6 +1113,9 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Per-call reasoning effort for this child. Beats the global
+    # delegation.reasoning_effort config; empty/None inherits as before.
+    reasoning_effort: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1251,27 +1303,10 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
-    parent_reasoning = getattr(parent_agent, "reasoning_config", None)
-    child_reasoning = parent_reasoning
-    try:
-        # Keep the raw value — ``str(x or "")`` would coerce a YAML boolean
-        # False (``reasoning_effort: false``) to "" and inherit the parent
-        # instead of disabling thinking for children.
-        delegation_effort = delegation_cfg.get("reasoning_effort")
-        if delegation_effort or delegation_effort is False:
-            from hermes_constants import parse_reasoning_effort
-
-            parsed = parse_reasoning_effort(delegation_effort)
-            if parsed is not None:
-                child_reasoning = parsed
-            else:
-                logger.warning(
-                    "Unknown delegation.reasoning_effort '%s', inheriting parent level",
-                    delegation_effort,
-                )
-    except Exception as exc:
-        logger.debug("Could not load delegation reasoning_effort: %s", exc)
+    # Resolve reasoning config: per-call override > delegation config > parent
+    child_reasoning = _resolve_child_reasoning(
+        parent_agent, delegation_cfg, reasoning_effort
+    )
 
     # Inherit the parent's fallback provider chain so subagents can recover
     # from rate-limits and credential exhaustion exactly like the top-level
@@ -2385,6 +2420,7 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    reasoning_effort: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2398,6 +2434,11 @@ def delegate_task(
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    'reasoning_effort' sets the child's thinking depth per delegation
+    (valid levels in hermes_constants.VALID_REASONING_EFFORTS, plus
+    'none' to disable thinking). Per-task values beat the top-level one;
+    both beat delegation.reasoning_effort from config; unset inherits.
 
     Returns JSON with results array, one entry per task.
     """
@@ -2492,7 +2533,11 @@ def delegate_task(
     if not task_list:
         return tool_error("No tasks provided.")
 
-    # Validate each task has a goal
+    # Validate each task has a goal, and reject unknown effort levels up
+    # front so the model gets a corrective error instead of a silently
+    # inherited level.
+    from hermes_constants import VALID_REASONING_EFFORTS, parse_reasoning_effort
+
     for i, task in enumerate(task_list):
         if not isinstance(task, dict):
             return tool_error(
@@ -2500,6 +2545,17 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+        task_effort = task.get("reasoning_effort", reasoning_effort)
+        if (
+            task_effort is not None
+            and str(task_effort).strip()
+            and parse_reasoning_effort(task_effort) is None
+        ):
+            return tool_error(
+                f"Task {i} has unknown reasoning_effort '{task_effort}'. "
+                f"Valid levels: {', '.join(VALID_REASONING_EFFORTS)}, "
+                "or 'none' to disable thinking. Omit to inherit."
+            )
 
     overall_start = time.monotonic()
     results = []
@@ -2524,6 +2580,8 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task effort beats top-level; both validated above.
+            task_effort = t.get("reasoning_effort", reasoning_effort)
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
@@ -2544,6 +2602,7 @@ def delegate_task(
                 override_acp_command=creds.get("command"),
                 override_acp_args=creds.get("args"),
                 role=effective_role,
+                reasoning_effort=task_effort,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -3448,6 +3507,14 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "reasoning_effort": {
+                            "type": "string",
+                            "enum": _REASONING_EFFORT_ENUM,
+                            "description": (
+                                "Per-task reasoning effort override. See "
+                                "top-level 'reasoning_effort' for semantics."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3460,6 +3527,19 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "reasoning_effort": {
+                "type": "string",
+                "enum": _REASONING_EFFORT_ENUM,
+                "description": (
+                    "Thinking depth for the subagent(s). Match it to the "
+                    "task: 'low' for mechanical work (rename, reformat, "
+                    "summarize), 'medium' for routine coding from a clear "
+                    "spec, 'high' for research/review/analysis, 'max' only "
+                    "for subtle debugging, security review, or high-stakes "
+                    "logic. Omit to inherit the parent's level. Per-task "
+                    "values in 'tasks' override this."
+                ),
             },
             "background": {
                 "type": "boolean",
@@ -3532,6 +3612,7 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
+        reasoning_effort=args.get("reasoning_effort"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## What does this PR do?

Adds an optional `reasoning_effort` field to `delegate_task` — both top-level and per-task inside `tasks[]` — so an orchestrating agent can match each subagent's thinking budget to its assignment (mechanical summary → `none`, routine coding → `medium`, high-stakes review → `max`) instead of every child inheriting one global setting.

Previously the only control was the global `delegation.reasoning_effort` config value, which forces a single effort level onto every delegated task in a batch regardless of how demanding each task actually is. With mixed batches (e.g. one cheap summarization + one security review) this wastes tokens on the easy task or starves the hard one.

Resolution priority: **per-task > top-level arg > `delegation.reasoning_effort` config > inherit from parent**. Unknown levels are rejected with a corrective `tool_error` before any child is spawned, so a typo can't silently fall back. Both dispatch paths forward the field (`run_agent._dispatch_delegate_task` and the registry fallback handler).

## Related Issue

No existing issue found (searched: #34006 covers per-platform request overrides, #7282 a runtime effort tool — both different scopes).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/delegate_tool.py` — schema: optional `reasoning_effort` enum at top level and inside `tasks[]` items; new `_resolve_child_reasoning()` helper implementing the priority chain; validation with corrective `tool_error` for unknown levels; registry handler forwards the field.
- `run_agent.py` — `_dispatch_delegate_task` forwards `reasoning_effort` (one line).
- `tests/tools/test_delegate.py` — 8 new tests in `TestPerTaskReasoningEffort` (priority chain, per-task override, config fallback, parent inherit, invalid-level rejection). Full delegate suite: 164 pass.

## Notes

Live-verified on a deepseek-v4-flash install: dispatched a parallel batch with `reasoning_effort: none` (mechanical task) and `reasoning_effort: max` (security review) and confirmed the actual per-child values from the recorded tool-call arguments.
