### PR TITLE
fix(discord): keep credential attachments path-only

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1699,6 +1699,23 @@ class EphemeralReply(str):
         return str.__str__(self)
 
 
+def _merge_pending_media_metadata(existing: MessageEvent, incoming: MessageEvent) -> None:
+    """Merge only attachment identity metadata that remains valid after media concatenation."""
+    incoming_metadata = incoming.metadata if isinstance(incoming.metadata, dict) else {}
+    values = incoming_metadata.get("discord_path_only_attachment_paths")
+    if not isinstance(values, list) or not values:
+        return
+    if not isinstance(existing.metadata, dict):
+        existing.metadata = {}
+    current = existing.metadata.setdefault("discord_path_only_attachment_paths", [])
+    if not isinstance(current, list):
+        current = []
+        existing.metadata["discord_path_only_attachment_paths"] = current
+    for value in values:
+        if value not in current:
+            current.append(value)
+
+
 def merge_pending_message_event(pending_messages: Dict[str, MessageEvent], session_key: str,
                                 event: MessageEvent, *, merge_text: bool = False) -> None:
     """Store or merge a pending event: photo bursts/albums merge into the queued event so the next
@@ -1726,6 +1743,7 @@ def merge_pending_message_event(pending_messages: Dict[str, MessageEvent], sessi
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
                 existing.media_text_inlined.extend(incoming_inline_flags)
+                _merge_pending_media_metadata(existing, event)
             if event.text:
                 existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
             if existing_is_photo or incoming_is_photo:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2088,11 +2088,18 @@ def _build_media_placeholder(event) -> str:
     return "\n".join(parts)
 
 
-def _build_document_context_note(display_name: str, agent_path: str, mtype: str) -> str:
+def _build_document_context_note(
+    display_name: str,
+    agent_path: str,
+    mtype: str,
+    *,
+    filename_requires_path_only: bool = False,
+) -> str:
     """Context note prepended to a user turn when they attach a document.
 
