### PR TITLE
fix(relaunch): add timeout and stdin=DEVNULL to Windows subprocess.run in relaunch

### DIFF
--- a/hermes_cli/relaunch.py
+++ b/hermes_cli/relaunch.py
@@ -185,7 +185,9 @@ def relaunch(
         # Windows: subprocess + exit, because execvp can't swap to .cmd/.exe shims.
         import subprocess
         try:
-            result = subprocess.run(new_argv)
+            result = subprocess.run(
+                new_argv, timeout=300, stdin=subprocess.DEVNULL,
+            )
             sys.exit(result.returncode)
         except KeyboardInterrupt:
             sys.exit(130)


### PR DESCRIPTION
Closing as duplicate