### PR TITLE
fix(kanban): avoid false dispatcher stuck warnings

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1077,10 +1077,8 @@ class GatewayKanbanWatchersMixin:
                 out.append((slug, _tick_once_for_board(slug)))
             return out
 
-        def _ready_nonempty() -> bool:
-            """Cheap probe: is there at least one ready+assigned+unclaimed
-            task on ANY board whose assignee maps to a real Hermes profile
-            (i.e. one the dispatcher would actually spawn for)?
+        def _boards_with_spawnable() -> set[str]:
+            """Cheap probe: return set of board slugs with spawnable work.
 
             Tasks assigned to control-plane lanes (e.g. ``orion-cc``,
             ``orion-research``) are pulled by terminals via
@@ -1093,15 +1091,16 @@ class GatewayKanbanWatchersMixin:
                 boards = _kb.list_boards(include_archived=False)
             except Exception:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            slugs = set()
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)
                     if _kb.has_spawnable_ready(conn):
-                        return True
+                        slugs.add(slug)
                     if _kb.has_spawnable_review(conn):
-                        return True
+                        slugs.add(slug)
                 except Exception:
                     continue
                 finally:
@@ -1110,7 +1109,7 @@ class GatewayKanbanWatchersMixin:
                             conn.close()
                         except Exception:
                             pass
-            return False
+            return slugs
 
         # Auto-decompose: turn fresh triage tasks into ready workgraphs
         # before the dispatcher fans out workers. Gated by
@@ -1233,10 +1232,8 @@ class GatewayKanbanWatchersMixin:
                 if _ad_enabled:
                     await asyncio.to_thread(_auto_decompose_tick, _ad_per_tick)
                 results = await asyncio.to_thread(_tick_once)
-                any_spawned = False
                 for slug, res in (results or []):
                     if res is not None and getattr(res, "spawned", None):
-                        any_spawned = True
                         # Quiet by default — only log when something actually
                         # happened, so an idle gateway stays silent.
                         logger.info(
@@ -1250,18 +1247,26 @@ class GatewayKanbanWatchersMixin:
                             res.promoted,
                             len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
                         )
-                # Health telemetry (aggregate across boards)
-                ready_pending = await asyncio.to_thread(_ready_nonempty)
-                intentionally_deferred = any(
-                    res is not None and (
+                # Health telemetry (board-local)
+                ready_boards = await asyncio.to_thread(_boards_with_spawnable)
+                deferred_slugs = {
+                    slug
+                    for slug, res in (results or [])
+                    if res is not None
+                    and (
                         getattr(res, "skipped_global_capped", False)
                         or bool(getattr(res, "skipped_per_profile_capped", ()))
                         or bool(getattr(res, "skipped_locked", False))
                         or bool(getattr(res, "respawn_guarded", ()))
                     )
-                    for _, res in (results or [])
-                )
-                if ready_pending and not any_spawned and not intentionally_deferred:
+                }
+                spawned_slugs = {
+                    slug
+                    for slug, res in (results or [])
+                    if res is not None and getattr(res, "spawned", None)
+                }
+                stuck = ready_boards - deferred_slugs - spawned_slugs
+                if stuck:
                     bad_ticks += 1
                 else:
                     bad_ticks = 0

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1252,7 +1252,16 @@ class GatewayKanbanWatchersMixin:
                         )
                 # Health telemetry (aggregate across boards)
                 ready_pending = await asyncio.to_thread(_ready_nonempty)
-                if ready_pending and not any_spawned:
+                intentionally_deferred = any(
+                    res is not None and (
+                        getattr(res, "skipped_global_capped", False)
+                        or bool(getattr(res, "skipped_per_profile_capped", ()))
+                        or bool(getattr(res, "skipped_locked", False))
+                        or bool(getattr(res, "respawn_guarded", ()))
+                    )
+                    for _, res in (results or [])
+                )
+                if ready_pending and not any_spawned and not intentionally_deferred:
                     bad_ticks += 1
                 else:
                     bad_ticks = 0

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1389,29 +1389,33 @@ def _print_gateway_process_mismatch(snapshot: GatewayRuntimeSnapshot) -> None:
         print("  can refuse to start another copy until this process stops.")
 
 
