### PR TITLE
fix(profiles): handle symlinks and hardlinks in profile archive import (#65530)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1976,10 +1976,40 @@ def _safe_extract_profile_archive(archive: Path, destination: Path) -> None:
                 target.mkdir(parents=True, exist_ok=True)
                 continue
 
+            if member.issym():
+                # Recreate relative symlinks; skip absolute ones (stale on other machines)
+                link_target = member.linkname
+                if os.path.isabs(link_target):
+                    print(
+                        f"⚠ Skipping absolute symlink: {member.name} -> {link_target}",
+                        file=sys.stderr,
+                    )
+                else:
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.symlink_to(link_target)
+                continue
+
+            if member.islnk():
+                # Hard link — recreate if the linked member has been extracted
+                link_target_parts = _normalize_profile_archive_parts(member.linkname)
+                link_dst = destination.joinpath(*link_target_parts)
+                if link_dst.exists():
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    os.link(str(link_dst), str(target))
+                else:
+                    print(
+                        f"⚠ Skipping hard link with missing target: "
+                        f"{member.name} -> {member.linkname}",
+                        file=sys.stderr,
+                    )
+                continue
+
             if not member.isfile():
-                raise ValueError(
-                    f"Unsupported archive member type: {member.name}"
+                print(
+                    f"⚠ Skipping unsupported archive member: {member.name}",
+                    file=sys.stderr,
                 )
+                continue
 
             target.parent.mkdir(parents=True, exist_ok=True)
             extracted = tf.extractfile(member)


### PR DESCRIPTION
Fixes #65530

## Problem
`hermes profile import` crashes with:
```
Error: Unsupported archive member type: coder/home/.cache/uv/wheels-v6/pypi/annotated-types/0.7.0-py3-none-any
```
when the archive contains symlinks (e.g. to `~/.cache/`) or hardlinks.

The `_safe_extract_profile_archive` function only handled `isdir()` and `isfile()` members — any other tar member type (symlink, hardlink, etc.) raised an immediate `ValueError`, aborting the entire import.

## Fix
Handle non-file, non-directory tar members gracefully instead of crashing:
- **Symlinks** (`member.issym()`): recreate relative symlinks; skip absolute ones with a stderr warning (they'd be stale on a different machine)
- **Hard links** (`member.islnk()`): recreate when the target member exists in the archive; skip with a warning otherwise
- **Other types**: skip with a stderr warning (FIFOs, devices, etc.)

## Tests
All 17 existing `TestExportImport` tests pass. The change is backward-compatible — existing plain-file archives import identically.