### PR TITLE
Add devin-acp as a first-class ACP provider

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -48,7 +48,17 @@ from agent.tool_guardrails import (
     ToolGuardrailDecision,
 )
 from hermes_cli.config import cfg_get
+from hermes_cli.providers import ACP_PROVIDERS as _ACP_PROVIDERS
 from hermes_cli.timeouts import get_provider_request_timeout
+
+
+def _ACP_PROVIDERS_LOCAL() -> frozenset[str]:
+    """Return the set of ACP-subprocess-backed provider slugs.
+
+    Small indirection so future ACP additions only touch
+    ``hermes_cli.providers.ACP_PROVIDERS``.
+    """
+    return _ACP_PROVIDERS
 from hermes_constants import get_hermes_home
 from utils import base_url_host_matches, is_truthy_value
 
@@ -521,8 +531,8 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
-        and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and agent.provider not in _ACP_PROVIDERS_LOCAL()
+        and not str(agent.base_url or "").lower().startswith("acp://")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (
@@ -946,7 +956,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in _ACP_PROVIDERS_LOCAL():
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1698,7 +1698,8 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+    from hermes_cli.providers import ACP_PROVIDERS as _ACP_PROVIDERS
+    if agent.provider in _ACP_PROVIDERS or str(client_kwargs.get("base_url", "")).lower().startswith("acp://"):
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5147,21 +5147,22 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
-        if provider == "copilot-acp":
+        from hermes_cli.providers import ACP_PROVIDERS as _ACP_PROVIDERS
+        if provider in _ACP_PROVIDERS:
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None
             args = list(creds.get("args") or [])
             if not final_model:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
+                    "resolve_provider_client: %s requested but no model "
+                    "was provided or configured", provider
                 )
                 return None, None
             if not api_key or not base_url:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
+                    "resolve_provider_client: %s requested but external "
+                    "process credentials are incomplete", provider
                 )
                 return None, None
             from agent.copilot_acp_client import CopilotACPClient
