### PR TITLE
fix(agent): sanitize file mutation warning paths

### DIFF
--- a/agent/turn_explainers.py
+++ b/agent/turn_explainers.py
@@ -232,6 +232,29 @@ class TurnExplainersMixin:
         r"(?<![/:\w.`])(?:~/|/|[A-Za-z]:[/\\])(?:[\w.\-]+[/\\])*[\w.\-]+\.[\w]+",
     )
 
+    # ``MEDIA:<path>`` tags are re-parsed from response text by the gateway
+    # media extractor (``MEDIA_TAG_CLEANUP_RE`` / ``MEDIA_EXTENSIONLESS_TAG_RE``
+    # in gateway/platforms/base.py, both case-insensitive).  In this footer a
+    # tag can only ever be untrusted error text, so the colon is rewritten
+    # into a visible escape no downstream parser recognises — the tag stays
+    # legible as data but can never execute as an attachment directive.
+    _FOOTER_MEDIA_TAG_RE = re.compile(r"MEDIA:", re.IGNORECASE)
+
+    # Delivery-behaviour toggles matched verbatim at the dispatch sites
+    # (gateway dispatch) and stripped by ``extract_media``.  Escaped underscores
+    # break the exact match while Markdown still renders the original text.
+    _FOOTER_MEDIA_DIRECTIVES = ("[[audio_as_voice]]", "[[as_document]]")
+
+    @classmethod
+    def _neutralize_footer_media_directives(cls, text: str) -> str:
+        """Rewrite delivery directives in untrusted footer text into visible, non-executable forms."""
+        if not text:
+            return text
+        text = cls._FOOTER_MEDIA_TAG_RE.sub(lambda m: m.group(0)[:-1] + r"\x3a", text)
+        for directive in cls._FOOTER_MEDIA_DIRECTIVES:
+            text = text.replace(directive, directive.replace("_", r"\_"))
+        return text
+
     @classmethod
     def _neutralize_footer_paths(cls, text: str) -> str:
         """Backtick bare file paths so the gateway's ``extract_local_files`` never auto-attaches them.
@@ -266,8 +289,11 @@ class TurnExplainersMixin:
         remaining = len(failed) - len(shown)
         if remaining > 0:
             lines.append(f"  • … and {remaining} more")
-        # Neutralize paths the preview echoed; the lookbehind prevents double-wrapping the bullet path.
-        return cls._neutralize_footer_paths("\n".join(lines))
+        # Neutralize delivery directives the preview carried, then paths it
+        # echoed; the lookbehind prevents double-wrapping the bullet path.
+        return cls._neutralize_footer_paths(
+            cls._neutralize_footer_media_directives("\n".join(lines))
+        )
 
     @staticmethod
     def _format_turn_completion_explanation(

--- a/run_agent.py
+++ b/run_agent.py
@@ -44,6 +44,7 @@ import sys
 import tempfile
 import time
 import threading
+import unicodedata
 import uuid
 from typing import List, Dict, Any, Optional, Callable
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
@@ -2983,6 +2984,60 @@ class AIAgent:
             return text
         return cls._FOOTER_PATH_RE.sub(lambda m: f"`{m.group(0)}`", text)
 
+    @staticmethod
+    def _sanitize_file_mutation_warning_fragment(value: Any, max_len: int) -> str:
+        """Render untrusted footer text as bounded, single-line Markdown."""
+
+        text = str(value)
+
+        def _escape(char: str) -> str:
+            if char == "`":
+                return "ˋ"
+            if char == "\n":
+                return r"\n"
+            if char == "\r":
+                return r"\r"
+            if char == "\t":
+                return r"\t"
+            if unicodedata.category(char) in {"Cc", "Cf", "Cs", "Zl", "Zp"}:
+                codepoint = ord(char)
+                if codepoint <= 0xFF:
+                    return f"\\x{codepoint:02x}"
+                if codepoint <= 0xFFFF:
+                    return f"\\u{codepoint:04x}"
+                return f"\\U{codepoint:08x}"
+            return char
+
+        escaped = [_escape(char) for char in text] if len(text) <= max_len else None
+        if escaped is not None and sum(map(len, escaped)) <= max_len:
+            return "".join(escaped)
+
+        separator = "…"
+        head_budget = (max_len - len(separator)) // 2
+        tail_budget = max_len - len(separator) - head_budget
+
+        head_tokens = escaped or [_escape(char) for char in text[:head_budget]]
+        tail_tokens = escaped or [_escape(char) for char in text[-tail_budget:]]
+
+        head: List[str] = []
+        used = 0
+        for token in head_tokens:
+            if used + len(token) > head_budget:
+                break
+            head.append(token)
+            used += len(token)
+
+        tail: List[str] = []
+        used = 0
+        for token in reversed(tail_tokens):
+            if used + len(token) > tail_budget:
+                break
+            tail.append(token)
+            used += len(token)
+        tail.reverse()
+
+        return "".join(head) + separator + "".join(tail)
+
     @classmethod
     def _format_file_mutation_failure_footer(cls, failed: Dict[str, Dict[str, Any]]) -> str:
         """Render the per-turn failed-mutation dict as a user-facing footer.
