### PR TITLE
fix(feishu): prevent [99992402] in thread and job delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1103,11 +1103,14 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
     if deliver_value == "origin":
         if origin:
-            return {
+            target = {
                 "platform": origin["platform"],
                 "chat_id": str(origin["chat_id"]),
                 "thread_id": origin.get("thread_id"),
             }
+            if str(origin["platform"]).lower() == "feishu" and origin.get("message_id"):
+                target["reply_to_message_id"] = str(origin["message_id"])
+            return target
         # Origin missing (e.g. job created via API/script) — try each
         # platform's home channel as a fallback instead of silently dropping.
         for platform_name in _iter_home_target_platforms():
@@ -1160,11 +1163,14 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
     platform_name = deliver_value
     if origin and origin.get("platform") == platform_name:
-        return {
+        target = {
             "platform": platform_name,
             "chat_id": str(origin["chat_id"]),
             "thread_id": origin.get("thread_id"),
         }
+        if str(platform_name).lower() == "feishu" and origin.get("message_id"):
+            target["reply_to_message_id"] = str(origin["message_id"])
+        return target
 
     if not _is_known_delivery_platform(platform_name):
         return None
@@ -1493,6 +1499,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
+        reply_to_message_id = target.get("reply_to_message_id")
 
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = _resolve_origin(job) or {}
@@ -1675,7 +1682,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {"job_id": job["id"]}
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
-                media_metadata = {"thread_id": thread_id} if thread_id else None
+                if reply_to_message_id:
+                    route_metadata["reply_to_message_id"] = str(reply_to_message_id)
+                media_metadata = {"thread_id": thread_id} if thread_id else {}
+                if reply_to_message_id:
+                    media_metadata["reply_to_message_id"] = str(reply_to_message_id)
+                media_metadata = media_metadata or None
 
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.
@@ -1810,7 +1822,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 target_errors.append(msg)
                                 adapter_ok = False  # fall through to standalone path
                             elif (
-                                send_raw_response
+                                isinstance(send_raw_response, dict)
                                 and thread_id
                                 and send_raw_response.get("thread_fallback")
                             ):
@@ -1900,7 +1912,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                thread_id=thread_id,
+                reply_to_message_id=reply_to_message_id,
+                media_files=media_files,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -1929,7 +1949,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        future = pool.submit(
+                            asyncio.run,
+                            _send_to_platform(
+                                platform,
+                                pconfig,
+                                chat_id,
+                                cleaned_delivery_content,
+                                thread_id=thread_id,
+                                reply_to_message_id=reply_to_message_id,
+                                media_files=media_files,
+                            ),
+                        )
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1108,6 +1108,9 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
                 "chat_id": str(origin["chat_id"]),
                 "thread_id": origin.get("thread_id"),
             }
+            # Feishu needs both values: thread_id identifies the conversation
+            # lane, while message_id is the API reply anchor. Keeping this only
+            # on origin delivery avoids inventing anchors for explicit targets.
             if str(origin["platform"]).lower() == "feishu" and origin.get("message_id"):
                 target["reply_to_message_id"] = str(origin["message_id"])
             return target
@@ -1682,6 +1685,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {"job_id": job["id"]}
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
+                # Unlike Telegram/Slack, Feishu cannot send directly to an
+                # omt_* thread. The adapter must receive the original om_* anchor
+                # and call message.reply(reply_in_thread=True). Propagate the same
+                # metadata to media so mixed cron reports stay in one topic.
                 if reply_to_message_id:
                     route_metadata["reply_to_message_id"] = str(reply_to_message_id)
                 media_metadata = {"thread_id": thread_id} if thread_id else {}
@@ -1821,6 +1828,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 )
                                 target_errors.append(msg)
                                 adapter_ok = False  # fall through to standalone path
