### PR TITLE
fix(mcp): close OAuth callback port races — closures, reuse_address, TOCTOU (salvage of #44872 + #22161)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -346,6 +346,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "78542984+Code-suphub@users.noreply.github.com": "Code-suphub",
     "hi@neueway.com": "brendandebeasi",
     "dorokuma@users.noreply.github.com": "dorokuma",
     "liuwei666888@users.noreply.github.com": "liuwei666888",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -346,6 +346,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "a54983334@163.com": "Code-suphub",
     "78542984+Code-suphub@users.noreply.github.com": "Code-suphub",
     "hi@neueway.com": "brendandebeasi",
     "dorokuma@users.noreply.github.com": "dorokuma",

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -424,6 +424,103 @@ class TestOAuthPortSharing:
 
 
 # ---------------------------------------------------------------------------
+# TOCTOU port reservation (#22161)
+# ---------------------------------------------------------------------------
+
+class TestCallbackPortReservation:
+    """The socket picked at selection time stays bound until callback bind.
+
+    _find_free_port() closed its probe socket before HTTPServer re-bound the
+    port, leaving a race window where another process could steal it
+    (#22161). _reserve_callback_port() keeps the bound socket parked in
+    _reserved_sockets until _wait_for_callback adopts it.
+    """
+
+    def test_reserved_port_cannot_be_stolen(self):
+        import socket as sock
+        import tools.mcp_oauth as mod
+
+        port = mod._reserve_callback_port()
+        try:
+            # The reservation holds the bind — a competing bind must fail.
+            thief = sock.socket(sock.AF_INET, sock.SOCK_STREAM)
+            with pytest.raises(OSError):
+                thief.bind(("127.0.0.1", port))
+            thief.close()
+        finally:
+            reserved = mod._reserved_sockets.pop(port, None)
+            if reserved is not None:
+                reserved.close()
+
+    def test_configure_callback_port_reserves_ephemeral(self):
+        import tools.mcp_oauth as mod
+
+        cfg: dict = {}
+        port = mod._configure_callback_port(cfg)
+        try:
+            assert cfg["_resolved_port"] == port
+            assert port in mod._reserved_sockets
+        finally:
+            reserved = mod._reserved_sockets.pop(port, None)
+            if reserved is not None:
+                reserved.close()
+
+    def test_pinned_port_is_not_reserved(self):
+        import tools.mcp_oauth as mod
+
+        cfg: dict = {"redirect_port": 49399}
+        port = mod._configure_callback_port(cfg)
+        assert port == 49399
+        assert 49399 not in mod._reserved_sockets
+
+    def test_reservation_pool_is_bounded(self):
+        import tools.mcp_oauth as mod
+
+        ports = [mod._reserve_callback_port() for _ in range(mod._MAX_RESERVED_SOCKETS + 3)]
+        try:
+            assert len(mod._reserved_sockets) <= mod._MAX_RESERVED_SOCKETS
+            # newest reservations survive
+            assert ports[-1] in mod._reserved_sockets
+        finally:
+            for p in list(mod._reserved_sockets):
+                mod._reserved_sockets.pop(p).close()
+
+    def test_wait_for_callback_adopts_reserved_socket(self, monkeypatch):
+        """E2E: reserve → _wait_for_callback binds the SAME socket and the
+        callback round-trips through it."""
+        import asyncio
+        import threading
+        import urllib.request
+        import tools.mcp_oauth as mod
+
+        cfg: dict = {}
+        port = mod._configure_callback_port(cfg)
+        monkeypatch.setattr(mod, "_is_interactive", lambda: False)
+        # Bypass the non-interactive guard — this test drives the flow directly.
+        monkeypatch.setattr(mod, "_raise_if_non_interactive", lambda lead: None)
+
+        async def drive():
+            task = asyncio.create_task(mod._wait_for_callback())
+            await asyncio.sleep(0.2)  # let the server adopt the socket
+
+            def hit():
+                urllib.request.urlopen(
+                    f"http://127.0.0.1:{port}/callback?code=abc123&state=xyz",
+                    timeout=5,
+                )
+
+            t = threading.Thread(target=hit, daemon=True)
+            t.start()
+            return await asyncio.wait_for(task, timeout=10)
+
+        code, state = asyncio.run(drive())
+        assert code == "abc123"
+        assert state == "xyz"
+        # Reservation was consumed by adoption.
+        assert port not in mod._reserved_sockets
+
+
+# ---------------------------------------------------------------------------
 # remove_oauth_tokens
 # ---------------------------------------------------------------------------
 
@@ -661,7 +758,7 @@ class TestNonInteractiveFailFastAtCallbackBoundary:
         )
 
         with pytest.raises(OAuthNonInteractiveError, match="browser authorization"):
