### PR TITLE
fix(permissions): add timeout to cua-driver permissions grant subprocess.run

### DIFF
--- a/tools/computer_use/permissions.py
+++ b/tools/computer_use/permissions.py
@@ -191,8 +191,12 @@ def request_permissions_grant(driver_cmd: Optional[str] = None) -> int:
                 [binary, "permissions", "grant"],
                 env=_child_env(),
                 stdin=subprocess.DEVNULL,
+                timeout=300,
             ).returncode
         )
+    except subprocess.TimeoutExpired:
+        print("cua-driver permissions grant timed out after 300s.", file=sys.stderr)
+        return 2
     except KeyboardInterrupt:  # pragma: no cover - interactive
         return 130
     except Exception as exc:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary

Add a timeout to the `cua-driver permissions grant` subprocess call and handle `TimeoutExpired` gracefully.

## Problem

The `subprocess.run` call for `cua-driver permissions grant` lacked a `timeout` parameter, which could cause the entire agent turn to block indefinitely if the macOS TCC permission dialog never appears or the subprocess hangs.

## Fix

Added `timeout=300` (5 minutes, appropriate for an interactive permission grant flow) and a `subprocess.TimeoutExpired` handler that returns exit code 2 with a clear error message.