### PR TITLE
fix(cron): caption HTML report attachments on Discord

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1277,6 +1277,7 @@ def _send_media_via_adapter(
     loop,
     job: dict,
     platform=None,
+    caption: str | None = None,
 ) -> None:
     """Send extracted MEDIA files as native platform attachments via a live adapter.
 
@@ -1289,6 +1290,7 @@ def _send_media_via_adapter(
     from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    media_caption = caption if len(media_files) == 1 else None
 
     for media_path, _is_voice in media_files:
         try:
@@ -1297,11 +1299,11 @@ def _send_media_via_adapter(
             if should_send_media_as_audio(route_platform, ext, is_voice=_is_voice):
                 coro = adapter.send_voice(chat_id=chat_id, audio_path=media_path, metadata=metadata)
             elif ext in _VIDEO_EXTS:
-                coro = adapter.send_video(chat_id=chat_id, video_path=media_path, metadata=metadata)
+                coro = adapter.send_video(chat_id=chat_id, video_path=media_path, caption=media_caption, metadata=metadata)
             elif ext in _IMAGE_EXTS:
-                coro = adapter.send_image_file(chat_id=chat_id, image_path=media_path, metadata=metadata)
+                coro = adapter.send_image_file(chat_id=chat_id, image_path=media_path, caption=media_caption, metadata=metadata)
             else:
-                coro = adapter.send_document(chat_id=chat_id, file_path=media_path, metadata=metadata)
+                coro = adapter.send_document(chat_id=chat_id, file_path=media_path, caption=media_caption, metadata=metadata)
 
             from agent.async_utils import safe_schedule_threadsafe
             future = safe_schedule_threadsafe(coro, loop)
@@ -1435,7 +1437,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         logger.warning("Job '%s': %s", job["id"], msg)
         return msg
 
-    from tools.send_message_tool import _send_to_platform
+    from tools.send_message_tool import _media_caption_split, _send_to_platform
     from gateway.config import load_gateway_config, Platform
 
     # Optionally wrap the content with a header/footer so the user knows this
@@ -1535,6 +1537,20 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             logger.warning("Job '%s': %s", job["id"], msg)
             delivery_errors.append(msg)
             continue
+
+        # Discord supports a native content field on a single multipart file
+        # upload. Keep a short cron brief and its report in one message instead
+        # of posting an orphan text message followed by an uncaptioned file.
+        # The standalone sender applies the same rule; this keeps the live
+        # adapter path byte-for-byte consistent at the delivery boundary.
+        live_delivery_content = cleaned_delivery_content
+        media_caption = None
+        if platform == Platform.DISCORD and media_files:
+            media_caption, live_delivery_content = _media_caption_split(
+                cleaned_delivery_content,
+                media_files,
+                max_caption_len=2000,
+            )
 
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
@@ -1685,7 +1701,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # standalone cron path lacked this, so DM-topic cron deliveries
                 # landed in the General topic or were rejected by Bot API 10.0
                 # (#22773).
-                text_to_send = cleaned_delivery_content.strip()
+                text_to_send = live_delivery_content.strip()
                 adapter_ok = True
                 timed_out = False
                 if text_to_send:
@@ -1840,6 +1856,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         loop,
                         job,
                         platform=platform,
+                        caption=media_caption,
                     )
                 elif timed_out and media_files:
                     msg = (

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3081,6 +3081,32 @@ class TestSendMediaViaAdapter:
         adapter.send_document.assert_called_once()
         assert adapter.send_document.call_args[1]["file_path"] == str(media_path)
 
+    def test_single_document_caption_is_forwarded(self, tmp_path, monkeypatch):
+        adapter = MagicMock()
+        adapter.send_document = AsyncMock()
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "report.html")
+        media_files = [(str(media_path), False)]
+        from concurrent.futures import Future
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            completed = Future()
+            completed.set_result(MagicMock(success=True))
+            return completed
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            _send_media_via_adapter(
+                adapter,
+                "123",
+                media_files,
+                None,
+                MagicMock(),
+                {"id": "j-caption"},
+                caption="SecurePath report",
+            )
+
+        assert adapter.send_document.call_args[1]["caption"] == "SecurePath report"
+
     def test_multiple_media_files_all_delivered(self, tmp_path, monkeypatch):
         adapter = MagicMock()
         adapter.send_voice = AsyncMock()

--- a/tests/tools/test_media_caption_split.py
+++ b/tests/tools/test_media_caption_split.py
@@ -42,6 +42,16 @@ def test_single_document_short_text_becomes_caption():
     assert body == ""
 
 
+def test_single_html_report_short_text_becomes_caption():
+    caption, body = _media_caption_split(
+        "SecurePath monthly report",
+        [("/tmp/securepath-monthly.html", False)],
+        max_caption_len=_DEFAULT_CAPTION_LIMIT,
+    )
+    assert caption == "SecurePath monthly report"
+    assert body == ""
+
+
 def test_multi_file_keeps_separate_body():
     text = "two photos"
     caption, body = _media_caption_split(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -71,7 +71,7 @@ _TELEGRAM_SEND_AUDIO_EXTS = {".mp3", ".m4a"}
 # voice note reads as a separate label rather than a bubble caption, and the
 # established convention is to keep the accompanying text as its own message.
 _CAPTIONABLE_EXTS = _IMAGE_EXTS | _VIDEO_EXTS | {
-    ".pdf", ".doc", ".docx", ".txt", ".md", ".csv", ".xlsx", ".zip",
+    ".pdf", ".doc", ".docx", ".txt", ".md", ".html", ".htm", ".csv", ".xlsx", ".zip",
 }
 
 # Per-platform native caption length limits (characters). Text longer than


### PR DESCRIPTION
## Summary
- treat `.html`/`.htm` reports as captionable Discord documents
- keep a short cron brief and its single HTML attachment in one native Discord message on both standalone and live-adapter delivery paths
- forward document/image/video captions through the live cron adapter
- add regression coverage for HTML caption selection and adapter forwarding

## Verification
- `pytest -q tests/tools/test_media_caption_split.py tests/tools/test_discord_send_message_caption.py tests/cron/test_scheduler.py` — 231 passed
- `ruff check cron/scheduler.py tests/cron/test_scheduler.py tests/tools/test_media_caption_split.py tools/send_message_tool.py` — passed
- live gateway cron preflight delivered one Discord message with both content and one HTML attachment
