### PR TITLE
feat(kanban): add task metadata column for task-level configuration

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -87,7 +87,7 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
@@ -836,6 +836,20 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
 # Data classes
 # ---------------------------------------------------------------------------
 
+def _parse_task_metadata(raw: str) -> Optional[dict]:
+    """Parse the ``tasks.metadata`` JSON column into a dict.
+
+    Returns ``None`` on invalid JSON or non-object payloads so a corrupt
+    value never breaks ``Task.from_row`` callers. Per-attempt run metadata
+    (``Run.metadata``) is unrelated; this is the task-level column.
+    """
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 @dataclass
 class Task:
     """In-memory view of a row from the ``tasks`` table."""
@@ -915,6 +929,11 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Free-form JSON metadata for task-level configuration (e.g. lane
+    # routing hints, launcher selection). Parsed from the ``metadata``
+    # column; ``None`` means the column is NULL (no metadata set).
+    # Distinct from ``Run.metadata``, which is per-attempt data.
+    metadata: Optional[dict] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -998,6 +1017,11 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            metadata=(
+                _parse_task_metadata(row["metadata"])
+                if "metadata" in keys and row["metadata"]
+                else None
             ),
         )
 
@@ -2417,6 +2441,7 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    metadata: Optional[dict] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2440,6 +2465,12 @@ def create_task(
     each name to ``hermes --skills ...``. Use this to pin a task to a
     specialist skill (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``metadata`` is an optional JSON-serializable dict of task-level
+    configuration (e.g. lane routing hints). Stored as JSON in the
+    ``metadata`` column; ``None`` (the default) leaves it NULL. Read it
+    via ``Task.metadata`` after ``get_task``. This is task-level config,
+    not per-attempt run data (see ``Run.metadata`` for that).
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
@@ -2645,8 +2676,9 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        metadata
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2669,6 +2701,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        json.dumps(metadata) if metadata else None,
                     ),
                 )
                 for pid in parents:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -87,7 +87,7 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
 from toolsets import get_toolset_names
@@ -1176,7 +1176,11 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Free-form JSON metadata for task-level configuration (e.g., lane
+    -- routing: coder profile uses claude_code_lane, claude_code_tier).
+    -- NULL = no metadata.
+    metadata             TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1986,6 +1990,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
+
+    if "metadata" not in cols:
+        # Free-form JSON metadata for task-level configuration (e.g., lane
+        # routing). NULL is the correct default for existing rows.
+        _add_column_if_missing(conn, "tasks", "metadata", "metadata TEXT")
 
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -175,3 +175,51 @@ def test_unseen_events_for_sub_survives_migrated_db(tmp_path, monkeypatch):
         )
         assert isinstance(cursor, int)
         assert isinstance(events, list)
+
+
+def test_metadata_column_present_on_fresh_db(tmp_path, monkeypatch):
+    """``tasks.metadata`` exists on a fresh DB (SCHEMA_SQL), not just via migration."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = kb.kanban_db_path(board="default")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with kb.connect(db_path) as conn:
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    assert "metadata" in cols
+
+
+def test_task_metadata_round_trip(tmp_path, monkeypatch):
+    """``create_task(metadata=...)`` persists JSON that ``get_task`` reads back
+    as ``Task.metadata``. ``None`` (the default) stays NULL -> ``None``.
+    Exercises the full create->read path, not just the column.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.discard(
+        str(kb.kanban_db_path(board="default").resolve())
+    )
+
+    with kb.connect(board="default") as conn:
+        # With metadata
+        meta = {"lane": "coder", "tier": "claude_code", "nested": {"k": [1, 2]}}
+        tid = kb.create_task(conn, title="routed task", metadata=meta)
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.metadata == meta
+
+        # Without metadata - column is NULL, Task.metadata is None
+        tid2 = kb.create_task(conn, title="plain task")
+        task2 = kb.get_task(conn, tid2)
+        assert task2 is not None
+        assert task2.metadata is None
+
+        # Empty dict is falsy -> stored as NULL, not "{}"
+        tid3 = kb.create_task(conn, title="empty meta", metadata={})
+        task3 = kb.get_task(conn, tid3)
+        assert task3 is not None
+        assert task3.metadata is None


### PR DESCRIPTION
## Summary

Adds a `metadata TEXT` column (NULL default) to the kanban `tasks` table for storing task-level configuration as JSON, with a safe migration for legacy boards and a concrete read/write surface so the column is immediately usable.

## Why

The dispatcher needs a way to carry per-task configuration (lane routing, tier, launcher hints) without hardcoding profile-specific values into core. A free-form `metadata` column populated by the task creator or a local hook keeps core generic and configurable.

## What changed

- `hermes_cli/kanban_db.py`:
  - `metadata TEXT` added to `tasks` table schema (NULL default)
  - Migration via `_add_column_if_missing` for legacy boards
  - `Task.metadata: Optional[dict]` field on the dataclass
  - `_parse_task_metadata()` helper (safe JSON parse, returns `None` on invalid/non-object payloads)
  - `Task.from_row()` wired to populate `metadata` from the column
  - `create_task(metadata=...)` parameter, JSON-serialized into the INSERT
- `tests/hermes_cli/test_kanban_db_init.py`:
  - `test_metadata_column_present_on_fresh_db` — column exists on a fresh DB
  - `test_task_metadata_round_trip` — full create→`get_task`→assert round-trip (including `None` default and empty-dict edge cases)

The column now has a concrete read/write surface (`Task` field + `create_task` param + `from_row` parser). Dispatcher-level lane routing that *consumes* this metadata remains a separate follow-up.

## Verification

- 7/7 tests in `test_kanban_db_init.py` pass
- 169/171 in `test_kanban_core_functionality.py` (2 pre-existing env-guard failures unrelated to this change)

## Risks / follow-ups

- Dispatcher-level lane routing (reading `metadata` for launcher selection) will follow in a separate change once the column + API are available upstream.
