### PR TITLE
fix(context): prefer max_input_tokens over max_tokens for Anthropic proxies

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -806,6 +806,36 @@ def _extract_max_completion_tokens(payload: Dict[str, Any]) -> Optional[int]:
     return _extract_first_int(payload, _MAX_COMPLETION_KEYS)
 
 
+def _context_length_from_model_payload(payload: Dict[str, Any]) -> Optional[int]:
+    """Extract a context *window* from a ``/v1/models`` model object.
+
+    Prefers input-window keys (``max_model_len``, ``max_input_tokens``,
+    ``context_length``, …) via :func:`_extract_context_length`. Falls back to
+    ``max_tokens`` only when no input-window field is present.
+
+    Anthropic (and Anthropic-compatible proxies such as local reverse
+    proxies) expose both ``max_input_tokens`` (context window, e.g. 1M) and
+    ``max_tokens`` (max *output* length, e.g. 128k). Using ``max_tokens`` as
+    the context window under-reports the real limit, persists a stale value
+    into ``context_length_cache.yaml``, and makes the compressor fire far too
+    early (e.g. at 75% of 128k instead of 75% of 1M).
+    """
+    if not isinstance(payload, dict):
+        return None
+    ctx = _extract_context_length(payload)
+    if ctx is not None:
+        return ctx
+    # Last resort for OpenAI-compat servers that only report max_tokens as
+    # the window. Safe for Anthropic shapes because max_input_tokens is
+    # present and already handled above.
+    raw = payload.get("max_tokens")
+    if isinstance(raw, (int, float)):
+        ivalue = int(raw)
+        if ivalue > 0:
+            return ivalue
+    return None
+
+
 def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
     novita_input = payload.get("input_token_price_per_m")
     novita_output = payload.get("output_token_price_per_m")
@@ -1784,14 +1814,17 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                                     return int(ctx)
                             break
 
-            # LM Studio / vLLM / llama.cpp: try /v1/models/{model}
+            # LM Studio / vLLM / llama.cpp / Anthropic-compat proxies:
+            # try /v1/models/{model}
             resp = client.get(f"{server_url}/v1/models/{model}")
             if resp.status_code == 200:
                 data = resp.json()
-                # vLLM returns max_model_len
-                ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")
-                if ctx and isinstance(ctx, (int, float)):
-                    return int(ctx)
+                if isinstance(data, dict):
+                    # Prefer max_model_len / max_input_tokens / context_length
+                    # over max_tokens (Anthropic max_tokens = max OUTPUT).
+                    ctx = _context_length_from_model_payload(data)
+                    if ctx is not None:
+                        return ctx
 
             # Try /v1/models and find the model in the list.
             # Use _model_id_matches to handle "publisher/slug" vs bare "slug".
@@ -1800,10 +1833,12 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                 data = resp.json()
                 models_list = data.get("data", [])
                 for m in models_list:
+                    if not isinstance(m, dict):
+                        continue
                     if _model_id_matches(m.get("id", ""), model):
-                        ctx = m.get("max_model_len") or m.get("context_length") or m.get("max_tokens")
-                        if ctx and isinstance(ctx, (int, float)):
-                            return int(ctx)
+                        ctx = _context_length_from_model_payload(m)
+                        if ctx is not None:
+                            return ctx
     except Exception:
         pass
 

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -260,6 +260,126 @@ class TestQueryLocalContextLengthModelsList:
         assert result is None
 
 