-    Text documents (``text/*``) have their content inlined upstream by the
-    platform adapter, so the note just confirms that and records the path.
+    Ordinary text documents (``text/*``) have their content inlined upstream
+    by the platform adapter. Discord credential-like filenames are explicitly
+    marked path-only, so their note must not claim that a body is present.
 
     Binary documents (PDF, DOCX, XLSX, …) cannot be inlined as text. The note
     must tell the agent to *extract* the text itself before answering — earlier
@@ -2100,6 +2107,14 @@ def _build_document_context_note(display_name: str, agent_path: str, mtype: str)
     model into punting back to the user, which is why attached PDFs/DOCX looked
     "unreadable" to the agent even though it has the tools to read them.
     """
+    if filename_requires_path_only:
+        return (
+            f"[The user sent a file attachment: '{display_name}'. "
+            f"It is saved at: {agent_path}. Its content was not automatically "
+            f"inlined because the filename indicates it may contain credentials "
+            f"or a private key. Read the saved file only if the user's request "
+            f"requires it.]"
+        )
     if mtype.startswith("text/"):
         return (
             f"[The user sent a text document: '{display_name}'. "
@@ -10710,6 +10725,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from tools.credential_files import to_agent_visible_cache_path
 
             _TEXT_EXTENSIONS = {".txt", ".md", ".csv", ".log", ".json", ".xml", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
+            _path_only_attachment_paths = set(
+                (getattr(event, "metadata", None) or {}).get(
+                    "discord_path_only_attachment_paths", []
+                )
+            )
             for i, path in enumerate(event.media_urls):
                 # Per-attachment document handling. Skip anything already routed
                 # as image / audio / video by the buckets above — only genuine
@@ -10749,7 +10769,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # cache directories are auto-mounted at /root/.hermes/cache/* by get_cache_directory_mounts().
                 agent_path = to_agent_visible_cache_path(path)
 
-                context_note = _build_document_context_note(display_name, agent_path, mtype)
+                context_note = _build_document_context_note(
+                    display_name,
+                    agent_path,
+                    mtype,
+                    filename_requires_path_only=(path in _path_only_attachment_paths),
+                )
                 message_text = f"{context_note}\n\n{message_text}"
 
         # Discord: surface the triggering message id per-turn on the user

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2389,10 +2389,23 @@ def _build_media_placeholder(event) -> str:
 
 
 def _build_document_context_note(
-    display_name: str, agent_path: str, mtype: str, *, content_inlined: bool = True) -> str:
+    display_name: str,
+    agent_path: str,
+    mtype: str,
+    *,
+    content_inlined: bool = True,
+    filename_requires_path_only: bool = False,
+) -> str:
     """Context note prepended to a user turn when they attach a document.
     ``content_inlined=False`` = cached without content, so tell the agent to read it. Binary docs must
     say *extract* the text; "ask the user" made it punt."""
+    if filename_requires_path_only:
+        return (
+            f"[The user sent a file attachment: '{display_name}'. It is saved at: {agent_path}. "
+            f"Its content was not automatically inlined because the filename indicates it may "
+            f"contain credentials or a private key. Read the saved file only if the user's "
+            f"request requires it.]"
+        )
     if mtype.startswith("text/") and content_inlined:
         return (
             f"[The user sent a text document: '{display_name}'. Its content has been included below. "

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1457,6 +1457,11 @@ class GatewayInboundMixin:
 
         _TEXT_EXTENSIONS = {".txt", ".md", ".csv", ".log", ".json", ".xml", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
         inline_flags = getattr(event, "media_text_inlined", None) or []
+        path_only_attachment_paths = set(
+            (getattr(event, "metadata", None) or {}).get(
+                "discord_path_only_attachment_paths", []
+            )
+        )
         for i, path in enumerate(event.media_urls):
             # A document mixed into a PHOTO/VOICE message (message-level type != DOCUMENT) still
             # reaches the agent; only genuine non-media files get a note.
@@ -1472,6 +1477,7 @@ class GatewayInboundMixin:
             inline_flag = inline_flags[i] if i < len(inline_flags) else None
             context_note = _build_document_context_note(
                 display_name, agent_path, mtype, content_inlined=inline_flag is not False,
+                filename_requires_path_only=path in path_only_attachment_paths,
             )
             message_text = f"{context_note}\n\n{message_text}"
         return message_text

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -60,6 +60,44 @@ _DISCORD_NONCONVERSATIONAL_METADATA_KEYS = frozenset({
     "non_conversational",
     "non_conversational_history",
 })
+_DISCORD_PATH_ONLY_TEXT_BASENAMES = frozenset({
+    ".env",
+    ".envrc",
+    ".git-credentials",
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "id_rsa",
+})
+_DISCORD_PATH_ONLY_TEXT_EXTENSIONS = frozenset({
+    ".jks",
+    ".kdbx",
+    ".key",
+    ".keystore",
+    ".p12",
+    ".pem",
+    ".pfx",
+    ".ppk",
+})
+_DISCORD_PATH_ONLY_TEXT_TOKENS = frozenset({
+    "apikey",
+    "auth",
+    "credential",
+    "credentials",
+    "key",
+    "oauth",
+    "passwd",
+    "password",
+    "passwords",
+    "privatekey",
+    "secret",
+    "secrets",
+    "token",
+    "tokens",
+})
 # Upgrade-bridge fallback only. The primary mechanism is the persisted
 # non-conversational message-ID set populated from explicitly marked sends
 # (metadata["non_conversational"]). These regexes exist solely to recognize
@@ -131,6 +169,27 @@ from tools.url_safety import is_safe_url
 def _truncate_discord_component_text(text: str, limit: int) -> str:
     """Return text within Discord's UTF-16 component field budget."""
     return _prefix_within_utf16_limit(str(text or ""), max(0, limit))
+
+
+def _discord_attachment_name_requires_path_only(filename: str | None) -> bool:
+    """Return whether filename metadata strongly indicates credentials.
+
+    This does not inspect file contents and is not secret detection. Matching
+    text files are still cached, but their bodies must not be copied into the
+    model-visible user turn automatically.
+    """
+    name = str(filename or "").replace("\\", "/").rsplit("/", 1)[-1]
+    name = name.strip().lower()
+    if not name:
+        return False
+    if (
+        name in _DISCORD_PATH_ONLY_TEXT_BASENAMES
+        or name.startswith(".env.")
+        or os.path.splitext(name)[1] in _DISCORD_PATH_ONLY_TEXT_EXTENSIONS
+    ):
+        return True
+    tokens = {part for part in re.split(r"[^a-z0-9]+", name) if part}
+    return bool(tokens & _DISCORD_PATH_ONLY_TEXT_TOKENS)
 
 
 async def _wait_for_ready_or_bot_exit(
@@ -6352,6 +6411,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # vision tool can access them reliably (Discord CDN URLs can expire).
         media_urls = []
         media_types = []
+        path_only_attachment_paths = []
         pending_text_injection: Optional[str] = None
         for att in all_attachments:
             content_type = att.content_type or "unknown"
@@ -6441,7 +6501,16 @@ class DiscordAdapter(BasePlatformAdapter):
                             ext in _TEXT_INJECT_EXTENSIONS
                             or (content_type or "").startswith("text/")
                         )
-                        if _is_text and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                        requires_path_only = (
+                            _discord_attachment_name_requires_path_only(att.filename)
+                        )
+                        if requires_path_only:
+                            path_only_attachment_paths.append(cached_path)
+                        if (
+                            _is_text
+                            and not requires_path_only
+                            and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES
+                        ):
                             try:
                                 text_content = raw_bytes.decode("utf-8")
                                 display_name = att.filename or f"document{ext or '.txt'}"
@@ -6593,6 +6662,11 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
             channel_context=_channel_context,
+            metadata=(
+                {"discord_path_only_attachment_paths": path_only_attachment_paths}
+                if path_only_attachment_paths
+                else {}
+            ),
         )
 
         # Track thread participation so the bot won't require @mention for

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -82,6 +82,17 @@ _DISCORD_COMMAND_SYNC_POLICIES = {"safe", "bulk", "off"}
 _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.json"
+_DISCORD_PATH_ONLY_TEXT_BASENAMES = frozenset({
+    ".env", ".envrc", ".git-credentials", ".netrc", ".npmrc", ".pypirc",
+    "id_dsa", "id_ecdsa", "id_ed25519", "id_rsa",
+})
+_DISCORD_PATH_ONLY_TEXT_EXTENSIONS = frozenset({
+    ".jks", ".kdbx", ".key", ".keystore", ".p12", ".pem", ".pfx", ".ppk",
+})
+_DISCORD_PATH_ONLY_TEXT_TOKENS = frozenset({
+    "apikey", "auth", "credential", "credentials", "key", "oauth", "passwd",
+    "password", "passwords", "privatekey", "secret", "secrets", "token", "tokens",
+})
 
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
@@ -319,6 +330,21 @@ def _abort_discord_websocket_transport(websocket: Any) -> bool:
         return False
     abort()
     return True
+
+
+def _discord_attachment_name_requires_path_only(filename: str | None) -> bool:
+    """Whether filename metadata strongly indicates credentials; contents are not inspected."""
+    name = str(filename or "").replace("\\", "/").rsplit("/", 1)[-1].strip().lower()
+    if not name:
+        return False
+    if (
+        name in _DISCORD_PATH_ONLY_TEXT_BASENAMES
+        or name.startswith(".env.")
+        or os.path.splitext(name)[1] in _DISCORD_PATH_ONLY_TEXT_EXTENSIONS
+    ):
+        return True
+    tokens = {part for part in re.split(r"[^a-z0-9]+", name) if part}
+    return bool(tokens & _DISCORD_PATH_ONLY_TEXT_TOKENS)
 
 
 async def _wait_for_ready_or_bot_exit(
@@ -5832,9 +5858,10 @@ class DiscordAdapter(BasePlatformAdapter):
             return att.url
 
     async def _collect_attachment_media(self, all_attachments: list) -> tuple:
-        """Cache every attachment and return ``(media_urls, media_types, pending_text_injection)``."""
+        """Cache attachments and return URLs, MIME types, safe inline text, and path-only identities."""
         media_urls = []
         media_types = []
+        path_only_attachment_paths = []
         pending_text_injection: Optional[str] = None
         for att in all_attachments:
             content_type = att.content_type or "unknown"
@@ -5883,7 +5910,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     # types rely on ``gateway/run.py`` emitting a (sandbox-translated) path note.
                     MAX_TEXT_INJECT_BYTES = 100 * 1024
                     _is_text = ext in _TEXT_INJECT_EXTENSIONS or (content_type or "").startswith("text/")
-                    if _is_text and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                    requires_path_only = _discord_attachment_name_requires_path_only(att.filename)
+                    if requires_path_only:
+                        path_only_attachment_paths.append(cached_path)
+                    if _is_text and not requires_path_only and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
                         try:
                             text_content = raw_bytes.decode("utf-8")
                             display_name = att.filename or f"document{ext or '.txt'}"
@@ -5897,7 +5927,7 @@ class DiscordAdapter(BasePlatformAdapter):
                             pass
                 except Exception as e:
                     logger.warning("[Discord] Failed to cache document %s: %s", att.filename, e, exc_info=True)
-        return media_urls, media_types, pending_text_injection
+        return media_urls, media_types, pending_text_injection, path_only_attachment_paths
 
     def _attachment_message_type(self, att: Any) -> MessageType:
         """MessageType from the first attachment's MIME. Any non-media (or untyped) attachment
@@ -6074,7 +6104,12 @@ class DiscordAdapter(BasePlatformAdapter):
                 or self._derive_auto_thread_name(message.content or "")
             ) if auto_threaded_channel is not None else None,
         )
-        media_urls, media_types, pending_text_injection = await self._collect_attachment_media(all_attachments)
+        (
+            media_urls,
+            media_types,
+            pending_text_injection,
+            path_only_attachment_paths,
+        ) = await self._collect_attachment_media(all_attachments)
         event_text = normalized_content
         if pending_text_injection:
             event_text = f"{pending_text_injection}\n\n{event_text}" if event_text else pending_text_injection
@@ -6124,6 +6159,11 @@ class DiscordAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to_id, reply_to_text=reply_to_text,
             timestamp=message.created_at, auto_skill=_skills, channel_prompt=_channel_prompt,
             channel_context=_channel_context,
+            metadata=(
+                {"discord_path_only_attachment_paths": path_only_attachment_paths}
+                if path_only_attachment_paths
+                else {}
+            ),
         )
         # Track participation so follow-ups in this thread don't need @mention.
         if thread_id:

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -8,13 +8,14 @@ to download, cache, and optionally inject text from non-image/audio files.
 import os
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import GatewayConfig, PlatformConfig
 from gateway.platforms.base import MessageType
 
 
@@ -58,7 +59,10 @@ def _ensure_discord_mock():
 _ensure_discord_mock()
 
 import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
-from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    DiscordAdapter,
+    _discord_attachment_name_requires_path_only,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -87,10 +91,11 @@ class FakeThread:
 
 @pytest.fixture(autouse=True)
 def _redirect_cache(tmp_path, monkeypatch):
-    """Point document cache to tmp_path so tests never write to ~/.hermes."""
+    """Keep document cache and fake CDN access isolated from the host."""
     monkeypatch.setattr(
         "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
     )
+    monkeypatch.setattr(discord_platform, "is_safe_url", lambda _url: True)
 
 
 @pytest.fixture
@@ -159,6 +164,42 @@ def _mock_aiohttp_download(raw_bytes: bytes):
 
 class TestIncomingDocumentHandling:
 
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            ".env",
+            ".env.production",
+            ".netrc",
+            ".git-credentials",
+            "id_ed25519",
+            "server-private-key.pem",
+            "api-key.txt",
+            "service-auth.txt",
+            "client-credentials.json",
+            "oauth-token.txt",
+            "database_password.md",
+            "shared.secret.txt",
+        ],
+    )
+    def test_credential_like_filename_requires_path_only(self, filename):
+        assert _discord_attachment_name_requires_path_only(filename) is True
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "monkey.txt",
+            "hockey.txt",
+            "keynote.txt",
+            "authentication-guide.md",
+            "tokenizer-notes.txt",
+            "secretary-agenda.txt",
+            "ordinary-notes.txt",
+            "readme.md",
+        ],
+    )
+    def test_ordinary_filename_remains_inline_eligible(self, filename):
+        assert _discord_attachment_name_requires_path_only(filename) is False
+
     @pytest.mark.asyncio
     async def test_pdf_document_cached(self, adapter):
         """A PDF attachment should be downloaded, cached, typed as DOCUMENT."""
@@ -193,6 +234,44 @@ class TestIncomingDocumentHandling:
         assert "summarize this" in event.text
         # injection prepended before caption
         assert event.text.index("[Content of") < event.text.index("summarize this")
+
+    @pytest.mark.asyncio
+    async def test_credential_attachment_body_absent_from_constructed_prompt(
+        self,
+        adapter,
+    ):
+        from gateway.run import GatewayRunner
+
+        sentinel = "SYNTHETIC_CREDENTIAL_BODY_MUST_NOT_ENTER_PROMPT"
+        with _mock_aiohttp_download(sentinel.encode()):
+            msg = make_message(
+                attachments=[
+                    make_attachment(
+                        filename="service-token.txt",
+                        content_type="text/plain",
+                    )
+                ],
+                content="inspect the saved file",
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args.args[0]
+        saved_path = event.media_urls[0]
+        assert Path(saved_path).read_text(encoding="utf-8") == sentinel
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig()
+        runner.adapters = {}
+        runner._has_setup_skill = lambda: False
+        prompt = await runner._prepare_inbound_message_text(
+            event=event,
+            source=event.source,
+            history=[],
+        )
+
+        assert sentinel not in prompt
+        assert saved_path in prompt
+        assert "content was not automatically inlined" in prompt
 
     @pytest.mark.asyncio
     async def test_md_content_injected(self, adapter):
@@ -510,4 +589,3 @@ class TestAllowAnyAttachment:
         """Garbage in max_attachment_bytes config falls back to 32 MiB."""
         adapter.config.extra["max_attachment_bytes"] = "not-a-number"
         assert adapter._discord_max_attachment_bytes() == 32 * 1024 * 1024
-

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -8,14 +8,15 @@ to download, cache, and optionally inject text from non-image/audio files.
 import os
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import PlatformConfig
-from gateway.platforms.base import MessageType
+from gateway.config import GatewayConfig, PlatformConfig
+from gateway.platforms.base import MessageType, merge_pending_message_event
 
 
 # ---------------------------------------------------------------------------
@@ -58,7 +59,10 @@ def _ensure_discord_mock():
 _ensure_discord_mock()
 
 import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
-from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    DiscordAdapter,
+    _discord_attachment_name_requires_path_only,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -162,6 +166,28 @@ def _mock_aiohttp_download(raw_bytes: bytes):
 
 class TestIncomingDocumentHandling:
 
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            ".env", ".env.production", ".netrc", ".git-credentials", "id_ed25519",
+            "server-private-key.pem", "api-key.txt", "service-auth.txt",
+            "client-credentials.json", "oauth-token.txt", "database_password.md",
+            "shared.secret.txt",
+        ],
+    )
+    def test_credential_like_filename_requires_path_only(self, filename):
+        assert _discord_attachment_name_requires_path_only(filename) is True
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "monkey.txt", "hockey.txt", "keynote.txt", "authentication-guide.md",
+            "tokenizer-notes.txt", "secretary-agenda.txt", "ordinary-notes.txt", "readme.md",
+        ],
+    )
+    def test_ordinary_filename_remains_inline_eligible(self, filename):
+        assert _discord_attachment_name_requires_path_only(filename) is False
+
 
     @pytest.mark.asyncio
     async def test_txt_content_injected(self, adapter):
@@ -181,6 +207,64 @@ class TestIncomingDocumentHandling:
         assert "summarize this" in event.text
         # injection prepended before caption
         assert event.text.index("[Content of") < event.text.index("summarize this")
+
+    @pytest.mark.asyncio
+    async def test_credential_attachment_body_absent_from_constructed_prompt(self, adapter):
+        from gateway.run import GatewayRunner
+
+        sentinel = "SYNTHETIC_CREDENTIAL_BODY_MUST_NOT_ENTER_PROMPT"
+        with _mock_aiohttp_download(sentinel.encode()):
+            msg = make_message(
+                attachments=[make_attachment(filename="service-token.txt", content_type="text/plain")],
+                content="inspect the saved file",
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args.args[0]
+        saved_path = event.media_urls[0]
+        assert Path(saved_path).read_text(encoding="utf-8") == sentinel
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig()
+        runner.adapters = {}
+        runner._has_setup_skill = lambda: False
+        prompt = await runner._prepare_inbound_message_text(event=event, source=event.source, history=[])
+        assert sentinel not in prompt
+        assert saved_path in prompt
+        assert "content was not automatically inlined" in prompt
+
+    @pytest.mark.asyncio
+    async def test_queued_credential_followup_keeps_path_only_context(self, adapter):
+        from gateway.run import GatewayRunner
+
+        with _mock_aiohttp_download(b"ordinary body"):
+            await adapter._handle_message(make_message(
+                attachments=[make_attachment(filename="notes.txt", content_type="text/plain")],
+                content="first",
+            ))
+        existing = adapter.handle_message.call_args.args[0]
+
+        sentinel = "QUEUED_CREDENTIAL_BODY_MUST_NOT_ENTER_PROMPT"
+        adapter.handle_message.reset_mock()
+        with _mock_aiohttp_download(sentinel.encode()):
+            await adapter._handle_message(make_message(
+                attachments=[make_attachment(filename="service-token.txt", content_type="text/plain")],
+                content="second",
+            ))
+        incoming = adapter.handle_message.call_args.args[0]
+        credential_path = incoming.media_urls[0]
+        pending = {"session": existing}
+        merge_pending_message_event(pending, "session", incoming)
+        merged = pending["session"]
+        assert credential_path in merged.metadata["discord_path_only_attachment_paths"]
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig()
+        runner.adapters = {}
+        runner._has_setup_skill = lambda: False
+        prompt = await runner._prepare_inbound_message_text(event=merged, source=merged.source, history=[])
+        assert sentinel not in prompt
+        assert credential_path in prompt
+        assert "content was not automatically inlined" in prompt
 
     @pytest.mark.asyncio
     async def test_md_content_injected(self, adapter):
@@ -349,5 +433,4 @@ class TestAllowAnyAttachment:
 
         event = adapter.handle_message.call_args[0][0]
         assert len(event.media_urls) == 1
-
 


### PR DESCRIPTION
## What does this PR do?

Discord text attachments are normally inlined into the model prompt. That is useful for ordinary documents, but unsafe as a default for filenames that clearly indicate environment files, credentials, tokens, passwords, or private keys.

This change:

- classifies credential-like attachments from filename metadata only;
- saves and exposes those files through their local cache path without automatically inlining their body;
- tells the agent accurately that the file was saved and its content was not inlined;
- preserves the historical inline behavior for ordinary text and Markdown files;
- avoids broad substring matching, so names such as `monkey.txt`, `hockey.txt`, `keynote.txt`, `tokenizer-notes.txt`, and `secretary-agenda.txt` remain inline-eligible.

This is not content-level secret detection. It is a conservative filename safety boundary.

## Verification

- [x] Tested on Ubuntu 26.04 / Linux x86_64
- [x] 54 Discord document and attachment regression tests passed
- [x] `ruff check` on all changed Python files
- [x] `python -m py_compile` on all changed Python files
- [x] `git diff --check`

The end-to-end test proves a synthetic credential body is absent from the constructed prompt while the saved file path remains available.