### PR TITLE
fix(backup): reject symlinks/hardlinks/device files in Python < 3.12 extractall fallback

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -630,7 +630,19 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
             try:
                 tf.extractall(str(skills), filter="data")  # type: ignore[call-arg]
             except TypeError:
-                # Python < 3.12 — no filter kwarg
+                # Python < 3.12 — no filter kwarg. Replicate the same
+                # protections manually: reject symlinks, hardlinks, and
+                # device/special files in addition to the path traversal
+                # check already done above.
+                for member in tf.getmembers():
+                    if member.issym() or member.islnk():
+                        raise tarfile.TarError(
+                            f"refusing to extract symlink/hardlink: {member.name!r}"
+                        )
+                    if not member.isfile() and not member.isdir():
+                        raise tarfile.TarError(
+                            f"refusing to extract non-regular file: {member.name!r}"
+                        )
                 tf.extractall(str(skills))
     except (OSError, tarfile.TarError) as e:
         # Best-effort recover: move staged contents back


### PR DESCRIPTION
## Problem (#65556)

`agent/curator_backup.py` has a pre-extraction path traversal check (lines 626–630) that validates member names for `..` and absolute paths before calling `extractall()`. The Python 3.12+ path uses `filter="data"` which automatically rejects symlinks, hardlinks, and device nodes. The Python < 3.12 fallback path (line 634) calls `tf.extractall(str(skills))` **without** `filter="data"` and **without** any post-validation for member types.

A malicious `.tar.gz` containing a symlink that points outside the extraction directory, or a hardlink/device node, would be extracted by the fallback path even though the 3.12+ path would reject it.

## Fix

Replicate the `filter="data"` protections manually in the Python < 3.12 fallback path. Iterate members before calling `extractall()` and raise `TarError` on:

- `issym()` — symlinks (could point outside the extraction root)
- `islnk()` — hardlinks (could reference existing system files)
- Anything that is neither `isfile()` nor `isdir()` — device nodes, FIFOs, sockets

The pre-extraction path traversal check (lines 626–630) already rejects `..` and absolute paths; this change adds the missing member-type validation for the fallback path.

```diff
             try:
                 tf.extractall(str(skills), filter="data")  # type: ignore[call-arg]
             except TypeError:
-                # Python < 3.12 — no filter kwarg
+                # Python < 3.12 — no filter kwarg. Replicate the same
+                # protections manually: reject symlinks, hardlinks, and
+                # device/special files in addition to the path traversal
+                # check already done above.
+                for member in tf.getmembers():
+                    if member.issym() or member.islnk():
+                        raise tarfile.TarError(
+                            f"refusing to extract symlink/hardlink: {member.name!r}"
+                        )
+                    if not member.isfile() and not member.isdir():
+                        raise tarfile.TarError(
+                            f"refusing to extract non-regular file: {member.name!r}"
+                        )
                 tf.extractall(str(skills))
```

## Test plan

- [ ] Manual on Python 3.11: a snapshot tarball containing a symlink is rejected with the new TarError.
- [ ] Manual on Python 3.12+: same tarball is still rejected by `filter="data"` (path unaffected).
- [ ] Existing snapshot restore tests pass on both 3.11 and 3.12.