+class TestContextLengthFromModelPayload:
+    """Anthropic / Anthropic-proxy model objects expose max_input_tokens
+    (context window) and max_tokens (max OUTPUT). The local probe must not
+    treat max_tokens as the context window."""
+
+    def test_prefers_max_input_tokens_over_max_tokens(self):
+        from agent.model_metadata import _context_length_from_model_payload
+
+        # Real Anthropic /v1/models shape for claude-fable-5
+        payload = {
+            "type": "model",
+            "id": "claude-fable-5",
+            "max_input_tokens": 1_000_000,
+            "max_tokens": 128_000,  # output cap, NOT context
+        }
+        assert _context_length_from_model_payload(payload) == 1_000_000
+
+    def test_prefers_max_model_len_over_max_tokens(self):
+        from agent.model_metadata import _context_length_from_model_payload
+
+        payload = {"id": "local-model", "max_model_len": 131072, "max_tokens": 4096}
+        assert _context_length_from_model_payload(payload) == 131072
+
+    def test_falls_back_to_max_tokens_when_no_input_window_field(self):
+        from agent.model_metadata import _context_length_from_model_payload
+
+        # Some OpenAI-compat servers only expose max_tokens for the window.
+        payload = {"id": "odd-server", "max_tokens": 65536}
+        assert _context_length_from_model_payload(payload) == 65536
+
+    def test_returns_none_for_empty_payload(self):
+        from agent.model_metadata import _context_length_from_model_payload
+
+        assert _context_length_from_model_payload({}) is None
+        assert _context_length_from_model_payload(None) is None  # type: ignore[arg-type]
+
+
+class TestQueryLocalContextLengthAnthropicProxy:
+    """Local Anthropic-compatible reverse proxies (e.g. 127.0.0.1:47821)
+    return Anthropic-shaped /v1/models entries. The probe must read
+    max_input_tokens, not max_tokens."""
+
+    def _make_resp(self, status_code, body):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json.return_value = body
+        return resp
+
+    def test_models_list_prefers_max_input_tokens(self):
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {
+                    "type": "model",
+                    "id": "claude-fable-5",
+                    "display_name": "Claude Fable 5",
+                    "max_input_tokens": 1_000_000,
+                    "max_tokens": 128_000,
+                },
+                {
+                    "type": "model",
+                    "id": "claude-haiku-4-5-20251001",
+                    "max_input_tokens": 200_000,
+                    "max_tokens": 64_000,
+                },
+            ]
+        })
+
+        call_count = [0]
+
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return detail_resp  # /v1/models/claude-fable-5
+            return list_resp  # /v1/models
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "claude-fable-5", "http://127.0.0.1:47821"
+            )
+
+        assert result == 1_000_000, (
+            f"Expected max_input_tokens (1M), got {result}. "
+            "If Hermes uses Anthropic max_tokens (128k), compression fires ~8x early."
+        )
+
+    def test_model_detail_prefers_max_input_tokens(self):
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(200, {
+            "type": "model",
+            "id": "claude-fable-5",
+            "max_input_tokens": 1_000_000,
+            "max_tokens": 128_000,
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.return_value = detail_resp
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "claude-fable-5", "http://127.0.0.1:47821/v1"
+            )
+
+        assert result == 1_000_000
+
+
 class TestQueryLocalContextLengthLmStudio:
     """_query_local_context_length with LM Studio native /api/v1/models response."""
 


### PR DESCRIPTION
## Summary

Local `/v1/models` probes treated Anthropic `max_tokens` as the **context window**. On Anthropic (and Anthropic-compatible reverse proxies), that field is the **max output** length.

| Field | Meaning | Example (claude-fable-5) |
|---|---|---:|
| `max_input_tokens` | context window | 1,000,000 |
| `max_tokens` | max **output** | 128,000 |

### What went wrong

`_query_local_context_length_uncached` used:

```python
ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")
```

For Anthropic-shaped responses (no `max_model_len` / `context_length`), it fell through to `max_tokens` → **128k**. That value was persisted into `context_length_cache.yaml` and reused forever. The compressor then raised its small-window floor to 75% of 128k → **~96k**, so sessions compacted roughly **8× too early** on a 1M model.

Observed in production with a local Anthropic reverse proxy (`http://127.0.0.1:…`):

```text
Cached context length claude-fable-5@http://127.0.0.1:47821 -> 128,000 tokens
Pre-API compression: ~101,454 request tokens >= 96,000 threshold (context=128,000)
```

The dedicated Anthropic path (`_query_anthropic_context_length`) already reads `max_input_tokens` correctly, but **local/custom endpoints short-circuit earlier** via the local probe and never reach it.

### Fix

- Add `_context_length_from_model_payload()` that prefers input-window keys via existing `_extract_context_length` (`max_model_len`, `max_input_tokens`, `context_length`, …).
- Fall back to `max_tokens` only when **no** input-window field is present (keeps OpenAI-compat servers that only expose `max_tokens` working).
- Use that helper for both `/v1/models/{id}` and `/v1/models` list matching in the local probe.

After this, live local reconcile will also correct any stale 128k cache entries on the next local probe.

## Test plan

- [x] `pytest tests/agent/test_model_metadata_local_ctx.py` — **40 passed**
- [x] Unit: Anthropic payload with both fields → **1M**, not 128k
- [x] Unit: vLLM `max_model_len` still preferred over `max_tokens`
- [x] Unit: pure-`max_tokens` OpenAI-compat servers still work as last resort
- [x] Integration-style: local probe against Anthropic-shaped `/v1/models` list and detail endpoints

## Notes

Workaround without this fix:

```yaml
providers:
  anthropic:
    api: http://127.0.0.1:47821
    models:
      claude-fable-5:
        context_length: 1000000
```

or clear `~/.hermes/context_length_cache.yaml` after deploying this change so stale 128k rows are re-probed.