### PR TITLE
feat(weixin): web-based QR onboarding + SSL/base_url fixes

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -123,16 +123,34 @@ def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
     When ``certifi`` is installed, use its Mozilla CA bundle to guarantee
     verification. Otherwise fall back to aiohttp's default (which honors
     ``SSL_CERT_FILE`` env var via ``trust_env=True``).
+
+    Note: In aiohttp 3.13+, ``TCPConnector()`` requires a running event loop.
+    If called outside an async context (e.g. during adapter init), this function
+    falls back to returning ``None`` so the caller can create the connector
+    later with ``ssl=_get_ssl_context()`` instead.
+    """
+    ssl_ctx = _get_ssl_context()
+    if ssl_ctx is None or not AIOHTTP_AVAILABLE:
+        return None
+    try:
+        return aiohttp.TCPConnector(ssl=ssl_ctx)
+    except RuntimeError:
+        # No running event loop — caller should use _get_ssl_context() directly
+        return None
+
+
+def _get_ssl_context() -> Optional["ssl.SSLContext"]:
+    """Return an SSLContext with certifi CA bundle, or None if unavailable.
+
+    This is safe to call from any context (sync or async) since it only
+    creates the SSL context, not the aiohttp connector.
     """
     try:
         import ssl
         import certifi
     except ImportError:
         return None
-    if not AIOHTTP_AVAILABLE:
-        return None
-    ssl_ctx = ssl.create_default_context(cafile=certifi.where())
-    return aiohttp.TCPConnector(ssl=ssl_ctx)
+    return ssl.create_default_context(cafile=certifi.where())
 
 ITEM_TEXT = 1
 ITEM_IMAGE = 2
@@ -1077,7 +1095,15 @@ async def qr_login(
             elif status == "scaned_but_redirect":
                 redirect_host = str(status_resp.get("redirect_host") or "")
                 if redirect_host:
-                    current_base_url = f"https://{redirect_host}"
+                    # iLink sometimes returns a redirect_host with the wrong
+                    # domain (e.g. ilinkai.wechat.com instead of
+                    # ilinkai.weixin.qq.com). Always normalise to the canonical
+                    # endpoint to avoid silent session failures.
+                    candidate = f"https://{redirect_host}"
+                    if "ilinkai.weixin.qq.com" in candidate:
+                        current_base_url = candidate
+                    else:
+                        current_base_url = ILINK_BASE_URL
             elif status == "expired":
                 refresh_count += 1
                 if refresh_count > 3:
@@ -1110,7 +1136,13 @@ async def qr_login(
             elif status == "confirmed":
                 account_id = str(status_resp.get("ilink_bot_id") or "")
                 token = str(status_resp.get("bot_token") or "")
-                base_url = str(status_resp.get("baseurl") or ILINK_BASE_URL)
+                # iLink sometimes returns a stale/wrong baseurl (e.g.
+                # ilinkai.wechat.com without the .qq.com suffix) in the QR
+                # confirmation response. Always normalise to the canonical
+                # ILINK_BASE_URL to avoid silent session failures caused by
+                # the wrong domain being saved to .env.
+                raw_base_url = str(status_resp.get("baseurl") or ILINK_BASE_URL)
+                base_url = ILINK_BASE_URL if "ilinkai.weixin.qq.com" not in raw_base_url else raw_base_url
                 user_id = str(status_resp.get("ilink_user_id") or "")
                 if not account_id or not token:
                     logger.error("weixin: QR confirmed but credential payload was incomplete")
@@ -1284,13 +1316,16 @@ class WeixinAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[%s] Token lock unavailable (non-fatal): %s", self.name, exc)
 
-        self._poll_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector())
+        _ssl_ctx = _get_ssl_context()
+        _poll_connector = aiohttp.TCPConnector(ssl=_ssl_ctx) if _ssl_ctx else None
+        self._poll_session = aiohttp.ClientSession(trust_env=True, connector=_poll_connector)
         # Disable aiohttp's built-in ClientTimeout (total=None) to prevent
         # "Timeout context manager should be used inside a task" errors when
         # send() is invoked via asyncio.run_coroutine_threadsafe() from cron.
         # Timeout is managed externally via asyncio.wait_for() in _api_post/_api_get.
         _no_aiohttp_timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=None, sock_read=None)
-        self._send_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector(), timeout=_no_aiohttp_timeout)
+        _send_connector = aiohttp.TCPConnector(ssl=_ssl_ctx) if _ssl_ctx else None
+        self._send_session = aiohttp.ClientSession(trust_env=True, connector=_send_connector, timeout=_no_aiohttp_timeout)
         self._token_store.restore(self._account_id)
         self._poll_task = asyncio.create_task(self._poll_loop(), name="weixin-poll")
         self._mark_connected()

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1099,11 +1099,9 @@ async def qr_login(
                     # domain (e.g. ilinkai.wechat.com instead of
                     # ilinkai.weixin.qq.com). Always normalise to the canonical
                     # endpoint to avoid silent session failures.
+                    from gateway.platforms.weixin_qr_session import _normalise_ilink_base_url
                     candidate = f"https://{redirect_host}"
-                    if "ilinkai.weixin.qq.com" in candidate:
-                        current_base_url = candidate
-                    else:
-                        current_base_url = ILINK_BASE_URL
+                    current_base_url = _normalise_ilink_base_url(candidate)
             elif status == "expired":
                 refresh_count += 1
                 if refresh_count > 3:
@@ -1141,8 +1139,9 @@ async def qr_login(
                 # confirmation response. Always normalise to the canonical
                 # ILINK_BASE_URL to avoid silent session failures caused by
                 # the wrong domain being saved to .env.
+                from gateway.platforms.weixin_qr_session import _normalise_ilink_base_url
                 raw_base_url = str(status_resp.get("baseurl") or ILINK_BASE_URL)
-                base_url = ILINK_BASE_URL if "ilinkai.weixin.qq.com" not in raw_base_url else raw_base_url
+                base_url = _normalise_ilink_base_url(raw_base_url)
                 user_id = str(status_resp.get("ilink_user_id") or "")
                 if not account_id or not token:
                     logger.error("weixin: QR confirmed but credential payload was incomplete")

--- a/gateway/platforms/weixin_qr_session.py
+++ b/gateway/platforms/weixin_qr_session.py
@@ -51,6 +51,7 @@ class WeixinQRSession:
 
     session_id: str
     hermes_home: str
+    profile: str = ""  # Bound at creation; apply must match.
     bot_type: str = "3"
     created_at_ts: float = field(default_factory=time.time)
     expires_at_ts: float = 0.0
@@ -162,6 +163,7 @@ class WeixinQRSessionManager:
         self,
         hermes_home: str,
         *,
+        profile: str = "",
         bot_type: str = "3",
         timeout_seconds: int = DEFAULT_SESSION_TIMEOUT_SECONDS,
     ) -> Dict[str, Any]:
@@ -178,6 +180,7 @@ class WeixinQRSessionManager:
             session = WeixinQRSession(
                 session_id=session_id,
                 hermes_home=hermes_home,
+                profile=profile,
                 bot_type=bot_type,
                 created_at_ts=now,
                 expires_at_ts=now + timeout_seconds,
@@ -232,6 +235,11 @@ class WeixinQRSessionManager:
             if not session or session.state != "confirmed":
                 return None
             return dict(session.credentials) if session.credentials else None
+
+    def get_session(self, session_id: str) -> Optional[WeixinQRSession]:
+        """Return the raw session object (for profile validation on apply)."""
+        with self._lock:
+            return self._sessions.get(session_id)
 
     # ------------------------------------------------------------------
     # Background task implementation
@@ -393,6 +401,13 @@ class WeixinQRSessionManager:
 
         # Render QR as base64 PNG for inline <img> rendering.
         session.qr_image_base64 = _render_qr_png_base64(session.qr_payload)
+        if not session.qr_image_base64:
+            session.state = "failed"
+            session.error_message = (
+                "QR rendering failed — the 'qrcode' package may be missing. "
+                "Install it with: pip install qrcode"
+            )
+            return False
         return True
 
     async def _handle_confirmed(
@@ -416,7 +431,7 @@ class WeixinQRSessionManager:
         # normalise to the canonical ILINK_BASE_URL to avoid silent session
         # failures caused by the wrong domain.
         raw_base_url = str(status_resp.get("baseurl") or ILINK_BASE_URL)
-        base_url = ILINK_BASE_URL if "ilinkai.weixin.qq.com" not in raw_base_url else raw_base_url
+        base_url = _normalise_ilink_base_url(raw_base_url)
         user_id = str(status_resp.get("ilink_user_id") or "")
 
         if not account_id or not token:
@@ -485,3 +500,25 @@ _weixin_qr_sessions = WeixinQRSessionManager()
 def get_weixin_qr_session_manager() -> WeixinQRSessionManager:
     """Return the process-global WeixinQRSessionManager."""
     return _weixin_qr_sessions
+
+
+def _normalise_ilink_base_url(raw_url: str) -> str:
+    """Normalise an iLink base URL to the canonical endpoint.
+
+    iLink sometimes returns ``ilinkai.wechat.com`` (missing ``.qq.com``) or
+    other variant domains.  Parse the URL and require an exact HTTPS hostname
+    match against ``ilinkai.weixin.qq.com`` before retaining a server-provided
+    URL; otherwise fall back to the canonical ``ILINK_BASE_URL``.
+    """
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(raw_url)
+        if (
+            parsed.scheme == "https"
+            and parsed.hostname == "ilinkai.weixin.qq.com"
+        ):
+            return raw_url
+    except Exception:
+        pass
+    return ILINK_BASE_URL

--- a/gateway/platforms/weixin_qr_session.py
+++ b/gateway/platforms/weixin_qr_session.py
@@ -1,0 +1,469 @@
+"""
+Weixin QR login session manager for web-based onboarding.
+
+Mirrors the Telegram onboarding pattern in ``hermes_cli/web_server.py``:
+an in-memory dict of active QR sessions, each backed by a background
+asyncio task that polls Tencent's iLink Bot API for scan status.
+
+The CLI wizard (``gateway/platforms/weixin.py::qr_login``) remains the
+canonical interactive path. This module exposes the same iLink flow as
+start/poll/cancel primitives so the dashboard can render a "Set up with
+QR" button that works entirely in the browser — no TTY required.
+
+Design notes:
+- Sessions are process-global and short-lived (default 8 min).
+- One background task per session polls iLink every ~1s.
+- QR refresh (iLink ``expired`` status) is handled inside the task,
+  up to 3 refreshes — same limit as the CLI wizard.
+- Credentials are saved to ``~/.hermes/weixin/accounts/<id>.json`` via
+  ``save_weixin_account`` on confirmation, matching the CLI path.
+- The web layer (``web_server.py``) is responsible for additionally
+  writing ``WEIXIN_ACCOUNT_ID`` / ``WEIXIN_TOKEN`` / ``WEIXIN_BASE_URL``
+  to ``.env`` and toggling ``platforms.weixin.enabled`` in config.yaml
+  — see ``apply_weixin_onboarding``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import logging
+import secrets
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Session lifetime — matches the CLI wizard default (480s).
+DEFAULT_SESSION_TIMEOUT_SECONDS = 480
+# Poll interval for iLink status checks.
+_POLL_INTERVAL_SECONDS = 1.0
+# Max QR refreshes before giving up (matches CLI wizard).
+_MAX_QR_REFRESHES = 3
+
+
+@dataclass
+class WeixinQRSession:
+    """In-memory state for a single QR login session."""
+
+    session_id: str
+    hermes_home: str
+    bot_type: str = "3"
+    created_at_ts: float = field(default_factory=time.time)
+    expires_at_ts: float = 0.0
+    # Mutable state updated by the background task.
+    state: str = "starting"  # starting | waiting | scanned | confirmed | failed | expired | cancelled
+    qr_payload: str = ""  # The scannable liteapp URL (preferred) or hex token.
+    qr_image_base64: str = ""  # PNG base64 for <img src="data:image/png;base64,..."> rendering.
+    error_message: str = ""
+    # Populated on confirmed.
+    credentials: Optional[Dict[str, str]] = None
+    # Internal — the background task handle.
+    _task: Optional[asyncio.Task] = None
+    _qrcode_value: str = ""  # Hex token used for status polling.
+    _current_base_url: str = ""  # May change on scaned_but_redirect.
+    _refresh_count: int = 0
+    _aiohttp_session: Any = None  # aiohttp.ClientSession, owned by the task.
+
+    @property
+    def expires_at_iso(self) -> str:
+        return time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ", time.gmtime(self.expires_at_ts)
+        )
+
+    def to_status_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable status snapshot for the polling endpoint."""
+        payload: Dict[str, Any] = {
+            "session_id": self.session_id,
+            "state": self.state,
+            "expires_at": self.expires_at_iso,
+        }
+        if self.qr_image_base64 and self.state in {"waiting", "scanned"}:
+            payload["qr_image_base64"] = self.qr_image_base64
+        if self.error_message:
+            payload["error"] = self.error_message
+        if self.credentials and self.state == "confirmed":
+            # Only expose non-secret fields to the browser. The token itself
+            # is saved server-side; the dashboard just needs to know it worked.
+            payload["account_id"] = self.credentials.get("account_id", "")
+            payload["base_url"] = self.credentials.get("base_url", "")
+        return payload
+
+
+class WeixinQRSessionManager:
+    """Process-global manager for concurrent Weixin QR login sessions.
+
+    Thread-safe for start/get/cancel from sync web handlers; the poll loop
+    itself runs on the dashboard's asyncio event loop.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, WeixinQRSession] = {}
+        self._lock = threading.RLock()
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    def set_event_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Bind the manager to the dashboard's event loop.
+
+        Called once at web_server startup. The poll tasks are scheduled on
+        this loop via ``asyncio.run_coroutine_threadsafe`` from the sync
+        ``start_session`` entry point.
+        """
+        self._loop = loop
+
+    def _get_loop(self) -> asyncio.AbstractEventLoop:
+        if self._loop is not None:
+            return self._loop
+        try:
+            return asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            return loop
+
+    def _prune_expired(self) -> None:
+        """Evict expired sessions. Caller must hold ``self._lock``."""
+        now = time.time()
+        expired = [
+            sid
+            for sid, session in self._sessions.items()
+            if session.expires_at_ts <= now and session.state not in {
+                "confirmed",
+                "failed",
+                "expired",
+                "cancelled",
+            }
+        ]
+        for sid in expired:
+            session = self._sessions.pop(sid, None)
+            if session and session._task and not session._task.done():
+                session._task.cancel()
+
+    def start_session(
+        self,
+        hermes_home: str,
+        *,
+        bot_type: str = "3",
+        timeout_seconds: int = DEFAULT_SESSION_TIMEOUT_SECONDS,
+    ) -> Dict[str, Any]:
+        """Start a new QR login session.
+
+        Returns the initial status dict (state="starting"). The caller
+        should poll ``get_status`` until state transitions to ``waiting``
+        (QR ready to scan) or ``failed``.
+        """
+        with self._lock:
+            self._prune_expired()
+            session_id = uuid.uuid4().hex
+            now = time.time()
+            session = WeixinQRSession(
+                session_id=session_id,
+                hermes_home=hermes_home,
+                bot_type=bot_type,
+                created_at_ts=now,
+                expires_at_ts=now + timeout_seconds,
+            )
+            self._sessions[session_id] = session
+
+        # Schedule the background poll task on the dashboard event loop.
+        loop = self._get_loop()
+        future = asyncio.run_coroutine_threadsafe(
+            self._run_session(session), loop
+        )
+        # Stash the task so cancel() can abort it. We can't get the actual
+        # asyncio.Task from run_coroutine_threadsafe, but the future is enough
+        # for cancellation via future.cancel().
+        session._task = future  # type: ignore[assignment]
+
+        return session.to_status_dict()
+
+    def get_status(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Return the current status of a session, or None if not found."""
+        with self._lock:
+            self._prune_expired()
+            session = self._sessions.get(session_id)
+            if not session:
+                return None
+            return session.to_status_dict()
+
+    def cancel_session(self, session_id: str) -> bool:
+        """Cancel a session. Returns True if a session was found and cancelled."""
+        with self._lock:
+            session = self._sessions.pop(session_id, None)
+        if not session:
+            return False
+        session.state = "cancelled"
+        task = session._task
+        if task is not None and not task.done():
+            try:
+                task.cancel()
+            except Exception:
+                pass
+        return True
+
+    def get_credentials(self, session_id: str) -> Optional[Dict[str, str]]:
+        """Return confirmed credentials for a session, or None.
+
+        Used by the apply endpoint to retrieve the token before saving
+        to .env. The session is NOT removed here — the caller removes it
+        via ``cancel_session`` after a successful apply.
+        """
+        with self._lock:
+            session = self._sessions.get(session_id)
+            if not session or session.state != "confirmed":
+                return None
+            return dict(session.credentials) if session.credentials else None
+
+    # ------------------------------------------------------------------
+    # Background task implementation
+    # ------------------------------------------------------------------
+
+    async def _run_session(self, session: WeixinQRSession) -> None:
+        """Background coroutine: fetch QR, poll for scan, save credentials."""
+        try:
+            from gateway.platforms.weixin import (
+                AIOHTTP_AVAILABLE,
+                ILINK_BASE_URL,
+                EP_GET_BOT_QR,
+                EP_GET_QR_STATUS,
+                QR_TIMEOUT_MS,
+                _api_get,
+                _make_ssl_connector,
+                _get_ssl_context,
+                save_weixin_account,
+            )
+
+            if not AIOHTTP_AVAILABLE:
+                session.state = "failed"
+                session.error_message = "aiohttp is required for Weixin QR login"
+                return
+
+            import aiohttp
+
+            connector = _make_ssl_connector()
+            ssl_ctx = _get_ssl_context() if connector is None else None
+            session_kwargs = {"trust_env": True}
+            if connector is not None:
+                session_kwargs["connector"] = connector
+            elif ssl_ctx is not None:
+                session_kwargs["ssl"] = ssl_ctx
+            async with aiohttp.ClientSession(**session_kwargs) as aiohttp_session:
+                session._aiohttp_session = aiohttp_session
+                session._current_base_url = ILINK_BASE_URL
+
+                # ── Initial QR fetch ────────────────────────────────────
+                if not await self._fetch_qr(session, aiohttp_session):
+                    return  # _fetch_qr sets state=failed on error
+
+                session.state = "waiting"
+
+                # ── Poll loop ───────────────────────────────────────────
+                deadline = session.expires_at_ts
+                while time.time() < deadline:
+                    if session.state == "cancelled":
+                        return
+                    await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+                    if session.state == "cancelled":
+                        return
+
+                    try:
+                        status_resp = await _api_get(
+                            aiohttp_session,
+                            base_url=session._current_base_url,
+                            endpoint=f"{EP_GET_QR_STATUS}?qrcode={session._qrcode_value}",
+                            timeout_ms=QR_TIMEOUT_MS,
+                        )
+                    except asyncio.TimeoutError:
+                        continue
+                    except Exception as exc:
+                        logger.warning("weixin QR session %s: poll error: %s", session.session_id, exc)
+                        continue
+
+                    status = str(status_resp.get("status") or "wait")
+                    if status == "wait":
+                        # Stay in waiting; QR still valid.
+                        if session.state != "waiting":
+                            session.state = "waiting"
+                    elif status == "scaned":
+                        session.state = "scanned"
+                    elif status == "scaned_but_redirect":
+                        redirect_host = str(status_resp.get("redirect_host") or "")
+                        if redirect_host:
+                            # Normalise: iLink sometimes redirects to
+                            # ilinkai.wechat.com (missing .qq.com).  Always
+                            # force the canonical domain so the token is
+                            # issued against the correct endpoint.
+                            if "ilinkai.weixin.qq.com" not in redirect_host:
+                                redirect_host = "ilinkai.weixin.qq.com"
+                            session._current_base_url = f"https://{redirect_host}"
+                        # Stay in scanned state until confirmed.
+                    elif status == "expired":
+                        session._refresh_count += 1
+                        if session._refresh_count > _MAX_QR_REFRESHES:
+                            session.state = "expired"
+                            session.error_message = "QR code expired after multiple refreshes. Start a new setup."
+                            return
+                        # Refresh: fetch a new QR, stay in waiting.
+                        if not await self._fetch_qr(session, aiohttp_session):
+                            return
+                        session.state = "waiting"
+                    elif status == "confirmed":
+                        await self._handle_confirmed(session, status_resp)
+                        return
+                    else:
+                        logger.warning(
+                            "weixin QR session %s: unknown status %r",
+                            session.session_id,
+                            status,
+                        )
+
+                # Deadline reached.
+                if session.state not in {"confirmed", "cancelled"}:
+                    session.state = "expired"
+                    session.error_message = "QR login timed out. Start a new setup."
+
+        except asyncio.CancelledError:
+            # Graceful cancellation from cancel_session().
+            if session.state != "cancelled":
+                session.state = "cancelled"
+        except Exception as exc:
+            logger.exception("weixin QR session %s: unexpected error", session.session_id)
+            session.state = "failed"
+            session.error_message = f"Unexpected error: {exc}"
+
+    async def _fetch_qr(
+        self, session: WeixinQRSession, aiohttp_session: Any
+    ) -> bool:
+        """Fetch a fresh QR from iLink and update session state.
+
+        Returns True on success, False on failure (session.state set to failed).
+        """
+        try:
+            from gateway.platforms.weixin import (
+                ILINK_BASE_URL,
+                EP_GET_BOT_QR,
+                QR_TIMEOUT_MS,
+                _api_get,
+            )
+
+            qr_resp = await _api_get(
+                aiohttp_session,
+                base_url=ILINK_BASE_URL,
+                endpoint=f"{EP_GET_BOT_QR}?bot_type={session.bot_type}",
+                timeout_ms=QR_TIMEOUT_MS,
+            )
+        except Exception as exc:
+            logger.error("weixin QR session %s: failed to fetch QR: %s", session.session_id, exc)
+            session.state = "failed"
+            session.error_message = f"Failed to fetch QR code from iLink: {exc}"
+            return False
+
+        qrcode_value = str(qr_resp.get("qrcode") or "")
+        qrcode_url = str(qr_resp.get("qrcode_img_content") or "")
+        if not qrcode_value:
+            session.state = "failed"
+            session.error_message = "iLink returned an empty QR code."
+            return False
+
+        session._qrcode_value = qrcode_value
+        # WeChat must scan the full liteapp URL, not the raw hex token.
+        session.qr_payload = qrcode_url if qrcode_url else qrcode_value
+
+        # Render QR as base64 PNG for inline <img> rendering.
+        session.qr_image_base64 = _render_qr_png_base64(session.qr_payload)
+        return True
+
+    async def _handle_confirmed(
+        self, session: WeixinQRSession, status_resp: Dict[str, Any]
+    ) -> None:
+        """Extract credentials from confirmed status and save to disk."""
+        try:
+            from gateway.platforms.weixin import (
+                ILINK_BASE_URL,
+                save_weixin_account,
+            )
+        except ImportError as exc:
+            session.state = "failed"
+            session.error_message = f"Failed to import weixin adapter: {exc}"
+            return
+
+        account_id = str(status_resp.get("ilink_bot_id") or "")
+        token = str(status_resp.get("bot_token") or "")
+        # iLink sometimes returns a stale/wrong baseurl (e.g. ilinkai.wechat.com
+        # without the .qq.com suffix) in the QR confirmation response.  Always
+        # normalise to the canonical ILINK_BASE_URL to avoid silent session
+        # failures caused by the wrong domain.
+        raw_base_url = str(status_resp.get("baseurl") or ILINK_BASE_URL)
+        base_url = ILINK_BASE_URL if "ilinkai.weixin.qq.com" not in raw_base_url else raw_base_url
+        user_id = str(status_resp.get("ilink_user_id") or "")
+
+        if not account_id or not token:
+            session.state = "failed"
+            session.error_message = "QR confirmed but credential payload was incomplete."
+            return
+
+        # Save to ~/.hermes/weixin/accounts/<account_id>.json (same path as CLI wizard).
+        try:
+            save_weixin_account(
+                session.hermes_home,
+                account_id=account_id,
+                token=token,
+                base_url=base_url,
+                user_id=user_id,
+            )
+        except Exception as exc:
+            session.state = "failed"
+            session.error_message = f"Failed to save WeChat credentials: {exc}"
+            return
+
+        session.credentials = {
+            "account_id": account_id,
+            "token": token,
+            "base_url": base_url,
+            "user_id": user_id,
+        }
+        session.state = "confirmed"
+        logger.info(
+            "weixin QR session %s: confirmed account_id=%s",
+            session.session_id,
+            account_id,
+        )
+
+
+def _render_qr_png_base64(data: str) -> str:
+    """Render a QR code as a base64-encoded PNG string.
+
+    Falls back to empty string if the ``qrcode`` package is unavailable.
+    The frontend will then display the raw URL as a fallback link.
+    """
+    try:
+        import qrcode
+
+        qr = qrcode.QRCode(
+            version=None,
+            error_correction=qrcode.constants.ERROR_CORRECT_M,
+            box_size=8,
+            border=2,
+        )
+        qr.add_data(data)
+        qr.make(fit=True)
+        img = qr.make_image(fill_color="black", back_color="white")
+        buffer = io.BytesIO()
+        img.save(buffer, format="PNG")
+        return base64.b64encode(buffer.getvalue()).decode("ascii")
+    except Exception as exc:
+        logger.warning("weixin QR: failed to render PNG: %s", exc)
+        return ""
+
+
+# Process-global singleton, mirroring _telegram_onboarding_pairings.
+_weixin_qr_sessions = WeixinQRSessionManager()
+
+
+def get_weixin_qr_session_manager() -> WeixinQRSessionManager:
+    """Return the process-global WeixinQRSessionManager."""
+    return _weixin_qr_sessions

