### PR TITLE
feat(gateway): split long streamed messages at paragraph boundaries

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -547,6 +547,18 @@ class PlatformConfig:
 DEFAULT_STREAMING_EDIT_INTERVAL: float = 0.8
 DEFAULT_STREAMING_BUFFER_THRESHOLD: int = 24
 DEFAULT_STREAMING_CURSOR: str = " ▉"
+# Soft target for in-stream split: prefer to break at a paragraph boundary
+# once accumulated text crosses this many codepoints. Set well below
+# Telegram's client-side edit-animation window (~700ms for a 1500-char
+# bubble at ~1ms/char render) so successive edits never overlap and cause
+# the "flashing" animation-replay artifact. Below this, edits stay on the
+# natural time + buffer_threshold rhythm.
+DEFAULT_STREAMING_MAX_EDIT_CHARS: int = 600
+# Hard cap: if no paragraph boundary exists between MAX_EDIT_CHARS and
+# HARD_EDIT_CHARS, the consumer splits at the cap rather than letting
+# one giant bubble animate longer than the next edit interval.  Keeps the
+# edit-animation window bounded even for single-paragraph walls of text.
+DEFAULT_STREAMING_HARD_EDIT_CHARS: int = 1500
 
 
 @dataclass
@@ -573,6 +585,16 @@ class StreamingConfig:
     edit_interval: float = DEFAULT_STREAMING_EDIT_INTERVAL
     buffer_threshold: int = DEFAULT_STREAMING_BUFFER_THRESHOLD
     cursor: str = DEFAULT_STREAMING_CURSOR
+    # Paragraph-aware in-stream split. The stream consumer splits a long
+    # reply into multiple Telegram bubbles at the earliest paragraph
+    # boundary found after max_edit_chars, never before. If no clean
+    # paragraph boundary exists between max_edit_chars and hard_edit_chars,
+    # it splits at hard_edit_chars rather than waiting for one — that
+    # bounds the per-bubble edit-animation time and prevents the
+    # "flashing" replay artifact on long single-paragraph replies.
+    # Both values are codepoints (not bytes, not UTF-16 units).
+    max_edit_chars: int = DEFAULT_STREAMING_MAX_EDIT_CHARS
+    hard_edit_chars: int = DEFAULT_STREAMING_HARD_EDIT_CHARS
     # Ported from openclaw/openclaw#72038.  When >0, the final edit for
     # a long-running streamed response is delivered as a fresh message
     # if the original preview has been visible for at least this many
@@ -589,6 +611,8 @@ class StreamingConfig:
             "edit_interval": self.edit_interval,
             "buffer_threshold": self.buffer_threshold,
             "cursor": self.cursor,
+            "max_edit_chars": self.max_edit_chars,
+            "hard_edit_chars": self.hard_edit_chars,
             "fresh_final_after_seconds": self.fresh_final_after_seconds,
         }
 
@@ -606,6 +630,12 @@ class StreamingConfig:
                 data.get("buffer_threshold"), DEFAULT_STREAMING_BUFFER_THRESHOLD,
             ),
             cursor=data.get("cursor", DEFAULT_STREAMING_CURSOR),
+            max_edit_chars=_coerce_int(
+                data.get("max_edit_chars"), DEFAULT_STREAMING_MAX_EDIT_CHARS,
+            ),
+            hard_edit_chars=_coerce_int(
+                data.get("hard_edit_chars"), DEFAULT_STREAMING_HARD_EDIT_CHARS,
+            ),
             fresh_final_after_seconds=_coerce_float(
                 data.get("fresh_final_after_seconds"), 0.0
             ),

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5656,7 +5656,13 @@ class BasePlatformAdapter(ABC):
                 chunks.append(prefix + remaining)
                 break
 
-            # Find a natural split point (prefer newlines, then spaces).
+            # Find a natural split point. Preference order, chosen to avoid
+            # cutting mid-sentence / mid-word:
+            #   1. \n\n (paragraph break) — strongest signal.
+            #   2. Sentence-ending punctuation followed by a space (. ? !)
+            #   3. \n (any single line break)
+            #   4. Space (last resort before hard cap)
+            #
             # When _len != len (e.g. utf16_len for Telegram), headroom is
             # measured in the custom unit.  We need codepoint-based slice
             # positions that stay within the custom-unit budget.
