### PR TITLE
fix: handle infinite Codex wait deadlines

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -189,6 +190,30 @@ def _env_float(name: str, default: float) -> float:
         return float(os.getenv(name, str(default)))
     except (TypeError, ValueError):
         return default
+
+
+def _codex_wait_notice_recovery(
+    *,
+    stale_timeout: float,
+    ttfb_enabled: bool,
+    ttfb_timeout: float,
+    last_event_ts: Optional[float],
+    call_start: float,
+    idle_enabled: bool,
+    idle_timeout: float,
+) -> str:
+    """Describe the earliest enabled Codex watchdog on the call timeline."""
+    deadlines: list[float] = []
+    if math.isfinite(stale_timeout):
+        deadlines.append(stale_timeout)
+    if last_event_ts is None:
+        if ttfb_enabled and math.isfinite(ttfb_timeout):
+            deadlines.append(ttfb_timeout)
+    elif idle_enabled and math.isfinite(idle_timeout):
+        deadlines.append(max(0.0, last_event_ts - call_start) + idle_timeout)
+    if not deadlines:
+        return ""
+    return f"; auto-reconnect at {int(min(deadlines))}s"
 
 
 # ── Cross-turn stale-call circuit breaker (#58962) ─────────────────────
@@ -611,16 +636,19 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # usually a slow/overloaded provider, but the UI never said so).
         if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
             _elapsed = time.time() - _call_start
-            _deadline = _stale_timeout
-            if (
-                _ttfb_enabled
-                and getattr(agent, "_codex_stream_last_event_ts", None) is None
-            ):
-                _deadline = min(_deadline, _ttfb_timeout)
+            _recovery = _codex_wait_notice_recovery(
+                stale_timeout=_stale_timeout,
+                ttfb_enabled=_ttfb_enabled,
+                ttfb_timeout=_ttfb_timeout,
+                last_event_ts=getattr(agent, "_codex_stream_last_event_ts", None),
+                call_start=_call_start,
+                idle_enabled=_codex_idle_enabled,
+                idle_timeout=_codex_idle_timeout,
+            )
             agent._emit_wait_notice(
                 f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
                 f"{int(_elapsed)}s with no response yet (provider may be slow "
-                f"or overloaded; auto-reconnect at {int(_deadline)}s)"
+                f"or overloaded{_recovery})"
             )
 
         _elapsed = time.time() - _call_start

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -316,6 +316,24 @@ def test_event_idle_kills_after_first_event_then_silence(tmp_path, monkeypatch):
         stop["flag"] = True
 
 
+def test_wait_notice_handles_infinite_local_stale_timeout():
+    """After the first SSE event, a local endpoint's infinite wall-clock
+    timeout must not reach ``int()``; report the finite idle watchdog instead."""
+    from agent import chat_completion_helpers as h
+
+    recovery = h._codex_wait_notice_recovery(
+        stale_timeout=float("inf"),
+        ttfb_enabled=True,
+        ttfb_timeout=120.0,
+        last_event_ts=130.0,
+        call_start=100.0,
+        idle_enabled=True,
+        idle_timeout=60.0,
+    )
+
+    assert recovery == "; auto-reconnect at 90s"
+
+
 def test_ttfb_disabled_via_env_zero(tmp_path, monkeypatch):
     """Setting HERMES_CODEX_TTFB_TIMEOUT_SECONDS=0 disables the TTFB watchdog;
     a no-event stall then falls through to the (here, 60s) stale timeout, so a


### PR DESCRIPTION
## Summary

- prevent the periodic Codex wait notice from converting a non-finite stale timeout to `int`
- compute the earliest enabled watchdog on the request timeline, including the stream-idle watchdog after the first SSE event
- omit the reconnect suffix only when no finite watchdog is enabled
- add a regression test for an infinite local-endpoint stale timeout after the first SSE event

## Problem

Local/private OpenAI-compatible endpoints use `float("inf")` to disable the generic wall-clock stale timeout when no explicit override is configured.

Before the first SSE event, the finite TTFB watchdog masks that value. After an event arrives, TTFB no longer applies, so the periodic 30-second wait notice formats the generic deadline directly:

```python
int(float("inf"))
```

That raises `OverflowError`, aborts an otherwise healthy client stream, and can turn a display heartbeat into a whole-turn retry.

## Fix

Build a list of finite enabled watchdog deadlines on the same call-relative timeline:

- generic wall-clock stale timeout, when finite
- TTFB timeout before the first SSE event
- event-idle timeout after the first SSE event

The notice reports the earliest deadline. If every relevant watchdog is disabled/non-finite, it does not claim that an automatic reconnect is scheduled.

This overlaps with #64924 and #65594, but those patches render the infinite generic timeout as `no limit`/`never`. After the first SSE event, a finite stream-idle watchdog is normally still active; this change reports that actual recovery deadline and locks the behavior down with a regression test.

## Validation

```text
14 passed in 72.60s
ruff: All checks passed
py_compile: passed
git diff --check: passed
```
