### PR TITLE
fix(agent): re-prompt model when finish_reason=tool_calls but tool_calls is empty

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4891,8 +4891,9 @@ def run_conversation(
                             })
                         continue
                 
-                # Reset retry counter on successful JSON validation
+                # Reset retry counters on successful JSON validation
                 agent._invalid_json_retries = 0
+                agent._ghost_tool_call_retries = 0
 
                 # ── Post-call guardrails ──────────────────────────
                 assistant_message.tool_calls = agent._cap_delegate_task_calls(
@@ -5187,6 +5188,9 @@ def run_conversation(
                             "finish_reason=tool_calls with empty tool_calls "
                             "persisted after 3 retries — treating as partial response"
                         )
+
+                # Reset ghost retry counter on normal (non-ghost) text completion
+                agent._ghost_tool_call_retries = 0
 
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5151,9 +5151,46 @@ def run_conversation(
                 continue
             
             else:
+                # Guard: if the provider signalled tool_calls but the
+                # normalized tool_calls list is empty (transport parsing
+                # lost them), do NOT treat the accompanying narration as
+                # a final response.  Re-prompt the model to emit the tool
+                # calls properly.  Cap retries to avoid infinite loops.
+                # See #65430.
+                if finish_reason == "tool_calls":
+                    _ghost_tc_retries = getattr(agent, "_ghost_tool_call_retries", 0)
+                    if _ghost_tc_retries < 3:
+                        agent._ghost_tool_call_retries = _ghost_tc_retries + 1
+                        logger.warning(
+                            "finish_reason=tool_calls but tool_calls is empty "
+                            "(attempt %d/3) — re-prompting model",
+                            _ghost_tc_retries + 1,
+                        )
+                        # Append the assistant message so context is preserved
+                        interim_msg = agent._build_assistant_message(
+                            assistant_message, "incomplete"
+                        )
+                        messages.append(interim_msg)
+                        messages.append({
+                            "role": "user",
+                            "content": (
+                                "[System: Your response indicated tool_calls but none "
+                                "were received. Please re-emit your tool calls.]"
+                            ),
+                        })
+                        agent._session_messages = messages
+                        continue
+                    else:
+                        # Exhausted retries — fall through as partial
+                        agent._ghost_tool_call_retries = 0
+                        logger.error(
+                            "finish_reason=tool_calls with empty tool_calls "
+                            "persisted after 3 retries — treating as partial response"
+                        )
+
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""
-                
+
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery
                 # status messages.  _mute_post_response was set during a

--- a/tests/run_agent/test_ghost_tool_calls_retry.py
+++ b/tests/run_agent/test_ghost_tool_calls_retry.py
@@ -11,11 +11,8 @@ a mock client that simulates the ghost tool_calls scenario.
 
 from __future__ import annotations
 
-import re
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch, PropertyMock
-
-import pytest
+from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent
 
@@ -42,22 +39,22 @@ class TestGhostToolCallGuard:
     def test_ghost_tool_calls_retried_then_normal_stop(self, _mock_close, mock_create):
         """Model returns finish_reason=tool_calls with no tool_calls on first
         call, then returns a proper stop response on second call."""
-        call_count = 0
-
         # We need to mock at the transport level
         agent = _make_agent()
 
-        # Track what normalize_response returns per call
+        # Track API calls to vary responses per-call
+        api_call_count = {"n": 0}
+
         original_get_transport = agent._get_transport
 
         def _patched_get_transport():
             transport = original_get_transport()
-            original_normalize = transport.normalize_response
 
             def _mock_normalize(response, **kwargs):
-                nonlocal call_count
-                call_count += 1
-                if call_count == 1:
+                # Keyed off the API call counter, NOT per-normalize call.
+                # normalize_response may be called multiple times per API
+                # response; return consistent results for the same response.
+                if api_call_count["n"] == 1:
                     # Ghost: finish_reason=tool_calls but no actual tools
                     return SimpleNamespace(
                         content="Let me check the remaining data...",
@@ -97,30 +94,33 @@ class TestGhostToolCallGuard:
 
         agent._get_transport = _patched_get_transport
 
-        # Mock the actual API client
-        mock_response = MagicMock()
-        mock_response.id = "resp-mock"
-        mock_response.model = "test/model"
-        mock_response.usage = SimpleNamespace(
-            prompt_tokens=100, completion_tokens=50, total_tokens=150
-        )
-        mock_response.choices = [
-            SimpleNamespace(
-                message=SimpleNamespace(
-                    content="text", tool_calls=None, role="assistant"
-                ),
-                finish_reason="stop",
+        # Mock the actual API client — vary per call
+        def _make_mock_response(*args, **kwargs):
+            api_call_count["n"] += 1
+            resp = MagicMock()
+            resp.id = f"resp-{api_call_count['n']}"
+            resp.model = "test/model"
+            resp.usage = SimpleNamespace(
+                prompt_tokens=100, completion_tokens=50, total_tokens=150
             )
-        ]
+            resp.choices = [
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="text", tool_calls=None, role="assistant"
+                    ),
+                    finish_reason="stop",
+                )
+            ]
+            return resp
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_client.chat.completions.create.side_effect = _make_mock_response
         mock_create.return_value = mock_client
 
         result = agent.run_conversation("Run full security audit")
 
-        # Should have called normalize at least twice
-        assert call_count >= 2
+        # Exactly 2 API calls: 1 ghost + 1 successful retry
+        assert mock_client.chat.completions.create.call_count == 2
         # Final response should be the real answer
         assert "complete security report" in result.get("final_response", "")
         # Should NOT contain the ghost narration
@@ -130,8 +130,6 @@ class TestGhostToolCallGuard:
     @patch("run_agent.AIAgent._close_request_openai_client")
     def test_ghost_tool_calls_caps_at_three_retries(self, _mock_close, mock_create):
         """After 3 retries of ghost tool_calls, fall through as response."""
-        call_count = 0
-
         agent = _make_agent()
         agent.max_iterations = 20
 
@@ -141,8 +139,6 @@ class TestGhostToolCallGuard:
             transport = original_get_transport()
 
             def _mock_normalize(response, **kwargs):
-                nonlocal call_count
-                call_count += 1
                 # Always return ghost tool_calls
                 return SimpleNamespace(
                     content="Still working on it...",
@@ -151,7 +147,7 @@ class TestGhostToolCallGuard:
                     refusal=None,
                     reasoning_content=None,
                     reasoning=None,
-                    id=f"resp-{call_count}",
+                    id="resp-ghost",
                     provider_data={},
                     model="test/model",
                     usage=SimpleNamespace(
@@ -165,28 +161,30 @@ class TestGhostToolCallGuard:
 
         agent._get_transport = _patched_get_transport
 
-        mock_response = MagicMock()
-        mock_response.id = "resp-mock"
-        mock_response.model = "test/model"
-        mock_response.usage = SimpleNamespace(
-            prompt_tokens=100, completion_tokens=50, total_tokens=150
-        )
-        mock_response.choices = [
-            SimpleNamespace(
-                message=SimpleNamespace(
-                    content="text", tool_calls=None, role="assistant"
-                ),
-                finish_reason="tool_calls",
+        def _make_mock_response(*args, **kwargs):
+            resp = MagicMock()
+            resp.id = "resp-mock"
+            resp.model = "test/model"
+            resp.usage = SimpleNamespace(
+                prompt_tokens=100, completion_tokens=50, total_tokens=150
             )
-        ]
+            resp.choices = [
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="text", tool_calls=None, role="assistant"
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ]
+            return resp
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_client.chat.completions.create.side_effect = _make_mock_response
         mock_create.return_value = mock_client
 
         result = agent.run_conversation("Run full audit")
 
-        # After 3 retries (calls 1-3 trigger re-prompt), call 4 falls through
-        assert call_count >= 4
+        # Exactly 4 API calls: 1 initial + 3 retries, then exhaustion
+        assert mock_client.chat.completions.create.call_count == 4
         # Should eventually produce a response (partial)
         assert result.get("final_response") is not None

--- a/tests/run_agent/test_ghost_tool_calls_retry.py
+++ b/tests/run_agent/test_ghost_tool_calls_retry.py
@@ -1,0 +1,192 @@
+"""Regression test: finish_reason=tool_calls with empty tool_calls (#65430).
+
+When a provider returns finish_reason="tool_calls" but the normalized
+tool_calls list is None/empty, the conversation loop must NOT treat the
+accompanying narration text as the final response.  Instead it should
+re-prompt the model to re-emit tool calls (up to 3 retries).
+
+This test validates the fix at the unit level by running the agent with
+a mock client that simulates the ghost tool_calls scenario.
+"""
+
+from __future__ import annotations
+
+import re
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent():
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent
+
+
+class TestGhostToolCallGuard:
+    """finish_reason=tool_calls with empty tool_calls should trigger re-prompts."""
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_ghost_tool_calls_retried_then_normal_stop(self, _mock_close, mock_create):
+        """Model returns finish_reason=tool_calls with no tool_calls on first
+        call, then returns a proper stop response on second call."""
+        call_count = 0
+
+        # We need to mock at the transport level
+        agent = _make_agent()
+
+        # Track what normalize_response returns per call
+        original_get_transport = agent._get_transport
+
+        def _patched_get_transport():
+            transport = original_get_transport()
+            original_normalize = transport.normalize_response
+
+            def _mock_normalize(response, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    # Ghost: finish_reason=tool_calls but no actual tools
+                    return SimpleNamespace(
+                        content="Let me check the remaining data...",
+                        tool_calls=None,
+                        finish_reason="tool_calls",
+                        refusal=None,
+                        reasoning_content=None,
+                        reasoning=None,
+                        id="resp-1",
+                        provider_data={},
+                        model="test/model",
+                        usage=SimpleNamespace(
+                            prompt_tokens=100, completion_tokens=50,
+                            total_tokens=150,
+                        ),
+                    )
+                else:
+                    # Proper final response
+                    return SimpleNamespace(
+                        content="Here is the complete security report with all findings.",
+                        tool_calls=None,
+                        finish_reason="stop",
+                        refusal=None,
+                        reasoning_content=None,
+                        reasoning=None,
+                        id="resp-2",
+                        provider_data={},
+                        model="test/model",
+                        usage=SimpleNamespace(
+                            prompt_tokens=200, completion_tokens=100,
+                            total_tokens=300,
+                        ),
+                    )
+
+            transport.normalize_response = _mock_normalize
+            return transport
+
+        agent._get_transport = _patched_get_transport
+
+        # Mock the actual API client
+        mock_response = MagicMock()
+        mock_response.id = "resp-mock"
+        mock_response.model = "test/model"
+        mock_response.usage = SimpleNamespace(
+            prompt_tokens=100, completion_tokens=50, total_tokens=150
+        )
+        mock_response.choices = [
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="text", tool_calls=None, role="assistant"
+                ),
+                finish_reason="stop",
+            )
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_create.return_value = mock_client
+
+        result = agent.run_conversation("Run full security audit")
+
+        # Should have called normalize at least twice
+        assert call_count >= 2
+        # Final response should be the real answer
+        assert "complete security report" in result.get("final_response", "")
+        # Should NOT contain the ghost narration
+        assert "Let me check" not in result.get("final_response", "")
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_ghost_tool_calls_caps_at_three_retries(self, _mock_close, mock_create):
+        """After 3 retries of ghost tool_calls, fall through as response."""
+        call_count = 0
+
+        agent = _make_agent()
+        agent.max_iterations = 20
+
+        original_get_transport = agent._get_transport
+
+        def _patched_get_transport():
+            transport = original_get_transport()
+
+            def _mock_normalize(response, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                # Always return ghost tool_calls
+                return SimpleNamespace(
+                    content="Still working on it...",
+                    tool_calls=None,
+                    finish_reason="tool_calls",
+                    refusal=None,
+                    reasoning_content=None,
+                    reasoning=None,
+                    id=f"resp-{call_count}",
+                    provider_data={},
+                    model="test/model",
+                    usage=SimpleNamespace(
+                        prompt_tokens=100, completion_tokens=50,
+                        total_tokens=150,
+                    ),
+                )
+
+            transport.normalize_response = _mock_normalize
+            return transport
+
+        agent._get_transport = _patched_get_transport
+
+        mock_response = MagicMock()
+        mock_response.id = "resp-mock"
+        mock_response.model = "test/model"
+        mock_response.usage = SimpleNamespace(
+            prompt_tokens=100, completion_tokens=50, total_tokens=150
+        )
+        mock_response.choices = [
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="text", tool_calls=None, role="assistant"
+                ),
+                finish_reason="tool_calls",
+            )
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_create.return_value = mock_client
+
+        result = agent.run_conversation("Run full audit")
+
+        # After 3 retries (calls 1-3 trigger re-prompt), call 4 falls through
+        assert call_count >= 4
+        # Should eventually produce a response (partial)
+        assert result.get("final_response") is not None


### PR DESCRIPTION
## Summary

- When a provider returns `finish_reason=tool_calls` but the normalized `tool_calls` list is empty, the conversation loop incorrectly treated the accompanying narration text as the final response
- This caused autonomous/cron jobs to silently deliver partial results (75% failure rate) marked as `succeeded`
- Added a guard that re-prompts the model up to 3 times when this discrepancy is detected, only falling through as partial after retries are exhausted

## Root Cause

In `agent/conversation_loop.py:4586`, the branching decision is made solely on `if assistant_message.tool_calls:` — the `finish_reason` is not consulted. When a router/provider sets `finish_reason="tool_calls"` but delivers an empty `tool_calls` array, the code falls into the `else` branch and returns the narration text as the final answer.

## Changes

- `agent/conversation_loop.py` — Added a guard at the top of the `else` (no-tool-calls) branch that detects `finish_reason == "tool_calls"` with no actual tool calls, re-prompts the model (up to 3 retries), and only falls through after exhaustion
- `tests/run_agent/test_ghost_tool_calls_retry.py` — Two test cases covering retry-then-success and retry-exhaustion paths

## Test plan

- [x] `test_ghost_tool_calls_retried_then_normal_stop` — verifies retry produces correct final response
- [x] `test_ghost_tool_calls_caps_at_three_retries` — verifies retry cap prevents infinite loops
- [ ] Manual test with a cron job that triggers the ghost tool_calls scenario

Closes #65430

🤖 Generated with [Claude Code](https://claude.com/claude-code)