@@ -3009,12 +3064,19 @@ class AIAgent:
         for path, info in failed.items():
             if shown >= 10:
                 break
-            preview = (info.get("error_preview") or "").strip()
-            tool = info.get("tool") or "patch"
+            display_path = cls._sanitize_file_mutation_warning_fragment(path, 240)
+            preview = cls._sanitize_file_mutation_warning_fragment(
+                (info.get("error_preview") or "").strip(),
+                180,
+            )
+            tool = cls._sanitize_file_mutation_warning_fragment(
+                info.get("tool") or "patch",
+                32,
+            )
             if preview:
-                lines.append(f"  • `{path}` — [{tool}] {preview}")
+                lines.append(f"  • `{display_path}` — [{tool}] {preview}")
             else:
-                lines.append(f"  • `{path}` — [{tool}] failed")
+                lines.append(f"  • `{display_path}` — [{tool}] failed")
             shown += 1
         remaining = len(failed) - shown
         if remaining > 0:

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -314,6 +314,74 @@ class TestFormatFooter:
         assert "Could not find old_string" in out
         assert "git status" in out  # user-actionable hint
 
+    def test_ordinary_path_is_unchanged(self):
+        path = "/workspace/src/agent.py"
+
+        out = AIAgent._format_file_mutation_failure_footer(
+            {path: {"tool": "patch", "error_preview": "not found"}},
+        )
+
+        assert f"`{path}`" in out
+
+    def test_path_newline_cannot_inject_another_footer_line(self):
+        path = "/tmp/report.md\n  • forged-path"
+
+        out = AIAgent._format_file_mutation_failure_footer(
+            {path: {"tool": "patch", "error_preview": "not found"}},
+        )
+
+        assert "/tmp/report.md\\n  • forged-path" in out
+        assert path not in out
+        bullet_lines = [line for line in out.splitlines() if line.lstrip().startswith("•")]
+        assert len(bullet_lines) == 1
+
+    def test_path_ansi_and_control_characters_are_visible_escapes(self):
+        path = "/tmp/\x1b[31mred\x00\x85.md"
+
+        out = AIAgent._format_file_mutation_failure_footer(
+            {path: {"tool": "patch", "error_preview": "not found"}},
+        )
+
+        assert r"/tmp/\x1b[31mred\x00\x85.md" in out
+        assert "\x1b" not in out
+        assert "\x00" not in out
+        assert "\x85" not in out
+
+    def test_path_bidi_controls_are_visible_escapes(self):
+        path = "/tmp/safe\u202etxt.exe\u2066"
+
+        out = AIAgent._format_file_mutation_failure_footer(
+            {path: {"tool": "patch", "error_preview": "not found"}},
+        )
+
+        assert r"/tmp/safe\u202etxt.exe\u2066" in out
+        assert "\u202e" not in out
+        assert "\u2066" not in out
+
+    def test_error_preview_cannot_inject_terminal_or_prompt_formatting(self):
+        preview = "failed\n\x1b[31mred\u202e"
+
+        out = AIAgent._format_file_mutation_failure_footer(
+            {"/tmp/a.md": {"tool": "patch", "error_preview": preview}},
+        )
+
+        assert r"failed\n\x1b[31mred\u202e" in out
+        assert preview not in out
+
+    def test_very_long_path_keeps_bounded_head_and_tail(self):
+        path = "/very/long/" + ("a" * 500) + "/tail/file.md"
+
+        out = AIAgent._format_file_mutation_failure_footer(
+            {path: {"tool": "patch", "error_preview": "not found"}},
+        )
+
+        bullet = next(line for line in out.splitlines() if line.lstrip().startswith("•"))
+        display_path = bullet.split("`", 2)[1]
+        assert len(display_path) <= 240
+        assert display_path.startswith("/very/long/")
+        assert display_path.endswith("/tail/file.md")
+        assert "…" in display_path
+
     def test_truncation_at_10_entries(self):
         failed = {
             f"/tmp/f{i}.md": {"tool": "patch", "error_preview": "err"}

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -380,3 +380,32 @@ def test_file_mutating_tools_set_shape():
     track it.  This test fails loudly on unilateral additions.
     """
     assert _FILE_MUTATING_TOOLS == frozenset({"write_file", "patch"})
+
+
+class TestFooterMediaDirectiveNeutralization:
+    """Untrusted error previews must not carry live delivery directives (#65514)."""
+
+    def _footer(self, preview):
+        from agent.turn_explainers import TurnExplainersMixin
+        return TurnExplainersMixin._format_file_mutation_failure_footer(
+            {"/tmp/a.md": {"tool": "patch", "error_preview": preview}},
+        )
+
+    def test_error_preview_media_directive_is_neutralized(self):
+        out = self._footer("diff mismatch near MEDIA:/home/user/notes.png")
+        assert "MEDIA:" not in out
+        assert "MEDIA\\x3a/home/user/notes.png" in out
+
+    def test_error_preview_media_directive_neutralized_case_insensitive(self):
+        for preview in ("see media:/home/user/notes.png", "see Media:/home/user/notes.png"):
+            out = self._footer(preview)
+            assert "media:" not in out
+            assert "Media:" not in out
+            assert "MEDIA:" not in out
+
+    def test_delivery_toggle_directives_are_neutralized(self):
+        out = self._footer("[[audio_as_voice]] [[as_document]]")
+        assert "[[audio_as_voice]]" not in out
+        assert "[[as_document]]" not in out
+        assert "[[audio\\_as\\_voice]]" in out
+        assert "[[as\\_document]]" in out


### PR DESCRIPTION
## What does this PR do?

File-mutation failures are rendered into the agent's turn footer. The target path and error preview can contain control characters, line breaks, bidi controls, ANSI escapes, Markdown delimiters, or extremely long text, allowing a malformed path to distort the warning or inject misleading lines.

This change sanitizes only the display form used by the footer:

- renders C0/C1 controls, CR/LF/tab, ANSI escapes, bidi and Unicode formatting controls as visible escapes;
- prevents backticks in a path from breaking its Markdown code span;
- bounds displayed paths to 240 characters while retaining recognizable head and tail context;
- bounds tool names and error previews;
- neutralizes `MEDIA:` tags (case-insensitive, matching the gateway's `re.IGNORECASE` tag regexes) and the verbatim `[[audio_as_voice]]` / `[[as_document]]` delivery toggles, so untrusted error previews can never execute as media directives — covered by an end-to-end regression against the real `BasePlatformAdapter.extract_media`;
- clamps truncation head/tail budgets at 0 for degenerate `max_len` values;
- leaves the original mutation path and all policy, resolution, verification, and file-operation logic unchanged.

## Verification

- [x] Tested on Ubuntu 26.04 / Linux x86_64 (original commit)
- [x] Tested on macOS arm64 (follow-up 2a9e02610): `pytest tests/run_agent/test_file_mutation_verifier.py -q` — 48 passed, including the extract_media end-to-end regression (verified to fail on the pre-fix commit)
- [x] `pytest tests/run_agent/test_file_mutation_verifier.py tests/tools/test_file_tools.py -q` on Ubuntu — 94 passed (original commit); on macOS the tool-tests file shows 7 failures identical with and without this change (environment-dependent, file untouched by this PR)
- [x] `ruff check run_agent.py tests/run_agent/test_file_mutation_verifier.py`
- [x] `python -m py_compile run_agent.py tests/run_agent/test_file_mutation_verifier.py`
- [x] `git diff --check`

Tests cover ordinary paths, newline injection, ANSI/C0/C1 characters, bidi controls, long paths, malicious error summaries, media-directive injection (all case variants), delivery toggles, and the preview→media boundary end-to-end.