### PR TITLE
fix(insights): include auxiliary usage in overview token totals

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -439,6 +439,18 @@ class InsightsEngine:
 
         if models:
             total_cost = sum(float(m.get("cost") or 0.0) for m in models)
+            # Token totals likewise: the per-model breakdown includes
+            # auxiliary usage rows (vision/compression/titles — task
+            # dimension in session_model_usage, #23270) plus reconciled
+            # residuals, while the sessions counters carry main-loop usage
+            # only. Summing the breakdown keeps overview totals consistent
+            # with the per-model table and stops `hermes insights`
+            # undercounting aux spend (#58592, #9979).
+            total_input = sum(int(m.get("input_tokens") or 0) for m in models)
+            total_output = sum(int(m.get("output_tokens") or 0) for m in models)
+            total_cache_read = sum(int(m.get("cache_read_tokens") or 0) for m in models)
+            total_cache_write = sum(int(m.get("cache_write_tokens") or 0) for m in models)
+            total_tokens = total_input + total_output + total_cache_read + total_cache_write
 
         # Session duration stats (guard against negative durations from clock drift)
         durations = []

--- a/tests/hermes_state/test_aux_usage_accounting.py
+++ b/tests/hermes_state/test_aux_usage_accounting.py
@@ -340,3 +340,49 @@ class TestAnalyticsAuxRows:
 
         tasks = _aux_task_summary(aux)
         assert {t["task"] for t in tasks} == {"vision", "compression"}
+
+
+class TestInsightsAuxTotals:
+    def test_overview_totals_include_aux_usage(self, db):
+        """`hermes insights` overview must count aux tokens, not just the
+        sessions counters (issues #58592, #9979)."""
+        from agent.insights import InsightsEngine
+
+        db.create_session("s1", source="cli")
+        db.update_token_counts(
+            "s1", input_tokens=1000, output_tokens=100,
+            model="main-model", billing_provider="nous", api_call_count=1,
+        )
+        db.record_auxiliary_usage(
+            "s1", "compression", model="glm-5",
+            billing_provider="openrouter", input_tokens=5000, output_tokens=500,
+        )
+        report = InsightsEngine(db).generate(days=30)
+        ov = report["overview"]
+        assert ov["total_input_tokens"] == 6000
+        assert ov["total_output_tokens"] == 600
+        models = {m["model"] for m in report["models"]}
+        assert {"main-model", "glm-5"} <= models
+
+    def test_overview_totals_not_double_counted_with_absolute_updates(self, db):
+        """Gateway absolute overwrites + aux rows must not inflate totals."""
+        from agent.insights import InsightsEngine
+
+        db.create_session("s2", source="telegram")
+        db.update_token_counts(
+            "s2", input_tokens=2000, output_tokens=200,
+            model="main-model", billing_provider="nous", api_call_count=1,
+        )
+        db.update_token_counts(
+            "s2", input_tokens=2000, output_tokens=200,
+            model="main-model", billing_provider="nous",
+            absolute=True, api_call_count=1,
+        )
+        db.record_auxiliary_usage(
+            "s2", "title_generation", model="main-model",
+            billing_provider="nous", input_tokens=40, output_tokens=8,
+        )
+        report = InsightsEngine(db).generate(days=30)
+        ov = report["overview"]
+        assert ov["total_input_tokens"] == 2040
+        assert ov["total_output_tokens"] == 208


### PR DESCRIPTION
## Summary

`hermes insights` overview token totals now include auxiliary model usage, fixing the top-line undercount reported in #58592 and requested in #9979.

Root cause: `_compute_overview` summed token counters from the `sessions` rows (main-loop usage only), while the per-model breakdown below it already included auxiliary usage rows (task dimension added in #65537) plus reconciled residuals — so the overview disagreed with its own per-model table and with provider bills whenever compression/vision/title calls burned tokens.

## Changes

- `agent/insights.py`: when the per-model breakdown is available, derive the overview's input/output/cache token totals from it — the exact pattern `total_cost` already used one line above. 12 lines.
- `tests/hermes_state/test_aux_usage_accounting.py`: 2 new tests — aux tokens included in overview totals; no double-count across incremental CLI deltas + gateway absolute overwrites + aux rows.

## Validation

| | Before | After |
|---|---|---|
| Overview total_input (1000 main + 5000 compression + 300 vision) | 1000 | 6300 |
| Overview vs per-model table | disagreed | consistent |
| Gateway absolute + aux mix | — | 2040 (no double count, verified) |

- 77 tests green across `test_aux_usage_accounting.py` + `test_insights.py`.
- E2E with real SessionDB: seeded CLI-style (incremental) and gateway-style (absolute overwrite) sessions plus aux rows; totals exact with zero double-counting.

Closes #58592. Closes #9979.
Related: #60758 (@Bartok9 identified the compression-summarizer undercount and proposed folding summarizer usage into session accounting — the recording half landed via #65537's chokepoint, this PR completes the insights half).

## Infographic

![Insights aux totals](https://v3b.fal.media/files/b/0aa279f5/-YEfafwIqYGctZ7NQRT72_XjRzZwFn.png)
