### PR TITLE
fix(codex): propagate runtime overrides to app-server turns

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -410,8 +410,30 @@ def run_codex_app_server_turn(
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
 
+    reasoning_config = getattr(agent, "reasoning_config", None)
+    reasoning_effort = None
+    if isinstance(reasoning_config, dict):
+        if reasoning_config.get("enabled") is False:
+            reasoning_effort = "none"
+        elif reasoning_config.get("effort"):
+            reasoning_effort = str(reasoning_config["effort"])
+
+    service_tier = getattr(agent, "service_tier", None)
+    if service_tier == "priority":
+        # Hermes uses the OpenAI API name; Codex app-server calls this tier fast.
+        service_tier = "fast"
+    elif service_tier in {None, "", "normal", "default"}:
+        # Send null rather than omitting the field so `/fast off` clears a tier
+        # selected by an earlier turn in the same Codex thread.
+        service_tier = None
+
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        turn = agent._codex_session.run_turn(
+            user_input=user_message,
+            model=str(getattr(agent, "model", "") or "").strip() or None,
+            reasoning_effort=reasoning_effort,
+            service_tier=service_tier,
+        )
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 # wedge watchdog, etc.). Small enough to keep error messages legible, large
 # enough to surface a config/provider/auth diagnostic.
 _STDERR_TAIL_LINES = 12
+_UNSET = object()
 
 
 # Permission profile mapping mirrors the docstring in PR proposal:
@@ -367,6 +368,9 @@ class CodexAppServerSession:
         self,
         user_input: Any,
         *,
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+        service_tier: Any = _UNSET,
         turn_timeout: float = 600.0,
         notification_poll_timeout: float = 0.25,
         post_tool_quiet_timeout: float = 90.0,
@@ -407,13 +411,21 @@ class CodexAppServerSession:
 
         # Send turn/start with the user input. Text-only for now (codex
         # supports rich content but Hermes' text path is the common case).
+        turn_params: dict[str, Any] = {
+            "threadId": self._thread_id,
+            "input": [{"type": "text", "text": user_input_text}],
+        }
+        if model:
+            turn_params["model"] = model
+        if reasoning_effort is not None:
+            turn_params["effort"] = reasoning_effort
+        if service_tier is not _UNSET:
+            # An explicit null clears a tier previously selected on this thread.
+            turn_params["serviceTier"] = service_tier
         try:
             ts = self._client.request(
                 "turn/start",
-                {
-                    "threadId": self._thread_id,
-                    "input": [{"type": "text", "text": user_input_text}],
-                },
+                turn_params,
                 timeout=10,
             )
         except CodexAppServerError as exc:

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -259,6 +259,43 @@ class TestRunTurn:
         assert "[Image attached at: /tmp/a.png]" in text
         assert "[image attached]" in text
 
+    def test_turn_start_includes_runtime_overrides(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        s = make_session(client)
+
+        s.run_turn(
+            "hi",
+            model="gpt-5.4",
+            reasoning_effort="high",
+            service_tier="fast",
+            turn_timeout=2.0,
+        )
+
+        _, params = next(req for req in client.requests if req[0] == "turn/start")
+        assert params["model"] == "gpt-5.4"
+        assert params["effort"] == "high"
+        assert params["serviceTier"] == "fast"
+
+    def test_turn_start_can_clear_service_tier(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        s = make_session(client)
+
+        s.run_turn("hi", service_tier=None, turn_timeout=2.0)
+
+        _, params = next(req for req in client.requests if req[0] == "turn/start")
+        assert "serviceTier" in params
+        assert params["serviceTier"] is None
+
     def test_tool_iteration_counter_ticks(self):
         client = FakeClient()
         # Two completed exec items + one final agent message

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -72,6 +72,46 @@ class TestApiModeAccepted:
 
 
 class TestRunConversationCodexPath:
+    @pytest.mark.parametrize(
+        "reasoning_config,service_tier,expected_effort,expected_tier",
+        [
+            ({"enabled": True, "effort": "high"}, "priority", "high", "fast"),
+            ({"enabled": False}, None, "none", None),
+        ],
+    )
+    def test_effective_runtime_settings_reach_codex_turn(
+        self,
+        monkeypatch,
+        reasoning_config,
+        service_tier,
+        expected_effort,
+        expected_tier,
+    ):
+        captured = {}
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            captured.update(kwargs)
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-settings-1",
+                thread_id="thread-settings-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        agent = _make_codex_agent(
+            model="gpt-5.4",
+            reasoning_config=reasoning_config,
+            service_tier=service_tier,
+        )
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        assert captured["model"] == "gpt-5.4"
+        assert captured["reasoning_effort"] == expected_effort
+        assert captured["service_tier"] == expected_tier
+
     def test_run_conversation_returns_codex_shape(self, fake_session):
         agent = _make_codex_agent()
         # No background review fork during tests
@@ -769,4 +809,3 @@ class TestCodexToolProgressBridge:
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
         assert ("tool.started", "exec_command", "pytest") in events
-


### PR DESCRIPTION
## What does this PR do?

Propagates Hermes runtime model, reasoning effort, and fast-mode selections to the Codex app-server through the supported `turn/start` fields. This keeps the effective Codex thread configuration aligned with what Hermes reports after gateway or TUI controls change.

The root cause was that Hermes constructed `turn/start` with only `threadId` and user input. The app-server therefore continued using its inherited Codex CLI settings even after Hermes updated its live agent state.

## Related Issue

Fixes #65056

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Pass the active Hermes model and reasoning effort to each Codex app-server turn.
- Translate Hermes `service_tier=priority` to Codex `serviceTier=fast`.
- Send an explicit null service tier for normal mode so `/fast off` clears a tier selected on an earlier turn.
- Add wire-level adapter tests and an AIAgent integration test covering enabled and disabled reasoning plus fast and normal tiers.

## How to Test

1. Configure `model.openai_runtime: codex_app_server`.
2. Change the model, reasoning effort, or fast mode through the existing runtime controls.
3. Inspect the next `turn/start` request and verify its `model`, `effort`, and `serviceTier` fields match Hermes state.

Automated validation:

```bash
scripts/run_tests.sh tests/agent/transports/test_codex_app_server_session.py tests/run_agent/test_codex_app_server_integration.py tests/agent/transports/test_codex_app_server_runtime.py tests/agent/test_codex_app_server_persist.py tests/run_agent/test_codex_app_server_compaction.py -q
ruff check agent/codex_runtime.py agent/transports/codex_app_server_session.py tests/agent/transports/test_codex_app_server_session.py tests/run_agent/test_codex_app_server_integration.py
```

Result: 137 tests passed; Ruff passed.

## Checklist

### Code

- [x] I read the Contributing Guide.
- [x] The commit follows Conventional Commits.
- [x] I searched for existing PRs and found no competing implementation.
- [x] The PR contains only changes related to this fix.
- [ ] I ran the complete repository test suite. Focused and adjacent Codex runtime suites pass.
- [x] I added regression tests.
- [x] I tested on macOS.

### Documentation and Housekeeping

- [x] Documentation update: N/A; this fixes existing control behavior.
- [x] `cli-config.yaml.example`: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md`: N/A; no architecture or workflow contract changed.
- [x] Cross-platform impact considered; the JSON-RPC field mapping is platform-independent.
- [x] Tool descriptions and schemas: N/A.

## Screenshots / Logs

Not applicable; this is a JSON-RPC runtime fix.