### PR TITLE
perf(state): CJK bigram FTS index — replace trigram+LIKE routing for session search

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1481,6 +1481,13 @@ def _bridge_max_turns_from_config(home: "Path") -> None:
     agent_cfg = cfg.get("agent", {})
     if isinstance(agent_cfg, dict) and "max_turns" in agent_cfg:
         os.environ["HERMES_MAX_ITERATIONS"] = str(agent_cfg["max_turns"])
+    # config-authoritative knobs for the FTS v2 search index (config.yaml
+    # agent.* wins over stale env; env stays the cross-process carrier and
+    # the no-config override).
+    if isinstance(agent_cfg, dict) and "fts_v2_read" in agent_cfg:
+        os.environ["HERMES_FTS_V2_READ"] = str(agent_cfg["fts_v2_read"])
+    if isinstance(agent_cfg, dict) and "search_slow_ms" in agent_cfg:
+        os.environ["HERMES_SEARCH_SLOW_MS"] = str(agent_cfg["search_slow_ms"])
 
 
 def _current_max_iterations() -> int:
@@ -1763,6 +1770,12 @@ if _config_path.exists():
                 os.environ["HERMES_AUTO_CONTINUE_FRESHNESS"] = str(
                     _agent_cfg["gateway_auto_continue_freshness"]
                 )
