### PR TITLE
fix(pricing): add deepseek-v4-flash entry + refresh stale DeepSeek snapshot to 2026-07 rates

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -477,6 +477,17 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
         pricing_version="deepseek-pricing-2026-05-12",
     ),
+    (
+        "deepseek",
+        "deepseek-v4-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
+        source="official_docs_snapshot",
+        source_url="https://api-docs.deepseek.com/quick_start/pricing",
+        pricing_version="deepseek-pricing-2026-05-12",
+    ),
     # Google Gemini
     (
         "google",

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -446,36 +446,41 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         pricing_version="anthropic-pricing-2026-05",
     ),
     # DeepSeek
+    # Snapshot of https://api-docs.deepseek.com/quick_start/pricing (2026-07).
+    # deepseek-chat / deepseek-reasoner are deprecated 2026-07-24 and now alias
+    # deepseek-v4-flash's non-thinking / thinking modes — same rates.
     (
         "deepseek",
         "deepseek-chat",
     ): PricingEntry(
         input_cost_per_million=Decimal("0.14"),
         output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-03-16",
+        pricing_version="deepseek-pricing-2026-07",
     ),
     (
         "deepseek",
         "deepseek-reasoner",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.55"),
-        output_cost_per_million=Decimal("2.19"),
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-03-16",
+        pricing_version="deepseek-pricing-2026-07",
     ),
     (
         "deepseek",
         "deepseek-v4-pro",
     ): PricingEntry(
-        input_cost_per_million=Decimal("1.74"),
-        output_cost_per_million=Decimal("3.48"),
-        cache_read_cost_per_million=Decimal("0.0145"),
+        input_cost_per_million=Decimal("0.435"),
+        output_cost_per_million=Decimal("0.87"),
+        cache_read_cost_per_million=Decimal("0.003625"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-05-12",
+        pricing_version="deepseek-pricing-2026-07",
     ),
     (
         "deepseek",
@@ -486,7 +491,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         cache_read_cost_per_million=Decimal("0.0028"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-05-12",
+        pricing_version="deepseek-pricing-2026-07",
     ),
     # Google Gemini
     (

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -351,6 +351,7 @@ AUTHOR_MAP = {
     "dirtyren@users.noreply.github.com": "dirtyren",
     "a54983334@163.com": "Code-suphub",
     "78542984+Code-suphub@users.noreply.github.com": "Code-suphub",
+    "shuangxinniao@gmail.com": "shuangxinniao",
     "hi@neueway.com": "brendandebeasi",
     "dorokuma@users.noreply.github.com": "dorokuma",
     "liuwei666888@users.noreply.github.com": "liuwei666888",

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -415,3 +415,37 @@ def test_fireworks_rows_all_carry_cache_read_pricing():
         entry = _OFFICIAL_DOCS_PRICING[key]
         assert entry.cache_read_cost_per_million is not None, key
         assert entry.cache_read_cost_per_million < entry.input_cost_per_million, key
+
+
+def test_deepseek_v4_flash_pricing_entry_exists():
+    """Regression test: deepseek-v4-flash must have a pricing entry.
+
+    Before this fix, deepseek-v4-flash sessions showed $0.00 / cost_source
+    "none" because the _OFFICIAL_DOCS_PRICING table had an entry for
+    deepseek-v4-pro but not the (newer) flash model.  DeepSeek's /models
+    endpoint returns no pricing, so the official-docs snapshot is the only
+    source for direct-provider routes.
+    """
+    entry = get_pricing_entry(
+        "deepseek-v4-flash",
+        provider="deepseek",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.14
+    assert float(entry.output_cost_per_million) == 0.28
+    assert float(entry.cache_read_cost_per_million) == 0.0028
+
+
+def test_deepseek_v4_flash_estimate_usage_cost():
+    """Ensure deepseek-v4-flash sessions get a dollar estimate, not $0/none."""
+    result = estimate_usage_cost(
+        "deepseek-v4-flash",
+        CanonicalUsage(input_tokens=1000000, output_tokens=500000),
+        provider="deepseek",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
+    assert float(result.amount_usd) == 0.28

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -223,7 +223,8 @@ def test_deepseek_v4_pro_pricing_entry_exists():
 
     Before this fix, deepseek-v4-pro sessions showed as unknown cost
     in hermes insights because the _OFFICIAL_DOCS_PRICING table had no
-    entry for that model.  See #24218.
+    entry for that model.  See #24218.  Rates track the 2026-07 price cut
+    ($1.74/$3.48 → $0.435/$0.87).
     """
     entry = get_pricing_entry(
         "deepseek-v4-pro",
@@ -233,9 +234,9 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert entry is not None
     assert entry.input_cost_per_million is not None
     assert entry.output_cost_per_million is not None
-    assert float(entry.input_cost_per_million) == 1.74
-    assert float(entry.output_cost_per_million) == 3.48
-    assert float(entry.cache_read_cost_per_million) == 0.0145
+    assert float(entry.input_cost_per_million) == 0.435
+    assert float(entry.output_cost_per_million) == 0.87
+    assert float(entry.cache_read_cost_per_million) == 0.003625
 
 
 def test_deepseek_v4_pro_estimate_usage_cost():
@@ -248,8 +249,39 @@ def test_deepseek_v4_pro_estimate_usage_cost():
 
     assert result.status == "estimated"
     assert result.amount_usd is not None
-    # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
-    assert float(result.amount_usd) == 3.48
+    # 1M input × $0.435/M + 500K output × $0.87/M = $0.435 + $0.435 = $0.87
+    assert float(result.amount_usd) == 0.87
+
+
+def test_deepseek_deprecated_aliases_price_as_v4_flash():
+    """Invariant: deepseek-chat / deepseek-reasoner are deprecated aliases for
+    deepseek-v4-flash's non-thinking / thinking modes (deprecation 2026-07-24)
+    — they must bill at identical rates to the flash entry, or sessions on the
+    legacy names over/under-report cost."""
+    flash = get_pricing_entry("deepseek-v4-flash", provider="deepseek")
+    assert flash is not None
+    for alias in ("deepseek-chat", "deepseek-reasoner"):
+        entry = get_pricing_entry(alias, provider="deepseek")
+        assert entry is not None, alias
+        assert entry.input_cost_per_million == flash.input_cost_per_million, alias
+        assert entry.output_cost_per_million == flash.output_cost_per_million, alias
+        assert (
+            entry.cache_read_cost_per_million == flash.cache_read_cost_per_million
+        ), alias
+
+
+def test_deepseek_rows_all_carry_cache_read_pricing():
+    """Invariant: DeepSeek publishes a cache-hit rate for every current model;
+    every deepseek snapshot row must carry cache_read < input so cached
+    sessions estimate correctly instead of billing reads at full price."""
+    from agent.usage_pricing import _OFFICIAL_DOCS_PRICING
+
+    ds_rows = [k for k in _OFFICIAL_DOCS_PRICING if k[0] == "deepseek"]
+    assert ds_rows, "expected at least one deepseek pricing row"
+    for key in ds_rows:
+        entry = _OFFICIAL_DOCS_PRICING[key]
+        assert entry.cache_read_cost_per_million is not None, key
+        assert entry.cache_read_cost_per_million < entry.input_cost_per_million, key
 
 
 def test_bedrock_claude_rows_all_carry_cache_pricing():


### PR DESCRIPTION
## Summary
DeepSeek sessions now bill at DeepSeek's current published rates: `deepseek-v4-flash` gets a pricing entry (was $0.00 / `cost_source: none`), and the rest of the DeepSeek snapshot — which had drifted 4x stale after DeepSeek's 2026-07 price cut — is refreshed with it.

Salvages #40127 by @shuangxinniao (cherry-picked, authorship preserved). @luarss submitted the same flash fix in #41719 three days later with an excellent root-cause writeup — both credited. Closes #41710.

Root cause: DeepSeek's `/models` endpoint returns no pricing, so direct-provider routes depend entirely on the hand-maintained `_OFFICIAL_DOCS_PRICING` snapshot, which had no flash entry and pre-cut rates everywhere else.

## Changes
- `agent/usage_pricing.py` (from #40127): `("deepseek", "deepseek-v4-flash")` entry — $0.14 in / $0.28 out / $0.0028 cache-read, per https://api-docs.deepseek.com/quick_start/pricing.
- `agent/usage_pricing.py` (class widening): `deepseek-v4-pro` $1.74/$3.48/$0.0145 → $0.435/$0.87/$0.003625 (every pro session was over-reporting cost ~4x); `deepseek-chat`/`deepseek-reasoner` (deprecated 2026-07-24, now aliases for flash's non-thinking/thinking modes) repriced to match flash — reasoner was $0.55/$2.19 with no cache rate; cache_read on every row; `pricing_version` unified at `deepseek-pricing-2026-07`.
- Tests: contributor's 2 regression tests + updated v4-pro pins + invariants (deprecated aliases bill identically to flash; every deepseek row carries cache_read < input).

Fireworks-hosted DeepSeek ids (`("fireworks", "deepseek-*")`) are intentionally untouched — Fireworks bills its own rates.

## Validation
| | Result |
|---|---|
| Offline E2E (temp HERMES_HOME, real imports) | all 4 model ids → `estimated` with correct dollars; fireworks-hosted rates unchanged |
| tests/agent/ full directory | 5,809/5,809 passed |
| Pricing suite | 25/25 |

## Infographic

![deepseek-pricing-refresh](https://v3b.fal.media/files/b/0aa27a13/UwXgzkzyCQSSzJ25Qf8hQ_5i3nI96h.png)
