### PR TITLE
fix(agent): refresh MCP tool snapshot mid-turn when registry advances

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4742,6 +4742,44 @@ def run_conversation(
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
 
+                # ── Mid-turn MCP tool refresh (#65428) ────────────────────
+                # An MCP server may have sent `notifications/tools/list_changed`
+                # during the tool call we just executed (e.g. mcp-dap-server
+                # swapping from the startup `debug` tool to session tools
+                # `context`/`step`/`breakpoint` once a debug session starts).
+                # `_refresh_tools()` updates the global registry immediately,
+                # but the agent snapshots `agent.tools` once per turn in
+                # `build_turn_context()`.  Without this check, newly registered
+                # tools are invisible to the next API call in the SAME turn —
+                # the agent must wait for the next user message before it can
+                # use them, breaking autonomous workflows that cross
+                # tool-set boundaries.
+                #
+                # Compare the registry generation stamp to the snapshot's
+                # stamp; if the registry advanced, rebuild the snapshot now.
+                # The cheap-generation short-circuit keeps the no-MCP case on
+                # the fast path.  `refresh_agent_mcp_tools` is additive-
+                # preserving, diff-by-name, and atomic under `_agent_tools_lock`
+                # — safe to call mid-turn.  It is a no-op when nothing changed,
+                # so an MCP server that fires list_changed without altering
+                # the visible tool set pays only the cheap generation compare.
+                if not getattr(agent, "_skip_mcp_refresh", False):
+                    try:
+                        import sys as _sys
+                        if "tools.mcp_tool" in _sys.modules:
+                            from tools.registry import registry as _snap_registry
+                            _reg_gen = getattr(_snap_registry, "_generation", 0)
+                            _agent_gen = getattr(agent, "_tool_snapshot_generation", 0)
+                            if isinstance(_reg_gen, int) and isinstance(_agent_gen, int) and _reg_gen > _agent_gen:
+                                from tools.mcp_tool import refresh_agent_mcp_tools
+                                refresh_agent_mcp_tools(agent, quiet_mode=True)
+                    except Exception:
+                        logger.debug(
+                            "Mid-turn MCP tool refresh failed (session=%s): exc_info=True",
+                            agent.session_id or "none",
+                            exc_info=True,
+                        )
+
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
                     _turn_exit_reason = "guardrail_halt"

--- a/tests/agent/test_mcp_mid_turn_refresh_65428.py
+++ b/tests/agent/test_mcp_mid_turn_refresh_65428.py
@@ -1,0 +1,188 @@
+"""Mid-turn MCP tool refresh (#65428).
+
+When an MCP server fires `notifications/tools/list_changed` during a tool call
+(e.g. mcp-dap-server swapping from the startup `debug` tool to session tools
+`context`/`step`/`breakpoint` once a debug session starts), the global registry
+advances its `_generation` stamp.  The agent's tool snapshot, however, is built
+once per turn in `build_turn_context()` — without a mid-turn check the newly
+registered tools are invisible to the next API call in the SAME turn, forcing
+the agent to wait for the next user message before it can use them.
+
+The fix lives in `agent/conversation_loop.py` immediately after
+`agent._execute_tool_calls(...)`.  It compares the registry's generation stamp
+to the agent's `_tool_snapshot_generation`; if the registry advanced, it calls
+`refresh_agent_mcp_tools(agent)` to rebuild the snapshot in-place before the
+next LLM call assembles its `tools=` kwarg.
+
+These tests exercise that check in isolation — bypassing the full conversation
+loop — by invoking the same guard expression the loop runs.  They assert:
+
+  * When the registry advanced, `refresh_agent_mcp_tools` is invoked and the
+    agent's snapshot is rebuilt (new tool lands in `agent.tools`).
+  * When the registry generation matches the snapshot, the refresh is NOT
+    called — a no-op `list_changed` (server fired it but the visible tool set
+    didn't change) pays only the cheap generation compare.
+  * When MCP support isn't imported (`tools.mcp_tool` not in `sys.modules`),
+    the check is a no-op — keeps the no-MCP fast path off the heavy import.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+
+def _tool(name: str) -> dict:
+    return {"type": "function", "function": {"name": name, "description": "", "parameters": {}}}
+
+
+def _make_agent(tool_names, *, snapshot_generation: int = 0, skip_mcp_refresh: bool = False):
+    """Minimal agent stub matching the loop's read surface."""
+    a = types.SimpleNamespace()
+    a.tools = [_tool(n) for n in tool_names]
+    a.valid_tool_names = set(tool_names)
+    a.enabled_toolsets = None
+    a.disabled_toolsets = None
+    a._tool_snapshot_generation = snapshot_generation
+    a._skip_mcp_refresh = skip_mcp_refresh
+    a.session_id = "test-session"
+    return a
+
+
+def _apply_mid_turn_mcp_refresh(agent) -> bool:
+    """Inline replay of the exact guard block added to conversation_loop.py.
+
+    Returns True iff `refresh_agent_mcp_tools` was actually called for this
+    agent — used by the tests below to assert the dispatch decision without
+    needing the full loop wiring.
+    """
+    if getattr(agent, "_skip_mcp_refresh", False):
+        return False
+    if "tools.mcp_tool" not in sys.modules:
+        return False
+    from tools.registry import registry as _snap_registry
+    _reg_gen = getattr(_snap_registry, "_generation", 0)
+    _agent_gen = getattr(agent, "_tool_snapshot_generation", 0)
+    if not (isinstance(_reg_gen, int) and isinstance(_agent_gen, int) and _reg_gen > _agent_gen):
+        return False
+    from tools.mcp_tool import refresh_agent_mcp_tools
+    refresh_agent_mcp_tools(agent, quiet_mode=True)
+    return True
+
+
+def test_mid_turn_refresh_fires_when_registry_advanced(monkeypatch):
+    """Registry generation > snapshot → refresh is called, snapshot rebuilt."""
+    import tools.mcp_tool as mcp_tool
+    import model_tools
+
+    agent = _make_agent(["read_file", "terminal"], snapshot_generation=2)
+
+    # Registry is one generation ahead → the loop should call refresh.
+    new_defs = [_tool(n) for n in ("read_file", "terminal", "mcp_dap_step")]
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: new_defs)
+
+    called = {"n": 0}
+    orig = mcp_tool.refresh_agent_mcp_tools
+
+    def _counter(agent, **kw):
+        called["n"] += 1
+        return orig(agent, **kw)
+
+    monkeypatch.setattr(mcp_tool, "refresh_agent_mcp_tools", _counter)
+
+    fired = _apply_mid_turn_mcp_refresh(agent)
+
+    assert fired is True
+    assert called["n"] == 1
+    # Snapshot was rebuilt — the new tool landed.
+    assert "mcp_dap_step" in agent.valid_tool_names
+    # Stamp advanced to the registry's.
+    assert agent._tool_snapshot_generation >= 2
+
+
+def test_mid_turn_refresh_skipped_when_generation_matches(monkeypatch):
+    """Registry generation == snapshot → no refresh, agent untouched."""
+    import tools.mcp_tool as mcp_tool
+
+    agent = _make_agent(["read_file", "terminal"], snapshot_generation=5)
+    original_tools = agent.tools
+
+    called = {"n": 0}
+
+    def _should_not_fire(agent, **kw):
+        called["n"] += 1
+        return set()
+
+    monkeypatch.setattr(mcp_tool, "refresh_agent_mcp_tools", _should_not_fire)
+    # Pretend the registry is at the same generation.
+    import tools.registry as registry_mod
+    monkeypatch.setattr(registry_mod.registry, "_generation", 5, raising=False)
+
+    fired = _apply_mid_turn_mcp_refresh(agent)
+
+    assert fired is False
+    assert called["n"] == 0
+    assert agent.tools is original_tools  # untouched
+
+
+def test_mid_turn_refresh_skipped_when_mcp_not_imported(monkeypatch):
+    """`tools.mcp_tool` not in sys.modules → no-op (no-MCP fast path)."""
+    # Temporarily hide the already-imported module from sys.modules to assert
+    # the gate short-circuits without touching the heavy import path.
+    saved = sys.modules.pop("tools.mcp_tool", None)
+    try:
+        agent = _make_agent(["read_file"], snapshot_generation=0)
+
+        fired = _apply_mid_turn_mcp_refresh(agent)
+
+        assert fired is False
+    finally:
+        if saved is not None:
+            sys.modules["tools.mcp_tool"] = saved
+
+
+def test_mid_turn_refresh_skipped_when_agent_opts_out(monkeypatch):
+    """`agent._skip_mcp_refresh = True` → no refresh, even if registry advanced."""
+    import tools.mcp_tool as mcp_tool
+
+    agent = _make_agent(["read_file"], snapshot_generation=0, skip_mcp_refresh=True)
+
+    called = {"n": 0}
+
+    def _should_not_fire(agent, **kw):
+        called["n"] += 1
+        return set()
+
+    monkeypatch.setattr(mcp_tool, "refresh_agent_mcp_tools", _should_not_fire)
+    import tools.registry as registry_mod
+    monkeypatch.setattr(registry_mod.registry, "_generation", 99, raising=False)
+
+    fired = _apply_mid_turn_mcp_refresh(agent)
+
+    assert fired is False
+    assert called["n"] == 0
+
+
+def test_mid_turn_refresh_handles_stale_snapshot_gracefully(monkeypatch):
+    """Snapshot stamp is non-int (defensive) → guard skips without TypeError."""
+    import tools.mcp_tool as mcp_tool
+
+    agent = _make_agent(["read_file"], snapshot_generation=0)
+    # Simulate a malformed stamp (a test mock or a future regression).
+    agent._tool_snapshot_generation = "not-an-int"  # type: ignore[assignment]
+
+    called = {"n": 0}
+
+    def _should_not_fire(agent, **kw):
+        called["n"] += 1
+        return set()
+
+    monkeypatch.setattr(mcp_tool, "refresh_agent_mcp_tools", _should_not_fire)
+
+    # Should not raise.
+    fired = _apply_mid_turn_mcp_refresh(agent)
+
+    assert fired is False
+    assert called["n"] == 0


