### PR TITLE
fix(terminal): recover from inaccessible cwd instead of wedging (#65583)

### DIFF
--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -14,8 +14,11 @@ import tempfile
 import threading
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from tools.environments.local import (
     LocalEnvironment,
+    _is_usable_cwd,
     _resolve_safe_cwd,
 )
 
@@ -50,6 +53,44 @@ class TestResolveSafeCwd:
         sep = os.path.sep
         monkeypatch.setattr(os.path, "isdir", lambda p: p == sep)
         assert _resolve_safe_cwd("/no/such/deep/dir") == sep
+
+    def test_walks_up_past_inaccessible_dir(self, monkeypatch, tmp_path):
+        """A directory that exists but is not searchable (``os.X_OK`` fails)
+        must be treated like a missing one — ``os.path.isdir`` alone returns
+        True for it, so recovery would otherwise hand ``Popen`` a cwd it
+        can't ``chdir`` into and raise ``PermissionError`` (#65583)."""
+        locked = tmp_path / "locked"
+        locked.mkdir()
+        blocked = str(locked)
+
+        # Simulate ``/root``-style access: the dir exists (isdir True) but the
+        # runtime user can't enter it (X_OK False).  tmp_path itself stays
+        # accessible so it becomes the recovery target.
+        monkeypatch.setattr(
+            os, "access", lambda p, mode: p != blocked
+        )
+
+        assert _resolve_safe_cwd(blocked) == str(tmp_path)
+
+
+class TestIsUsableCwd:
+    """``_is_usable_cwd`` must require BOTH existence and search access."""
+
+    def test_existing_accessible_dir_is_usable(self, tmp_path):
+        assert _is_usable_cwd(str(tmp_path)) is True
+
+    def test_empty_is_not_usable(self):
+        assert _is_usable_cwd("") is False
+
+    def test_missing_is_not_usable(self, tmp_path):
+        assert _is_usable_cwd(str(tmp_path / "nope")) is False
+
+    def test_inaccessible_dir_is_not_usable(self, monkeypatch, tmp_path):
+        blocked = str(tmp_path)
+        monkeypatch.setattr(os, "access", lambda p, mode: False)
+        # isdir is still True, but the missing X_OK makes it unusable.
+        assert os.path.isdir(blocked) is True
+        assert _is_usable_cwd(blocked) is False
 
 
 def _fake_interrupt():
@@ -128,7 +169,55 @@ class TestRunBashCwdRecovery:
         assert env.cwd == str(tmp_path)
 
         # The warning surfaces the wedge so it isn't silently masked.
-        assert any("missing on disk" in rec.message for rec in caplog.records)
+        assert any("unusable" in rec.message for rec in caplog.records)
+
+    @pytest.mark.skipif(
+        os.name == "nt", reason="POSIX directory-permission semantics only"
+    )
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root bypasses directory search permissions",
+    )
+    def test_recovers_when_cwd_is_inaccessible(self, tmp_path, caplog):
+        """Reproduces #65583: the configured cwd exists but the runtime user
+        can't enter it (the ``/root`` case under a non-root systemd/cron
+        runtime).  ``os.path.isdir`` returns True, so without the ``os.X_OK``
+        guard ``Popen`` would raise ``PermissionError`` and wedge every
+        terminal/file-tool call while the job still reports success."""
+        locked = tmp_path / "locked"
+        locked.mkdir()
+
+        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(cwd=str(locked), timeout=10)
+
+        # Remove search/execute permission so the process can't chdir into it.
+        os.chmod(locked, 0o000)
+        try:
+            assert os.path.isdir(str(locked)) is True
+            assert os.access(str(locked), os.X_OK) is False
+
+            captured = {}
+            fds: list = []
+            try:
+                with patch("tools.environments.local._find_bash", return_value="/bin/bash"), \
+                     patch("subprocess.Popen", side_effect=_make_fake_popen(captured, fds)), \
+                     patch("tools.terminal_tool._interrupt_event", _fake_interrupt()), \
+                     caplog.at_level("WARNING", logger="tools.environments.local"):
+                    env.execute("echo hello")
+            finally:
+                _close_fds(fds)
+        finally:
+            # Restore so tmp_path cleanup can remove the tree.
+            os.chmod(locked, 0o755)
+
+        # Popen must have been handed an accessible directory, never the
+        # locked one that would raise PermissionError.
+        assert captured["cwd"] != str(locked)
+        assert os.path.isdir(captured["cwd"])
+        assert os.access(captured["cwd"], os.X_OK)
+
+        assert env.cwd == captured["cwd"]
+        assert any("unusable" in rec.message for rec in caplog.records)
 
     def test_no_warning_when_cwd_still_exists(self, tmp_path, caplog):
         with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -135,33 +135,56 @@ def _quote_bash_path(path: str) -> str:
     return shlex.quote(_bash_safe_path(path))
 
 
+def _is_usable_cwd(path: str) -> bool:
+    """True if *path* is a directory the current process can actually enter.
+
+    ``os.path.isdir`` alone is NOT sufficient: a directory that exists but is
+    not searchable by the runtime user still passes it, because ``stat``
+    succeeds through the parent directory.  The classic case is ``/root``
+    under a non-root runtime (systemd ``User=hermes``, cron): ``isdir('/root')``
+    returns True, but ``subprocess.Popen(..., cwd='/root')`` raises
+    ``PermissionError: [Errno 13] Permission denied: '/root'`` the moment it
+    tries to ``chdir`` into it (#65583).  Require execute/search access
+    (``os.X_OK``) too so callers fall back to an accessible ancestor instead
+    of wedging every terminal/file-tool call.
+    """
+    return bool(path) and os.path.isdir(path) and os.access(path, os.X_OK)
+
+
 def _resolve_safe_cwd(cwd: str) -> str:
