### PR TITLE
feat(desktop): show Codex usage in status bar

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING, Any, Optional
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
-from hermes_cli.auth import AuthError, _read_codex_tokens, resolve_codex_runtime_credentials
+from hermes_cli.auth import (
+    AuthError,
+    _decode_jwt_claims,
+    _read_codex_tokens,
+    resolve_codex_runtime_credentials,
+)
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
 if TYPE_CHECKING:
@@ -129,6 +134,7 @@ def serialize_account_usage_snapshot(snapshot: AccountUsageSnapshot) -> dict[str
     an unprivileged renderer.
     """
     return {
+        "available": snapshot.available,
         "provider": snapshot.provider,
         "source": snapshot.source,
         "fetched_at": snapshot.fetched_at.isoformat(),
@@ -137,7 +143,11 @@ def serialize_account_usage_snapshot(snapshot: AccountUsageSnapshot) -> dict[str
         "windows": [
             {
                 "label": window.label,
-                "used_percent": window.used_percent,
+                "used_percent": (
+                    max(0.0, min(100.0, float(window.used_percent)))
+                    if _is_finite_num(window.used_percent)
+                    else None
+                ),
                 "reset_at": window.reset_at.isoformat() if window.reset_at else None,
                 "detail": window.detail,
             }
@@ -477,6 +487,27 @@ def _resolve_codex_usage_url(base_url: str) -> str:
     return _codex_backend_urls(base_url)[0]
 
 
+def codex_account_id_from_token(token: Any) -> Optional[str]:
+    """Return the ChatGPT account selected by an OAuth token, if present.
+
+    Codex logins can coexist in the credential pool.  Account-scoped requests
+    must derive this header from the same token they send, rather than pairing
+    a selected token with the legacy singleton store's account id.
+    """
+    claims = _decode_jwt_claims(token)
+    auth_claim = claims.get("https://api.openai.com/auth")
+    candidates = [
+        auth_claim.get("chatgpt_account_id") if isinstance(auth_claim, dict) else None,
+        claims.get("https://api.openai.com/auth.chatgpt_account_id"),
+        claims.get("chatgpt_account_id"),
+    ]
+    for candidate in candidates:
+        account_id = str(candidate or "").strip()
+        if account_id:
+            return account_id
+    return None
+
+
 def _resolve_codex_usage_credentials(
     base_url: Optional[str],
     api_key: Optional[str],
@@ -490,7 +521,11 @@ def _resolve_codex_usage_credentials(
     """
     explicit_key = str(api_key or "").strip()
     if explicit_key:
-        return explicit_key, str(base_url or "").strip(), None
+        return (
+            explicit_key,
+            str(base_url or "").strip(),
+            codex_account_id_from_token(explicit_key),
+        )
 
     # Tier 2: the native runtime resolver. It ALREADY falls back to the
     # credential pool when the singleton is empty (see
@@ -509,30 +544,38 @@ def _resolve_codex_usage_credentials(
     # otherwise-usable resolver credential and force a header-less pool fallback.
     try:
         creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
-        account_id: Optional[str] = None
-        try:
-            token_data = _read_codex_tokens()
-            tokens = token_data.get("tokens") or {}
-            account_id = str(tokens.get("account_id", "") or "").strip() or None
-        except AuthError:
-            # Pool-only creds carry no singleton account_id; header is optional.
-            logger.debug("codex ▸ /usage account_id read failed (best-effort)", exc_info=True)
-        return creds["api_key"], str(creds.get("base_url", "") or "").strip(), account_id
+        selected_key = creds["api_key"]
+        account_id = codex_account_id_from_token(selected_key)
+        selected_from_pool = str(creds.get("source", "") or "").strip() == "credential_pool"
+        if account_id is None and not selected_from_pool:
+            try:
+                token_data = _read_codex_tokens()
+                tokens = token_data.get("tokens") or {}
+                account_id = str(tokens.get("account_id", "") or "").strip() or None
+            except AuthError:
+                # Opaque/legacy tokens may need the singleton account id. A JWT
+                # selected from the pool carries its own identity above.
+                logger.debug("codex ▸ /usage account_id read failed (best-effort)", exc_info=True)
+        return selected_key, str(creds.get("base_url", "") or "").strip(), account_id
     except AuthError:
         logger.debug("codex ▸ /usage runtime resolver returned no creds; trying pool", exc_info=True)
 
     # Tier 3: direct pool select. Reached only when the resolver itself raises
     # AuthError (e.g. singleton missing AND its own pool read found nothing at
-    # resolve time, but a pool entry is usable now). Pool credentials have no
-    # account_id concept, so the ChatGPT-Account-Id header is intentionally
-    # omitted here.
+    # resolve time, but a pool entry is usable now). JWT pool credentials carry
+    # their own account claim; opaque pool tokens intentionally omit the header.
     from agent.credential_pool import load_pool
 
     pool = load_pool("openai-codex")
     entry = pool.select()
     if entry is None:
         raise RuntimeError("No available openai-codex credential in credential pool")
-    return entry.runtime_api_key, str(entry.runtime_base_url or base_url or "").strip(), None
+    selected_key = entry.runtime_api_key
+    return (
+        selected_key,
+        str(entry.runtime_base_url or base_url or "").strip(),
+        codex_account_id_from_token(selected_key),
+    )
 
 
 def _fetch_codex_account_usage(

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -120,6 +120,34 @@ def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, mark
     return lines
 
 
+def serialize_account_usage_snapshot(snapshot: AccountUsageSnapshot) -> dict[str, Any]:
+    """Return the secret-free JSON wire shape used by UI clients.
+
+    Datetimes are normalized to ISO-8601 strings here instead of asking each
+    surface to understand Python objects.  The snapshot never contains the
+    credential used to fetch it, so this is safe to send across the gateway to
+    an unprivileged renderer.
+    """
+    return {
+        "provider": snapshot.provider,
+        "source": snapshot.source,
+        "fetched_at": snapshot.fetched_at.isoformat(),
+        "title": snapshot.title,
+        "plan": snapshot.plan,
+        "windows": [
+            {
+                "label": window.label,
+                "used_percent": window.used_percent,
+                "reset_at": window.reset_at.isoformat() if window.reset_at else None,
+                "detail": window.detail,
+            }
+            for window in snapshot.windows
+        ],
+        "details": list(snapshot.details),
+        "unavailable_reason": snapshot.unavailable_reason,
+    }
+
+
 def _fmt_usd(d: float) -> str:
     return f"${d:,.2f}"
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -753,20 +753,11 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
         "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
         "originator": "codex_cli_rs",
     }
-    if not isinstance(access_token, str) or not access_token.strip():
-        return headers
-    try:
-        import base64
-        parts = access_token.split(".")
-        if len(parts) < 2:
-            return headers
-        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
-        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
-        acct_id = claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
-        if isinstance(acct_id, str) and acct_id:
-            headers["ChatGPT-Account-ID"] = acct_id
-    except Exception:
-        pass
+    from agent.account_usage import codex_account_id_from_token
+
+    account_id = codex_account_id_from_token(access_token)
+    if account_id:
+        headers["ChatGPT-Account-ID"] = account_id
     return headers
 
 

--- a/apps/desktop/src/app/shell/codex-usage-statusbar-item.test.tsx
+++ b/apps/desktop/src/app/shell/codex-usage-statusbar-item.test.tsx
@@ -1,8 +1,11 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ComponentProps } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
+import type { GatewayRequester } from '@/hooks/use-codex-account-usage'
 import type { AccountUsageResponse, AccountUsageSnapshot } from '@/types/hermes'
 
 import {
@@ -32,6 +35,7 @@ afterEach(() => {
 })
 
 const snapshot: AccountUsageSnapshot = {
+  available: true,
   details: ['Credits balance: $12.50'],
   fetched_at: '2026-07-16T01:02:03+00:00',
   plan: 'Plus',
@@ -46,17 +50,28 @@ const snapshot: AccountUsageSnapshot = {
 }
 
 function Harness({
+  connectionScope = 'local:',
   gatewayState = 'open',
+  profile = 'default',
   provider = 'openai-codex',
   requestGateway,
   sessionId = 'runtime-1'
 }: {
+  connectionScope?: string
   gatewayState?: string
+  profile?: string
   provider?: string
-  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  requestGateway: GatewayRequester
   sessionId?: null | string
 }) {
-  const item = useCodexUsageStatusbarItem({ gatewayState, provider, requestGateway, sessionId })
+  const item = useCodexUsageStatusbarItem({
+    connectionScope,
+    gatewayState,
+    profile,
+    provider,
+    requestGateway,
+    sessionId
+  })
 
   return (
     <I18nProvider configClient={null} initialLocale="en">
@@ -65,6 +80,16 @@ function Harness({
       </MemoryRouter>
     </I18nProvider>
   )
+}
+
+function renderHarness(props: ComponentProps<typeof Harness>) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { gcTime: Number.POSITIVE_INFINITY, retry: false } }
+  })
+
+  return render(<Harness {...props} />, {
+    wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  })
 }
 
 describe('Codex usage statusbar item', () => {
@@ -77,7 +102,7 @@ describe('Codex usage statusbar item', () => {
 
   it('stays hidden unless an active Codex session returns valid limits', async () => {
     const requestGateway = vi.fn(async () => ({ account_usage: snapshot }) as never)
-    const { rerender } = render(<Harness provider="anthropic" requestGateway={requestGateway} />)
+    const { rerender } = renderHarness({ provider: 'anthropic', requestGateway })
 
     await act(async () => undefined)
     expect(requestGateway).not.toHaveBeenCalled()
@@ -86,12 +111,17 @@ describe('Codex usage statusbar item', () => {
     rerender(<Harness requestGateway={requestGateway} />)
 
     expect(await screen.findByRole('button', { name: /Codex 79% left/i })).toBeTruthy()
-    expect(requestGateway).toHaveBeenCalledWith('session.account_usage', { session_id: 'runtime-1' })
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.account_usage',
+      { session_id: 'runtime-1' },
+      45_000,
+      expect.any(AbortSignal)
+    )
   })
 
   it('shows both windows, credits, refresh time, and the web fallback', async () => {
     const requestGateway = vi.fn(async () => ({ account_usage: snapshot }) as never)
-    render(<Harness requestGateway={requestGateway} />)
+    renderHarness({ requestGateway })
 
     fireEvent.pointerDown(await screen.findByRole('button', { name: /Codex 79% left/i }), { button: 0 })
 
@@ -110,7 +140,7 @@ describe('Codex usage statusbar item', () => {
       .mockResolvedValueOnce({ account_usage: snapshot })
       .mockRejectedValueOnce(new Error('auth expired'))
 
-    render(<Harness requestGateway={requestGateway as never} />)
+    renderHarness({ requestGateway: requestGateway as never })
     fireEvent.pointerDown(await screen.findByRole('button', { name: /Codex 79% left/i }), { button: 0 })
     fireEvent.click(await screen.findByRole('button', { name: 'Refresh Codex usage' }))
 

--- a/apps/desktop/src/app/shell/codex-usage-statusbar-item.test.tsx
+++ b/apps/desktop/src/app/shell/codex-usage-statusbar-item.test.tsx
@@ -1,0 +1,122 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import type { AccountUsageResponse, AccountUsageSnapshot } from '@/types/hermes'
+
+import {
+  accountUsageRemaining,
+  primaryAccountUsageWindow,
+  useCodexUsageStatusbarItem
+} from './codex-usage-statusbar-item'
+import { StatusbarControls } from './statusbar-controls'
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+const snapshot: AccountUsageSnapshot = {
+  details: ['Credits balance: $12.50'],
+  fetched_at: '2026-07-16T01:02:03+00:00',
+  plan: 'Plus',
+  provider: 'openai-codex',
+  source: 'usage_api',
+  title: 'Account limits',
+  unavailable_reason: null,
+  windows: [
+    { label: 'Session', reset_at: '2026-07-16T03:02:03+00:00', used_percent: 21 },
+    { label: 'Weekly', reset_at: '2026-07-20T03:02:03+00:00', used_percent: 59 }
+  ]
+}
+
+function Harness({
+  gatewayState = 'open',
+  provider = 'openai-codex',
+  requestGateway,
+  sessionId = 'runtime-1'
+}: {
+  gatewayState?: string
+  provider?: string
+  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  sessionId?: null | string
+}) {
+  const item = useCodexUsageStatusbarItem({ gatewayState, provider, requestGateway, sessionId })
+
+  return (
+    <I18nProvider configClient={null} initialLocale="en">
+      <MemoryRouter>
+        <StatusbarControls items={[item]} />
+      </MemoryRouter>
+    </I18nProvider>
+  )
+}
+
+describe('Codex usage statusbar item', () => {
+  it('derives the compact remaining allowance from the first valid window', () => {
+    expect(accountUsageRemaining({ label: 'Session', used_percent: 21 })).toBe(79)
+    expect(accountUsageRemaining({ label: 'Session', used_percent: 140 })).toBe(0)
+    expect(accountUsageRemaining({ label: 'Session' })).toBeNull()
+    expect(primaryAccountUsageWindow(snapshot)?.label).toBe('Session')
+  })
+
+  it('stays hidden unless an active Codex session returns valid limits', async () => {
+    const requestGateway = vi.fn(async () => ({ account_usage: snapshot }) as never)
+    const { rerender } = render(<Harness provider="anthropic" requestGateway={requestGateway} />)
+
+    await act(async () => undefined)
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect(screen.queryByText(/Codex/)).toBeNull()
+
+    rerender(<Harness requestGateway={requestGateway} />)
+
+    expect(await screen.findByRole('button', { name: /Codex 79% left/i })).toBeTruthy()
+    expect(requestGateway).toHaveBeenCalledWith('session.account_usage', { session_id: 'runtime-1' })
+  })
+
+  it('shows both windows, credits, refresh time, and the web fallback', async () => {
+    const requestGateway = vi.fn(async () => ({ account_usage: snapshot }) as never)
+    render(<Harness requestGateway={requestGateway} />)
+
+    fireEvent.pointerDown(await screen.findByRole('button', { name: /Codex 79% left/i }), { button: 0 })
+
+    expect(await screen.findByText('79% remaining')).toBeTruthy()
+    expect(screen.getByText('41% remaining')).toBeTruthy()
+    expect(screen.getByText('Credits balance: $12.50')).toBeTruthy()
+    expect(screen.getByText(/Updated/)).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Open Codex Usage' }).getAttribute('href')).toBe(
+      'https://chatgpt.com/codex/settings/usage'
+    )
+  })
+
+  it('keeps the last good snapshot visible when a refresh fails', async () => {
+    const requestGateway = vi
+      .fn<() => Promise<AccountUsageResponse>>()
+      .mockResolvedValueOnce({ account_usage: snapshot })
+      .mockRejectedValueOnce(new Error('auth expired'))
+
+    render(<Harness requestGateway={requestGateway as never} />)
+    fireEvent.pointerDown(await screen.findByRole('button', { name: /Codex 79% left/i }), { button: 0 })
+    fireEvent.click(await screen.findByRole('button', { name: 'Refresh Codex usage' }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Showing the last successful result/i)).toBeTruthy()
+      expect(screen.getByText('Codex 79% left')).toBeTruthy()
+    })
+  })
+})

--- a/apps/desktop/src/app/shell/codex-usage-statusbar-item.tsx
+++ b/apps/desktop/src/app/shell/codex-usage-statusbar-item.tsx
@@ -1,34 +1,17 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { useI18n } from '@/i18n'
+import { type CodexAccountUsageOptions, useCodexAccountUsage } from '@/hooks/use-codex-account-usage'
 import { ExternalLink } from '@/lib/external-link'
 import { AlertCircle, BarChart3, Loader2, RefreshCw } from '@/lib/icons'
 import { fmtDateTime, relativeTime } from '@/lib/time'
 import { cn } from '@/lib/utils'
-import type { AccountUsageResponse, AccountUsageSnapshot, AccountUsageWindow } from '@/types/hermes'
+import type { AccountUsageSnapshot, AccountUsageWindow } from '@/types/hermes'
 
 import type { StatusbarItem } from './statusbar-controls'
 
 const CODEX_USAGE_URL = 'https://chatgpt.com/codex/settings/usage'
-const REFRESH_MS = 3 * 60_000
-
-type GatewayRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
-
-interface CodexUsageStatusbarOptions {
-  gatewayState: string
-  provider: string
-  requestGateway: GatewayRequester
-  sessionId: string | null
-}
-
-interface UsageState {
-  error: boolean
-  loading: boolean
-  snapshot: AccountUsageSnapshot | null
-}
-
-const EMPTY_STATE: UsageState = { error: false, loading: false, snapshot: null }
 
 function finitePercent(value: null | number | undefined): number | null {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
@@ -48,62 +31,10 @@ export function primaryAccountUsageWindow(snapshot: AccountUsageSnapshot): Accou
   return snapshot.windows.find(window => accountUsageRemaining(window) !== null) ?? null
 }
 
-function useCodexUsage({ gatewayState, provider, requestGateway, sessionId }: CodexUsageStatusbarOptions) {
-  const enabled = gatewayState === 'open' && provider.trim().toLowerCase() === 'openai-codex' && Boolean(sessionId)
-  const generation = useRef(0)
-  const [state, setState] = useState<UsageState>(EMPTY_STATE)
-
-  const refresh = useCallback(async () => {
-    if (!enabled || !sessionId) {
-      return
-    }
-
-    const requestGeneration = ++generation.current
-    setState(current => ({ ...current, loading: true }))
-
-    try {
-      const response = await requestGateway<AccountUsageResponse>('session.account_usage', { session_id: sessionId })
-
-      if (requestGeneration !== generation.current) {
-        return
-      }
-
-      const snapshot = response?.account_usage ?? null
-      setState(current =>
-        snapshot
-          ? { error: false, loading: false, snapshot }
-          : { error: true, loading: false, snapshot: current.snapshot }
-      )
-    } catch {
-      if (requestGeneration === generation.current) {
-        setState(current => ({ ...current, error: true, loading: false }))
-      }
-    }
-  }, [enabled, requestGateway, sessionId])
-
-  useEffect(() => {
-    ++generation.current
-    setState(EMPTY_STATE)
-
-    if (!enabled) {
-      return
-    }
-
-    void refresh()
-    const timer = window.setInterval(() => void refresh(), REFRESH_MS)
-
-    return () => {
-      window.clearInterval(timer)
-    }
-  }, [enabled, provider, refresh, sessionId])
-
-  return { ...state, refresh }
-}
-
-export function useCodexUsageStatusbarItem(options: CodexUsageStatusbarOptions): StatusbarItem {
+export function useCodexUsageStatusbarItem(options: CodexAccountUsageOptions): StatusbarItem {
   const { t } = useI18n()
   const copy = t.shell.statusbar
-  const { error, loading, refresh, snapshot } = useCodexUsage(options)
+  const { error, loading, refresh, snapshot } = useCodexAccountUsage(options)
   const primaryWindow = snapshot ? primaryAccountUsageWindow(snapshot) : null
   const remaining = primaryWindow ? accountUsageRemaining(primaryWindow) : null
   const codexActive = options.provider.trim().toLowerCase() === 'openai-codex'

--- a/apps/desktop/src/app/shell/codex-usage-statusbar-item.tsx
+++ b/apps/desktop/src/app/shell/codex-usage-statusbar-item.tsx
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { useI18n } from '@/i18n'
+import { ExternalLink } from '@/lib/external-link'
+import { AlertCircle, BarChart3, Loader2, RefreshCw } from '@/lib/icons'
+import { fmtDateTime, relativeTime } from '@/lib/time'
+import { cn } from '@/lib/utils'
+import type { AccountUsageResponse, AccountUsageSnapshot, AccountUsageWindow } from '@/types/hermes'
+
+import type { StatusbarItem } from './statusbar-controls'
+
+const CODEX_USAGE_URL = 'https://chatgpt.com/codex/settings/usage'
+const REFRESH_MS = 3 * 60_000
+
+type GatewayRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+
+interface CodexUsageStatusbarOptions {
+  gatewayState: string
+  provider: string
+  requestGateway: GatewayRequester
+  sessionId: string | null
+}
+
+interface UsageState {
+  error: boolean
+  loading: boolean
+  snapshot: AccountUsageSnapshot | null
+}
+
+const EMPTY_STATE: UsageState = { error: false, loading: false, snapshot: null }
+
+function finitePercent(value: null | number | undefined): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null
+  }
+
+  return Math.max(0, Math.min(100, value))
+}
+
+export function accountUsageRemaining(window: AccountUsageWindow): number | null {
+  const used = finitePercent(window.used_percent)
+
+  return used === null ? null : Math.round(100 - used)
+}
+
+export function primaryAccountUsageWindow(snapshot: AccountUsageSnapshot): AccountUsageWindow | null {
+  return snapshot.windows.find(window => accountUsageRemaining(window) !== null) ?? null
+}
+
+function useCodexUsage({ gatewayState, provider, requestGateway, sessionId }: CodexUsageStatusbarOptions) {
+  const enabled = gatewayState === 'open' && provider.trim().toLowerCase() === 'openai-codex' && Boolean(sessionId)
+  const generation = useRef(0)
+  const [state, setState] = useState<UsageState>(EMPTY_STATE)
+
+  const refresh = useCallback(async () => {
+    if (!enabled || !sessionId) {
+      return
+    }
+
+    const requestGeneration = ++generation.current
+    setState(current => ({ ...current, loading: true }))
+
+    try {
+      const response = await requestGateway<AccountUsageResponse>('session.account_usage', { session_id: sessionId })
+
+      if (requestGeneration !== generation.current) {
+        return
+      }
+
+      const snapshot = response?.account_usage ?? null
+      setState(current =>
+        snapshot
+          ? { error: false, loading: false, snapshot }
+          : { error: true, loading: false, snapshot: current.snapshot }
+      )
+    } catch {
+      if (requestGeneration === generation.current) {
+        setState(current => ({ ...current, error: true, loading: false }))
+      }
+    }
+  }, [enabled, requestGateway, sessionId])
+
+  useEffect(() => {
+    ++generation.current
+    setState(EMPTY_STATE)
+
+    if (!enabled) {
+      return
+    }
+
+    void refresh()
+    const timer = window.setInterval(() => void refresh(), REFRESH_MS)
+
+    return () => {
+      window.clearInterval(timer)
+    }
+  }, [enabled, provider, refresh, sessionId])
+
+  return { ...state, refresh }
+}
+
+export function useCodexUsageStatusbarItem(options: CodexUsageStatusbarOptions): StatusbarItem {
+  const { t } = useI18n()
+  const copy = t.shell.statusbar
+  const { error, loading, refresh, snapshot } = useCodexUsage(options)
+  const primaryWindow = snapshot ? primaryAccountUsageWindow(snapshot) : null
+  const remaining = primaryWindow ? accountUsageRemaining(primaryWindow) : null
+  const codexActive = options.provider.trim().toLowerCase() === 'openai-codex'
+
+  return useMemo(
+    () => ({
+      className: cn(
+        error && 'text-amber-600 hover:text-amber-600',
+        remaining !== null && remaining <= 10 && 'text-destructive hover:text-destructive'
+      ),
+      hidden: !codexActive || !snapshot || remaining === null,
+      icon: loading ? <Loader2 className="size-3 animate-spin" /> : <BarChart3 className="size-3" />,
+      id: 'codex-account-usage',
+      label: remaining === null ? copy.codexUsage : copy.codexUsageLabel(remaining),
+      menuAlign: 'end',
+      menuClassName: 'w-auto border-(--ui-stroke-secondary) p-0',
+      menuContent: snapshot ? (
+        <CodexUsagePanel error={error} loading={loading} onRefresh={() => void refresh()} snapshot={snapshot} />
+      ) : undefined,
+      title: copy.openCodexUsage,
+      variant: 'menu'
+    }),
+    [codexActive, copy, error, loading, refresh, remaining, snapshot]
+  )
+}
+
+export function CodexUsagePanel({
+  error,
+  loading,
+  onRefresh,
+  snapshot
+}: {
+  error: boolean
+  loading: boolean
+  onRefresh: () => void
+  snapshot: AccountUsageSnapshot
+}) {
+  const { t } = useI18n()
+  const copy = t.shell.statusbar.codexUsagePanel
+  const fetchedAt = Date.parse(snapshot.fetched_at)
+
+  return (
+    <div className="flex w-80 flex-col text-[0.75rem]" data-slot="codex-usage-panel">
+      <div className="flex items-center justify-between gap-3 border-b border-(--ui-stroke-tertiary) px-3 py-2.5">
+        <div className="min-w-0">
+          <p className="font-medium text-foreground">{copy.title}</p>
+          <p className="truncate text-[0.6875rem] text-muted-foreground">
+            {snapshot.plan ? copy.plan(snapshot.plan) : copy.subscription}
+          </p>
+        </div>
+
+        <Button
+          aria-label={copy.refresh}
+          className="text-muted-foreground hover:text-foreground"
+          disabled={loading}
+          onClick={onRefresh}
+          size="icon-xs"
+          variant="ghost"
+        >
+          <RefreshCw className={cn(loading && 'animate-spin')} />
+        </Button>
+      </div>
+
+      <ul className="flex flex-col gap-3 px-3 py-3">
+        {snapshot.windows.map(window => {
+          const used = finitePercent(window.used_percent)
+          const remaining = accountUsageRemaining(window)
+          const resetAt = window.reset_at ? Date.parse(window.reset_at) : Number.NaN
+
+          return (
+            <li className="flex flex-col gap-1.5" key={window.label}>
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="font-medium text-foreground">{window.label}</span>
+                <span className="tabular-nums text-foreground">
+                  {remaining === null ? copy.unavailable : copy.remaining(remaining)}
+                </span>
+              </div>
+
+              <div className="h-1.5 overflow-hidden rounded-full bg-(--ui-stroke-tertiary)">
+                <span
+                  className="block h-full rounded-full bg-primary transition-[width]"
+                  style={{ width: `${used ?? 0}%` }}
+                />
+              </div>
+
+              <div className="flex items-center justify-between gap-3 text-[0.6875rem] text-muted-foreground">
+                <span>{used === null ? window.detail : copy.used(Math.round(used))}</span>
+                {Number.isFinite(resetAt) && <span>{copy.resets(relativeTime(resetAt))}</span>}
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+
+      {snapshot.details.length > 0 && (
+        <ul className="border-t border-(--ui-stroke-tertiary) px-3 py-2 text-[0.6875rem] text-muted-foreground">
+          {snapshot.details.map(detail => (
+            <li key={detail}>{detail}</li>
+          ))}
+        </ul>
+      )}
+
+      {error && (
+        <div className="flex items-start gap-2 border-t border-(--ui-stroke-tertiary) px-3 py-2 text-amber-700">
+          <AlertCircle className="mt-0.5 size-3 shrink-0" />
+          <span>{copy.stale}</span>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-3 border-t border-(--ui-stroke-tertiary) px-3 py-2 text-[0.6875rem] text-muted-foreground">
+        <span>{Number.isFinite(fetchedAt) ? copy.updated(fmtDateTime.format(fetchedAt)) : copy.updatedUnknown}</span>
+        <ExternalLink href={CODEX_USAGE_URL} showExternalIcon={false}>
+          {copy.openUsage}
+        </ExternalLink>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import type { CommandCenterSection } from '@/app/command-center'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { useApprovalModeStatusbarItem } from '@/app/shell/approval-mode-menu'
+import { useCodexUsageStatusbarItem } from '@/app/shell/codex-usage-statusbar-item'
 import { ContextUsagePanel } from '@/app/shell/context-usage-panel'
 import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
 import { Codicon } from '@/components/ui/codicon'
@@ -22,6 +23,7 @@ import {
   $busy,
   $connection,
   $currentCwd,
+  $currentProvider,
   $currentUsage,
   $selectedStoredSessionId,
   $sessions,
@@ -98,6 +100,7 @@ export function useStatusbarItems({
   // the tree changes; null (no named project) falls back to the cwd leaf below.
   const projectTree = useStore($projectTree)
   const projectName = useMemo(() => projectNameForCwd(currentCwd), [currentCwd, projectTree])
+  const primaryProvider = useStore($currentProvider)
   const primaryUsage = useStore($currentUsage)
   const gatewayRestarting = useStore($gatewayRestarting)
   const primarySessionStartedAt = useStore($sessionStartedAt)
@@ -127,6 +130,7 @@ export function useStatusbarItems({
   // EMPTY_USAGE (module constant) keeps the fallback referentially stable —
   // a fresh `{...}` each render would bust the usage-label memos below.
   const currentUsage = primaryFocused ? primaryUsage : (focusedState?.usage ?? EMPTY_USAGE)
+  const provider = primaryFocused ? primaryProvider : (focusedState?.provider ?? '')
 
   const turnStartedAt = primaryFocused ? primaryTurnStartedAt : (focusedState?.turnStartedAt ?? null)
 
@@ -145,6 +149,13 @@ export function useStatusbarItems({
   const contextUsage = useMemo(() => usageContextLabel(currentUsage), [currentUsage])
   const contextBar = useMemo(() => contextBarLabel(currentUsage), [currentUsage])
   const approvalModeItem = useApprovalModeStatusbarItem(activeGatewayProfile, requestGateway)
+
+  const codexUsageItem = useCodexUsageStatusbarItem({
+    gatewayState,
+    provider,
+    requestGateway,
+    sessionId: activeSessionId
+  })
 
   const gatewayMenuContent = useMemo(
     () => (close: () => void) => (
@@ -447,6 +458,7 @@ export function useStatusbarItems({
         title: copy.currentTurnElapsed,
         variant: 'text'
       },
+      codexUsageItem,
       {
         detail: contextBar || undefined,
         hidden: !contextUsage,
@@ -492,6 +504,7 @@ export function useStatusbarItems({
       busy,
       chatOpen,
       clientVersionItem,
+      codexUsageItem,
       contextBar,
       contextUsage,
       copy,

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -10,6 +10,7 @@ import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
 import { Codicon } from '@/components/ui/codicon'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { useI18n } from '@/i18n'
+import type { GatewayRequester } from '@/hooks/use-codex-account-usage'
 import { Activity, AlertCircle, Clock, Command, FolderOpen, Hash, Loader2, Terminal } from '@/lib/icons'
 import type { RuntimeReadinessResult } from '@/lib/runtime-readiness'
 import { contextBarLabel, LiveDuration, usageContextLabel } from '@/lib/statusbar'
@@ -67,7 +68,7 @@ interface StatusbarItemsOptions {
   openAgents: () => void
   openCommandCenterSection: (section: CommandCenterSection) => void
   freshDraftReady: boolean
-  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  requestGateway: GatewayRequester
   statusSnapshot: StatusResponse | null
   toggleCommandCenter: () => void
 }
@@ -151,7 +152,9 @@ export function useStatusbarItems({
   const approvalModeItem = useApprovalModeStatusbarItem(activeGatewayProfile, requestGateway)
 
   const codexUsageItem = useCodexUsageStatusbarItem({
+    connectionScope: `${connection?.mode ?? 'unknown'}:${connection?.baseUrl ?? ''}`,
     gatewayState,
+    profile: activeGatewayProfile,
     provider,
     requestGateway,
     sessionId: activeSessionId

--- a/apps/desktop/src/hooks/use-codex-account-usage.test.tsx
+++ b/apps/desktop/src/hooks/use-codex-account-usage.test.tsx
@@ -1,0 +1,144 @@
+import { act, cleanup, render, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { PropsWithChildren } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { AccountUsageResponse, AccountUsageSnapshot } from '@/types/hermes'
+
+import {
+  AccountUsageMethodUnavailableError,
+  CODEX_USAGE_BACKOFF_MS,
+  CODEX_USAGE_REFRESH_MS,
+  type CodexAccountUsageOptions,
+  codexAccountUsageQueryKey,
+  codexUsageRefetchInterval,
+  type GatewayRequester,
+  useCodexAccountUsage
+} from './use-codex-account-usage'
+
+afterEach(cleanup)
+
+const snapshot = (usedPercent: number): AccountUsageSnapshot => ({
+  available: true,
+  details: [],
+  fetched_at: '2026-07-16T01:02:03+00:00',
+  plan: 'Plus',
+  provider: 'openai-codex',
+  source: 'usage_api',
+  title: 'Account limits',
+  unavailable_reason: null,
+  windows: [{ label: 'Session', used_percent: usedPercent }]
+})
+
+function queryWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { gcTime: Number.POSITIVE_INFINITY, retry: false } }
+  })
+
+  return function Wrapper({ children }: PropsWithChildren) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  }
+}
+
+function options(requestGateway: GatewayRequester, over: Partial<CodexAccountUsageOptions> = {}) {
+  return {
+    connectionScope: 'local:',
+    gatewayState: 'open',
+    profile: 'default',
+    provider: 'openai-codex',
+    requestGateway,
+    sessionId: 'runtime-1',
+    ...over
+  } satisfies CodexAccountUsageOptions
+}
+
+describe('useCodexAccountUsage', () => {
+  it('does not request usage for a non-Codex provider or missing runtime session', async () => {
+    const requestGateway = vi.fn() as unknown as GatewayRequester
+    const { rerender } = renderHook(props => useCodexAccountUsage(props), {
+      initialProps: options(requestGateway, { provider: 'anthropic' }),
+      wrapper: queryWrapper()
+    })
+
+    await act(async () => undefined)
+    expect(requestGateway).not.toHaveBeenCalled()
+
+    rerender(options(requestGateway, { sessionId: null }))
+    await act(async () => undefined)
+    expect(requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('keys data by connection, profile, runtime session, and provider without carrying stale data', async () => {
+    const requestGateway = vi
+      .fn<() => Promise<AccountUsageResponse>>()
+      .mockResolvedValueOnce({ account_usage: snapshot(10) })
+      .mockResolvedValueOnce({ account_usage: snapshot(80) })
+    const first = options(requestGateway as never)
+    const { result, rerender } = renderHook(props => useCodexAccountUsage(props), {
+      initialProps: first,
+      wrapper: queryWrapper()
+    })
+
+    await waitFor(() => expect(result.current.snapshot?.windows[0].used_percent).toBe(10))
+
+    const second = options(requestGateway as never, {
+      connectionScope: 'remote:https://backend-b',
+      profile: 'work',
+      sessionId: 'runtime-2'
+    })
+    expect(codexAccountUsageQueryKey(first)).not.toEqual(codexAccountUsageQueryKey(second))
+    rerender(second)
+    expect(result.current.snapshot).toBeNull()
+
+    await waitFor(() => expect(result.current.snapshot?.windows[0].used_percent).toBe(80))
+    expect(requestGateway).toHaveBeenCalledTimes(2)
+  })
+
+  it('deduplicates two consumers of the same account-usage scope', async () => {
+    let resolveRequest: ((value: AccountUsageResponse) => void) | undefined
+    const requestGateway = vi.fn(
+      () =>
+        new Promise<AccountUsageResponse>(resolve => {
+          resolveRequest = resolve
+        })
+    ) as unknown as GatewayRequester
+    const sharedOptions = options(requestGateway)
+
+    function Pair() {
+      useCodexAccountUsage(sharedOptions)
+      useCodexAccountUsage(sharedOptions)
+      return null
+    }
+
+    render(<Pair />, { wrapper: queryWrapper() })
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(1))
+
+    await act(async () => resolveRequest?.({ account_usage: snapshot(25) }))
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+  })
+
+  it('recognizes an older backend and disables its polling interval', async () => {
+    const error = Object.assign(new Error('Method not found: session.account_usage'), { code: -32601 })
+    const requestGateway = vi.fn(async () => Promise.reject(error)) as unknown as GatewayRequester
+    const { result } = renderHook(() => useCodexAccountUsage(options(requestGateway)), {
+      wrapper: queryWrapper()
+    })
+
+    await waitFor(() => expect(result.current.methodUnavailable).toBe(true))
+    expect(
+      codexUsageRefetchInterval({
+        state: { error: new AccountUsageMethodUnavailableError(), fetchFailureCount: 1 }
+      })
+    ).toBe(false)
+  })
+
+  it('backs polling off after repeated failures and restores the normal cadence otherwise', () => {
+    expect(codexUsageRefetchInterval({ state: { error: new Error('offline'), fetchFailureCount: 2 } })).toBe(
+      CODEX_USAGE_REFRESH_MS
+    )
+    expect(codexUsageRefetchInterval({ state: { error: new Error('offline'), fetchFailureCount: 3 } })).toBe(
+      CODEX_USAGE_BACKOFF_MS
+    )
+    expect(codexUsageRefetchInterval({ state: { error: null, fetchFailureCount: 0 } })).toBe(CODEX_USAGE_REFRESH_MS)
+  })
+})

--- a/apps/desktop/src/hooks/use-codex-account-usage.ts
+++ b/apps/desktop/src/hooks/use-codex-account-usage.ts
@@ -1,0 +1,126 @@
+import { useQuery } from '@tanstack/react-query'
+
+import type { AccountUsageResponse, AccountUsageSnapshot } from '@/types/hermes'
+
+export const CODEX_USAGE_REFRESH_MS = 3 * 60_000
+export const CODEX_USAGE_BACKOFF_MS = 15 * 60_000
+export const CODEX_USAGE_REQUEST_TIMEOUT_MS = 45_000
+
+export type GatewayRequester = <T = unknown>(
+  method: string,
+  params?: Record<string, unknown>,
+  timeoutMs?: number,
+  signal?: AbortSignal
+) => Promise<T>
+
+export interface CodexAccountUsageOptions {
+  connectionScope: string
+  gatewayState: string
+  profile: string
+  provider: string
+  requestGateway: GatewayRequester
+  sessionId: null | string
+}
+
+interface UsageQueryState {
+  state: {
+    error: unknown
+    fetchFailureCount: number
+  }
+}
+
+export class AccountUsageUnavailableError extends Error {
+  constructor() {
+    super('Codex account usage is unavailable')
+    this.name = 'AccountUsageUnavailableError'
+  }
+}
+
+export class AccountUsageMethodUnavailableError extends Error {
+  constructor() {
+    super('The connected Hermes backend does not support account usage')
+    this.name = 'AccountUsageMethodUnavailableError'
+  }
+}
+
+export function codexAccountUsageQueryKey({
+  connectionScope,
+  profile,
+  provider,
+  sessionId
+}: Pick<CodexAccountUsageOptions, 'connectionScope' | 'profile' | 'provider' | 'sessionId'>) {
+  return [
+    'account-usage',
+    'openai-codex',
+    connectionScope,
+    profile,
+    sessionId ?? '',
+    provider.trim().toLowerCase()
+  ] as const
+}
+
+function isUnknownMethodError(error: unknown): boolean {
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error
+      ? Number((error as { code?: unknown }).code)
+      : Number.NaN
+  const message = error instanceof Error ? error.message : String(error)
+
+  return code === -32601 || /unknown method|method not found|no such method/i.test(message)
+}
+
+export function codexUsageRefetchInterval(query: UsageQueryState): false | number {
+  if (query.state.error instanceof AccountUsageMethodUnavailableError) {
+    return false
+  }
+
+  return query.state.fetchFailureCount >= 3 ? CODEX_USAGE_BACKOFF_MS : CODEX_USAGE_REFRESH_MS
+}
+
+export function useCodexAccountUsage(options: CodexAccountUsageOptions) {
+  const provider = options.provider.trim().toLowerCase()
+  const enabled = options.gatewayState === 'open' && provider === 'openai-codex' && Boolean(options.sessionId)
+  const query = useQuery<AccountUsageSnapshot>({
+    enabled,
+    queryFn: async ({ signal }) => {
+      try {
+        const response = await options.requestGateway<AccountUsageResponse>(
+          'session.account_usage',
+          { session_id: options.sessionId },
+          CODEX_USAGE_REQUEST_TIMEOUT_MS,
+          signal
+        )
+        const snapshot = response?.account_usage ?? null
+
+        if (!snapshot || snapshot.available === false) {
+          throw new AccountUsageUnavailableError()
+        }
+
+        return snapshot
+      } catch (error) {
+        if (isUnknownMethodError(error)) {
+          throw new AccountUsageMethodUnavailableError()
+        }
+        throw error
+      }
+    },
+    queryKey: codexAccountUsageQueryKey({
+      connectionScope: options.connectionScope,
+      profile: options.profile,
+      provider,
+      sessionId: options.sessionId
+    }),
+    refetchInterval: codexUsageRefetchInterval,
+    refetchIntervalInBackground: false,
+    retry: false,
+    staleTime: CODEX_USAGE_REFRESH_MS
+  })
+
+  return {
+    error: query.isError,
+    loading: query.isFetching,
+    methodUnavailable: query.error instanceof AccountUsageMethodUnavailableError,
+    refresh: query.refetch,
+    snapshot: query.data ?? null
+  }
+}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2244,6 +2244,23 @@ export const en: Translations = {
       openStarmap: 'Open memory graph',
       turnRunning: 'Running',
       currentTurnElapsed: 'Current turn elapsed',
+      codexUsage: 'Codex usage',
+      codexUsageLabel: remaining => `Codex ${remaining}% left`,
+      openCodexUsage: 'Open Codex usage details',
+      codexUsagePanel: {
+        openUsage: 'Open Codex Usage',
+        plan: plan => `${plan} plan`,
+        refresh: 'Refresh Codex usage',
+        remaining: remaining => `${remaining}% remaining`,
+        resets: time => `resets ${time}`,
+        stale: 'Usage could not be refreshed. Showing the last successful result.',
+        subscription: 'ChatGPT subscription',
+        title: 'Codex Usage',
+        unavailable: 'Unavailable',
+        updated: time => `Updated ${time}`,
+        updatedUnknown: 'Updated time unavailable',
+        used: used => `${used}% used`
+      },
       contextUsage: 'Context usage',
       contextUsagePanel: {
         categories: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2180,6 +2180,23 @@ export const ja = defineLocale({
       openStarmap: 'メモリグラフを開く',
       turnRunning: '実行中',
       currentTurnElapsed: '現在のターン経過時間',
+      codexUsage: 'Codex 使用状況',
+      codexUsageLabel: remaining => `Codex 残り${remaining}%`,
+      openCodexUsage: 'Codex 使用状況の詳細を開く',
+      codexUsagePanel: {
+        openUsage: 'Codex 使用状況を開く',
+        plan: plan => `${plan} プラン`,
+        refresh: 'Codex 使用状況を更新',
+        remaining: remaining => `残り ${remaining}%`,
+        resets: time => `${time}にリセット`,
+        stale: '使用状況を更新できませんでした。最後に取得できた結果を表示しています。',
+        subscription: 'ChatGPT サブスクリプション',
+        title: 'Codex 使用状況',
+        unavailable: '利用不可',
+        updated: time => `更新: ${time}`,
+        updatedUnknown: '更新時刻は不明です',
+        used: used => `${used}% 使用済み`
+      },
       contextUsage: 'コンテキスト使用状況',
       contextUsagePanel: {
         categories: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1867,6 +1867,23 @@ export interface Translations {
       openStarmap: string
       turnRunning: string
       currentTurnElapsed: string
+      codexUsage: string
+      codexUsageLabel: (remaining: number) => string
+      openCodexUsage: string
+      codexUsagePanel: {
+        openUsage: string
+        plan: (plan: string) => string
+        refresh: string
+        remaining: (remaining: number) => string
+        resets: (time: string) => string
+        stale: string
+        subscription: string
+        title: string
+        unavailable: string
+        updated: (time: string) => string
+        updatedUnknown: string
+        used: (used: number) => string
+      }
       contextUsage: string
       contextUsagePanel: {
         categories: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2111,6 +2111,23 @@ export const zhHant = defineLocale({
       openStarmap: '開啟記憶圖譜',
       turnRunning: '執行中',
       currentTurnElapsed: '目前回合已用時間',
+      codexUsage: 'Codex 使用量',
+      codexUsageLabel: remaining => `Codex 剩餘 ${remaining}%`,
+      openCodexUsage: '開啟 Codex 使用量詳細資料',
+      codexUsagePanel: {
+        openUsage: '開啟 Codex 使用量頁面',
+        plan: plan => `${plan} 方案`,
+        refresh: '重新整理 Codex 使用量',
+        remaining: remaining => `剩餘 ${remaining}%`,
+        resets: time => `${time}重設`,
+        stale: '無法重新整理使用量。正在顯示上次成功取得的結果。',
+        subscription: 'ChatGPT 訂閱',
+        title: 'Codex 使用量',
+        unavailable: '無法使用',
+        updated: time => `更新於 ${time}`,
+        updatedUnknown: '無法取得更新時間',
+        used: used => `已用 ${used}%`
+      },
       contextUsage: '上下文使用量',
       contextUsagePanel: {
         categories: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2422,6 +2422,23 @@ export const zh: Translations = {
       openStarmap: '打开记忆图谱',
       turnRunning: '运行中',
       currentTurnElapsed: '当前回合已用时间',
+      codexUsage: 'Codex 用量',
+      codexUsageLabel: remaining => `Codex 剩余 ${remaining}%`,
+      openCodexUsage: '打开 Codex 用量详情',
+      codexUsagePanel: {
+        openUsage: '打开 Codex 用量页面',
+        plan: plan => `${plan} 方案`,
+        refresh: '刷新 Codex 用量',
+        remaining: remaining => `剩余 ${remaining}%`,
+        resets: time => `${time}重置`,
+        stale: '无法刷新用量。正在显示上次成功获取的结果。',
+        subscription: 'ChatGPT 订阅',
+        title: 'Codex 用量',
+        unavailable: '不可用',
+        updated: time => `更新于 ${time}`,
+        updatedUnknown: '更新时间不可用',
+        used: used => `已用 ${used}%`
+      },
       contextUsage: '上下文用量',
       contextUsagePanel: {
         categories: {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -505,6 +505,7 @@ export interface AccountUsageWindow {
 }
 
 export interface AccountUsageSnapshot {
+  available?: boolean
   details: string[]
   fetched_at: string
   plan?: null | string

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -497,6 +497,28 @@ export interface UsageStats {
   total: number
 }
 
+export interface AccountUsageWindow {
+  detail?: null | string
+  label: string
+  reset_at?: null | string
+  used_percent?: null | number
+}
+
+export interface AccountUsageSnapshot {
+  details: string[]
+  fetched_at: string
+  plan?: null | string
+  provider: string
+  source: string
+  title: string
+  unavailable_reason?: null | string
+  windows: AccountUsageWindow[]
+}
+
+export interface AccountUsageResponse {
+  account_usage?: AccountUsageSnapshot | null
+}
+
 /** One graph node in the star map (learned skill or memory chunk). */
 export interface StarmapNode {
   id: string

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -237,6 +237,29 @@ def test_codex_usage_treats_wham_used_percent_as_used_not_remaining(monkeypatch)
     assert "86% used" not in rendered
 
 
+def test_serialize_account_usage_snapshot_is_json_safe(codex_usage_payload, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    payload = account_usage.serialize_account_usage_snapshot(snapshot)
+    assert payload["provider"] == "openai-codex"
+    assert payload["plan"] == "Plus"
+    assert payload["windows"][0]["used_percent"] == 21
+    assert payload["windows"][0]["reset_at"].endswith("+00:00")
+    assert "token" not in repr(payload).lower()
+
+
 # ── Banked rate-limit reset credits (`/usage reset`) ─────────────────────────
 
 

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -1,8 +1,20 @@
+import base64
+import json
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
 
 from agent import account_usage
+
+
+def _codex_token(account_id: str) -> str:
+    payload = json.dumps(
+        {"https://api.openai.com/auth": {"chatgpt_account_id": account_id}},
+        separators=(",", ":"),
+    ).encode()
+    encoded = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+    return f"header.{encoded}.signature"
 
 
 class _FakeResponse:
@@ -63,10 +75,11 @@ def test_codex_usage_prefers_explicit_live_agent_credentials(monkeypatch, codex_
         lambda **kwargs: (_ for _ in ()).throw(AssertionError("legacy auth should not be used")),
     )
 
+    token = _codex_token("acct-live")
     snapshot = account_usage.fetch_account_usage(
         "openai-codex",
         base_url="https://chatgpt.com/backend-api/codex",
-        api_key="live-agent-token",
+        api_key=token,
     )
 
     assert snapshot is not None
@@ -75,7 +88,29 @@ def test_codex_usage_prefers_explicit_live_agent_credentials(monkeypatch, codex_
     assert [w.label for w in snapshot.windows] == ["Session", "Weekly"]
     assert snapshot.windows[0].used_percent == 21
     assert calls[0]["url"] == "https://chatgpt.com/backend-api/wham/usage"
-    assert calls[0]["headers"]["Authorization"] == "Bearer live-agent-token"
+    assert calls[0]["headers"]["Authorization"] == f"Bearer {token}"
+    assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acct-live"
+
+
+def test_codex_usage_rotated_token_changes_account_header(monkeypatch, codex_usage_payload):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    for account_id in ("acct-one", "acct-two"):
+        assert account_usage.fetch_account_usage(
+            "openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key=_codex_token(account_id),
+        ) is not None
+
+    assert [call["headers"]["ChatGPT-Account-Id"] for call in calls] == [
+        "acct-one",
+        "acct-two",
+    ]
 
 
 def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usage_payload):
@@ -194,6 +229,37 @@ def test_codex_usage_account_id_read_failure_keeps_singleton_token(monkeypatch, 
     assert "ChatGPT-Account-Id" not in calls[0]["headers"]
 
 
+def test_codex_usage_pool_selection_never_pairs_stale_singleton_account_id(
+    monkeypatch, codex_usage_payload
+):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_codex_runtime_credentials",
+        lambda **kwargs: {
+            "api_key": "opaque-pool-token",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "source": "credential_pool",
+        },
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "_read_codex_tokens",
+        lambda: {"tokens": {"account_id": "acct-stale-singleton"}},
+    )
+
+    snapshot = account_usage.fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert calls[0]["headers"]["Authorization"] == "Bearer opaque-pool-token"
+    assert "ChatGPT-Account-Id" not in calls[0]["headers"]
+
+
 def test_codex_usage_treats_wham_used_percent_as_used_not_remaining(monkeypatch):
     """ChatGPT UI says "left"; /wham/usage.used_percent is already used."""
     payload = {
@@ -253,11 +319,36 @@ def test_serialize_account_usage_snapshot_is_json_safe(codex_usage_payload, monk
 
     assert snapshot is not None
     payload = account_usage.serialize_account_usage_snapshot(snapshot)
+    assert payload["available"] is True
     assert payload["provider"] == "openai-codex"
     assert payload["plan"] == "Plus"
     assert payload["windows"][0]["used_percent"] == 21
     assert payload["windows"][0]["reset_at"].endswith("+00:00")
     assert "token" not in repr(payload).lower()
+
+
+def test_serialize_account_usage_snapshot_sanitizes_non_finite_percentages():
+    snapshot = account_usage.AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            account_usage.AccountUsageWindow(label="NaN", used_percent=float("nan")),
+            account_usage.AccountUsageWindow(label="Infinite", used_percent=float("inf")),
+            account_usage.AccountUsageWindow(label="Low", used_percent=-10),
+            account_usage.AccountUsageWindow(label="High", used_percent=140),
+        ),
+    )
+
+    payload = account_usage.serialize_account_usage_snapshot(snapshot)
+
+    assert [window["used_percent"] for window in payload["windows"]] == [
+        None,
+        None,
+        0.0,
+        100.0,
+    ]
+    json.dumps(payload, allow_nan=False)
 
 
 # ── Banked rate-limit reset credits (`/usage reset`) ─────────────────────────

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2629,6 +2629,71 @@ def _session(agent=None, **extra):
     }
 
 
+def test_session_account_usage_returns_normalized_secret_free_snapshot(monkeypatch):
+    agent = types.SimpleNamespace(
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="oauth-secret",
+    )
+    server._sessions["usage-sid"] = _session(agent=agent)
+    captured = {}
+
+    def _fetch(provider, *, base_url=None, api_key=None):
+        from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+
+        captured.update(provider=provider, base_url=base_url, api_key=api_key)
+        return AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=datetime.fromisoformat("2026-07-16T01:02:03+00:00"),
+            plan="Plus",
+            windows=(AccountUsageWindow(label="Session", used_percent=27),),
+        )
+
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", _fetch)
+    try:
+        response = server._methods["session.account_usage"](
+            "r1", {"session_id": "usage-sid"}
+        )
+    finally:
+        server._sessions.pop("usage-sid", None)
+
+    payload = response["result"]["account_usage"]
+    assert captured == {
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_key": "oauth-secret",
+    }
+    assert payload["plan"] == "Plus"
+    assert payload["windows"] == [
+        {
+            "label": "Session",
+            "used_percent": 27,
+            "reset_at": None,
+            "detail": None,
+        }
+    ]
+    assert "oauth-secret" not in repr(payload)
+
+
+def test_session_account_usage_hides_unavailable_or_unbuilt_accounts(monkeypatch):
+    server._sessions["usage-sid"] = _session(agent=types.SimpleNamespace())
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", lambda *a, **k: None)
+    try:
+        unavailable = server._methods["session.account_usage"](
+            "r1", {"session_id": "usage-sid"}
+        )
+        server._sessions["usage-sid"]["agent"] = None
+        unbuilt = server._methods["session.account_usage"](
+            "r2", {"session_id": "usage-sid"}
+        )
+    finally:
+        server._sessions.pop("usage-sid", None)
+
+    assert unavailable["result"] == {"account_usage": None}
+    assert unbuilt["result"] == {"account_usage": None}
+
+
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     calls = {"hooks": []}
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2664,6 +2664,7 @@ def test_session_account_usage_returns_normalized_secret_free_snapshot(monkeypat
         "base_url": "https://chatgpt.com/backend-api/codex",
         "api_key": "oauth-secret",
     }
+    assert payload["available"] is True
     assert payload["plan"] == "Plus"
     assert payload["windows"] == [
         {
@@ -2692,6 +2693,27 @@ def test_session_account_usage_hides_unavailable_or_unbuilt_accounts(monkeypatch
 
     assert unavailable["result"] == {"account_usage": None}
     assert unbuilt["result"] == {"account_usage": None}
+
+
+def test_session_account_usage_never_falls_back_without_live_codex_key(monkeypatch):
+    server._sessions["usage-sid"] = _session(
+        agent=types.SimpleNamespace(
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="",
+        )
+    )
+    fetch = Mock(side_effect=AssertionError("credential fallback must not run"))
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", fetch)
+    try:
+        response = server._methods["session.account_usage"](
+            "r1", {"session_id": "usage-sid"}
+        )
+    finally:
+        server._sessions.pop("usage-sid", None)
+
+    assert response["result"] == {"account_usage": None}
+    fetch.assert_not_called()
 
 
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7418,9 +7418,9 @@ def _(rid, params: dict) -> dict:
 def _(rid, params: dict) -> dict:
     """Return normalized provider limits without exposing runtime credentials.
 
-    This deliberately stays session-scoped: the live agent is authoritative for
-    the provider, endpoint, and selected credential.  A renderer receives only
-    the normalized quota snapshot, never the OAuth token or account headers.
+    This deliberately stays session-scoped: the live agent selects the provider,
+    endpoint, and exact credential identity.  A renderer receives only the
+    normalized quota snapshot, never the OAuth token or account headers.
     Missing agents, unsupported providers, expired auth, and transient network
     failures all fail closed to ``None`` so optional chrome can hide cleanly.
     """
@@ -7431,6 +7431,14 @@ def _(rid, params: dict) -> dict:
     if agent is None:
         return _ok(rid, {"account_usage": None})
 
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    api_key = str(getattr(agent, "api_key", "") or "").strip()
+    if provider == "openai-codex" and not api_key:
+        # The generic /usage helper may select a singleton or pool credential
+        # when no key is supplied. A session-scoped read must never substitute
+        # another account for the credential already chosen by this live agent.
+        return _ok(rid, {"account_usage": None})
+
     try:
         from agent.account_usage import (
             fetch_account_usage,
@@ -7438,9 +7446,9 @@ def _(rid, params: dict) -> dict:
         )
 
         snapshot = fetch_account_usage(
-            getattr(agent, "provider", None),
+            provider,
             base_url=getattr(agent, "base_url", None),
-            api_key=getattr(agent, "api_key", None),
+            api_key=api_key,
         )
         payload = (
             serialize_account_usage_snapshot(snapshot)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -256,6 +256,10 @@ _LONG_HANDLERS = frozenset(
         # so a delayed status rehydrate cannot block runtime readiness, prompt
         # submission, or interrupts queued behind it on the same socket.
         "session.active_list",
+        # Account-limit probes call provider-owned HTTP endpoints. Keep the
+        # Desktop's periodic status-bar refresh off the JSON-RPC reader thread
+        # so a slow or unavailable provider cannot stall chat and interrupts.
+        "session.account_usage",
         "session.branch",
         "session.compress",
         "session.list",
@@ -7408,6 +7412,45 @@ def _(rid, params: dict) -> dict:
     except Exception:
         pass
     return _ok(rid, usage)
+
+
+@method("session.account_usage")
+def _(rid, params: dict) -> dict:
+    """Return normalized provider limits without exposing runtime credentials.
+
+    This deliberately stays session-scoped: the live agent is authoritative for
+    the provider, endpoint, and selected credential.  A renderer receives only
+    the normalized quota snapshot, never the OAuth token or account headers.
+    Missing agents, unsupported providers, expired auth, and transient network
+    failures all fail closed to ``None`` so optional chrome can hide cleanly.
+    """
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    agent = session.get("agent")
+    if agent is None:
+        return _ok(rid, {"account_usage": None})
+
+    try:
+        from agent.account_usage import (
+            fetch_account_usage,
+            serialize_account_usage_snapshot,
+        )
+
+        snapshot = fetch_account_usage(
+            getattr(agent, "provider", None),
+            base_url=getattr(agent, "base_url", None),
+            api_key=getattr(agent, "api_key", None),
+        )
+        payload = (
+            serialize_account_usage_snapshot(snapshot)
+            if snapshot is not None and snapshot.available
+            else None
+        )
+    except Exception:
+        logger.debug("failed to fetch session account usage", exc_info=True)
+        payload = None
+    return _ok(rid, {"account_usage": payload})
 
 
 @method("session.context_breakdown")


### PR DESCRIPTION
## What does this PR do?

Adds a glanceable OpenAI Codex subscription-usage item to the Electron Desktop status bar. When the focused session uses `openai-codex`, Desktop shows `Codex N% left` and a popover with plan, quota windows, reset times, credit/account details, refresh state, and a link to Codex usage settings.

The quota is account-level subscription allowance, not per-chat spend. The runtime session ID only selects the focused live agent's provider and exact credential; credentials and account headers remain backend-only.

### Alignment with #50813

The model-pill hover card proposed in #50813 remains a separate UI surface. This PR makes `session.account_usage`, `serialize_account_usage_snapshot()`, the shared renderer snapshot type, and `useCodexAccountUsage()` the reusable transport/cache seam. A second Desktop surface can therefore consume the same backend contract without maintaining a parallel quota implementation or changing the status-bar UI added here.

### Security and failure behavior

- Derives `ChatGPT-Account-Id` from the same selected OAuth token used for the request.
- Fails closed when the active Codex agent does not have an explicit selected credential.
- Never pairs a pool-selected opaque token with stale singleton account identity.
- Keeps OAuth tokens and account headers out of renderer responses.
- Returns a normalized, secret-free snapshot with finite/clamped percentages.
- Retains the last successful renderer snapshot during transient failures.
- Uses a 3-minute refresh cadence, a 15-minute backoff after three consecutive failures, and stops polling when an older backend reports method-not-found.

## Related Issue

Related to #16643, #33094, #57476, and #50813.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add canonical account-usage serialization and Codex account-ID extraction in `agent/account_usage.py`.
- Reuse the shared account-ID extraction path in `agent/auxiliary_client.py`.
- Add the long-running `session.account_usage` RPC in `tui_gateway/server.py`, scoped to the active session's exact live credential.
- Add shared renderer types and `useCodexAccountUsage()`, keyed by connection, profile, runtime session, and provider.
- Add the status-bar item, popover, focus-aware visibility, and locale copy in `apps/desktop/src/`.
- Add backend and renderer coverage for identity selection, secret redaction, serialization, cache scoping, deduplication, backoff, older-backend handling, and non-Codex suppression.

## How to Test

1. Configure and authenticate the `openai-codex` provider.
2. Start the Hermes backend and Electron Desktop, then focus a session using that provider.
3. Confirm the bottom status bar shows `Codex N% left`.
4. Click the item and confirm plan, quota windows, reset times, credits/account details, refresh state, and the usage-settings link render.
5. Switch to a non-Codex session and confirm the item is hidden.
6. Return to the Codex session and confirm a manual refresh works without exposing credentials in the renderer payload.
7. Stop or invalidate the backend temporarily and confirm the last successful snapshot remains visible with an error state and retry action.

### Validation

- Focused account-usage suite: 20 passed.
- Broader affected backend pair: 356 passed; one unrelated browser-management test failed because no Chromium-family binary is installed in the local environment.
- Ruff: passed.
- Prettier on all changed Desktop files: passed.
- Focused Desktop TypeScript compilation: passed.
- Windows-footgun scan and `git diff --check`: passed.
- Renderer query invariants were exercised directly; subsequent Vitest launches in this environment could not start workers, including for an unchanged existing test file.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.2 arm64

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A; user-facing copy and inline code documentation are included
- [x] `cli-config.yaml.example` update: N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A; no contributor workflow changed
- [x] Cross-platform impact considered per the compatibility guide
- [x] Tool descriptions/schemas update: N/A; no agent tool schema changed

## Screenshots / Logs

<img width="420" height="242" alt="Codex usage status-bar popover" src="https://github.com/user-attachments/assets/52639b02-227d-48fc-b008-111e1866f402" />