-            asyncio.run(mod._redirect_handler("https://idp.example.com/authorize?x=1"))
+            asyncio.run(mod._make_redirect_handler(49300)("https://idp.example.com/authorize?x=1"))
 
         err = capsys.readouterr().err
         assert "https://idp.example.com/authorize" not in err
@@ -673,7 +770,7 @@ class TestNonInteractiveFailFastAtCallbackBoundary:
 
         monkeypatch.setattr(mod, "_is_interactive", lambda: False)
         with pytest.raises(OAuthNonInteractiveError, match="hermes mcp login"):
-            asyncio.run(mod._redirect_handler("https://idp.example.com/authorize"))
+            asyncio.run(mod._make_redirect_handler(49301)("https://idp.example.com/authorize"))
 
         mod._oauth_port = _find_free_port()
         with pytest.raises(OAuthNonInteractiveError, match="hermes mcp login"):
@@ -698,7 +795,7 @@ class TestNonInteractiveFailFastAtCallbackBoundary:
         monkeypatch.delenv("SSH_TTY", raising=False)
         monkeypatch.setattr(mod, "_can_open_browser", lambda: False)
 
-        asyncio.run(mod._redirect_handler("https://idp.example.com/authorize?x=9"))
+        asyncio.run(mod._make_redirect_handler(49302)("https://idp.example.com/authorize?x=9"))
 
         err = capsys.readouterr().err
         assert "https://idp.example.com/authorize?x=9" in err

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -21,7 +21,7 @@ from tools.mcp_oauth import (
     _is_interactive,
     _wait_for_callback,
     _make_callback_handler,
-    _redirect_handler,
+    _make_redirect_handler,
     _paste_callback_reader,
 )
 
@@ -254,20 +254,20 @@ class TestUtilities:
 
 
 class TestRedirectHandlerSshHint:
-    """_redirect_handler must print an SSH tunnel hint on remote sessions."""
+    """_make_redirect_handler must print an SSH tunnel hint on remote sessions."""
 
     def _run(self, coro):
         return asyncio.get_event_loop().run_until_complete(coro)
 
     def test_ssh_hint_shown_on_ssh_session(self, monkeypatch, capsys):
         import tools.mcp_oauth as mco
-        monkeypatch.setattr(mco, "_oauth_port", 49200)
         monkeypatch.setattr(mco, "_is_interactive", lambda: True)
         monkeypatch.setenv("SSH_CLIENT", "1.2.3.4 1234 22")
         monkeypatch.delenv("SSH_TTY", raising=False)
         monkeypatch.setattr(mco, "_can_open_browser", lambda: False)
 
-        self._run(_redirect_handler("https://example.com/auth?foo=bar"))
+        handler = _make_redirect_handler(49200)
+        self._run(handler("https://example.com/auth?foo=bar"))
 
         err = capsys.readouterr().err
         assert "49200" in err
@@ -276,13 +276,13 @@ class TestRedirectHandlerSshHint:
 
     def test_ssh_hint_shown_via_ssh_tty(self, monkeypatch, capsys):
         import tools.mcp_oauth as mco
-        monkeypatch.setattr(mco, "_oauth_port", 49201)
         monkeypatch.setattr(mco, "_is_interactive", lambda: True)
         monkeypatch.delenv("SSH_CLIENT", raising=False)
         monkeypatch.setenv("SSH_TTY", "/dev/pts/1")
         monkeypatch.setattr(mco, "_can_open_browser", lambda: False)
 
-        self._run(_redirect_handler("https://example.com/auth"))
+        handler = _make_redirect_handler(49201)
+        self._run(handler("https://example.com/auth"))
 
         err = capsys.readouterr().err
         assert "49201" in err
