### PR TITLE
fix(video-gen): omit duration for range-based FAL families when unspecified (#36066 salvage)

### DIFF
--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -180,7 +180,11 @@ def _clamp_duration(family: Dict[str, Any], duration: Optional[int]) -> Optional
     if not durations:
         return duration
     if duration is None:
-        return durations[0]
+        # Range families (e.g. pixverse-v6 (1,15)) should omit the field so
+        # the FAL endpoint applies its own default rather than receiving the
+        # minimum value.  Enum families (e.g. veo3.1 (4,6,8)) keep sending
+        # their first entry as the default.
+        return None if _is_duration_range(durations) else durations[0]
     if _is_duration_range(durations):
         lo, hi = durations
         return max(lo, min(hi, duration))

--- a/tests/plugins/video_gen/test_fal_plugin.py
+++ b/tests/plugins/video_gen/test_fal_plugin.py
@@ -322,6 +322,29 @@ class TestPayloadBuilder:
         assert p["generate_audio"] is True
         assert p["negative_prompt"] == "ugly"
 
+    def test_range_families_omit_duration_when_unspecified(self):
+        """Range-based families must omit `duration` when the caller doesn't
+        specify one so FAL applies its endpoint default, not the minimum."""
+        from plugins.video_gen.fal import FAL_FAMILIES, _build_payload
+
+        for family_id in ("pixverse-v6", "seedance-2.0", "kling-v3-4k"):
+            meta = FAL_FAMILIES[family_id]
+            p = _build_payload(
+                meta,
+                prompt="x",
+                image_url=None,
+                duration=None,
+                aspect_ratio="16:9",
+                resolution="720p",
+                negative_prompt=None,
+                audio=None,
+                seed=None,
+            )
+            assert "duration" not in p, (
+                f"{family_id}: duration=None should omit the field, "
+                f"got {p.get('duration')!r}"
+            )
+
     def test_happy_horse_minimal_payload(self):
         """Happy Horse has sparse docs — payload should be minimal."""
         from plugins.video_gen.fal import FAL_FAMILIES, _build_payload


### PR DESCRIPTION
## Summary
FAL video generation no longer forces 1-second videos on range-based duration families when the agent doesn't specify a duration — the field is omitted so FAL applies its own default.

Root cause: `_clamp_duration` returned `durations[0]` for `duration=None` before the `_is_duration_range` check ran. `pixverse-v6` (the DEFAULT_MODEL, range `(1,15)`) therefore sent `duration="1"` on every default call; `seedance-2.0` and `kling-v3-4k` were also affected. `_build_payload` already guards `if clamped is not None`, so returning `None` cleanly omits the field. Enum families (veo3.1) unchanged.

Salvage of #36066 by @AhmetArif0 — clean cherry-pick onto current main, authorship preserved.

## Changes
- `plugins/video_gen/fal/__init__.py`: return `None` from `_clamp_duration` for unspecified duration on range families.
- `tests/plugins/video_gen/test_fal_plugin.py`: regression test.

## Validation
| | Before | After |
|---|---|---|
| default `video_generate` on pixverse-v6 | `duration="1"` → 1-second video | field omitted → provider default |
| explicit duration | clamped to range | unchanged |
| enum families | first enum value | unchanged |

`scripts/run_tests.sh tests/plugins/video_gen/test_fal_plugin.py` → 20 passed.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa27622/c8_Nb6ZP0zdt2dMtn6L9__DNYDjzC4.png)