### PR DESCRIPTION
## Problem

Closes #65428.

When an MCP server fires `notifications/tools/list_changed` during a tool call (e.g. `mcp-dap-server` swapping from the startup `debug` tool to session tools `context`/`step`/`breakpoint` once a debug session starts), the global registry updates immediately via `_refresh_tools()` but the agent's `agent.tools` snapshot is only rebuilt in `build_turn_context()` at the start of each turn.  Newly registered tools are invisible until the next user message — breaking autonomous MCP workflows that cross tool-set boundaries within a single turn.

## Fix

Adds a generation-stamp check after `_execute_tool_calls` in the main conversation loop.  When the registry's `_generation` stamp exceeds the agent's `_tool_snapshot_generation`, we call `refresh_agent_mcp_tools(agent)` to rebuild the snapshot in-place before the next LLM call assembles its `tools=` kwarg.

This is cache-safe: it runs *between* tool execution and the next API call, so it only ever extends a fresh request prefix — never mutates the cached prefix of an in-flight turn.  It's also idempotent: `refresh_agent_mcp_tools` diffs by name and is a no-op when nothing changed, so an MCP server that fires `list_changed` without altering the visible tool set pays only the cheap generation compare.

## Contracts relied on (already in `refresh_agent_mcp_tools`)

- **Additive-preserving**: existing tools are not stripped.
- **Diff-by-name**: no churn when the set is unchanged.
- **Atomic under `_agent_tools_lock`**: safe to call mid-turn.
- **Agent-scoped**: respects `enabled_toolsets`/`disabled_toolsets` overrides.

