### PR TITLE
fix(gateway): queue media messages while sessions are busy

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5347,6 +5347,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # still small enough to never threaten memory.
     _BUSY_QUEUE_MAX_PENDING = 32
 
+    @staticmethod
+    def _is_plain_text_followup(event: MessageEvent) -> bool:
+        """Return whether a busy-session event is safe to inject as text."""
+        return (
+            event.message_type == MessageType.TEXT
+            and not event.media_urls
+            and not event.media_types
+        )
+
     def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
         adapter = self._adapter_for_source(event.source)
         if not adapter:
@@ -5356,25 +5365,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # the single pending slot when consecutive text messages arrived
         # in ``busy_input_mode: queue``. Route through the FIFO
         # infrastructure shared with ``/queue`` so each follow-up gets
-        # its own turn in arrival order. Photo bursts still merge into
-        # the head slot via ``merge_pending_message_event`` (album
-        # semantics); everything else appends to the overflow tail.
-        pending_slot = getattr(adapter, "_pending_messages", None)
-        existing = pending_slot.get(session_key) if isinstance(pending_slot, dict) else None
-        if existing is not None and (
-            getattr(existing, "message_type", None) == MessageType.PHOTO
-            or event.message_type == MessageType.PHOTO
-            or bool(getattr(existing, "media_urls", None))
-            or bool(getattr(event, "media_urls", None))
-        ):
-            # Preserve photo-burst / media-merge semantics for the head slot.
-            merge_pending_message_event(
-                adapter._pending_messages,
-                session_key,
-                event,
-                merge_text=event.message_type == MessageType.TEXT,
-            )
-            return
+        # its own turn in arrival order. Keep media events intact as well:
+        # merging them into the head slot discards the incoming event's raw
+        # platform object and attachment metadata.
 
         if self._queue_depth(session_key, adapter=adapter) >= self._BUSY_QUEUE_MAX_PENDING:
             logger.warning(
@@ -5575,6 +5568,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             steer_text = (event.text or "").strip()
             can_steer = (
                 steer_text
+                and self._is_plain_text_followup(event)
                 and running_agent is not None
                 and running_agent is not _AGENT_PENDING_SENTINEL
                 and hasattr(running_agent, "steer")
@@ -9505,6 +9499,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 steer_text = event.get_command_args().strip()
                 if not steer_text:
                     return "Usage: /steer <prompt>"
+                if (
+                    event.message_type not in {MessageType.TEXT, MessageType.COMMAND}
+                    or event.media_urls
+                    or event.media_types
+                ):
+                    # Preserve the complete platform event, but strip the
+                    # command prefix before queueing. Replaying the original
+                    # ``/steer`` text at the next turn would dispatch it as a
+                    # command again instead of processing the attachment.
+                    queued_event = dataclasses.replace(event, text=steer_text)
+                    self._queue_or_replace_pending_event(_quick_key, queued_event)
+                    return "Attachment queued for the next turn; only plain text can steer the current run."
                 running_agent = self._running_agents.get(_quick_key)
                 if running_agent is _AGENT_PENDING_SENTINEL:
                     # Agent hasn't started yet — queue as turn-boundary fallback.
@@ -9655,9 +9661,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
-                adapter = self._adapter_for_source(source)
-                if adapter:
-                    merge_pending_message_event(adapter._pending_messages, _quick_key, event)
+                self._queue_or_replace_pending_event(_quick_key, event)
                 return None
 
             _telegram_followup_grace = float(
@@ -9666,7 +9670,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _started_at = self._running_agents_ts.get(_quick_key, 0)
             if (
                 source.platform == Platform.TELEGRAM
-                and event.message_type == MessageType.TEXT
+                and self._is_plain_text_followup(event)
                 and _telegram_followup_grace > 0
                 and _started_at
                 and (time.time() - _started_at) <= _telegram_followup_grace
@@ -9699,14 +9703,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return EphemeralReply("⚡ Force-stopped. The agent was still starting — session unlocked.")
                 # Queue the message so it will be picked up after the
                 # agent starts.
-                adapter = self._adapter_for_source(source)
-                if adapter:
-                    merge_pending_message_event(
-                        adapter._pending_messages,
-                        _quick_key,
-                        event,
-                        merge_text=True,
-                    )
+                self._queue_or_replace_pending_event(_quick_key, event)
                 return None
             if self._draining:
                 if self._queue_during_drain_enabled():
@@ -9726,7 +9723,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # is empty, the agent lacks steer(), or steer() rejects.
                 steer_text = (event.text or "").strip()
                 steered = False
-                if steer_text and hasattr(running_agent, "steer"):
+                if (
+                    steer_text
+                    and self._is_plain_text_followup(event)
+                    and hasattr(running_agent, "steer")
+                ):
                     try:
                         steered = bool(running_agent.steer(steer_text))
                     except Exception as exc:

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -7,6 +7,7 @@ for GatewayRunner (mixin bound via the MRO).
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from typing import TYPE_CHECKING
 import asyncio
@@ -297,13 +298,21 @@ class GatewayBusySessionMixin:
                 for key in self._SECURITY_METADATA_KEYS
             )
         )
-        if same_security_context and (
-            getattr(existing, "message_type", None) == MessageType.PHOTO
-            or event.message_type == MessageType.PHOTO
-            or bool(getattr(existing, "media_urls", None))
-            or bool(getattr(event, "media_urls", None))
+        merge_types = {
+            getattr(existing, "message_type", None),
+            getattr(event, "message_type", None),
+        }
+        if (
+            same_security_context
+            and MessageType.PHOTO in merge_types
+            and merge_types <= {MessageType.TEXT, MessageType.PHOTO}
         ):
-            # Preserve photo-burst / media-merge semantics for the head slot.
+            # Preserve one-turn photo-burst/album semantics while retaining every native event.
+            merged_sources = getattr(existing, "_merged_media_source_events", None)
+            if merged_sources is None:
+                merged_sources = [existing]
+                setattr(existing, "_merged_media_source_events", merged_sources)
+            merged_sources.extend(getattr(event, "_merged_media_source_events", None) or [event])
             merge_pending_message_event(
                 adapter._pending_messages, session_key, event,
                 merge_text=event.message_type == MessageType.TEXT,
@@ -856,6 +865,14 @@ class GatewayBusySessionMixin:
         steer_text = event.get_command_args().strip()
         if not steer_text:
             return "Usage: /steer <prompt>"
+        if (
+            event.message_type not in {MessageType.TEXT, MessageType.COMMAND}
+            or event.media_urls
+            or event.media_types
+        ):
+            queued_event = dataclasses.replace(event, text=steer_text)
+            self._queue_or_replace_pending_event(quick_key, queued_event)
+            return "Attachment queued for the next turn; only plain text can steer the current run."
         _steer_state = self._peek_session_state(quick_key)
         running_agent = _steer_state.turn.agent if _steer_state else None
 

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -445,6 +445,66 @@ class TestBusySessionAck:
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
         assert "Queued for the next turn" in content
 
+    @pytest.mark.parametrize(
+        ("platform", "message_type", "media_url", "media_type"),
+        [
+            (
+                Platform.DISCORD,
+                MessageType.DOCUMENT,
+                "/tmp/fixture.pdf",
+                "application/pdf",
+            ),
+            (Platform.TELEGRAM, MessageType.VOICE, "/tmp/fixture.ogg", "audio/ogg"),
+            (Platform.TELEGRAM, MessageType.TEXT, "/tmp/replied-voice.ogg", "audio/ogg"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_steer_mode_queues_media_event_with_native_context_intact(
+        self,
+        platform,
+        message_type,
+        media_url,
+        media_type,
+    ):
+        """Discord and Telegram media stay complete instead of becoming text."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter(platform_val=platform.value)
+        source = SessionSource(
+            platform=platform,
+            chat_id="chat-1",
+            chat_type="dm",
+            user_id="user-1",
+        )
+        raw_message = object()
+        event = MessageEvent(
+            text="inspect this attachment",
+            message_type=message_type,
+            source=source,
+            raw_message=raw_message,
+            message_id="media-message",
+            platform_update_id=42,
+            media_urls=[media_url],
+            media_types=[media_type],
+            metadata={"native_attachment_id": "fixture-attachment"},
+        )
+        sk = build_session_key(source)
+        runner.adapters[source.platform] = adapter
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.steer.assert_not_called()
+        queued = adapter._pending_messages[sk]
+        assert queued is event
+        assert queued.raw_message is raw_message
+        assert queued.platform_update_id == 42
+        assert queued.media_urls == [media_url]
+        assert queued.media_types == [media_type]
+        assert queued.metadata == {"native_attachment_id": "fixture-attachment"}
+
     @pytest.mark.asyncio
     async def test_interrupt_mode_text_followups_fifo_not_merged(self):
         """Two TEXT follow-ups during a busy turn (interrupt mode) must each

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -317,6 +317,52 @@ class TestBusySessionAck:
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
         assert "Queued for the next turn" in content
 
+    @pytest.mark.parametrize(
+        ("platform", "message_type", "media_url", "media_type"),
+        [
+            (Platform.DISCORD, MessageType.DOCUMENT, "/tmp/fixture.pdf", "application/pdf"),
+            (Platform.TELEGRAM, MessageType.DOCUMENT, "/tmp/fixture.pdf", "application/pdf"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_steer_mode_queues_media_event_with_native_context_intact(
+        self, platform, message_type, media_url, media_type
+    ):
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter(platform_val=platform.value)
+        source = SessionSource(
+            platform=platform, chat_id="chat-1", chat_type="dm", user_id="user-1"
+        )
+        raw_message = object()
+        event = MessageEvent(
+            text="inspect this attachment",
+            message_type=message_type,
+            source=source,
+            raw_message=raw_message,
+            message_id="media-message",
+            platform_update_id=42,
+            media_urls=[media_url],
+            media_types=[media_type],
+            metadata={"native_attachment_id": "fixture-attachment"},
+        )
+        sk = build_session_key(source)
+        runner.adapters[source.platform] = adapter
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.steer.assert_not_called()
+        queued = adapter._pending_messages[sk]
+        assert queued is event
+        assert queued.raw_message is raw_message
+        assert queued.platform_update_id == 42
+        assert queued.media_urls == [media_url]
+        assert queued.media_types == [media_type]
+        assert queued.metadata == {"native_attachment_id": "fixture-attachment"}
+
     @pytest.mark.asyncio
     async def test_interrupt_mode_text_followups_fifo_not_merged(self):
         """Two TEXT follow-ups during a busy turn (interrupt mode) must each
@@ -446,7 +492,7 @@ class TestBusySessionOnboardingHint:
 
         # The flag is now persisted to tmp_path/config.yaml
         import yaml
-        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
+        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
         assert cfg["onboarding"]["seen"]["busy_input_prompt"] is True
 
 
@@ -469,5 +515,4 @@ class TestLongRunningNotificationOwnership:
         assert runner._should_emit_long_running_notification(
             "sess", original_agent, executor_task=None
         ) is False
-
 

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -430,27 +430,36 @@ class TestBusyInputModeQueueFifo:
         # The last accepted overflow item is msg-{cap-1}.
         assert runner._queued_events[session_key][-1].text == f"msg-{cap - 1:03d}"
 
-    def test_photo_burst_still_merges_in_head_slot(self):
-        """Photo bursts must keep album-merge semantics, not split into N turns."""
+    def test_media_events_are_queued_in_fifo_order_without_merging(self):
+        """Busy queueing must retain each media event and its native context."""
         runner, adapter = self._make_runner_and_adapter()
         session_key = "telegram:user:burst"
 
         source = MagicMock(chat_id="c1", platform=Platform.TELEGRAM, profile=None)
+        events = []
+        raw_messages = []
         for i in range(3):
-            runner._queue_or_replace_pending_event(
-                session_key,
-                MessageEvent(
-                    text="",
-                    message_type=MessageType.PHOTO,
-                    source=source,
-                    message_id=f"p-{i}",
-                    media_urls=[f"http://example.com/{i}.jpg"],
-                    media_types=["image/jpeg"],
-                ),
+            raw_message = object()
+            event = MessageEvent(
+                text="",
+                message_type=MessageType.PHOTO,
+                source=source,
+                raw_message=raw_message,
+                message_id=f"p-{i}",
+                media_urls=[f"https://example.invalid/{i}.jpg"],
+                media_types=["image/jpeg"],
+                metadata={"native_id": f"attachment-{i}"},
             )
+            events.append(event)
+            raw_messages.append(raw_message)
+            runner._queue_or_replace_pending_event(session_key, event)
 
-        # Single merged head event with all three media URLs.
-        assert session_key not in runner._queued_events or not runner._queued_events[session_key]
-        head = adapter._pending_messages[session_key]
-        assert head.message_type == MessageType.PHOTO
-        assert len(head.media_urls) == 3
+        assert adapter._pending_messages[session_key] is events[0]
+        assert runner._queued_events[session_key][0] is events[1]
+        assert runner._queued_events[session_key][1] is events[2]
+        assert [event.raw_message for event in events] == raw_messages
+        assert [event.metadata["native_id"] for event in events] == [
+            "attachment-0",
+            "attachment-1",
+            "attachment-2",
+        ]

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -219,4 +219,56 @@ class TestBusyInputModeQueueFifo:
         ]
         assert runner._queue_depth(session_key, adapter=adapter) == len(texts)
 
+    def _media_event(self, kind: MessageType, index: int) -> MessageEvent:
+        source = MagicMock(chat_id="c1", platform=Platform.TELEGRAM, profile=None)
+        suffix = "jpg" if kind == MessageType.PHOTO else "pdf"
+        mime = "image/jpeg" if kind == MessageType.PHOTO else "application/pdf"
+        return MessageEvent(
+            text="",
+            message_type=kind,
+            source=source,
+            raw_message=object(),
+            message_id=f"media-{index}",
+            platform_update_id=index,
+            media_urls=[f"https://example.invalid/{index}.{suffix}"],
+            media_types=[mime],
+            metadata={"native_id": f"attachment-{index}"},
+        )
+
+    def test_photo_burst_stays_one_turn_with_constituent_context(self):
+        runner, adapter = self._make_runner_and_adapter()
+        session_key = "telegram:user:album"
+        events = [self._media_event(MessageType.PHOTO, i) for i in range(3)]
+        for event in events:
+            runner._queue_or_replace_pending_event(session_key, event)
+
+        merged = adapter._pending_messages[session_key]
+        assert merged is events[0]
+        assert session_key not in runner._queued_events
+        assert merged.media_urls == [event.media_urls[0] for event in events]
+        assert merged._merged_media_source_events == events
+        assert [event.raw_message for event in merged._merged_media_source_events] == [
+            event.raw_message for event in events
+        ]
+        assert [event.platform_update_id for event in merged._merged_media_source_events] == [0, 1, 2]
+        assert [event.metadata["native_id"] for event in merged._merged_media_source_events] == [
+            "attachment-0", "attachment-1", "attachment-2"
+        ]
+
+    def test_non_album_media_events_remain_complete_fifo_turns(self):
+        runner, adapter = self._make_runner_and_adapter()
+        session_key = "telegram:user:documents"
+        events = [self._media_event(MessageType.DOCUMENT, i) for i in range(3)]
+        for event in events:
+            runner._queue_or_replace_pending_event(session_key, event)
+
+        assert adapter._pending_messages[session_key] is events[0]
+        assert runner._queued_events[session_key] == events[1:]
+        assert [event.raw_message for event in events] == [
+            event.raw_message
+            for event in [adapter._pending_messages[session_key], *runner._queued_events[session_key]]
+        ]
+        assert [event.metadata["native_id"] for event in events] == [
+            "attachment-0", "attachment-1", "attachment-2"
+        ]
 

--- a/tests/gateway/test_steer_command.py
+++ b/tests/gateway/test_steer_command.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
@@ -185,6 +185,40 @@ async def test_steer_rejected_payload_returns_rejection_message():
 
     assert result is not None
     assert "rejected" in result.lower() or "empty" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_steer_with_attachment_queues_original_event():
+    """A media-bearing /steer keeps the platform event for the next turn."""
+    runner, adapter = _make_runner(_session_entry())
+    sk = build_session_key(_make_source())
+    raw_message = object()
+    event = MessageEvent(
+        text="/steer inspect this",
+        message_type=MessageType.DOCUMENT,
+        source=_make_source(),
+        raw_message=raw_message,
+        message_id="m-media",
+        media_urls=["/tmp/fixture-document.pdf"],
+        media_types=["application/pdf"],
+        metadata={"attachment_id": "fixture-attachment"},
+    )
+    running_agent = MagicMock()
+    running_agent.steer.return_value = True
+    runner._running_agents[sk] = running_agent
+
+    result = await runner._handle_message(event)
+
+    assert result is not None
+    assert "queued" in result.lower()
+    running_agent.steer.assert_not_called()
+    queued = adapter._pending_messages[sk]
+    assert queued is not event
+    assert queued.text == "inspect this"
+    assert queued.raw_message is raw_message
+    assert queued.media_urls == ["/tmp/fixture-document.pdf"]
+    assert queued.media_types == ["application/pdf"]
+    assert queued.metadata == {"attachment_id": "fixture-attachment"}
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/gateway/test_steer_command.py
+++ b/tests/gateway/test_steer_command.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
@@ -167,6 +167,38 @@ async def test_steer_agent_without_steer_method_falls_back():
         adapter._pending_messages[sk].channel_context
         == "[Thread context]\nAlice: earlier request"
     )
+
+@pytest.mark.asyncio
+async def test_steer_with_attachment_queues_original_event():
+    runner, adapter = _make_runner(_session_entry())
+    sk = build_session_key(_make_source())
+    raw_message = object()
+    event = MessageEvent(
+        text="/steer inspect this",
+        message_type=MessageType.DOCUMENT,
+        source=_make_source(),
+        raw_message=raw_message,
+        message_id="m-media",
+        media_urls=["/tmp/fixture-document.pdf"],
+        media_types=["application/pdf"],
+        metadata={"attachment_id": "fixture-attachment"},
+    )
+    running_agent = MagicMock()
+    running_agent.steer.return_value = True
+    runner._running_agents[sk] = running_agent
+
+    result = await runner._handle_message(event)
+
+    assert result is not None
+    assert "queued" in result.lower()
+    running_agent.steer.assert_not_called()
+    queued = adapter._pending_messages[sk]
+    assert queued is not event
+    assert queued.text == "inspect this"
+    assert queued.raw_message is raw_message
+    assert queued.media_urls == ["/tmp/fixture-document.pdf"]
+    assert queued.media_types == ["application/pdf"]
+    assert queued.metadata == {"attachment_id": "fixture-attachment"}
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## What does this PR do?

When a session is already running, media-bearing follow-ups can enter the text steering or media-merge paths. That can discard the incoming event's raw platform object and per-attachment metadata, or turn an attachment into plain steering text.

This change:

- allows direct steering only for truly text-only events;
- queues image, document, voice, and other media events as complete `MessageEvent` objects in FIFO order;
- preserves media URLs, MIME types, raw platform messages, update IDs, and event metadata;
- prevents `/steer` attachments from being replayed as `/steer` commands on the next turn by queueing a cloned event with the command prefix removed;
- retains existing plain-text steering behavior and queue depth limits.

## Verification

- [x] Tested on Ubuntu 26.04 / Linux x86_64
- [x] 175 busy-session, queue, interrupt, compression, Telegram-thread, and steer regression tests passed
- [x] `ruff check` on all changed Python files
- [x] `python -m py_compile` on all changed Python files
- [x] `git diff --check`

All fixtures are synthetic; no live Discord or Telegram messages are used.