### PR TITLE
feat(providers): support custom models_url

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -100,6 +100,8 @@ model:
   # providers:
   #   my-proxy:
   #     base_url: "https://llm.internal.example.com/v1"
+  #     # Optional full catalog URL when model discovery is hosted elsewhere.
+  #     models_url: "https://catalog.internal.example.com/api/models"
   #     key_env: "MY_PROXY_API_KEY"
   #     extra_headers:
   #       CF-Access-Client-Id: "xxxx.access"

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -127,6 +127,8 @@ model:
   # providers:
   #   my-proxy:
   #     base_url: "https://llm.internal.example.com/v1"
+  #     # Optional full catalog URL when model discovery is hosted elsewhere.
+  #     models_url: "https://catalog.internal.example.com/api/models"
   #     key_env: "MY_PROXY_API_KEY"
   #     extra_headers:
   #       CF-Access-Client-Id: "xxxx.access"

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4755,6 +4755,7 @@ def _normalize_custom_provider_entry(
     _CAMEL_ALIASES: Dict[str, str] = {
         "apiKey": "api_key",
         "baseUrl": "base_url",
+        "modelsUrl": "models_url",
         "apiMode": "api_mode",
         "keyEnv": "key_env",
         "apiKeyEnv": "key_env",  # alias — OpenClaw-compatible + docs variant
@@ -4773,7 +4774,7 @@ def _normalize_custom_provider_entry(
         # into provider entries. Accept it silently so those (self-written)
         # configs don't warn on every load.
         "provider",
-        "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
+        "name", "api", "url", "base_url", "models_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
@@ -4838,6 +4839,22 @@ def _normalize_custom_provider_entry(
         "name": name,
         "base_url": base_url,
     }
+
+    raw_models_url = entry.get("models_url")
+    if isinstance(raw_models_url, str) and raw_models_url.strip():
+        models_url = raw_models_url.strip()
+        if re.search(r"\{[^}]+\}", models_url):
+            normalized["models_url"] = models_url
+        else:
+            parsed_models_url = urlparse(models_url)
+            if parsed_models_url.scheme and parsed_models_url.netloc:
+                normalized["models_url"] = models_url
+            else:
+                logger.warning(
+                    "providers.%s: 'models_url' value '%s' is not a valid URL "
+                    "(no scheme or host) — ignored",
+                    provider_key or "?", models_url,
+                )
 
     provider_key = provider_key.strip()
     if provider_key:
@@ -4940,6 +4957,7 @@ def _custom_provider_entry_to_provider_config(
 
     for field in (
         "name",
+        "models_url",
         "api_key",
         "key_env",
         "models",
@@ -5289,7 +5307,7 @@ _KNOWN_ROOT_KEYS = {
 
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
-    "name", "base_url", "api_key", "api_mode", "model", "models",
+    "name", "base_url", "models_url", "api_key", "api_mode", "model", "models",
     "context_length", "rate_limit_delay", "extra_body",
     "ssl_ca_cert", "ssl_verify",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1303,6 +1303,7 @@ def _normalize_custom_provider_entry(
     _CAMEL_ALIASES: Dict[str, str] = {
         "apiKey": "api_key",
         "baseUrl": "base_url",
+        "modelsUrl": "models_url",
         "apiMode": "api_mode",
         "keyEnv": "key_env",
         "apiKeyEnv": "key_env",  # alias — OpenClaw-compatible + docs variant
@@ -1321,7 +1322,7 @@ def _normalize_custom_provider_entry(
         # into provider entries. Accept it silently so those (self-written)
         # configs don't warn on every load.
         "provider",
-        "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
+        "name", "api", "url", "base_url", "models_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
@@ -1386,6 +1387,22 @@ def _normalize_custom_provider_entry(
         "name": name,
         "base_url": base_url,
     }
+
+    raw_models_url = entry.get("models_url")
+    if isinstance(raw_models_url, str) and raw_models_url.strip():
+        models_url = raw_models_url.strip()
+        if re.search(r"\{[^}]+\}", models_url):
+            normalized["models_url"] = models_url
+        else:
+            parsed_models_url = urlparse(models_url)
+            if parsed_models_url.scheme and parsed_models_url.netloc:
+                normalized["models_url"] = models_url
+            else:
+                logger.warning(
+                    "providers.%s: 'models_url' value '%s' is not a valid URL "
+                    "(no scheme or host) — ignored",
+                    provider_key or "?", models_url,
+                )
 
     provider_key = provider_key.strip()
     if provider_key:
@@ -1491,6 +1508,7 @@ def _custom_provider_entry_to_provider_config(
 
     for field in (
         "name",
+        "models_url",
         "api_key",
         "key_env",
         "models",
@@ -1882,7 +1900,7 @@ _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
-    "name", "base_url", "api_key", "api_mode", "model", "models",
+    "name", "base_url", "models_url", "api_key", "api_mode", "model", "models",
     "context_length", "rate_limit_delay", "extra_body",
     "ssl_ca_cert", "ssl_verify",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3242,8 +3242,10 @@ def select_provider_and_model(args=None):
             custom_provider_map[key] = {
                 "name": name,
                 "base_url": base_url,
+                "models_url": entry.get("models_url", ""),
                 "api_key": entry.get("api_key", ""),
                 "key_env": entry.get("key_env", ""),
+                "extra_headers": entry.get("extra_headers", {}),
                 "model": entry.get("model", ""),
                 "models": entry.get("models", {}),
                 "discover_models": entry.get("discover_models", True),

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -24,6 +24,7 @@ import argparse
 import os
 import subprocess
 import urllib.parse
+from typing import Any
 
 from hermes_cli.config import clear_model_endpoint_credentials
 from hermes_cli.providers import custom_provider_slug
@@ -1516,6 +1517,7 @@ def _model_flow_named_custom(config, provider_info):
 
     name = provider_info["name"]
     base_url = provider_info["base_url"]
+    models_url = str(provider_info.get("models_url") or "").strip()
     api_mode = provider_info.get("api_mode", "")
     api_key = provider_info.get("api_key", "")
     key_env = provider_info.get("key_env", "")
@@ -1558,9 +1560,14 @@ def _model_flow_named_custom(config, provider_info):
         models = configured_models
     else:
         print("Fetching available models...")
-        fetch_kwargs = {"timeout": 8.0}
+        fetch_kwargs: dict[str, Any] = {"timeout": 8.0}
         if api_mode:
             fetch_kwargs["api_mode"] = api_mode
+        if models_url:
+            fetch_kwargs["models_url"] = models_url
+        extra_headers = provider_info.get("extra_headers")
+        if isinstance(extra_headers, dict) and extra_headers:
+            fetch_kwargs["headers"] = extra_headers
         live_models = fetch_api_models(api_key, base_url, **fetch_kwargs)
         # If the probe came back empty but the operator configured an explicit
         # list, fall back to it rather than forcing manual entry.

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1152,14 +1152,24 @@ def switch_model(
 
     provider_changed = target_provider != current_provider
     provider_label = get_label(target_provider)
+    models_url = ""
     if target_provider == "custom" and current_base_url:
         provider_label = "Custom endpoint"
+    target_pdef: ProviderDef | None = None
     if target_provider.startswith("custom:"):
-        custom_pdef = resolve_provider_full(
+        target_pdef = resolve_provider_full(
             target_provider,
             user_providers,
             custom_providers,
         )
+    elif isinstance(user_providers, dict) and target_provider in user_providers:
+        from hermes_cli.providers import resolve_user_provider
+
+        target_pdef = resolve_user_provider(target_provider, user_providers)
+    if target_pdef is not None:
+        models_url = target_pdef.models_url
+    if target_provider.startswith("custom:"):
+        custom_pdef = target_pdef
         if custom_pdef is not None:
             provider_label = custom_pdef.name
 
@@ -1182,6 +1192,7 @@ def switch_model(
             if _user_pdef is None:
                 _user_pdef = _ruser(target_provider, user_providers)
         if _user_pdef is not None and _user_pdef.base_url:
+            models_url = _user_pdef.models_url
             _ucfg = (user_providers or {}).get(explicit_provider.strip().lower()) \
                 or (user_providers or {}).get(target_provider) or {}
             _ukey = str(_ucfg.get("api_key", "") or "").strip()
@@ -1260,13 +1271,23 @@ def switch_model(
 
     # --- Validate ---
     try:
-        validation = validate_requested_model(
-            new_model,
-            target_provider,
-            api_key=api_key,
-            base_url=base_url,
-            api_mode=api_mode or None,
-        )
+        if models_url:
+            validation = validate_requested_model(
+                new_model,
+                target_provider,
+                api_key=api_key,
+                base_url=base_url,
+                api_mode=api_mode or None,
+                models_url=models_url,
+            )
+        else:
+            validation = validate_requested_model(
+                new_model,
+                target_provider,
+                api_key=api_key,
+                base_url=base_url,
+                api_mode=api_mode or None,
+            )
     except Exception as e:
         validation = {
             "accepted": False,
@@ -1419,6 +1440,26 @@ def _extra_headers_from_config(entry: Any) -> dict[str, str]:
     from hermes_cli.config import normalize_extra_headers
 
     return normalize_extra_headers(entry.get("extra_headers"))
+
+
+def _fetch_configured_api_models(
+    api_key: str,
+    base_url: str,
+    *,
+    headers: dict[str, str] | None,
+    models_url: str = "",
+) -> list[str] | None:
+    """Fetch a custom catalog without changing legacy calls when unset."""
+    from hermes_cli.models import fetch_api_models
+
+    if models_url:
+        return fetch_api_models(
+            api_key,
+            base_url,
+            headers=headers,
+            models_url=models_url,
+        )
+    return fetch_api_models(api_key, base_url, headers=headers)
 
 
 def prewarm_picker_cache_async() -> Optional["_threading.Thread"]:
@@ -2090,11 +2131,13 @@ def list_authenticated_providers(
             )
             if should_probe:
                 try:
-                    from hermes_cli.models import fetch_api_models
-                    live_models = fetch_api_models(
+                    extra_headers = _extra_headers_from_config(ep_cfg) or None
+                    models_url = str(ep_cfg.get("models_url") or "").strip()
+                    live_models = _fetch_configured_api_models(
                         api_key,
                         api_url,
-                        headers=_extra_headers_from_config(ep_cfg) or None,
+                        headers=extra_headers,
+                        models_url=models_url,
                     )
                     if live_models:
                         models_list = live_models
@@ -2177,12 +2220,12 @@ def list_authenticated_providers(
     if custom_providers and isinstance(custom_providers, list):
         from collections import OrderedDict
 
-        # Key by endpoint + credential identity + wire protocol instead of
+        # Key by inference/catalog endpoints + credential identity + wire protocol instead of
         # slug: names frequently differ per model ("Ollama — X") while the
         # endpoint stays the same.  Keep same-host providers with distinct
         # env-backed credentials or API protocols separate so picker selection
         # cannot route through the wrong credential/mode pair.
-        groups: "OrderedDict[tuple, dict]" = OrderedDict()
+        groups: "OrderedDict[tuple, dict[str, Any]]" = OrderedDict()
         for entry in custom_providers:
             if not isinstance(entry, dict):
                 continue
@@ -2206,6 +2249,7 @@ def list_authenticated_providers(
                 or entry.get("transport")
                 or ""
             ).strip().lower()
+            models_url = str(entry.get("models_url") or "").strip()
             credential_identity = (
                 inline_api_key
                 if inline_api_key
@@ -2228,7 +2272,13 @@ def list_authenticated_providers(
             entry_extra_headers = _extra_headers_from_config(entry)
             headers_identity = tuple(sorted(entry_extra_headers.items()))
 
-            group_key = (api_url, credential_identity, api_mode, headers_identity)
+            group_key = (
+                api_url,
+                models_url,
+                credential_identity,
+                api_mode,
+                headers_identity,
+            )
             if group_key not in groups:
                 # Strip per-model suffix so "Ollama — GLM 5.1" becomes
                 # "Ollama" for the grouped row. Em dash is the convention
@@ -2247,6 +2297,7 @@ def list_authenticated_providers(
                     "name": display_name,
                     "api_url": api_url,
                     "api_key": api_key,
+                    "models_url": models_url,
                     "models": [],
                     "has_explicit_models": False,
                     "discover_models": discover,
@@ -2366,12 +2417,12 @@ def list_authenticated_providers(
             )
             if should_probe:
                 try:
-                    from hermes_cli.models import fetch_api_models
-
-                    live_models = fetch_api_models(
+                    extra_headers = grp.get("extra_headers") or None
+                    live_models = _fetch_configured_api_models(
                         api_key,
                         api_url,
-                        headers=grp.get("extra_headers") or None,
+                        headers=extra_headers,
+                        models_url=grp.get("models_url") or "",
                     )
                     if live_models:
                         grp["models"] = live_models

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1153,6 +1153,7 @@ def switch_model(
     provider_changed = target_provider != current_provider
     provider_label = get_label(target_provider)
     models_url = ""
+    validation_headers: dict[str, str] | None = None
     if target_provider == "custom" and current_base_url:
         provider_label = "Custom endpoint"
     target_pdef: ProviderDef | None = None
@@ -1168,6 +1169,18 @@ def switch_model(
         target_pdef = resolve_user_provider(target_provider, user_providers)
     if target_pdef is not None:
         models_url = target_pdef.models_url
+    if isinstance(user_providers, dict):
+        target_user_cfg = user_providers.get(target_provider)
+        if isinstance(target_user_cfg, dict):
+            validation_headers = _extra_headers_from_config(target_user_cfg) or None
+    if target_provider.startswith("custom:") and isinstance(custom_providers, list):
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            display_name = str(entry.get("name") or "").strip()
+            if display_name and custom_provider_slug(display_name) == target_provider:
+                validation_headers = _extra_headers_from_config(entry) or None
+                break
     if target_provider.startswith("custom:"):
         custom_pdef = target_pdef
         if custom_pdef is not None:
@@ -1195,6 +1208,7 @@ def switch_model(
             models_url = _user_pdef.models_url
             _ucfg = (user_providers or {}).get(explicit_provider.strip().lower()) \
                 or (user_providers or {}).get(target_provider) or {}
+            validation_headers = _extra_headers_from_config(_ucfg) or None
             _ukey = str(_ucfg.get("api_key", "") or "").strip()
             if _ukey.startswith("${") and _ukey.endswith("}"):
                 _ukey = os.environ.get(_ukey[2:-1], "").strip()
@@ -1271,23 +1285,20 @@ def switch_model(
 
     # --- Validate ---
     try:
+        validation_options: dict[str, Any] = {
+            "api_key": api_key,
+            "base_url": base_url,
+            "api_mode": api_mode or None,
+        }
         if models_url:
-            validation = validate_requested_model(
-                new_model,
-                target_provider,
-                api_key=api_key,
-                base_url=base_url,
-                api_mode=api_mode or None,
-                models_url=models_url,
-            )
-        else:
-            validation = validate_requested_model(
-                new_model,
-                target_provider,
-                api_key=api_key,
-                base_url=base_url,
-                api_mode=api_mode or None,
-            )
+            validation_options["models_url"] = models_url
+        if validation_headers:
+            validation_options["headers"] = validation_headers
+        validation = validate_requested_model(
+            new_model,
+            target_provider,
+            **validation_options,
+        )
     except Exception as e:
         validation = {
             "accepted": False,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1671,14 +1671,24 @@ def switch_model(
 
     provider_changed = target_provider != current_provider
     provider_label = get_label(target_provider)
+    models_url = ""
     if target_provider == "custom" and current_base_url:
         provider_label = "Custom endpoint"
+    target_pdef: ProviderDef | None = None
     if target_provider.startswith("custom:"):
-        custom_pdef = resolve_provider_full(
+        target_pdef = resolve_provider_full(
             target_provider,
             user_providers,
             custom_providers,
         )
+    elif isinstance(user_providers, dict) and target_provider in user_providers:
+        from hermes_cli.providers import resolve_user_provider
+
+        target_pdef = resolve_user_provider(target_provider, user_providers)
+    if target_pdef is not None:
+        models_url = target_pdef.models_url
+    if target_provider.startswith("custom:"):
+        custom_pdef = target_pdef
         if custom_pdef is not None:
             provider_label = custom_pdef.name
 
@@ -1701,6 +1711,7 @@ def switch_model(
             if _user_pdef is None:
                 _user_pdef = _ruser(target_provider, user_providers)
         if _user_pdef is not None and _user_pdef.base_url:
+            models_url = _user_pdef.models_url
             _ucfg = (user_providers or {}).get(explicit_provider.strip().lower()) \
                 or (user_providers or {}).get(target_provider) or {}
             _ukey = str(_ucfg.get("api_key", "") or "").strip()
@@ -1802,12 +1813,17 @@ def switch_model(
 
     # --- Validate ---
     try:
+        validation_options: dict[str, Any] = {
+            "api_key": api_key,
+            "base_url": base_url,
+            "api_mode": api_mode or None,
+        }
+        if models_url:
+            validation_options["models_url"] = models_url
         validation = validate_requested_model(
             new_model,
             target_provider,
-            api_key=api_key,
-            base_url=base_url,
-            api_mode=api_mode or None,
+            **validation_options,
         )
     except Exception as e:
         validation = {
@@ -2692,6 +2708,7 @@ def list_authenticated_providers(
                 or ep_cfg.get("url", "")
                 or ""
             )
+            models_url = str(ep_cfg.get("models_url") or "").strip()
             key_env = str(ep_cfg.get("key_env", "") or "").strip()
             inline_api_key = str(ep_cfg.get("api_key", "") or "").strip()
             api_mode = str(
@@ -2712,7 +2729,13 @@ def list_authenticated_providers(
             # URL, routed by header) and must keep distinct picker rows.
             entry_extra_headers = _extra_headers_from_config(ep_cfg)
             headers_identity = tuple(sorted(entry_extra_headers.items()))
-            group_key = (api_url_norm, credential_identity, api_mode, headers_identity)
+            group_key = (
+                api_url_norm,
+                models_url,
+                credential_identity,
+                api_mode,
+                headers_identity,
+            )
 
             # ``default_model`` is the legacy key; ``model`` matches what
             # custom_providers entries use, so accept either.
@@ -2758,6 +2781,7 @@ def list_authenticated_providers(
                     "slug": grp_slug,
                     "name": grp_display or display_name,
                     "api_url": api_url,
+                    "models_url": models_url,
                     "models": [],
                     "has_explicit_models": False,
                     "ep_cfg": ep_cfg,  # used below for discover_models / api_key
@@ -2864,6 +2888,7 @@ def list_authenticated_providers(
                         timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
                         api_mode=grp.get("api_mode") or None,
                         headers=_extra_headers_from_config(ep_cfg) or None,
+                        models_url=grp.get("models_url") or None,
                         cache_only=not _probe_live,
                     )
                     if live_models:
@@ -2990,6 +3015,7 @@ def list_authenticated_providers(
                 or entry.get("api", "")
                 or ""
             ).strip().rstrip("/")
+            models_url = str(entry.get("models_url") or "").strip()
             if not raw_name or not api_url:
                 continue
             inline_api_key = (entry.get("api_key") or "").strip()
@@ -3030,7 +3056,14 @@ def list_authenticated_providers(
                     _display_prefix = _display_prefix.split(sep)[0].strip()
                     break
 
-            group_key = (api_url, credential_identity, api_mode, headers_identity, _display_prefix.lower())
+            group_key = (
+                api_url,
+                models_url,
+                credential_identity,
+                api_mode,
+                headers_identity,
+                _display_prefix.lower(),
+            )
             if group_key not in groups:
                 # Reuse the prefix computed above as the row display name;
                 # fall back to the raw name if stripping left it empty.
@@ -3042,6 +3075,7 @@ def list_authenticated_providers(
                     "name": display_name,
                     "api_url": api_url,
                     "api_key": api_key,
+                    "models_url": models_url,
                     "models": [],
                     "has_explicit_models": False,
                     "discover_models": discover,
@@ -3207,6 +3241,7 @@ def list_authenticated_providers(
                         timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
                         api_mode=grp.get("api_mode") or None,
                         headers=grp.get("extra_headers") or None,
+                        models_url=grp.get("models_url") or None,
                         cache_only=not _probe_live,
                     )
                     if live_models:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1672,6 +1672,7 @@ def switch_model(
     provider_changed = target_provider != current_provider
     provider_label = get_label(target_provider)
     models_url = ""
+    validation_headers: dict[str, str] | None = None
     if target_provider == "custom" and current_base_url:
         provider_label = "Custom endpoint"
     target_pdef: ProviderDef | None = None
@@ -1687,6 +1688,19 @@ def switch_model(
         target_pdef = resolve_user_provider(target_provider, user_providers)
     if target_pdef is not None:
         models_url = target_pdef.models_url
+    if isinstance(user_providers, dict):
+        target_user_cfg = user_providers.get(target_provider)
+        if isinstance(target_user_cfg, dict):
+            validation_headers = _extra_headers_from_config(target_user_cfg) or None
+    if target_provider.startswith("custom:") and isinstance(custom_providers, list):
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            display_name = str(entry.get("name") or "").strip()
+            provider_key = str(entry.get("provider") or "").strip()
+            if target_provider in custom_provider_aliases(display_name, provider_key):
+                validation_headers = _extra_headers_from_config(entry) or None
+                break
     if target_provider.startswith("custom:"):
         custom_pdef = target_pdef
         if custom_pdef is not None:
@@ -1714,6 +1728,7 @@ def switch_model(
             models_url = _user_pdef.models_url
             _ucfg = (user_providers or {}).get(explicit_provider.strip().lower()) \
                 or (user_providers or {}).get(target_provider) or {}
+            validation_headers = _extra_headers_from_config(_ucfg) or None
             _ukey = str(_ucfg.get("api_key", "") or "").strip()
             if _ukey.startswith("${") and _ukey.endswith("}"):
                 # Same class as the picker reads below: a raw os.environ read
@@ -1820,6 +1835,8 @@ def switch_model(
         }
         if models_url:
             validation_options["models_url"] = models_url
+        if validation_headers:
+            validation_options["headers"] = validation_headers
         validation = validate_requested_model(
             new_model,
             target_provider,
@@ -2882,14 +2899,16 @@ def list_authenticated_providers(
             if _discovery_allowed:
                 try:
                     from hermes_cli.models import cached_fetch_api_models
+                    fetch_options: dict[str, Any] = {
+                        "timeout": 1.5 if for_picker else 5.0,
+                        "api_mode": grp.get("api_mode") or None,
+                        "headers": _extra_headers_from_config(ep_cfg) or None,
+                        "cache_only": not _probe_live,
+                    }
+                    if grp.get("models_url"):
+                        fetch_options["models_url"] = grp["models_url"]
                     live_models = cached_fetch_api_models(
-                        api_key,
-                        api_url,
-                        timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
-                        api_mode=grp.get("api_mode") or None,
-                        headers=_extra_headers_from_config(ep_cfg) or None,
-                        models_url=grp.get("models_url") or None,
-                        cache_only=not _probe_live,
+                        api_key, api_url, **fetch_options
                     )
                     if live_models:
                         models_list = live_models
@@ -3234,15 +3253,16 @@ def list_authenticated_providers(
             if _discovery_allowed:
                 try:
                     from hermes_cli.models import cached_fetch_api_models
-
+                    fetch_options: dict[str, Any] = {
+                        "timeout": 1.5 if for_picker else 5.0,
+                        "api_mode": grp.get("api_mode") or None,
+                        "headers": grp.get("extra_headers") or None,
+                        "cache_only": not _probe_live,
+                    }
+                    if grp.get("models_url"):
+                        fetch_options["models_url"] = grp["models_url"]
                     live_models = cached_fetch_api_models(
-                        api_key,
-                        api_url,
-                        timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
-                        api_mode=grp.get("api_mode") or None,
-                        headers=grp.get("extra_headers") or None,
-                        models_url=grp.get("models_url") or None,
-                        cache_only=not _probe_live,
+                        api_key, api_url, **fetch_options
                     )
                     if live_models:
                         grp["models"] = live_models

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3618,14 +3618,47 @@ def github_model_reasoning_efforts(
     return _github_reasoning_efforts_for_model_id(str(model_id or normalized))
 
 
+def _catalog_model_ids(payload: Any) -> list[str]:
+    """Extract callable model identifiers from common catalog response shapes."""
+    native_models = False
+    if isinstance(payload, list):
+        items = payload
+    elif isinstance(payload, dict) and isinstance(payload.get("data"), list):
+        items = payload["data"]
+    elif isinstance(payload, dict) and isinstance(payload.get("models"), list):
+        items = payload["models"]
+        native_models = True
+    else:
+        return []
+
+    model_ids: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if native_models and str(item.get("type") or "").lower() in {
+            "embedding",
+            "embeddings",
+        }:
+            continue
+        model_id = item.get("key") or item.get("id")
+        if isinstance(model_id, str) and model_id.strip():
+            model_ids.append(model_id.strip())
+    return model_ids
+
+
 def probe_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
     timeout: float = 5.0,
     api_mode: Optional[str] = None,
     request_headers: Optional[dict[str, str]] = None,
+    models_url: Optional[str] = None,
 ) -> dict[str, Any]:
     """Probe a ``/models`` endpoint with light URL heuristics.
+
+    When ``models_url`` is provided, it is treated as the complete catalog URL
+    and the inference base URL is left untouched. The usual ``/v1`` fallback is
+    only used when no explicit catalog URL is configured.
 
     For ``anthropic_messages`` mode, uses ``x-api-key`` and
     ``anthropic-version`` headers (Anthropic's native auth) instead of
@@ -3633,7 +3666,8 @@ def probe_api_models(
     identical, so the same parser works for both.
     """
     normalized = (base_url or "").strip().rstrip("/")
-    if not normalized:
+    explicit_models_url = (models_url or "").strip()
+    if not normalized and not explicit_models_url:
         return {
             "models": None,
             "probed_url": None,
@@ -3642,7 +3676,7 @@ def probe_api_models(
             "used_fallback": False,
         }
 
-    if _is_github_models_base_url(normalized):
+    if not explicit_models_url and _is_github_models_base_url(normalized):
         models = _fetch_github_models(api_key=api_key, timeout=timeout)
         return {
             "models": models,
@@ -3652,18 +3686,22 @@ def probe_api_models(
             "used_fallback": False,
         }
 
-    if normalized.endswith("/v1"):
+    if explicit_models_url:
+        alternate_base = ""
+        candidates: list[tuple[str, bool]] = [(normalized, False)]
+    elif normalized.endswith("/v1"):
         alternate_base = normalized[:-3].rstrip("/")
+        candidates = [(normalized, False)]
     else:
         alternate_base = normalized + "/v1"
-
-    candidates: list[tuple[str, bool]] = [(normalized, False)]
-    if alternate_base and alternate_base != normalized:
+        candidates = [(normalized, False)]
+    if not explicit_models_url and alternate_base and alternate_base != normalized:
         candidates.append((alternate_base, True))
 
     tried: list[str] = []
     headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
-    if urllib.parse.urlparse(normalized).hostname == "generativelanguage.googleapis.com":
+    header_url = explicit_models_url or normalized
+    if urllib.parse.urlparse(header_url).hostname == "generativelanguage.googleapis.com":
         headers["X-Goog-Api-Client"] = f"hermes-agent/{_HERMES_VERSION}"
     if api_key and api_mode == "anthropic_messages":
         headers["x-api-key"] = api_key
@@ -3680,17 +3718,21 @@ def probe_api_models(
         headers.update(normalize_extra_headers(request_headers))
 
     for candidate_base, is_fallback in candidates:
-        url = candidate_base.rstrip("/") + "/models"
+        url = explicit_models_url or candidate_base.rstrip("/") + "/models"
         tried.append(url)
         req = urllib.request.Request(url, headers=headers)
         try:
             with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
                 return {
-                    "models": [m.get("id", "") for m in data.get("data", [])],
+                    "models": _catalog_model_ids(data),
                     "probed_url": url,
                     "resolved_base_url": candidate_base.rstrip("/"),
-                    "suggested_base_url": alternate_base if alternate_base != candidate_base else normalized,
+                    "suggested_base_url": (
+                        None
+                        if explicit_models_url
+                        else alternate_base if alternate_base != candidate_base else normalized
+                    ),
                     "used_fallback": is_fallback,
                 }
         except Exception:
@@ -3698,9 +3740,17 @@ def probe_api_models(
 
     return {
         "models": None,
-        "probed_url": tried[0] if tried else normalized.rstrip("/") + "/models",
+        "probed_url": (
+            tried[0]
+            if tried
+            else explicit_models_url or normalized.rstrip("/") + "/models"
+        ),
         "resolved_base_url": normalized,
-        "suggested_base_url": alternate_base if alternate_base != normalized else None,
+        "suggested_base_url": (
+            None
+            if explicit_models_url
+            else alternate_base if alternate_base != normalized else None
+        ),
         "used_fallback": False,
     }
 
@@ -3932,8 +3982,12 @@ def fetch_api_models(
     timeout: float = 5.0,
     api_mode: Optional[str] = None,
     headers: Optional[dict[str, str]] = None,
+    models_url: Optional[str] = None,
 ) -> Optional[list[str]]:
     """Fetch the list of available model IDs from the provider's ``/models`` endpoint.
+
+    ``models_url`` may override the complete catalog URL independently of the
+    inference ``base_url``.
 
     Returns a list of model ID strings, or ``None`` if the endpoint could not
     be reached (network error, timeout, auth failure, etc.).
@@ -3944,6 +3998,7 @@ def fetch_api_models(
         timeout=timeout,
         api_mode=api_mode,
         request_headers=headers,
+        models_url=models_url,
     ).get("models")
 
 
@@ -4087,6 +4142,7 @@ def validate_requested_model(
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
     api_mode: Optional[str] = None,
+    models_url: Optional[str] = None,
 ) -> dict[str, Any]:
     """
     Validate a ``/model`` value for the active provider.
@@ -4182,9 +4238,14 @@ def validate_requested_model(
     if normalized == "custom" or normalized.startswith("custom:"):
         # Try probing with correct auth for the api_mode.
         if api_mode == "anthropic_messages":
-            probe = probe_api_models(api_key, base_url, api_mode=api_mode)
+            probe = probe_api_models(
+                api_key,
+                base_url,
+                api_mode=api_mode,
+                models_url=models_url,
+            )
         else:
-            probe = probe_api_models(api_key, base_url)
+            probe = probe_api_models(api_key, base_url, models_url=models_url)
         api_models = probe.get("models")
         if api_models is not None:
             if requested_for_lookup in set(api_models):

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4143,6 +4143,7 @@ def validate_requested_model(
     base_url: Optional[str] = None,
     api_mode: Optional[str] = None,
     models_url: Optional[str] = None,
+    headers: Optional[dict[str, str]] = None,
 ) -> dict[str, Any]:
     """
     Validate a ``/model`` value for the active provider.
@@ -4242,10 +4243,16 @@ def validate_requested_model(
                 api_key,
                 base_url,
                 api_mode=api_mode,
+                request_headers=headers,
                 models_url=models_url,
             )
         else:
-            probe = probe_api_models(api_key, base_url, models_url=models_url)
+            probe = probe_api_models(
+                api_key,
+                base_url,
+                request_headers=headers,
+                models_url=models_url,
+            )
         api_models = probe.get("models")
         if api_models is not None:
             if requested_for_lookup in set(api_models):
@@ -4476,7 +4483,13 @@ def validate_requested_model(
     # Anthropic Messages API: many proxies don't implement /v1/models.
     # Try probing with correct auth; if it fails, accept with a warning.
     if api_mode == "anthropic_messages":
-        api_models = fetch_api_models(api_key, base_url, api_mode=api_mode)
+        api_models = fetch_api_models(
+            api_key,
+            base_url,
+            api_mode=api_mode,
+            headers=headers,
+            models_url=models_url,
+        )
         if api_models is not None:
             if requested_for_lookup in set(api_models):
                 return {
@@ -4509,7 +4522,12 @@ def validate_requested_model(
         }
 
     # Probe the live API to check if the model actually exists
-    api_models = fetch_api_models(api_key, base_url)
+    api_models = fetch_api_models(
+        api_key,
+        base_url,
+        headers=headers,
+        models_url=models_url,
+    )
 
     if api_models is not None:
         # Gemini's OpenAI-compat /v1beta/openai/models endpoint returns IDs

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4333,14 +4333,47 @@ def github_model_reasoning_efforts(
     return _github_reasoning_efforts_for_model_id(str(model_id or normalized))
 
 
+def _catalog_model_ids(payload: Any) -> list[str]:
+    """Extract callable model identifiers from common catalog response shapes."""
+    native_models = False
+    if isinstance(payload, list):
+        items = payload
+    elif isinstance(payload, dict) and isinstance(payload.get("data"), list):
+        items = payload["data"]
+    elif isinstance(payload, dict) and isinstance(payload.get("models"), list):
+        items = payload["models"]
+        native_models = True
+    else:
+        return []
+
+    model_ids: list[str] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if native_models and str(item.get("type") or "").lower() in {
+            "embedding",
+            "embeddings",
+        }:
+            continue
+        model_id = item.get("key") or item.get("id")
+        if isinstance(model_id, str) and model_id.strip():
+            model_ids.append(model_id.strip())
+    return model_ids
+
+
 def probe_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
     timeout: float = 5.0,
     api_mode: Optional[str] = None,
     request_headers: Optional[dict[str, str]] = None,
+    models_url: Optional[str] = None,
 ) -> dict[str, Any]:
     """Probe a ``/models`` endpoint with light URL heuristics.
+
+    When ``models_url`` is provided, it is treated as the complete catalog URL
+    and the inference base URL is left untouched. The usual ``/v1`` fallback is
+    only used when no explicit catalog URL is configured.
 
     For ``anthropic_messages`` mode, uses ``x-api-key`` and
     ``anthropic-version`` headers (Anthropic's native auth) instead of
@@ -4348,7 +4381,8 @@ def probe_api_models(
     identical, so the same parser works for both.
     """
     normalized = (base_url or "").strip().rstrip("/")
-    if not normalized:
+    explicit_models_url = (models_url or "").strip()
+    if not normalized and not explicit_models_url:
         return {
             "models": None,
             "probed_url": None,
@@ -4357,7 +4391,7 @@ def probe_api_models(
             "used_fallback": False,
         }
 
-    if _is_github_models_base_url(normalized):
+    if not explicit_models_url and _is_github_models_base_url(normalized):
         models = _fetch_github_models(api_key=api_key, timeout=timeout)
         return {
             "models": models,
@@ -4367,18 +4401,22 @@ def probe_api_models(
             "used_fallback": False,
         }
 
-    if normalized.endswith("/v1"):
+    if explicit_models_url:
+        alternate_base = ""
+        candidates: list[tuple[str, bool]] = [(normalized, False)]
+    elif normalized.endswith("/v1"):
         alternate_base = normalized[:-3].rstrip("/")
+        candidates = [(normalized, False)]
     else:
         alternate_base = normalized + "/v1"
-
-    candidates: list[tuple[str, bool]] = [(normalized, False)]
-    if alternate_base and alternate_base != normalized:
+        candidates = [(normalized, False)]
+    if not explicit_models_url and alternate_base and alternate_base != normalized:
         candidates.append((alternate_base, True))
 
     tried: list[str] = []
     headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
-    if urllib.parse.urlparse(normalized).hostname == "generativelanguage.googleapis.com":
+    header_url = explicit_models_url or normalized
+    if urllib.parse.urlparse(header_url).hostname == "generativelanguage.googleapis.com":
         headers["X-Goog-Api-Client"] = f"hermes-agent/{_HERMES_VERSION}"
     if api_key and api_mode == "anthropic_messages":
         headers["x-api-key"] = api_key
@@ -4395,17 +4433,21 @@ def probe_api_models(
         headers.update(normalize_extra_headers(request_headers))
 
     for candidate_base, is_fallback in candidates:
-        url = candidate_base.rstrip("/") + "/models"
+        url = explicit_models_url or candidate_base.rstrip("/") + "/models"
         tried.append(url)
         req = urllib.request.Request(url, headers=headers)
         try:
             with _urlopen_model_catalog_request(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
                 return {
-                    "models": [m.get("id", "") for m in data.get("data", [])],
+                    "models": _catalog_model_ids(data),
                     "probed_url": url,
                     "resolved_base_url": candidate_base.rstrip("/"),
-                    "suggested_base_url": alternate_base if alternate_base != candidate_base else normalized,
+                    "suggested_base_url": (
+                        None
+                        if explicit_models_url
+                        else alternate_base if alternate_base != candidate_base else normalized
+                    ),
                     "used_fallback": is_fallback,
                 }
         except Exception:
@@ -4413,9 +4455,17 @@ def probe_api_models(
 
     return {
         "models": None,
-        "probed_url": tried[0] if tried else normalized.rstrip("/") + "/models",
+        "probed_url": (
+            tried[0]
+            if tried
+            else explicit_models_url or normalized.rstrip("/") + "/models"
+        ),
         "resolved_base_url": normalized,
-        "suggested_base_url": alternate_base if alternate_base != normalized else None,
+        "suggested_base_url": (
+            None
+            if explicit_models_url
+            else alternate_base if alternate_base != normalized else None
+        ),
         "used_fallback": False,
     }
 
@@ -4677,8 +4727,12 @@ def fetch_api_models(
     timeout: float = 5.0,
     api_mode: Optional[str] = None,
     headers: Optional[dict[str, str]] = None,
+    models_url: Optional[str] = None,
 ) -> Optional[list[str]]:
     """Fetch the list of available model IDs from the provider's ``/models`` endpoint.
+
+    ``models_url`` may override the complete catalog URL independently of the
+    inference ``base_url``.
 
     Returns a list of model ID strings, or ``None`` if the endpoint could not
     be reached (network error, timeout, auth failure, etc.).
@@ -4689,6 +4743,7 @@ def fetch_api_models(
         timeout=timeout,
         api_mode=api_mode,
         request_headers=headers,
+        models_url=models_url,
     ).get("models")
 
 
@@ -4741,6 +4796,7 @@ def cached_fetch_api_models(
     timeout: float = 5.0,
     api_mode: Optional[str] = None,
     headers: Optional[dict[str, str]] = None,
+    models_url: Optional[str] = None,
     force_refresh: bool = False,
     cache_only: bool = False,
     ttl_seconds: int = _PROVIDER_MODELS_CACHE_TTL,
@@ -4751,7 +4807,9 @@ def cached_fetch_api_models(
     stale-while-revalidate tier — but keys ``provider_models_cache.json``
     off ``custom:<base_url>`` instead of a ``PROVIDER_REGISTRY`` slug, since
     custom endpoints (named ``custom_providers`` rows, bare
-    ``provider: custom``, and per-endpoint-map entries) have none. Same
+    ``provider: custom``, and per-endpoint-map entries) have none. Explicit
+    catalog URLs extend that key so providers sharing an inference endpoint
+    cannot reuse each other's discovered catalog. Same
     stale-beats-nothing fallback policy: a live-fetch failure serves the
     last same-fingerprint result rather than an empty list. Returns whatever
     :func:`fetch_api_models` would (a list or ``None``); corrupt cache rows
@@ -4765,16 +4823,24 @@ def cached_fetch_api_models(
     reaches the picker instead of collapsing to the config-declared subset.
     """
     normalized_url = str(base_url or "").strip().rstrip("/").lower()
-    if not normalized_url:
+    normalized_models_url = str(models_url or "").strip().rstrip("/").lower()
+    if not normalized_url and not normalized_models_url:
         if cache_only:
             return None
         # No base_url means nothing to key the cache on — fall through to a
         # live call so callers keep getting fetch_api_models' own behavior.
         return fetch_api_models(
-            api_key, base_url, timeout=timeout, api_mode=api_mode, headers=headers
+            api_key,
+            base_url,
+            timeout=timeout,
+            api_mode=api_mode,
+            headers=headers,
+            models_url=models_url,
         )
 
     cache_key = f"custom:{normalized_url}"
+    if normalized_models_url:
+        cache_key += f"|models:{normalized_models_url}"
     fp = _custom_endpoint_fingerprint(api_key, api_mode, headers)
     cache = _load_provider_models_cache()
     entry = cache.get(cache_key)
@@ -4804,6 +4870,7 @@ def cached_fetch_api_models(
                 live = fetch_api_models(
                     api_key, base_url,
                     timeout=timeout, api_mode=api_mode, headers=headers,
+                    models_url=models_url,
                 )
                 if not live:
                     return None
@@ -4813,7 +4880,12 @@ def cached_fetch_api_models(
             return list(entry["models"])
 
     live = fetch_api_models(
-        api_key, base_url, timeout=timeout, api_mode=api_mode, headers=headers
+        api_key,
+        base_url,
+        timeout=timeout,
+        api_mode=api_mode,
+        headers=headers,
+        models_url=models_url,
     )
     if live:
         cache[cache_key] = {"fp": fp, "at": now, "models": list(live)}
@@ -4967,6 +5039,7 @@ def validate_requested_model(
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
     api_mode: Optional[str] = None,
+    models_url: Optional[str] = None,
 ) -> dict[str, Any]:
     """
     Validate a ``/model`` value for the active provider.
@@ -5062,9 +5135,14 @@ def validate_requested_model(
     if normalized == "custom" or normalized.startswith("custom:"):
         # Try probing with correct auth for the api_mode.
         if api_mode == "anthropic_messages":
-            probe = probe_api_models(api_key, base_url, api_mode=api_mode)
+            probe = probe_api_models(
+                api_key,
+                base_url,
+                api_mode=api_mode,
+                models_url=models_url,
+            )
         else:
-            probe = probe_api_models(api_key, base_url)
+            probe = probe_api_models(api_key, base_url, models_url=models_url)
         api_models = probe.get("models")
         if api_models is not None:
             if requested_for_lookup in set(api_models):

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4824,19 +4824,23 @@ def cached_fetch_api_models(
     """
     normalized_url = str(base_url or "").strip().rstrip("/").lower()
     normalized_models_url = str(models_url or "").strip().rstrip("/").lower()
+
+    def _fetch_live() -> Optional[list[str]]:
+        fetch_options: dict[str, Any] = {
+            "timeout": timeout,
+            "api_mode": api_mode,
+            "headers": headers,
+        }
+        if models_url:
+            fetch_options["models_url"] = models_url
+        return fetch_api_models(api_key, base_url, **fetch_options)
+
     if not normalized_url and not normalized_models_url:
         if cache_only:
             return None
         # No base_url means nothing to key the cache on — fall through to a
         # live call so callers keep getting fetch_api_models' own behavior.
-        return fetch_api_models(
-            api_key,
-            base_url,
-            timeout=timeout,
-            api_mode=api_mode,
-            headers=headers,
-            models_url=models_url,
-        )
+        return _fetch_live()
 
     cache_key = f"custom:{normalized_url}"
     if normalized_models_url:
@@ -4867,11 +4871,7 @@ def cached_fetch_api_models(
             # (#72762's stall class, which a plain TTL would reintroduce an
             # hour into the session); refresh off-thread for the next open.
             def _refresh_custom():
-                live = fetch_api_models(
-                    api_key, base_url,
-                    timeout=timeout, api_mode=api_mode, headers=headers,
-                    models_url=models_url,
-                )
+                live = _fetch_live()
                 if not live:
                     return None
                 return {"fp": fp, "at": time.time(), "models": list(live)}
@@ -4879,14 +4879,7 @@ def cached_fetch_api_models(
             _spawn_swr_refresh(cache_key, _refresh_custom)
             return list(entry["models"])
 
-    live = fetch_api_models(
-        api_key,
-        base_url,
-        timeout=timeout,
-        api_mode=api_mode,
-        headers=headers,
-        models_url=models_url,
-    )
+    live = _fetch_live()
     if live:
         cache[cache_key] = {"fp": fp, "at": now, "models": list(live)}
         _save_provider_models_cache(cache)
@@ -5040,6 +5033,7 @@ def validate_requested_model(
     base_url: Optional[str] = None,
     api_mode: Optional[str] = None,
     models_url: Optional[str] = None,
+    headers: Optional[dict[str, str]] = None,
 ) -> dict[str, Any]:
     """
     Validate a ``/model`` value for the active provider.
@@ -5134,15 +5128,16 @@ def validate_requested_model(
 
     if normalized == "custom" or normalized.startswith("custom:"):
         # Try probing with correct auth for the api_mode.
+        probe_options: dict[str, Any] = {}
+        if headers:
+            probe_options["request_headers"] = headers
+        if models_url:
+            probe_options["models_url"] = models_url
         if api_mode == "anthropic_messages":
-            probe = probe_api_models(
-                api_key,
-                base_url,
-                api_mode=api_mode,
-                models_url=models_url,
-            )
+            probe_options["api_mode"] = api_mode
+            probe = probe_api_models(api_key, base_url, **probe_options)
         else:
-            probe = probe_api_models(api_key, base_url, models_url=models_url)
+            probe = probe_api_models(api_key, base_url, **probe_options)
         api_models = probe.get("models")
         if api_models is not None:
             if requested_for_lookup in set(api_models):
@@ -5373,7 +5368,12 @@ def validate_requested_model(
     # Anthropic Messages API: many proxies don't implement /v1/models.
     # Try probing with correct auth; if it fails, accept with a warning.
     if api_mode == "anthropic_messages":
-        api_models = fetch_api_models(api_key, base_url, api_mode=api_mode)
+        fetch_options: dict[str, Any] = {"api_mode": api_mode}
+        if headers:
+            fetch_options["headers"] = headers
+        if models_url:
+            fetch_options["models_url"] = models_url
+        api_models = fetch_api_models(api_key, base_url, **fetch_options)
         if api_models is not None:
             if requested_for_lookup in set(api_models):
                 return {
@@ -5406,7 +5406,12 @@ def validate_requested_model(
         }
 
     # Probe the live API to check if the model actually exists
-    api_models = fetch_api_models(api_key, base_url)
+    fetch_options = {}
+    if headers:
+        fetch_options["headers"] = headers
+    if models_url:
+        fetch_options["models_url"] = models_url
+    api_models = fetch_api_models(api_key, base_url, **fetch_options)
 
     if api_models is not None:
         # Gemini's OpenAI-compat /v1beta/openai/models endpoint returns IDs

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -242,6 +242,7 @@ class ProviderDef:
     auth_type: str = "api_key"
     doc: str = ""
     source: str = ""                      # "models.dev", "hermes", "user-config"
+    models_url: str = ""                  # explicit catalog URL, separate from inference
 
 
 # -- Aliases ------------------------------------------------------------------
@@ -613,6 +614,7 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
     # Extract fields
     display_name = entry.get("name", "") or name
     api_url = entry.get("api", "") or entry.get("url", "") or entry.get("base_url", "") or ""
+    models_url = entry.get("models_url", "") or ""
     key_env = entry.get("key_env", "") or ""
     transport = entry.get("transport", "openai_chat") or "openai_chat"
 
@@ -626,6 +628,7 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
         transport=transport,
         api_key_env_vars=tuple(env_vars),
         base_url=api_url,
+        models_url=models_url,
         is_aggregator=False,
         auth_type="api_key",
         source="user-config",
@@ -658,7 +661,7 @@ def resolve_custom_provider(
     # from a prior model-switch bug), fall back to the first custom
     # provider entry so existing configs self-heal.  (GH #17478)
     bare_custom_fallback = requested == "custom"
-    first_valid: Optional[Tuple[str, str, Tuple[str, ...]]] = None
+    first_valid: Optional[Tuple[str, str, str, Tuple[str, ...]]] = None
 
     for entry in custom_providers:
         if not isinstance(entry, dict):
@@ -671,6 +674,7 @@ def resolve_custom_provider(
             or entry.get("api", "")
             or ""
         ).strip()
+        models_url = (entry.get("models_url") or "").strip()
         if not display_name or not api_url:
             continue
 
@@ -681,7 +685,7 @@ def resolve_custom_provider(
 
         # Stash the first valid entry for bare-"custom" fallback
         if first_valid is None:
-            first_valid = (display_name, api_url, tuple(env_vars))
+            first_valid = (display_name, api_url, models_url, tuple(env_vars))
 
         slug = custom_provider_slug(display_name)
         if requested not in {display_name.lower(), slug}:
@@ -693,6 +697,7 @@ def resolve_custom_provider(
             transport="openai_chat",
             api_key_env_vars=tuple(env_vars),
             base_url=api_url,
+            models_url=models_url,
             is_aggregator=False,
             auth_type="api_key",
             source="user-config",
@@ -700,7 +705,7 @@ def resolve_custom_provider(
 
     # Self-heal: bare "custom" matched nothing — return first valid entry
     if bare_custom_fallback and first_valid:
-        dname, aurl, denv = first_valid
+        dname, aurl, murl, denv = first_valid
         slug = custom_provider_slug(dname)
         return ProviderDef(
             id=slug,
@@ -708,6 +713,7 @@ def resolve_custom_provider(
             transport="openai_chat",
             api_key_env_vars=denv,
             base_url=aurl,
+            models_url=murl,
             is_aggregator=False,
             auth_type="api_key",
             source="user-config",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -265,6 +265,7 @@ class ProviderDef:
     auth_type: str = "api_key"
     doc: str = ""
     source: str = ""                      # "models.dev", "hermes", "user-config"
+    models_url: str = ""                  # explicit catalog URL, separate from inference
 
 
 # -- Aliases ------------------------------------------------------------------
@@ -726,6 +727,7 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
     # Extract fields
     display_name = entry.get("name", "") or name
     api_url = entry.get("api", "") or entry.get("url", "") or entry.get("base_url", "") or ""
+    models_url = entry.get("models_url", "") or ""
     key_env = entry.get("key_env", "") or ""
     transport = entry.get("transport", "openai_chat") or "openai_chat"
 
@@ -739,6 +741,7 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
         transport=transport,
         api_key_env_vars=tuple(env_vars),
         base_url=api_url,
+        models_url=models_url,
         is_aggregator=False,
         auth_type="api_key",
         source="user-config",
@@ -793,7 +796,7 @@ def resolve_custom_provider(
     # from a prior model-switch bug), fall back to the first custom
     # provider entry so existing configs self-heal.  (GH #17478)
     bare_custom_fallback = requested == "custom"
-    first_valid: Optional[Tuple[str, str, Tuple[str, ...], str]] = None
+    first_valid: Optional[Tuple[str, str, str, Tuple[str, ...], str]] = None
 
     for entry in custom_providers:
         if not isinstance(entry, dict):
@@ -806,6 +809,7 @@ def resolve_custom_provider(
             or entry.get("api", "")
             or ""
         ).strip()
+        models_url = (entry.get("models_url") or "").strip()
         if not display_name or not api_url:
             continue
 
@@ -820,6 +824,7 @@ def resolve_custom_provider(
             first_valid = (
                 display_name,
                 api_url,
+                models_url,
                 tuple(env_vars),
                 custom_provider_slug(display_name, provider_key),
             )
@@ -834,6 +839,7 @@ def resolve_custom_provider(
             transport="openai_chat",
             api_key_env_vars=tuple(env_vars),
             base_url=api_url,
+            models_url=models_url,
             is_aggregator=False,
             auth_type="api_key",
             source="user-config",
@@ -841,13 +847,14 @@ def resolve_custom_provider(
 
     # Self-heal: bare "custom" matched nothing — return first valid entry
     if bare_custom_fallback and first_valid:
-        dname, aurl, denv, slug = first_valid
+        dname, aurl, murl, denv, slug = first_valid
         return ProviderDef(
             id=slug,
             name=dname,
             transport="openai_chat",
             api_key_env_vars=denv,
             base_url=aurl,
+            models_url=murl,
             is_aggregator=False,
             auth_type="api_key",
             source="user-config",

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -221,7 +221,10 @@ class TestCustomProviderModelSwitch:
             "custom_providers:\n"
             "- name: NeuralWatt\n"
             "  base_url: ${NEURALWATT_API_BASE}\n"
+            "  models_url: https://catalog.neuralwatt.com/models\n"
             "  api_key: ${NEURALWATT_API_KEY}\n"
+            "  extra_headers:\n"
+            "    X-Catalog-Token: catalog-token\n"
             "  model: qwen3.6-35b-fast\n"
             "  models: []\n"
         )
@@ -254,6 +257,12 @@ class TestCustomProviderModelSwitch:
         mock_fetch.assert_called_once()
         probe_args, probe_kwargs = mock_fetch.call_args
         assert probe_args[0] == "sk-live-neuralwatt-secret"
+        assert probe_args[1] == "https://api.neuralwatt.com/v1"
+        assert probe_kwargs == {
+            "timeout": 8.0,
+            "models_url": "https://catalog.neuralwatt.com/models",
+            "headers": {"X-Catalog-Token": "catalog-token"},
+        }
 
         # But config.yaml must keep the env reference, not the plaintext secret.
         saved = config_path.read_text()

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -239,6 +239,8 @@ def test_is_routing_aggregator_excludes_flat_namespace_resellers():
 
 def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     """Shared /model switch pipeline should accept --provider for custom_providers."""
+    validation_calls = []
+
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
         lambda **kwargs: {
@@ -247,7 +249,11 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
             "api_mode": "chat_completions",
         },
     )
-    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    def fake_validate(*args, **kwargs):
+        validation_calls.append((args, kwargs))
+        return _MOCK_VALIDATION
+
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", fake_validate)
     monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
     monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
 
@@ -263,6 +269,7 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
             {
                 "name": "Local (127.0.0.1:4141)",
                 "base_url": "http://127.0.0.1:4141/v1",
+                "models_url": "http://127.0.0.1:4141/api/v1/models",
                 "model": "rotator-openrouter-coding",
             }
         ],
@@ -274,6 +281,9 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     assert result.new_model == "rotator-openrouter-coding"
     assert result.base_url == "http://127.0.0.1:4141/v1"
     assert result.api_key == "no-key-required"
+    assert validation_calls[0][1]["models_url"] == (
+        "http://127.0.0.1:4141/api/v1/models"
+    )
 
 
 def test_list_groups_same_name_custom_providers_into_one_row(monkeypatch):
@@ -957,6 +967,7 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
             "name": "my-gateway",
             "api_key": "sk-gateway-key",
             "base_url": "https://gateway.example.com/v1",
+            "models_url": "https://catalog.example.com/models",
             "model": "gateway-model-a",
             "models": {
                 "gateway-model-a": {"context_length": 128000},
@@ -983,7 +994,14 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
 
     assert gateway_prov is not None, "Custom provider group not found in results"
     assert calls == [
-        ("sk-gateway-key", "https://gateway.example.com/v1", {"headers": None})
+        (
+            "sk-gateway-key",
+            "https://gateway.example.com/v1",
+            {
+                "headers": None,
+                "models_url": "https://catalog.example.com/models",
+            },
+        )
     ], "fetch_api_models must be called with the custom provider's credentials"
     assert gateway_prov["models"] == [
         "gateway-model-a",
@@ -1293,6 +1311,7 @@ def test_resolve_custom_provider_passes_key_env():
             {
                 "name": "token-plan",
                 "base_url": "https://token-plan-sgp.xiaomimimo.com/v1",
+                "models_url": "https://catalog.xiaomimimo.com/models",
                 "key_env": "XIAOMI_MIMO_API_KEY",
                 "model": "mimo-v2-pro",
             }
@@ -1302,6 +1321,7 @@ def test_resolve_custom_provider_passes_key_env():
     assert resolved is not None
     assert resolved.api_key_env_vars == ("XIAOMI_MIMO_API_KEY",)
     assert resolved.base_url == "https://token-plan-sgp.xiaomimimo.com/v1"
+    assert resolved.models_url == "https://catalog.xiaomimimo.com/models"
 
 
 def test_resolve_custom_provider_bare_custom_self_heal_passes_key_env():

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -621,6 +621,7 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
             "name": "my-gateway",
             "api_key": "sk-gateway-key",
             "base_url": "https://gateway.example.com/v1",
+            "models_url": "https://catalog.example.com/models",
             "model": "gateway-model-a",
             "models": {
                 "gateway-model-a": {"context_length": 128000},
@@ -650,7 +651,12 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
         (
             "sk-gateway-key",
             "https://gateway.example.com/v1",
-            {"timeout": 5.0, "api_mode": None, "headers": None},
+            {
+                "timeout": 5.0,
+                "api_mode": None,
+                "headers": None,
+                "models_url": "https://catalog.example.com/models",
+            },
         )
     ], "fetch_api_models must be called with the custom provider's credentials"
     assert gateway_prov["models"] == [
@@ -733,6 +739,7 @@ def test_resolve_custom_provider_passes_key_env():
             {
                 "name": "token-plan",
                 "base_url": "https://token-plan-sgp.xiaomimimo.com/v1",
+                "models_url": "https://catalog.xiaomimimo.com/models",
                 "key_env": "XIAOMI_MIMO_API_KEY",
                 "model": "mimo-v2-pro",
             }
@@ -742,6 +749,7 @@ def test_resolve_custom_provider_passes_key_env():
     assert resolved is not None
     assert resolved.api_key_env_vars == ("XIAOMI_MIMO_API_KEY",)
     assert resolved.base_url == "https://token-plan-sgp.xiaomimimo.com/v1"
+    assert resolved.models_url == "https://catalog.xiaomimimo.com/models"
 
 
 def test_discovered_models_auto_saved_to_cache(monkeypatch):

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -305,6 +305,37 @@ class TestFetchApiModels:
         assert probe["resolved_base_url"] == "http://localhost:8000/v1"
         assert probe["used_fallback"] is True
 
+    def test_probe_api_models_uses_explicit_native_catalog_url(self):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"models": [{"key": "loaded-chat", "type": "llm"}, {"key": "embed-only", "type": "embedding"}]}'
+
+        with patch(
+            "hermes_cli.models._urlopen_model_catalog_request",
+            return_value=_Resp(),
+        ) as mock_urlopen:
+            probe = probe_api_models(
+                "key",
+                "https://inference.example.com/v1",
+                models_url="https://catalog.example.com/api/v1/models",
+            )
+
+        assert mock_urlopen.call_count == 1
+        assert (
+            mock_urlopen.call_args[0][0].full_url
+            == "https://catalog.example.com/api/v1/models"
+        )
+        assert probe["models"] == ["loaded-chat"]
+        assert probe["resolved_base_url"] == "https://inference.example.com/v1"
+        assert probe["suggested_base_url"] is None
+        assert probe["used_fallback"] is False
+
     def test_probe_api_models_uses_copilot_catalog(self):
         class _Resp:
             def __enter__(self):

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -323,14 +323,15 @@ class TestFetchApiModels:
             probe = probe_api_models(
                 "key",
                 "https://inference.example.com/v1",
+                request_headers={"X-Catalog-Token": "catalog-token"},
                 models_url="https://catalog.example.com/api/v1/models",
             )
 
         assert mock_urlopen.call_count == 1
-        assert (
-            mock_urlopen.call_args[0][0].full_url
-            == "https://catalog.example.com/api/v1/models"
-        )
+        request = mock_urlopen.call_args[0][0]
+        assert request.full_url == "https://catalog.example.com/api/v1/models"
+        assert request.get_header("Authorization") == "Bearer key"
+        assert request.get_header("X-catalog-token") == "catalog-token"
         assert probe["models"] == ["loaded-chat"]
         assert probe["resolved_base_url"] == "https://inference.example.com/v1"
         assert probe["suggested_base_url"] is None
@@ -654,6 +655,30 @@ class TestValidateApiFound:
         assert result["accepted"] is True
         assert result["persist"] is True
         assert result["recognized"] is True
+
+    def test_named_provider_uses_explicit_catalog_url_and_headers(self):
+        headers = {"X-Catalog-Token": "catalog-token"}
+        with patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["catalog-model"],
+        ) as mock_fetch:
+            result = validate_requested_model(
+                "catalog-model",
+                "private-gateway",
+                api_key="gateway-key",
+                base_url="https://inference.example.com/v1",
+                models_url="https://catalog.example.com/models",
+                headers=headers,
+            )
+
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+        mock_fetch.assert_called_once_with(
+            "gateway-key",
+            "https://inference.example.com/v1",
+            headers=headers,
+            models_url="https://catalog.example.com/models",
+        )
 
 
 # -- validate — API not found ------------------------------------------------

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -200,6 +200,37 @@ class TestFetchApiModels:
         assert probe["resolved_base_url"] == "http://localhost:8000/v1"
         assert probe["used_fallback"] is True
 
+    def test_probe_api_models_uses_explicit_native_catalog_url(self):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"models": [{"key": "loaded-chat", "type": "llm"}, {"key": "embed-only", "type": "embedding"}]}'
+
+        with patch(
+            "hermes_cli.models._urlopen_model_catalog_request",
+            return_value=_Resp(),
+        ) as mock_urlopen:
+            probe = probe_api_models(
+                "key",
+                "https://inference.example.com/v1",
+                models_url="https://catalog.example.com/api/v1/models",
+            )
+
+        assert mock_urlopen.call_count == 1
+        assert (
+            mock_urlopen.call_args[0][0].full_url
+            == "https://catalog.example.com/api/v1/models"
+        )
+        assert probe["models"] == ["loaded-chat"]
+        assert probe["resolved_base_url"] == "https://inference.example.com/v1"
+        assert probe["suggested_base_url"] is None
+        assert probe["used_fallback"] is False
+
     def test_probe_api_models_uses_copilot_catalog(self):
         class _Resp:
             def __enter__(self):

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -218,14 +218,15 @@ class TestFetchApiModels:
             probe = probe_api_models(
                 "key",
                 "https://inference.example.com/v1",
+                request_headers={"X-Catalog-Token": "catalog-token"},
                 models_url="https://catalog.example.com/api/v1/models",
             )
 
         assert mock_urlopen.call_count == 1
-        assert (
-            mock_urlopen.call_args[0][0].full_url
-            == "https://catalog.example.com/api/v1/models"
-        )
+        request = mock_urlopen.call_args[0][0]
+        assert request.full_url == "https://catalog.example.com/api/v1/models"
+        assert request.get_header("Authorization") == "Bearer key"
+        assert request.get_header("X-catalog-token") == "catalog-token"
         assert probe["models"] == ["loaded-chat"]
         assert probe["resolved_base_url"] == "https://inference.example.com/v1"
         assert probe["suggested_base_url"] is None
@@ -390,6 +391,31 @@ class TestValidateFormatChecks:
 
 # -- validate — API found ----------------------------------------------------
 
+class TestValidateApiFound:
+    def test_named_provider_uses_explicit_catalog_url_and_headers(self):
+        headers = {"X-Catalog-Token": "catalog-token"}
+        with patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["catalog-model"],
+        ) as mock_fetch:
+            result = validate_requested_model(
+                "catalog-model",
+                "private-gateway",
+                api_key="gateway-key",
+                base_url="https://inference.example.com/v1",
+                models_url="https://catalog.example.com/models",
+                headers=headers,
+            )
+
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+        mock_fetch.assert_called_once_with(
+            "gateway-key",
+            "https://inference.example.com/v1",
+            headers=headers,
+            models_url="https://catalog.example.com/models",
+        )
+
 
 # -- validate — API not found ------------------------------------------------
 
@@ -552,5 +578,4 @@ class TestProbeApiModelsUserAgent:
         assert ua and ua.startswith("hermes-cli/")
         # No Authorization was set, but UA must still be present.
         assert req.get_header("Authorization") is None
-
 

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -10,6 +10,7 @@ import pytest
 
 from hermes_cli.config import (
     _PROVIDER_NORMALIZE_WARNED,
+    _custom_provider_entry_to_provider_config,
     _normalize_custom_provider_entry,
 )
 
@@ -37,6 +38,46 @@ class TestNormalizeCustomProviderEntry:
         assert result["name"] == "myhost"
         assert result["base_url"] == "https://api.example.com/v1"
         assert result["api_key"] == "sk-test-key"
+
+    def test_models_url_is_preserved(self):
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "models_url": "https://catalog.example.com/api/models",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="myhost")
+        assert result is not None
+        assert result["models_url"] == "https://catalog.example.com/api/models"
+
+    def test_camel_case_models_url_mapped(self):
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "modelsUrl": "https://catalog.example.com/api/models",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="myhost")
+        assert result is not None
+        assert result["models_url"] == "https://catalog.example.com/api/models"
+
+    def test_invalid_models_url_is_ignored(self, caplog):
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "models_url": "catalog-without-scheme",
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="myhost")
+        assert result is not None
+        assert "models_url" not in result
+        assert any("models_url" in record.message for record in caplog.records)
+
+    def test_legacy_conversion_preserves_models_url(self):
+        result = _custom_provider_entry_to_provider_config(
+            {
+                "name": "remote",
+                "base_url": "https://api.example.com/v1",
+                "models_url": "https://catalog.example.com/api/models",
+            }
+        )
+        assert result is not None
+        assert result["models_url"] == "https://catalog.example.com/api/models"
 
     def test_camel_case_api_key_mapped(self):
         """camelCase apiKey should be auto-mapped to api_key."""

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -10,6 +10,7 @@ import pytest
 
 from hermes_cli.config import (
     _PROVIDER_NORMALIZE_WARNED,
+    _custom_provider_entry_to_provider_config,
     _normalize_custom_provider_entry,
 )
 
@@ -25,6 +26,52 @@ class TestNormalizeCustomProviderEntry:
         _PROVIDER_NORMALIZE_WARNED.clear()
         yield
         _PROVIDER_NORMALIZE_WARNED.clear()
+
+    def test_models_url_is_preserved(self):
+        result = _normalize_custom_provider_entry(
+            {
+                "base_url": "https://api.example.com/v1",
+                "models_url": "https://catalog.example.com/api/models",
+            },
+            provider_key="myhost",
+        )
+        assert result is not None
+        assert result["models_url"] == "https://catalog.example.com/api/models"
+
+    def test_camel_case_models_url_mapped(self):
+        result = _normalize_custom_provider_entry(
+            {
+                "base_url": "https://api.example.com/v1",
+                "modelsUrl": "https://catalog.example.com/api/models",
+            },
+            provider_key="myhost",
+        )
+        assert result is not None
+        assert result["models_url"] == "https://catalog.example.com/api/models"
+
+    def test_invalid_models_url_is_ignored(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(
+                {
+                    "base_url": "https://api.example.com/v1",
+                    "models_url": "catalog-without-scheme",
+                },
+                provider_key="myhost",
+            )
+        assert result is not None
+        assert "models_url" not in result
+        assert any("models_url" in record.message for record in caplog.records)
+
+    def test_legacy_conversion_preserves_models_url(self):
+        result = _custom_provider_entry_to_provider_config(
+            {
+                "name": "remote",
+                "base_url": "https://api.example.com/v1",
+                "models_url": "https://catalog.example.com/api/models",
+            }
+        )
+        assert result is not None
+        assert result["models_url"] == "https://catalog.example.com/api/models"
 
 
 
@@ -66,5 +113,4 @@ class TestNormalizeCustomProviderEntry:
         result = _normalize_custom_provider_entry(entry, provider_key="PROVIDER_A")
         assert result is not None
         assert result["base_url"] == "${PROVIDER_A_BASE_URL}"
-
 

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -904,6 +904,69 @@ def test_switch_model_resolves_user_provider_credentials(monkeypatch, tmp_path):
     assert result.error_message == ""
 
 
+def test_switch_model_named_provider_validates_with_catalog_config(monkeypatch):
+    """Named providers keep inference routing separate from catalog auth."""
+    validation_calls = []
+    inference_url = "https://inference.example.com/v1"
+    catalog_url = "https://catalog.example.com/models"
+    catalog_headers = {"X-Catalog-Token": "catalog-token"}
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "gateway-key",
+            "base_url": inference_url,
+            "api_mode": "chat_completions",
+        },
+    )
+
+    def fake_validate(*args, **kwargs):
+        validation_calls.append((args, kwargs))
+        return {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "message": None,
+        }
+
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", fake_validate)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="catalog-model",
+        current_provider="openai-codex",
+        current_model="gpt-5.4",
+        current_base_url="https://chatgpt.com/backend-api/codex",
+        explicit_provider="private-gateway",
+        user_providers={
+            "private-gateway": {
+                "name": "Private Gateway",
+                "base_url": inference_url,
+                "models_url": catalog_url,
+                "api_key": "gateway-key",
+                "extra_headers": catalog_headers,
+            }
+        },
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert result.base_url == inference_url
+    assert validation_calls == [
+        (
+            ("catalog-model", "private-gateway"),
+            {
+                "api_key": "gateway-key",
+                "base_url": inference_url,
+                "api_mode": "chat_completions",
+                "models_url": catalog_url,
+                "headers": catalog_headers,
+            },
+        )
+    ]
+
+
 # =============================================================================
 # Regression: providers: dict ``transport`` field must be honored
 # =============================================================================

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -231,6 +231,44 @@ def test_user_provider_live_model_probe_uses_extra_headers(monkeypatch):
     assert user_prov["models"] == ["live-model"]
 
 
+def test_user_provider_live_model_probe_uses_models_url(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
+        return ["catalog-model"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    providers = list_authenticated_providers(
+        current_provider="remote-lm-studio",
+        user_providers={
+            "remote-lm-studio": {
+                "base_url": "https://lm.example.com/v1",
+                "models_url": "https://lm.example.com/api/v1/models",
+                "api_key": "local-key",
+            }
+        },
+        custom_providers=[],
+    )
+
+    user_prov = next(p for p in providers if p.get("is_user_defined"))
+    assert calls == [
+        (
+            "local-key",
+            "https://lm.example.com/v1",
+            {
+                "headers": None,
+                "models_url": "https://lm.example.com/api/v1/models",
+            },
+        )
+    ]
+    assert user_prov["models"] == ["catalog-model"]
+
+
 def test_list_authenticated_providers_dict_models_without_default_model(monkeypatch):
     """Dict-format ``models:`` without a ``default_model`` must still expose
     every dict key, not collapse to an empty list."""
@@ -344,6 +382,7 @@ def test_resolve_provider_full_user_config_openai_beats_alias():
         "openai": {
             "name": "OpenAI-API",
             "api": "https://api.openai.com/v1",
+            "models_url": "https://catalog.example.com/openai/models",
             "transport": "codex_responses",
             "models": {"gpt-5.4-nano": {}},
         }
@@ -354,6 +393,7 @@ def test_resolve_provider_full_user_config_openai_beats_alias():
     assert pdef.id == "openai"
     assert pdef.source == "user-config"
     assert pdef.base_url == "https://api.openai.com/v1"
+    assert pdef.models_url == "https://catalog.example.com/openai/models"
     assert "openrouter" not in pdef.base_url
 
 

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -457,6 +457,69 @@ def test_switch_model_resolves_user_provider_credentials(monkeypatch, tmp_path):
     assert result.error_message == ""
 
 
+def test_switch_model_named_provider_validates_with_catalog_config(monkeypatch):
+    """Named providers keep inference routing separate from catalog auth."""
+    validation_calls = []
+    inference_url = "https://inference.example.com/v1"
+    catalog_url = "https://catalog.example.com/models"
+    catalog_headers = {"X-Catalog-Token": "catalog-token"}
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "gateway-key",
+            "base_url": inference_url,
+            "api_mode": "chat_completions",
+        },
+    )
+
+    def fake_validate(*args, **kwargs):
+        validation_calls.append((args, kwargs))
+        return {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "message": None,
+        }
+
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", fake_validate)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="catalog-model",
+        current_provider="openai-codex",
+        current_model="gpt-5.4",
+        current_base_url="https://chatgpt.com/backend-api/codex",
+        explicit_provider="private-gateway",
+        user_providers={
+            "private-gateway": {
+                "name": "Private Gateway",
+                "base_url": inference_url,
+                "models_url": catalog_url,
+                "api_key": "gateway-key",
+                "extra_headers": catalog_headers,
+            }
+        },
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert result.base_url == inference_url
+    assert validation_calls == [
+        (
+            ("catalog-model", "private-gateway"),
+            {
+                "api_key": "gateway-key",
+                "base_url": inference_url,
+                "api_mode": "chat_completions",
+                "models_url": catalog_url,
+                "headers": catalog_headers,
+            },
+        )
+    ]
+
+
 # =============================================================================
 # Regression: providers: dict ``transport`` field must be honored
 # =============================================================================

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -169,6 +169,68 @@ def test_list_authenticated_providers_uses_live_models_for_user_provider(monkeyp
     assert user_prov["total_models"] == 2
 
 
+def test_user_provider_live_model_probe_uses_models_url(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url, kwargs))
+        return ["catalog-model"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+    monkeypatch.setattr(
+        "hermes_cli.models._load_provider_models_cache", lambda: {}
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="remote-lm-studio",
+        user_providers={
+            "remote-lm-studio": {
+                "base_url": "https://lm.example.com/v1",
+                "models_url": "https://lm.example.com/api/v1/models",
+                "api_key": "local-key",
+            }
+        },
+        custom_providers=[],
+    )
+
+    user_prov = next(p for p in providers if p.get("is_user_defined"))
+    assert calls == [
+        (
+            "local-key",
+            "https://lm.example.com/v1",
+            {
+                "timeout": 5.0,
+                "api_mode": None,
+                "headers": None,
+                "models_url": "https://lm.example.com/api/v1/models",
+            },
+        )
+    ]
+    assert user_prov["models"] == ["catalog-model"]
+
+
+def test_resolve_user_provider_preserves_models_url():
+    from hermes_cli.providers import resolve_provider_full
+
+    provider = resolve_provider_full(
+        "private-gateway",
+        {
+            "private-gateway": {
+                "base_url": "https://inference.example.com/v1",
+                "models_url": "https://catalog.example.com/models",
+            }
+        },
+        [],
+    )
+
+    assert provider is not None
+    assert provider.base_url == "https://inference.example.com/v1"
+    assert provider.models_url == "https://catalog.example.com/models"
+
+
 
 
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1231,6 +1231,22 @@ extra_body:
 
 The `hermes model` → Custom Endpoint wizard now prompts for `api_mode` explicitly and persists your answer to `config.yaml`. URL-based auto-detection (e.g. `/anthropic` paths → `anthropic_messages`) still happens as a fallback when the field is left blank.
 
+If model discovery uses a different endpoint from inference, set `models_url`
+to the complete catalog URL. Hermes uses it for model listing and `/model`
+validation without changing where chat requests are sent:
+
+```yaml
+custom_providers:
+  - name: remote-lm-studio
+    base_url: https://lm.example.com/v1
+    models_url: https://lm.example.com/api/v1/models
+    key_env: LM_API_KEY
+```
+
+`models_url` accepts both OpenAI-compatible `data[].id` catalogs and LM Studio
+native `models[].key` catalogs. When omitted, Hermes keeps probing
+`{base_url}/models` and its existing `/v1` fallback.
+
 **Native vision for custom-provider models.** If your custom endpoint serves a vision-capable model that isn't in models.dev, set `model.supports_vision: true` so Hermes routes attached images natively (as `image_url` parts) instead of pre-processing them through `vision_analyze`. Single knob — no need to also set `agent.image_input_mode: native`.
 
 ```yaml

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1307,6 +1307,22 @@ extra_body:
 
 The `hermes model` → Custom Endpoint wizard now prompts for the API mode explicitly and persists your answer to `config.yaml` (as `transport` on the provider entry). URL-based auto-detection (e.g. `/anthropic` paths → `anthropic_messages`) still happens as a fallback when the field is left blank.
 
+If model discovery uses a different endpoint from inference, set `models_url`
+to the complete catalog URL. Hermes uses it for model listing and `/model`
+validation without changing where chat requests are sent:
+
+```yaml
+custom_providers:
+  - name: remote-lm-studio
+    base_url: https://lm.example.com/v1
+    models_url: https://lm.example.com/api/v1/models
+    key_env: LM_API_KEY
+```
+
+`models_url` accepts both OpenAI-compatible `data[].id` catalogs and LM Studio
+native `models[].key` catalogs. When omitted, Hermes keeps probing
+`{base_url}/models` and its existing `/v1` fallback.
+
 **Native vision for custom-provider models.** If your custom endpoint serves a vision-capable model that isn't in models.dev, set `model.supports_vision: true` so Hermes routes attached images natively (as `image_url` parts) instead of pre-processing them through `vision_analyze`. Single knob — no need to also set `agent.image_input_mode: native`.
 
 ```yaml


### PR DESCRIPTION
## Summary

- accept `models_url` (and `modelsUrl`) in custom provider configuration
- use the exact configured catalog URL and custom headers for model listing, validation, and named-provider setup while preserving `base_url` for inference
- isolate model catalog caches by catalog URL so providers sharing an inference endpoint cannot reuse each other's results
- support OpenAI-compatible `data[].id`, list payloads, and LM Studio native `models[].key` catalogs
- document the option and validate malformed catalog URLs independently

## Root cause

Custom providers currently use their inference `base_url` for both chat requests and model discovery. The discovery path then appends `/models` and applies `/v1` fallback heuristics, so providers whose catalog endpoint lives elsewhere cannot be represented without breaking inference routing.

When `models_url` is configured, discovery requests that full URL exactly and skips URL rewriting. The value and normalized `extra_headers` now flow through provider resolution, model pickers, typed validation, cached discovery, and the named custom-provider setup flow. Existing providers without the option retain the current behavior and call shape.

This is complementary to #64513: that PR concerns authoritative live metadata for provider plugins, while this change wires an independent catalog URL through user-defined provider config, model selection, setup, and validation.

## Validation

- 135 focused tests passed across config validation, model validation, cached discovery, and custom/user provider switching
- 99 adjacent provider/config/runtime/setup tests passed
- `ruff check` passed for all changed Python files
- `python scripts/check-windows-footguns.py --all`
- `git diff --check`
- broader suite reached 4,550 passing tests with zero failures before being stopped due to its 26k-test local runtime; CI runs the complete sharded matrix

Closes #65481