-def _print_other_profiles_gateway_status() -> None:
-    """Print a summary of gateway status across all profiles.
-
-    Shown at the bottom of ``hermes gateway status`` output so users with
-    multiple profiles can tell at a glance which gateways are running and
-    avoid confusing another profile's process with the current one.
-    """
+def _other_profiles_gateway_processes() -> list[ProfileGatewayProcess]:
     try:
         from hermes_cli.profiles import get_active_profile_name
 
         current = get_active_profile_name()
-        other_processes = [
+        return [
             p for p in find_profile_gateway_processes() if p.profile != current
         ]
-        if not other_processes:
-            return
-
-        print()
-        print("Other profiles:")
-        for proc in other_processes:
-            print(f"  ✓ {proc.profile:<16s} — PID {proc.pid}")
     except Exception:
-        pass
+        return []
+
+
+def _print_other_profiles_gateway_status(
+    processes: list[ProfileGatewayProcess] | None = None,
+) -> None:
+    """Print a summary of live gateways outside the active profile."""
+    other_processes = (
+        _other_profiles_gateway_processes() if processes is None else processes
+    )
+    if not other_processes:
+        return
+
+    print()
+    print("Live gateways in other profiles:")
+    for proc in other_processes:
+        label = "default" if proc.profile == "default" else proc.profile
+        print(f"  ✓ {label:<16s} — PID {proc.pid}")
 
 
 def _gateway_list() -> None:
@@ -7031,6 +7035,7 @@ def _gateway_command_inner(args):
         full = getattr(args, "full", False)
         system = getattr(args, "system", False)
         snapshot = get_gateway_runtime_snapshot(system=system)
+        other_profile_processes = _other_profiles_gateway_processes()
 
         # Check for service first
         _windows_service_installed = False
@@ -7056,7 +7061,10 @@ def _gateway_command_inner(args):
             # Check for manually running processes
             pids = list(snapshot.gateway_pids)
             if pids:
-                print(f"✓ Gateway is running (PID: {', '.join(map(str, pids))})")
+                print(
+                    f"✓ Gateway is running for the active profile "
+                    f"(PID: {', '.join(map(str, pids))})"
+                )
                 print("  (Running manually, not as a system service)")
                 runtime_lines = _runtime_health_lines()
                 if runtime_lines:
@@ -7086,7 +7094,9 @@ def _gateway_command_inner(args):
                     print("  hermes gateway install")
                     print("  sudo hermes gateway install --system")
             else:
-                print("✗ Gateway is not running")
+                print("✗ Gateway is not running for the active profile")
+                if other_profile_processes:
+                    print("  A gateway is still live for another profile; this is not a system-wide outage.")
                 runtime_lines = _runtime_health_lines()
                 if runtime_lines:
                     print()
@@ -7117,8 +7127,7 @@ def _gateway_command_inner(args):
                         "  sudo hermes gateway install --system  # Install as boot-time system service"
                     )
 
-        # Show other profiles' gateway status for multi-profile awareness
-        _print_other_profiles_gateway_status()
+        _print_other_profiles_gateway_status(other_profile_processes)
 
     elif subcmd == "list":
         _gateway_list()

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2176,6 +2176,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "skipped_global_capped": res.skipped_global_capped,
             "skipped_per_profile_capped": [
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
@@ -2208,6 +2209,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         )
     if res.skipped_unassigned:
         print(f"Skipped (unassigned): {', '.join(res.skipped_unassigned)}")