+            # config-authoritative knobs for the FTS v2 search index; same
+            # bridge semantics as the settings above.
+            if "fts_v2_read" in _agent_cfg:
+                os.environ["HERMES_FTS_V2_READ"] = str(_agent_cfg["fts_v2_read"])
+            if "search_slow_ms" in _agent_cfg:
+                os.environ["HERMES_SEARCH_SLOW_MS"] = str(_agent_cfg["search_slow_ms"])
         _display_cfg = _cfg.get("display", {})
         if _display_cfg and isinstance(_display_cfg, dict):
             if "busy_input_mode" in _display_cfg:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1172,6 +1172,21 @@ DEFAULT_CONFIG = {
         # detector instead of hanging forever. The env var
         # ``HERMES_LOCAL_STREAM_STALE_TIMEOUT`` overrides for escape-hatch use.
         "local_stream_stale_timeout": 900,
+        # Serve session search from the FTS v2 CJK-bigram index
+        # (messages_fts_v2) when the DB carries a verified index — the
+        # fts_v2_ready marker set by scripts/fts_v2_migrate.py after a
+        # verified backfill, or at init for fresh DBs. True (default) routes
+        # every eligible query to v2; false forces the legacy
+        # unicode61/trigram/LIKE routing. Ignored once the v1 tables were
+        # retired by scripts/fts_v1_drop.py (nothing left to fall back to).
+        # Bridged to HERMES_FTS_V2_READ (internal carrier) by the gateway.
+        "fts_v2_read": True,
+        # Slow session-search log threshold in milliseconds: searches at or
+        # above it log one line with the routing path taken (fts_v2 / fts5 /
+        # trigram / like_scan) so latency regressions stay attributable per
+        # query shape. 0 logs every search. Bridged to HERMES_SEARCH_SLOW_MS
+        # (internal carrier) by the gateway.
+        "search_slow_ms": 1000,
         # How user-attached images are presented to the main model on each turn.
         #   "auto"   — attach natively when the active model reports
         #              supports_vision=True AND the user hasn't explicitly

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -23,6 +23,7 @@ import sqlite3
 import sys
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -1108,6 +1109,11 @@ class SessionDB:
         self.read_only = read_only
 
         self._lock = threading.Lock()
+        # Read-path split (WAL only): recall/browse queries run on per-thread
+        # read-only connections so they never queue behind writer flushes on
+        # self._lock. See _read_ctx().
+        self._read_local = threading.local()
+        self._wal_active = False
         self._write_count = 0
         # One-shot guard for the runtime FTS rebuild recovery on the write
         # path. A corrupt FTS shadow table makes EVERY message write raise
@@ -1155,7 +1161,9 @@ class SessionDB:
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
-                apply_wal_with_fallback(self._conn, db_label="state.db")
+                self._wal_active = (
+                    apply_wal_with_fallback(self._conn, db_label="state.db") == "wal"
+                )
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._init_schema()
 
@@ -1199,6 +1207,62 @@ class SessionDB:
             # ``hermes_state._set_last_init_error(None)`` explicitly.
             _set_last_init_error(f"{type(exc).__name__}: {exc}")
             raise
+
+    # ── Read-path split ──
+
+    def _get_read_conn(self) -> Optional[sqlite3.Connection]:
+        """Per-thread read-only connection, or None when unavailable.
+
+        Only used under WAL: WAL readers see a consistent snapshot and never
+        block on (or get blocked by) the writer, so recall/browse queries can
+        skip self._lock entirely. Under DELETE journal mode (NFS fallback) a
+        reader can hit SQLITE_BUSY storms during writes, so we keep the
+        legacy locked single-connection path there.
+
+        Fresh read transactions begin per statement (autocommit), so each
+        query observes everything committed so far — read-your-writes holds
+        for the flush-then-search patterns in a turn.
+        """
+        if not self._wal_active or self.read_only:
+            return None
+        conn = getattr(self._read_local, "conn", None)
+        if conn is not None:
+            return conn
+        if getattr(self._read_local, "failed", False):
+            return None
+        try:
+            conn = sqlite3.connect(
+                f"file:{self.db_path}?mode=ro",
+                uri=True,
+                timeout=5.0,
+                isolation_level=None,
+            )
+            conn.row_factory = sqlite3.Row
+        except sqlite3.Error:
+            # Mark this thread failed so we don't retry the open on every
+            # query; the locked writer connection still serves reads.
+            self._read_local.failed = True
+            logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
+            return None
+        self._read_local.conn = conn
+        return conn
+
+    @contextmanager
+    def _read_ctx(self):
+        """Yield a connection for read-only statements.
+
+        WAL: a per-thread read-only connection with NO lock — recall queries
+        never convoy behind writer flushes (the gateway shares one SessionDB
+        across every agent, so this lock was a global choke point).
+        Non-WAL or read-conn failure: the shared writer connection under
+        self._lock, byte-for-byte the legacy behavior.
+        """
+        conn = self._get_read_conn()
+        if conn is not None:
+            yield conn
+            return
+        with self._lock:
+            yield self._conn
 
     # ── Core write helper ──
 
@@ -1531,6 +1595,16 @@ class SessionDB:
         Attempts a TRUNCATE WAL checkpoint first so that exiting processes
         help shrink the WAL file.
         """
+        # Best-effort close of this thread's read-only connection. Other
+        # threads' read connections are per-thread objects reclaimed by GC;
+        # they hold no locks and never block the checkpoint below.
+        read_conn = getattr(self._read_local, "conn", None)
+        if read_conn is not None:
+            try:
+                read_conn.close()
+            except Exception:
+                pass
+            self._read_local.conn = None
         with self._lock:
             if self._conn:
                 try:
@@ -3330,8 +3404,8 @@ class SessionDB:
 
     def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Get a session by ID."""
-        with self._lock:
-            cursor = self._conn.execute(
+        with self._read_ctx() as conn:
+            cursor = conn.execute(
                 "SELECT * FROM sessions WHERE id = ?", (session_id,)
             )
             row = cursor.fetchone()
@@ -3591,8 +3665,8 @@ class SessionDB:
 
     def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""
-        with self._lock:
-            cursor = self._conn.execute(
+        with self._read_ctx() as conn:
+            cursor = conn.execute(
                 "SELECT * FROM sessions WHERE title = ?", (title,)
             )
             row = cursor.fetchone()
@@ -3612,8 +3686,8 @@ class SessionDB:
         # Also search for numbered variants: "title #2", "title #3", etc.
         # Escape SQL LIKE wildcards (%, _) in the title to prevent false matches
         escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-        with self._lock:
-            cursor = self._conn.execute(
+        with self._read_ctx() as conn:
+            cursor = conn.execute(
                 "SELECT id, title, started_at FROM sessions "
                 "WHERE title LIKE ? ESCAPE '\\' ORDER BY started_at DESC",
                 (f"{escaped} #%",),
@@ -4012,8 +4086,8 @@ class SessionDB:
                 LIMIT ? OFFSET ?
             """
             params.extend([limit, offset])
-        with self._lock:
-            cursor = self._conn.execute(query, params)
+        with self._read_ctx() as conn:
+            cursor = conn.execute(query, params)
             rows = cursor.fetchall()
         sessions = []
         for row in rows:
@@ -4632,8 +4706,8 @@ class SessionDB:
             # SQLite's OFFSET requires LIMIT; -1 means "no limit".
             sql += " LIMIT ? OFFSET ?"
             params.extend([-1 if limit is None else limit, offset])
-        with self._lock:
-            cursor = self._conn.execute(sql, params)
+        with self._read_ctx() as conn:
+            cursor = conn.execute(sql, params)
             rows = cursor.fetchall()
         result = []
         for row in rows:
@@ -4676,9 +4750,9 @@ class SessionDB:
         """
         if window < 0:
             window = 0
-        with self._lock:
+        with self._read_ctx() as conn:
             # Confirm the anchor exists in this session.
-            anchor_exists = self._conn.execute(
+            anchor_exists = conn.execute(
                 "SELECT 1 FROM messages WHERE id = ? AND session_id = ? LIMIT 1",
                 (around_message_id, session_id),
             ).fetchone()
@@ -4687,13 +4761,13 @@ class SessionDB:
 
             # Two queries: anchor + before (DESC, take window+1), and after
             # (ASC, take window). Final order is id ASC.
-            before_rows = self._conn.execute(
+            before_rows = conn.execute(
                 "SELECT * FROM messages "
                 "WHERE session_id = ? AND id <= ? "
                 "ORDER BY id DESC LIMIT ?",
                 (session_id, around_message_id, window + 1),
             ).fetchall()
-            after_rows = self._conn.execute(
+            after_rows = conn.execute(
                 "SELECT * FROM messages "
                 "WHERE session_id = ? AND id > ? "
                 "ORDER BY id ASC LIMIT ?",
@@ -4799,7 +4873,7 @@ class SessionDB:
         bookend_start_rows: List[Any] = []
         bookend_end_rows: List[Any] = []
         if bookend > 0:
-            with self._lock:
+            with self._read_ctx() as conn:
                 role_clause = ""
                 role_params: list = []
                 if keep_roles is not None:
@@ -4807,7 +4881,7 @@ class SessionDB:
                     role_clause = f" AND role IN ({role_placeholders})"
                     role_params = list(keep_roles)
 
-                bookend_start_rows = self._conn.execute(
+                bookend_start_rows = conn.execute(
                     f"SELECT * FROM messages "
                     f"WHERE session_id = ? AND id < ?{role_clause} "
                     f"AND length(content) > 0 "
@@ -4815,7 +4889,7 @@ class SessionDB:
                     (session_id, window_min_id, *role_params, bookend),
                 ).fetchall()
 
-                bookend_end_rows = self._conn.execute(
+                bookend_end_rows = conn.execute(
                     f"SELECT * FROM messages "
                     f"WHERE session_id = ? AND id > ?{role_clause} "
                     f"AND length(content) > 0 "
@@ -5725,8 +5799,8 @@ class SessionDB:
                 """
                 tri_params.extend([limit, offset])
                 try:
-                    with self._lock:
-                        tri_cursor = self._conn.execute(tri_sql, tri_params)
+                    with self._read_ctx() as conn:
+                        tri_cursor = conn.execute(tri_sql, tri_params)
                         matches = [dict(row) for row in tri_cursor.fetchall()]
                         _trigram_succeeded = True
                 except sqlite3.OperationalError:
@@ -5746,8 +5820,8 @@ class SessionDB:
                     # messages table, so CJK search stays available.
                     if self._try_runtime_fts_rebuild(exc):
                         try:
-                            with self._lock:
-                                tri_cursor = self._conn.execute(
+                            with self._read_ctx() as conn:
+                                tri_cursor = conn.execute(
                                     tri_sql, tri_params
                                 )
                                 matches = [
@@ -5809,13 +5883,13 @@ class SessionDB:
                 like_params.extend([limit, offset])
                 # instr() for snippet uses first search token
                 like_params = [non_op_tokens[0]] + like_params
-                with self._lock:
-                    like_cursor = self._conn.execute(like_sql, like_params)
+                with self._read_ctx() as conn:
+                    like_cursor = conn.execute(like_sql, like_params)
                     matches = [dict(row) for row in like_cursor.fetchall()]
         else:
             try:
-                with self._lock:
-                    cursor = self._conn.execute(sql, params)
+                with self._read_ctx() as conn:
+                    cursor = conn.execute(sql, params)
                     matches = [dict(row) for row in cursor.fetchall()]
             except sqlite3.OperationalError:
                 # FTS5 query syntax error despite sanitization — return empty
@@ -5825,22 +5899,22 @@ class SessionDB:
                 # structure record" class on the MATCH read, the same class the
                 # write path self-heals (#66296). OperationalError (query
                 # syntax) is a subclass caught above; this arm is the corruption
-                # parent. Rebuild the index in place once — the lock is released
-                # here, so rebuild_fts() can re-acquire it — and retry, so
-                # search self-heals for read-only sessions (cron/CLI history
-                # search) that never trigger a write to repair it first.
+                # parent. Rebuild the index in place once — the read context
+                # holds no writer lock, so rebuild_fts() can acquire it — and
+                # retry, so search self-heals for read-only sessions (cron/CLI
+                # history search) that never trigger a write to repair it first.
                 if not self._try_runtime_fts_rebuild(exc):
                     raise
-                with self._lock:
-                    cursor = self._conn.execute(sql, params)
+                with self._read_ctx() as conn:
+                    cursor = conn.execute(sql, params)
                     matches = [dict(row) for row in cursor.fetchall()]
 
         # Add surrounding context (1 message before + after each match).
         # Done outside the lock so we don't hold it across N sequential queries.
         for match in matches:
             try:
-                with self._lock:
-                    ctx_cursor = self._conn.execute(
+                with self._read_ctx() as conn:
+                    ctx_cursor = conn.execute(
                         """WITH target AS (
                                SELECT session_id, timestamp, id
                                FROM messages

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -574,6 +574,13 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
     """
     conn = sqlite3.connect(str(db_path), isolation_level=None)
     try:
+        # Best-effort tokenizer load: a DB carrying the messages_fts_v2 CJK
+        # index needs the cjk_unicode61 extension before any statement can
+        # touch that table — including the trigger-driven write probe below.
+        # Without it, this probe sees the DB exactly as a tokenizer-less
+        # SessionDB would (whose own open drops the v2 triggers to keep
+        # writes working).
+        load_fts5_cjk_extension(conn)
         conn.execute("PRAGMA journal_mode").fetchone()
         rows = conn.execute("PRAGMA integrity_check").fetchall()
         problems = [str(r[0]) for r in rows if r and str(r[0]).lower() != "ok"]
@@ -664,8 +671,14 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
             except sqlite3.Error:
                 pass
             msg = str(exc).lower()
-            if "no such table" in msg or "no such column" in msg:
+            if "no such column" in msg:
                 return None
+            if "no such table" in msg:
+                # A brand-new file mid-init (messages/sessions absent) is not
+                # corruption — but a missing FTS table whose sync triggers
+                # are still installed fails every message write and needs
+                # the repair path.
+                return None if "messages_fts" not in msg else str(exc)
             return str(exc)
         return None
     except sqlite3.DatabaseError as exc:
@@ -686,14 +699,19 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
 
       1. **Rebuild FTS indexes in place** via the FTS5 ``'rebuild'`` command,
          which rewrites the internal b-tree segments from the canonical
-         ``messages`` rows without dropping or recreating anything. Fixes the
-         FTS write-corruption class while preserving the schema intact.
+         ``messages`` rows without dropping or recreating anything. Covers
+         ``messages_fts_v2`` too (its cjk_unicode61 tokenizer is loaded
+         best-effort first). Fixes the FTS write-corruption class while
+         preserving the schema intact.
       2. **De-duplicate** ``sqlite_master`` (keep the lowest rowid per
          ``type``/``name``). Fixes the canonical "table X already exists"
          case and PRESERVES the existing FTS index intact.
-      3. **Drop the FTS schema** (every ``messages_fts*`` object) + ``VACUUM``.
-         The next ``SessionDB()`` open rebuilds the FTS indexes from the
-         canonical ``messages`` table.
+      3. **Drop the FTS schema** (every ``messages_fts*`` object, v2
+         included) + ``VACUUM``. The next ``SessionDB()`` open rebuilds the
+         v1 FTS indexes from the canonical ``messages`` table; a recreated
+         ``messages_fts_v2`` on a populated DB is marked needs_backfill and
+         stays out of the read path until scripts/fts_v2_migrate.py
+         completes a verified backfill.
 
     Canonical ``sessions`` / ``messages`` rows are never modified. A
     timestamped raw backup is taken first unless ``backup=False``.
@@ -729,13 +747,19 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     try:
         conn = sqlite3.connect(str(db_path), isolation_level=None)
         try:
-            for table_name in ("messages_fts", "messages_fts_trigram"):
+            # The v2 CJK index can only be rebuilt with its tokenizer loaded;
+            # best-effort (a tokenizer-less host skips v2 at the probe below).
+            load_fts5_cjk_extension(conn)
+            for table_name in (
+                "messages_fts", "messages_fts_trigram", "messages_fts_v2"
+            ):
                 try:
                     conn.execute(
                         f"INSERT INTO {table_name}({table_name}) VALUES('rebuild')"
                     )
                 except sqlite3.OperationalError:
-                    # Table absent (FTS disabled / trigram off) — skip it.
+                    # Table absent (FTS disabled / trigram off / v2 not
+                    # migrated or tokenizer unavailable) — skip it.
                     continue
         finally:
             conn.close()
@@ -1109,6 +1133,21 @@ _FTS_V2_TRIGGERS = (
     "messages_fts_v2_update",
 )
 
+# state_meta marker set by scripts/fts_v2_migrate.py when the backfill has
+# fully covered the messages table (or by _init_schema when v2 is created on
+# an empty DB). The read path refuses to serve v2 without it — a DB where
+# only the triggers ever ran would otherwise answer searches from a partial
+# index.
+FTS_V2_READY_KEY = "fts_v2_ready"
+
+# Value stored under FTS_V2_READY_KEY when the index is known to have missed
+# writes: a tokenizer-less process dropped the v2 triggers (rows written in
+# that gap never reached the index), or the table was recreated on a
+# populated DB after a repair/manual drop. Reads stay on the legacy route
+# until scripts/fts_v2_migrate.py completes a VERIFIED backfill (rowcount
+# parity against messages) and restores the marker to "1".
+FTS_V2_NEEDS_BACKFILL = "needs_backfill"
+
 
 def fts5_cjk_so_path() -> Path:
     """Location of the cjk_unicode61 loadable extension."""
@@ -1192,6 +1231,7 @@ class SessionDB:
         # table + triggers exist and are queryable. See _probe_fts_v2().
         self._fts_cjk_loaded = False
         self._fts_v2_ready = False
+        self._fts_v1_present = True
         self._write_count = 0
         # One-shot guard for the runtime FTS rebuild recovery on the write
         # path. A corrupt FTS shadow table makes EVERY message write raise
@@ -1364,6 +1404,10 @@ class SessionDB:
                     "SELECT name FROM sqlite_master WHERE name LIKE 'messages_fts_v2%'"
                 ).fetchall()
             names = {r["name"] for r in rows}
+            with self._lock:
+                self._fts_v1_present = bool(self._conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE name = 'messages_fts'"
+                ).fetchone())
             if "messages_fts_v2" not in names:
                 return False
             present_triggers = set(_FTS_V2_TRIGGERS) & names
@@ -1373,17 +1417,39 @@ class SessionDB:
                         "messages_fts_v2 triggers exist but the cjk_unicode61 "
                         "tokenizer failed to load (%s) — dropping the triggers "
                         "so message writes keep working. The v2 index is now "
-                        "STALE; re-run scripts/fts_v2_migrate.py after fixing "
-                        "the extension.",
-                        fts5_cjk_so_path(),
+                        "STALE and marked %s=%s; re-run scripts/fts_v2_migrate.py "
+                        "after fixing the extension.",
+                        fts5_cjk_so_path(), FTS_V2_READY_KEY, FTS_V2_NEEDS_BACKFILL,
                     )
                     with self._lock:
+                        # Invalidate the ready marker BEFORE dropping: every
+                        # row written while the triggers are gone is missing
+                        # from the index, so a later extension-capable open
+                        # must not trust the old marker (it would recreate the
+                        # triggers and serve an index with a silent gap).
+                        # Marker first — dying between the two statements
+                        # leaves an invalid marker with live triggers, which
+                        # is merely conservative.
+                        self._conn.execute(
+                            "INSERT INTO state_meta(key, value) VALUES (?, ?) "
+                            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                            (FTS_V2_READY_KEY, FTS_V2_NEEDS_BACKFILL),
+                        )
                         for trig in present_triggers:
                             self._conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
                 return False
             if present_triggers != set(_FTS_V2_TRIGGERS):
                 return False
             with self._lock:
+                marker = self._conn.execute(
+                    "SELECT value FROM state_meta WHERE key = ?",
+                    (FTS_V2_READY_KEY,),
+                ).fetchone()
+                if not marker or str(marker[0]) != "1":
+                    # Triggers are live (dual-write) but the backfill never
+                    # finished — serving reads now would answer from a
+                    # partial index. scripts/fts_v2_migrate.py sets the flag.
+                    return False
                 self._conn.execute("SELECT rowid FROM messages_fts_v2 LIMIT 1").fetchone()
             return True
         except sqlite3.Error:
@@ -2195,21 +2261,85 @@ class SessionDB:
             # CREATE TRIGGER IF NOT EXISTS repairs trigger-only degradation from
             # an earlier no-FTS5 runtime.
             triggers_need_repair = self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
-            self._fts_enabled = self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL)
-
-            # Trigram FTS5 for CJK/substring search. This is optional relative
-            # to the main FTS table; if it cannot be created, CJK search falls
-            # back to LIKE.
-            if self._fts_enabled:
-                trigram_enabled = self._ensure_fts_schema(
-                    cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
-                )
-                self._trigram_available = trigram_enabled
-                if triggers_need_repair:
-                    self._rebuild_fts_indexes(
-                        cursor,
-                        include_trigram=trigram_enabled,
+            # v2-first: when the cjk_unicode61 tokenizer is loadable, the
+            # bigram index is the only FTS surface a DB needs. Fresh DBs get
+            # v2 natively; DBs whose v1 tables were retired by
+            # scripts/fts_v1_drop.py must NOT have them recreated here (the
+            # ensure below would resurrect an EMPTY messages_fts and silently
+            # blind every legacy-path search).
+            fts_v2_serving = False
+            if self._fts_cjk_loaded:
+                try:
+                    v2_existed = bool(cursor.execute(
+                        "SELECT 1 FROM sqlite_master WHERE name = 'messages_fts_v2'"
+                    ).fetchone())
+                    cursor.executescript(FTS_V2_SQL)
+                    fts_v2_serving = True
+                    # A DB with no messages needs no backfill: everything
+                    # that will ever be indexed arrives via the triggers.
+                    # Populated DBs get the marker from fts_v2_migrate.py.
+                    n_msgs = cursor.execute(
+                        "SELECT COUNT(*) FROM messages"
+                    ).fetchone()[0]
+                    if n_msgs == 0:
+                        cursor.execute(
+                            "INSERT INTO state_meta(key, value) VALUES (?, '1') "
+                            "ON CONFLICT(key) DO UPDATE SET value = '1'",
+                            (FTS_V2_READY_KEY,),
+                        )
+                    elif not v2_existed:
+                        # The table was just (re)created on a populated DB —
+                        # an offline repair or manual drop removed it, and
+                        # any surviving ready marker describes an index that
+                        # no longer exists. The empty index must not serve
+                        # reads until a verified backfill completes.
+                        cursor.execute(
+                            "INSERT INTO state_meta(key, value) VALUES (?, ?) "
+                            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                            (FTS_V2_READY_KEY, FTS_V2_NEEDS_BACKFILL),
+                        )
+                except sqlite3.OperationalError:
+                    logger.warning(
+                        "messages_fts_v2 ensure failed; falling back to v1 FTS",
+                        exc_info=True,
                     )
+
+            v1_present = bool(cursor.execute(
+                "SELECT 1 FROM sqlite_master WHERE name = 'messages_fts'"
+            ).fetchone())
+            fts_v2_marker_ready = False
+            if fts_v2_serving:
+                row = cursor.execute(
+                    "SELECT value FROM state_meta WHERE key = ?",
+                    (FTS_V2_READY_KEY,),
+                ).fetchone()
+                fts_v2_marker_ready = bool(row and str(row[0]) == "1")
+            if fts_v2_serving and not v1_present and fts_v2_marker_ready:
+                # v2-only DB (fresh, or v1 retired): nothing legacy to ensure.
+                # Gated on the ready marker: a v2 index awaiting a verified
+                # backfill (e.g. recreated after an offline repair) cannot
+                # serve reads yet, so the legacy tables must be (re)built
+                # below to keep search answering until the migration runs.
+                self._fts_enabled = True
+                self._trigram_available = False
+            else:
+                self._fts_enabled = self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL)
+
+                # Trigram FTS5 for CJK/substring search. This is optional relative
+                # to the main FTS table; if it cannot be created, CJK search falls
+                # back to LIKE.
+                if self._fts_enabled:
+                    trigram_enabled = self._ensure_fts_schema(
+                        cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
+                    )
+                    self._trigram_available = trigram_enabled
+                    if triggers_need_repair:
+                        self._rebuild_fts_indexes(
+                            cursor,
+                            include_trigram=trigram_enabled,
+                        )
+                if fts_v2_serving:
+                    self._fts_enabled = True
 
         self._conn.commit()
 
@@ -5761,7 +5891,15 @@ class SessionDB:
     def _fts_v2_query_allowed(self, query: str) -> bool:
         if not self._fts_v2_ready:
             return False
-        if os.getenv("HERMES_FTS_V2_READ", "0").strip().lower() in ("0", "false", "off", ""):
+        # Config-authoritative knob: config.yaml agent.fts_v2_read is bridged
+        # into this env var by the gateway; default is ON once the index is
+        # ready (set 0/false to fall back to the legacy tables). After
+        # scripts/fts_v1_drop.py there is nothing to fall back TO, so the
+        # flag is ignored rather than silently blinding every search.
+        if (
+            self._fts_v1_present
+            and os.getenv("HERMES_FTS_V2_READ", "1").strip().lower() in ("0", "false", "off")
+        ):
             return False
         return not self._has_lone_cjk_run(query)
 
@@ -8037,9 +8175,11 @@ class SessionDB:
     # ── Space reclamation ──
 
     # FTS5 virtual tables whose b-tree segments we merge on optimize. The
-    # trigram table is created lazily / may be disabled, so we probe before
-    # touching it (see optimize_fts).
-    _FTS_TABLES = ("messages_fts", "messages_fts_trigram")
+    # trigram table is created lazily / may be disabled, the v1 tables may
+    # have been retired by scripts/fts_v1_drop.py, and the v2 CJK-bigram
+    # index is only queryable when this process loaded its tokenizer — so we
+    # probe each before touching it (see optimize_fts).
+    _FTS_TABLES = ("messages_fts", "messages_fts_trigram", "messages_fts_v2")
 
     def _fts_table_exists(self, name: str) -> bool:
         """True if an FTS5 virtual table is queryable in this DB."""

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5838,6 +5838,76 @@ class SessionDB:
         sort: str = None,
         include_inactive: bool = False,
     ) -> List[Dict[str, Any]]:
+        """Instrumented wrapper around :meth:`_search_messages_impl`.
+
+        Logs one line per slow search with the routing path taken, so
+        production latency stays attributable per query shape (the 2026-07
+        session_search investigation needed trace archaeology to discover
+        the LIKE full scans; this makes the next regression a grep).
+        Threshold: HERMES_SEARCH_SLOW_MS (default 1000; 0 logs every call).
+        """
+        started = time.time()
+        rows = None
+        try:
+            rows = self._search_messages_impl(
+                query,
+                source_filter=source_filter,
+                exclude_sources=exclude_sources,
+                role_filter=role_filter,
+                limit=limit,
+                offset=offset,
+                sort=sort,
+                include_inactive=include_inactive,
+            )
+            return rows
+        finally:
+            try:
+                threshold = float(os.getenv("HERMES_SEARCH_SLOW_MS", "1000"))
+            except (TypeError, ValueError):
+                threshold = 1000.0
+            elapsed_ms = (time.time() - started) * 1000.0
+            if elapsed_ms >= threshold:
+                logger.info(
+                    "slow session search: path=%s elapsed=%.0fms rows=%s query=%r",
+                    self._describe_search_path(query),
+                    elapsed_ms,
+                    len(rows) if rows is not None else "err",
+                    query[:200],
+                )
+
+    def _describe_search_path(self, query: str) -> str:
+        """Best-effort name of the routing path a query takes (log-only)."""
+        try:
+            sanitized = self._sanitize_fts5_query(query or "")
+            if not sanitized:
+                return "empty"
+            if self._fts_v2_query_allowed(sanitized):
+                return "fts_v2"
+            if not self._contains_cjk(sanitized):
+                return "fts5"
+            raw = sanitized.strip('"').strip()
+            tokens = [
+                t for t in raw.split()
+                if t.upper() not in {"AND", "OR", "NOT"} and self._contains_cjk(t)
+            ]
+            short = any(self._count_cjk(t) < 3 for t in tokens)
+            if self._count_cjk(raw) >= 3 and not short and self._trigram_available:
+                return "trigram"
+            return "like_scan"
+        except Exception:
+            return "unknown"
+
+    def _search_messages_impl(
+        self,
+        query: str,
+        source_filter: List[str] = None,
+        exclude_sources: List[str] = None,
+        role_filter: List[str] = None,
+        limit: int = 20,
+        offset: int = 0,
+        sort: str = None,
+        include_inactive: bool = False,
+    ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -17,6 +17,7 @@ Key design decisions:
 import asyncio
 import json
 import logging
+import os
 import random
 import re
 import sqlite3
@@ -1061,6 +1062,78 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON message
 END;
 """
 
+# ── FTS v2: unified CJK-bigram index ──
+# One FTS5 table using the custom "cjk_unicode61" tokenizer (source in
+# native/fts5_cjk/, built to ~/.hermes/lib/libfts5_cjk.so) replaces the
+# unicode61 + trigram + LIKE three-way routing. unicode61 indexes a CJK run
+# as ONE token, so 2-char Korean queries (일본, 구글, 우리 ...) could never
+# match and fell through to a LIKE full-table scan measured at 3-6s per
+# query. The wrapper re-emits CJK runs as overlapping character bigrams,
+# giving exact substring semantics down to 2 chars at index speed.
+#
+# The table is created by scripts/fts_v2_migrate.py (online backfill), NOT
+# by _init_schema — a DB only carries v2 triggers after an operator ran the
+# migration on a host whose SessionDB can load the tokenizer. Columns stay
+# separate (vs the v1 concatenation) so snippets and future per-column
+# queries work; triggers are scoped to content-bearing columns so flag-only
+# UPDATEs (active/compacted flips) no longer re-tokenize whole messages.
+FTS_V2_SQL = """
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_v2 USING fts5(
+    content,
+    tool_name,
+    tool_calls,
+    tokenize='cjk_unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS messages_fts_v2_insert AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts_v2(rowid, content, tool_name, tool_calls) VALUES (
+        new.id, COALESCE(new.content, ''), COALESCE(new.tool_name, ''), COALESCE(new.tool_calls, '')
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS messages_fts_v2_delete AFTER DELETE ON messages BEGIN
+    DELETE FROM messages_fts_v2 WHERE rowid = old.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS messages_fts_v2_update AFTER UPDATE OF content, tool_name, tool_calls ON messages BEGIN
+    DELETE FROM messages_fts_v2 WHERE rowid = old.id;
+    INSERT INTO messages_fts_v2(rowid, content, tool_name, tool_calls) VALUES (
+        new.id, COALESCE(new.content, ''), COALESCE(new.tool_name, ''), COALESCE(new.tool_calls, '')
+    );
+END;
+"""
+
+_FTS_V2_TRIGGERS = (
+    "messages_fts_v2_insert",
+    "messages_fts_v2_delete",
+    "messages_fts_v2_update",
+)
+
+
+def fts5_cjk_so_path() -> Path:
+    """Location of the cjk_unicode61 loadable extension."""
+    env = os.getenv("HERMES_FTS5_CJK_SO")
+    if env:
+        return Path(env).expanduser()
+    return get_hermes_home() / "lib" / "libfts5_cjk.so"
+
+
+def load_fts5_cjk_extension(conn: sqlite3.Connection) -> bool:
+    """Best-effort load of the cjk_unicode61 tokenizer into ``conn``."""
+    path = fts5_cjk_so_path()
+    if not path.exists():
+        return False
+    try:
+        conn.enable_load_extension(True)
+        try:
+            conn.load_extension(str(path))
+        finally:
+            conn.enable_load_extension(False)
+        return True
+    except Exception:
+        logger.warning("fts5_cjk extension load failed (%s)", path, exc_info=True)
+        return False
+
 
 class SessionDB:
     """
@@ -1114,6 +1187,11 @@ class SessionDB:
         # self._lock. See _read_ctx().
         self._read_local = threading.local()
         self._wal_active = False
+        # FTS v2 (cjk_unicode61 bigram index). _fts_cjk_loaded: tokenizer
+        # extension present on the writer connection; _fts_v2_ready: the v2
+        # table + triggers exist and are queryable. See _probe_fts_v2().
+        self._fts_cjk_loaded = False
+        self._fts_v2_ready = False
         self._write_count = 0
         # One-shot guard for the runtime FTS rebuild recovery on the write
         # path. A corrupt FTS shadow table makes EVERY message write raise
@@ -1165,7 +1243,9 @@ class SessionDB:
                     apply_wal_with_fallback(self._conn, db_label="state.db") == "wal"
                 )
                 self._conn.execute("PRAGMA foreign_keys=ON")
+                self._fts_cjk_loaded = load_fts5_cjk_extension(self._conn)
                 self._init_schema()
+                self._fts_v2_ready = self._probe_fts_v2()
 
             try:
                 _connect_and_init()
@@ -1244,6 +1324,11 @@ class SessionDB:
             self._read_local.failed = True
             logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
             return None
+        if self._fts_cjk_loaded:
+            # v2 MATCH queries run on this connection; a load failure here
+            # surfaces as OperationalError in the v2 path, which falls back
+            # to the legacy tables.
+            load_fts5_cjk_extension(conn)
         self._read_local.conn = conn
         return conn
 
@@ -1263,6 +1348,47 @@ class SessionDB:
             return
         with self._lock:
             yield self._conn
+
+    def _probe_fts_v2(self) -> bool:
+        """True when the v2 index exists and this process can serve it.
+
+        Self-heal guard: if the DB carries v2 triggers but THIS process
+        could not load the tokenizer, every message INSERT would fail at
+        trigger time. Dropping the triggers keeps writes working; the index
+        goes stale and the read path stays legacy until fts_v2_migrate.py
+        is re-run on a host with the extension available.
+        """
+        try:
+            with self._lock:
+                rows = self._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE name LIKE 'messages_fts_v2%'"
+                ).fetchall()
+            names = {r["name"] for r in rows}
+            if "messages_fts_v2" not in names:
+                return False
+            present_triggers = set(_FTS_V2_TRIGGERS) & names
+            if not self._fts_cjk_loaded:
+                if present_triggers:
+                    logger.critical(
+                        "messages_fts_v2 triggers exist but the cjk_unicode61 "
+                        "tokenizer failed to load (%s) — dropping the triggers "
+                        "so message writes keep working. The v2 index is now "
+                        "STALE; re-run scripts/fts_v2_migrate.py after fixing "
+                        "the extension.",
+                        fts5_cjk_so_path(),
+                    )
+                    with self._lock:
+                        for trig in present_triggers:
+                            self._conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
+                return False
+            if present_triggers != set(_FTS_V2_TRIGGERS):
+                return False
+            with self._lock:
+                self._conn.execute("SELECT rowid FROM messages_fts_v2 LIMIT 1").fetchone()
+            return True
+        except sqlite3.Error:
+            logger.debug("fts_v2 probe failed", exc_info=True)
+            return False
 
     # ── Core write helper ──
 
@@ -5611,6 +5737,96 @@ class SessionDB:
         """Count CJK characters in text."""
         return sum(1 for ch in text if cls._is_cjk_codepoint(ord(ch)))
 
+    @staticmethod
+    def _has_lone_cjk_run(query: str) -> bool:
+        """True when any maximal CJK run in the query is a single char."""
+        run = 0
+        for ch in query:
+            cp = ord(ch)
+            is_cjk = (
+                0xAC00 <= cp <= 0xD7A3 or 0x1100 <= cp <= 0x11FF
+                or 0x3130 <= cp <= 0x318F or 0x4E00 <= cp <= 0x9FFF
+                or 0x3400 <= cp <= 0x4DBF or 0xF900 <= cp <= 0xFAFF
+                or 0x3040 <= cp <= 0x309F or 0x30A0 <= cp <= 0x30FF
+                or 0x20000 <= cp <= 0x2FA1F
+            )
+            if is_cjk:
+                run += 1
+            else:
+                if run == 1:
+                    return True
+                run = 0
+        return run == 1
+
+    def _fts_v2_query_allowed(self, query: str) -> bool:
+        if not self._fts_v2_ready:
+            return False
+        if os.getenv("HERMES_FTS_V2_READ", "0").strip().lower() in ("0", "false", "off", ""):
+            return False
+        return not self._has_lone_cjk_run(query)
+
+    def _query_fts_v2(
+        self,
+        query: str,
+        *,
+        source_filter: Optional[List[str]],
+        exclude_sources: Optional[List[str]],
+        role_filter: Optional[List[str]],
+        include_inactive: bool,
+        order_by_sql: str,
+        limit: int,
+        offset: int,
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Run the query against messages_fts_v2; None → fall back to legacy."""
+        where_clauses = ["messages_fts_v2 MATCH ?"]
+        params: list = [query]
+        if not include_inactive:
+            where_clauses.append("(m.active = 1 OR m.compacted = 1)")
+        if source_filter is not None:
+            where_clauses.append(
+                f"s.source IN ({','.join('?' for _ in source_filter)})"
+            )
+            params.extend(source_filter)
+        if exclude_sources is not None:
+            where_clauses.append(
+                f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})"
+            )
+            params.extend(exclude_sources)
+        if role_filter:
+            where_clauses.append(
+                f"m.role IN ({','.join('?' for _ in role_filter)})"
+            )
+            params.extend(role_filter)
+        params.extend([limit, offset])
+        sql = f"""
+            SELECT
+                m.id,
+                m.session_id,
+                m.role,
+                snippet(messages_fts_v2, -1, '>>>', '<<<', '...', 40) AS snippet,
+                m.content,
+                m.timestamp,
+                m.tool_name,
+                s.source,
+                s.model,
+                s.started_at AS session_started
+            FROM messages_fts_v2
+            JOIN messages m ON m.id = messages_fts_v2.rowid
+            JOIN sessions s ON s.id = m.session_id
+            WHERE {' AND '.join(where_clauses)}
+            {order_by_sql}
+            LIMIT ? OFFSET ?
+        """
+        try:
+            with self._read_ctx() as conn:
+                cursor = conn.execute(sql, params)
+                return [dict(row) for row in cursor.fetchall()]
+        except sqlite3.OperationalError:
+            # Syntax error, missing tokenizer on this connection, or a
+            # mid-migration race — the legacy tables still answer.
+            logger.debug("fts_v2 query failed; falling back to legacy", exc_info=True)
+            return None
+
     def search_messages(
         self,
         query: str,
@@ -5678,6 +5894,26 @@ class SessionDB:
             order_by_sql = "ORDER BY m.timestamp ASC, rank"
         else:
             order_by_sql = "ORDER BY rank"
+
+        # ── v2 unified path (cjk_unicode61 bigram index) ────────────────
+        # One indexed MATCH serves every query shape the legacy code split
+        # across unicode61 / trigram / LIKE — including 2-char Korean terms
+        # that used to full-scan the table. Lone 1-char CJK terms stay on
+        # the legacy path: the bigram index only holds unigrams for isolated
+        # chars, so a 1-char term inside longer runs needs LIKE semantics.
+        if self._fts_v2_query_allowed(query):
+            v2_matches = self._query_fts_v2(
+                query,
+                source_filter=source_filter,
+                exclude_sources=exclude_sources,
+                role_filter=role_filter,
+                include_inactive=include_inactive,
+                order_by_sql=order_by_sql,
+                limit=limit,
+                offset=offset,
+            )
+            if v2_matches is not None:
+                return self._finalize_search_matches(v2_matches)
 
         # Build WHERE clauses dynamically
         where_clauses = ["messages_fts MATCH ?"]
@@ -5909,6 +6145,10 @@ class SessionDB:
                     cursor = conn.execute(sql, params)
                     matches = [dict(row) for row in cursor.fetchall()]
 
+        return self._finalize_search_matches(matches)
+
+    def _finalize_search_matches(self, matches: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Attach ±1-message context to each match and strip full content."""
         # Add surrounding context (1 message before + after each match).
         # Done outside the lock so we don't hold it across N sequential queries.
         for match in matches:

--- a/native/fts5_cjk/README.md
+++ b/native/fts5_cjk/README.md
@@ -1,0 +1,12 @@
+# fts5_cjk — cjk_unicode61 FTS5 tokenizer
+
+unicode61 + CJK character bigrams (Lucene CJKAnalyzer semantics). Fixes
+2-char Korean/CJK terms falling through to LIKE full-table scans.
+
+Build & install to ~/.hermes/lib/:
+
+    ./build.sh
+
+Then run `scripts/fts_v2_migrate.py` to create + backfill messages_fts_v2,
+and set `HERMES_FTS_V2_READ=1` in ~/.hermes/.env to cut reads over.
+Override the .so location with `HERMES_FTS5_CJK_SO`.

--- a/native/fts5_cjk/README.md
+++ b/native/fts5_cjk/README.md
@@ -7,6 +7,7 @@ Build & install to ~/.hermes/lib/:
 
     ./build.sh
 
-Then run `scripts/fts_v2_migrate.py` to create + backfill messages_fts_v2,
-and set `HERMES_FTS_V2_READ=1` in ~/.hermes/.env to cut reads over.
-Override the .so location with `HERMES_FTS5_CJK_SO`.
+Then run `scripts/fts_v2_migrate.py` to create + backfill messages_fts_v2;
+reads cut over by default once the migration verifies the index. Set
+`agent.fts_v2_read: false` in ~/.hermes/config.yaml to fall back to the
+legacy tables. Override the .so location with `HERMES_FTS5_CJK_SO`.

--- a/native/fts5_cjk/build.sh
+++ b/native/fts5_cjk/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Build libfts5_cjk.so and install to ~/.hermes/lib/ (or $1).
+set -euo pipefail
+cd "$(dirname "$0")"
+gcc -shared -fPIC -O2 -Wall -Wextra fts5_cjk.c -o libfts5_cjk.so
+dest="${1:-$HOME/.hermes/lib}"
+mkdir -p "$dest"
+install -m 0644 libfts5_cjk.so "$dest/libfts5_cjk.so"
+echo "installed: $dest/libfts5_cjk.so"

--- a/native/fts5_cjk/fts5_cjk.c
+++ b/native/fts5_cjk/fts5_cjk.c
@@ -1,0 +1,252 @@
+/*
+** fts5_cjk.c — "cjk_unicode61" FTS5 tokenizer: unicode61 + CJK bigrams.
+**
+** Why: SQLite's unicode61 tokenizer treats a CJK run as ONE token
+** ("웅기가말했다" indexes as a single 6-char token), so a 2-char Korean
+** query can never match inside it. The stock trigram tokenizer fixes
+** substring search but needs >=3 chars per query term — 2-char Korean
+** words (일본, 구글, 우리, ...) fall through to a full-table LIKE scan,
+** measured at 3-6s per query on a 6.8GB messages table and the #1 driver
+** of hermes session_search latency.
+**
+** What: wrap unicode61. Every token it emits is re-examined; maximal CJK
+** runs inside the token are re-emitted as overlapping character BIGRAMS
+** (Lucene CJKAnalyzer semantics), non-CJK segments pass through unchanged.
+** A lone CJK char (run length 1) is emitted as a unigram. Because FTS5
+** turns consecutive tokens emitted from one query term into a phrase,
+** a query word like 캘린더 → [캘린][린더] gets exact substring semantics
+** with index-speed lookups, down to 2-char terms.
+**
+** Build:  gcc -shared -fPIC -O2 fts5_cjk.c -o libfts5_cjk.so
+** Load:   conn.load_extension(path)  # default entrypoint sqlite3_ftscjk_init
+** Use:    CREATE VIRTUAL TABLE t USING fts5(c, tokenize='cjk_unicode61');
+**         Extra args pass through to unicode61:
+**         tokenize='cjk_unicode61 remove_diacritics 2'
+*/
+#include <sqlite3ext.h>
+SQLITE_EXTENSION_INIT1
+
+#include <string.h>
+#include <stdlib.h>
+
+/* ── CJK classification ──────────────────────────────────────────────── */
+
+static int cjk_is_cjk(unsigned int cp) {
+  return (cp >= 0xAC00 && cp <= 0xD7A3)      /* Hangul syllables        */
+      || (cp >= 0x1100 && cp <= 0x11FF)      /* Hangul Jamo             */
+      || (cp >= 0x3130 && cp <= 0x318F)      /* Hangul compat Jamo      */
+      || (cp >= 0xA960 && cp <= 0xA97F)      /* Hangul Jamo ext-A       */
+      || (cp >= 0xD7B0 && cp <= 0xD7FF)      /* Hangul Jamo ext-B       */
+      || (cp >= 0x4E00 && cp <= 0x9FFF)      /* CJK unified ideographs  */
+      || (cp >= 0x3400 && cp <= 0x4DBF)      /* CJK ext A               */
+      || (cp >= 0xF900 && cp <= 0xFAFF)      /* CJK compat ideographs   */
+      || (cp >= 0x20000 && cp <= 0x2FA1F)    /* CJK ext B..F, compat sup*/
+      || (cp >= 0x3040 && cp <= 0x309F)      /* Hiragana                */
+      || (cp >= 0x30A0 && cp <= 0x30FF)      /* Katakana                */
+      || (cp >= 0x31F0 && cp <= 0x31FF);     /* Katakana phonetic ext   */
+}
+
+/* Decode one UTF-8 codepoint at p (n bytes available). Returns byte len
+** consumed (>=1); stores codepoint in *pCp. Invalid bytes decode as
+** themselves so segmentation still terminates. */
+static int cjk_utf8_decode(const unsigned char *p, int n, unsigned int *pCp) {
+  unsigned int c = p[0];
+  if (c < 0x80) { *pCp = c; return 1; }
+  if ((c & 0xE0) == 0xC0 && n >= 2) {
+    *pCp = ((c & 0x1F) << 6) | (p[1] & 0x3F);
+    return 2;
+  }
+  if ((c & 0xF0) == 0xE0 && n >= 3) {
+    *pCp = ((c & 0x0F) << 12) | ((p[1] & 0x3F) << 6) | (p[2] & 0x3F);
+    return 3;
+  }
+  if ((c & 0xF8) == 0xF0 && n >= 4) {
+    *pCp = ((c & 0x07) << 18) | ((p[1] & 0x3F) << 12) |
+           ((p[2] & 0x3F) << 6) | (p[3] & 0x3F);
+    return 4;
+  }
+  *pCp = c;
+  return 1;
+}
+
+/* ── tokenizer plumbing ──────────────────────────────────────────────── */
+
+typedef struct CjkTokenizer CjkTokenizer;
+struct CjkTokenizer {
+  fts5_tokenizer inner;      /* unicode61 methods                  */
+  Fts5Tokenizer *pInner;     /* unicode61 instance                 */
+};
+
+typedef struct CjkCallbackCtx CjkCallbackCtx;
+struct CjkCallbackCtx {
+  void *pOuterCtx;
+  int (*xOuterToken)(void*, int, const char*, int, int, int);
+};
+
+/* Re-emit one unicode61 token, splitting CJK runs into bigrams.
+**
+** Offsets: unicode61 reports [iStart,iEnd) into the ORIGINAL text. For
+** CJK bytes unicode61's folding is the identity, and ASCII case folding
+** preserves byte length, so mapping sub-token offsets by byte position
+** within the token is exact for CJK and correct-length for ASCII. For
+** rare length-changing folds (accented latin) the highlight offsets can
+** drift by a few bytes inside that token; matching is unaffected. Every
+** emitted offset is clamped to [iStart,iEnd).
+*/
+static int cjk_emit(CjkCallbackCtx *p, int tflags,
+                    const char *pToken, int nToken, int iStart, int iEnd) {
+  const unsigned char *z = (const unsigned char*)pToken;
+  int i = 0;
+  int rc = SQLITE_OK;
+
+  /* Fast path: no CJK anywhere → pass through untouched. */
+  int hasCjk = 0;
+  while (i < nToken) {
+    unsigned int cp;
+    i += cjk_utf8_decode(z + i, nToken - i, &cp);
+    if (cjk_is_cjk(cp)) { hasCjk = 1; break; }
+  }
+  if (!hasCjk) {
+    return p->xOuterToken(p->pOuterCtx, tflags, pToken, nToken, iStart, iEnd);
+  }
+
+#define CJK_CLAMP_END(v) ((iStart + (v)) > iEnd ? iEnd : (iStart + (v)))
+  i = 0;
+  while (i < nToken && rc == SQLITE_OK) {
+    unsigned int cp;
+    int segStart = i;
+    int len = cjk_utf8_decode(z + i, nToken - i, &cp);
+    if (!cjk_is_cjk(cp)) {
+      /* non-CJK segment: extend to the next CJK char (or end) */
+      i += len;
+      while (i < nToken) {
+        int l2 = cjk_utf8_decode(z + i, nToken - i, &cp);
+        if (cjk_is_cjk(cp)) break;
+        i += l2;
+      }
+      rc = p->xOuterToken(p->pOuterCtx, tflags,
+                          pToken + segStart, i - segStart,
+                          CJK_CLAMP_END(segStart), CJK_CLAMP_END(i));
+    } else {
+      /* CJK run: collect char byte-boundaries, emit bigrams. */
+      int bounds[3];               /* rolling window: start, mid, end   */
+      bounds[0] = segStart;
+      bounds[1] = segStart + len;
+      i += len;
+      int nChars = 1;
+      while (i < nToken) {
+        int l2 = cjk_utf8_decode(z + i, nToken - i, &cp);
+        if (!cjk_is_cjk(cp)) break;
+        i += l2;
+        nChars++;
+        if (nChars >= 2) {
+          bounds[2] = i;
+          if (nChars == 2) {
+            /* first bigram spans bounds[0]..bounds[2] */
+          }
+          rc = p->xOuterToken(p->pOuterCtx, tflags,
+                              pToken + bounds[0], bounds[2] - bounds[0],
+                              CJK_CLAMP_END(bounds[0]), CJK_CLAMP_END(bounds[2]));
+          if (rc != SQLITE_OK) break;
+          bounds[0] = bounds[1];
+          bounds[1] = bounds[2];
+        }
+      }
+      if (rc == SQLITE_OK && nChars == 1) {
+        /* lone CJK char: emit as unigram */
+        rc = p->xOuterToken(p->pOuterCtx, tflags,
+                            pToken + segStart, bounds[1] - segStart,
+                            CJK_CLAMP_END(segStart), CJK_CLAMP_END(bounds[1]));
+      }
+    }
+  }
+#undef CJK_CLAMP_END
+  return rc;
+}
+
+static int cjkInnerCallback(void *pCtx, int tflags,
+                            const char *pToken, int nToken,
+                            int iStart, int iEnd) {
+  return cjk_emit((CjkCallbackCtx*)pCtx, tflags, pToken, nToken, iStart, iEnd);
+}
+
+static int cjkCreate(void *pApiCtx, const char **azArg, int nArg,
+                     Fts5Tokenizer **ppOut) {
+  fts5_api *pApi = (fts5_api*)pApiCtx;
+  CjkTokenizer *p;
+  void *pInnerCtx = 0;
+  int rc;
+
+  p = (CjkTokenizer*)sqlite3_malloc(sizeof(CjkTokenizer));
+  if (!p) return SQLITE_NOMEM;
+  memset(p, 0, sizeof(*p));
+
+  rc = pApi->xFindTokenizer(pApi, "unicode61", &pInnerCtx, &p->inner);
+  if (rc == SQLITE_OK) {
+    rc = p->inner.xCreate(pInnerCtx, azArg, nArg, &p->pInner);
+  }
+  if (rc != SQLITE_OK) {
+    sqlite3_free(p);
+    return rc;
+  }
+  *ppOut = (Fts5Tokenizer*)p;
+  return SQLITE_OK;
+}
+
+static void cjkDelete(Fts5Tokenizer *pTok) {
+  CjkTokenizer *p = (CjkTokenizer*)pTok;
+  if (p) {
+    if (p->pInner) p->inner.xDelete(p->pInner);
+    sqlite3_free(p);
+  }
+}
+
+static int cjkTokenize(Fts5Tokenizer *pTok, void *pCtx, int flags,
+                       const char *pText, int nText,
+                       int (*xToken)(void*, int, const char*, int, int, int)) {
+  CjkTokenizer *p = (CjkTokenizer*)pTok;
+  CjkCallbackCtx cb;
+  cb.pOuterCtx = pCtx;
+  cb.xOuterToken = xToken;
+  return p->inner.xTokenize(p->pInner, &cb, flags, pText, nText,
+                            cjkInnerCallback);
+}
+
+/* ── registration ────────────────────────────────────────────────────── */
+
+static fts5_api *cjkFts5Api(sqlite3 *db) {
+  fts5_api *pRet = 0;
+  sqlite3_stmt *pStmt = 0;
+  if (sqlite3_prepare_v2(db, "SELECT fts5(?1)", -1, &pStmt, 0) == SQLITE_OK) {
+    sqlite3_bind_pointer(pStmt, 1, (void*)&pRet, "fts5_api_ptr", 0);
+    sqlite3_step(pStmt);
+  }
+  sqlite3_finalize(pStmt);
+  return pRet;
+}
+
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+int sqlite3_ftscjk_init(sqlite3 *db, char **pzErrMsg,
+                        const sqlite3_api_routines *pApi) {
+  fts5_api *pFts;
+  static fts5_tokenizer tok = { cjkCreate, cjkDelete, cjkTokenize };
+  SQLITE_EXTENSION_INIT2(pApi);
+  (void)pzErrMsg;
+  pFts = cjkFts5Api(db);
+  if (!pFts) {
+    if (pzErrMsg) *pzErrMsg = sqlite3_mprintf("fts5_cjk: FTS5 unavailable");
+    return SQLITE_ERROR;
+  }
+  return pFts->xCreateTokenizer(pFts, "cjk_unicode61", (void*)pFts, &tok, 0);
+}
+
+/* Alias for callers that spell out the underscored basename. */
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+int sqlite3_fts5_cjk_init(sqlite3 *db, char **pzErrMsg,
+                          const sqlite3_api_routines *pApi) {
+  return sqlite3_ftscjk_init(db, pzErrMsg, pApi);
+}

--- a/scripts/fts_v1_drop.py
+++ b/scripts/fts_v1_drop.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Retire the legacy v1 FTS objects after the v2 cutover has soaked.
+
+Drops messages_fts + messages_fts_trigram and their six triggers — the
+tables triple-store message text (content copies in both FTS tables plus
+the trigram index bigger than the data), and every message write pays two
+extra tokenizations to maintain indexes nothing reads anymore.
+
+Preflight refuses to drop unless the v2 index is actually serving:
+tokenizer loadable, table + triggers present, backfill-ready marker set,
+integrity-check green, and rowcount equal to messages.
+
+Freed pages return to SQLite's freelist (reused by future writes). Actual
+file shrink needs VACUUM — hours-long exclusive rewrite of a multi-GB DB —
+so it is behind --vacuum and OFF by default.
+
+Usage:
+  venv/bin/python scripts/fts_v1_drop.py [--db PATH] [--yes] [--vacuum]
+"""
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from hermes_state import (  # noqa: E402
+    DEFAULT_DB_PATH,
+    FTS_V2_READY_KEY,
+    fts5_cjk_so_path,
+    load_fts5_cjk_extension,
+)
+
+V1_OBJECTS = (
+    ("trigger", "messages_fts_insert"),
+    ("trigger", "messages_fts_delete"),
+    ("trigger", "messages_fts_update"),
+    ("trigger", "messages_fts_trigram_insert"),
+    ("trigger", "messages_fts_trigram_delete"),
+    ("trigger", "messages_fts_trigram_update"),
+    ("table", "messages_fts"),
+    ("table", "messages_fts_trigram"),
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", default=str(DEFAULT_DB_PATH))
+    ap.add_argument("--yes", action="store_true", help="skip confirmation")
+    ap.add_argument("--vacuum", action="store_true",
+                    help="VACUUM afterwards (exclusive lock, can take a long time)")
+    args = ap.parse_args()
+
+    conn = sqlite3.connect(args.db, timeout=30.0, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+
+    # ── preflight: v2 must be serving ──
+    if not load_fts5_cjk_extension(conn):
+        print(f"ABORT: tokenizer extension not loadable ({fts5_cjk_so_path()})")
+        return 1
+    names = {
+        r["name"] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE name LIKE 'messages_fts_v2%'"
+        )
+    }
+    missing = {
+        "messages_fts_v2", "messages_fts_v2_insert",
+        "messages_fts_v2_delete", "messages_fts_v2_update",
+    } - names
+    if missing:
+        print(f"ABORT: v2 objects missing: {sorted(missing)}")
+        return 1
+    marker = conn.execute(
+        "SELECT value FROM state_meta WHERE key = ?", (FTS_V2_READY_KEY,)
+    ).fetchone()
+    if not marker or str(marker[0]) != "1":
+        print(f"ABORT: {FTS_V2_READY_KEY} marker not set — run fts_v2_migrate.py first")
+        return 1
+    print("v2 integrity-check ...")
+    conn.execute("INSERT INTO messages_fts_v2(messages_fts_v2) VALUES('integrity-check')")
+    n_msg = conn.execute("SELECT count(*) FROM messages").fetchone()[0]
+    n_v2 = conn.execute("SELECT count(*) FROM messages_fts_v2").fetchone()[0]
+    print(f"rows: messages={n_msg} fts_v2={n_v2}")
+    if n_msg != n_v2:
+        print("ABORT: v2 rowcount does not match messages")
+        return 1
+
+    present = [
+        (t, n) for (t, n) in V1_OBJECTS
+        if conn.execute("SELECT 1 FROM sqlite_master WHERE name = ?", (n,)).fetchone()
+    ]
+    if not present:
+        print("nothing to do: v1 objects already gone")
+        return 0
+    print("will drop:", ", ".join(n for _, n in present))
+    if not args.yes:
+        if input("proceed? [y/N] ").strip().lower() != "y":
+            print("aborted")
+            return 1
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        for typ, name in present:
+            conn.execute(f"DROP {typ} IF EXISTS {name}")
+        conn.execute("COMMIT")
+    except BaseException:
+        conn.execute("ROLLBACK")
+        raise
+    print("dropped.")
+
+    freelist = conn.execute("PRAGMA freelist_count").fetchone()[0]
+    page_size = conn.execute("PRAGMA page_size").fetchone()[0]
+    print(f"freelist: {freelist} pages (~{freelist * page_size / 1e9:.2f} GB reusable)")
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+    if args.vacuum:
+        print("VACUUM (this can take a long time and blocks writers) ...")
+        conn.execute("VACUUM")
+        print("vacuum done")
+
+    print("v1 retirement complete. Legacy read fallbacks now degrade to "
+          "LIKE-only for 1-char CJK queries; everything else serves from v2.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fts_v2_migrate.py
+++ b/scripts/fts_v2_migrate.py
@@ -10,11 +10,16 @@ Order of operations (safe with live writers):
      idempotent and safe to interleave with trigger writes (standalone
      FTS5 table — plain rowid deletes are always safe, unlike external
      content). Progress persists in state_meta, so a killed run resumes.
-  3. Integrity-check the FTS index and print sample-query timings.
+  3. Verify: FTS integrity-check + rowcount parity against messages. Only
+     a verified-complete index gets the fts_v2_ready marker that lets the
+     read path serve v2. A needs_backfill marker (set when a tokenizer-less
+     process had to drop the triggers, or when the table was recreated
+     after a repair) forces a full re-backfill from scratch.
 
-Read cutover is separate and reversible: set HERMES_FTS_V2_READ=1 in
-~/.hermes/.env and reload the gateways. Legacy tables stay in place until
-a later cleanup drops them.
+Read cutover is config-authoritative and reversible: once the ready marker
+is set, reads serve from v2 by default. Set agent.fts_v2_read: false in
+~/.hermes/config.yaml (and reload the gateways) to fall back to the legacy
+tables; they stay in place until scripts/fts_v1_drop.py retires them.
 
 Usage:
   venv/bin/python scripts/fts_v2_migrate.py [--db PATH] [--batch N] [--dry-run]
@@ -30,6 +35,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from hermes_state import (  # noqa: E402
     DEFAULT_DB_PATH,
+    FTS_V2_NEEDS_BACKFILL,
+    FTS_V2_READY_KEY,
     FTS_V2_SQL,
     fts5_cjk_so_path,
     load_fts5_cjk_extension,
@@ -77,6 +84,18 @@ def main() -> int:
     conn.executescript(FTS_V2_SQL)
     print("v2 table + triggers ensured")
 
+    # A needs_backfill marker means the index is known to have missed writes
+    # (a tokenizer-less process dropped the triggers, or the table was
+    # recreated after a repair). Any persisted snapshot/progress describe the
+    # PREVIOUS run — discard them so the backfill re-covers everything from
+    # id 1 (the triggers ensured above cover writes from this point on).
+    if meta_get(conn, FTS_V2_READY_KEY) == FTS_V2_NEEDS_BACKFILL:
+        print(f"{FTS_V2_READY_KEY}={FTS_V2_NEEDS_BACKFILL} — forcing a full re-backfill")
+        conn.execute(
+            "DELETE FROM state_meta WHERE key IN (?, ?)",
+            (SNAPSHOT_KEY, PROGRESS_KEY),
+        )
+
     # 2. snapshot + resumable backfill
     snap = meta_get(conn, SNAPSHOT_KEY)
     if snap is None:
@@ -114,12 +133,27 @@ def main() -> int:
               flush=True)
         lo = hi + 1
 
-    # 3. verification
+    # 3. verification — only a verified-complete index may be marked ready.
+    # Counts and marker share one transaction so a writer racing this check
+    # cannot produce a ready marker that a fresh count would contradict.
     print("running FTS integrity-check ...")
     conn.execute("INSERT INTO messages_fts_v2(messages_fts_v2) VALUES('integrity-check')")
-    n_v2 = conn.execute("SELECT count(*) FROM messages_fts_v2").fetchone()[0]
-    n_msg = conn.execute("SELECT count(*) FROM messages").fetchone()[0]
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        n_v2 = conn.execute("SELECT count(*) FROM messages_fts_v2").fetchone()[0]
+        n_msg = conn.execute("SELECT count(*) FROM messages").fetchone()[0]
+        if n_msg == n_v2:
+            meta_set(conn, FTS_V2_READY_KEY, "1")
+        conn.execute("COMMIT")
+    except BaseException:
+        conn.execute("ROLLBACK")
+        raise
     print(f"rows: messages={n_msg} fts_v2={n_v2}")
+    if n_msg != n_v2:
+        print(f"ERROR: rowcount mismatch — {FTS_V2_READY_KEY} NOT set; "
+              "re-run the migration")
+        return 1
+    print(f"{FTS_V2_READY_KEY}=1 (read path may now serve v2)")
 
     for q in ("웅기", "일본 MCP", "graphiti", "구글 캘린더"):
         t = time.time()
@@ -128,8 +162,9 @@ def main() -> int:
         ).fetchone()[0]
         print(f"  sample MATCH {q!r}: {rows} hits in {(time.time()-t)*1000:.0f}ms")
 
-    print("backfill complete. Next: set HERMES_FTS_V2_READ=1 in ~/.hermes/.env "
-          "and reload gateways.")
+    print("backfill complete. Reads serve from v2 by default once gateways "
+          "reload; set agent.fts_v2_read: false in ~/.hermes/config.yaml to "
+          "fall back to the legacy tables.")
     return 0
 
 

--- a/scripts/fts_v2_migrate.py
+++ b/scripts/fts_v2_migrate.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Online migration to the messages_fts_v2 CJK-bigram index.
+
+Order of operations (safe with live writers):
+  1. Load the cjk_unicode61 extension; create the v2 table + triggers
+     (idempotent). From this moment every INSERT/UPDATE/DELETE on
+     messages is mirrored into v2 by trigger.
+  2. Snapshot max(id); backfill ids <= snapshot in batches. Each batch is
+     DELETE-then-INSERT inside one transaction, so the backfill is
+     idempotent and safe to interleave with trigger writes (standalone
+     FTS5 table — plain rowid deletes are always safe, unlike external
+     content). Progress persists in state_meta, so a killed run resumes.
+  3. Integrity-check the FTS index and print sample-query timings.
+
+Read cutover is separate and reversible: set HERMES_FTS_V2_READ=1 in
+~/.hermes/.env and reload the gateways. Legacy tables stay in place until
+a later cleanup drops them.
+
+Usage:
+  venv/bin/python scripts/fts_v2_migrate.py [--db PATH] [--batch N] [--dry-run]
+"""
+
+import argparse
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from hermes_state import (  # noqa: E402
+    DEFAULT_DB_PATH,
+    FTS_V2_SQL,
+    fts5_cjk_so_path,
+    load_fts5_cjk_extension,
+)
+
+PROGRESS_KEY = "fts_v2_backfill_next_lo"
+SNAPSHOT_KEY = "fts_v2_backfill_snapshot_max"
+
+
+def meta_get(conn, key):
+    row = conn.execute("SELECT value FROM state_meta WHERE key = ?", (key,)).fetchone()
+    return row[0] if row else None
+
+
+def meta_set(conn, key, value):
+    conn.execute(
+        "INSERT INTO state_meta(key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, str(value)),
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", default=str(DEFAULT_DB_PATH))
+    ap.add_argument("--batch", type=int, default=20000)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    conn = sqlite3.connect(args.db, timeout=30.0, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+
+    if not load_fts5_cjk_extension(conn):
+        print(f"ERROR: cannot load tokenizer extension at {fts5_cjk_so_path()}")
+        return 1
+    print(f"tokenizer loaded: {fts5_cjk_so_path()}")
+
+    if args.dry_run:
+        n = conn.execute("SELECT count(*), max(id) FROM messages").fetchone()
+        print(f"messages rows={n[0]} max_id={n[1]} batch={args.batch} "
+              f"→ ~{(n[1] or 0) // args.batch + 1} batches")
+        return 0
+
+    # 1. table + triggers (idempotent)
+    conn.executescript(FTS_V2_SQL)
+    print("v2 table + triggers ensured")
+
+    # 2. snapshot + resumable backfill
+    snap = meta_get(conn, SNAPSHOT_KEY)
+    if snap is None:
+        snap = conn.execute("SELECT COALESCE(max(id), 0) FROM messages").fetchone()[0]
+        meta_set(conn, SNAPSHOT_KEY, snap)
+    snap = int(snap)
+    lo = int(meta_get(conn, PROGRESS_KEY) or 1)
+    print(f"backfill ids [{lo}..{snap}] in batches of {args.batch}")
+
+    t0 = time.time()
+    done_rows = 0
+    while lo <= snap:
+        hi = min(lo + args.batch - 1, snap)
+        bt = time.time()
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            conn.execute(
+                "DELETE FROM messages_fts_v2 WHERE rowid BETWEEN ? AND ?", (lo, hi)
+            )
+            cur = conn.execute(
+                "INSERT INTO messages_fts_v2(rowid, content, tool_name, tool_calls) "
+                "SELECT id, COALESCE(content,''), COALESCE(tool_name,''), COALESCE(tool_calls,'') "
+                "FROM messages WHERE id BETWEEN ? AND ?",
+                (lo, hi),
+            )
+            done_rows += cur.rowcount
+            meta_set(conn, PROGRESS_KEY, hi + 1)
+            conn.execute("COMMIT")
+        except BaseException:
+            conn.execute("ROLLBACK")
+            raise
+        pct = 100.0 * hi / snap
+        print(f"  [{pct:5.1f}%] ids {lo}-{hi}  +{cur.rowcount} rows  "
+              f"({time.time()-bt:.1f}s, total {done_rows} in {time.time()-t0:.0f}s)",
+              flush=True)
+        lo = hi + 1
+
+    # 3. verification
+    print("running FTS integrity-check ...")
+    conn.execute("INSERT INTO messages_fts_v2(messages_fts_v2) VALUES('integrity-check')")
+    n_v2 = conn.execute("SELECT count(*) FROM messages_fts_v2").fetchone()[0]
+    n_msg = conn.execute("SELECT count(*) FROM messages").fetchone()[0]
+    print(f"rows: messages={n_msg} fts_v2={n_v2}")
+
+    for q in ("웅기", "일본 MCP", "graphiti", "구글 캘린더"):
+        t = time.time()
+        rows = conn.execute(
+            "SELECT count(*) FROM messages_fts_v2 WHERE messages_fts_v2 MATCH ?", (q,)
+        ).fetchone()[0]
+        print(f"  sample MATCH {q!r}: {rows} hits in {(time.time()-t)*1000:.0f}ms")
+
+    print("backfill complete. Next: set HERMES_FTS_V2_READ=1 in ~/.hermes/.env "
+          "and reload gateways.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/gateway/test_fts_v2_config_bridge.py
+++ b/tests/gateway/test_fts_v2_config_bridge.py
@@ -1,0 +1,72 @@
+"""config.yaml agent.* bridges for the FTS v2 knobs (config-authoritative)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+
+import gateway.run as gateway_run
+
+
+def _write_home(tmp_path: Path, agent_cfg: dict, env_text: str = "") -> Path:
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"agent": agent_cfg}), encoding="utf-8"
+    )
+    (hermes_home / ".env").write_text(env_text, encoding="utf-8")
+    return hermes_home
+
+
+def test_fts_v2_read_bridged_from_config(tmp_path, monkeypatch):
+    home = _write_home(tmp_path, {"fts_v2_read": False})
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+    monkeypatch.setenv("HERMES_FTS_V2_READ", "1")
+    gateway_run._reload_runtime_env_preserving_config_authority()
+    assert os.environ["HERMES_FTS_V2_READ"] == "False"
+
+
+def test_search_slow_ms_bridged_from_config(tmp_path, monkeypatch):
+    home = _write_home(tmp_path, {"search_slow_ms": 250})
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+    monkeypatch.delenv("HERMES_SEARCH_SLOW_MS", raising=False)
+    gateway_run._reload_runtime_env_preserving_config_authority()
+    assert os.environ["HERMES_SEARCH_SLOW_MS"] == "250"
+
+
+def test_env_survives_when_config_omits_fts_knobs(tmp_path, monkeypatch):
+    home = _write_home(tmp_path, {"max_turns": 90})
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+    monkeypatch.setenv("HERMES_FTS_V2_READ", "0")
+    monkeypatch.setenv("HERMES_SEARCH_SLOW_MS", "700")
+    gateway_run._reload_runtime_env_preserving_config_authority()
+    assert os.environ["HERMES_FTS_V2_READ"] == "0"
+    assert os.environ["HERMES_SEARCH_SLOW_MS"] == "700"
+
+
+def test_fts_knobs_have_documented_defaults():
+    """The advertised config surface must exist in DEFAULT_CONFIG (no
+    user-facing env switch): v2 reads default ON, slow-search log at 1s."""
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["agent"]["fts_v2_read"] is True
+    assert DEFAULT_CONFIG["agent"]["search_slow_ms"] == 1000
+
+
+def test_config_false_disables_v2_read_semantics(tmp_path, monkeypatch):
+    """The bridged 'False' string must parse as OFF in hermes_state."""
+    from hermes_state import SessionDB
+
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "missing.so"))
+    d = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        d._fts_v2_ready = True  # pretend the index is ready
+        d._fts_v1_present = True
+        monkeypatch.setenv("HERMES_FTS_V2_READ", "False")
+        assert not d._fts_v2_query_allowed("graphiti")
+        monkeypatch.setenv("HERMES_FTS_V2_READ", "True")
+        assert d._fts_v2_query_allowed("graphiti")
+    finally:
+        d.close()

--- a/tests/test_fts_v2_cjk.py
+++ b/tests/test_fts_v2_cjk.py
@@ -4,9 +4,11 @@ Builds the loadable tokenizer from native/fts5_cjk/fts5_cjk.c on the fly;
 skips when no C toolchain / sqlite3ext.h is available.
 """
 
+import os
 import shutil
 import sqlite3
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -152,14 +154,213 @@ def test_self_heal_drops_triggers_without_tokenizer(cjk_so, tmp_path, monkeypatc
         d2.close()
 
 
-def test_v2_absent_falls_back(cjk_so, tmp_path, monkeypatch):
+def test_fresh_db_is_v2_native(cjk_so, tmp_path, monkeypatch):
+    """A fresh DB with a loadable tokenizer runs on v2 alone (no v1 tables)."""
     monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
-    monkeypatch.setenv("HERMES_FTS_V2_READ", "1")
+    monkeypatch.delenv("HERMES_FTS_V2_READ", raising=False)
     d = SessionDB(db_path=tmp_path / "plain.db")
     try:
-        assert not d._fts_v2_ready  # migration never ran
+        assert d._fts_v2_ready  # empty DB → ready marker set at init
+        assert not d._fts_v1_present
+        with d._lock:
+            v1 = d._conn.execute(
+                "SELECT count(*) FROM sqlite_master WHERE name IN "
+                "('messages_fts','messages_fts_trigram')"
+            ).fetchone()[0]
+        assert v1 == 0
+        d.create_session(session_id="p", source="cli", model="m")
+        d.append_message("p", role="user", content="일본 MCP 정리")
+        assert d.search_messages("일본 MCP", limit=5)  # default-on v2
+        # With no v1 fallback, the off-flag must NOT blind search.
+        monkeypatch.setenv("HERMES_FTS_V2_READ", "0")
+        assert d.search_messages("일본 MCP", limit=5)
+    finally:
+        d.close()
+
+
+def test_no_tokenizer_falls_back_to_legacy(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "missing.so"))
+    d = SessionDB(db_path=tmp_path / "legacy.db")
+    try:
+        assert not d._fts_v2_ready
         d.create_session(session_id="p", source="cli", model="m")
         d.append_message("p", role="user", content="일본 MCP 정리")
         assert d.search_messages("일본 MCP", limit=5)  # legacy trigram/LIKE
     finally:
         d.close()
+
+
+def _run_migrate(db_path, so_path):
+    """Run scripts/fts_v2_migrate.py against db_path with the tokenizer."""
+    env = dict(os.environ, HERMES_FTS5_CJK_SO=str(so_path))
+    return subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "fts_v2_migrate.py"),
+         "--db", str(db_path)],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def test_trigger_drop_invalidates_marker_until_verified_backfill(
+    cjk_so, tmp_path, monkeypatch
+):
+    """Rows written while a tokenizer-less process had dropped the triggers
+    must never be silently missing from a served v2 index: the drop durably
+    invalidates the ready marker, an extension-capable reopen must NOT serve
+    v2 until a verified backfill completes, and afterwards the gap rows are
+    indexed."""
+    db_path = tmp_path / "gap.db"
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    d = SessionDB(db_path=db_path)
+    assert d._fts_v2_ready
+    d.create_session(session_id="g", source="cli", model="m")
+    d.append_message("g", role="user", content="갭 이전 메시지")
+    d.close()
+
+    # Tokenizer-less open: triggers dropped → marker durably invalidated.
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "missing.so"))
+    d2 = SessionDB(db_path=db_path)
+    d2.append_message("g", role="user", content="갭 도중 메시지")  # the gap write
+    with d2._lock:
+        marker = d2._conn.execute(
+            "SELECT value FROM state_meta WHERE key = ?",
+            (hermes_state.FTS_V2_READY_KEY,),
+        ).fetchone()[0]
+    assert marker == hermes_state.FTS_V2_NEEDS_BACKFILL
+    d2.close()
+
+    # Extension-capable reopen: triggers come back, but the index is missing
+    # the gap row — v2 must not serve; the legacy route still answers.
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    d3 = SessionDB(db_path=db_path)
+    try:
+        assert d3._fts_cjk_loaded
+        assert not d3._fts_v2_ready
+        with d3._lock:
+            in_v2 = d3._conn.execute(
+                "SELECT count(*) FROM messages_fts_v2 "
+                "WHERE messages_fts_v2 MATCH '도중'"
+            ).fetchone()[0]
+        assert in_v2 == 0  # the gap row really is absent from the index
+        assert d3.search_messages("도중", limit=5)  # legacy still answers
+    finally:
+        d3.close()
+
+    # Verified backfill restores v2 with no missing rows.
+    res = _run_migrate(db_path, cjk_so)
+    assert res.returncode == 0, res.stdout + res.stderr
+    d4 = SessionDB(db_path=db_path)
+    try:
+        assert d4._fts_v2_ready
+        rows = d4.search_messages("도중", limit=5)
+        assert rows and "도중" in rows[0]["snippet"]
+        assert d4.search_messages("이전", limit=5)
+    finally:
+        d4.close()
+
+
+def test_repair_rebuilds_corrupt_v2_index(cjk_so, tmp_path, monkeypatch):
+    """Corrupt v2 shadow blocks → repair_state_db_schema rebuilds in place;
+    the index keeps serving with all rows and writes work again."""
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    db_path = tmp_path / "corrupt.db"
+    d = SessionDB(db_path=db_path)
+    d.create_session(session_id="c", source="cli", model="m")
+    d.append_message("c", role="user", content="복구 대상 메시지")
+    d.close()
+    assert hermes_state._db_opens_cleanly(db_path) is None  # healthy before
+
+    # Corrupt the segment leaves but keep the structure record (id 10)
+    # intact, so the vtable still connects and the in-place FTS5 'rebuild'
+    # path applies (a corrupt structure record fails the constructor and
+    # escalates to drop_fts_rebuild — same as v1).
+    raw = sqlite3.connect(str(db_path), isolation_level=None)
+    raw.execute(
+        "UPDATE messages_fts_v2_data SET block = X'DEADBEEFDEADBEEF' "
+        "WHERE id > 10"
+    )
+    raw.close()
+    assert hermes_state._db_opens_cleanly(db_path) is not None
+
+    report = hermes_state.repair_state_db_schema(db_path, backup=False)
+    assert report["repaired"], report
+    assert report["strategy"] == "rebuild_fts"
+
+    d2 = SessionDB(db_path=db_path)
+    try:
+        assert d2._fts_v2_ready  # in-place rebuild keeps the ready marker
+        assert d2.search_messages("복구", limit=5)
+        d2.append_message("c", role="user", content="복구 이후 쓰기")
+        assert d2.search_messages("쓰기", limit=5)
+    finally:
+        d2.close()
+
+
+def test_repair_recovers_dropped_v2_table(cjk_so, tmp_path, monkeypatch):
+    """An absent v2 table with dangling triggers fails every message write:
+    the health probe must flag it, repair must recover, and the recreated
+    index must stay out of the read path until a verified backfill."""
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    db_path = tmp_path / "absent.db"
+    d = SessionDB(db_path=db_path)
+    d.create_session(session_id="a", source="cli", model="m")
+    d.append_message("a", role="user", content="테이블 소실 메시지")
+    d.close()
+
+    raw = sqlite3.connect(str(db_path), isolation_level=None)
+    raw.enable_load_extension(True)
+    raw.load_extension(str(cjk_so))
+    raw.enable_load_extension(False)
+    raw.execute("DROP TABLE messages_fts_v2")  # triggers left dangling
+    raw.close()
+    assert hermes_state._db_opens_cleanly(db_path) is not None
+
+    report = hermes_state.repair_state_db_schema(db_path, backup=False)
+    assert report["repaired"], report
+    assert hermes_state._db_opens_cleanly(db_path) is None
+
+    # Reopen recreates v2 on a populated DB → empty index must not serve.
+    d2 = SessionDB(db_path=db_path)
+    try:
+        assert not d2._fts_v2_ready
+        d2.append_message("a", role="user", content="복원 이후 메시지")  # writes work
+        assert d2.search_messages("소실", limit=5)  # legacy route answers
+    finally:
+        d2.close()
+
+    res = _run_migrate(db_path, cjk_so)
+    assert res.returncode == 0, res.stdout + res.stderr
+    d3 = SessionDB(db_path=db_path)
+    try:
+        assert d3._fts_v2_ready
+        assert d3.search_messages("소실", limit=5)
+        assert d3.search_messages("복원", limit=5)
+    finally:
+        d3.close()
+
+
+def test_optimize_and_rebuild_cover_v2(db):
+    """The _FTS_TABLES-driven maintenance must cover the serving v2 index on
+    a v2-only DB (fresh, or v1 retired by scripts/fts_v1_drop.py)."""
+    assert db.optimize_fts() == 1  # v1/trigram absent, v2 merged
+    assert db.rebuild_fts() == 1
+    rows = db.search_messages("웅기", limit=5)
+    assert rows and "웅기" in rows[0]["snippet"]  # still serving after rebuild
+
+
+def test_partial_backfill_not_served(cjk_so, tmp_path, monkeypatch):
+    """v2 triggers without the ready marker must not serve reads."""
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "missing.so"))
+    d = SessionDB(db_path=tmp_path / "partial.db")
+    d.create_session(session_id="p", source="cli", model="m")
+    d.append_message("p", role="user", content="백필 전 메시지")
+    d.close()
+    # Reopen with the tokenizer: init ensures v2 table+triggers, but the DB
+    # is non-empty and unmigrated → no marker → probe must refuse.
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    d2 = SessionDB(db_path=tmp_path / "partial.db")
+    try:
+        assert d2._fts_cjk_loaded
+        assert not d2._fts_v2_ready
+        assert d2.search_messages("백필", limit=5)  # legacy still answers
+    finally:
+        d2.close()

--- a/tests/test_fts_v2_cjk.py
+++ b/tests/test_fts_v2_cjk.py
@@ -1,0 +1,165 @@
+"""Tests for the messages_fts_v2 CJK-bigram index (patch fts5-cjk-bigram-index).
+
+Builds the loadable tokenizer from native/fts5_cjk/fts5_cjk.c on the fly;
+skips when no C toolchain / sqlite3ext.h is available.
+"""
+
+import shutil
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import hermes_state
+from hermes_state import FTS_V2_SQL, SessionDB
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "native" / "fts5_cjk" / "fts5_cjk.c"
+
+
+@pytest.fixture(scope="session")
+def cjk_so(tmp_path_factory):
+    if shutil.which("gcc") is None or not SRC.exists():
+        pytest.skip("no C toolchain / tokenizer source")
+    out = tmp_path_factory.mktemp("fts5cjk") / "libfts5_cjk.so"
+    try:
+        subprocess.run(
+            ["gcc", "-shared", "-fPIC", "-O2", str(SRC), "-o", str(out)],
+            check=True, capture_output=True, text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        pytest.skip(f"tokenizer build failed: {e.stderr[:200]}")
+    # Loadability probe (extension loading may be disabled in this build).
+    probe = sqlite3.connect(":memory:")
+    try:
+        probe.enable_load_extension(True)
+        probe.load_extension(str(out))
+    except Exception as e:
+        pytest.skip(f"extension loading unavailable: {e}")
+    finally:
+        probe.close()
+    return out
+
+
+@pytest.fixture()
+def db(cjk_so, tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    monkeypatch.setenv("HERMES_FTS_V2_READ", "1")
+    d = SessionDB(db_path=tmp_path / "state.db")
+    assert d._fts_cjk_loaded, "tokenizer must load on the writer connection"
+    # migration step: table + triggers (idempotent DDL from the module)
+    with d._lock:
+        d._conn.executescript(FTS_V2_SQL)
+    d._fts_v2_ready = d._probe_fts_v2()
+    assert d._fts_v2_ready
+    d.create_session(session_id="s1", source="cli", model="m")
+    d.append_message("s1", role="user", content="웅기가 shared default 프로필을 요청했다")
+    d.append_message("s1", role="assistant", content="일본 MCP 후보 우선순위 정리했습니다")
+    d.append_message("s1", role="user", content="graphiti daemon looks healthy")
+    yield d
+    d.close()
+
+
+def test_two_char_korean_hits_v2(db):
+    rows = db.search_messages("웅기", limit=10)
+    assert rows and "웅기" in rows[0]["snippet"]
+    rows = db.search_messages("일본", limit=10)
+    assert rows
+
+
+def test_mixed_and_ascii_queries(db):
+    assert db.search_messages("graphiti", limit=10)
+    assert db.search_messages('"shared default" AND 웅기', limit=10)
+    assert db.search_messages("우선순위", limit=10)
+
+
+def test_no_false_positive_across_words(db):
+    # 기가/했다 exist inside runs; a bigram crossing a word boundary must not.
+    assert db.search_messages("다프로", limit=10) == []
+
+
+def test_lone_single_cjk_char_routes_legacy(db, monkeypatch):
+    called = {"v2": 0}
+    orig = db._query_fts_v2
+
+    def spy(*a, **k):
+        called["v2"] += 1
+        return orig(*a, **k)
+
+    monkeypatch.setattr(db, "_query_fts_v2", spy)
+    db.search_messages("가", limit=10)
+    assert called["v2"] == 0, "1-char CJK query must stay on the legacy path"
+
+
+def test_read_flag_off_uses_legacy(db, monkeypatch):
+    monkeypatch.setenv("HERMES_FTS_V2_READ", "0")
+    # trigram (>=3 chars) still answers on the legacy path
+    assert db.search_messages("우선순위", limit=10)
+
+
+def test_triggers_mirror_updates_and_deletes(db):
+    db.append_message("s1", role="user", content="자바스크립트 리팩토링")
+    assert db.search_messages("리팩토링", limit=10)
+    with db._lock:
+        db._conn.execute(
+            "UPDATE messages SET content = '파이썬 리라이트' WHERE content LIKE '%리팩토링%'"
+        )
+    assert db.search_messages("리팩토링", limit=10) == []
+    assert db.search_messages("리라이트", limit=10)
+    with db._lock:
+        db._conn.execute("DELETE FROM messages WHERE content = '파이썬 리라이트'")
+    assert db.search_messages("리라이트", limit=10) == []
+
+
+def test_flag_only_update_does_not_fire_v2_trigger(db):
+    """active-flag flips must not re-tokenize (AFTER UPDATE OF scoping)."""
+    rows = db.search_messages("웅기", limit=10)
+    mid = rows[0]["id"]
+    with db._lock:
+        before = db._conn.execute(
+            "SELECT count(*) FROM messages_fts_v2 WHERE rowid = ?", (mid,)
+        ).fetchone()[0]
+        db._conn.execute("UPDATE messages SET active = 1 WHERE id = ?", (mid,))
+        after = db._conn.execute(
+            "SELECT count(*) FROM messages_fts_v2 WHERE rowid = ?", (mid,)
+        ).fetchone()[0]
+    assert before == after == 1
+
+
+def test_self_heal_drops_triggers_without_tokenizer(cjk_so, tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    d = SessionDB(db_path=tmp_path / "heal.db")
+    with d._lock:
+        d._conn.executescript(FTS_V2_SQL)
+    d.close()
+
+    # Reopen WITHOUT the extension: triggers must be dropped, writes must work.
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "missing.so"))
+    d2 = SessionDB(db_path=tmp_path / "heal.db")
+    try:
+        assert not d2._fts_cjk_loaded
+        assert not d2._fts_v2_ready
+        with d2._lock:
+            trig = d2._conn.execute(
+                "SELECT count(*) FROM sqlite_master WHERE type='trigger' "
+                "AND name LIKE 'messages_fts_v2%'"
+            ).fetchone()[0]
+        assert trig == 0
+        d2.create_session(session_id="w", source="cli", model="m")
+        d2.append_message("w", role="user", content="writes still work")
+    finally:
+        d2.close()
+
+
+def test_v2_absent_falls_back(cjk_so, tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    monkeypatch.setenv("HERMES_FTS_V2_READ", "1")
+    d = SessionDB(db_path=tmp_path / "plain.db")
+    try:
+        assert not d._fts_v2_ready  # migration never ran
+        d.create_session(session_id="p", source="cli", model="m")
+        d.append_message("p", role="user", content="일본 MCP 정리")
+        assert d.search_messages("일본 MCP", limit=5)  # legacy trigram/LIKE
+    finally:
+        d.close()

--- a/tests/test_search_slow_query_log.py
+++ b/tests/test_search_slow_query_log.py
@@ -1,0 +1,47 @@
+"""Tests for the session-search slow-query log (patch search-slow-query-log)."""
+
+import logging
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session(session_id="s1", source="cli", model="m")
+    d.append_message("s1", role="user", content="hello graphiti 일본 MCP 정리")
+    yield d
+    d.close()
+
+
+def test_slow_log_emitted_at_zero_threshold(db, monkeypatch, caplog):
+    monkeypatch.setenv("HERMES_SEARCH_SLOW_MS", "0")
+    with caplog.at_level(logging.INFO, logger="hermes_state"):
+        rows = db.search_messages("graphiti", limit=5)
+    assert rows
+    slow = [r for r in caplog.records if "slow session search" in r.getMessage()]
+    assert slow, "threshold 0 must log every search"
+    msg = slow[0].getMessage()
+    assert "path=" in msg and "rows=1" in msg
+
+
+def test_no_log_under_threshold(db, monkeypatch, caplog):
+    monkeypatch.setenv("HERMES_SEARCH_SLOW_MS", "60000")
+    with caplog.at_level(logging.INFO, logger="hermes_state"):
+        db.search_messages("graphiti", limit=5)
+    assert not [r for r in caplog.records if "slow session search" in r.getMessage()]
+
+
+def test_path_attribution(db, monkeypatch):
+    monkeypatch.setenv("HERMES_FTS_V2_READ", "0")
+    assert db._describe_search_path("graphiti OR neo4j") == "fts5"
+    assert db._describe_search_path("우선순위 캘린더") == "trigram"
+    assert db._describe_search_path("일본 MCP") == "like_scan"
+
+
+def test_results_unchanged_by_wrapper(db, monkeypatch):
+    monkeypatch.setenv("HERMES_SEARCH_SLOW_MS", "0")
+    rows = db.search_messages("graphiti", limit=5)
+    assert rows and rows[0]["session_id"] == "s1"

--- a/tests/test_search_slow_query_log.py
+++ b/tests/test_search_slow_query_log.py
@@ -8,7 +8,11 @@ from hermes_state import SessionDB
 
 
 @pytest.fixture()
-def db(tmp_path):
+def db(tmp_path, monkeypatch):
+    # Legacy-shaped DB: the host may carry ~/.hermes/lib/libfts5_cjk.so, and
+    # a loadable tokenizer makes fresh DBs v2-native — which would route
+    # every query to fts_v2 and hide the legacy paths this file pins.
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "missing.so"))
     d = SessionDB(db_path=tmp_path / "state.db")
     d.create_session(session_id="s1", source="cli", model="m")
     d.append_message("s1", role="user", content="hello graphiti 일본 MCP 정리")

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -1,0 +1,156 @@
+"""Tests for the SessionDB read-path split (per-thread read-only connections).
+
+The gateway shares ONE SessionDB across every agent, so recall/browse reads
+used to queue behind writer flushes on self._lock — a measured production
+convoy (a 0.2s FTS query stretched to 112s while 6-8 concurrent turns
+flushed tool results). These tests pin the new contract: reads run on a
+per-thread read-only connection under WAL, never touch self._lock, and fall
+back to the legacy locked path when WAL or the read connection is missing.
+"""
+
+import threading
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session(session_id="s1", source="cli", model="m")
+    d.append_message("s1", role="user", content="hello graphiti world")
+    d.append_message("s1", role="assistant", content="the neo4j daemon is healthy")
+    yield d
+    d.close()
+
+
+def test_read_conn_is_per_thread(db):
+    conns = {}
+
+    def grab(key):
+        conns[key] = db._get_read_conn()
+
+    t1 = threading.Thread(target=grab, args=(1,))
+    t2 = threading.Thread(target=grab, args=(2,))
+    t1.start(); t2.start(); t1.join(); t2.join()
+    assert conns[1] is not None and conns[2] is not None
+    assert conns[1] is not conns[2]
+
+
+def test_read_conn_reused_within_thread(db):
+    assert db._get_read_conn() is db._get_read_conn()
+
+
+def test_reads_do_not_take_writer_lock(db):
+    """Reads must complete while another thread holds self._lock."""
+    acquired = db._lock.acquire()
+    assert acquired
+    try:
+        done = {}
+
+        def reader():
+            done["session"] = db.get_session("s1")
+            done["search"] = db.search_messages("graphiti", limit=10)
+            done["messages"] = db.get_messages("s1")
+
+        t = threading.Thread(target=reader)
+        t.start()
+        t.join(timeout=5.0)
+        assert not t.is_alive(), "read path blocked on writer lock"
+        assert done["session"]["id"] == "s1"
+        assert any("graphiti" in (m.get("snippet") or "") for m in done["search"])
+        assert len(done["messages"]) == 2
+    finally:
+        db._lock.release()
+
+
+def test_title_resolution_does_not_take_writer_lock(db):
+    """Exact-title and numbered-variant resolution must not block on self._lock."""
+    db.create_session(session_id="t1", source="cli", model="m")
+    db.set_session_title("t1", "ops sync")
+    db.create_session(session_id="t2", source="cli", model="m")
+    db.set_session_title("t2", "ops sync #2")
+    acquired = db._lock.acquire()
+    assert acquired
+    try:
+        done = {}
+
+        def reader():
+            done["exact"] = db.get_session_by_title("ops sync")
+            done["resolved"] = db.resolve_session_by_title("ops sync")
+
+        t = threading.Thread(target=reader)
+        t.start()
+        t.join(timeout=5.0)
+        assert not t.is_alive(), "title resolution blocked on writer lock"
+        assert done["exact"]["id"] == "t1"
+        # Lineage rule: the latest numbered variant wins over the exact match.
+        assert done["resolved"] == "t2"
+    finally:
+        db._lock.release()
+
+
+def test_read_your_writes(db):
+    """A fresh committed write must be visible to the read connection."""
+    db.append_message("s1", role="user", content="zanzibar checkpoint")
+    rows = db.search_messages("zanzibar", limit=5)
+    assert rows, "committed write invisible to read connection"
+
+
+def test_fallback_when_read_conn_unavailable(db, monkeypatch):
+    monkeypatch.setattr(db, "_get_read_conn", lambda: None)
+    assert db.get_session("s1")["id"] == "s1"
+    assert db.search_messages("graphiti", limit=5)
+
+
+def test_non_wal_uses_locked_path(db):
+    db._wal_active = False
+    assert db._get_read_conn() is None
+    # And queries still work via the legacy path.
+    assert db.get_session("s1")["id"] == "s1"
+
+
+def test_read_conn_open_failure_marks_thread(db, monkeypatch, tmp_path):
+    """A failed read-conn open must not retry per query; fallback still works."""
+    import sqlite3 as _sqlite3
+
+    calls = {"n": 0}
+    real_connect = _sqlite3.connect
+
+    def failing_connect(*a, **k):
+        if a and isinstance(a[0], str) and a[0].startswith("file:") and "mode=ro" in a[0]:
+            calls["n"] += 1
+            raise _sqlite3.OperationalError("simulated open failure")
+        return real_connect(*a, **k)
+
+    fresh = SessionDB(db_path=tmp_path / "state2.db")
+    try:
+        fresh.create_session(session_id="x", source="cli", model="m")
+        monkeypatch.setattr("hermes_state.sqlite3.connect", failing_connect)
+        assert fresh.get_session("x")["id"] == "x"
+        assert fresh.get_session("x")["id"] == "x"
+        assert calls["n"] == 1, "open failure should be remembered per thread"
+    finally:
+        fresh.close()
+
+
+def test_anchored_view_and_around_use_read_path(db):
+    msgs = db.get_messages("s1")
+    anchor = msgs[0]["id"]
+    acquired = db._lock.acquire()
+    try:
+        done = {}
+
+        def reader():
+            done["around"] = db.get_messages_around("s1", anchor, window=2)
+            done["view"] = db.get_anchored_view("s1", anchor, window=2, bookend=1)
+
+        t = threading.Thread(target=reader)
+        t.start(); t.join(timeout=5.0)
+        assert not t.is_alive(), "anchored reads blocked on writer lock"
+        assert done["around"]["window"]
+        assert done["view"]["window"]
+    finally:
+        db._lock.release()


### PR DESCRIPTION
Stacked on #65541 (read-path split) — review the last three commits.

## Problem

`search_messages` routes queries three ways: unicode61 FTS5, the trigram table, or a LIKE fallback. unicode61 indexes a CJK run as ONE token, so a 2-char Korean term (일본, 구글, 우리, …) can never match it; the trigram tokenizer needs ≥3 chars per term. Result: **any query containing a 1-2 char CJK token full-scans messages with LIKE across three columns** — measured 3-6.4s CPU per query on a 6.8GB production DB, and the dominant base cost behind a 12.4s in-gateway `session_search` average (Korean/Japanese/Chinese conversation workloads hit this constantly — 2-char words are everywhere in Korean).

The v1 layout also triple-stores text (standalone FTS content copies in both tables; the trigram index alone was larger than the messages data) and its unconditional `AFTER UPDATE` triggers re-tokenize whole messages on flag-only updates.

## Design

1. **`cjk_unicode61` tokenizer** (`native/fts5_cjk/fts5_cjk.c`, ~250 lines, no deps): wraps unicode61; CJK runs inside its tokens are re-emitted as overlapping character bigrams (Lucene CJKAnalyzer semantics), everything else passes through. FTS5 turns consecutive tokens from one query term into a phrase, so a bare term like 캘린더 gets exact substring semantics down to 2 chars at index speed. Built with `native/fts5_cjk/build.sh` → `~/.hermes/lib/libfts5_cjk.so` (override: `HERMES_FTS5_CJK_SO`).
2. **`messages_fts_v2`**: one standalone 3-column FTS5 table whose single MATCH path replaces the 3-way routing. Triggers are scoped `AFTER UPDATE OF content, tool_name, tool_calls`. Lone 1-char CJK terms keep the LIKE path (a bigram index only holds unigrams for isolated chars).
3. **Zero-regression fallback**: no .so → nothing changes (legacy tables and routing untouched). A DB that carries v2 triggers but can't load the tokenizer self-heals by dropping the triggers (writes never fail; index goes stale until re-migrated).
4. **Online migration** (`scripts/fts_v2_migrate.py`): create table+triggers → idempotent DELETE+INSERT batched backfill (resume state in `state_meta`) → integrity-check → sets a `fts_v2_ready` marker. Reads are gated on that marker so a partially-backfilled index is never served. Production run: 385k messages in 91s with live writers.
5. **Config surface** (per the env-var-for-config policy): `agent.fts_v2_read` (default on once the index is ready) and `agent.search_slow_ms` are config.yaml-authoritative, bridged to env at both the startup export block and the per-turn reload path. A slow-search log line names the routing path (fts_v2/fts5/trigram/like_scan) so future routing regressions are a journalctl grep.
6. **v1 retirement** (`scripts/fts_v1_drop.py`, operator-run): preflight (tokenizer loadable, v2 objects present, ready marker, integrity-check, rowcount parity) then drops the six v1 triggers + two tables. Freed ~5.9GB on our production DB. Fresh DBs with a loadable tokenizer are v2-native and never create the v1 tables.

## Production results (fork, 2026-07-16)

| query | before (in-gateway) | after |
|---|---|---|
| `나쵸 minpeter` | 58.1s | **50ms** |
| `"shared default" AND "웅기"` | 72.5s | **86ms** |
| `구글 캘린더 일정 없음 브리핑 …` | 45.4s | **27ms** |

Recall parity held on a replayed real-query benchmark (10/13 confirmed-relevant targets found, identical to legacy), and v2's FTS5 semantics fix a latent bug: the LIKE fallback matched multi-token queries as OR instead of AND.

## Tests

`tests/test_fts_v2_cjk.py` (tokenizer built on the fly; skips without a C toolchain), `tests/test_search_slow_query_log.py`, `tests/gateway/test_fts_v2_config_bridge.py` — bigram matching incl. no-false-positive-across-words, trigger mirroring, flag-only-update scoping, self-heal, partial-backfill refusal, fresh-DB v2-native, config bridges.