@@ -6131,6 +6132,7 @@ def _resolve_task_provider_model(
                 "anthropic",
                 "copilot",
                 "copilot-acp",
+                "devin-acp",
                 "minimax-oauth",
                 "nous",
                 "openai-codex",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -66,7 +66,16 @@ from agent.retry_utils import (
 )
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from hermes_cli.providers import ACP_PROVIDERS as _ACP_PROVIDERS, is_acp_base_url
 from hermes_constants import PARTIAL_STREAM_STUB_ID
+
+
+def _is_acp_agent(agent) -> bool:
+    """True when *agent* is bound to an ACP-subprocess-backed provider."""
+    return (
+        (getattr(agent, "provider", "") or "") in _ACP_PROVIDERS
+        or is_acp_base_url(getattr(agent, "base_url", "") or "")
+    )
 from hermes_logging import set_session_context
 from tools.skill_provenance import set_current_write_origin
 from utils import base_url_host_matches, env_var_enabled
@@ -1324,8 +1333,7 @@ def run_conversation(
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider in {"copilot-acp"}
-                    or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    _is_acp_agent(agent)
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -46,7 +46,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "devin-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek", "deepinfra",
     "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
     "qwen-oauth",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -96,6 +96,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_DEVIN_ACP_BASE_URL = "acp://devin"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -231,6 +232,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "devin-acp": ProviderConfig(
+        id="devin-acp",
+        name="Devin ACP",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_DEVIN_ACP_BASE_URL,
+        base_url_env_var="DEVIN_ACP_BASE_URL",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -6287,19 +6295,61 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+_EXTERNAL_PROCESS_DEFAULTS: Dict[str, Dict[str, Any]] = {
+    "copilot-acp": {
+        "command_env_vars": ("HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"),
+        "args_env_var": "HERMES_COPILOT_ACP_ARGS",
+        "default_command": "copilot",
+        "default_args": ["--acp", "--stdio"],
+        "missing_command_hint": (
+            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+        ),
+        "missing_command_code": "missing_copilot_cli",
+    },
+    "devin-acp": {
+        "command_env_vars": ("HERMES_DEVIN_ACP_COMMAND",),
+        "args_env_var": "HERMES_DEVIN_ACP_ARGS",
+        "default_command": "devin",
+        "default_args": ["acp"],
+        "missing_command_hint": (
+            "Install Devin CLI (Devin.app or `devin` on PATH) or set HERMES_DEVIN_ACP_COMMAND."
+        ),
+        "missing_command_code": "missing_devin_cli",
+    },
+}
+
+
+def _resolve_external_process_command(provider_id: str) -> tuple[str, list[str]]:
+    """Return the (command, args) pair for an external-process provider.
+
+    Reads per-provider env-var overrides, then falls back to the built-in
+    defaults registered in ``_EXTERNAL_PROCESS_DEFAULTS``.
+    """
+    defaults = _EXTERNAL_PROCESS_DEFAULTS.get(provider_id) or {}
+    command = ""
+    for var in defaults.get("command_env_vars", ()):
+        command = os.getenv(var, "").strip()
+        if command:
+            break
+    if not command:
+        command = str(defaults.get("default_command", "") or "")
+
+    args_env = defaults.get("args_env_var", "") or ""
+    raw_args = os.getenv(args_env, "").strip() if args_env else ""
+    if raw_args:
+        args = shlex.split(raw_args)
+    else:
+        args = list(defaults.get("default_args") or [])
+    return command, args
+
+
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    command, args = _resolve_external_process_command(provider_id)
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
@@ -6334,7 +6384,10 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    if target in _EXTERNAL_PROCESS_DEFAULTS or (
+        PROVIDER_REGISTRY.get(target) is not None
+        and PROVIDER_REGISTRY[target].auth_type == "external_process"
+    ):
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -6517,25 +6570,23 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    command, args = _resolve_external_process_command(provider_id)
     resolved_command = shutil.which(command) if command else None
+    defaults = _EXTERNAL_PROCESS_DEFAULTS.get(provider_id) or {}
     if not resolved_command and not base_url.startswith("acp+tcp://"):
+        hint = str(
+            defaults.get("missing_command_hint")
+            or f"Install the {pconfig.name} CLI or set the appropriate HERMES_*_ACP_COMMAND env var."
+        )
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the {pconfig.name} CLI command '{command}'. {hint}",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code=str(defaults.get("missing_command_code") or "missing_external_process_cli"),
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -629,6 +629,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_devin_acp,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock_api_key,
@@ -3134,6 +3135,8 @@ def select_provider_and_model(args=None):
         _model_flow_minimax_oauth(config, current_model, args=args)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "devin-acp":
+        _model_flow_devin_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -12379,7 +12382,7 @@ def _build_provider_choices() -> list[str]:
     except Exception:
         # Fallback: static list guarantees the CLI always works
         return [
-            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "copilot",
+            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "devin-acp", "copilot",
             "anthropic", "gemini", "vertex", "xai", "bedrock", "azure-foundry",
             "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn",
             "stepfun", "minimax", "minimax-cn", "kilocode", "novita", "xiaomi", "arcee",

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -79,6 +79,7 @@ _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
 _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
     "copilot",
     "copilot-acp",
+    "devin-acp",
     "openai-codex",
 })
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1925,6 +1925,86 @@ def _model_flow_copilot_acp(config, current_model=""):
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
 
+def _model_flow_devin_acp(config, current_model=""):
+    """Devin ACP flow — spawns Cognition's `devin acp` subprocess.
+
+    Mirrors ``_model_flow_copilot_acp`` but uses the static devin-acp catalog
+    (no GitHub Copilot live-catalog fetch — Devin owns its own model list).
+    """
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "devin-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = (
+        status.get("resolved_command") or status.get("command") or "devin"
+    )
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Devin ACP delegates Hermes turns to `devin acp` (Cognition's SWE agent).")
+    print("  Hermes spawns a fresh ACP subprocess for each request.")
+    print("  Devin owns its own auth — run `devin auth` if you have not already.")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print("  Install the Devin CLI or set HERMES_DEVIN_ACP_COMMAND to the binary path.")
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+
+    model_list = list(_PROVIDER_MODELS.get(provider_id, []))
+    if model_list:
+        selected = _prompt_model_selection(
+            model_list,
+            current_model=current_model,
+            confirm_provider=provider_id,
+            confirm_base_url=effective_base,
+            confirm_api_key="",
+        )
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -273,6 +273,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "devin-acp": [
+        "devin-swe-1.6",
+        "devin-swe-1",
+        "swe-1.6",
+        "swe-1",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -1067,6 +1073,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("devin-acp",      "Devin ACP",                "Devin ACP (Spawns `devin acp` — Cognition's SWE-tuned agent)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("vertex",         "Google Vertex AI",         "Google Vertex AI (Gemini via GCP; OAuth2 service account or ADC, GCP billing/quotas)"),
@@ -1228,6 +1235,10 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "devin": "devin-acp",
+    "devin-acp-agent": "devin-acp",
+    "cognition": "devin-acp",
+    "cognition-devin": "devin-acp",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -28,6 +28,27 @@ from utils import base_url_host_matches, base_url_hostname
 logger = logging.getLogger(__name__)
 
 
+# -- ACP provider set --------------------------------------------------------
+# Providers backed by an external ACP subprocess (Copilot CLI, Devin CLI, ...).
+# Add a slug here when adding a new external_process ACP provider so the
+# ~15 runtime branch guards across agent/ and hermes_cli/ pick it up in one place.
+ACP_PROVIDERS: frozenset[str] = frozenset({"copilot-acp", "devin-acp"})
+
+
+def is_acp_provider(provider: str) -> bool:
+    """True when *provider* is an ACP-subprocess-backed provider."""
+    return (provider or "").strip().lower() in ACP_PROVIDERS
+
+
+def is_acp_base_url(base_url: str) -> bool:
+    """True when *base_url* is an ACP marker URL (``acp://<provider>``).
+
+    Distinct from ``acp+tcp://`` — that scheme is a remote-TCP ACP transport
+    handled separately from the local-subprocess spawn path.
+    """
+    return str(base_url or "").lower().startswith("acp://")
+
+
 # -- Hermes overlay ----------------------------------------------------------
 # Hermes-specific metadata that models.dev doesn't provide.
 
@@ -93,6 +114,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         auth_type="external_process",
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "devin-acp": HermesOverlay(
+        transport="codex_responses",
+        auth_type="external_process",
+        base_url_override="acp://devin",
+        base_url_env_var="DEVIN_ACP_BASE_URL",
     ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
@@ -296,6 +323,12 @@ ALIASES: Dict[str, str] = {
     "github": "github-copilot",
     "github-copilot-acp": "copilot-acp",
 
+    # devin-acp
+    "devin": "devin-acp",
+    "devin-acp-agent": "devin-acp",
+    "cognition": "devin-acp",
+    "cognition-devin": "devin-acp",
+
     # opencode (models.dev ID for OpenCode Zen)
     "opencode-zen": "opencode",
     "zen": "opencode",
@@ -382,6 +415,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "devin-acp": "Devin ACP",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1851,10 +1851,11 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
 
-    if provider == "copilot-acp":
+    from hermes_cli.providers import ACP_PROVIDERS as _ACP_PROVIDERS
+    if provider in _ACP_PROVIDERS:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -74,6 +74,12 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "devin-acp": [
+        "devin-swe-1.6",
+        "devin-swe-1",
+        "swe-1.6",
+        "swe-1",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8336,6 +8336,18 @@ def _copilot_acp_status() -> Dict[str, Any]:
     }
 
 
+def _devin_acp_status() -> Dict[str, Any]:
+    """Status for devin-acp — credentials are owned by the Devin CLI."""
+    return {
+        "logged_in": False,
+        "source": "devin_cli",
+        "source_label": "Managed by the Devin CLI",
+        "token_preview": None,
+        "expires_at": None,
+        "has_refresh_token": False,
+    }
+
+
 # Explicit, hand-tuned OAuth/account provider cards. These carry the bits that
 # can't be derived from the unified provider catalog: the OAuth ``flow`` shape,
 # the per-provider ``status_fn``, the ``cli_command`` fallback, and curated
@@ -8405,6 +8417,14 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "cli_command": "copilot /login",
         "docs_url": "https://docs.github.com/en/copilot",
         "status_fn": _copilot_acp_status,
+    },
+    {
+        "id": "devin-acp",
+        "name": "Devin (ACP)",
+        "flow": "external",
+        "cli_command": "devin auth",
+        "docs_url": "https://docs.devin.ai/",
+        "status_fn": _devin_acp_status,
     },
     # ── Anthropic / Claude entries sit at the bottom: the API-key path
     # first, then the subscription OAuth path (which only works with extra


### PR DESCRIPTION
## Summary

Promotes the recent Devin ACP prototype from "config-only via env-var override under `copilot-acp`" to a proper first-class `devin-acp` provider. `hermes model` now shows "Devin ACP" as its own picker row alongside GitHub Copilot ACP, ships its own curated catalog (`devin-swe-1.6`, `devin-swe-1`, `swe-1.6`, `swe-1`), and does not require env-var hacks to route through.

## What changes

- **New `ACP_PROVIDERS` set in `hermes_cli/providers.py`** (`{"copilot-acp", "devin-acp"}`). Every runtime guard in `agent/agent_init.py`, `agent/agent_runtime_helpers.py`, `agent/auxiliary_client.py`, and `agent/conversation_loop.py` now checks membership in this set and matches `base_url.startswith("acp://")` instead of `"acp://copilot"`. The next ACP-backed provider is a one-line add.
- **Per-provider external-process defaults in `hermes_cli/auth.py`**. `resolve_external_process_provider_credentials` and `get_external_process_provider_status` now read a small `_EXTERNAL_PROCESS_DEFAULTS` table:
  - copilot-acp → `HERMES_COPILOT_ACP_COMMAND` / `HERMES_COPILOT_ACP_ARGS`, defaults `copilot --acp --stdio` (unchanged)
  - devin-acp → `HERMES_DEVIN_ACP_COMMAND` / `HERMES_DEVIN_ACP_ARGS`, defaults `devin acp`
- **Full Devin ACP registration**: `HermesOverlay`, `ProviderConfig`, `ProviderEntry`, aliases (`devin`, `devin-acp-agent`, `cognition`, `cognition-devin`), model list in `_PROVIDER_MODELS`, dedicated `_model_flow_devin_acp` setup flow, Accounts-tab status card in `web_server.py`, inclusion in `_STRIP_VENDOR_ONLY_PROVIDERS`.
- **`CopilotACPClient` is reused verbatim** — it already accepts `command` / `args` kwargs, so the resolved Devin binary and args flow through `hermes_cli/runtime_provider.py`'s ACP branch (now keyed on `ACP_PROVIDERS`, and `provider=devin-acp` is preserved end-to-end instead of being hard-coded back to `\"copilot-acp\"`).

## Regression check

`copilot-acp` still uses the GitHub Copilot CLI with the same env-var contract, the same curated catalog fallback, and the same live catalog lookup. Verified by re-running `hermes_cli.auth._resolve_external_process_command('copilot-acp')` (returns `('copilot', ['--acp', '--stdio'])`) and `provider_model_ids('copilot-acp')` (returns the GitHub-derived list).

## Verified from a headless shell

- `provider_model_ids('devin-acp')` → `['devin-swe-1.6', 'devin-swe-1', 'swe-1.6', 'swe-1']`
- `provider_model_ids('devin')` (alias) → same
- `get_label('devin-acp')` → `Devin ACP`
- `_resolve_external_process_command('devin-acp')` respects `HERMES_DEVIN_ACP_COMMAND` and defaults to `('devin', ['acp'])`
- `resolve_external_process_provider_credentials('devin-acp')` returns full creds shape with base_url `acp://devin`
- All 14 modified files parse (`ast.parse`) and re-import cleanly

## Test plan (needs a Hermes install with Devin CLI)

- [ ] `hermes model` shows "Devin ACP" as a picker row alongside "GitHub Copilot ACP"
- [ ] `hermes -z "hi" -m devin-swe-1.6 --provider devin-acp` spawns `devin acp` (verify with `ps -ef | grep 'devin acp'`) and streams a reply back — with **no `HERMES_COPILOT_ACP_*` env-var hacks**
- [ ] Hermes Desktop model picker labels the active session "Devin ACP / devin-swe-1.6" and no longer emits the "not in curated catalog" warning
- [ ] Stop button in the Hermes UI cancels the Devin task (the WIN-195 loose end)
- [ ] `copilot-acp` regression check: `hermes -z "hi" -m copilot-acp --provider copilot-acp` still works unchanged