### PR TITLE
fix(agent): default context lookup for empty model IDs

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2125,6 +2125,13 @@ def get_model_context_length(
         except Exception:
             pass  # fall through to probing
 
+    if not str(model or "").strip():
+        logger.info(
+            "No model id provided for context length resolution — defaulting to %s tokens.",
+            f"{DEFAULT_FALLBACK_CONTEXT:,}",
+        )
+        return DEFAULT_FALLBACK_CONTEXT
+
     # Normalise provider-prefixed model names (e.g. "local:model-name" →
     # "model-name") so cache lookups and server queries use the bare ID that
     # local servers actually know about.  Ollama "model:tag" colons are preserved.

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -174,6 +174,10 @@ class TestEstimateRequestTokensRough:
 # =========================================================================
 
 class TestDefaultContextLengths:
+    def test_empty_model_uses_fallback_context(self):
+        assert get_model_context_length("") == DEFAULT_FALLBACK_CONTEXT
+        assert get_model_context_length(None) == DEFAULT_FALLBACK_CONTEXT  # type: ignore[arg-type]
+
     def test_grok_substring_matching(self):
         # Longest-first substring matching must resolve the real xAI model
         # IDs to the correct fallback entries without 128k probe-down.


### PR DESCRIPTION
## Summary

This is the focused current-main replacement for the unique safety fix in #26873.

`get_model_context_length()` can be called while a runtime/model selection is still empty. Before this guard, an empty or `None` model flowed into provider-prefix normalization and then into cache/probe logic. Return the documented 256K fallback immediately instead.

The replacement intentionally excludes the unrelated runtime-switch, Feishu, cron, auxiliary-client, metadata, and compressor changes from #26873. Those concerns overlap with later upstream work and should not be resurrected as one conflicted patch.

## Verification

- `scripts/run_tests.sh tests/agent/test_model_metadata.py -q` — 122 passed
- `ruff check agent/model_metadata.py tests/agent/test_model_metadata.py`
- `python -m py_compile agent/model_metadata.py tests/agent/test_model_metadata.py`
- `git diff --check`

Closes the unique empty-model failure mode extracted from #26873; the historical PR remains separate until maintainers decide how to handle its now-overlapping runtime-switch changes.