--- a/gateway/platforms/weixin_qr_session.py
+++ b/gateway/platforms/weixin_qr_session.py
@@ -29,7 +29,6 @@ import asyncio
 import base64
 import io
 import logging
-import secrets
 import threading
 import time
 import uuid
@@ -126,8 +125,11 @@ class WeixinQRSessionManager:
             return loop
 
     def _prune_expired(self) -> None:
-        """Evict expired sessions. Caller must hold ``self._lock``."""
+        """Evict expired and stale terminal sessions. Caller must hold ``self._lock``."""
         now = time.time()
+        # Sessions still in a non-terminal state whose deadline has passed.
+        # The background task may still be running — cancel it so it doesn't
+        # race with eviction.
         expired = [
             sid
             for sid, session in self._sessions.items()
@@ -142,6 +144,19 @@ class WeixinQRSessionManager:
             session = self._sessions.pop(sid, None)
             if session and session._task and not session._task.done():
                 session._task.cancel()
+
+        # Evict terminal sessions after a 5-minute retention window so the
+        # UI has time to display the final state (confirmed/failed/expired/
+        # cancelled) before the session is garbage-collected.
+        _TERMINAL_RETENTION = 300  # seconds
+        stale_terminal = [
+            sid
+            for sid, session in self._sessions.items()
+            if session.state in {"confirmed", "failed", "expired", "cancelled"}
+            and session.expires_at_ts + _TERMINAL_RETENTION <= now
+        ]
+        for sid in stale_terminal:
+            self._sessions.pop(sid, None)
 
     def start_session(
         self,
@@ -245,12 +260,15 @@ class WeixinQRSessionManager:
             import aiohttp
 
             connector = _make_ssl_connector()
-            ssl_ctx = _get_ssl_context() if connector is None else None
+            if connector is None:
+                # _make_ssl_connector() returns None when called outside an
+                # event loop (aiohttp 3.13+). Build a TCPConnector from the
+                # pre-built SSL context instead.
+                ssl_ctx = _get_ssl_context()
+                connector = aiohttp.TCPConnector(ssl=ssl_ctx) if ssl_ctx else None
             session_kwargs = {"trust_env": True}
             if connector is not None:
                 session_kwargs["connector"] = connector
-            elif ssl_ctx is not None:
-                session_kwargs["ssl"] = ssl_ctx
             async with aiohttp.ClientSession(**session_kwargs) as aiohttp_session:
                 session._aiohttp_session = aiohttp_session
                 session._current_base_url = ILINK_BASE_URL
@@ -438,7 +456,7 @@ def _render_qr_png_base64(data: str) -> str:
     """Render a QR code as a base64-encoded PNG string.
 
     Falls back to empty string if the ``qrcode`` package is unavailable.
-    The frontend will then display the raw URL as a fallback link.
+    The frontend will show an error message in that case.
     """
     try:
         import qrcode

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5589,8 +5589,8 @@ def _setup_weixin():
     if base_url:
         # Defensive: ensure the base URL is always the canonical iLink
         # endpoint, even if the QR session somehow captured a stale one.
-        if "ilinkai.weixin.qq.com" not in base_url:
-            base_url = "https://ilinkai.weixin.qq.com"
+        from gateway.platforms.weixin_qr_session import _normalise_ilink_base_url
+        base_url = _normalise_ilink_base_url(base_url)
         save_env_value("WEIXIN_BASE_URL", base_url)
     save_env_value(
         "WEIXIN_CDN_BASE_URL",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5587,6 +5587,10 @@ def _setup_weixin():
     save_env_value("WEIXIN_ACCOUNT_ID", account_id)
     save_env_value("WEIXIN_TOKEN", token)
     if base_url:
+        # Defensive: ensure the base URL is always the canonical iLink
+        # endpoint, even if the QR session somehow captured a stale one.
+        if "ilinkai.weixin.qq.com" not in base_url:
+            base_url = "https://ilinkai.weixin.qq.com"
         save_env_value("WEIXIN_BASE_URL", base_url)
     save_env_value(
         "WEIXIN_CDN_BASE_URL",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8107,7 +8107,7 @@ async def start_weixin_onboarding(body: WeixinOnboardingStart, profile: Optional
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     manager = _weixin_qr_manager()
-    return manager.start_session(hermes_home)
+    return manager.start_session(hermes_home, profile=effective_profile or "")
 
 
 @app.get("/api/messaging/weixin/onboarding/{session_id}/status")
@@ -8148,15 +8148,26 @@ async def apply_weixin_onboarding(
         )
 
     effective_profile = body.profile or profile
+
+    # Reject profile mismatch: the session was started under a specific
+    # profile, and applying under a different one would write credentials
+    # to the wrong profile's .env/config.
+    session = manager.get_session(session_id)
+    if session and session.profile and effective_profile and session.profile != effective_profile:
+        raise HTTPException(
+            status_code=409,
+            detail="The management profile changed since the QR session was started. "
+            "Please cancel and start a new setup under the correct profile.",
+        )
+
     try:
         with _profile_scope(effective_profile):
             save_env_value("WEIXIN_ACCOUNT_ID", credentials["account_id"])
             save_env_value("WEIXIN_TOKEN", credentials["token"])
             # Defensive: ensure the base URL is always the canonical iLink
             # endpoint, even if the QR session somehow captured a stale one.
-            base_url = credentials["base_url"]
-            if "ilinkai.weixin.qq.com" not in base_url:
-                base_url = "https://ilinkai.weixin.qq.com"
+            from gateway.platforms.weixin_qr_session import _normalise_ilink_base_url
+            base_url = _normalise_ilink_base_url(credentials["base_url"])
             save_env_value("WEIXIN_BASE_URL", base_url)
             _write_platform_enabled("weixin", True)
     except HTTPException:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -914,6 +914,12 @@ class WhatsAppOnboardingStart(BaseModel):
 class WhatsAppOnboardingApply(BaseModel):
     mode: Optional[str] = None
     allowed_users: Optional[str] = None
+
+class WeixinOnboardingStart(BaseModel):
+    profile: Optional[str] = None
+
+
+class WeixinOnboardingApply(BaseModel):
     profile: Optional[str] = None
 
 
@@ -8064,6 +8070,125 @@ async def apply_telegram_onboarding(
 async def cancel_telegram_onboarding(pairing_id: str):
     with _telegram_onboarding_lock:
         _telegram_onboarding_pairings.pop(pairing_id, None)
+    return {"ok": True}
+
+
+# =============================================================================
+# Weixin (WeChat personal) QR onboarding — mirrors Telegram onboarding shape
+# =============================================================================
+
+def _weixin_qr_manager():
+    """Lazy import + bind to the dashboard event loop on first use."""
+    from gateway.platforms.weixin_qr_session import get_weixin_qr_session_manager
+
+    manager = get_weixin_qr_session_manager()
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            manager.set_event_loop(loop)
+    except RuntimeError:
+        pass
+    return manager
+
+
+@app.post("/api/messaging/weixin/onboarding/start")
+async def start_weixin_onboarding(body: WeixinOnboardingStart, profile: Optional[str] = None):
+    """Start a Weixin QR login session.
+
+    Returns ``{session_id, state, expires_at}`` with ``state="starting"``.
+    The frontend polls ``/status`` until ``state`` transitions to
+    ``waiting`` (QR ready), ``confirmed`` (scan complete), or ``failed``.
+    """
+    effective_profile = body.profile or profile
+    try:
+        with _profile_scope(effective_profile):
+            hermes_home = str(get_hermes_home())
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    manager = _weixin_qr_manager()
+    return manager.start_session(hermes_home)
+
+
+@app.get("/api/messaging/weixin/onboarding/{session_id}/status")
+async def get_weixin_onboarding_status(session_id: str):
+    """Poll a Weixin QR login session.
+
+    Returns ``{session_id, state, expires_at, qr_image_base64?, error?, account_id?, base_url?}``.
+    ``qr_image_base64`` is present when ``state`` is ``waiting`` or ``scanned``
+    and contains a base64-encoded PNG suitable for ``<img src="data:image/png;base64,...">``.
+    """
+    manager = _weixin_qr_manager()
+    status = manager.get_status(session_id)
+    if status is None:
+        raise HTTPException(
+            status_code=404,
+            detail="WeChat setup session was not found. Start a new setup.",
+        )
+    return status
+
+
+@app.post("/api/messaging/weixin/onboarding/{session_id}/apply")
+async def apply_weixin_onboarding(
+    session_id: str, body: WeixinOnboardingApply, profile: Optional[str] = None
+):
+    """Save confirmed Weixin credentials to .env and enable the platform.
+
+    Called by the frontend after ``status`` returns ``state="confirmed"``.
+    Writes ``WEIXIN_ACCOUNT_ID``, ``WEIXIN_TOKEN``, ``WEIXIN_BASE_URL`` to
+    ``.env``, sets ``platforms.weixin.enabled: true`` in config.yaml, and
+    triggers a gateway restart — mirroring ``apply_telegram_onboarding``.
+    """
+    manager = _weixin_qr_manager()
+    credentials = manager.get_credentials(session_id)
+    if not credentials:
+        raise HTTPException(
+            status_code=409,
+            detail="WeChat setup is not ready yet. Scan the QR code first.",
+        )
+
+    effective_profile = body.profile or profile
+    try:
+        with _profile_scope(effective_profile):
+            save_env_value("WEIXIN_ACCOUNT_ID", credentials["account_id"])
+            save_env_value("WEIXIN_TOKEN", credentials["token"])
+            # Defensive: ensure the base URL is always the canonical iLink
+            # endpoint, even if the QR session somehow captured a stale one.
+            base_url = credentials["base_url"]
+            if "ilinkai.weixin.qq.com" not in base_url:
+                base_url = "https://ilinkai.weixin.qq.com"
+            save_env_value("WEIXIN_BASE_URL", base_url)
+            _write_platform_enabled("weixin", True)
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        _log.exception("Weixin onboarding apply failed")
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to save WeChat setup.",
+        ) from exc
+
+    # Remove the session now that credentials are persisted.
+    manager.cancel_session(session_id)
+
+    restart_result = _restart_gateway_after_telegram_onboarding(effective_profile)
+
+    return {
+        "ok": True,
+        "platform": "weixin",
+        "account_id": credentials["account_id"],
+        "needs_restart": not restart_result["restart_started"],
+        **restart_result,
+    }
+
+
+@app.delete("/api/messaging/weixin/onboarding/{session_id}")
+async def cancel_weixin_onboarding(session_id: str):
+    """Cancel a Weixin QR login session."""
+    manager = _weixin_qr_manager()
+    manager.cancel_session(session_id)
     return {"ok": True}
 
 

--- a/tests/gateway/test_weixin_qr_session.py
+++ b/tests/gateway/test_weixin_qr_session.py
@@ -1,0 +1,305 @@
+"""Tests for the Weixin QR session manager (web-based onboarding).
+
+Tests the session lifecycle: start → poll → confirm, plus timeout,
+cancellation, and concurrent session handling. Mirrors the patterns
+from ``TestWeixinQrLogin`` in ``tests/gateway/test_weixin.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.platforms.weixin_qr_session import (
+    DEFAULT_SESSION_TIMEOUT_SECONDS,
+    WeixinQRSession,
+    WeixinQRSessionManager,
+    _render_qr_png_base64,
+)
+
+
+def _make_qr_response(qrcode: str = "qr-1", url: str = "https://example.com/qr-1"):
+    return {"qrcode": qrcode, "qrcode_img_content": url}
+
+
+def _make_confirmed_response(
+    account_id: str = "acc-1",
+    token: str = "tok-1",
+    base_url: str = "https://ilinkai.weixin.qq.com",
+    user_id: str = "user-1",
+):
+    return {
+        "status": "confirmed",
+        "ilink_bot_id": account_id,
+        "bot_token": token,
+        "baseurl": base_url,
+        "ilink_user_id": user_id,
+    }
+
+
+class TestWeixinQRSessionManagerLifecycle:
+    """Start → poll → confirm happy path."""
+
+    @pytest.mark.asyncio
+    async def test_start_session_returns_starting_state(self, tmp_path):
+        manager = WeixinQRSessionManager()
+        manager.set_event_loop(asyncio.get_event_loop())
+
+        with patch(
+            "gateway.platforms.weixin_qr_session.WeixinQRSessionManager._run_session",
+            new_callable=AsyncMock,
+        ):
+            result = manager.start_session(str(tmp_path))
+
+        assert result["state"] == "starting"
+        assert "session_id" in result
+        assert "expires_at" in result
+
+    @pytest.mark.asyncio
+    async def test_get_status_returns_none_for_unknown_session(self, tmp_path):
+        manager = WeixinQRSessionManager()
+        assert manager.get_status("nonexistent") is None
+
+    @pytest.mark.asyncio
+    async def test_cancel_session_removes_it(self, tmp_path):
+        manager = WeixinQRSessionManager()
+        manager.set_event_loop(asyncio.get_event_loop())
+
+        with patch(
+            "gateway.platforms.weixin_qr_session.WeixinQRSessionManager._run_session",
+            new_callable=AsyncMock,
+        ):
+            result = manager.start_session(str(tmp_path))
+            session_id = result["session_id"]
+
+        assert manager.cancel_session(session_id) is True
+        assert manager.get_status(session_id) is None
+
+    @pytest.mark.asyncio
+    async def test_cancel_unknown_session_returns_false(self, tmp_path):
+        manager = WeixinQRSessionManager()
+        assert manager.cancel_session("nonexistent") is False
+
+
+class TestWeixinQRSessionManagerBackgroundTask:
+    """Test the background poll task with mocked iLink API."""
+
+    @pytest.mark.asyncio
+    async def test_confirmed_flow_saves_credentials(self, tmp_path):
+        """QR fetch → wait → confirmed → credentials saved."""
+        manager = WeixinQRSessionManager()
+        manager.set_event_loop(asyncio.get_event_loop())
+
+        qr_response = _make_qr_response()
+        confirmed_response = _make_confirmed_response()
+
+        saved_calls = []
+
+        def fake_save(hermes_home, *, account_id, token, base_url, user_id=""):
+            saved_calls.append(
+                {
+                    "hermes_home": hermes_home,
+                    "account_id": account_id,
+                    "token": token,
+                    "base_url": base_url,
+                    "user_id": user_id,
+                }
+            )
+
+        with patch(
+            "gateway.platforms.weixin._api_get", new_callable=AsyncMock
+        ) as api_get_mock, \
+             patch("gateway.platforms.weixin.AIOHTTP_AVAILABLE", True), \
+             patch("gateway.platforms.weixin.aiohttp.ClientSession", create=True) as session_cls, \
+             patch("gateway.platforms.weixin.save_weixin_account", side_effect=fake_save), \
+             patch("gateway.platforms.weixin_qr_session._POLL_INTERVAL_SECONDS", 0.01):
+            api_get_mock.side_effect = [qr_response, confirmed_response]
+            session = AsyncMock()
+            session.__aenter__.return_value = session
+            session.__aexit__.return_value = False
+            session_cls.return_value = session
+
+            result = manager.start_session(str(tmp_path), timeout_seconds=30)
+            session_id = result["session_id"]
+
+            # Wait for the background task to complete.
+            await asyncio.sleep(0.5)
+
+        status = manager.get_status(session_id)
+        assert status is not None
+        assert status["state"] == "confirmed"
+        assert status["account_id"] == "acc-1"
+        assert status["base_url"] == "https://ilinkai.weixin.qq.com"
+
+        # Verify credentials were saved to disk.
+        assert len(saved_calls) == 1
+        assert saved_calls[0]["account_id"] == "acc-1"
+        assert saved_calls[0]["token"] == "tok-1"
+
+    @pytest.mark.asyncio
+    async def test_failed_qr_fetch_sets_failed_state(self, tmp_path):
+        """If iLink returns an error, session state becomes 'failed'."""
+        manager = WeixinQRSessionManager()
+        manager.set_event_loop(asyncio.get_event_loop())
+
+        with patch(
+            "gateway.platforms.weixin._api_get", new_callable=AsyncMock
+        ) as api_get_mock, \
+             patch("gateway.platforms.weixin.AIOHTTP_AVAILABLE", True), \
+             patch("gateway.platforms.weixin.aiohttp.ClientSession", create=True) as session_cls:
+            api_get_mock.side_effect = RuntimeError("iLink HTTP 500")
+            session = AsyncMock()
+            session.__aenter__.return_value = session
+            session.__aexit__.return_value = False
+            session_cls.return_value = session
+
+            result = manager.start_session(str(tmp_path), timeout_seconds=30)
+            session_id = result["session_id"]
+
+            await asyncio.sleep(0.3)
+
+        status = manager.get_status(session_id)
+        assert status is not None
+        assert status["state"] == "failed"
+        assert "Failed to fetch QR" in status.get("error", "")
+
+    @pytest.mark.asyncio
+    async def test_expired_status_triggers_refresh(self, tmp_path):
+        """When iLink returns 'expired', the session refreshes the QR."""
+        manager = WeixinQRSessionManager()
+        manager.set_event_loop(asyncio.get_event_loop())
+
+        first_qr = _make_qr_response("qr-1", "https://example.com/qr-1")
+        expired = {"status": "expired"}
+        refreshed_qr = _make_qr_response("qr-2", "https://example.com/qr-2")
+        confirmed = _make_confirmed_response()
+
+        with patch(
+            "gateway.platforms.weixin._api_get", new_callable=AsyncMock
+        ) as api_get_mock, \
+             patch("gateway.platforms.weixin.AIOHTTP_AVAILABLE", True), \
+             patch("gateway.platforms.weixin.aiohttp.ClientSession", create=True) as session_cls, \
+             patch("gateway.platforms.weixin.save_weixin_account"), \
+             patch("gateway.platforms.weixin_qr_session._POLL_INTERVAL_SECONDS", 0.01):
+            # QR fetch, then expired, then refresh QR fetch, then confirmed.
+            api_get_mock.side_effect = [first_qr, expired, refreshed_qr, confirmed]
+            session = AsyncMock()
+            session.__aenter__.return_value = session
+            session.__aexit__.return_value = False
+            session_cls.return_value = session
+
+            result = manager.start_session(str(tmp_path), timeout_seconds=30)
+            session_id = result["session_id"]
+
+            await asyncio.sleep(0.5)
+
+        status = manager.get_status(session_id)
+        assert status is not None
+        assert status["state"] == "confirmed"
+
+    @pytest.mark.asyncio
+    async def test_max_refreshes_exceeded_sets_expired_state(self, tmp_path):
+        """After 3 refreshes, the session gives up with 'expired' state."""
+        manager = WeixinQRSessionManager()
+        manager.set_event_loop(asyncio.get_event_loop())
+
+        qr = _make_qr_response()
+        expired = {"status": "expired"}
+
+        with patch(
+            "gateway.platforms.weixin._api_get", new_callable=AsyncMock
+        ) as api_get_mock, \
+             patch("gateway.platforms.weixin.AIOHTTP_AVAILABLE", True), \
+             patch("gateway.platforms.weixin.aiohttp.ClientSession", create=True) as session_cls, \
+             patch("gateway.platforms.weixin_qr_session._POLL_INTERVAL_SECONDS", 0.01), \
+             patch("gateway.platforms.weixin_qr_session._MAX_QR_REFRESHES", 2):
+            # Initial fetch, then expired×2 (refreshes), then expired again (gives up).
+            api_get_mock.side_effect = [qr, expired, qr, expired, qr, expired]
+            session = AsyncMock()
+            session.__aenter__.return_value = session
+            session.__aexit__.return_value = False
+            session_cls.return_value = session
+
+            result = manager.start_session(str(tmp_path), timeout_seconds=30)
+            session_id = result["session_id"]
+
+            await asyncio.sleep(0.5)
+
+        status = manager.get_status(session_id)
+        assert status is not None
+        assert status["state"] == "expired"
+
+
+class TestWeixinQRSessionStatusDict:
+    """Test the to_status_dict serialization."""
+
+    def test_status_dict_includes_required_fields(self):
+        session = WeixinQRSession(
+            session_id="test-1",
+            hermes_home="/tmp",
+            expires_at_ts=time.time() + 300,
+        )
+        session.state = "waiting"
+        session.qr_image_base64 = "base64data"
+
+        result = session.to_status_dict()
+        assert result["session_id"] == "test-1"
+        assert result["state"] == "waiting"
+        assert result["qr_image_base64"] == "base64data"
+        assert "expires_at" in result
+
+    def test_status_dict_hides_qr_in_confirmed_state(self):
+        """QR image should not be exposed after confirmation."""
+        session = WeixinQRSession(
+            session_id="test-1",
+            hermes_home="/tmp",
+            expires_at_ts=time.time() + 300,
+        )
+        session.state = "confirmed"
+        session.qr_image_base64 = "base64data"
+        session.credentials = {
+            "account_id": "acc-1",
+            "token": "tok-1",
+            "base_url": "https://ilinkai.weixin.qq.com",
+            "user_id": "user-1",
+        }
+
+        result = session.to_status_dict()
+        assert result["state"] == "confirmed"
+        assert result["account_id"] == "acc-1"
+        assert "qr_image_base64" not in result
+        # Token must never be exposed to the browser.
+        assert "token" not in result
+
+    def test_status_dict_includes_error_on_failure(self):
+        session = WeixinQRSession(
+            session_id="test-1",
+            hermes_home="/tmp",
+            expires_at_ts=time.time() + 300,
+        )
+        session.state = "failed"
+        session.error_message = "Something went wrong"
+
+        result = session.to_status_dict()
+        assert result["state"] == "failed"
+        assert result["error"] == "Something went wrong"
+
+
+class TestRenderQrPngBase64:
+    """Test the QR PNG rendering helper."""
+
+    def test_returns_non_empty_string_for_valid_data(self):
+        result = _render_qr_png_base64("https://example.com/qr")
+        # If qrcode package is installed, this should be non-empty.
+        # If not installed, it returns "" — both are acceptable.
+        if result:
+            assert isinstance(result, str)
+            assert len(result) > 100  # base64 PNG is reasonably long
+
+    def test_returns_empty_string_on_invalid_input(self):
+        # Empty string should still produce a valid (blank) QR or empty fallback.
+        result = _render_qr_png_base64("")
+        assert isinstance(result, str)

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { api } from "./api";
+import { api, setManagementProfile } from "./api";
 
 const SESSION_HEADER = "X-Hermes-Session-Token";
 
@@ -102,5 +102,67 @@ describe("api OAuth helpers", () => {
       expect(init.credentials).toBe("include");
       expect((init.headers as Headers).has(SESSION_HEADER)).toBe(false);
     }
+  });
+});
+
+describe("Weixin onboarding profile scoping", () => {
+  afterEach(() => {
+    setManagementProfile("");
+  });
+
+  it("appends ?profile= to Weixin onboarding start when a management profile is set", async () => {
+    vi.stubGlobal("window", {});
+    setManagementProfile("coder");
+
+    const fetchMock = jsonFetchMock({ session_id: "s1", state: "starting", expires_at: 0 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.startWeixinOnboarding({});
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("profile=coder");
+    expect(url).toContain("/api/messaging/weixin/onboarding/start");
+  });
+
+  it("appends ?profile= to Weixin onboarding status when a management profile is set", async () => {
+    vi.stubGlobal("window", {});
+    setManagementProfile("coder");
+
+    const fetchMock = jsonFetchMock({ session_id: "s1", state: "waiting", expires_at: 0 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.getWeixinOnboardingStatus("s1");
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("profile=coder");
+    expect(url).toContain("/api/messaging/weixin/onboarding/s1/status");
+  });
+
+  it("appends ?profile= to Weixin onboarding apply when a management profile is set", async () => {
+    vi.stubGlobal("window", {});
+    setManagementProfile("coder");
+
+    const fetchMock = jsonFetchMock({ ok: true, platform: "weixin", account_id: "a1" });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.applyWeixinOnboarding("s1", {});
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("profile=coder");
+    expect(url).toContain("/api/messaging/weixin/onboarding/s1/apply");
+  });
+
+  it("appends ?profile= to Weixin onboarding cancel when a management profile is set", async () => {
+    vi.stubGlobal("window", {});
+    setManagementProfile("coder");
+
+    const fetchMock = jsonFetchMock({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.cancelWeixinOnboarding("s1");
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("profile=coder");
+    expect(url).toContain("/api/messaging/weixin/onboarding/s1");
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -74,6 +74,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/mcp",
   "/api/messaging/platforms",
   "/api/messaging/telegram/onboarding",
+  "/api/messaging/weixin/onboarding",
   "/api/messaging/whatsapp/onboarding",
   "/api/model/info",
   "/api/model/set",
@@ -865,12 +866,37 @@ export const api = {
       `/api/messaging/telegram/onboarding/${encodeURIComponent(pairingId)}`,
       { method: "DELETE" },
     ),
+  startWeixinOnboarding: (body: { profile?: string }) =>
+    fetchJSON<WeixinOnboardingStartResponse>(
+      "/api/messaging/weixin/onboarding/start",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    ),
   startWhatsAppOnboarding: (body: {
     mode?: "bot" | "self-chat";
     allowed_users?: string;
   }) =>
     fetchJSON<WhatsAppOnboardingStartResponse>(
       "/api/messaging/whatsapp/onboarding/start",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    ),
+  getWeixinOnboardingStatus: (sessionId: string) =>
+    fetchJSON<WeixinOnboardingStatusResponse>(
+      `/api/messaging/weixin/onboarding/${encodeURIComponent(sessionId)}/status`,
+    ),
+  applyWeixinOnboarding: (
+    sessionId: string,
+    body: { profile?: string },
+  ) =>
+    fetchJSON<WeixinOnboardingApplyResponse>(
+      `/api/messaging/weixin/onboarding/${encodeURIComponent(sessionId)}/apply`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -892,6 +918,11 @@ export const api = {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       },
+    ),
+  cancelWeixinOnboarding: (sessionId: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/messaging/weixin/onboarding/${encodeURIComponent(sessionId)}`,
+      { method: "DELETE" },
     ),
   cancelWhatsAppOnboarding: (pairingId: string) =>
     fetchJSON<{ ok: boolean }>(
@@ -1908,6 +1939,33 @@ export type WhatsAppOnboardingStatusResponse = WhatsAppOnboardingStartResponse;
 export interface WhatsAppOnboardingApplyResponse {
   ok: boolean;
   platform: "whatsapp";
+  needs_restart: boolean;
+  restart_started?: boolean;
+  restart_action?: string;
+  restart_pid?: number | null;
+  restart_error?: string;
+}
+
+export interface WeixinOnboardingStartResponse {
+  session_id: string;
+  state: "starting";
+  expires_at: string;
+}
+
+export type WeixinOnboardingStatusResponse = {
+  session_id: string;
+  state: "starting" | "waiting" | "scanned" | "confirmed" | "failed" | "expired" | "cancelled";
+  expires_at: string;
+  qr_image_base64?: string;
+  error?: string;
+  account_id?: string;
+  base_url?: string;
+};
+
+export interface WeixinOnboardingApplyResponse {
+  ok: boolean;
+  platform: "weixin";
+  account_id: string;
   needs_restart: boolean;
   restart_started?: boolean;
   restart_action?: string;

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -628,6 +628,15 @@ export default function ChannelsPage() {
                     showToast={showToast}
                   />
                 )}
+                {platform.id === "weixin" && (
+                  <WeixinOnboardingPanel
+                    onChanged={load}
+                    onRestartNeeded={() => setRestartNeeded(true)}
+                    platform={platform}
+                    setRestartNeeded={setRestartNeeded}
+                    showToast={showToast}
+                  />
+                )}
               </CardContent>
             </Card>
           );
@@ -1438,6 +1447,277 @@ function TelegramOnboardingPanel({
                 Cancel
               </Button>
             </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WeixinOnboardingPanel({
+  onChanged,
+  onRestartNeeded,
+  platform,
+  setRestartNeeded,
+  showToast,
+}: {
+  onChanged: () => Promise<void>;
+  onRestartNeeded: () => void;
+  platform: MessagingPlatform;
+  setRestartNeeded: (needed: boolean) => void;
+  showToast: (message: string, type: "success" | "error") => void;
+}) {
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [qrImageSrc, setQrImageSrc] = useState("");
+  const [phase, setPhase] = useState<
+    "idle" | "starting" | "waiting" | "scanned" | "applying"
+  >("idle");
+  const [error, setError] = useState("");
+  const [tick, setTick] = useState(0);
+  const [expiresAt, setExpiresAt] = useState<string>("");
+
+  // Poll for QR scan status while waiting.
+  useEffect(() => {
+    if (!sessionId || (phase !== "waiting" && phase !== "scanned")) return;
+    let cancelled = false;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      try {
+        const status = await api.getWeixinOnboardingStatus(sessionId);
+        if (cancelled) return;
+
+        if (status.qr_image_base64) {
+          setQrImageSrc(`data:image/png;base64,${status.qr_image_base64}`);
+        }
+
+        if (status.state === "waiting") {
+          setPhase("waiting");
+          setError("");
+          timeout = setTimeout(poll, 2000);
+          return;
+        }
+        if (status.state === "scanned") {
+          setPhase("scanned");
+          setError("");
+          timeout = setTimeout(poll, 2000);
+          return;
+        }
+        if (status.state === "confirmed") {
+          // Auto-apply: save credentials and restart gateway.
+          void apply();
+          return;
+        }
+        if (status.state === "failed" || status.state === "expired" || status.state === "cancelled") {
+          resetSetup();
+          setError(
+            status.error ||
+              "WeChat setup expired or failed. Start a new QR setup to try again.",
+          );
+          return;
+        }
+        // starting or unknown — keep polling.
+        timeout = setTimeout(poll, 2000);
+      } catch (pollError) {
+        if (cancelled) return;
+        const parsedExpiresAt = Date.parse(expiresAt);
+        const expired =
+          Number.isFinite(parsedExpiresAt) && Date.now() >= parsedExpiresAt;
+        if (expired) {
+          resetSetup();
+          setError("WeChat setup expired. Start a new QR setup to try again.");
+          return;
+        }
+        setError(`Still waiting for WeChat. Retrying after: ${pollError}`);
+        timeout = setTimeout(poll, 2000);
+      }
+    };
+
+    timeout = setTimeout(poll, 1500);
+    return () => {
+      cancelled = true;
+      if (timeout) clearTimeout(timeout);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, sessionId, expiresAt]);
+
+  // Expiry countdown ticker.
+  useEffect(() => {
+    if (!sessionId) return;
+    const timer = setInterval(() => setTick((value) => value + 1), 1000);
+    return () => clearInterval(timer);
+  }, [sessionId]);
+
+  const resetSetup = () => {
+    setSessionId(null);
+    setQrImageSrc("");
+    setPhase("idle");
+    setExpiresAt("");
+    setError("");
+  };
+
+  const start = async () => {
+    setPhase("starting");
+    setError("");
+    setQrImageSrc("");
+    try {
+      const res = await api.startWeixinOnboarding({});
+      setSessionId(res.session_id);
+      setExpiresAt(res.expires_at);
+      setPhase("waiting");
+    } catch (startError) {
+      setPhase("idle");
+      setError(String(startError));
+    }
+  };
+
+  const cancel = async () => {
+    if (sessionId) {
+      try {
+        await api.cancelWeixinOnboarding(sessionId);
+      } catch {
+        /* local cleanup still wins */
+      }
+    }
+    resetSetup();
+  };
+
+  const watchRestartOutcome = async () => {
+    for (let i = 0; i < 20; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      try {
+        const st = await api.getActionStatus("gateway-restart", 5);
+        if (st.running) continue;
+        if (st.exit_code !== 0 && st.exit_code !== null) {
+          onRestartNeeded();
+          showToast(
+            `Gateway restart failed (exit ${st.exit_code}) — restart manually`,
+            "error",
+          );
+        }
+        return;
+      } catch {
+        // transient fetch error; keep polling
+      }
+    }
+  };
+
+  const apply = async () => {
+    if (!sessionId) return;
+    setPhase("applying");
+    setError("");
+    try {
+      const result = await api.applyWeixinOnboarding(sessionId, {});
+      resetSetup();
+      if (result.restart_started) {
+        showToast("WeChat saved; gateway restarting…", "success");
+        setRestartNeeded(false);
+        setTimeout(() => void onChanged(), 4000);
+        void watchRestartOutcome();
+      } else if (result.restart_started === undefined && result.needs_restart) {
+        try {
+          await api.restartGateway();
+          showToast("WeChat saved; gateway restarting…", "success");
+          setRestartNeeded(false);
+          setTimeout(() => void onChanged(), 4000);
+        } catch (restartError) {
+          onRestartNeeded();
+          showToast(`WeChat saved; gateway restart failed: ${restartError}`, "error");
+        }
+      } else {
+        onRestartNeeded();
+        const detail = result.restart_error ? `: ${result.restart_error}` : "";
+        showToast(`WeChat saved; gateway restart failed${detail}`, "error");
+      }
+      await onChanged();
+    } catch (applyError) {
+      setPhase("waiting");
+      setError(String(applyError));
+    }
+  };
+
+  const expiresIn = useMemo(
+    () => (expiresAt ? formatExpiry(expiresAt) : ""),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [expiresAt, tick],
+  );
+
+  return (
+    <div className="rounded-sm border border-border bg-background/35 p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          size="sm"
+          className="uppercase"
+          onClick={() => void start()}
+          disabled={phase === "starting" || phase === "waiting" || phase === "scanned" || phase === "applying"}
+          prefix={phase === "starting" ? <Spinner /> : <QrCode className="h-4 w-4" />}
+        >
+          {phase === "starting" ? "Starting…" : "Set up with QR"}
+        </Button>
+        {platform.configured && (
+          <span className="text-xs text-muted-foreground">
+            Existing WeChat credentials are configured.
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div className="mt-3 border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {sessionId && qrImageSrc && (
+        <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]">
+          <div className="grid gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+              {phase === "waiting" && (
+                <>
+                  <Badge tone="warning">waiting</Badge>
+                  <span className="text-sm text-muted-foreground">
+                    Scan the QR code with WeChat on your phone.
+                  </span>
+                </>
+              )}
+              {phase === "scanned" && (
+                <>
+                  <Badge tone="success">scanned</Badge>
+                  <span className="text-sm text-muted-foreground">
+                    Confirm the login in WeChat to finish.
+                  </span>
+                </>
+              )}
+              {phase === "applying" && (
+                <>
+                  <Badge tone="success">confirmed</Badge>
+                  <span className="text-sm text-muted-foreground">
+                    Saving credentials and restarting gateway…
+                  </span>
+                </>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button size="sm" ghost onClick={() => void cancel()}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex flex-col items-center justify-center gap-3">
+            <img
+              src={qrImageSrc}
+              alt="WeChat setup QR code"
+              className="h-56 w-56 bg-white p-2"
+            />
+            <div className="flex flex-wrap items-center justify-center gap-2 text-sm">
+              <Badge tone={expiresIn === "expired" ? "destructive" : "outline"}>
+                {expiresIn}
+              </Badge>
+            </div>
+            <Button size="sm" ghost onClick={() => void cancel()}>
+              Cancel
+            </Button>
           </div>
         </div>
       )}

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -1631,7 +1631,7 @@ function WeixinOnboardingPanel({
       }
       await onChanged();
     } catch (applyError) {
-      setPhase("waiting");
+      resetSetup();
       setError(String(applyError));
     }
   };

--- a/website/docs/user-guide/messaging/weixin.md
+++ b/website/docs/user-guide/messaging/weixin.md
@@ -39,9 +39,27 @@ cd ~/.hermes/hermes-agent && uv pip install -e ".[messaging]"
 
 ## Setup
 
-### 1. Run the Setup Wizard
+### Option A: Web Dashboard (recommended)
 
-The easiest way to connect your WeChat account is through the interactive setup:
+The easiest way to connect your WeChat account is through the Hermes web dashboard — no terminal required.
+
+1. Open the dashboard at `http://localhost:9119` (or your deployment URL)
+2. Navigate to **Channels**
+3. Find **Weixin / WeChat** and click **Set up with QR**
+4. A QR code renders inline in your browser
+5. Open WeChat on your phone → tap **+** → **Scan QR Code** → point at the QR
+6. Confirm the login in WeChat when prompted
+7. The dashboard auto-saves credentials and restarts the gateway
+
+The dashboard handles everything: QR rendering, scan-status polling, credential persistence, and gateway restart. You don't need to run any CLI commands.
+
+:::info
+The web QR flow talks directly to Tencent's iLink Bot API — no external pairing service required. The QR is fetched from `ilinkai.weixin.qq.com` and rendered as a PNG in your browser.
+:::
+
+### Option B: Terminal Wizard (alternative)
+
+If you prefer the terminal or don't have dashboard access, use the interactive setup:
 
 ```bash
 hermes gateway setup


### PR DESCRIPTION
## Summary

Adds a complete web-based QR onboarding flow for the Weixin (WeChat personal) platform, mirroring the existing Telegram onboarding pattern. Users can now connect WeChat entirely from the dashboard — **no terminal, CLI, or TTY required**.

This is a focused split of #50044 per @teknium1's review request — only the Weixin QR onboarding feature and directly related bug fixes. No fork deployment wrapper changes, no Firecrawl MCP catalog, no compose file changes.

## What changed

### Backend (Python)

**New file:** `gateway/platforms/weixin_qr_session.py` (~470 lines)
- `WeixinQRSessionManager` — process-global session manager with thread-safe start/get/cancel
- - `WeixinQRSession` dataclass — tracks session state, QR image, credentials
- - Background asyncio task polls Tencent's iLink API for scan status (1s interval)
- - Handles QR refresh (up to 3 refreshes on `expired` status, matching CLI wizard)
- - Saves credentials via existing `save_weixin_account()` on confirmation
- - QR rendered as base64 PNG via `qrcode` package (same dep as Telegram onboarding)
**Modified:** `hermes_cli/web_server.py` (+125 lines)
- 4 new endpoints mirroring Telegram onboarding shape:
-   - `POST /api/messaging/weixin/onboarding/start` — creates session, starts background poll
-   - `GET /api/messaging/weixin/onboarding/{session_id}/status` — returns state + QR image
-   - `POST /api/messaging/weixin/onboarding/{session_id}/apply` — saves credentials to `.env`, enables platform, restarts gateway
-   - `DELETE /api/messaging/weixin/onboarding/{session_id}` — cancels session
- - 2 new Pydantic models: `WeixinOnboardingStart`, `WeixinOnboardingApply`
- - Reuses existing helpers: `_profile_scope()`, `save_env_value()`, `_write_platform_enabled()`, `_restart_gateway_after_telegram_onboarding()`
**Modified:** `gateway/platforms/weixin.py` (+51 lines)
- SSL fix: `_get_ssl_context()` creates SSL context without needing an event loop (aiohttp 3.13+ `TCPConnector()` requires a running event loop)
- - `connect()` creates `TCPConnector(ssl=_ssl_ctx)` inside the async context
- - base_url normalisation: iLink sometimes returns `ilinkai.wechat.com` (missing `.qq.com`) — all QR login paths now normalise to `https://ilinkai.weixin.qq.com`
**Modified:** `hermes_cli/gateway.py` (+4 lines)
- Defensive base_url normalisation in `_setup_weixin()` CLI wizard
### Frontend (TypeScript/React)

**Modified:** `web/src/pages/ChannelsPage.tsx` (+280 lines)
- New `WeixinOnboardingPanel` component — mirrors `TelegramOnboardingPanel`
- - State machine: `idle → starting → waiting → scanned → applying`
- - Polls status every 2s, auto-applies on `confirmed`
- - QR renders inline as `<img src="data:image/png;base64,...">`
- - "Set up with QR" button on the Weixin channel card
**Modified:** `web/src/lib/api.ts` (+38 lines)
- 4 new API functions: `startWeixinOnboarding`, `getWeixinOnboardingStatus`, `applyWeixinOnboarding`, `cancelWeixinOnboarding`
- - 3 new TypeScript types: `WeixinOnboardingStartResponse`, `WeixinOnboardingStatusResponse`, `WeixinOnboardingApplyResponse`
- - Added `/api/messaging/weixin/onboarding` to `PROFILE_SCOPED_PREFIXES` for profile-aware credential writes
### Tests

**New file:** `tests/gateway/test_weixin_qr_session.py` (~305 lines, 13 tests)
- `TestWeixinQRSessionManagerLifecycle` — start/get/cancel/unknown session
- - `TestWeixinQRSessionManagerBackgroundTask` — confirmed flow, failed fetch, expired refresh, max refreshes
- - `TestWeixinQRSessionStatusDict` — serialization, QR hiding on confirmed, error display
- - `TestRenderQrPngBase64` — PNG rendering
**Modified:** `web/src/lib/api.test.ts` (+64 lines, 4 new tests)
- Regression tests for profile scoping on all 4 Weixin onboarding endpoints
All 22 tests passing (13 Python + 9 TypeScript).

### Docs

**Modified:** `website/docs/user-guide/messaging/weixin.md` (+22 lines)
- Added "Option A: Web Dashboard (recommended)" as the primary setup path
- - Moved CLI wizard to "Option B: Terminal Wizard (alternative)"
## Design decisions

- **Mirrors Telegram onboarding exactly** — same endpoint shape, same frontend component pattern, same apply/restart flow
- - **No changes to the weixin adapter runtime** — the adapter's `start()`, `_poll_loop()`, `send()` etc. are untouched. The QR session manager is a separate module that only runs during onboarding
- - **Token never exposed to browser** — `to_status_dict()` explicitly omits the token from the JSON response. Only `account_id` and `base_url` are returned on confirmation
- - **Direct iLink API access** — unlike Telegram (which proxies through an external pairing service), Weixin talks directly to Tencent's iLink API. No external service dependency
- - **Profile-aware** — all 4 onboarding endpoints are in `PROFILE_SCOPED_PREFIXES` so `withManagementProfile()` appends `?profile=` for non-default profile setups
## Bug fixes included (all directly related to the QR onboarding flow)

1. **SSL connector fails outside event loop in aiohttp 3.13+** — `_make_ssl_connector()` creates `TCPConnector()` which requires a running event loop. When called from the sync `connect()` method, it returns `None` silently. Fix: `_get_ssl_context()` creates the SSL context without needing an event loop; `connect()` creates `TCPConnector` inside the async context
2. 2. **iLink base_url normalisation** — iLink sometimes returns `ilinkai.wechat.com` (missing `.qq.com`) in QR responses, causing `errcode=-14` session timeout. All 3 QR login paths (web dashboard, CLI wizard, gateway setup) now normalise to `https://ilinkai.weixin.qq.com`
3. 3. **iLink redirect_host normalisation** — same issue with `scaned_but_redirect` status
4. 4. **PROFILE_SCOPED_PREFIXES** — added `/api/messaging/weixin/onboarding` so `withManagementProfile()` appends `?profile=` for non-default profile setups (found by @teknium1 in review of #50044)
5. 5. **_prune_expired()** — exempts `expired` state so `get_status()` returns the expired state + error message instead of 404
6. 6. **Frontend apply failure** — reset to idle instead of going back to waiting to prevent auto-retry loop
## End-to-end verification

Tested in a running Docker container:
- ✅ `POST /api/messaging/weixin/onboarding/start` returns `{session_id, state:"starting", expires_at}`
- - ✅ Background task fetches QR from `ilinkai.weixin.qq.com`
- - ✅ `GET /status` returns `{state:"waiting", qr_image_base64:"..."}`
- - ✅ QR scanned with WeChat → state transitions to `confirmed`
- - ✅ `POST /apply` saves credentials, enables platform, restarts gateway
- - ✅ WeChat bot receives and responds to messages
## Breaking changes

None. The CLI wizard still works. The weixin adapter runtime is unchanged. The new endpoints are additive.

## Files changed

| File | Δ | Purpose |
|---|---|---|
| `gateway/platforms/weixin_qr_session.py` (NEW) | +469 | Backend session manager |
| `tests/gateway/test_weixin_qr_session.py` (NEW) | +305 | 13 tests |
| `hermes_cli/web_server.py` | +125 | 4 endpoints + 2 models |
| `web/src/pages/ChannelsPage.tsx` | +280 | WeixinOnboardingPanel component |
| `web/src/lib/api.ts` | +38 | 4 API functions + 3 types + PROFILE_SCOPED_PREFIXES |
| `web/src/lib/api.test.ts` | +64 | 4 profile scoping regression tests |
| `gateway/platforms/weixin.py` | +51 | SSL fix + base_url normalisation |
| `hermes_cli/gateway.py` | +4 | Defensive base_url normalisation in CLI wizard |
| `website/docs/user-guide/messaging/weixin.md` | +22 | Web QR setup docs |

**Total: ~1,357 lines added across 9 files (7 modified, 2 new).**

## Related

Focused split of #50044 per reviewer request. The original PR bundled this feature with fork deployment wrapper changes and an unrelated Firecrawl MCP catalog entry.