### PR TITLE
fix(desktop): preserve node-pty helper in packaged app

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -19,7 +19,8 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
-  rmSync
+  rmSync,
+  writeFileSync
 } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { isMain } from './utils.mjs'
@@ -27,6 +28,30 @@ import { isMain } from './utils.mjs'
 const here = dirname(fileURLToPath(import.meta.url))
 const projectRoot = resolve(here, '..')
 const require = createRequire(import.meta.url)
+
+function makeExecutable(filePath) {
+  chmodSync(filePath, 0o755)
+}
+
+function patchUnixTerminalAsarPaths(destRoot) {
+  const filePath = join(destRoot, 'lib', 'unixTerminal.js')
+  if (!existsSync(filePath)) return
+
+  const source = readFileSync(filePath, 'utf8')
+  const patched = source
+    .replace(
+      "helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');",
+      "helperPath = helperPath.replace(/app\\.asar(?!\\.unpacked)/, 'app.asar.unpacked');"
+    )
+    .replace(
+      "helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');",
+      "helperPath = helperPath.replace(/node_modules\\.asar(?!\\.unpacked)/, 'node_modules.asar.unpacked');"
+    )
+
+  if (patched !== source) {
+    writeFileSync(filePath, patched)
+  }
+}
 
 /**
  * Locate node-pty's package root via real module resolution, so this
@@ -75,7 +100,11 @@ function copyBuildRelease(srcDir, destDir) {
       continue
     }
     if (entry.name === 'spawn-helper' || /\.(node|dll|exe)$/.test(entry.name)) {
-      cpSync(join(srcDir, entry.name), join(destDir, entry.name))
+      const destFile = join(destDir, entry.name)
+      cpSync(join(srcDir, entry.name), destFile)
+      if (entry.name === 'spawn-helper') {
+        makeExecutable(destFile)
+      }
     }
   }
 }
@@ -220,6 +249,7 @@ export function stageNodePtyInto(srcRoot, destRoot, { platform = process.platfor
 
   // lib/**/*.js — the JS surface node-pty's `main` points into.
   copyGlobByExt(join(srcRoot, 'lib'), join(destRoot, 'lib'), ['.js'])
+  patchUnixTerminalAsarPaths(destRoot)
 
   // prebuilds/<platform>-<arch>/* — the prebuild-install payload for the
   // *target* we're packaging, not necessarily the host running this script.
@@ -239,8 +269,9 @@ export function stageNodePtyInto(srcRoot, destRoot, { platform = process.platfor
         continue
       }
       if (entry.name === 'spawn-helper') {
-        cpSync(join(prebuildDir, entry.name), join(destPrebuild, entry.name))
-        chmodSync(join(destPrebuild, entry.name), 0o775)
+        const destFile = join(destPrebuild, entry.name)
+        cpSync(join(prebuildDir, entry.name), destFile)
+        makeExecutable(destFile)
       }
     }
   }

--- a/apps/desktop/scripts/stage-native-deps.test.mjs
+++ b/apps/desktop/scripts/stage-native-deps.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import fs, { existsSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { test } from 'vitest'
 
 import {
@@ -41,6 +42,19 @@ function makeFakeNodePty(srcRoot, { prebuildPlatform, prebuildArch } = {}) {
     const prebuildDir = join(srcRoot, 'prebuilds', `${prebuildPlatform}-${prebuildArch}`)
     makeFakeNode(join(prebuildDir, 'pty.node'), prebuildPlatform)
   }
+}
+
+function makeFakeUnixTerminal(srcRoot) {
+  fs.writeFileSync(
+    join(srcRoot, 'lib', 'unixTerminal.js'),
+    [
+      "exports.resolveHelper = function (helperPath) {",
+      "  helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');",
+      "  helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');",
+      '  return helperPath;',
+      '};'
+    ].join('\n')
+  )
 }
 
 // ─── classifyNativeBinary tests ─────────────────────────────────────
@@ -261,6 +275,66 @@ test('host-target: host build/Release IS staged for a matching target', () => {
     fs.rmSync(tmp, { recursive: true, force: true })
   }
 })
