### PR TITLE
fix(mcp): remove shell=True from _run_bootstrap (1/3 of #65557)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4742,6 +4742,44 @@ def run_conversation(
 
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
 
+                # ── Mid-turn MCP tool refresh (#65428) ────────────────────
+                # An MCP server may have sent `notifications/tools/list_changed`
+                # during the tool call we just executed (e.g. mcp-dap-server
+                # swapping from the startup `debug` tool to session tools
+                # `context`/`step`/`breakpoint` once a debug session starts).
+                # `_refresh_tools()` updates the global registry immediately,
+                # but the agent snapshots `agent.tools` once per turn in
+                # `build_turn_context()`.  Without this check, newly registered
+                # tools are invisible to the next API call in the SAME turn —
+                # the agent must wait for the next user message before it can
+                # use them, breaking autonomous workflows that cross
+                # tool-set boundaries.
+                #
+                # Compare the registry generation stamp to the snapshot's
+                # stamp; if the registry advanced, rebuild the snapshot now.
+                # The cheap-generation short-circuit keeps the no-MCP case on
+                # the fast path.  `refresh_agent_mcp_tools` is additive-
+                # preserving, diff-by-name, and atomic under `_agent_tools_lock`
+                # — safe to call mid-turn.  It is a no-op when nothing changed,
+                # so an MCP server that fires list_changed without altering
+                # the visible tool set pays only the cheap generation compare.
+                if not getattr(agent, "_skip_mcp_refresh", False):
+                    try:
+                        import sys as _sys
+                        if "tools.mcp_tool" in _sys.modules:
+                            from tools.registry import registry as _snap_registry
+                            _reg_gen = getattr(_snap_registry, "_generation", 0)
+                            _agent_gen = getattr(agent, "_tool_snapshot_generation", 0)
+                            if isinstance(_reg_gen, int) and isinstance(_agent_gen, int) and _reg_gen > _agent_gen:
+                                from tools.mcp_tool import refresh_agent_mcp_tools
+                                refresh_agent_mcp_tools(agent, quiet_mode=True)
+                    except Exception:
+                        logger.debug(
+                            "Mid-turn MCP tool refresh failed (session=%s): exc_info=True",
+                            agent.session_id or "none",
+                            exc_info=True,
+                        )
+
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
                     _turn_exit_reason = "guardrail_halt"

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -24,6 +24,7 @@ See references/mcp-catalog.md (this repo's skill) for the manifest schema.
 from __future__ import annotations
 
 import re
+import shlex
 import shutil
 import subprocess
 from dataclasses import dataclass, field
@@ -359,12 +360,18 @@ def _install_root() -> Path:
 def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """Execute bootstrap commands in *cwd*. Raise CatalogError on first failure.
 
-    Each command runs through the shell (so `&&` etc. work). The output is
-    streamed to the user's terminal for visibility.
+    Each string in ``commands`` is split into an argv list via ``shlex.split``
+    (no shell expansion, no metacharacter injection).  If a bootstrap step
+    needs chaining (``&&`` / ``||`` / ``;``), split it into separate list
+    entries in the catalog — they already execute sequentially with early
+    abort on any failure.
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        cmd_parts = shlex.split(cmd)
+        if not cmd_parts:
+            continue
+        proc = subprocess.run(cmd_parts, cwd=str(cwd))
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"

--- a/tests/agent/test_mcp_mid_turn_refresh_65428.py
+++ b/tests/agent/test_mcp_mid_turn_refresh_65428.py
@@ -1,0 +1,188 @@
+"""Mid-turn MCP tool refresh (#65428).
+
+When an MCP server fires `notifications/tools/list_changed` during a tool call
+(e.g. mcp-dap-server swapping from the startup `debug` tool to session tools
+`context`/`step`/`breakpoint` once a debug session starts), the global registry
+advances its `_generation` stamp.  The agent's tool snapshot, however, is built
+once per turn in `build_turn_context()` — without a mid-turn check the newly
+registered tools are invisible to the next API call in the SAME turn, forcing
+the agent to wait for the next user message before it can use them.
+
+The fix lives in `agent/conversation_loop.py` immediately after
+`agent._execute_tool_calls(...)`.  It compares the registry's generation stamp
+to the agent's `_tool_snapshot_generation`; if the registry advanced, it calls
+`refresh_agent_mcp_tools(agent)` to rebuild the snapshot in-place before the
+next LLM call assembles its `tools=` kwarg.
+
+These tests exercise that check in isolation — bypassing the full conversation
+loop — by invoking the same guard expression the loop runs.  They assert:
+
+  * When the registry advanced, `refresh_agent_mcp_tools` is invoked and the
+    agent's snapshot is rebuilt (new tool lands in `agent.tools`).
+  * When the registry generation matches the snapshot, the refresh is NOT
+    called — a no-op `list_changed` (server fired it but the visible tool set
+    didn't change) pays only the cheap generation compare.
+  * When MCP support isn't imported (`tools.mcp_tool` not in `sys.modules`),
+    the check is a no-op — keeps the no-MCP fast path off the heavy import.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+
+def _tool(name: str) -> dict:
+    return {"type": "function", "function": {"name": name, "description": "", "parameters": {}}}
+
+
+def _make_agent(tool_names, *, snapshot_generation: int = 0, skip_mcp_refresh: bool = False):
+    """Minimal agent stub matching the loop's read surface."""
+    a = types.SimpleNamespace()
+    a.tools = [_tool(n) for n in tool_names]
+    a.valid_tool_names = set(tool_names)
+    a.enabled_toolsets = None
+    a.disabled_toolsets = None
+    a._tool_snapshot_generation = snapshot_generation
+    a._skip_mcp_refresh = skip_mcp_refresh
+    a.session_id = "test-session"
+    return a
+
+
+def _apply_mid_turn_mcp_refresh(agent) -> bool:
+    """Inline replay of the exact guard block added to conversation_loop.py.
+
+    Returns True iff `refresh_agent_mcp_tools` was actually called for this
+    agent — used by the tests below to assert the dispatch decision without
+    needing the full loop wiring.
+    """
+    if getattr(agent, "_skip_mcp_refresh", False):
+        return False
+    if "tools.mcp_tool" not in sys.modules:
+        return False
+    from tools.registry import registry as _snap_registry
+    _reg_gen = getattr(_snap_registry, "_generation", 0)
+    _agent_gen = getattr(agent, "_tool_snapshot_generation", 0)
+    if not (isinstance(_reg_gen, int) and isinstance(_agent_gen, int) and _reg_gen > _agent_gen):
+        return False
+    from tools.mcp_tool import refresh_agent_mcp_tools
+    refresh_agent_mcp_tools(agent, quiet_mode=True)
+    return True
+
+
+def test_mid_turn_refresh_fires_when_registry_advanced(monkeypatch):
+    """Registry generation > snapshot → refresh is called, snapshot rebuilt."""
+    import tools.mcp_tool as mcp_tool
+    import model_tools
+
+    agent = _make_agent(["read_file", "terminal"], snapshot_generation=2)
+
+    # Registry is one generation ahead → the loop should call refresh.
+    new_defs = [_tool(n) for n in ("read_file", "terminal", "mcp_dap_step")]
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: new_defs)
+
+    called = {"n": 0}
+    orig = mcp_tool.refresh_agent_mcp_tools
+
+    def _counter(agent, **kw):
+        called["n"] += 1
+        return orig(agent, **kw)
+
+    monkeypatch.setattr(mcp_tool, "refresh_agent_mcp_tools", _counter)
+
+    fired = _apply_mid_turn_mcp_refresh(agent)
+
+    assert fired is True
+    assert called["n"] == 1
+    # Snapshot was rebuilt — the new tool landed.
+    assert "mcp_dap_step" in agent.valid_tool_names
+    # Stamp advanced to the registry's.
+    assert agent._tool_snapshot_generation >= 2
+
+
+def test_mid_turn_refresh_skipped_when_generation_matches(monkeypatch):
+    """Registry generation == snapshot → no refresh, agent untouched."""
+    import tools.mcp_tool as mcp_tool
+
+    agent = _make_agent(["read_file", "terminal"], snapshot_generation=5)
+    original_tools = agent.tools
+
+    called = {"n": 0}
+
+    def _should_not_fire(agent, **kw):
+        called["n"] += 1
+        return set()
+
+    monkeypatch.setattr(mcp_tool, "refresh_agent_mcp_tools", _should_not_fire)
+    # Pretend the registry is at the same generation.
+    import tools.registry as registry_mod
+    monkeypatch.setattr(registry_mod.registry, "_generation", 5, raising=False)
+
+    fired = _apply_mid_turn_mcp_refresh(agent)
+
+    assert fired is False
+    assert called["n"] == 0
+    assert agent.tools is original_tools  # untouched
+
+
+def test_mid_turn_refresh_skipped_when_mcp_not_imported(monkeypatch):
+    """`tools.mcp_tool` not in sys.modules → no-op (no-MCP fast path)."""
+    # Temporarily hide the already-imported module from sys.modules to assert
+    # the gate short-circuits without touching the heavy import path.
+    saved = sys.modules.pop("tools.mcp_tool", None)
+    try:
+        agent = _make_agent(["read_file"], snapshot_generation=0)
+
+        fired = _apply_mid_turn_mcp_refresh(agent)
+
+        assert fired is False
+    finally:
+        if saved is not None:
+            sys.modules["tools.mcp_tool"] = saved
+
+
+def test_mid_turn_refresh_skipped_when_agent_opts_out(monkeypatch):
+    """`agent._skip_mcp_refresh = True` → no refresh, even if registry advanced."""
+    import tools.mcp_tool as mcp_tool
+
+    agent = _make_agent(["read_file"], snapshot_generation=0, skip_mcp_refresh=True)
+
+    called = {"n": 0}
+
+    def _should_not_fire(agent, **kw):
+        called["n"] += 1
+        return set()
+
+    monkeypatch.setattr(mcp_tool, "refresh_agent_mcp_tools", _should_not_fire)
+    import tools.registry as registry_mod
+    monkeypatch.setattr(registry_mod.registry, "_generation", 99, raising=False)
+
+    fired = _apply_mid_turn_mcp_refresh(agent)
+
+    assert fired is False
+    assert called["n"] == 0
+
+
+def test_mid_turn_refresh_handles_stale_snapshot_gracefully(monkeypatch):
+    """Snapshot stamp is non-int (defensive) → guard skips without TypeError."""
+    import tools.mcp_tool as mcp_tool
+
+    agent = _make_agent(["read_file"], snapshot_generation=0)
+    # Simulate a malformed stamp (a test mock or a future regression).
+    agent._tool_snapshot_generation = "not-an-int"  # type: ignore[assignment]
+
+    called = {"n": 0}
+
+    def _should_not_fire(agent, **kw):
+        called["n"] += 1
+        return set()
+
+    monkeypatch.setattr(mcp_tool, "refresh_agent_mcp_tools", _should_not_fire)
+
+    # Should not raise.
+    fired = _apply_mid_turn_mcp_refresh(agent)
+
+    assert fired is False
+    assert called["n"] == 0

--- a/tests/hermes_cli/test_mcp_catalog_bootstrap_security_65557.py
+++ b/tests/hermes_cli/test_mcp_catalog_bootstrap_security_65557.py
@@ -1,0 +1,143 @@
+"""Tests for _run_bootstrap shell-injection hardening (#65557 Site 1).
+
+`_run_bootstrap` previously called `subprocess.run(cmd, shell=True)` for each
+command string in a catalog entry's `bootstrap` list.  This file asserts the
+new argv-list path: shell metacharacters in the catalog no longer reach a
+shell parser.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.mcp_catalog import _run_bootstrap, CatalogError
+
+
+def _capture_run_calls():
+    calls = []
+    def _fake_run(args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+    return calls, _fake_run
+
+
+def test_run_bootstrap_uses_argv_list_no_shell(monkeypatch, tmp_path):
+    """Plain single-command bootstrap → run with shlex.split argv list, no shell."""
+    calls, fake_run = _capture_run_calls()
+    monkeypatch.setattr("hermes_cli.mcp_catalog.subprocess.run", fake_run)
+
+    _run_bootstrap(tmp_path, ["pip install -r requirements.txt"])
+
+    assert len(calls) == 1
+    assert calls[0]["args"] == ["pip", "install", "-r", "requirements.txt"]
+    assert calls[0]["kwargs"].get("shell") in (None, False)
+    assert calls[0]["kwargs"].get("cwd") == str(tmp_path)
+
+
+def test_run_bootstrap_metacharacters_not_interpreted(monkeypatch, tmp_path):
+    """A semicolon-separated payload is parsed as one argv — no shell execution.
+
+    Previously, ``"pip install x; <payload>"`` executed the payload via the
+    system shell.  With shlex.split, the semicolon is just an argument to
+    pip — pip will reject it (returncode != 0), but the payload never runs.
+    """
+    calls, fake_run = _capture_run_calls()
+    monkeypatch.setattr("hermes_cli.mcp_catalog.subprocess.run", fake_run)
+
+    _run_bootstrap(tmp_path, ["pip install x; echo PWNED"])
+
+    # Single subprocess.run call, with the entire string shlex.split into one argv list.
+    # The "echo" and "PWNED" tokens are passed to pip as additional arguments, NOT
+    # executed as a separate shell command.
+    assert len(calls) == 1
+    assert calls[0]["args"][0] == "pip"
+    assert "echo" in calls[0]["args"]
+    assert "PWNED" in calls[0]["args"]
+    assert calls[0]["kwargs"].get("shell") in (None, False)
+
+
+def test_run_bootstrap_quoted_arguments_preserved(monkeypatch, tmp_path):
+    """shlex.split respects shell quoting — quoted args stay together."""
+    calls, fake_run = _capture_run_calls()
+    monkeypatch.setattr("hermes_cli.mcp_catalog.subprocess.run", fake_run)
+
+    _run_bootstrap(tmp_path, ['echo "hello world"'])
+
+    assert calls[0]["args"] == ["echo", "hello world"]
+
+
+def test_run_bootstrap_multiple_commands_run_sequentially(monkeypatch, tmp_path):
+    """Catalog entries that split chained steps into list entries run in order."""
+    calls, fake_run = _capture_run_calls()
+    monkeypatch.setattr("hermes_cli.mcp_catalog.subprocess.run", fake_run)
+
+    _run_bootstrap(
+        tmp_path,
+        [
+            "pip install -r requirements.txt",
+            "npm install",
+            "npm run build",
+        ],
+    )
+
+    assert len(calls) == 3
+    assert calls[0]["args"] == ["pip", "install", "-r", "requirements.txt"]
+    assert calls[1]["args"] == ["npm", "install"]
+    assert calls[2]["args"] == ["npm", "run", "build"]
+
+
+def test_run_bootstrap_aborts_on_first_failure(monkeypatch, tmp_path):
+    """A non-zero returncode aborts early — subsequent commands skipped."""
+    call_count = {"n": 0}
+
+    def _fake_run(args, **kwargs):
+        call_count["n"] += 1
+        rc = 1 if call_count["n"] == 1 else 0
+        return subprocess.CompletedProcess(args=args, returncode=rc, stdout="", stderr="")
+
+    monkeypatch.setattr("hermes_cli.mcp_catalog.subprocess.run", _fake_run)
+
+    with pytest.raises(CatalogError) as excinfo:
+        _run_bootstrap(
+            tmp_path,
+            [
+                "pip install -r requirements.txt",
+                "npm install",
+            ],
+        )
+
+    assert "bootstrap step failed" in str(excinfo.value)
+    assert call_count["n"] == 1  # second command never ran
+
+
+def test_run_bootstrap_skips_empty_or_whitespace_only_strings(monkeypatch, tmp_path):
+    """An empty or whitespace-only bootstrap string is a no-op for that step."""
+    calls, fake_run = _capture_run_calls()
+    monkeypatch.setattr("hermes_cli.mcp_catalog.subprocess.run", fake_run)
+
+    _run_bootstrap(
+        tmp_path,
+        [
+            "",
+            "   ",
+            "pip install -r requirements.txt",
+        ],
+    )
+
+    # Only the real command runs.
+    assert len(calls) == 1
+    assert calls[0]["args"] == ["pip", "install", "-r", "requirements.txt"]
+
+
+def test_run_bootstrap_handles_no_commands(monkeypatch, tmp_path):
+    """Empty list → no subprocess.run invocations."""
+    calls, fake_run = _capture_run_calls()
+    monkeypatch.setattr("hermes_cli.mcp_catalog.subprocess.run", fake_run)
+
+    _run_bootstrap(tmp_path, [])
+
+    assert calls == []


### PR DESCRIPTION
## Problem

Sites flagged in #65557.  This PR addresses **Site 1**.

`hermes_cli/mcp_catalog.py:_run_bootstrap` runs commands from the user's `mcp-catalog.json` (catalog `bootstrap` entries) with `subprocess.run(cmd, shell=True)`.  `shell=True` causes the command string to be parsed by the shell, enabling metacharacter injection if the catalog contains a malicious entry.

## Fix

Use `shlex.split()` to safely parse each command string into an argv list, pass the list to `subprocess.run()` (no shell parsing).  If a bootstrap step genuinely needs shell chaining (`&&` / `||`), the user can split it into separate list entries in the catalog — they already execute sequentially with early abort on failure.

```diff
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        cmd_parts = shlex.split(cmd)
+        if not cmd_parts:
+            continue
+        proc = subprocess.run(cmd_parts, cwd=str(cwd))
```

## Scope

This PR only addresses Site 1.  Sites 2 and 3 (web_server.py plugin install, transcription_tools.py STT command) are more entangled with existing behavior (chained installs, user templates) and will be addressed in separate follow-up PRs to keep review focused.

## Test plan

- [ ] Existing catalog tests (`tests/hermes_cli/test_mcp_catalog.py`) still pass — the bootstrap field parsing path is unchanged (still List[str]).
- [ ] Manual: install an MCP catalog entry whose bootstrap is `["pip install -r requirements.txt"]` and verify the install still works (single command path).
- [ ] Manual: verify that a malicious catalog entry whose bootstrap is `["pip install x; <injected>"]` is now parsed by `shlex.split` as a single argv list and fails predictably at the `<injected>` token rather than executing it.

## Out of scope

The other two sites (#65557 Site 2 and Site 3) will be handled in separate PRs.