## Gates (cheap fast paths)

- `agent._skip_mcp_refresh` — existing opt-out (e.g. for subagents/special agents) is honoured.
- `tools.mcp_tool` not in `sys.modules` → skip entirely (no MCP server could have registered, so the heavy import is avoided — same gate used in `agent/turn_context.py:197` since #64072).
- `registry._generation` <= `agent._tool_snapshot_generation` → skip (the common case: no `list_changed` arrived).
- Defensive `isinstance(int)` check on both stamps — a malformed stamp short-circuits rather than raising.

## Tests

```
tests/agent/test_mcp_mid_turn_refresh_65428.py
```

Five focused unit tests covering the dispatch decision without the full conversation loop wiring:

1. `test_mid_turn_refresh_fires_when_registry_advanced` — registry > snapshot → `refresh_agent_mcp_tools` called, new tool lands in `agent.tools`.
2. `test_mid_turn_refresh_skipped_when_generation_matches` — registry == snapshot → no refresh, snapshot object untouched.
3. `test_mid_turn_refresh_skipped_when_mcp_not_imported` — no-MCP fast path (hides `tools.mcp_tool` from `sys.modules`).
4. `test_mid_turn_refresh_skipped_when_agent_opts_out` — `_skip_mcp_refresh=True` short-circuits even when registry advanced.
5. `test_mid_turn_refresh_handles_stale_snapshot_gracefully` — non-int stamp → no `TypeError`.

```
============================= 5 passed in 1.63s ===============================
```

## Out of scope

- The between-turns refresh in `turn_context.py` (the existing path) is unchanged; this PR is purely additive for the mid-turn case.
- Actual `mcp-dap-server` integration testing is left to the MCP server team — this PR fixes the agent-side plumbing.