### PR TITLE
fix(desktop): load runtime plugins from remote backend

### DIFF
--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -6,26 +6,48 @@ import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
 import { $pluginRecords, type PluginRecord, setPluginEnabled } from '@/contrib/plugins-store'
 import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
-import { getStatus } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { copyTextToClipboard, desktopHermesHome, isDesktopFsRemoteMode } from '@/lib/desktop-fs'
 import { triggerHaptic } from '@/lib/haptics'
 import { Package } from '@/lib/icons'
-import { notifyError } from '@/store/notifications'
+import { notify, notifyError } from '@/store/notifications'
 
 import { EmptyState, ListRow, Pill, SectionHeading, SettingsContent } from './primitives'
 
 const KIND_ORDER: Record<PluginRecord['kind'], number> = { disk: 0, runtime: 1, bundled: 2 }
 
+function notifyCopied(path: string) {
+  notify({
+    kind: 'info',
+    message: 'Remote plugins path copied',
+    detail: path
+  })
+}
+
 function reveal(file: string) {
+  if (isDesktopFsRemoteMode()) {
+    void copyTextToClipboard(file).then(() => notifyCopied(file)).catch(err => notifyError(err, 'Could not copy plugin path'))
+
+    return
+  }
+
   void window.hermesDesktop?.revealPath?.(file)?.catch(() => undefined)
 }
 
 async function revealPluginsDir() {
   try {
-    const { hermes_home } = await getStatus()
+    const { desktop_plugins } = await desktopHermesHome()
+
+    if (isDesktopFsRemoteMode()) {
+      await copyTextToClipboard(desktop_plugins)
+      notifyCopied(desktop_plugins)
+
+      return
+    }
+
     // openDir (not reveal): the door often doesn't exist on first use, and
     // showItemInFolder on a missing path silently no-ops (esp. Windows).
-    const result = await window.hermesDesktop?.openDir?.(`${hermes_home}/desktop-plugins`)
+    const result = await window.hermesDesktop?.openDir?.(desktop_plugins)
 
     if (result && !result.ok) {
       notifyError(result.error ?? 'unknown error', 'Could not open the plugins folder')

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -27,7 +27,13 @@
  * trust seam.
  */
 
-import { getStatus } from '@/hermes'
+import {
+  desktopFsCacheKey,
+  desktopHermesHome,
+  isDesktopFsRemoteMode,
+  readDesktopDir,
+  readDesktopFileText
+} from '@/lib/desktop-fs'
 import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
 import { notifyError } from '@/store/notifications'
 
@@ -202,14 +208,33 @@ interface DiskPlugin {
 const disk = new Map<string, DiskPlugin>()
 let watching = false
 let scanning = false
+let diskSourceKey = ''
+
+function dropAllDiskPlugins(): void {
+  const desktop = window.hermesDesktop
+
+  for (const [name, record] of disk) {
+    if (record.id) {
+      unloadRuntimePlugin(record.id)
+      dropPlugin(record.id)
+    }
+
+    dropPlugin(name)
+
+    if (record.watchId) {
+      void desktop?.stopPreviewFileWatch(record.watchId)
+    }
+  }
+
+  disk.clear()
+}
 
 async function loadDiskPlugin(name: string, file: string): Promise<void> {
-  const desktop = window.hermesDesktop!
   const entry = disk.get(name)
   const prevId = entry?.id
 
   try {
-    const { text } = await desktop.readFileText(file)
+    const { text } = await readDesktopFileText(file)
     const id = await loadRuntimePlugin(text, name, { file })
 
     // A hot-edit that changes `plugin.id`: loadRuntimePlugin only disposes the
@@ -246,8 +271,16 @@ async function scanDiskPlugins(): Promise<void> {
   scanning = true
 
   try {
-    const { hermes_home } = await getStatus()
-    const { entries } = await desktop.readDir(`${hermes_home}/desktop-plugins`)
+    const { desktop_plugins } = await desktopHermesHome()
+    const sourceKey = `${desktopFsCacheKey()}:${desktop_plugins}`
+
+    if (diskSourceKey && diskSourceKey !== sourceKey) {
+      dropAllDiskPlugins()
+    }
+
+    diskSourceKey = sourceKey
+
+    const { entries } = await readDesktopDir(desktop_plugins)
     const seen = new Set<string>()
 
     for (const dir of entries.filter(e => e.isDirectory)) {
@@ -260,7 +293,7 @@ async function scanDiskPlugins(): Promise<void> {
       const file = `${dir.path}/plugin.js`
 
       try {
-        await desktop.readFileText(file)
+        await readDesktopFileText(file)
       } catch {
         continue // No plugin.js (yet) — not a plugin folder.
       }
@@ -269,11 +302,13 @@ async function scanDiskPlugins(): Promise<void> {
       disk.set(dir.name, record)
       await loadDiskPlugin(dir.name, file)
 
-      try {
-        record.watchId = (await desktop.watchPreviewFile(file)).id
-      } catch {
-        // Unwatchable — the poll still reconciles new folders; edits need a
-        // manual "Reload desktop plugins".
+      if (!isDesktopFsRemoteMode()) {
+        try {
+          record.watchId = (await desktop.watchPreviewFile(file)).id
+        } catch {
+          // Unwatchable — the poll still reconciles new folders; edits need a
+          // manual "Reload desktop plugins".
+        }
       }
     }
 

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -1,11 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { getStatus } from '@/hermes'
 import { $connection } from '@/store/session'
+
+vi.mock('@/hermes', () => ({
+  getStatus: vi.fn(async () => ({ hermes_home: '/local/hermes' }))
+}))
 
 import {
   desktopDefaultCwd,
   desktopFileDiff,
   desktopGitRoot,
+  desktopHermesHome,
   readDesktopDir,
   readDesktopFileDataUrl,
   readDesktopFileText,
@@ -38,6 +44,10 @@ const api = vi.fn(async ({ path }: { path: string }) => {
 
   if (path === '/api/fs/default-cwd') {
     return { cwd: '/backend/project', branch: 'main' }
+  }
+
+  if (path === '/api/fs/hermes-home') {
+    return { hermes_home: '/remote/hermes', desktop_plugins: '/remote/hermes/desktop-plugins' }
   }
 
   if (path.startsWith('/api/git/file-diff?')) {
@@ -82,12 +92,17 @@ describe('desktop filesystem facade', () => {
     await expect(readDesktopFileText('/work/file.txt')).resolves.toMatchObject({ text: 'local' })
     await expect(readDesktopFileDataUrl('/work/file.txt')).resolves.toBe('data:text/plain;base64,bG9jYWw=')
     await expect(desktopGitRoot('/work')).resolves.toBe('/local')
+    await expect(desktopHermesHome()).resolves.toEqual({
+      hermes_home: '/local/hermes',
+      desktop_plugins: '/local/hermes/desktop-plugins'
+    })
     await expect(selectDesktopPaths({ directories: true })).resolves.toEqual(['/local'])
 
     expect(readDir).toHaveBeenCalledWith('/work')
     expect(readFileText).toHaveBeenCalledWith('/work/file.txt')
     expect(readFileDataUrl).toHaveBeenCalledWith('/work/file.txt')
     expect(gitRoot).toHaveBeenCalledWith('/work')
+    expect(getStatus).toHaveBeenCalled()
     expect(selectPaths).toHaveBeenCalledWith({ directories: true })
     expect(api).not.toHaveBeenCalled()
   })
@@ -100,12 +115,17 @@ describe('desktop filesystem facade', () => {
     await expect(readDesktopFileDataUrl('/home/user/project/a b.txt')).resolves.toBe('data:text/plain;base64,cmVtb3Rl')
     await expect(desktopGitRoot('/home/user/project')).resolves.toBe('/remote')
     await expect(desktopDefaultCwd()).resolves.toEqual({ cwd: '/backend/project', branch: 'main' })
+    await expect(desktopHermesHome()).resolves.toEqual({
+      hermes_home: '/remote/hermes',
+      desktop_plugins: '/remote/hermes/desktop-plugins'
+    })
 
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/list?path=%2Fhome%2Fuser%2Fproject' })
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/read-text?path=%2Fhome%2Fuser%2Fproject%2Fa%20b.txt' })
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/read-data-url?path=%2Fhome%2Fuser%2Fproject%2Fa%20b.txt' })
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/git-root?path=%2Fhome%2Fuser%2Fproject' })
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd' })
+    expect(api).toHaveBeenCalledWith({ path: '/api/fs/hermes-home' })
     expect(readDir).not.toHaveBeenCalled()
     expect(readFileText).not.toHaveBeenCalled()
     expect(readFileDataUrl).not.toHaveBeenCalled()

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -4,6 +4,7 @@ import type {
   HermesReadFileTextResult,
   HermesSelectPathsOptions
 } from '@/global'
+import { getStatus } from '@/hermes'
 import { $connection } from '@/store/session'
 
 export interface DesktopFsRemotePicker {
@@ -72,6 +73,25 @@ export async function readDesktopFileText(path: string): Promise<HermesReadFileT
   }
 
   return remoteFsApi<HermesReadFileTextResult>(fsPath('read-text', path))
+}
+
+export interface DesktopHermesHome {
+  hermes_home: string
+  desktop_plugins: string
+}
+
+export async function desktopHermesHome(): Promise<DesktopHermesHome> {
+  if (!isDesktopFsRemoteMode()) {
+    const { hermes_home } = await getStatus()
+
+    if (!hermes_home) {
+      throw new Error('Hermes home is unavailable')
+    }
+
+    return { hermes_home, desktop_plugins: `${hermes_home}/desktop-plugins` }
+  }
+
+  return remoteFsApi<DesktopHermesHome>('/api/fs/hermes-home')
 }
 
 // Save UTF-8 text back to a file. Local writes go through the hardened Electron

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2298,6 +2298,23 @@ async def fs_default_cwd():
     return {"cwd": cwd, "branch": _fs_git_branch(cwd)}
 
 
+@app.get("/api/fs/hermes-home")
+async def fs_hermes_home():
+    """Return the active backend's Hermes home for authenticated desktop clients.
+
+    /api/status intentionally omits host paths when dashboard auth is enabled
+    because it is also the public liveness endpoint. The desktop app still
+    needs the backend HERMES_HOME in remote mode to discover trusted runtime
+    plugins under <HERMES_HOME>/desktop-plugins, so expose just that narrow
+    path pair on an authenticated /api/fs endpoint.
+    """
+    home = get_hermes_home()
+    return {
+        "hermes_home": str(home),
+        "desktop_plugins": str(home / "desktop-plugins"),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Git ops — the remote half of the desktop coding rail + review pane.
 #

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -174,6 +174,19 @@ def test_fs_default_cwd_falls_back_when_terminal_cwd_is_invalid(client, tmp_path
     assert response.json() == {"cwd": str(fallback), "branch": ""}
 
 
+def test_fs_hermes_home_returns_desktop_plugin_path(client, tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: hermes_home)
+
+    response = client.get("/api/fs/hermes-home")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "hermes_home": str(hermes_home),
+        "desktop_plugins": str(hermes_home / "desktop-plugins"),
+    }
+
+
 def test_fs_endpoints_require_auth(tmp_path):
     client = TestClient(web_server.app)
     target = tmp_path / "secret.txt"
@@ -182,7 +195,9 @@ def test_fs_endpoints_require_auth(tmp_path):
     list_response = client.get("/api/fs/list", params={"path": str(tmp_path)})
     read_response = client.get("/api/fs/read-text", params={"path": str(target)})
     default_response = client.get("/api/fs/default-cwd")
+    hermes_home_response = client.get("/api/fs/hermes-home")
 
     assert list_response.status_code == 401
     assert read_response.status_code == 401
     assert default_response.status_code == 401
+    assert hermes_home_response.status_code == 401


### PR DESCRIPTION
# fix(desktop): load runtime plugins from remote backend

## Summary
- add authenticated `/api/fs/hermes-home` endpoint so Desktop can resolve the active backend's `HERMES_HOME` without exposing host paths via public `/api/status`
- route runtime desktop plugin discovery through the remote-aware desktop FS facade (`readDesktopDir`, `readDesktopFileText`)
- avoid local OS reveal/open actions for remote plugin paths; copy the remote path instead
- cover the backend endpoint and Desktop FS remote/local Hermes-home behavior with tests

## Why
In authenticated remote mode, `/api/status` intentionally omits host paths. The Desktop runtime plugin loader still read `status.hermes_home` and then scanned `${hermes_home}/desktop-plugins`, which could become `undefined/desktop-plugins` (or `undefined\\desktop-plugins` on Windows). That prevents thin Desktop clients from loading trusted runtime plugins written into the remote backend's `$HERMES_HOME/desktop-plugins`.

## Test plan
- `PYTHONPATH=/tmp/hermes-test-deps:. python3 -m pytest tests/hermes_cli/test_web_server_fs.py -q`
- `cd apps/desktop && npm run test -- src/lib/desktop-fs.test.ts`
- `cd apps/desktop && npm run typecheck`
- `cd apps/desktop && npx eslint src/contrib/runtime-loader.ts src/app/settings/plugins-settings.tsx src/lib/desktop-fs.ts src/lib/desktop-fs.test.ts`