-    """Return ``cwd`` if it exists as a directory, else the nearest existing
+    """Return ``cwd`` if it is a usable directory, else the nearest usable
     ancestor.  Falls back to ``tempfile.gettempdir()`` only if walking up the
-    path can't find any existing directory (effectively never on a healthy
+    path can't find any usable directory (effectively never on a healthy
     filesystem, but cheap belt-and-braces).
 
+    "Usable" means the directory both exists AND is searchable by the current
+    process (see ``_is_usable_cwd``).  A present-but-inaccessible directory
+    (e.g. ``/root`` under a non-root systemd/cron runtime) is treated the same
+    as a missing one so recovery walks up to an accessible ancestor.
+
     On Windows, also normalizes Git Bash / MSYS-style POSIX paths
-    (``/c/Users/x``) to native Windows form before the isdir check so a
+    (``/c/Users/x``) to native Windows form before the check so a
     perfectly valid ``pwd -P`` result from bash doesn't get rejected as
     "missing" (see ``_msys_to_windows_path``).
 
-    Used by ``_run_bash`` to recover when the configured cwd is gone — most
-    commonly because a previous tool call deleted its own working directory
-    (issue #17558).  Without this guard, ``subprocess.Popen(..., cwd=...)``
-    raises ``FileNotFoundError`` before bash starts, wedging every subsequent
-    terminal call until the gateway restarts.
+    Used by ``_run_bash`` to recover when the configured cwd is unusable —
+    either because a previous tool call deleted its own working directory
+    (``FileNotFoundError``, issue #17558) or because the configured cwd is a
+    directory the runtime user can't enter (``PermissionError``, issue
+    #65583).  Without this guard, ``subprocess.Popen(..., cwd=...)`` raises
+    before bash starts, wedging every subsequent terminal call until the
+    gateway restarts.
     """
     cwd = _msys_to_windows_path(cwd) if _IS_WINDOWS else cwd
-    if cwd and os.path.isdir(cwd):
+    if _is_usable_cwd(cwd):
         return cwd
     parent = os.path.dirname(cwd) if cwd else ""
     while parent:
-        if os.path.isdir(parent):
+        if _is_usable_cwd(parent):
             return parent
         next_parent = os.path.dirname(parent)
         if next_parent == parent:
-            # Reached the filesystem root and it doesn't exist either —
+            # Reached the filesystem root and it isn't usable either —
             # genuinely nothing to fall back to except the temp dir.
             break
         parent = next_parent
@@ -1234,12 +1257,15 @@ class LocalEnvironment(BaseEnvironment):
         if safe_cwd != self.cwd:
             # MSYS → Windows translation alone shouldn't surface as a warning
             # (it's a benign normalization, not a recovery). Only warn when
-            # the directory really doesn't exist on disk.
+            # the directory is genuinely unusable — either missing on disk or
+            # present but inaccessible to the runtime user (e.g. ``/root``
+            # under a non-root systemd/cron runtime, #65583).
             normalized = _msys_to_windows_path(self.cwd) if _IS_WINDOWS else self.cwd
             if safe_cwd != normalized:
                 logger.warning(
-                    "LocalEnvironment cwd %r is missing on disk; "
-                    "falling back to %r so terminal commands keep working.",
+                    "LocalEnvironment cwd %r is unusable (missing or "
+                    "inaccessible); falling back to %r so terminal commands "
+                    "keep working.",
                     self.cwd,
                     safe_cwd,
                 )


### PR DESCRIPTION
## Summary

Fixes #65583 — every cron `terminal` / `read_file` / `write_file` / `search_files` call failing with `PermissionError: [Errno 13] Permission denied: '/root'` under a non-root runtime (systemd `User=hermes`, cron), while the turn still reports success.

**Root cause:** `_resolve_safe_cwd` in `tools/environments/local.py` only rejected a cwd when `os.path.isdir(cwd)` was `False`. But `isdir` returns `True` for a directory that **exists but is not searchable** by the runtime user — `stat` succeeds through the parent. `/root` under a non-root process is the textbook case. So the unusable cwd was handed straight to `subprocess.Popen(cwd=...)`, which raises `PermissionError` the instant it tries to `chdir` into it. Since `init_session` and every subsequent command spawn go through this path, the whole terminal/file toolset wedges.

This is the local backend (systemd/cron) case, which is distinct from — and not fixed by — the Docker/default-cwd change in #65614.

## Fix

- Add `_is_usable_cwd(path)` requiring **both** existence *and* `os.access(path, os.X_OK)` (search access).
- Route `_resolve_safe_cwd` through it, so a present-but-inaccessible directory is treated like a missing one and recovery walks up to the nearest accessible ancestor (mirroring the deleted-cwd recovery from #17558), falling back to the temp dir only if nothing on the path is usable.
- Update the fallback warning to `unusable (missing or inaccessible)` so the recovery is visible in `agent.log` instead of silently masked.

No behavior change on Windows or when the cwd is already accessible.

## Test plan

- [x] `scripts/run_tests.sh tests/tools/test_local_env_cwd_recovery.py -q` — 15 passed
- [x] `scripts/run_tests.sh tests/tools/test_local_env_windows_msys.py tests/tools/test_local_env_relative_cwd.py -q` — 44 passed (no regression)
- New coverage: `_is_usable_cwd` existence+X_OK contract, `_resolve_safe_cwd` walking up past an inaccessible dir, and an E2E `LocalEnvironment.execute` reproduction of the `/root` wedge with a real mode-000 directory (skipped on Windows / when running as root, which bypasses directory search permissions).