### PR TITLE
fix(plugin): remove shell=True from memory provider install (2/3 of #65557)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4707,9 +4707,8 @@ def _install_memory_provider_external_dependencies(
         if install_cmd:
             try:
                 install = _run_setup_command(
-                    install_cmd,
+                    shlex.split(install_cmd),
                     display=install_cmd,
-                    shell=True,
                     timeout=300,
                 )
             except Exception as exc:


### PR DESCRIPTION
## Problem

Site 2 of #65557.

`hermes_cli/web_server.py:_install_memory_provider_external_dependencies` calls
`_run_setup_command(install_cmd, shell=True, ...)` while the sibling `check_cmd`
path on the same function already uses the safe `shlex.split(check_cmd)` + list
form. The asymmetry was inconsistent and re-introduced the shell-injection
surface for the install step.

## Fix

Align the install path with the check path — pass `shlex.split(install_cmd)`
as an argv list, drop `shell=True`.

```diff
         if install_cmd:
             try:
                 install = _run_setup_command(
-                    install_cmd,
+                    shlex.split(install_cmd),
                     display=install_cmd,
-                    shell=True,
                     timeout=300,
                 )
```

## Scope

This is Site 2 of three sites flagged in #65557. Site 1 (mcp_catalog.py) is
handled in #65572. Site 3 (transcription_tools.py STT command template) will
be addressed in a separate follow-up PR.

## Test plan

- [ ] Existing memory provider install tests still pass.
- [ ] Manual: configure a memory provider with an `install` command like
      `"pip install foo && rm -rf /tmp/x"` — the chained command no longer
      executes through a shell; pip rejects the unexpected tokens.
