### PR TITLE
fix: refresh Codex OAuth token on demand

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -739,10 +739,12 @@ class CredentialPool:
             # another process means our entry's pair is consumed/stale.
             entry_access = entry.access_token or ""
             entry_refresh = entry.refresh_token or ""
-            if store_access and (
-                store_access != entry_access
-                or (store_refresh and store_refresh != entry_refresh)
-            ):
+            if (
+                store_access and (
+                    store_access != entry_access
+                    or (store_refresh and store_refresh != entry_refresh)
+                )
+            ) or (not store_access and store_refresh and store_refresh != entry_refresh):
                 logger.debug(
                     "Pool entry %s: syncing Codex tokens from auth.json "
                     "(refreshed by another process)",
@@ -1082,9 +1084,13 @@ class CredentialPool:
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced
+                logger.info(
+                    "Codex OAuth pool entry %s access token missing/expiring; refreshing on demand",
+                    entry.id,
+                )
                 refreshed = auth_mod.refresh_codex_oauth_pure(
-                    entry.access_token,
-                    entry.refresh_token,
+                    str(entry.access_token or ""),
+                    str(entry.refresh_token or ""),
                 )
                 updated = replace(
                     entry,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2206,6 +2206,8 @@ def _nous_effective_provider_state(state: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _codex_access_token_is_expiring(access_token: Any, skew_seconds: int) -> bool:
+    if not isinstance(access_token, str) or not access_token.strip():
+        return True
     claims = _decode_jwt_claims(access_token)
     exp = claims.get("exp")
     if not isinstance(exp, (int, float)):
@@ -3229,7 +3231,7 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
-def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+def _read_codex_tokens(*, _lock: bool = True, allow_missing_access_token: bool = False) -> Dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
     
     Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
@@ -3259,12 +3261,15 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     access_token = tokens.get("access_token")
     refresh_token = tokens.get("refresh_token")
     if not isinstance(access_token, str) or not access_token.strip():
-        raise AuthError(
-            "Codex auth is missing access_token. Run `hermes auth` to re-authenticate.",
-            provider="openai-codex",
-            code="codex_auth_missing_access_token",
-            relogin_required=True,
-        )
+        if allow_missing_access_token:
+            access_token = ""
+        else:
+            raise AuthError(
+                "Codex auth is missing access_token. Run `hermes auth` to re-authenticate.",
+                provider="openai-codex",
+                code="codex_auth_missing_access_token",
+                relogin_required=True,
+            )
     if not isinstance(refresh_token, str) or not refresh_token.strip():
         raise AuthError(
             "Codex auth is missing refresh_token. Run `hermes auth` to re-authenticate.",
@@ -3565,6 +3570,7 @@ def _refresh_codex_auth_tokens(
     
     Saves the new tokens to Hermes auth store automatically.
     """
+    logger.info("Codex OAuth access token missing/expiring; refreshing on demand")
     try:
         refreshed = refresh_codex_oauth_pure(
             str(tokens.get("access_token", "") or ""),
@@ -3654,7 +3660,7 @@ def resolve_codex_runtime_credentials(
     """
     read_error: Optional[AuthError] = None
     try:
-        data = _read_codex_tokens()
+        data = _read_codex_tokens(allow_missing_access_token=True)
     except AuthError as exc:
         read_error = exc
         if getattr(exc, "relogin_required", False) and getattr(exc, "code", None) in {
@@ -3724,7 +3730,7 @@ def resolve_codex_runtime_credentials(
     if should_refresh:
         # Re-read under lock to avoid racing with other Hermes processes
         with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
-            data = _read_codex_tokens(_lock=False)
+            data = _read_codex_tokens(_lock=False, allow_missing_access_token=True)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2832,6 +2832,22 @@ def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, m
     assert available == []
 
 
+def test_codex_missing_access_token_needs_refresh():
+    """A pool entry with only refresh_token must refresh before selection."""
+    from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+
+    entry = PooledCredential.from_dict("openai-codex", {
+        "id": "codex-missing-access",
+        "source": "device_code",
+        "auth_type": AUTH_TYPE_OAUTH,
+        "access_token": "",
+        "refresh_token": "refresh-present",
+    })
+    pool = CredentialPool("openai-codex", [entry])
+
+    assert pool._entry_needs_refresh(entry) is True
+
+
 # ---------------------------------------------------------------------------
 # xAI OAuth terminal error quarantine
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -72,16 +72,26 @@ def test_read_codex_tokens_missing(tmp_path, monkeypatch):
     assert exc.value.code == "codex_auth_missing"
 
 
-def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkeypatch):
+def test_resolve_codex_runtime_credentials_missing_access_token_refreshes(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
-    _setup_hermes_auth(hermes_home, access_token="")
+    _setup_hermes_auth(hermes_home, access_token="", refresh_token="refresh-old")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex"))
 
-    with pytest.raises(AuthError) as exc:
-        resolve_codex_runtime_credentials()
-    assert exc.value.code == "codex_auth_missing_access_token"
-    assert exc.value.relogin_required is True
+    called = {"count": 0}
+
+    def _fake_refresh(tokens, timeout_seconds):
+        called["count"] += 1
+        assert tokens["access_token"] == ""
+        assert tokens["refresh_token"] == "refresh-old"
+        return {"access_token": "access-new", "refresh_token": "refresh-new"}
+
+    monkeypatch.setattr("hermes_cli.auth._refresh_codex_auth_tokens", _fake_refresh)
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert called["count"] == 1
+    assert resolved["api_key"] == "access-new"
 
 
 def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Treat blank/missing Codex access tokens as refreshable in runtime credential resolution when a refresh token is present
- Re-read under the existing auth-store lock before refreshing, then save/use the rotated token immediately
- Make Codex credential-pool refresh logging/type handling explicit and sync refresh-token-only auth-store changes

## Safety
- Additive/defensive: failed refresh continues through existing AuthError/fallback behavior
- No live gateway restart or deployment performed
- Cron sync remains untouched as a backstop

## Test plan
- python3 -m py_compile hermes_cli/auth.py agent/credential_pool.py tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_credential_pool.py
- /home/tomek/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_credential_pool.py -q -o 'addopts='\n- Isolated smoke: missing access_token + present refresh_token in temp HERMES_HOME -> fake OAuth refresh -> saved_access=True exp_in_seconds=3599\n\nKanban: t_99fa8273