### PR TITLE
fix(runtime): ignore child mounts during container detection

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1085,6 +1085,40 @@ def translate_cwd_for_wsl_backend(cwd: str) -> str:
 _container_detected: bool | None = None
 
 
+def _root_mount_has_container_runtime(mountinfo: str) -> bool:
+    """Return whether the process root mount names a container runtime."""
+    runtime_markers = (
+        "docker",
+        "kubepods",
+        "containerd",
+        "crio",
+        "/lxc/",
+        "containers/storage",
+    )
+    mountinfo_escapes = {
+        r"\040": " ",
+        r"\011": "\t",
+        r"\012": "\n",
+        r"\134": "\\",
+    }
+    for line in mountinfo.splitlines():
+        fields = line.split()
+        try:
+            separator = fields.index("-", 6)
+        except (ValueError, IndexError):
+            continue
+        if separator + 3 >= len(fields):
+            continue
+        mount_point = fields[4]
+        for escaped, unescaped in mountinfo_escapes.items():
+            mount_point = mount_point.replace(escaped, unescaped)
+        if mount_point == "/" and any(
+            marker in line.lower() for marker in runtime_markers
+        ):
+            return True
+    return False
+
+
 def is_container() -> bool:
     """Return True when running inside a container.
 
@@ -1096,7 +1130,8 @@ def is_container() -> bool:
     Kubernetes/k3s) were previously missed. To cover those, also check:
       * ``KUBERNETES_SERVICE_HOST`` env var — set in every Kubernetes pod.
       * ``kubepods`` / ``containerd`` / ``crio`` markers in ``/proc/1/cgroup``.
-      * the same markers in ``/proc/self/mountinfo`` (cgroup-v2 fallback).
+      * runtime markers on the root mount in ``/proc/self/mountinfo``
+        (cgroup-v2 fallback). Child container mounts on a host are ignored.
 
     Result is cached for the process lifetime.  Import-safe — no heavy deps.
 
@@ -1125,12 +1160,12 @@ def is_container() -> bool:
     except OSError:
         pass
     # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
-    # runtime still shows up in the mount table (overlay rootfs, runtime mount
-    # paths), so scan mountinfo as a last resort.
+    # runtime can still show up in this process's root mount. Do not scan child
+    # mounts: a normal container host exposes runtime paths for its guests.
     try:
         with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
             mountinfo = f.read()
-            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
+            if _root_mount_has_container_runtime(mountinfo):
                 _container_detected = True
                 return True
     except OSError:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1018,6 +1018,57 @@ def translate_cwd_for_wsl_backend(cwd: str) -> str:
 _container_detected: bool | None = None
 
 
+def _root_mount_has_container_runtime(mountinfo: str) -> bool:
+    """Return whether the process root mount names a container runtime."""
+    runtime_markers = (
+        "docker",
+        "kubepods",
+        "containerd",
+        "crio",
+        "/lxc/",
+        "containers/storage",
+    )
+    mountinfo_escapes = {
+        r"\040": " ",
+        r"\011": "\t",
+        r"\012": "\n",
+        r"\134": "\\",
+    }
+    for line in mountinfo.splitlines():
+        fields = line.split()
+        try:
+            separator = fields.index("-", 6)
+        except (ValueError, IndexError):
+            continue
+        if separator + 3 >= len(fields):
+            continue
+        mount_point = fields[4]
+        for escaped, unescaped in mountinfo_escapes.items():
+            mount_point = mount_point.replace(escaped, unescaped)
+        if mount_point != "/":
+            continue
+        # After the "-" separator the fields are [fstype, mount source,
+        # super options...]. A host root mount's source can name a backing
+        # device such as /dev/mapper/docker--vg-root whose text merely happens
+        # to contain a runtime marker, so match the mount point, the root
+        # path (field 3, e.g. /containerd/.../rootfs inside the container),
+        # the fstype, and the super options — never the mount source, and
+        # never the pre-separator device fields.
+        match_fields = [
+            mount_point,
+            fields[3],
+            fields[separator + 1],
+            *fields[separator + 3 :],
+        ]
+        if any(
+            marker in field.lower()
+            for field in match_fields
+            for marker in runtime_markers
+        ):
+            return True
+    return False
+
+
 def is_container() -> bool:
     """True inside a container (Docker/Podman/LXC/Kubernetes markers); cached per process.
 
@@ -1047,6 +1098,15 @@ def _detect_container() -> bool:
     ):
         return True
     # cgroup v2: /proc/1/cgroup is just "0::/"; the runtime still shows in mountinfo.
+    # Scan only the root mount's structural fields (never the mount source — a
+    # host root device like /dev/mapper/docker--vg-root would false-positive).
+    try:
+        with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
+            mountinfo = f.read()
+        if _root_mount_has_container_runtime(mountinfo):
+            return True
+    except OSError:
+        pass
     return _proc_file_has_marker("/proc/self/mountinfo", ("kubepods", "containerd", "crio"))
 
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -116,6 +116,45 @@ class TestGetHermesHome:
         assert get_hermes_home() == local_appdata / "hermes"
 
 
