### PR TITLE
fix(desktop): preserve expanded messaging pages across polling

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -205,3 +205,47 @@ describe('refreshSessions batches slices into one request', () => {
     )
   })
 })
+
+describe('refreshMessagingSessions request guard', () => {
+  const msgRow = (id: string, source: string, over: Partial<SessionInfo> = {}): SessionInfo =>
+    ({ archived: false, cwd: null, ended_at: null, id, input_tokens: 0, is_active: false, last_active: 0, message_count: 2, model: null, output_tokens: 0, preview: null, source, started_at: 0, title: id, tool_call_count: 0, ...over }) as SessionInfo
+
+  it('ignores a stale refresh that resolves after a newer one', async () => {
+    let resolveOlder!: (value: { limit: number; offset: number; sessions: SessionInfo[]; total: number }) => void
+    let resolveNewer!: typeof resolveOlder
+
+    const older = new Promise<Parameters<typeof resolveOlder>[0]>(r => { resolveOlder = r })
+    const newer = new Promise<Parameters<typeof resolveNewer>[0]>(r => { resolveNewer = r })
+
+    const olderRows = [msgRow('feishu-old', 'feishu')]
+    const newerRows = [msgRow('feishu-new-0', 'feishu'), msgRow('feishu-new-1', 'feishu')]
+
+    listAllProfileSessions
+      .mockImplementationOnce(() => older)
+      .mockImplementationOnce(() => newer)
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'all' }))
+
+    let olderDone!: Promise<void>
+    let newerDone!: Promise<void>
+    await act(async () => {
+      olderDone = result.current.refreshMessagingSessions()
+      newerDone = result.current.refreshMessagingSessions()
+    })
+
+    // Newer finishes first
+    await act(async () => {
+      resolveNewer({ limit: newerRows.length, offset: 0, sessions: newerRows, total: newerRows.length })
+      await newerDone
+    })
+
+    // Then stale older resolves — must not clobber
+    await act(async () => {
+      resolveOlder({ limit: olderRows.length, offset: 0, sessions: olderRows, total: olderRows.length })
+      await olderDone
+    })
+
+    const feishu = $messagingSessions.get().filter(r => r.source === 'feishu')
+    expect(feishu.map(r => r.id)).toEqual(['feishu-new-0', 'feishu-new-1'])
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -18,6 +18,7 @@ import {
   CRON_SECTION_LIMIT,
   mergeSessionPage,
   MESSAGING_SECTION_LIMIT,
+  reconcileMessagingRefresh,
   setCronSessions,
   setMessagingPlatformTotals,
   setMessagingSessions,
@@ -74,12 +75,15 @@ interface UseSessionListActionsArgs {
  *  wires into the sidebar and refresh effects. */
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
   const refreshSessionsRequestRef = useRef(0)
+  const refreshMessagingRequestRef = useRef(0)
 
   // Messaging-platform sessions as their own slice, fetched separately from
   // local recents so each platform renders a self-managed section and never
   // competes with local chats for the recents page budget. One combined fetch
   // seeds every platform; the sidebar splits the rows per source.
   const refreshMessagingSessions = useCallback(async () => {
+    const requestId = ++refreshMessagingRequestRef.current
+
     try {
       const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', 'all', {
         excludeSources: MESSAGING_EXCLUDED_SOURCES
@@ -87,12 +91,21 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
       // Drop any non-messaging source the broad exclude didn't catch (custom
       // sources) — those stay in local recents, not a platform section.
-      const rows = result.sessions.filter(s => isMessagingSource(s.source))
+      if (refreshMessagingRequestRef.current !== requestId) {
+        return
+      }
 
-      setMessagingSessions(prev => (sameCronSignature(prev, rows) ? prev : rows))
+      const rows = result.sessions.filter(s => isMessagingSource(s.source))
+      const truncated = result.sessions.length >= MESSAGING_SECTION_LIMIT
+
+      setMessagingSessions(prev => {
+        const next = reconcileMessagingRefresh(prev, rows, truncated)
+
+        return sameCronSignature(prev, next) ? prev : next
+      })
       // Hit the cap → at least one platform may have more on disk than loaded,
       // so platform sections offer their own per-platform "load more".
-      setMessagingTruncated(result.sessions.length >= MESSAGING_SECTION_LIMIT)
+      setMessagingTruncated(truncated)
     } catch {
       // Non-fatal: the messaging sections just stay empty/stale.
     }

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -12,6 +12,7 @@ import {
   $unreadFinishedSessionIds,
   applyConfiguredDefaultProjectDir,
   mergeSessionPage,
+  reconcileMessagingRefresh,
   sessionPinId,
   setCurrentCwd,
   setSelectedStoredSessionId,
@@ -372,5 +373,44 @@ describe('unread finished sessions', () => {
 
     setSelectedStoredSessionId('s1')
     expect($unreadFinishedSessionIds.get()).toEqual([])
+  })
+})
+
+describe('reconcileMessagingRefresh', () => {
+  const row = (id: string, source: string, over: Partial<SessionInfo> = {}): SessionInfo =>
+    ({ archived: false, cwd: null, ended_at: null, id, input_tokens: 0, is_active: false, last_active: 0, message_count: 2, model: null, output_tokens: 0, preview: null, source, started_at: 0, title: id, tool_call_count: 0, ...over }) as SessionInfo
+
+  it('keeps paged-over rows when the cap was hit', () => {
+    const paged = Array.from({ length: 13 }, (_, i) => row(`f-${i}`, 'feishu'))
+    const seed = [
+      ...paged.slice(0, 4).map(r => ({ ...r, last_active: r.last_active + 1 })),
+      ...Array.from({ length: 96 }, (_, i) => row(`t-${i}`, 'telegram'))
+    ]
+
+    const result = reconcileMessagingRefresh(paged, seed, true)
+
+    expect(result.filter(s => s.source === 'feishu')).toHaveLength(13)
+    expect(result.filter(s => s.source === 'telegram')).toHaveLength(96)
+  })
+
+  it('truncates to incoming when not truncated', () => {
+    const paged = Array.from({ length: 5 }, (_, i) => row(`f-${i}`, 'feishu'))
+    const seed = [row('f-0', 'feishu', { last_active: 2 })]
+
+    const result = reconcileMessagingRefresh(paged, seed, false)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('f-0')
+  })
+
+  it('deduplicates paged rows that appear in the incoming seed', () => {
+    const paged = [row('f-0', 'feishu'), row('f-1', 'feishu')]
+    const seed = [row('f-0', 'feishu', { last_active: 10, title: 'updated' })]
+
+    const result = reconcileMessagingRefresh(paged, seed, true)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].title).toBe('updated')
+    expect(result[1].id).toBe('f-1')
   })
 })

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -4,6 +4,7 @@ import { lastVisibleMessageIsUser } from '@/app/chat/thread-loading'
 import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
 import type { ChatMessage } from '@/lib/chat-messages'
+import { normalizeSessionSource } from '@/lib/session-source'
 import { persistBoolean, persistString, storedBoolean, storedString } from '@/lib/storage'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
@@ -210,6 +211,51 @@ export function mergeSessionPage(
   )
 
   return survivors.length ? [...survivors, ...merged] : merged
+}
+
+/** Reconcile the background messaging seed with rows the user paged in.
+ * A seed that hit its aggregate cap is not authoritative for any one platform,
+ * so it may replace rows but cannot reduce that platform's loaded count. A
+ * shorter seed is exhaustive and may drop deleted or archived rows. */
+export function reconcileMessagingRefresh(
+  previous: SessionInfo[],
+  incoming: SessionInfo[],
+  truncated: boolean
+): SessionInfo[] {
+  if (!truncated) {
+    return incoming
+  }
+
+  const preserveSlots = new Map<string | null, number>()
+  const incomingIds = new Set(incoming.map(session => session.id))
+  const incomingLineages = new Set(incoming.map(session => session._lineage_root_id ?? session.id))
+  const paged: SessionInfo[] = []
+
+  for (const session of previous) {
+    const source = normalizeSessionSource(session.source)
+    preserveSlots.set(source, (preserveSlots.get(source) ?? 0) + 1)
+  }
+
+  for (const session of incoming) {
+    const source = normalizeSessionSource(session.source)
+    preserveSlots.set(source, Math.max(0, (preserveSlots.get(source) ?? 0) - 1))
+  }
+
+  for (const session of previous) {
+    if (incomingIds.has(session.id) || incomingLineages.has(session._lineage_root_id ?? session.id)) {
+      continue
+    }
+
+    const source = normalizeSessionSource(session.source)
+    const slots = preserveSlots.get(source) ?? 0
+
+    if (slots > 0) {
+      paged.push(session)
+      preserveSlots.set(source, slots - 1)
+    }
+  }
+
+  return paged.length ? [...incoming, ...paged] : incoming
 }
 
 export const $connection = atom<HermesConnection | null>(null)


### PR DESCRIPTION
## What does this PR do?

Prevents Desktop messaging sections from shrinking after the user loads more conversations and the 10-second background poll runs.

## Regression

The live messaging poll added by #57636 correctly keeps Telegram / WeChat / Feishu traffic fresh, but its combined seed is capped at 100 rows across all platforms. A per-platform load-more request can load 13 Feishu conversations while the next combined seed contains only 4 Feishu rows. The refresh previously replaced the entire messaging cache, so the section appeared to collapse from 13 back to 4.

This was discovered while manually validating #51407 and is intentionally kept separate from that scrollbar-only PR.

## Changes

- Reconcile capped messaging refreshes instead of clobbering the cache.
- Preserve the already-loaded count independently for each messaging platform.
- Let fresh seed rows replace older rows, so repeated polling does not grow the cache indefinitely.
- Keep sub-cap refreshes authoritative so externally deleted or archived sessions can disappear.
- Add store-level and hook-level behavioral regression coverage.

## Reproduction covered by the test

1. Load 13 Feishu conversations through the platform pager.
2. Return a capped combined seed containing 4 Feishu rows and 96 Telegram rows.
3. Run refreshMessagingSessions().
4. Feishu remains at 13 rows instead of shrinking to 4.

The hook-level test failed on unmodified main with: expected 13, received 4.

## Validation

- npm run test:ui --workspace apps/desktop -- src/store/session.test.ts src/app/session/hooks/use-session-list-actions.test.tsx — 26 passed
- npm run typecheck --workspace apps/desktop — passed
- ESLint on all changed files — passed with no warnings
- Prettier check on all changed files — passed
- git diff --check — passed

## Scope

Desktop renderer state reconciliation only. No gateway, database, API, CSS, or polling-interval changes.