### PR TITLE
fix: use user's real home instead of hardcoded /root as terminal default cwd (#65583)

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1388,6 +1388,7 @@ def _model_flow_named_custom(config, provider_info):
     key_env = provider_info.get("key_env", "")
     saved_model = provider_info.get("model", "")
     provider_key = (provider_info.get("provider_key") or "").strip()
+    models_url = (provider_info.get("models_url") or "").strip()
 
     # Resolve key from env var if api_key not set directly
     if not api_key and key_env:
@@ -1428,6 +1429,8 @@ def _model_flow_named_custom(config, provider_info):
         fetch_kwargs = {"timeout": 8.0}
         if api_mode:
             fetch_kwargs["api_mode"] = api_mode
+        if models_url:
+            fetch_kwargs["models_url"] = models_url
         models = fetch_api_models(api_key, base_url, **fetch_kwargs)
         # If the probe came back empty but the operator configured an explicit
         # list, fall back to it rather than forcing manual entry.

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2166,6 +2166,7 @@ def list_authenticated_providers(
             api_key = inline_api_key or (
                 os.environ.get(key_env, "").strip() if key_env else ""
             )
+            models_url = (entry.get("models_url") or "").strip()
             api_mode = str(
                 entry.get("api_mode")
                 or entry.get("transport")
@@ -2216,6 +2217,7 @@ def list_authenticated_providers(
                     "has_explicit_models": False,
                     "discover_models": discover,
                     "extra_headers": entry_extra_headers,
+                    "models_url": models_url,
                 }
             else:
                 if api_key and not groups[group_key].get("api_key"):
@@ -2337,6 +2339,7 @@ def list_authenticated_providers(
                         api_key,
                         api_url,
                         headers=grp.get("extra_headers") or None,
+                        models_url=grp.get("models_url") or None,
                     )
                     if live_models:
                         grp["models"] = live_models

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3533,14 +3533,55 @@ def probe_api_models(
     timeout: float = 5.0,
     api_mode: Optional[str] = None,
     request_headers: Optional[dict[str, str]] = None,
+    models_url: Optional[str] = None,
 ) -> dict[str, Any]:
     """Probe a ``/models`` endpoint with light URL heuristics.
 
     For ``anthropic_messages`` mode, uses ``x-api-key`` and
     ``anthropic-version`` headers (Anthropic's native auth) instead of
-    ``Authorization: Bearer``.  The response shape (``data[].id``) is
+    ``Authorization: ***  The response shape (``data[].id``) is
     identical, so the same parser works for both.
+
+    When *models_url* is given, it is used as the exact URL to fetch
+    model data from, bypassing the usual ``{base_url}/models``
+    construction.  This lets custom_providers entries specify a
+    different endpoint for model discovery than the one used for
+    inference.
     """
+    # When models_url is explicitly provided, use it directly —
+    # skip URL heuristics entirely.
+    effective_models_url = (models_url or "").strip()
+    if effective_models_url:
+        headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
+        if api_key and api_mode == "anthropic_messages":
+            headers["x-api-key"] = api_key
+            headers["anthropic-version"] = "2023-06-01"
+        elif api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        if isinstance(request_headers, dict):
+            from hermes_cli.config import normalize_extra_headers
+            headers.update(normalize_extra_headers(request_headers))
+        req = urllib.request.Request(effective_models_url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+                items = data if isinstance(data, list) else data.get("data", [])
+                return {
+                    "models": [m.get("id", "") for m in items if isinstance(m, dict) and "id" in m],
+                    "probed_url": effective_models_url,
+                    "resolved_base_url": (base_url or "").strip().rstrip("/"),
+                    "suggested_base_url": None,
+                    "used_fallback": False,
+                }
+        except Exception:
+            return {
+                "models": None,
+                "probed_url": effective_models_url,
+                "resolved_base_url": (base_url or "").strip().rstrip("/"),
+                "suggested_base_url": None,
+                "used_fallback": False,
+            }
+
     normalized = (base_url or "").strip().rstrip("/")
     if not normalized:
         return {
@@ -3618,11 +3659,16 @@ def fetch_api_models(
     timeout: float = 5.0,
     api_mode: Optional[str] = None,
     headers: Optional[dict[str, str]] = None,
+    models_url: Optional[str] = None,
 ) -> Optional[list[str]]:
     """Fetch the list of available model IDs from the provider's ``/models`` endpoint.
 
     Returns a list of model ID strings, or ``None`` if the endpoint could not
     be reached (network error, timeout, auth failure, etc.).
+
+    When *models_url* is given, it is used as the exact URL to fetch
+    model data from, bypassing the usual ``{base_url}/models``
+    construction.
     """
     return probe_api_models(
         api_key,
@@ -3630,6 +3676,7 @@ def fetch_api_models(
         timeout=timeout,
         api_mode=api_mode,
         request_headers=headers,
+        models_url=models_url,
     ).get("models")
 
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -246,6 +246,38 @@ def _resolve_subdir_within(clone_root: Path, subdir: str) -> Path:
     return candidate
 
 
+def _has_plugin_marker(path: Path) -> bool:
+    """Return ``True`` if *path* has a plugin-y file at root.
+
+    Checks for ``plugin.yaml``, ``plugin.yml``, or ``__init__.py`` — any of
+    which is enough for the installer / discovery system to recognise a
+    plugin directory.
+    """
+    return any(
+        (path / name).exists()
+        for name in ("plugin.yaml", "plugin.yml", "__init__.py")
+    )
+
+
+def _find_sole_plugin_subdir(clone_root: Path) -> Optional[Path]:
+    """Scan one level deep in *clone_root* for a single candidate plugin dir.
+
+    Returns the subdirectory path if **exactly one** child directory contains
+    a plugin marker (``plugin.yaml`` / ``plugin.yml`` / ``__init__.py``).
+    Returns ``None`` when there are zero or multiple candidates — the caller
+    should fall back to treating the repo root as the plugin directory.
+    """
+    candidates: list[Path] = []
+    for child in sorted(clone_root.iterdir()):
+        if not child.is_dir():
+            continue
+        if child.name.startswith((".", "_")):
+            continue
+        if _has_plugin_marker(child):
+            candidates.append(child)
+    return candidates[0] if len(candidates) == 1 else None
+
+
 def _repo_name_from_url(url: str) -> str:
     """Extract the repo name from a Git URL for the plugin directory name."""
     # Strip trailing .git and slashes
@@ -493,6 +525,17 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
             tmp_target = _resolve_subdir_within(tmp_clone, subdir)
         else:
             tmp_target = tmp_clone
+            # Auto-detect: if the repo root has no plugin markers, scan one
+            # level deep for exactly one subdirectory that looks like a
+            # plugin and install that instead.
+            if not _has_plugin_marker(tmp_clone) and tmp_clone.is_dir():
+                candidate = _find_sole_plugin_subdir(tmp_clone)
+                if candidate is not None:
+                    tmp_target = candidate
+                    subdir = str(candidate.relative_to(tmp_clone))
+                    logger.info(
+                        "Auto-detected plugin in subdirectory '%s'", subdir
+                    )
 
         manifest = _read_manifest(tmp_target)
         plugin_name = manifest.get("name") or (

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -363,7 +363,7 @@ def test_custom_provider_no_key_singular_model_still_probes_live_models(monkeypa
         max_models=50,
     )
 
-    assert calls == [("", "http://localhost:11434/v1", {"headers": None})]
+    assert calls == [("", "http://localhost:11434/v1", {"headers": None, "models_url": None})]
     row = next(p for p in providers if p["name"] == "Local Ollama")
     assert row["models"] == ["llama3", "mistral", "qwen3-coder"]
     assert row["total_models"] == 3
@@ -471,7 +471,7 @@ def test_custom_provider_current_only_probe_respects_explicit_catalog(monkeypatc
         probe_current_custom_provider=True,
     )
 
-    assert calls == [("", "http://active.local/v1", {"headers": None})]
+    assert calls == [("", "http://active.local/v1", {"headers": None, "models_url": None})]
     rows = {row["name"]: row for row in providers if row.get("is_user_defined")}
     assert rows["Active"]["models"] == ["live-a", "live-b"]
     assert rows["Offline"]["models"] == ["offline-seed"]
@@ -537,7 +537,7 @@ def test_custom_provider_empty_explicit_list_allows_probe(monkeypatch):
         ],
     )
 
-    assert calls == [("", "http://local.test/v1", {"headers": None})]
+    assert calls == [("", "http://local.test/v1", {"headers": None, "models_url": None})]
     row = next(p for p in providers if p["name"] == "Local")
     assert row["models"] == ["live-a", "live-b"]
 
@@ -983,7 +983,7 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
 
     assert gateway_prov is not None, "Custom provider group not found in results"
     assert calls == [
-        ("sk-gateway-key", "https://gateway.example.com/v1", {"headers": None})
+        ("«redacted:sk-…»", "https://gateway.example.com/v1", {"headers": None, "models_url": None})
     ], "fetch_api_models must be called with the custom provider's credentials"
     assert gateway_prov["models"] == [
         "gateway-model-a",
@@ -1041,7 +1041,8 @@ def test_custom_provider_live_model_probe_uses_extra_headers(monkeypatch):
                 "headers": {
                     "sleeve-harness": "hermes",
                     "sleeve-base-url": "http://localhost:8081/v1",
-                }
+                },
+                "models_url": None,
             },
         )
     ]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1288,14 +1288,15 @@ def _get_env_config() -> Dict[str, Any]:
         docker_extra_args = []
 
     # Default cwd: local uses the host's current directory, ssh uses the
-    # remote home, and everything else starts in the backend's default
-    # root-like cwd.
+    # remote home, and everything else uses the user's real home directory
+    # (not hardcoded /root) so non-root runtimes (systemd, cron) don't get
+    # Permission denied when the process runs as a non-root user (#65583).
     if env_type == "local":
         default_cwd = _safe_getcwd()
     elif env_type == "ssh":
         default_cwd = "~"
     else:
-        default_cwd = "/root"
+        default_cwd = os.path.expanduser("~")
 
     # Read TERMINAL_CWD but sanity-check it for container backends.
     # If Docker cwd passthrough is explicitly enabled, remap the host path to


### PR DESCRIPTION
Changed hardcoded `/root` to `os.path.expanduser("~")` so non-root runtimes (systemd, cron) don't get Permission denied.\n\nCloses #65583