### PR TITLE
fix: auto-append /v1 to custom OpenAI-compatible endpoints when missing (#65488)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -770,6 +770,25 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
     return headers
 
 
+def _url_has_versioned_path(url: str) -> bool:
+    """Check if a URL path already includes a version indicator (e.g. /v1, /v2, /v1beta).
+
+    Returns True when any path segment matches the pattern ``v<digit>...``, which
+    covers standard API versioning schemes such as ``/v1/``, ``/api/v1/``,
+    ``/v1beta/``, ``/v2023-01-01/``, etc.  This prevents double-versioning when
+    ``_to_openai_base_url`` is called on already-correct URLs.
+    """
+    parsed = urlparse(url)
+    path = parsed.path.rstrip("/")
+    if not path:
+        return False
+    segments = [s for s in path.split("/") if s]
+    for segment in segments:
+        if segment.startswith("v") and len(segment) > 1 and segment[1].isdigit():
+            return True
+    return False
+
+
 def _to_openai_base_url(base_url: str) -> str:
     """Normalize an Anthropic-style base URL to OpenAI-compatible format.
 
@@ -778,8 +797,16 @@ def _to_openai_base_url(base_url: str) -> str:
     completions.  The auxiliary client uses the OpenAI SDK, so it must hit the
     ``/v1`` surface.  Passing the raw ``inference_base_url`` causes requests to
     land on ``/anthropic/chat/completions`` — a 404.
+
+    For generic OpenAI-compatible endpoints, auto-appends ``/v1`` when the URL
+    path doesn't already include a versioned prefix (e.g. ``http://localhost:8000``
+    is normalized to ``http://localhost:8000/v1``).  This is needed because the
+    OpenAI SDK appends ``/chat/completions`` to the base URL, and standard servers
+    expect ``/v1/chat/completions``.  See GitHub #65488.
     """
     url = str(base_url or "").strip().rstrip("/")
+    if not url:
+        return url
     if url.endswith("/anthropic"):
         # ZAI (open.bigmodel.cn) uses /api/anthropic for Anthropic wire
         # but /api/paas/v4 for OpenAI wire — the generic /v1 rewrite is wrong.
@@ -796,6 +823,13 @@ def _to_openai_base_url(base_url: str) -> str:
         # Without /v1 here, OpenAI SDK hits /coding/chat/completions — a 404.
         rewritten = url + "/v1"
         logger.debug("Auxiliary client: rewrote Kimi base URL %s → %s", url, rewritten)
+        return rewritten
+    # Auto-append /v1 for generic OpenAI-compatible endpoints that omit
+    # the version prefix (e.g., http://localhost:8000 instead of
+    # http://localhost:8000/v1). (#65488)
+    if not _url_has_versioned_path(url):
+        rewritten = url + "/v1"
+        logger.debug("Auxiliary client: auto-appended /v1 to base URL %s → %s", url, rewritten)
         return rewritten
     return url
 
@@ -2573,6 +2607,10 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
         return None, None
     if custom_base.lower().startswith(_CODEX_AUX_BASE_URL.lower()):
         return None, None
+    # Normalize through _to_openai_base_url so a custom endpoint configured
+    # without a /v1 prefix (e.g., http://localhost:8000) is rewritten to
+    # http://localhost:8000/v1 before the OpenAI SDK appends /chat/completions. (#65488)
+    custom_base = _to_openai_base_url(custom_base)
     model = _read_main_model() or "gpt-4o-mini"
     logger.debug("Auxiliary client: custom endpoint (%s, api_mode=%s)", model, custom_mode or "chat_completions")
     _clean_base, _dq = _extract_url_query_params(custom_base)
@@ -4932,7 +4970,7 @@ def resolve_provider_client(
             _main_base = str(main_runtime.get("base_url") or "").strip().rstrip("/")
             _main_key = str(main_runtime.get("api_key") or "").strip()
             if _main_base and _main_key:
-                custom_base = _main_base
+                custom_base = _to_openai_base_url(_main_base)
                 custom_key = _main_key
         if custom_base and custom_key:
             final_model = _normalize_resolved_model(

--- a/tests/agent/test_minimax_auxiliary_url.py
+++ b/tests/agent/test_minimax_auxiliary_url.py
@@ -9,7 +9,60 @@ import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from agent.auxiliary_client import _to_openai_base_url
+from agent.auxiliary_client import _to_openai_base_url, _url_has_versioned_path
+
+
+class TestUrlHasVersionedPath:
+    def test_empty_url(self):
+        assert _url_has_versioned_path("") is False
+
+    def test_no_path(self):
+        assert _url_has_versioned_path("https://example.com") is False
+
+    def test_root_path(self):
+        assert _url_has_versioned_path("https://example.com/") is False
+
+    def test_v1_path(self):
+        assert _url_has_versioned_path("https://example.com/v1") is True
+
+    def test_v1_trailing_slash(self):
+        assert _url_has_versioned_path("https://example.com/v1/") is True
+
+    def test_api_v1_path(self):
+        assert _url_has_versioned_path("https://example.com/api/v1") is True
+
+    def test_v1beta_path(self):
+        assert _url_has_versioned_path("https://example.com/v1beta") is True
+
+    def test_v2023_path(self):
+        assert _url_has_versioned_path("https://example.com/v2023-01-01") is True
+
+    def test_v2_path(self):
+        assert _url_has_versioned_path("https://example.com/v2") is True
+
+    def test_anthropic_path(self):
+        """/anthropic is not a versioned path — contains no digits after 'v'."""
+        assert _url_has_versioned_path("https://api.minimax.io/anthropic") is False
+
+    def test_custom_non_versioned_path(self):
+        """A custom path like /proxy/openai is not versioned."""
+        assert _url_has_versioned_path("https://proxy.example.com/openai") is False
+
+    def test_custom_deep_path(self):
+        """Deep non-versioned path should not match."""
+        assert _url_has_versioned_path("https://example.com/a/b/c") is False
+
+    def test_ip_with_port_no_path(self):
+        assert _url_has_versioned_path("http://192.168.1.1:8000") is False
+
+    def test_ip_with_v1(self):
+        assert _url_has_versioned_path("http://192.168.1.1:8000/v1") is True
+
+    def test_localhost_no_path(self):
+        assert _url_has_versioned_path("http://localhost:8000") is False
+
+    def test_localhost_v1(self):
+        assert _url_has_versioned_path("http://localhost:8000/v1") is True
 
 
 class TestToOpenaiBaseUrl:
@@ -28,12 +81,38 @@ class TestToOpenaiBaseUrl:
     def test_openrouter_url_unchanged(self):
         assert _to_openai_base_url("https://openrouter.ai/api/v1") == "https://openrouter.ai/api/v1"
 
-    def test_anthropic_domain_unchanged(self):
-        """api.anthropic.com doesn't end with /anthropic — should be untouched."""
-        assert _to_openai_base_url("https://api.anthropic.com") == "https://api.anthropic.com"
+    def test_anthropic_domain_v1_appended(self):
+        """api.anthropic.com has no versioned path — /v1 is now appended for OpenAI-wire use."""
+        assert _to_openai_base_url("https://api.anthropic.com") == "https://api.anthropic.com/v1"
 
-    def test_anthropic_in_subpath_unchanged(self):
-        assert _to_openai_base_url("https://example.com/anthropic/extra") == "https://example.com/anthropic/extra"
+    def test_anthropic_in_subpath_v1_appended(self):
+        """URLs with /anthropic as a non-suffix subpath get /v1 appended
+        since they don't end with /anthropic and have no versioned segment."""
+        assert _to_openai_base_url("https://example.com/anthropic/extra") == "https://example.com/anthropic/extra/v1"
+
+    def test_localhost_v1_appended(self):
+        """The canonical fix for #65488: bare localhost gets /v1."""
+        assert _to_openai_base_url("http://localhost:8000") == "http://localhost:8000/v1"
+
+    def test_localhost_v1_present_unchanged(self):
+        assert _to_openai_base_url("http://localhost:8000/v1") == "http://localhost:8000/v1"
+
+    def test_bare_ip_v1_appended(self):
+        assert _to_openai_base_url("http://192.168.1.1:8080") == "http://192.168.1.1:8080/v1"
+
+    def test_bare_ip_with_v1_unchanged(self):
+        assert _to_openai_base_url("http://192.168.1.1:8080/v1") == "http://192.168.1.1:8080/v1"
+
+    def test_deepseek_v1_appended(self):
+        assert _to_openai_base_url("https://api.deepseek.com") == "https://api.deepseek.com/v1"
+
+    def test_groq_v1_appended(self):
+        """Groq uses /openai/v1 — already versioned, so unchanged."""
+        assert _to_openai_base_url("https://api.groq.com/openai/v1") == "https://api.groq.com/openai/v1"
+
+    def test_custom_non_standard_path_unchanged(self):
+        """A path segment starting with 'v' followed by a digit is treated as versioned."""
+        assert _to_openai_base_url("https://proxy.example.com/proxy/v1") == "https://proxy.example.com/proxy/v1"
 
     def test_empty_string(self):
         assert _to_openai_base_url("") == ""


### PR DESCRIPTION
Custom OpenAI-compatible endpoints configured without `/v1` suffix (e.g. `http://localhost:8000` instead of `http://localhost:8000/v1`) now have `/v1` automatically appended, preventing 404 errors on chat calls.\n\n- New helper `_url_has_versioned_path()` detects existing version segments\n- `_to_openai_base_url()` now appends `/v1` when no versioned path is present\n- Both `resolve_provider_client()` and `_try_custom_endpoint()` normalize through this\n\nCloses #65488