### PR TITLE
fix(achievements): stop card hover click loop (#36025 salvage)

### DIFF
--- a/plugins/hermes-achievements/dashboard/dist/style.css
+++ b/plugins/hermes-achievements/dashboard/dist/style.css
@@ -21,7 +21,7 @@
 .ha-pills button.active, .ha-pills button:hover { color: var(--color-foreground); border-color: var(--ha-tier, var(--color-ring)); background: color-mix(in srgb, var(--color-primary) 16%, var(--color-card)); }
 .ha-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: .9rem; }
 .ha-card { --ha-tier: var(--color-border); position: relative; overflow: hidden; min-height: 214px; border: 1px solid color-mix(in srgb, var(--ha-tier) 46%, var(--color-border)); background: radial-gradient(circle at 2.6rem 2.2rem, color-mix(in srgb, var(--ha-tier) 16%, transparent), transparent 34%), linear-gradient(180deg, rgba(255,255,255,.04), transparent), color-mix(in srgb, var(--color-card) 92%, #000); transition: transform .16s ease, border-color .16s ease, opacity .16s ease, box-shadow .16s ease; }
-.ha-card:hover { transform: translateY(-2px); border-color: var(--ha-tier); box-shadow: 0 0 0 1px color-mix(in srgb, var(--ha-tier) 16%, transparent); }
+.ha-card:hover { border-color: var(--ha-tier); box-shadow: 0 0 0 1px color-mix(in srgb, var(--ha-tier) 16%, transparent); }
 .ha-card-content { position: relative; z-index: 1; padding: 1rem !important; display: flex; flex-direction: column; gap: .75rem; height: 100%; }
 .ha-card-head { display: grid; grid-template-columns: 3.1rem minmax(0, 1fr) auto; gap: .85rem; align-items: start; }
 .ha-icon { display: grid; place-items: center; width: 2.9rem; height: 2.9rem; color: var(--ha-tier); }

--- a/plugins/hermes-achievements/tests/test_achievement_engine.py
+++ b/plugins/hermes-achievements/tests/test_achievement_engine.py
@@ -151,6 +151,21 @@ class AchievementEngineTests(unittest.TestCase):
         stats = plugin_api.analyze_messages("s2", "Real config", [{"content": "edited config.yaml, manifest.json, and .env.local"}])
         self.assertGreaterEqual(stats["config_events"], 3)
 
+    def test_dashboard_card_hover_does_not_move_click_target(self):
+        style_css = (
+            Path(__file__).resolve().parents[1]
+            / "dashboard"
+            / "dist"
+            / "style.css"
+        ).read_text(encoding="utf-8")
+
+        hover_rule = next(
+            line for line in style_css.splitlines() if line.startswith(".ha-card:hover")
+        )
+        self.assertNotIn("transform:", hover_rule)
+        self.assertIn("border-color: var(--ha-tier)", hover_rule)
+        self.assertIn("box-shadow:", hover_rule)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Achievement dashboard cards no longer oscillate/auto-click on hover: the `transform: translateY(-2px)` hover rule moved the card out from under the pointer at its own boundary, causing a hover-enter/leave loop. Border/shadow hover feedback preserved.

Fixes #35116. Salvage of #36025 by @nima20002000 — clean cherry-pick, authorship preserved. `dist/` is the checked-in artifact for this plugin (no `src/`), so the CSS edit lands there directly.

## Changes
- `plugins/hermes-achievements/dashboard/dist/style.css`: remove the hover transform.
- `plugins/hermes-achievements/tests/test_achievement_engine.py`: regression test (hover rule contains no `transform:`).
- `scripts/release.py`: AUTHOR_MAP entry.

## Validation
`scripts/run_tests.sh plugins/hermes-achievements/tests/test_achievement_engine.py` → 11 passed.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa27650/qOoh-SF9ehvrQzBtlmLHS_BZcoNDPD.png)
