### PR TITLE
fix(web): stop npm-install fallback from drifting lockfile; ensure devDeps (tsc: not found on hermes update)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4840,7 +4840,9 @@ def _run_npm_install_deterministic(
 
     lockfile = cwd / "package-lock.json"
     if lockfile.exists():
-        ci_cmd = [npm, "ci", *extra_args]
+        # --include=dev: force devDependencies even if NODE_ENV=production
+        # or an .npmrc `omit=dev` is in effect — web build needs tsc/vite.
+        ci_cmd = [npm, "ci", "--include=dev", *extra_args]
         ci_result = subprocess.run(
             ci_cmd,
             cwd=cwd,
@@ -4855,7 +4857,15 @@ def _run_npm_install_deterministic(
             return ci_result
         # Fall through to `npm install` — lockfile may be out of sync on a
         # WIP fork/branch, or `npm ci` may not be available on very old npm.
-    install_cmd = [npm, "install", *extra_args]
+        #
+        # --no-save: prevent the fallback from rewriting the committed
+        #   lockfile. A drifted lockfile makes every future `npm ci` fail
+        #   "out of sync", a self-reinforcing cycle where web devDeps
+        #   (typescript, @vitejs/plugin-react) never install → tsc: not
+        #   found → stale dist served on every update.
+        # --include=dev: guarantee devDependencies regardless of
+        #   NODE_ENV=production / npm config omit settings.
+    install_cmd = [npm, "install", "--no-save", "--include=dev", *extra_args]
     return subprocess.run(
         install_cmd,
         cwd=cwd,


### PR DESCRIPTION
# `hermes update` web build fails with `tsc: not found` — self-reinforcing lockfile drift from `npm install` fallback

## Summary

On `hermes update`, the web UI build step fails with `sh: 1: tsc: not found` (npm error code 127) and Hermes falls back to a stale `hermes_cli/web_dist/`. The failure repeats on every subsequent update once it starts.

## Reproduce / observe

`~/.hermes/logs/update.log` shows, across many consecutive updates:

```
→ Building web UI...
> tsc -b && vite build
sh: 1: tsc: not found
npm error code 127
⚠ Web UI build failed — serving stale dist as fallback
```

State after a regressed update:
- `node_modules/typescript` and `node_modules/.bin/tsc` are **missing** (typescript is a `web` devDependency).
- `node_modules/vite` is still present (hoisted from another workspace's regular deps).
- `package-lock.json` is **dirty** vs the committed version — e.g. `npm install` added `"eslint": "^9.39.4"` to the `tests-js` workspace entry.

## Root cause

`_build_web_ui` → `_run_npm_install_deterministic` runs `npm ci --workspace web`, falling back to `npm install --workspace web` if `npm ci` fails.

1. A transient `npm ci` failure (registry/network) → fallback to `npm install --workspace web`.
2. `npm install` **rewrites the committed `package-lock.json`** (drift).
3. The next `hermes update`'s `git pull` doesn't touch the drifted section (upstream unchanged) → the drifted lockfile persists → `npm ci` now fails every time with *"lockfile out of sync with package.json"*.
4. The `npm install` fallback runs against the poisoned lockfile and never resolves `web`'s **devDependencies** (`typescript`, `@vitejs/plugin-react`) → `tsc: not found` → stale dist.
5. Repeats every update.

`typescript` is the canary because it's *only* in `web`'s devDependencies; `vite` survives because another workspace lists it as a regular dep.

## Fix

In `_run_npm_install_deterministic` (`hermes_cli/main.py`):

- Add `--include=dev` to both `npm ci` and the `npm install` fallback so devDependencies are always installed (defends against `NODE_ENV=production` / `.npmrc omit=dev`).
- Add `--no-save` to the `npm install` fallback so it never rewrites the committed lockfile — this **breaks the self-reinforcing drift cycle**.

```diff
@@ hermes_cli/main.py — _run_npm_install_deterministic @@
     lockfile = cwd / "package-lock.json"
     if lockfile.exists():
-        ci_cmd = [npm, "ci", *extra_args]
+        # --include=dev: force devDependencies even if NODE_ENV=production
+        # or an .npmrc `omit=dev` is in effect — web build needs tsc/vite.
+        ci_cmd = [npm, "ci", "--include=dev", *extra_args]
         ...
         if ci_result.returncode == 0:
             return ci_result
         # Fall through to `npm install` — lockfile may be out of sync on a
         # WIP fork/branch, or `npm ci` may not be available on very old npm.
-    install_cmd = [npm, "install", *extra_args]
+        #
+        # --no-save: prevent the fallback from rewriting the committed
+        #   lockfile. A drifted lockfile makes every future `npm ci` fail
+        #   "out of sync", a self-reinforcing cycle where web devDeps
+        #   (typescript, @vitejs/plugin-react) never install → tsc: not
+        #   found → stale dist served on every update.
+        # --include=dev: guarantee devDependencies regardless of
+        #   NODE_ENV=production / npm config omit settings.
+    install_cmd = [npm, "install", "--no-save", "--include=dev", *extra_args]
```

`--no-save` is the key change: it stops the cycle. `--include=dev` is defense-in-depth for the devDeps themselves.

## Verification

- `npm install --workspace web` restored the build (205 packages, build OK).
- `git checkout -- package-lock.json` (remove drift) + `npm ci --workspace web` → `typescript` installed, exit 0.
- `cd web && npm run build` → ✓ built in 6.49s, `git status` clean.
- Patched `hermes_cli/main.py` passes `python3 -m py_compile`.

## Environment

- npm 10.9.8, Node v22.23.1, Ubuntu 24.04
- Repo: NousResearch/Hermes-Agent, `web` workspace with `typescript`/`vite`/`@vitejs/plugin-react` in devDependencies