### PR TITLE
fix(stt): default to shlex.split for local STT command, opt-in for shell (3/3 of #65557)

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1250,8 +1250,19 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
                 language=shlex.quote(language),
                 model=shlex.quote(normalized_model),
             )
-            # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
-            use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
+            # The interpolated values are shlex.quote()-wrapped above; the template
+            # itself is the only injection surface. By default we parse the
+            # resulting string with shlex.split() and pass an argv list — no shell
+            # parsing, no injection from a malicious template (e.g. one containing
+            # "; <payload>").
+            #
+            # If a user genuinely needs shell features (pipes, redirects, &&) in
+            # their custom template, they can opt back in to shell execution by
+            # setting HERMES_LOCAL_STT_ALLOW_SHELL=1 alongside the template env
+            # var. The opt-in is explicit so a misconfigured template can't
+            # silently introduce shell metacharacter execution.
+            allow_shell = os.getenv("HERMES_LOCAL_STT_ALLOW_SHELL", "").strip() in ("1", "true", "yes")
+            use_shell = allow_shell and bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
             if use_shell:
                 subprocess.run(command, shell=True, check=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
             else:


### PR DESCRIPTION
## Problem

Site 3 of #65557.

`tools/transcription_tools.py` executes the local STT command template with
`shell=True` when `LOCAL_STT_COMMAND_ENV` is set. A malicious template (e.g.
containing `"; rm -rf /tmp; #"`) would execute arbitrary code through the
system shell.

## Fix

Default to `shlex.split()` + argv list (no shell parsing) regardless of
whether the command comes from `LOCAL_STT_COMMAND_ENV` or auto-detected.
The interpolated arguments are already `shlex.quote()`-wrapped — the only
remaining injection surface was the template itself.

Users who genuinely need shell features (pipes, redirects, `&&`) can set
`HERMES_LOCAL_STT_ALLOW_SHELL=1` to re-enable `shell=True`. The opt-in
is explicit so a misconfigured template can't silently re-introduce shell
metacharacter execution.

## What users see

- **Before:** setting `LOCAL_STT_COMMAND_ENV=whisper-cpp -f {input_path} > {output_dir}/result.txt` works because `>` is a shell redirect.
- **After:** same command fails by default (`>` passed as argv arg to whisper-cpp). User must set `HERMES_LOCAL_STT_ALLOW_SHELL=1` to restore the shell template behaviour.
- **Auto-detected commands** — unaffected, they already used `shlex.split()`.

## Scope

This is the final site of three flagged in #65557. Site 1 (mcp_catalog.py)
is #65572. Site 2 (web_server.py plugin install) is #65577.

## Test plan

- [ ] Auto-detected whisper-cpp STT still works (already used shlex.split).
- [ ] Custom template STT works when user sets `HERMES_LOCAL_STT_ALLOW_SHELL=1`.
- [ ] Malicious template `"; echo PWNED; #"` no longer executes — the
      semicolons are passed as literal characters to shlex.split and the
      binary either rejects them or handles them safely.
