### PR TITLE
fix(acp): reset session counters on /reset (#36045 salvage)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1903,7 +1903,18 @@ class HermesACPAgent(acp.Agent):
 
     def _cmd_reset(self, args: str, state: SessionState) -> str:
         state.history.clear()
-        self.session_manager.save_session(state.session_id)
+        reset_failed = False
+        try:
+            reset_session_state = getattr(state.agent, "reset_session_state", None)
+            if callable(reset_session_state):
+                reset_session_state()
+        except Exception:
+            reset_failed = True
+            logger.warning("ACP session state reset failed for %s", state.session_id, exc_info=True)
+        finally:
+            self.session_manager.save_session(state.session_id)
+        if reset_failed:
+            return "Conversation history cleared. Agent session state reset failed; see logs."
         return "Conversation history cleared."
 
     def _cmd_compact(self, args: str, state: SessionState) -> str:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1541,6 +1541,37 @@ class TestSlashCommands:
         assert "cleared" in result.lower()
         assert len(state.history) == 0
 
+    def test_reset_resets_agent_session_state(self, agent, mock_manager):
+        state = self._make_state(mock_manager)
+        state.history = [{"role": "user", "content": "hello"}]
+        state.agent.reset_session_state = MagicMock()
+
+        with patch.object(agent.session_manager, "save_session") as mock_save:
+            result = agent._handle_slash_command("/reset", state)
+
+        assert "cleared" in result.lower()
+        assert state.history == []
+        state.agent.reset_session_state.assert_called_once_with()
+        mock_save.assert_called_once_with(state.session_id)
+
+    def test_reset_saves_session_when_agent_state_reset_fails(self, agent, mock_manager):
+        state = self._make_state(mock_manager)
+        state.history = [{"role": "user", "content": "hello"}]
+        state.agent.reset_session_state = MagicMock(side_effect=RuntimeError("boom"))
+
+        with (
+            patch.object(agent.session_manager, "save_session") as mock_save,
+            patch("acp_adapter.server.logger") as mock_logger,
+        ):
+            result = agent._handle_slash_command("/reset", state)
+
+        assert "cleared" in result.lower()
+        assert "state reset failed" in result.lower()
+        assert state.history == []
+        state.agent.reset_session_state.assert_called_once_with()
+        mock_save.assert_called_once_with(state.session_id)
+        mock_logger.warning.assert_called_once()
+
     def test_version(self, agent, mock_manager):
         state = self._make_state(mock_manager)
         result = agent._handle_slash_command("/version", state)


### PR DESCRIPTION
## Summary
ACP `/reset` now clears session token counters and compressor state, not just history — previously `_cmd_reset` only did `state.history.clear()`, so context-usage numbers leaked into the next conversation.

Fixes #35823. Salvage of #36045 by @BlackishGreen33 — clean cherry-pick, authorship preserved. The same fix was independently proposed in #35827 by @liuhao1024 (submitted first — credited); this implementation was chosen as the more defensive of the two (guarded `getattr`/callable check, try/except with degraded message, save in `finally`).

Note on scope: ACP has no separate `/new` — `reset` is the registered slash command (`_SLASH_COMMANDS`/dispatch table), so this single site covers the reported symptom.

## Changes
- `acp_adapter/server.py`: `_cmd_reset` calls `state.agent.reset_session_state()` (exists on `AIAgent`), warns + returns a degraded message on failure, always saves.
- `tests/acp/test_server.py`: 2 regression tests.

## Validation
`scripts/run_tests.sh tests/acp/test_server.py` → 82 passed.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa27696/qFKdpQNcXc-Cg4thryOdJ_XYZgf6H1.png)
