### PR TITLE
test(tui): de-flake notification-requeue ordering assertion

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2765,13 +2765,26 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
         assert nested_started.wait(timeout=5)
         threads[0].join(timeout=5)
         assert not threads[0].is_alive()
-        queued = []
-        while not isolated_queue.empty():
-            queued.append(isolated_queue.get_nowait())
-        assert [event["session_id"] for event in queued] == [
+        # Membership, not order: the completion_queue is process-global, and
+        # notification pollers leaked by earlier session.init tests in this
+        # file legitimately steal-and-requeue foreign-session events (see
+        # _notification_poller_loop's belongs-elsewhere branch), rotating the
+        # queue. The requeue contract is that batch_2 and batch_3 both remain
+        # queued (never consumed) while batch_1's turn is in flight — so drain
+        # with a deadline (an event may be transiently held by a poller
+        # mid-cycle) and assert exactly {batch_2, batch_3} come back.
+        queued: dict = {}
+        deadline = time.time() + 5.0
+        while time.time() < deadline and set(queued) != {
             "proc_batch_2",
             "proc_batch_3",
-        ]
+        }:
+            try:
+                evt = isolated_queue.get(timeout=0.1)
+            except _queue_mod.Empty:
+                continue
+            queued[evt["session_id"]] = evt
+        assert set(queued) == {"proc_batch_2", "proc_batch_3"}
     finally:
         release_nested.set()
         for thread in threads:


### PR DESCRIPTION
## Summary
De-flakes `test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_threading` (tests/test_tui_gateway_server.py) — the test asserted strict FIFO order of requeued events, but queue rotation is designed behavior, so it failed intermittently in CI (slice 6/8 on #65476: got `[batch_3, batch_2]`).

Root cause: the `completion_queue` is process-global, and notification pollers leaked by earlier `session.init` tests in the same file legitimately steal-and-requeue foreign-session events (`_notification_poller_loop`'s belongs-elsewhere branch), rotating the queue under the test's feet. Both events were always present — only the order moved.

## Changes
- `tests/test_tui_gateway_server.py`: assert the actual requeue contract — batch_1 consumed by the running turn, batch_2 and batch_3 both still queued — as set membership with a deadline drain (`get(timeout=0.1)` loop, 5s cap) that tolerates an event transiently held by a poller mid-cycle. Fix, not a rerun-band-aid; no production code touched.

## Validation
| | Result |
|---|---|
| Single test, CI-parity runner | 10/10 runs green |
| Full file (337 tests) | 337/337 × 3 consecutive runs |

## Infographic

![deflake-notification-requeue](https://v3b.fal.media/files/b/0aa275bb/HWQ9eNB9IyN-YpT8Zdzgf_uININHiC.png)