+    if res.skipped_global_capped:
+        print("Deferred (global in-progress cap reached)")
     if res.skipped_per_profile_capped:
         for tid, who, current in res.skipped_per_profile_capped:
             print(
@@ -2291,8 +2294,14 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
 
     def _on_tick(res):
         ready_pending = bool(res.skipped_unassigned) or _ready_queue_nonempty()
+        intentionally_deferred = (
+            res.skipped_global_capped
+            or bool(res.skipped_per_profile_capped)
+            or bool(res.skipped_locked)
+            or bool(res.respawn_guarded)
+        )
         spawned_any = bool(res.spawned)
-        if ready_pending and not spawned_any:
+        if ready_pending and not spawned_any and not intentionally_deferred:
             health_state["bad_ticks"] += 1
         else:
             health_state["bad_ticks"] = 0

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5934,6 +5934,9 @@ class DispatchResult:
     operator-actionable failure. Tracked separately so health telemetry
     can distinguish "real stuck" (nothing spawned but spawnable work
     available) from "correctly idle" (nothing spawnable in the queue)."""
+    skipped_global_capped: bool = False
+    """True when ``kanban.max_in_progress`` already filled the board's
+    global worker capacity for this tick."""
     skipped_per_profile_capped: list[tuple[str, str, int]] = field(default_factory=list)
     """Tasks deferred this tick because their assignee is already at
     ``kanban.max_in_progress_per_profile`` (#21582). Each entry is
@@ -7491,6 +7494,7 @@ def _dispatch_once_locked(
             "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
         ).fetchone()[0]
         if in_progress >= max_in_progress:
+            result.skipped_global_capped = True
             return result
         # Only spawn enough to reach the cap, respecting max_spawn too.
         remaining = max_in_progress - in_progress

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1884,9 +1884,35 @@ class TestGatewaySystemServiceRouting:
         gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
 
         out = capsys.readouterr().out
-        assert "Gateway is not running" in out
+        assert "Gateway is not running for the active profile" in out
         assert "nohup hermes gateway" in out
         assert "install as user service" not in out
+
+    def test_gateway_status_promotes_live_other_profile(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_runtime_snapshot",
+            lambda system=False: gateway_cli.GatewayRuntimeSnapshot(manager="manual"),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_other_profiles_gateway_processes",
+            lambda: [gateway_cli.ProfileGatewayProcess("default", Path("/tmp"), 4321)],
+        )
+        monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
+
+        out = capsys.readouterr().out
+        assert "not running for the active profile" in out
+        assert "not a system-wide outage" in out
+        assert "Live gateways in other profiles:" in out
+        assert "default" in out
+        assert "PID 4321" in out
 
     def test_gateway_restart_does_not_fallback_to_foreground_when_launchd_restart_fails(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3725,7 +3725,7 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
         # PR salvage (#32857 commit 7): the dispatcher now reaps zombies at
         # the top of each tick via ``asyncio.to_thread(_kb.reap_worker_zombies)``
         # BEFORE the per-board tick work. Each tick now issues 3 ``to_thread``
-        # calls (reaper + ``_tick_once`` + ``_ready_nonempty``) instead of 2,
+        # calls (reaper + ``_tick_once`` + ``_boards_with_spawnable``) instead of 2,
         # so this counter must reach 6 to allow the same 2 dispatch ticks the
         # pre-reaper test expected at 4. Connect counts in the assertion below
         # are unchanged.
@@ -3852,6 +3852,375 @@ def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
     assert sum("not a valid SQLite database" in msg for msg in messages) == 2
     assert any("database fingerprint unchanged" in msg for msg in messages)
     assert calls["tick"] == 3
+
+
+def test_gateway_multi_board_deferral_does_not_mask_stuck(monkeypatch, caplog):
+    """Board A's deferral does NOT mask board B's stuck state (key regression test).
+
+    With two boards:
+    - Board "alpha": has spawnable ready work, but dispatch returns
+      skipped_global_capped=True (intentionally deferred).
+    - Board "beta": has spawnable ready work, dispatch returns empty spawned=[]
+      with NO deferral flags (genuinely stuck).
+
+    After HEALTH_WINDOW ticks, the stuck warning should fire — proving
+    board A's deferral does NOT hide board B's problem.
+    """
+    from unittest.mock import MagicMock
+    import asyncio
+    import logging
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+    from hermes_cli.kanban_db import DispatchResult
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 0.1,
+            }
+        },
+    )
+
+    # Two boards
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [
+            {"slug": "alpha"},
+            {"slug": "beta"},
+        ],
+    )
+    monkeypatch.setattr(
+        _kb,
+        "read_board_metadata",
+        lambda slug: {"slug": slug},
+    )
+
+    # Track connection -> board mapping
+    conn_to_board = {}
+
+    def _connect(board=None):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        conn_to_board[conn] = board or "default"
+        return conn
+
+    spawnable_boards = {"alpha", "beta"}
+
+    def _has_spawnable_ready(conn):
+        board = conn_to_board.get(conn, "default")
+        return board in spawnable_boards
+
+    def _has_spawnable_review(conn):
+        return False
+
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr(_kb, "has_spawnable_ready", _has_spawnable_ready)
+    monkeypatch.setattr(_kb, "has_spawnable_review", _has_spawnable_review)
+    monkeypatch.setattr(_kb, "reap_worker_zombies", lambda: [])
+
+    # Dispatch results: alpha deferred, beta stuck
+    def _dispatch_once(conn, **kwargs):
+        return (
+            DispatchResult(skipped_global_capped=True)
+            if conn_to_board.get(conn) == "alpha"
+            else DispatchResult()
+        )
+
+    monkeypatch.setattr(_kb, "dispatch_once", _dispatch_once)
+
+    # Mock to_thread to count ticks
+    to_thread_calls = []
+    tick_once_calls = 0
+
+    async def _to_thread(fn, *args, **kwargs):
+        nonlocal tick_once_calls
+        result = fn(*args, **kwargs)
+        fn_name = getattr(fn, "__name__", str(fn))
+        to_thread_calls.append(fn_name)
+        if fn_name == "_tick_once":
+            tick_once_calls += 1
+            if tick_once_calls >= 8:
+                runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.sleep", _sleep)
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    stuck_warnings = [msg for msg in messages if "kanban dispatcher stuck" in msg]
+    assert len(stuck_warnings) >= 1, f"Expected stuck warning, got {messages}"
+
+
+def test_gateway_single_board_deferral_resets_bad_ticks(monkeypatch, caplog):
+    """Single board with skipped_global_capped=True: NO stuck warning.
+
+    When a board has spawnable work but is intentionally deferred (capped),
+    the bad_ticks counter should reset each tick, not accumulate.
+    """
+    from unittest.mock import MagicMock
+    import asyncio
+    import logging
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+    from hermes_cli.kanban_db import DispatchResult
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 0.1,
+            }
+        },
+    )
+
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": "default"}],
+    )
+    monkeypatch.setattr(_kb, "read_board_metadata", lambda slug: {"slug": slug})
+
+    def _connect(board=None):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        return conn
+
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr(_kb, "has_spawnable_ready", lambda conn: True)
+    monkeypatch.setattr(_kb, "has_spawnable_review", lambda conn: False)
+    monkeypatch.setattr(_kb, "reap_worker_zombies", lambda: [])
+
+    # Always deferred
+    monkeypatch.setattr(
+        _kb,
+        "dispatch_once",
+        lambda conn, **kwargs: DispatchResult(skipped_global_capped=True),
+    )
+
+    to_thread_calls = []
+    tick_once_calls = 0
+
+    async def _to_thread(fn, *args, **kwargs):
+        nonlocal tick_once_calls
+        result = fn(*args, **kwargs)
+        fn_name = getattr(fn, "__name__", str(fn))
+        to_thread_calls.append(fn_name)
+        if fn_name == "_tick_once":
+            tick_once_calls += 1
+            if tick_once_calls >= 8:
+                runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.sleep", _sleep)
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    stuck_warnings = [msg for msg in messages if "kanban dispatcher stuck" in msg]
+    assert len(stuck_warnings) == 0, f"Expected NO stuck warning with deferral, got {stuck_warnings}"
+
+
+def test_gateway_single_board_stuck_fires_warning(monkeypatch, caplog):
+    """Single board with spawnable work, no deferral, no spawn: warning fires.
+
+    Baseline test: when a board genuinely has spawnable work but nothing
+    is spawned and there's no deferral flag, the stuck warning should fire
+    after HEALTH_WINDOW consecutive ticks.
+    """
+    from unittest.mock import MagicMock
+    import asyncio
+    import logging
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+    from hermes_cli.kanban_db import DispatchResult
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 0.1,
+            }
+        },
+    )
+
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": "default"}],
+    )
+    monkeypatch.setattr(_kb, "read_board_metadata", lambda slug: {"slug": slug})
+
+    def _connect(board=None):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        return conn
+
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr(_kb, "has_spawnable_ready", lambda conn: True)
+    monkeypatch.setattr(_kb, "has_spawnable_review", lambda conn: False)
+    monkeypatch.setattr(_kb, "reap_worker_zombies", lambda: [])
+
+    # Always stuck: no spawn, no deferral flags
+    monkeypatch.setattr(_kb, "dispatch_once", lambda conn, **kwargs: DispatchResult())
+
+    to_thread_calls = []
+    tick_once_calls = 0
+
+    async def _to_thread(fn, *args, **kwargs):
+        nonlocal tick_once_calls
+        result = fn(*args, **kwargs)
+        fn_name = getattr(fn, "__name__", str(fn))
+        to_thread_calls.append(fn_name)
+        if fn_name == "_tick_once":
+            tick_once_calls += 1
+            if tick_once_calls >= 8:
+                runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.sleep", _sleep)
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    stuck_warnings = [msg for msg in messages if "kanban dispatcher stuck" in msg]
+    assert len(stuck_warnings) >= 1, f"Expected stuck warning, got {messages}"
+
+
+def test_daemon_health_predicate_logic():
+    """Test the daemon path health predicate directly.
+
+    The daemon path (hermes_cli/kanban.py _on_tick closure) uses this logic:
+        intentionally_deferred = (
+            res.skipped_global_capped
+            or bool(res.skipped_per_profile_capped)
+            or bool(res.skipped_locked)
+            or bool(res.respawn_guarded)
+        )
+        if ready_pending and not spawned_any and not intentionally_deferred:
+            bad_ticks += 1
+
+    This test verifies the predicate behavior by constructing real
+    DispatchResult objects and checking the condition.
+    """
+    from hermes_cli.kanban_db import DispatchResult
+
+    # Case 1: Deferral flags set → should NOT increment bad_ticks
+    res_deferred = DispatchResult(skipped_global_capped=True)
+    ready_pending = True
+    spawned_any = False
+    intentionally_deferred = (
+        res_deferred.skipped_global_capped
+        or bool(res_deferred.skipped_per_profile_capped)
+        or bool(res_deferred.skipped_locked)
+        or bool(res_deferred.respawn_guarded)
+    )
+    assert intentionally_deferred is True
+    assert not (ready_pending and not spawned_any and not intentionally_deferred)
+
+    # Case 2: No deferral but ready work → SHOULD increment bad_ticks
+    res_stuck = DispatchResult()  # Empty, no flags
+    intentionally_deferred = (
+        res_stuck.skipped_global_capped
+        or bool(res_stuck.skipped_per_profile_capped)
+        or bool(res_stuck.skipped_locked)
+        or bool(res_stuck.respawn_guarded)
+    )
+    assert intentionally_deferred is False
+    assert ready_pending and not spawned_any and not intentionally_deferred
+
+    # Case 3: Spawn → should NOT increment bad_ticks
+    res_spawned = DispatchResult(spawned=[("t1", "alice", "/tmp")])
+    spawned_any = True
+    assert not (ready_pending and not spawned_any)
+
+    # Case 4: skipped_locked flag
+    res_locked = DispatchResult(skipped_locked=True)
+    intentionally_deferred = (
+        res_locked.skipped_global_capped
+        or bool(res_locked.skipped_per_profile_capped)
+        or bool(res_locked.skipped_locked)
+        or bool(res_locked.respawn_guarded)
+    )
+    assert intentionally_deferred is True
+
+    # Case 5: skipped_per_profile_capped
+    res_profile_capped = DispatchResult(
+        skipped_per_profile_capped=[("t1", "alice", 5)]
+    )
+    intentionally_deferred = (
+        res_profile_capped.skipped_global_capped
+        or bool(res_profile_capped.skipped_per_profile_capped)
+        or bool(res_profile_capped.skipped_locked)
+        or bool(res_profile_capped.respawn_guarded)
+    )
+    assert intentionally_deferred is True
+
+    # Case 6: respawn_guarded
+    res_guarded = DispatchResult(respawn_guarded=[("t1", "recent_success")])
+    intentionally_deferred = (
+        res_guarded.skipped_global_capped
+        or bool(res_guarded.skipped_per_profile_capped)
+        or bool(res_guarded.skipped_locked)
+        or bool(res_guarded.respawn_guarded)
+    )
+    assert intentionally_deferred is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -118,6 +118,25 @@ def test_invalid_cap_treated_as_no_cap(isolated_kanban_home_with_profiles, cap):
     assert len(res.spawned) == 3
 
 