@@ -290,26 +290,26 @@ class TestRedirectHandlerSshHint:
 
     def test_no_ssh_hint_on_local_session(self, monkeypatch, capsys):
         import tools.mcp_oauth as mco
-        monkeypatch.setattr(mco, "_oauth_port", 49202)
         monkeypatch.setattr(mco, "_is_interactive", lambda: True)
         monkeypatch.delenv("SSH_CLIENT", raising=False)
         monkeypatch.delenv("SSH_TTY", raising=False)
         monkeypatch.setattr(mco, "_can_open_browser", lambda: True)
         monkeypatch.setattr("webbrowser.open", lambda url, **kw: True)
 
-        self._run(_redirect_handler("https://example.com/auth"))
+        handler = _make_redirect_handler(49202)
+        self._run(handler("https://example.com/auth"))
 
         err = capsys.readouterr().err
         assert "ssh -N -L" not in err
 
-    def test_no_ssh_hint_when_port_not_set(self, monkeypatch, capsys):
+    def test_no_ssh_hint_when_port_is_zero(self, monkeypatch, capsys):
         import tools.mcp_oauth as mco
-        monkeypatch.setattr(mco, "_oauth_port", None)
         monkeypatch.setattr(mco, "_is_interactive", lambda: True)
         monkeypatch.setenv("SSH_CLIENT", "1.2.3.4 1234 22")
         monkeypatch.setattr(mco, "_can_open_browser", lambda: False)
 
-        self._run(_redirect_handler("https://example.com/auth"))
+        handler = _make_redirect_handler(0)
+        self._run(handler("https://example.com/auth"))
 
         err = capsys.readouterr().err
         assert "ssh -N -L" not in err

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -155,6 +155,43 @@ def _find_free_port() -> int:
         return s.getsockname()[1]
 
 
+# Bound-but-not-listening sockets reserved for pending OAuth callback flows,
+# keyed by port. Holding the socket from port-selection time until
+# _wait_for_callback adopts it closes the TOCTOU window where another process
+# could grab the port between _find_free_port() closing its probe socket and
+# HTTPServer binding minutes later (#22161). Bounded FIFO so repeated
+# build_oauth_auth calls (reconnect loops) cannot leak fds.
+_reserved_sockets: "dict[int, socket.socket]" = {}
+_MAX_RESERVED_SOCKETS = 8
+
+
+def _reserve_callback_port() -> int:
+    """Pick an ephemeral callback port and keep its socket bound.
+
+    Returns the port. The bound (not yet listening) socket is parked in
+    ``_reserved_sockets`` so no other process can bind the port before
+    ``_wait_for_callback`` adopts it. Adoption (or ``server_close``) owns
+    the socket's lifetime from there.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(("127.0.0.1", 0))
+    except OSError:
+        s.close()
+        raise
+    port = s.getsockname()[1]
+    # Evict oldest reservations past the cap (dict preserves insertion order).
+    while len(_reserved_sockets) >= _MAX_RESERVED_SOCKETS:
+        _, stale = next(iter(_reserved_sockets.items()))
+        _reserved_sockets.pop(next(iter(_reserved_sockets)), None)
+        try:
+            stale.close()
+        except OSError:
+            pass
+    _reserved_sockets[port] = s
+    return port
+
+
 def _is_interactive() -> bool:
     """Return True if we can reasonably expect to interact with a user."""
     if not _oauth_interactive_enabled.get():
@@ -659,13 +696,29 @@ async def _wait_for_callback() -> tuple[str, str | None]:
     # We just need to poll for the result.
     handler_cls, result = _make_callback_handler()
 
-    # Start a temporary server on the known port.
-    # allow_reuse_address prevents TIME_WAIT on the socket after the flow
-    # completes, so the next OAuth flow on the same port can bind immediately
-    # (fixes #44590).
+    # Start a temporary server on the known port, adopting the socket
+    # reserved at port-selection time when one exists. Holding the bound
+    # socket from _reserve_callback_port() until here closes the TOCTOU
+    # window where another process could steal the port between selection
+    # and bind (#22161). allow_reuse_address is set BEFORE binding (setting
+    # it after the constructor has already bound is a no-op) so a lingering
+    # TIME_WAIT socket from a previous flow cannot block the next one
+    # (#44590).
     try:
-        server = HTTPServer(("127.0.0.1", _oauth_port), handler_cls)
-        server.allow_reuse_address = True
+        server = HTTPServer(
+            ("127.0.0.1", _oauth_port), handler_cls, bind_and_activate=False
+        )
+        reserved = _reserved_sockets.pop(_oauth_port, None)
+        if reserved is not None:
+            # Adopt the reserved (already bound) socket and start listening.
+            server.socket.close()
+            server.socket = reserved
+            server.server_address = reserved.getsockname()
+            server.server_activate()
+        else:
+            server.allow_reuse_address = True
+            server.server_bind()
+            server.server_activate()
     except OSError:
         # Port already in use — the server from build_oauth_auth is running.
         # Fall back to polling the server started by build_oauth_auth.
@@ -840,7 +893,10 @@ def _configure_callback_port(cfg: dict) -> int:
     """
     global _oauth_port
     requested = int(cfg.get("redirect_port", 0))
