### PR TITLE
fix: add encoding='utf-8' to read_text/fdopen in core agent and tools files

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1700,7 +1700,7 @@ def _read_nous_auth() -> Optional[dict]:
     try:
         if not _AUTH_JSON_PATH.is_file():
             return None
-        data = json.loads(_AUTH_JSON_PATH.read_text())
+        data = json.loads(_AUTH_JSON_PATH.read_text(encoding="utf-8"))
         if data.get("active_provider") != "nous":
             return None
         provider = data.get("providers", {}).get("nous", {})

--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -117,7 +117,7 @@ def record_nous_rate_limit(
         # Atomic write: write to temp file + rename
         fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(state, f)
             atomic_replace(tmp_path, path)
         except Exception:

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -632,7 +632,7 @@ def allowlist_path() -> Path:
 def load_allowlist() -> Dict[str, Any]:
     """Return the parsed allowlist, or an empty skeleton if absent."""
     try:
-        raw = json.loads(allowlist_path().read_text())
+        raw = json.loads(allowlist_path().read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return {"approvals": []}
     if not isinstance(raw, dict):
@@ -656,7 +656,7 @@ def save_allowlist(data: Dict[str, Any]) -> None:
             prefix=f"{p.name}.", suffix=".tmp", dir=str(p.parent),
         )
         try:
-            with os.fdopen(fd, "w") as fh:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 fh.write(json.dumps(data, indent=2, sort_keys=True))
             atomic_replace(tmp_path, p)
         except Exception:

--- a/cli.py
+++ b/cli.py
@@ -1454,7 +1454,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
     gitignore = Path(repo_root) / ".gitignore"
     _ignore_entry = ".worktrees/"
     try:
-        existing = gitignore.read_text() if gitignore.exists() else ""
+        existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
         if _ignore_entry not in existing.splitlines():
             with open(gitignore, "a", encoding="utf-8") as f:
                 if existing and not existing.endswith("\n"):
@@ -1504,7 +1504,7 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
         try:
             repo_root_resolved = Path(repo_root).resolve()
             wt_path_resolved = wt_path.resolve()
-            for line in include_file.read_text().splitlines():
+            for line in include_file.read_text(encoding="utf-8").splitlines():
                 entry = line.strip()
                 if not entry or entry.startswith("#"):
                     continue

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -83,7 +83,7 @@ def get_hermes_home() -> Path:
         try:
             fallback_home = _get_platform_default_hermes_home()
             active_path = fallback_home / "active_profile"
-            active = active_path.read_text().strip() if active_path.exists() else ""
+            active = active_path.read_text(encoding="utf-8").strip() if active_path.exists() else ""
         except (UnicodeDecodeError, OSError):
             active = ""
         if active and active != "default":

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -37,7 +37,7 @@ def _read_nous_provider_state() -> Optional[dict]:
         path = auth_json_path()
         if not path.is_file():
             return None
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         providers = data.get("providers", {})
         if not isinstance(providers, dict):
             return None

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -41,7 +41,7 @@ def has_xai_credentials() -> bool:
         auth_path = get_hermes_home() / "auth.json"
         if not auth_path.exists():
             return False
-        store = json.loads(auth_path.read_text())
+        store = json.loads(auth_path.read_text(encoding="utf-8"))
         providers = store.get("providers") if isinstance(store, dict) else None
         xai_state = providers.get("xai-oauth") if isinstance(providers, dict) else None
         tokens = xai_state.get("tokens") if isinstance(xai_state, dict) else None


### PR DESCRIPTION
## Summary

Add explicit `encoding="utf-8"` to `Path.read_text()` and `os.fdopen()` calls in core agent/ and tools/ files that were missing it.

## Problem

`Path.read_text()` and `os.fdopen()` without `encoding=` default to the system locale:
- **Linux**: UTF-8 (usually fine)
- **Windows**: cp1252 (silently corrupts non-ASCII: emoji, CJK, accented chars)

The project's ruff rule PLW1514 only flags `open()` calls — `Path.read_text()` and `os.fdopen()` are **not caught by linting**. These are silent data corruption bugs on Windows.

## Changes (7 files, 9 sites)

- `hermes_constants.py` — active profile name (could contain non-ASCII)
- `cli.py` — `.gitignore` read + git include file parsing (2 sites)
- `agent/auxiliary_client.py` — auth.json provider config
- `agent/shell_hooks.py` — allowlist read + atomic write (2 sites)
- `agent/nous_rate_guard.py` — rate limit state atomic write
- `tools/managed_tool_gateway.py` — custom provider auth config
- `tools/xai_http.py` — X/OAuth token store

## Risk

None — UTF-8 is the correct encoding for all JSON/text config files in this project. The change is a no-op on Linux (already defaults to UTF-8) and a correctness fix on Windows.