+def test_global_cap_marks_dispatch_as_intentionally_deferred(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        running = kb.create_task(conn, title="running", assignee="alpha")
+        kb.create_task(conn, title="ready", assignee="alpha")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'running', claim_lock = 'test:1' WHERE id = ?",
+                (running,),
+            )
+    with kb.connect_closing() as conn:
+        result = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=True, max_in_progress=1,
+        )
+    assert result.skipped_global_capped is True
+    assert result.spawned == []
+
+
 def test_capped_tasks_dispatched_on_subsequent_tick(isolated_kanban_home_with_profiles):
     """A task deferred this tick because its profile was at cap should be
     eligible for dispatch on the next tick (after running tasks complete).


### PR DESCRIPTION
## Problem

The kanban dispatcher's health telemetry raises "stuck" warnings whenever the ready queue is non-empty and no workers spawn on a tick — even when the non-spawn is **intentional and correct** (concurrency caps reached, profile already at `max_in_progress_per_profile`, a task is locked, or respawn is guarded). This produces noisy false-positive stuck warnings that make real stalls harder to spot and erode trust in health monitoring.

## What changed

- **`DispatchResult` gains `skipped_global_capped`** — set when the board's global `max_in_progress` is already filled, mirroring the existing `skipped_per_profile_capped`.
- **Dispatcher health (both gateway and daemon paths)** now treats intentional deferrals (global cap, per-profile cap, locked, respawn-guarded) as healthy ticks. `bad_ticks` only increments when spawnable work is genuinely stuck, not deliberately deferred.
- **`hermes kanban dispatch` CLI** surfaces `skipped_global_capped` so operators see "Deferred (global in-progress cap reached)" instead of silent nothing.
- **`hermes gateway status`** now scopes its running/not-running messaging to the **active profile**, and when the active profile is down but another profile's gateway is live, it says so explicitly ("not a system-wide outage") with a "Live gateways in other profiles" section.

## Why it matters

On multi-profile hosts the gateway-status wording previously implied a system-wide outage when only one profile was idle, and the health telemetry cried "stuck" on every tick where caps correctly prevented over-spawning. Both undermine operator confidence in the very signals meant to catch real problems.

## Verification

- `tests/hermes_cli/test_kanban_per_profile_cap.py` — new `test_global_cap_marks_dispatch_as_intentionally_deferred`; all 10 tests pass
- `tests/hermes_cli/test_gateway_service.py` — new `test_gateway_status_promotes_live_other_profile`; all 189 tests pass
- Combined: 199 passed, 0 failed

## Risks / follow-ups

- A genuine stall that coincides with a cap/lock/respawn-guard state on the same tick will not increment `bad_ticks`. This is a deliberate trade (false-positive reduction) but means a real stall masked by concurrent deferral would rely on subsequent ticks where the deferral clears.
