### PR TITLE
fix(agent): guard float infinity to int conversions in stale timeout watchdogs

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -617,10 +617,11 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 and getattr(agent, "_codex_stream_last_event_ts", None) is None
             ):
                 _deadline = min(_deadline, _ttfb_timeout)
+            _deadline_str = f"{int(_deadline)}s" if _deadline != float("inf") else "never"
             agent._emit_wait_notice(
                 f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
                 f"{int(_elapsed)}s with no response yet (provider may be slow "
-                f"or overloaded; auto-reconnect at {int(_deadline)}s)"
+                f"or overloaded; auto-reconnect at {_deadline_str})"
             )
 
         _elapsed = time.time() - _call_start
@@ -675,15 +676,16 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # Wait briefly for the worker to notice the closed connection.
             t.join(timeout=2.0)
             if result["error"] is None and result["response"] is None:
+                _ttfb_threshold_str = f"{int(_ttfb_timeout)}s" if _ttfb_timeout != float("inf") else "inf"
                 if _silent_hint:
                     result["error"] = TimeoutError(
                         f"Codex stream produced no bytes within {int(_elapsed)}s "
-                        f"(TTFB threshold: {int(_ttfb_timeout)}s). {_silent_hint}"
+                        f"(TTFB threshold: {_ttfb_threshold_str}). {_silent_hint}"
                     )
                 else:
                     result["error"] = TimeoutError(
                         f"Codex stream produced no bytes within {int(_elapsed)}s "
-                        f"(TTFB threshold: {int(_ttfb_timeout)}s)"
+                        f"(TTFB threshold: {_ttfb_threshold_str})"
                     )
             break
 
@@ -720,9 +722,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
             )
             t.join(timeout=2.0)
             if result["error"] is None and result["response"] is None:
+                _codex_idle_threshold_str = f"{int(_codex_idle_timeout)}s" if _codex_idle_timeout != float("inf") else "inf"
                 result["error"] = TimeoutError(
                     f"Codex stream produced no SSE events for {int(_event_stale_elapsed)}s "
-                    f"after first byte (threshold: {int(_codex_idle_timeout)}s)"
+                    f"after first byte (threshold: {_codex_idle_threshold_str})"
                 )
             break
 
@@ -772,16 +775,17 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # Wait briefly for the thread to notice the closed connection.
             t.join(timeout=2.0)
             if result["error"] is None and result["response"] is None:
+                _stale_threshold_str = f"{int(_stale_timeout)}s" if _stale_timeout != float("inf") else "inf"
                 if _silent_hint:
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s). "
+                        f"with no response (threshold: {_stale_threshold_str}). "
                         f"{_silent_hint}"
                     )
                 else:
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s)"
+                        f"with no response (threshold: {_stale_threshold_str})"
                     )
             break
 

--- a/tests/agent/test_infinite_stale_timeout_wait_notice.py
+++ b/tests/agent/test_infinite_stale_timeout_wait_notice.py
@@ -1,0 +1,45 @@
+"""Regression coverage for unbounded local/MoA API-call timeouts."""
+
+from types import SimpleNamespace
+
+
+def test_moa_wait_notice_formats_infinite_deadline_without_overflow(monkeypatch):
+    """The 30-second heartbeat must not cast MoA's ``float('inf')`` to int."""
+    from agent import chat_completion_helpers as helpers
+
+    notices: list[str] = []
+    agent = SimpleNamespace(
+        platform="desktop",
+        api_mode="chat_completions",
+        provider="moa",
+        _consecutive_stale_streams=0,
+        _interrupt_requested=False,
+        _compute_non_stream_stale_timeout=lambda _kwargs: float("inf"),
+        _touch_activity=lambda _message: None,
+        _emit_wait_notice=lambda message: notices.append(message),
+    )
+
+    class HeartbeatThread:
+        """Keep the synthetic worker alive for exactly one 100-poll heartbeat."""
+
+        def __init__(self, *, target, daemon):
+            self._polls = 0
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+        def is_alive(self):
+            self._polls += 1
+            return self._polls <= 100
+
+    monkeypatch.setattr(helpers.threading, "Thread", HeartbeatThread)
+
+    response = helpers.interruptible_api_call(agent, {"model": "default"})
+
+    assert response is None
+    assert len(notices) == 1
+    assert "waiting on default" in notices[0]
+    assert "auto-reconnect at never" in notices[0]


### PR DESCRIPTION
## Summary

Prevent `OverflowError: cannot convert float infinity to integer` when the non-streaming API watchdog formats an unbounded timeout.

## Root cause / reproduction

`_compute_non_stream_stale_timeout()` intentionally returns `float("inf")` for local endpoints such as `moa://local`. After 100 polling intervals (`100 × 0.3s ≈ 30s`), the wait-notice heartbeat formatted that value with `int(_deadline)`, aborting an otherwise-live MoA request. The outer conversation loop then retried, producing failures at approximately 30s, 62s, and 97s.

This PR now includes a deterministic regression test that drives the exact 100-poll MoA heartbeat without waiting 30 seconds. Before the fix it fails at `chat_completion_helpers.py` with the reported `OverflowError`; after the fix it emits `auto-reconnect at never` and leaves the request alive.

## Fix

Guard infinite timeout formatting in the wait-notice path and the related TTFB, stream-idle, and stale-timeout diagnostic paths.

## Relation to #64924

This overlaps with #64924 on the primary wait-notice cast. It is broader rather than independent: it also guards the related watchdog diagnostic/error formatting and adds direct MoA regression coverage for the observed 30-second failure.

## Verification

- `tests/agent/test_infinite_stale_timeout_wait_notice.py`: 1 passed
- `tests/agent/test_reasoning_stale_timeout_floor.py`: 57 passed
- `tests/agent/test_codex_ttfb_watchdog.py`: 13 passed