+                            # Telegram adapters use a dict raw_response to report
+                            # a deliberate thread fallback. Feishu returns an SDK
+                            # Create/ReplyMessageResponse object instead; calling
+                            # .get() on it caused a false live-send failure and a
+                            # duplicate/misrouted standalone retry.
                             elif (
                                 isinstance(send_raw_response, dict)
                                 and thread_id

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4625,34 +4625,26 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
-        _thread_id = (metadata or {}).get("thread_id")
-        if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request("thread_id", body)
-        else:
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
+        # Feishu topics do not support direct creation by thread_id. Entering a
+        # topic requires message.reply with reply_in_thread=True, which in turn
+        # requires a message anchor. Async/resumed sends can retain thread_id
+        # after that anchor is gone; deliver those to the parent chat rather than
+        # issuing the invalid receive_id_type="thread_id" request (error 99992402).
+        receive_id = chat_id
+        receive_id_type = "chat_id"
+        if chat_id.startswith("feishu_user_id:"):
+            receive_id = chat_id.split(":", 1)[1]
+            receive_id_type = "user_id"
+        elif chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
 
-            body = self._build_create_message_body(
-                receive_id=receive_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request(receive_id_type, body)
+        body = self._build_create_message_body(
+            receive_id=receive_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+        )
+        request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -5393,6 +5393,7 @@ async def _standalone_send(
     message,
     *,
     thread_id=None,
+    reply_to_message_id=None,
     media_files=None,
     force_document=False,
 ):
@@ -5412,7 +5413,12 @@ async def _standalone_send(
         domain_name = getattr(adapter, "_domain_name", "feishu")
         domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
         adapter._client = adapter._build_lark_client(domain)
-        metadata = {"thread_id": thread_id} if thread_id else None
+        metadata = {}
+        if thread_id:
+            metadata["thread_id"] = thread_id
+        if reply_to_message_id:
+            metadata["reply_to_message_id"] = reply_to_message_id
+        metadata = metadata or None
 
         last_result = None
         if message.strip():

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4612,6 +4612,12 @@ class FeishuAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
         effective_reply_to = reply_to
+        # Feishu exposes two different APIs here:
+        #   * message.reply(message_id, reply_in_thread=True) enters a topic;
+        #   * message.create(receive_id_type=...) only accepts chat/user IDs.
+        # A thread_id (omt_*) is routing context, not a valid create recipient.
+        # Cron/resumed paths therefore carry the original message_id separately
+        # as reply_to_message_id so they can still use the reply API later.
         if not effective_reply_to and metadata and metadata.get("thread_id"):
             effective_reply_to = metadata.get("reply_to_message_id")
         reply_in_thread = bool((metadata or {}).get("thread_id"))
@@ -4628,8 +4634,10 @@ class FeishuAdapter(BasePlatformAdapter):
         # Feishu topics do not support direct creation by thread_id. Entering a
         # topic requires message.reply with reply_in_thread=True, which in turn
         # requires a message anchor. Async/resumed sends can retain thread_id
-        # after that anchor is gone; deliver those to the parent chat rather than
-        # issuing the invalid receive_id_type="thread_id" request (error 99992402).
+        # after that anchor is gone. Trade-off: an actually anchorless delivery
+        # loses topic placement but still reaches the parent chat. This is safer
+        # than issuing receive_id_type="thread_id", which Feishu rejects with
+        # [99992402] field validation failed and drops the delivery entirely.
         receive_id = chat_id
         receive_id_type = "chat_id"
         if chat_id.startswith("feishu_user_id:"):
@@ -5403,6 +5411,11 @@ async def _standalone_send(
     succeed when cron runs separately from the gateway. Builds a transient
     FeishuAdapter, hydrates its lark client, and sends text + native media
     (images, video, voice, documents). Replaces the legacy _send_feishu helper.
+
+    ``thread_id`` alone cannot address a Feishu topic. Keep the persisted
+    ``reply_to_message_id`` beside it so this path has the same reply-API routing
+    as the live gateway; otherwise a gateway outage would silently change a
+    thread-scoped cron result into a parent-chat message.
     """
     if not FEISHU_AVAILABLE:
         return {"error": "Feishu dependencies not installed. Run: pip install 'hermes-agent[feishu]'"}

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -153,6 +153,24 @@ class TestResolveDeliveryTarget:
             "thread_id": "17585",
         }
 
+    def test_feishu_origin_delivery_preserves_reply_anchor(self):
+        job = {
+            "deliver": "origin",
+            "origin": {
+                "platform": "feishu",
+                "chat_id": "oc_chat",
+                "thread_id": "omt_topic",
+                "message_id": "om_trigger",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "feishu",
+            "chat_id": "oc_chat",
+            "thread_id": "omt_topic",
+            "reply_to_message_id": "om_trigger",
+        }
+
     @pytest.mark.parametrize(
         ("platform", "env_var", "chat_id"),
         [
@@ -925,6 +943,34 @@ class TestDeliverResultWrapping:
 
         send_mock.assert_called_once()
         assert send_mock.call_args.kwargs["thread_id"] == "17585"
+
+    def test_feishu_origin_delivery_forwards_reply_anchor_to_standalone(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.FEISHU: pconfig}
+
+        job = {
+            "id": "feishu-topic-job",
+            "deliver": "origin",
+            "origin": {
+                "platform": "feishu",
+                "chat_id": "oc_chat",
+                "thread_id": "omt_topic",
+                "message_id": "om_trigger",
+            },
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            result = _deliver_result(job, "hello")
+
+        assert result is None
+        send_mock.assert_awaited_once()
+        assert send_mock.call_args.kwargs["thread_id"] == "omt_topic"
+        assert send_mock.call_args.kwargs["reply_to_message_id"] == "om_trigger"
 
 
 class TestDeliverResultErrorReturns:
@@ -3901,6 +3947,69 @@ class TestDeliverResultTimeoutCancelsFuture:
         # Forum target routes via message_thread_id (mode 1), not DM-topic.
         sent_metadata = adapter.send.call_args[1]["metadata"]
         assert not sent_metadata.get("direct_messages_topic_id")
+
+    def test_feishu_live_delivery_replies_to_origin_message_without_sdk_raw_get(self):
+        """A Feishu cron created in a topic must reply through its triggering
+        message, and an SDK response object must not be treated as a dict."""
+        from concurrent.futures import Future
+        from types import SimpleNamespace
+
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SendResult(
+            success=True,
+            message_id="om_delivery",
+            raw_response=SimpleNamespace(code=0),
+        ))
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.FEISHU: pconfig}
+        mock_cfg.filter_silence_narration = False
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {
+            "id": "feishu-topic-job",
+            "deliver": "origin",
+            "origin": {
+                "platform": "feishu",
+                "chat_id": "oc_chat",
+                "thread_id": "omt_topic",
+                "message_id": "om_trigger",
+            },
+        }
+
+        def fake_run_coro(coro, _loop):
+            import asyncio as _asyncio
+            future = Future()
+            try:
+                future.set_result(_asyncio.run(coro))
+            except BaseException as exc:  # noqa: BLE001
+                future.set_exception(exc)
+            return future
+
+        standalone_send = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(
+                job,
+                "Hello world",
+                adapters={Platform.FEISHU: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        standalone_send.assert_not_awaited()
+        sent_metadata = adapter.send.call_args.kwargs["metadata"]
+        assert sent_metadata["thread_id"] == "omt_topic"
+        assert sent_metadata["reply_to_message_id"] == "om_trigger"
 
 
 class TestDeliverResultLiveAdapterUnconfirmed:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2145,6 +2145,39 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(result.message_id, "om_reply")
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_standalone_send_preserves_cron_topic_reply_anchor(self):
+        from plugins.platforms.feishu import adapter as feishu_module
+
+        adapter = Mock()
+        adapter._domain_name = "feishu"
+        adapter._build_lark_client.return_value = Mock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True,
+            message_id="om_delivery",
+        ))
+
+        with patch.object(feishu_module, "FEISHU_AVAILABLE", True), \
+             patch.object(feishu_module, "FeishuAdapter", return_value=adapter):
+            result = asyncio.run(feishu_module._standalone_send(
+                Mock(),
+                "oc_chat",
+                "reminder",
+                thread_id="omt_topic",
+                reply_to_message_id="om_trigger",
+            ))
+
+        self.assertTrue(result["success"])
+        adapter.send.assert_awaited_once_with(
+            "oc_chat",
+            "reminder",
+            metadata={
+                "thread_id": "omt_topic",
+                "reply_to_message_id": "om_trigger",
+            },
+        )
+
     @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_metadata_reply_target_for_threaded_feishu_topic(self):
         from gateway.config import PlatformConfig

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -249,7 +249,6 @@ class TestFeishuFallbackThreadRouting:
     async def test_create_uses_chat_id_when_no_thread(self):
         """When reply_to=None and metadata has no thread_id, message.create
         should use receive_id_type='chat_id' (original behavior)."""
-        from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
         mock_client = MagicMock()
@@ -260,7 +259,6 @@ class TestFeishuFallbackThreadRouting:
         mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
 
         adapter = MagicMock(spec=FeishuAdapter)
-        adapter.config = PlatformConfig()
         adapter._client = mock_client
         adapter._build_create_message_body = FeishuAdapter._build_create_message_body
         adapter._build_create_message_request = FeishuAdapter._build_create_message_request

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -174,12 +174,16 @@ class TestOverflowFirstMessage:
 
 
 class TestFeishuFallbackThreadRouting:
-    """Verify FeishuAdapter._send_raw_message routes to topic on fallback."""
+    """Verify FeishuAdapter._send_raw_message safely handles missing reply anchors."""
 
     @pytest.mark.asyncio
-    async def test_create_uses_thread_id_when_available(self):
-        """When reply_to=None and metadata has thread_id, message.create
-        should use receive_id_type='thread_id'."""
+    async def test_create_falls_back_to_chat_when_thread_has_no_reply_anchor(self):
+        """Feishu cannot create a message with receive_id_type='thread_id'.
+
+        If an async/resumed send retains only thread metadata, deliver it to the
+        parent chat instead of issuing a request that Feishu rejects with
+        ``99992402 field validation failed``.
+        """
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
         # We test the _send_raw_message method directly by mocking the client
@@ -218,31 +222,34 @@ class TestFeishuFallbackThreadRouting:
         # Verify message.create was called (not message.reply)
         mock_client.im.v1.message.create.assert_called_once()
 
-        # The request should have receive_id_type="thread_id"
+        # The create API must target the parent chat. Feishu topics can only be
+        # entered through message.reply(reply_in_thread=True), which requires a
+        # message anchor that this fallback path does not have.
         call_args = mock_client.im.v1.message.create.call_args[0][0]
         # Lark SDK builder exposes .body; the in-tree fallback exposes .request_body.
         # The contributor's branch had the lark SDK installed, the test environment
         # may not — handle both shapes.
         body = getattr(call_args, "body", None) or getattr(call_args, "request_body", None)
         assert body is not None, "request has neither .body nor .request_body"
-        # receive_id should be the thread_id, not the chat_id
+        # receive_id should be the chat_id, not the unsupported thread_id.
         receive_id = getattr(body, "receive_id", None)
         if receive_id is None and isinstance(body, str):
             import json as _json
             receive_id = _json.loads(body).get("receive_id")
-        assert receive_id == "omt_topic_abc", (
-            f"Expected receive_id='omt_topic_abc', got '{receive_id}'"
+        assert receive_id == "oc_main_chat", (
+            f"Expected receive_id='oc_main_chat', got '{receive_id}'"
         )
-        # And receive_id_type must be 'thread_id', not 'chat_id'
+        # ``thread_id`` is not a valid receive_id_type for /im/v1/messages.
         receive_id_type = getattr(call_args, "receive_id_type", None)
-        assert receive_id_type == "thread_id", (
-            f"Expected receive_id_type='thread_id', got '{receive_id_type}'"
+        assert receive_id_type == "chat_id", (
+            f"Expected receive_id_type='chat_id', got '{receive_id_type}'"
         )
 
     @pytest.mark.asyncio
     async def test_create_uses_chat_id_when_no_thread(self):
         """When reply_to=None and metadata has no thread_id, message.create
         should use receive_id_type='chat_id' (original behavior)."""
+        from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
         mock_client = MagicMock()
@@ -253,6 +260,7 @@ class TestFeishuFallbackThreadRouting:
         mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
 
         adapter = MagicMock(spec=FeishuAdapter)
+        adapter.config = PlatformConfig()
         adapter._client = mock_client
         adapter._build_create_message_body = FeishuAdapter._build_create_message_body
         adapter._build_create_message_request = FeishuAdapter._build_create_message_request

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -657,6 +657,26 @@ class TestLocalDeliveryNotice:
         assert created["deliver"] == "origin"
         assert "local-only cron job" not in created["message"]
 
+    def test_gateway_origin_captures_triggering_message_as_reply_anchor(self):
+        from gateway.session_context import set_session_vars
+        from tools.cronjob_tools import _origin_from_env
+
+        set_session_vars(
+            platform="feishu",
+            chat_id="oc_chat",
+            thread_id="omt_topic",
+            message_id="om_trigger",
+        )
+
+        assert _origin_from_env() == {
+            "platform": "feishu",
+            "chat_id": "oc_chat",
+            "chat_name": None,
+            "thread_id": "omt_topic",
+            "message_id": "om_trigger",
+            "user_id": None,
+        }
+
 
 class TestValidateCronBaseUrl:
     """The cron base_url guard must not let a NAMED custom provider's stored

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -306,9 +306,11 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
         }
         if origin_platform.lower() == "feishu":
-            # Feishu topics can only be entered through message.reply; thread_id
-            # alone is not a valid create-message receive_id_type. Preserve the
-            # triggering message as the durable reply anchor for cron delivery.
+            # Feishu's create-message API cannot target thread_id (omt_*); topic
+            # delivery must call message.reply on an om_* message anchor with
+            # reply_in_thread=true. Cron runs after the inbound event is gone, so
+            # persist that anchor now. We scope this extra origin field to Feishu
+            # rather than changing every platform's stored-job schema.
             origin["message_id"] = get_session_env("HERMES_SESSION_MESSAGE_ID") or None
         return origin
     return None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -293,7 +293,7 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
                 "Cron origin captured thread_id=%s for %s:%s",
                 thread_id, origin_platform, origin_chat_id,
             )
-        return {
+        origin = {
             "platform": origin_platform,
             "chat_id": origin_chat_id,
             "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
@@ -305,6 +305,12 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             # gateway.mirror.mirror_to_session. Harmless for DMs/shared sessions.
             "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
         }
+        if origin_platform.lower() == "feishu":
+            # Feishu topics can only be entered through message.reply; thread_id
+            # alone is not a valid create-message receive_id_type. Preserve the
+            # triggering message as the durable reply anchor for cron delivery.
+            origin["message_id"] = get_session_env("HERMES_SESSION_MESSAGE_ID") or None
+        return origin
     return None
 
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -792,6 +792,11 @@ async def _send_to_platform(
     Long messages are automatically chunked to fit within platform limits
     using the same smart-splitting algorithm as the gateway adapters
     (preserves code-block boundaries, adds part indicators).
+
+    ``reply_to_message_id`` is keyword-only to preserve the long-standing
+    positional calling convention. It is currently needed by Feishu standalone
+    cron delivery because Feishu topics are entered by replying to an om_* message;
+    thread_id alone is not a supported create-message recipient.
     """
     from gateway.config import Platform
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -776,7 +776,17 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    *,
+    reply_to_message_id=None,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -1071,7 +1081,14 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _registry_standalone_send("dingtalk", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.FEISHU:
-            result = await _registry_standalone_send("feishu", pconfig, chat_id, chunk, thread_id)
+            result = await _registry_standalone_send(
+                "feishu",
+                pconfig,
+                chat_id,
+                chunk,
+                thread_id,
+                reply_to_message_id=reply_to_message_id,
+            )
         elif platform == Platform.WECOM:
             result = await _registry_standalone_send("wecom", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.BLUEBUBBLES:
@@ -1429,7 +1446,15 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 # (plugins/platforms/slack/adapter.py), wired via standalone_sender_fn. #41112.
 
 
-async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None):
+async def _registry_standalone_send(
+    platform_name,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    *,
+    reply_to_message_id=None,
+):
     """Dispatch a one-shot send through a migrated platform plugin's
     standalone_sender_fn (registry hook).  Used for platforms whose adapter
     moved out of gateway/platforms/ into plugins/platforms/<name>/ (#41112):
@@ -1442,7 +1467,10 @@ async def _registry_standalone_send(platform_name, pconfig, chat_id, message, th
     entry = platform_registry.get(platform_name)
     if entry is None or entry.standalone_sender_fn is None:
         return {"error": f"{platform_name} plugin not registered or missing standalone_sender_fn"}
-    return await entry.standalone_sender_fn(pconfig, chat_id, message, thread_id=thread_id)
+    kwargs = {"thread_id": thread_id}
+    if reply_to_message_id is not None:
+        kwargs["reply_to_message_id"] = reply_to_message_id
+    return await entry.standalone_sender_fn(pconfig, chat_id, message, **kwargs)
 
 
 # _send_whatsapp moved to plugins/platforms/whatsapp/adapter.py::_standalone_send,


### PR DESCRIPTION
## Summary

- stop sending unsupported `receive_id_type=thread_id` requests, which Feishu rejects with `[99992402] field validation failed`
- use `message.reply(..., reply_in_thread=True)` when a valid message anchor is available
- persist the triggering Feishu message ID when a job is created inside a thread
- propagate that reply anchor through both live gateway and standalone cron delivery
- fix cases where jobs created in a Feishu thread could fail delivery or send the result to the parent chat, causing users to miss the reply in the originating thread
- avoid treating Feishu SDK response objects as dictionaries and triggering a false standalone retry
- retain parent-chat fallback only for genuinely anchorless sends, with comments documenting the API limitation and trade-off

## Scope

This PR contains only the API validation and thread/job delivery fixes. The configurable `feishu.reply_in_thread` feature is submitted separately.

## Testing

- `scripts/run_tests.sh tests/cron/test_scheduler.py tests/tools/test_cronjob_tools.py tests/tools/test_send_message_tool.py tests/gateway/test_feishu.py tests/gateway/test_stream_consumer_thread_routing.py tests/gateway/test_run_progress_topics.py -q --tb=short`
- 705 tests passed
- `git diff --check`