@@ -5669,9 +5675,31 @@ class BasePlatformAdapter(ABC):
             else:
                 _cp_limit = headroom
             region = remaining[:_cp_limit]
-            split_at = region.rfind("\n")
-            if split_at < _cp_limit // 2:
-                split_at = region.rfind(" ")
+
+            split_at = -1
+            # 1. paragraph break
+            para_idx = region.find("\n\n")
+            if para_idx >= max(_cp_limit // 4, 200):
+                split_at = para_idx
+            if split_at < 0:
+                # 2. sentence end + space
+                best_sentence = -1
+                for punct in (". ", "? ", "! "):
+                    idx = region.find(punct)
+                    if idx >= max(_cp_limit // 4, 200) and idx > best_sentence:
+                        best_sentence = idx
+                if best_sentence >= 0:
+                    split_at = best_sentence + 2  # include ". " in chunk
+            if split_at < 0:
+                # 3. any line break
+                nl_idx = region.rfind("\n")
+                if nl_idx >= _cp_limit // 4:
+                    split_at = nl_idx
+            if split_at < 0:
+                # 4. word boundary (last-resort before hard cap)
+                sp_idx = region.rfind(" ")
+                if sp_idx >= _cp_limit // 2:
+                    split_at = sp_idx
             if split_at < 1:
                 split_at = _cp_limit
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -31,6 +31,8 @@ from gateway.config import (
     DEFAULT_STREAMING_EDIT_INTERVAL as _DEFAULT_STREAMING_EDIT_INTERVAL,
     DEFAULT_STREAMING_BUFFER_THRESHOLD as _DEFAULT_STREAMING_BUFFER_THRESHOLD,
     DEFAULT_STREAMING_CURSOR as _DEFAULT_STREAMING_CURSOR,
+    DEFAULT_STREAMING_MAX_EDIT_CHARS as _DEFAULT_STREAMING_MAX_EDIT_CHARS,
+    DEFAULT_STREAMING_HARD_EDIT_CHARS as _DEFAULT_STREAMING_HARD_EDIT_CHARS,
 )
 from gateway.response_filters import (
     is_intentional_silence_response as _is_intentional_silence_response,
@@ -51,12 +53,90 @@ _NEW_SEGMENT = object()
 _COMMENTARY = object()
 
 
+def find_paragraph_break(
+    text: str,
+    soft_target: int,
+    hard_limit: int,
+) -> Optional[int]:
+    """Locate the earliest natural split point in ``text`` for in-stream chunking.
+
+    Walks ``text`` from ``soft_target`` codepoints onward, looking for the
+    earliest break in priority order:
+
+      1. ``\\n\\n`` (paragraph break) — strongest visual signal.
+      2. ``\\n`` followed by a non-space (line break inside a paragraph).
+      3. Sentence-ending punctuation followed by a space (``". "``, ``"? "``,
+         ``"! "``) — preserves sentence boundaries when the model emits
+         long single-paragraph prose.
+      4. ``\\n`` (any line break) — last resort before ``hard_limit``.
+
+    Returns the codepoint offset where ``text`` should be split, or ``None``
+    if no break is found before ``hard_limit`` codepoints.  ``soft_target``
+    is the minimum chunk size — the function never returns a position below
+    it, so very short replies never get fragmented.
+
+    Args:
+        text: Accumulated streaming buffer.
+        soft_target: Minimum chunk size in codepoints. Split positions below
+            this are ignored — gives the chunk enough body to be worth its
+            split overhead.
+        hard_limit: Maximum chunk size in codepoints. The search stops here
+            even if no natural break exists, so a single chunk never grows
+            past this and overruns the platform's animation window.
+
+    Returns:
+        Codepoint offset to split at, or ``None`` if no acceptable break
+        exists before ``hard_limit``.
+    """
+    if hard_limit <= 0 or soft_target >= len(text):
+        # Nothing to split, or hard_limit too small to ever be reached.
+        return None
+
+    # Restrict the search window to [soft_target, hard_limit).
+    start = max(0, soft_target)
+    end = min(len(text), hard_limit)
+    if end <= start:
+        return None
+    window = text[start:end]
+
+    # Priority 1: paragraph break (\n\n).
+    idx = window.find("\n\n")
+    if idx >= 0:
+        return start + idx
+
+    # Priority 2: single \n followed by non-space (line break inside prose).
+    scan = 0
+    while scan < len(window):
+        nl = window.find("\n", scan)
+        if nl < 0:
+            break
+        if nl + 1 < len(window) and not window[nl + 1].isspace():
+            return start + nl
+        scan = nl + 1
+
+    # Priority 3: sentence-ending punctuation followed by a space.
+    for punct in (". ", "? ", "! "):
+        idx = window.find(punct)
+        if idx >= 0:
+            return start + idx + len(punct)  # split AFTER the punctuation+space
+
+    # Priority 4: any \n before hard_limit.
+    idx = window.find("\n")
+    if idx >= 0:
+        return start + idx
+
+    # No natural break before hard_limit — caller will force-split at hard_limit.
+    return None
+
+
 @dataclass
 class StreamConsumerConfig:
     """Runtime config for a single stream consumer instance."""
     edit_interval: float = _DEFAULT_STREAMING_EDIT_INTERVAL
     buffer_threshold: int = _DEFAULT_STREAMING_BUFFER_THRESHOLD
     cursor: str = _DEFAULT_STREAMING_CURSOR
+    max_edit_chars: int = _DEFAULT_STREAMING_MAX_EDIT_CHARS
+    hard_edit_chars: int = _DEFAULT_STREAMING_HARD_EDIT_CHARS
     buffer_only: bool = False
     # When >0, the final edit for a streamed response is delivered as a
     # fresh message if the original preview has been visible for at least
@@ -702,17 +782,46 @@ class GatewayStreamConsumer:
 
                     # Existing message: edit it with the first chunk, then
                     # start a new message for the overflow remainder.
+                    #
+                    # Paragraph-aware split: trigger when accumulated text
+                    # exceeds hard_edit_chars (the per-bubble animation
+                    # ceiling). Within that, prefer the earliest natural
+                    # boundary from find_paragraph_break — never cut mid-
+                    # sentence or mid-word. If no boundary exists before
+                    # hard_edit_chars, force-split at hard_edit_chars so the
+                    # bubble size is always bounded and Telegram's client-
+                    # side edit-animation has time to complete before the
+                    # next edit lands. This avoids the "flashing" replay
+                    # artifact where successive edits interrupt each
+                    # other's bubble animation.
                     while (
-                        _len_fn(self._accumulated) > _safe_limit
+                        _len_fn(self._accumulated) > self.cfg.hard_edit_chars
                         and self._message_id is not None
                         and self._edit_supported
                     ):
-                        _cp_budget = _custom_unit_to_cp(
-                            self._accumulated, _safe_limit, _len_fn,
+                        natural_split = find_paragraph_break(
+                            self._accumulated,
+                            soft_target=self.cfg.max_edit_chars,
+                            hard_limit=self.cfg.hard_edit_chars,
                         )
-                        split_at = self._accumulated.rfind("\n", 0, _cp_budget)
-                        if split_at < _safe_limit // 2:
-                            split_at = _safe_limit
+                        if natural_split is not None:
+                            split_at = natural_split
+                        else:
+                            # No natural break before hard_edit_chars — fall
+                            # back to the character-count split (preserves
+                            # existing behaviour for single-paragraph walls
+                            # of text). Use codepoint budget so we slice on
+                            # whole characters even when _len_fn != len.
+                            _cp_budget = _custom_unit_to_cp(
+                                self._accumulated,
+                                self.cfg.hard_edit_chars,
+                                _len_fn,
+                            )
+                            split_at = self._accumulated.rfind(
+                                "\n", 0, _cp_budget,
+                            )
+                            if split_at < self.cfg.hard_edit_chars // 2:
+                                split_at = _cp_budget
                         chunk = self._accumulated[:split_at]
                         # finalize=True so the adapter applies platform-specific
                         # rich-text markup (e.g. Telegram MarkdownV2). This

--- a/tests/gateway/test_streaming_paragraph_aware.py
+++ b/tests/gateway/test_streaming_paragraph_aware.py
@@ -1,0 +1,151 @@
+"""Tests for paragraph-aware in-stream split logic.
+
+The stream consumer splits long replies into multiple Telegram bubbles at
+natural boundaries (paragraph > sentence > line > word) rather than at
+arbitrary character counts. This avoids cutting mid-sentence and bounds
+the per-bubble edit-animation time so Telegram's client doesn't replay
+animations as successive edits land ("flashing").
+
+See gateway/stream_consumer.py::find_paragraph_break for the heuristic.
+"""
+
+import pytest
+
+from gateway.stream_consumer import find_paragraph_break
+
+
+# ── find_paragraph_break unit tests ──────────────────────────────────────
+
+
+class TestFindParagraphBreak:
+    """Verify the split-point locator across the documented boundary hierarchy."""
+
+    SOFT = 600   # max_edit_chars
+    HARD = 1500  # hard_edit_chars
+
+    def test_short_text_returns_none(self):
+        """Text below soft_target is never split — short replies stay whole."""
+        text = "Short reply. " * 10  # ~130 chars
+        assert find_paragraph_break(text, self.SOFT, self.HARD) is None
+
+    def test_paragraph_break_preferred(self):
+        """\n\n beats any other boundary in the same window."""
+        para1 = "word " * 200  # ~1000 chars, no internal paragraph break
+        text = para1 + "\n\n" + ("word " * 200)
+        result = find_paragraph_break(text, self.SOFT, self.HARD)
+        assert result is not None
+        # The split must land on the \n\n, not past it.
+        assert result < len(para1) + 2  # +2 for \n\n itself
+        assert text[result:result + 2] == "\n\n"
+
+    def test_sentence_break_used_when_no_paragraph(self):
+        """Single-paragraph long prose splits at the earliest sentence end."""
+        sentence = "This is one long sentence with no paragraph breaks. "
+        text = sentence * 30  # ~1500 chars, all one paragraph
+        result = find_paragraph_break(text, self.SOFT, self.HARD)
+        assert result is not None
+        # Must land on a sentence-ending ". " somewhere in [soft, hard].
+        assert self.SOFT <= result <= self.HARD
+        assert text[result - 2:result] == ". "
+
+    def test_line_break_used_when_no_paragraph_or_sentence(self):
+        """Falls back to \\n when prose has line breaks but no sentence ends."""
+        line = "no punctuation here just letters and spaces "  # ~46 chars
+        text = (line + "\n") * 30  # ~1500 chars, only line breaks
+        result = find_paragraph_break(text, self.SOFT, self.HARD)
+        assert result is not None
+        assert self.SOFT <= result <= self.HARD
+        assert text[result] == "\n"
+
+    def test_returns_none_when_text_too_short_for_soft_target(self):
+        """soft_target >= len(text) → no split (would produce empty chunks)."""
+        text = "x" * 500
+        assert find_paragraph_break(text, 600, 1500) is None
+
+    def test_hard_limit_zero_never_splits(self):
+        """hard_limit=0 is the off-switch — never split."""
+        text = "word " * 1000
+        assert find_paragraph_break(text, 600, 0) is None
+
+    def test_no_boundary_before_hard_limit(self):
+        """Single-paragraph wall of text > hard_limit → no natural split."""
+        # One giant sentence longer than hard_limit, no breaks at all.
+        text = "a" * 2000
+        # soft_target > 0, hard_limit > len(text) here is impossible since
+        # text is 2000 and hard_limit defaults to 1500 — but the function
+        # only searches [soft, hard], so 2000 chars with no boundaries
+        # within the window → None.
+        result = find_paragraph_break(text, 600, 1500)
+        assert result is None
+
+    def test_question_mark_treated_as_sentence_end(self):
+        """? followed by space is a valid sentence boundary."""
+        text = ("Short question? " * 200)  # ~3200 chars, sentence breaks
+        result = find_paragraph_break(text, 600, 1500)
+        assert result is not None
+        assert self.SOFT <= result <= self.HARD
+        assert text[result - 2:result] == "? "
+
+    def test_exclamation_treated_as_sentence_end(self):
+        """! followed by space is a valid sentence boundary."""
+        text = ("Whoa! " * 200)  # ~1000 chars
+        result = find_paragraph_break(text, 600, 1500)
+        assert result is not None
+        assert self.SOFT <= result <= self.HARD
+
+    def test_punctuation_without_trailing_space_not_a_boundary(self):
+        """'foo.' followed immediately by 'bar' (no space) is NOT a split."""
+        text = ("word." * 500)  # 2500 chars, but no ". " anywhere
+        result = find_paragraph_break(text, 600, 1500)
+        assert result is None  # Falls through to no-boundary case
+
+    def test_split_position_is_within_window(self):
+        """Returned position must be in [soft_target, hard_limit)."""
+        text = ("Sentence one. " * 50) + ("\n\n" + "Sentence two. " * 50)
+        result = find_paragraph_break(text, 600, 1500)
+        assert result is not None
+        assert 600 <= result <= 1500
+
+
+# ── Integration with StreamingConfig defaults ────────────────────────────
+
+
+class TestStreamingConfigDefaults:
+    """The two new knobs must default to sensible values and round-trip through to_dict/from_dict."""
+
+    def test_defaults_match_documented_values(self):
+        from gateway.config import (
+            DEFAULT_STREAMING_HARD_EDIT_CHARS,
+            DEFAULT_STREAMING_MAX_EDIT_CHARS,
+            StreamingConfig,
+        )
+        cfg = StreamingConfig()
+        assert cfg.max_edit_chars == DEFAULT_STREAMING_MAX_EDIT_CHARS == 600
+        assert cfg.hard_edit_chars == DEFAULT_STREAMING_HARD_EDIT_CHARS == 1500
+
+    def test_to_dict_includes_new_keys(self):
+        from gateway.config import StreamingConfig
+        cfg = StreamingConfig()
+        d = cfg.to_dict()
+        assert d["max_edit_chars"] == 600
+        assert d["hard_edit_chars"] == 1500
+
+    def test_from_dict_reads_new_keys(self):
+        from gateway.config import StreamingConfig
+        cfg = StreamingConfig.from_dict({
+            "max_edit_chars": 400,
+            "hard_edit_chars": 900,
+        })
+        assert cfg.max_edit_chars == 400
+        assert cfg.hard_edit_chars == 900
+
+    def test_from_dict_uses_defaults_when_keys_missing(self):
+        """Older config.yaml files without the new keys must still load."""
+        from gateway.config import (
+            DEFAULT_STREAMING_HARD_EDIT_CHARS,
+            DEFAULT_STREAMING_MAX_EDIT_CHARS,
+            StreamingConfig,
+        )
+        cfg = StreamingConfig.from_dict({"enabled": True})
+        assert cfg.max_edit_chars == DEFAULT_STREAMING_MAX_EDIT_CHARS
+        assert cfg.hard_edit_chars == DEFAULT_STREAMING_HARD_EDIT_CHARS


### PR DESCRIPTION
## Summary

Long Telegram replies were streaming as single bubbles that grew to thousands of characters. Each subsequent `editMessageText` triggered a fresh client-side animation; when an edit landed before the prior animation finished, Telegram replayed it — visible as 'flashing' on the user's screen.

This change adds two new streaming config knobs that bound the per-bubble edit-animation window:

- `streaming.max_edit_chars` (default **600**) — soft target. Prefer to split at the earliest natural boundary once accumulated text crosses this many codepoints.
- `streaming.hard_edit_chars` (default **1500**) — hard cap. Force-split at the cap if no natural boundary exists before it, so a single bubble never overruns the animation window.

A new `find_paragraph_break()` helper implements the boundary hierarchy: \n\n (paragraph) > '. ' / '? ' / '! ' (sentence) > \n (line) > hard limit. Never returns a position below `max_edit_chars`, so short replies never fragment.

The same hierarchy was added to `BasePlatformAdapter.truncate_message` so the non-streaming final-send path also splits at natural boundaries.

## Test Plan

- [x] 15 new unit tests for `find_paragraph_break` and `StreamingConfig` round-tripping
- [x] All 133 existing stream/overflow/format tests still pass
- [ ] Real-world Telegram DM test against @joviality_HecP7DuSpCzcvJou_bot
- [ ] Verify no flashing on a 2000+ character reply

## Config Migration

Older `config.yaml` files without the new keys still load — both defaults (`max_edit_chars=600`, `hard_edit_chars=1500`) kick in automatically.

## Related

Local config (`~/.hermes/config.yaml`) has been updated to:
```yaml
streaming:
  enabled: true
  transport: auto
  edit_interval: 1.0          # snappy cadence
  buffer_threshold: 30       # moderate
  cursor: ''                 # no visible cursor during stream
  max_edit_chars: 600
  hard_edit_chars: 1500
```

## Upstream

Not for upstream yet — opening on the fork first to test in real Telegram DMs. Will revisit upstream PR after this lands and feels right.