+
+test.skipIf(process.platform === 'win32')(
+  'host-target: staged node-pty resolves an already-unpacked helper and preserves executable helpers',
+  async () => {
+    const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))
+    try {
+      const srcRoot = join(tmp, 'node-pty')
+      const destRoot = join(tmp, 'dest')
+      const prebuildDir = join(srcRoot, 'prebuilds', `${process.platform}-${process.arch}`)
+      const buildReleaseDir = join(srcRoot, 'build', 'Release')
+
+      makeFakeNodePty(srcRoot, {
+        prebuildPlatform: process.platform,
+        prebuildArch: process.arch
+      })
+      makeFakeUnixTerminal(srcRoot)
+      makeFakeNode(join(buildReleaseDir, 'pty.node'), process.platform)
+      fs.writeFileSync(join(prebuildDir, 'spawn-helper'), 'prebuild helper')
+      fs.writeFileSync(join(buildReleaseDir, 'spawn-helper'), 'build helper')
+      fs.chmodSync(join(prebuildDir, 'spawn-helper'), 0o644)
+      fs.chmodSync(join(buildReleaseDir, 'spawn-helper'), 0o644)
+
+      stageNodePtyInto(srcRoot, destRoot, { platform: process.platform, arch: process.arch })
+
+      const stagedUnixTerminalUrl = pathToFileURL(join(destRoot, 'lib', 'unixTerminal.js'))
+      stagedUnixTerminalUrl.searchParams.set('t', String(Date.now()))
+      const stagedUnixTerminal = await import(stagedUnixTerminalUrl.href)
+      const unpackedHelper = join(
+        tmp,
+        'Hermes.app',
+        'Contents',
+        'Resources',
+        'app.asar.unpacked',
+        'dist',
+        'node_modules',
+        'node-pty',
+        'prebuilds',
+        `${process.platform}-${process.arch}`,
+        'spawn-helper'
+      )
+      const nodeModulesUnpackedHelper = unpackedHelper.replace(
+        `${path.sep}node_modules${path.sep}`,
+        `${path.sep}node_modules.asar.unpacked${path.sep}`
+      )
+
+      assert.equal(stagedUnixTerminal.resolveHelper(unpackedHelper), unpackedHelper)
+      assert.equal(
+        stagedUnixTerminal.resolveHelper(nodeModulesUnpackedHelper),
+        nodeModulesUnpackedHelper
+      )
+      assert.equal(
+        fs.statSync(join(destRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'spawn-helper')).mode & 0o777,
+        0o755
+      )
+      assert.equal(fs.statSync(join(destRoot, 'build', 'Release', 'spawn-helper')).mode & 0o777, 0o755)
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  }
+)
 
 test('validation rejects a staged binary with the wrong platform magic', () => {
   const tmp = fs.mkdtempSync(join(os.tmpdir(), 'hermes-stage-'))


### PR DESCRIPTION
## Summary

Salvages the complementary macOS Desktop terminal fixes from #61395 and #63789 onto current `main`:

- guard node-pty's staged `app.asar` and `node_modules.asar` rewrites so already-unpacked paths do not become `.unpacked.unpacked`
- normalize staged `spawn-helper` permissions to `0755`
- cover both prebuilt and locally compiled `build/Release` helper layouts
- add behavioral staging coverage for both unpacked path forms and both helper layouts

This preserves @zwcf5200's authorship and credits @liuhao1024 for the complementary execute-bit work.

Fixes #61389.
Supersedes #61395 and #63789.

## Verification

- `npm run test:desktop:platforms -- scripts/stage-native-deps.test.mjs` — 16/16 passed
- `npm run typecheck` — passed
- targeted ESLint + `git diff --check` — passed
- `npm run pack` — packaged macOS arm64 app built successfully
- `HERMES_DESKTOP_SKIP_BUILD=1 npm run test:desktop:all` — packaged app + DMG validation passed
- packaged `spawn-helper` verified as mode `0755`
- packaged `unixTerminal.js` verified to contain guarded rewrites
- direct packaged node-pty smoke test spawned `/bin/zsh -il` and printed `HERMES_PACKAGED_PTY_OK`
- real packaged Hermes Desktop UI driven via Codex Computer Use: opened the integrated Terminal pane, observed a live `1. zsh` prompt with no `posix_spawnp failed`, ran the marker command, and visibly confirmed `HERMES_DESKTOP_UI_PTY_OK`
