### PR TITLE
fix(telegram): button-caller authorization breaks on multiplexed profiles (handler introspection)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -912,17 +912,38 @@ class TelegramAdapter(BasePlatformAdapter):
         if not normalized_user_id:
             return False
 
+        normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
+        if normalized_chat_type == "private":
+            normalized_chat_type = "dm"
+        elif normalized_chat_type == "supergroup":
+            normalized_chat_type = "forum" if thread_id is not None else "group"
+
+        # Preferred path: the auth callback GatewayRunner injects at
+        # connection time (set_authorization_check), which delegates to the
+        # full _is_user_authorized chain -- env allowlists, group allowlists,
+        # pairing store, allow-all flags. Unlike the __self__ introspection
+        # below, this also works for a secondary multiplexed adapter, whose
+        # _message_handler is a profile closure with no __self__ (the same
+        # gap the admin-tier check had -- resolved the same way). The getattr
+        # tolerates partially-constructed adapters (object.__new__ in tests)
+        # that never ran BasePlatformAdapter.__init__.
+        if getattr(self, "_authorization_check", None) is not None:
+            injected = self._is_sender_authorized(
+                normalized_user_id,
+                chat_type=normalized_chat_type,
+                chat_id=str(chat_id or normalized_user_id),
+            )
+            if injected is not None:
+                return injected
+
+        # Legacy path: resolve the runner off the bound message handler.
+        # Still reachable for adapters wired without set_authorization_check
+        # (bare-adapter tests, direct embedding).
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             try:
                 from gateway.session import SessionSource
-
-                normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
-                if normalized_chat_type == "private":
-                    normalized_chat_type = "dm"
-                elif normalized_chat_type == "supergroup":
-                    normalized_chat_type = "forum" if thread_id is not None else "group"
 
                 source = SessionSource(
                     platform=Platform.TELEGRAM,

--- a/tests/gateway/test_telegram_callback_auth_fail_closed.py
+++ b/tests/gateway/test_telegram_callback_auth_fail_closed.py
@@ -87,3 +87,70 @@ class TestCallbackAuthFailClosed:
         assert adapter._is_callback_user_authorized("12345") is True
 
 
+    def test_allowlist_wildcard_permits(self, monkeypatch):
+        """TELEGRAM_ALLOWED_USERS=* → allow everyone."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "*")
+        adapter = _make_adapter()
+        adapter._message_handler = None
+        assert adapter._is_callback_user_authorized("12345") is True
+
+
+class TestCallbackAuthPrefersInjectedCheck:
+    """_is_callback_user_authorized must use the auth callback GatewayRunner
+    injects via set_authorization_check before the _message_handler.__self__
+    introspection.
+
+    A secondary multiplexed adapter's _message_handler is a profile closure
+    (no __self__), so the introspection path resolves to nothing and the old
+    code fell through to the env-only fallback — which knows nothing about
+    profile config allowlists or the pairing store. The injected callback is
+    registered for every gateway-connected adapter, including multiplexed
+    secondaries, and delegates to the full _is_user_authorized chain.
+    """
+
+    def test_injected_check_used_when_handler_is_a_closure(self, monkeypatch):
+        """Multiplexed shape: closure handler (no __self__) + injected check
+        registered → the injected check decides, not the env fallback."""
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        adapter = _make_adapter()
+        adapter._message_handler = lambda *a, **kw: None  # no __self__
+        seen = {}
+
+        def _check(user_id, chat_type=None, chat_id=None):
+            seen.update(user_id=user_id, chat_type=chat_type, chat_id=chat_id)
+            return user_id == "999"
+
+        adapter._authorization_check = _check
+
+        # Env fallback would deny (empty allowlist); the injected check allows.
+        assert adapter._is_callback_user_authorized(
+            "999", chat_id="777", chat_type="supergroup"
+        ) is True
+        assert seen == {"user_id": "999", "chat_type": "group", "chat_id": "777"}
+
+    def test_injected_check_deny_wins_over_env_allowlist(self, monkeypatch):
+        """The injected check is authoritative when registered — an env
+        allowlist entry must not override its deny."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "12345")
+        adapter = _make_adapter()
+        adapter._message_handler = lambda *a, **kw: None
+        adapter._authorization_check = lambda user_id, chat_type=None, chat_id=None: False
+
+        assert adapter._is_callback_user_authorized("12345") is False
+
+    def test_injected_check_error_falls_back_to_env(self, monkeypatch):
+        """A raising injected check is treated as unregistered (base returns
+        None), preserving the env fallback rather than crashing the button."""
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "12345")
+        adapter = _make_adapter()
+        adapter.platform = Platform.TELEGRAM  # for _is_sender_authorized's log line
+        adapter._message_handler = None
+
+        def _boom(user_id, chat_type=None, chat_id=None):
+            raise RuntimeError("auth backend down")
+
+        adapter._authorization_check = _boom
+
+        assert adapter._is_callback_user_authorized("12345") is True
+        assert adapter._is_callback_user_authorized("67890") is False


### PR DESCRIPTION
## Problem

`TelegramAdapter._is_callback_user_authorized` — the gate for inline-button callers (exec-approval buttons, and the guest-mode caller gate in #56476 once that lands) — resolves the gateway's authorization chain by introspecting `_message_handler.__self__`.

For a **secondary multiplexed adapter**, the message handler is a per-profile closure built by `GatewayRunner._make_profile_message_handler`, which has no `__self__`. The introspection silently resolves to nothing and the method falls through to its env-only fallback — which consults only `TELEGRAM_ALLOWED_USERS`/`GATEWAY_ALLOW_ALL_USERS` and knows nothing about config-file allowlists or the pairing store. Every button caller authorized via those is denied on that profile. The failure direction is closed (deny, not allow), so it's not an escalation — but it makes button auth structurally broken on multiplexed profiles, and it's the same introspection gap #59857's review flagged for the admin-tier check.

## Fix

Prefer the auth callback `GatewayRunner` already injects at adapter-connection time via `set_authorization_check` — registered for primary and multiplexed adapters alike, delegating to the full `_is_user_authorized` chain (env allowlists, group allowlists, pairing store, allow-all flags). The `__self__` introspection and the fail-closed env fallback are kept, in that order, for adapters wired without the injected check (bare-adapter embedding, existing tests). Same resolution pattern #59857 uses for the admin-tier gate.

Decision-equivalence note: the injected callback carries `(user_id, chat_type, chat_id)` but not `user_name`/`thread_id`; verified `is_authorized()` never consults either, so nothing is lost relative to the introspection path's fuller `SessionSource`.

## Tests

`TestCallbackAuthPrefersInjectedCheck` (3 tests): a closure-handler adapter (multiplexed shape) with the injected check registered is decided by that check rather than the env fallback; an injected deny wins over an env allowlist entry; a raising injected check degrades to the env fallback instead of crashing the button. The two behavior-asserting tests fail against the previous code. Full Telegram gateway sweep (48 files, 1071 tests): all passing. The 5 pre-existing fail-closed fallback tests (#24457) are unchanged and still pass.