-    port = _find_free_port() if requested == 0 else requested
+    # Ephemeral selection reserves the bound socket until _wait_for_callback
+    # adopts it, closing the select→bind TOCTOU race (#22161). An explicit
+    # user-pinned port is used as-is.
+    port = _reserve_callback_port() if requested == 0 else requested
     cfg["_resolved_port"] = port
     _oauth_port = port  # legacy consumer: _wait_for_callback reads this
     return port

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -538,58 +538,79 @@ def _make_callback_handler() -> tuple[type, dict]:
 # ---------------------------------------------------------------------------
 
 
-async def _redirect_handler(authorization_url: str) -> None:
-    """Show the authorization URL to the user.
+def _make_redirect_handler(port: int):
+    """Return a redirect handler closure that closes over the given port.
 
-    Opens the browser automatically when possible; always prints the URL
-    as a fallback for headless/SSH/gateway environments.
+    Using a closure instead of reading the module-level ``_oauth_port`` avoids
+    cross-server state pollution when multiple MCP servers run OAuth
+    concurrently (fixes #44588).
     """
-    # Fail fast at the authorization boundary in non-interactive contexts
-    # (systemd gateway, cron, background MCP discovery). A cached-but-unusable
-    # token (expired/revoked, refresh rejected) makes the SDK fall through to
-    # the authorization-code flow even though build_oauth_auth's token-file
-    # guard passed. Without this check we would print a URL and launch a
-    # browser flow no operator can complete, then block in _wait_for_callback
-    # for the full timeout. Raise before launching so gateway adapters start
-    # promptly and the caller can skip this server with an actionable warning.
-    # This intentionally re-checks interactivity here rather than trusting the
-    # token-file existence guard alone. See #57836.
-    _raise_if_non_interactive(
-        "MCP OAuth requires browser authorization but no interactive "
-        "session is available (non-interactive/background context)."
-    )
+    async def _redirect_handler(authorization_url: str) -> None:
+        """Show the authorization URL to the user.
 
-    msg = (
-        f"\n  MCP OAuth: authorization required.\n"
-        f"  Open this URL in your browser:\n\n"
-        f"    {authorization_url}\n"
-    )
-    print(msg, file=sys.stderr)
-
-    # On a remote SSH session the OAuth provider redirects to
-    # http://127.0.0.1:<port>/callback, which reaches the callback server on
-    # the *remote* machine — not the user's local machine where the browser
-    # opened.  Two ways out: paste the redirect URL back (default fallback,
-    # offered by _wait_for_callback on interactive TTYs), or set up an SSH
-    # port forward so the redirect tunnels through.
-    if _oauth_port and (os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY")):
-        print(
-            f"  Remote session detected. After you authorize, the provider redirects to\n"
-            f"    http://127.0.0.1:{_oauth_port}/callback\n"
-            f"  which only the listener on THIS machine can receive. Two options:\n"
-            f"\n"
-            f"    1. Easiest — when your browser shows a connection error after\n"
-            f"       authorizing, copy the full URL from the address bar and paste\n"
-            f"       it at the prompt below. The pasted ``code=...&state=...`` is\n"
-            f"       enough to complete the flow.\n"
-            f"\n"
-            f"    2. Or forward the port first in a separate terminal:\n"
-            f"         ssh -N -L {_oauth_port}:127.0.0.1:{_oauth_port} <user>@<this-host>\n"
-            f"       then open the URL above and let it redirect normally.\n"
-            f"\n"
-            f"  See: https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh\n",
-            file=sys.stderr,
+        Opens the browser automatically when possible; always prints the URL
+        as a fallback for headless/SSH/gateway environments.
+        """
+        # Fail fast at the authorization boundary in non-interactive contexts
+        # (systemd gateway, cron, background MCP discovery). A cached-but-unusable
+        # token (expired/revoked, refresh rejected) makes the SDK fall through to
+        # the authorization-code flow even though build_oauth_auth's token-file
+        # guard passed. Without this check we would print a URL and launch a
+        # browser flow no operator can complete, then block in _wait_for_callback
+        # for the full timeout. Raise before launching so gateway adapters start
+        # promptly and the caller can skip this server with an actionable warning.
+        # This intentionally re-checks interactivity here rather than trusting the
+        # token-file existence guard alone. See #57836.
+        _raise_if_non_interactive(
+            "MCP OAuth requires browser authorization but no interactive "
+            "session is available (non-interactive/background context)."
         )
+
+        msg = (
+            f"\n  MCP OAuth: authorization required.\n"
+            f"  Open this URL in your browser:\n\n"
+            f"    {authorization_url}\n"
+        )
+        print(msg, file=sys.stderr)
+
+        # On a remote SSH session the OAuth provider redirects to
+        # http://127.0.0.1:<port>/callback, which reaches the callback server on
+        # the *remote* machine — not the user's local machine where the browser
+        # opened.  Two ways out: paste the redirect URL back (default fallback,
+        # offered by _wait_for_callback on interactive TTYs), or set up an SSH
+        # port forward so the redirect tunnels through.
+        if port and (os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY")):
+            print(
+                f"  Remote session detected. After you authorize, the provider redirects to\n"
+                f"    http://127.0.0.1:{port}/callback\n"
+                f"  which only the listener on THIS machine can receive. Two options:\n"
+                f"\n"
+                f"    1. Easiest — when your browser shows a connection error after\n"
+                f"       authorizing, copy the full URL from the address bar and paste\n"
+                f"       it at the prompt below. The pasted ``code=...&state=...`` is\n"
+                f"       enough to complete the flow.\n"
+                f"\n"
+                f"    2. Or forward the port first in a separate terminal:\n"
+                f"         ssh -N -L {port}:127.0.0.1:{port} <user>@<this-host>\n"
+                f"       then open the URL above and let it redirect normally.\n"
+                f"\n"
+                f"  See: https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh\n",
+                file=sys.stderr,
+            )
+
+        if _can_open_browser():
+            try:
+                opened = webbrowser.open(authorization_url)
+                if opened:
+                    print("  (Browser opened automatically.)\n", file=sys.stderr)
+                else:
+                    print("  (Could not open browser — please open the URL manually.)\n", file=sys.stderr)
+            except Exception:
+                print("  (Could not open browser — please open the URL manually.)\n", file=sys.stderr)
+        else:
+            print("  (Headless environment detected — open the URL manually.)\n", file=sys.stderr)
+
+    return _redirect_handler
 
     if _can_open_browser():
         try:
@@ -650,9 +671,13 @@ async def _wait_for_callback() -> tuple[str, str | None]:
     # We just need to poll for the result.
     handler_cls, result = _make_callback_handler()
 
-    # Start a temporary server on the known port
+    # Start a temporary server on the known port.
+    # allow_reuse_address prevents TIME_WAIT on the socket after the flow
+    # completes, so the next OAuth flow on the same port can bind immediately
+    # (fixes #44590).
     try:
         server = HTTPServer(("127.0.0.1", _oauth_port), handler_cls)
+        server.allow_reuse_address = True
     except OSError:
         # Port already in use — the server from build_oauth_auth is running.
         # Fall back to polling the server started by build_oauth_auth.
@@ -938,11 +963,15 @@ def build_oauth_auth(
     client_metadata = _build_client_metadata(cfg)
     _maybe_preregister_client(storage, cfg, client_metadata)
 
+    # Use closure factories to avoid global state pollution (#44588).
+    resolved_port = cfg.get("_resolved_port", _oauth_port)
+    redirect_handler = _make_redirect_handler(resolved_port)
+
     return OAuthClientProvider(
         server_url=server_url,
         client_metadata=client_metadata,
         storage=storage,
-        redirect_handler=_redirect_handler,
+        redirect_handler=redirect_handler,
         callback_handler=_wait_for_callback,
         timeout=float(cfg.get("timeout", 300)),
     )

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -612,18 +612,6 @@ def _make_redirect_handler(port: int):
 
     return _redirect_handler
 
-    if _can_open_browser():
-        try:
-            opened = webbrowser.open(authorization_url)
-            if opened:
-                print("  (Browser opened automatically.)\n", file=sys.stderr)
-            else:
-                print("  (Could not open browser — please open the URL manually.)\n", file=sys.stderr)
-        except Exception:
-            print("  (Could not open browser — please open the URL manually.)\n", file=sys.stderr)
-    else:
-        print("  (Headless environment detected — open the URL manually.)\n", file=sys.stderr)
-
 
 async def _wait_for_callback() -> tuple[str, str | None]:
     """Wait for the OAuth callback to arrive on the local callback server.

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -522,7 +522,7 @@ class MCPOAuthManager:
             _configure_callback_port,
             _is_interactive,
             _maybe_preregister_client,
-            _redirect_handler,
+            _make_redirect_handler,
             _wait_for_callback,
         )
 
@@ -545,13 +545,16 @@ class MCPOAuthManager:
         client_metadata = _build_client_metadata(cfg)
         _maybe_preregister_client(storage, cfg, client_metadata)
 
+        resolved_port = cfg.get("_resolved_port", 0)
+        redirect_handler = _make_redirect_handler(resolved_port)
+
         return _HERMES_PROVIDER_CLS(
             server_name=server_name,
             preregistered=bool(cfg.get("client_id")),
             server_url=entry.server_url,
             client_metadata=client_metadata,
             storage=storage,
-            redirect_handler=_redirect_handler,
+            redirect_handler=redirect_handler,
             callback_handler=_wait_for_callback,
             timeout=float(cfg.get("timeout", 300)),
         )


### PR DESCRIPTION
## Infographic

![mcp-oauth-callback-cluster](https://v3b.fal.media/files/b/0aa27a7d/FFD6SzqQzHUJlxsq6SmZ4_CmBiQ91T.png)

## Summary

Closes three races in the MCP OAuth callback flow: cross-server port pollution on concurrent flows, TIME_WAIT lockout on sequential flows, and the select-to-bind TOCTOU on the callback port.

Salvage of **#44872 by @Code-suphub** (cherry-picked, authorship preserved) with the TOCTOU fix from **#22161 by @amathxbt** folded in. The same closure-factory direction was independently submitted in **#5345 by @caseyg (earliest)**, #44607 (@LeonSGP43), and #44685 (@HrushiYadav); the `allow_reuse_address` half also in #44611 (@LeonSGP43). Credit to all six contributors.

Fixes #44588, fixes #44590, fixes #5344.

## Changes

- `tools/mcp_oauth.py`:
  - `_make_redirect_handler(port)` closure factory replaces the module-level handler reading the shared `_oauth_port` global — concurrent OAuth flows no longer print each other's ports (#44588). The #57836 non-interactive fail-fast guard is preserved inside the closure.
  - `_reserve_callback_port()`: ephemeral callback ports keep their socket bound (bounded FIFO pool) from selection until `_wait_for_callback` adopts it via `bind_and_activate=False` — no process can steal the port in between (#22161).
  - `allow_reuse_address` set BEFORE binding (the original #44872 set it after the constructor had bound, a no-op) so TIME_WAIT from a previous flow can't block the next (#44590).
- `tools/mcp_oauth_manager.py`: consume the closure factory.
- `tests/tools/test_mcp_oauth.py`: `TestCallbackPortReservation` (steal-attempt rejected, pool bounded, pinned port untouched, live adopt + callback round-trip); #57836 guard tests updated to the factory API.

## Validation (live E2E, real sockets)

| Check | Result |
|---|---|
| Two concurrent flows: each handler prints its own port, global overwritten | pass |
| Steal attempt on reserved port | rejected |
| Callback round-trip through the adopted reserved socket | pass |
| Sequential reflow on the same pinned port immediately after | pass |
| `test_mcp_oauth.py` + `test_mcp_oauth_manager.py` | 98/98 |