+class TestContainerDetectionMountinfo:
+    def test_host_child_container_mount_does_not_mark_host_root(self):
+        mountinfo = "\n".join(
+            (
+                "35 2 8:2 / / rw,relatime - ext4 /dev/sda2 rw",
+                "104 35 0:52 / /var/lib/docker/containers/abc/mounts/shm "
+                "rw - tmpfs shm rw",
+                "105 35 0:53 / /run/containerd/io.containerd.runtime.v2.task/"
+                r"k8s.io/pod\040name rw - tmpfs tmpfs rw",
+            )
+        )
+
+        assert hermes_constants._root_mount_has_container_runtime(mountinfo) is False
+
+    @pytest.mark.parametrize(
+        "root_mount",
+        [
+            "35 2 0:52 / / rw - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/fs",
+            "35 2 0:52 / / rw - overlay overlay rw,lowerdir=/var/lib/containerd/snapshots/1/fs",
+            "35 2 0:52 / / rw - overlay overlay rw,lowerdir=/var/lib/kubelet/pods/x/kubepods/fs",
+            "35 2 0:52 / / rw - overlay overlay rw,lowerdir=/var/lib/containers/storage/overlay/l/fs",
+        ],
+    )
+    def test_container_runtime_backed_root_is_detected(self, root_mount):
+        assert hermes_constants._root_mount_has_container_runtime(root_mount) is True
+
+    @pytest.mark.parametrize(
+        "mountinfo",
+        [
+            "",
+            "malformed",
+            "35 2 0:52 / / rw containerd",
+            "35 2 8:2 / / rw,relatime - ext4 /dev/sda2 rw",
+        ],
+    )
+    def test_non_container_or_malformed_root_is_not_detected(self, mountinfo):
+        assert hermes_constants._root_mount_has_container_runtime(mountinfo) is False
+
+
 class TestHermesManagedNode:
     def test_windows_node_dir_prefers_portable_root(self, tmp_path, monkeypatch):
         home = tmp_path / "hermes"

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -153,6 +153,31 @@ class TestGetProcessHermesHome:
         assert get_process_hermes_home() == home
 
 
+    @pytest.mark.parametrize(
+        "mountinfo",
+        [
+            "",
+            "malformed",
+            "35 2 0:52 / / rw containerd",
+            "35 2 8:2 / / rw,relatime - ext4 /dev/sda2 rw",
+            # Host root on a volume group that merely contains "docker" in the
+            # backing device name — the marker is in the mount source field,
+            # not in the fstype/super-options, so it must not be detected.
+            "35 2 253:0 / / rw,relatime - ext4 /dev/mapper/docker--vg-root rw",
+            "35 2 253:0 / / rw,relatime - xfs /dev/mapper/containers--vg-docker--pool rw",
+        ],
+    )
+    def test_non_container_or_malformed_root_is_not_detected(self, mountinfo):
+        assert hermes_constants._root_mount_has_container_runtime(mountinfo) is False
+
+    def test_runtime_marker_in_super_options_is_detected_despite_device_source(self):
+        # Marker lives in the super options (docker overlay upperdir) while the
+        # mount source itself is a docker-named host device — still a container.
+        mountinfo = (
+            "35 2 253:0 / / rw - overlay /dev/mapper/docker--vg-root/lowerdir "
+            "rw,upperdir=/var/lib/docker/overlay2/x/upper"
+        )
+        assert hermes_constants._root_mount_has_container_runtime(mountinfo) is True
 
 
 class TestHermesManagedNode:


### PR DESCRIPTION
## Summary

Container detection's cgroup-v2 fallback scanned every line of `/proc/self/mountinfo`. A normal host running Docker/containerd therefore looked like a container whenever a child guest mount contained `kubepods`, `containerd`, `crio`, or another runtime path.

This change parses mountinfo structurally and inspects only the process root mount:

- child container mounts are ignored;
- the root mount's root path, filesystem type, and super options may prove a container runtime;
- the mount source and pre-separator device fields are excluded, so a host volume such as `/dev/mapper/docker--vg-root` is not a false positive;
- Docker, Kubernetes/containerd, CRI-O, LXC, and containers/storage root markers remain recognized;
- malformed mountinfo fails closed to the existing non-container result.

This is narrower than #58141/#65060: it fixes the mountinfo input boundary without changing the other `is_container()` cgroup/environment heuristics.

## Verification

- `tests/test_hermes_constants.py`: **76 passed, 5 Windows-only skipped on macOS**;
- public `is_container()` regression proves a child containerd mount on a host returns `False`;
- positive root-mount cases cover Docker, containerd, kubepods, containers/storage, and super-option markers;
- negative cases cover malformed input and docker-named ext4/xfs mount sources;
- `py_compile`, `ruff check`, and `git diff --check`: passed;
- current base: v0.20.6 / `5fc308a70`.