### PR TITLE
fix(codex): preserve active Responses streams

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -237,7 +237,13 @@ def _check_stale_giveup(agent) -> None:
         )
 
 
-def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
+def _dispatch_nonstreaming_api_request(
+    agent,
+    api_kwargs: dict,
+    *,
+    make_client,
+    on_codex_event_activity=None,
+):
     """Run one non-streaming LLM request for the active api_mode and return it.
 
     Shared by the interrupt-worker path (``interruptible_api_call``) and the
@@ -251,6 +257,10 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
     MoA branches manage their own clients and never call it. All interrupt,
     abort, cancellation, and close semantics stay in the callers — this helper
     only issues the request.
+
+    ``on_codex_event_activity(timestamp)`` is request-local. The interruptible
+    caller uses it for TTFB/event-idle decisions so a daemon worker left over
+    from an older request cannot publish liveness into a newer request.
     """
     if agent.api_mode == "codex_responses":
         request_client = make_client("codex_stream_request")
@@ -258,6 +268,7 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
             api_kwargs,
             client=request_client,
             on_first_delta=getattr(agent, "_codex_on_first_delta", None),
+            on_event_activity=on_codex_event_activity,
         )
     if agent.api_mode == "anthropic_messages":
         return agent._anthropic_messages_create(api_kwargs)
@@ -380,7 +391,11 @@ def interruptible_api_call(agent, api_kwargs: dict):
     if should_use_direct_api_call(agent):
         return direct_api_call(agent, api_kwargs)
 
-    result = {"response": None, "error": None}
+    result: Dict[str, Any] = {"response": None, "error": None}
+    codex_activity: Dict[str, Optional[float]] = {"last_event_ts": None}
+
+    def _record_codex_event_activity(event_ts: float) -> None:
+        codex_activity["last_event_ts"] = event_ts
 
     # Cross-turn stale-call circuit breaker (#58962) — non-streaming sibling
     # of the guard in interruptible_streaming_api_call.  Quiet-mode /
@@ -455,6 +470,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
                         reason=reason, api_kwargs=api_kwargs
                     )
                 ),
+                on_codex_event_activity=_record_codex_event_activity,
             )
         except Exception as e:
             # If the request was cancelled by the main thread's interrupt
@@ -520,11 +536,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # limit. Tunable via HERMES_CODEX_HARD_TIMEOUT_SECONDS (set to 0 to
     # disable the ceiling entirely; that restores the pre-fix behavior).
     _codex_hard_timeout = _env_float("HERMES_CODEX_HARD_TIMEOUT_SECONDS", 1500.0)
-    if (
+    _codex_hard_ceiling_enabled = (
         _codex_watchdog_enabled
         and _openai_codex_backend
         and _codex_hard_timeout > 0
-    ):
+    )
+    if _codex_hard_ceiling_enabled:
         _stale_timeout = min(_stale_timeout, _codex_hard_timeout)
 
     if _est_tokens_for_codex_watchdog > 100_000:
@@ -589,8 +606,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
         _codex_idle_enabled = False
 
     if _codex_watchdog_enabled:
-        # Reset before the worker starts so a marker left over from a previous
-        # call on this agent can't be misread as first-byte for this one.
+        # Reset legacy diagnostic markers. Watchdog decisions below use the
+        # request-local ``codex_activity`` closure, so a surviving older worker
+        # cannot publish first-byte/activity into this request.
         agent._codex_stream_last_event_ts = None
         agent._codex_stream_last_progress_ts = None
 
@@ -611,17 +629,35 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # usually a slow/overloaded provider, but the UI never said so).
         if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
             _elapsed = time.time() - _call_start
-            _deadline = _stale_timeout
-            if (
-                _ttfb_enabled
-                and getattr(agent, "_codex_stream_last_event_ts", None) is None
-            ):
-                _deadline = min(_deadline, _ttfb_timeout)
-            agent._emit_wait_notice(
-                f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
-                f"{int(_elapsed)}s with no response yet (provider may be slow "
-                f"or overloaded; auto-reconnect at {int(_deadline)}s)"
-            )
+            _last_event_ts = codex_activity["last_event_ts"]
+            if _codex_watchdog_enabled and _last_event_ts is not None:
+                _stream_limits = []
+                if _codex_idle_enabled:
+                    _stream_limits.append(
+                        f"reconnect after {int(_codex_idle_timeout)}s without stream events"
+                    )
+                    if _codex_hard_ceiling_enabled:
+                        _stream_limits.append(
+                            f"hard stop at {int(_codex_hard_timeout)}s total"
+                        )
+                else:
+                    _stream_limits.append(
+                        f"completion timeout at {int(_stale_timeout)}s"
+                    )
+                agent._emit_wait_notice(
+                    f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
+                    f"{int(_elapsed)}s; response stream active "
+                    f"({'; '.join(_stream_limits)})"
+                )
+            else:
+                _deadline = _stale_timeout
+                if _ttfb_enabled:
+                    _deadline = min(_deadline, _ttfb_timeout)
+                agent._emit_wait_notice(
+                    f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
+                    f"{int(_elapsed)}s with no response yet (provider may be slow "
+                    f"or overloaded; auto-reconnect at {int(_deadline)}s)"
+                )
 
         _elapsed = time.time() - _call_start
 
@@ -633,7 +669,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
         if (
             _ttfb_enabled
             and _elapsed > _ttfb_timeout
-            and getattr(agent, "_codex_stream_last_event_ts", None) is None
+            and codex_activity["last_event_ts"] is None
         ):
             _silent_hint: Optional[str] = None
             _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
@@ -690,7 +726,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # Stream-idle detector: the Codex backend emitted at least one SSE
         # frame, then stopped emitting events. Valid keepalive / in_progress
         # frames refresh _codex_stream_last_event_ts and should not be killed.
-        _last_codex_event_ts = getattr(agent, "_codex_stream_last_event_ts", None)
+        _last_codex_event_ts = codex_activity["last_event_ts"]
         if (
             _codex_idle_enabled
             and _last_codex_event_ts is not None
@@ -726,35 +762,102 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 )
             break
 
-        # Stale-call detector: kill the connection if no response
-        # arrives within the configured timeout.
-        if _elapsed > _stale_timeout:
+        # Generic stale-call detection is for requests that have produced no
+        # observable response. Codex Responses is internally streamed: after
+        # its first SSE event, an enabled event-idle watchdog above owns liveness
+        # so a healthy long-running reasoning/tool-call stream is not killed
+        # merely because its terminal response takes longer than this wall-clock
+        # threshold. If event-idle is disabled, generic stale detection remains
+        # the fallback. The explicit openai-codex hard ceiling remains absolute.
+        _codex_stream_started = (
+            _codex_watchdog_enabled
+            and codex_activity["last_event_ts"] is not None
+        )
+        _codex_idle_owns_liveness = _codex_stream_started and _codex_idle_enabled
+        _codex_hard_ceiling_reached = (
+            _codex_hard_ceiling_enabled
+            and _elapsed > _codex_hard_timeout
+        )
+        if (
+            _elapsed > _stale_timeout
+            and (not _codex_idle_owns_liveness or _codex_hard_ceiling_reached)
+        ):
+            _stale_kill_threshold = (
+                _codex_hard_timeout
+                if _codex_hard_ceiling_reached
+                else _stale_timeout
+            )
+            _hard_ceiling_kill = (
+                _codex_stream_started and _codex_hard_ceiling_reached
+            )
+            _stream_completion_timeout_kill = (
+                _codex_stream_started and not _hard_ceiling_kill
+            )
             _est_ctx = estimate_request_context_tokens(api_kwargs)
             _silent_hint: Optional[str] = None
-            _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
-            if callable(_hint_fn):
-                try:
-                    _silent_hint = _hint_fn(model=api_kwargs.get("model"))
-                except Exception:
-                    _silent_hint = None
-            logger.warning(
-                "Non-streaming API call stale for %.0fs (threshold %.0fs). "
-                "model=%s context=~%s tokens. Killing connection.",
-                _elapsed, _stale_timeout,
-                api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
-            )
-            if _silent_hint:
+            if not _codex_stream_started:
+                _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
+                if callable(_hint_fn):
+                    try:
+                        _hint_result = _hint_fn(model=api_kwargs.get("model"))
+                        _silent_hint = (
+                            _hint_result if isinstance(_hint_result, str) else None
+                        )
+                    except Exception:
+                        _silent_hint = None
+            if _hard_ceiling_kill:
+                logger.warning(
+                    "Codex Responses stream reached its hard ceiling after %.0fs "
+                    "(threshold %.0fs, model=%s, context=~%s tokens). Stream "
+                    "events were received; killing the connection at the "
+                    "configured total-duration limit.",
+                    _elapsed,
+                    _stale_kill_threshold,
+                    api_kwargs.get("model", "unknown"),
+                    f"{_est_ctx:,}",
+                )
                 agent._buffer_status(
-                    f"⚠️ No response from provider for {int(_elapsed)}s "
-                    f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"{_silent_hint}"
+                    f"⚠️ Codex response stream reached its "
+                    f"{int(_stale_kill_threshold)}s hard limit "
+                    f"(model: {api_kwargs.get('model', 'unknown')}). Aborting call."
+                )
+            elif _stream_completion_timeout_kill:
+                logger.warning(
+                    "Codex Responses stream did not complete within its fallback "
+                    "timeout (%.0fs > %.0fs, model=%s, context=~%s tokens). "
+                    "Event-idle watchdog is disabled; killing the connection.",
+                    _elapsed,
+                    _stale_kill_threshold,
+                    api_kwargs.get("model", "unknown"),
+                    f"{_est_ctx:,}",
+                )
+                agent._buffer_status(
+                    f"⚠️ Codex response stream did not complete within "
+                    f"{int(_stale_kill_threshold)}s "
+                    f"(model: {api_kwargs.get('model', 'unknown')}; "
+                    f"event-idle watchdog disabled). Aborting call."
                 )
             else:
-                agent._buffer_status(
-                    f"⚠️ No response from provider for {int(_elapsed)}s "
-                    f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"Aborting call."
+                logger.warning(
+                    "Non-streaming API call stale for %.0fs (threshold %.0fs). "
+                    "model=%s context=~%s tokens. Killing connection.",
+                    _elapsed,
+                    _stale_kill_threshold,
+                    api_kwargs.get("model", "unknown"),
+                    f"{_est_ctx:,}",
                 )
+                if _silent_hint:
+                    agent._buffer_status(
+                        f"⚠️ No response from provider for {int(_elapsed)}s "
+                        f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
+                        f"{_silent_hint}"
+                    )
+                else:
+                    agent._buffer_status(
+                        f"⚠️ No response from provider for {int(_elapsed)}s "
+                        f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
+                        f"Aborting call."
+                    )
             try:
                 if agent.api_mode == "anthropic_messages":
                     agent._anthropic_client.close()
@@ -766,22 +869,44 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # Circuit breaker (#58962): count the stale kill.  See the
             # canonical comment block above ``_stale_streak()``.
             _bump_stale_streak(agent)
-            agent._touch_activity(
-                f"stale non-streaming call killed after {int(_elapsed)}s"
-            )
+            if _hard_ceiling_kill:
+                agent._touch_activity(
+                    f"codex response stream killed at {int(_elapsed)}s hard ceiling"
+                )
+            elif _stream_completion_timeout_kill:
+                agent._touch_activity(
+                    f"codex response stream killed at {int(_elapsed)}s fallback timeout"
+                )
+            else:
+                agent._touch_activity(
+                    f"stale non-streaming call killed after {int(_elapsed)}s"
+                )
             # Wait briefly for the thread to notice the closed connection.
             t.join(timeout=2.0)
             if result["error"] is None and result["response"] is None:
-                if _silent_hint:
+                if _hard_ceiling_kill:
+                    result["error"] = TimeoutError(
+                        f"Codex Responses stream exceeded its total hard ceiling "
+                        f"after {int(_elapsed)}s "
+                        f"(threshold: {int(_stale_kill_threshold)}s)"
+                    )
+                elif _stream_completion_timeout_kill:
+                    result["error"] = TimeoutError(
+                        f"Codex Responses stream did not complete before its "
+                        f"fallback timeout after {int(_elapsed)}s "
+                        f"(threshold: {int(_stale_kill_threshold)}s; "
+                        f"event-idle watchdog disabled)"
+                    )
+                elif _silent_hint:
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s). "
+                        f"with no response (threshold: {int(_stale_kill_threshold)}s). "
                         f"{_silent_hint}"
                     )
                 else:
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s)"
+                        f"with no response (threshold: {int(_stale_kill_threshold)}s)"
                     )
             break
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -838,7 +838,13 @@ def _consume_codex_event_stream(
     return final
 
 
-def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
+def run_codex_stream(
+    agent,
+    api_kwargs: dict,
+    client: Any = None,
+    on_first_delta=None,
+    on_event_activity=None,
+):
     """Execute one streaming Responses API request and return the final response.
 
     Uses ``responses.create(stream=True)`` (low-level raw event iteration)
@@ -846,6 +852,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     us structurally immune to backend drift in the ``response.completed``
     payload shape — we never let the SDK reconstruct a typed object from
     the terminal event's ``output`` field.
+
+    ``on_event_activity`` receives the timestamp of every SSE frame. The
+    interruptible caller binds it to request-local watchdog state; the agent
+    field remains a diagnostic/compatibility marker only.
     """
     import httpx as _httpx
 
@@ -863,7 +873,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
 
     def _on_event(event: Any) -> None:
         # TTFB watchdog and activity touch — runs once per SSE event.
-        agent._codex_stream_last_event_ts = time.time()
+        event_ts = time.time()
+        agent._codex_stream_last_event_ts = event_ts
+        if on_event_activity is not None:
+            on_event_activity(event_ts)
         agent._touch_activity("receiving stream response")
 
     def _interrupt_check() -> bool:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4253,10 +4253,22 @@ class AIAgent:
                 exc,
             )
 
-    def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
+    def _run_codex_stream(
+        self,
+        api_kwargs: dict,
+        client: Any = None,
+        on_first_delta: Optional[Callable] = None,
+        on_event_activity: Optional[Callable] = None,
+    ):
         """Forwarder — see ``agent.codex_runtime.run_codex_stream``."""
         from agent.codex_runtime import run_codex_stream
-        return run_codex_stream(self, api_kwargs, client, on_first_delta)
+        return run_codex_stream(
+            self,
+            api_kwargs,
+            client,
+            on_first_delta,
+            on_event_activity=on_event_activity,
+        )
 
     def _run_codex_create_stream_fallback(self, api_kwargs: dict, client: Any = None):
         """Forwarder — see ``agent.codex_runtime.run_codex_create_stream_fallback``."""

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -8,15 +8,16 @@ retry loop can reconnect promptly. Once any stream event arrives, the TTFB
 watchdog is satisfied and a separate idle watchdog handles streams that stop
 emitting SSE events.
 
-The "bytes flowing" signal is ``agent._codex_stream_last_event_ts``, set on
-*any* event by ``codex_runtime.run_codex_stream`` — so reasoning-only or
-tool-call-only turns (which emit no output-text deltas) are not mistaken for a
-stall.
+The "bytes flowing" signal is a request-local activity callback fired on *any*
+event by ``codex_runtime.run_codex_stream`` — so reasoning-only or tool-call-only
+turns (which emit no output-text deltas) are not mistaken for a stall, and a
+surviving worker from an older request cannot keep a newer watchdog alive.
 """
 
 from __future__ import annotations
 
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
@@ -57,6 +58,28 @@ def _make_codex_agent(tmp_path, monkeypatch):
     return agent
 
 
+def _use_custom_codex_backend(agent) -> None:
+    setattr(agent, "provider", "custom")
+    agent.base_url = "https://example.invalid/v1"
+    agent._base_url_lower = agent.base_url.lower()
+    agent._base_url_hostname = "example.invalid"
+
+
+def _capture_request_closes(agent, monkeypatch) -> list:
+    closes: list = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(
+        agent, "_create_request_openai_client", lambda **k: dummy_client
+    )
+    monkeypatch.setattr(
+        agent, "_abort_request_openai_client", lambda c, reason=None: closes.append(reason)
+    )
+    monkeypatch.setattr(
+        agent, "_close_request_openai_client", lambda c, reason=None: closes.append(reason)
+    )
+    return closes
+
+
 def test_ttfb_kills_when_no_stream_event(tmp_path, monkeypatch):
     """Backend accepts the connection but emits no event -> killed at the TTFB
     cutoff, well before the 60s wall-clock stale timeout, with a retryable
@@ -80,7 +103,7 @@ def test_ttfb_kills_when_no_stream_event(tmp_path, monkeypatch):
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
         # Never set _codex_stream_last_event_ts: simulate zero events arriving.
         deadline = time.time() + 30
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
@@ -128,12 +151,15 @@ def test_ttfb_default_tolerates_slow_first_event(tmp_path, monkeypatch):
 
     sentinel = SimpleNamespace(ok=True)
 
-    def fake_slow_first_event(api_kwargs, client=None, on_first_delta=None):
+    def fake_slow_first_event(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
         # Backend is alive but slow to admit: first event lands after ~2s,
         # well under the 120s default cutoff. Mark the first byte so the
         # no-byte detector sees activity, then return the response.
         time.sleep(2.0)
-        agent._codex_stream_last_event_ts = time.time()
+        event_ts = time.time()
+        setattr(agent, "_codex_stream_last_event_ts", event_ts)
+        assert on_event_activity is not None
+        on_event_activity(event_ts)
         return sentinel
 
     monkeypatch.setattr(agent, "_run_codex_stream", fake_slow_first_event)
@@ -168,7 +194,7 @@ def test_ttfb_includes_silent_hang_hint_for_gpt_5_5(tmp_path, monkeypatch):
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
         deadline = time.time() + 30
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)
@@ -213,7 +239,7 @@ def test_ttfb_high_env_is_capped_for_openai_codex(tmp_path, monkeypatch):
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
         deadline = time.time() + 30
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)
@@ -255,10 +281,13 @@ def test_ttfb_does_not_kill_when_events_flow(tmp_path, monkeypatch):
 
     sentinel = SimpleNamespace(ok=True)
 
-    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+    def fake_stream(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
         # Bytes flowing: mark stream activity right away, then keep generating
         # past the 1s TTFB cutoff before returning a real response.
-        agent._codex_stream_last_event_ts = time.time()
+        event_ts = time.time()
+        setattr(agent, "_codex_stream_last_event_ts", event_ts)
+        assert on_event_activity is not None
+        on_event_activity(event_ts)
         if on_first_delta:
             on_first_delta()
         time.sleep(2.0)
@@ -269,6 +298,182 @@ def test_ttfb_does_not_kill_when_events_flow(tmp_path, monkeypatch):
     resp = h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
     assert resp is sentinel
     assert "codex_ttfb_kill" not in closes
+
+
+def test_active_responses_stream_outlives_nonstream_stale_timeout(tmp_path, monkeypatch):
+    """After the first SSE event, event-idle detection owns stream liveness.
+
+    A custom Responses endpoint may legitimately stream reasoning or tool-call
+    arguments longer than the generic non-streaming stale timeout. Fresh events
+    must keep that request alive until it returns a terminal response.
+    """
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    _use_custom_codex_backend(agent)
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 1.0
+    )
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "1")
+
+    closes = _capture_request_closes(agent, monkeypatch)
+
+    sentinel = SimpleNamespace(ok=True)
+    stop = threading.Event()
+    worker_done = threading.Event()
+
+    def fake_active_stream(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        on_event_activity=None,
+    ):
+        try:
+            assert on_event_activity is not None
+            deadline = time.time() + 4.0
+            while time.time() < deadline and not stop.is_set():
+                event_ts = time.time()
+                # Keep the legacy diagnostic marker realistic while the request-
+                # local callback drives this invocation's watchdog state.
+                setattr(agent, "_codex_stream_last_event_ts", event_ts)
+                on_event_activity(event_ts)
+                time.sleep(0.02)
+            return sentinel
+        finally:
+            worker_done.set()
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_active_stream)
+
+    try:
+        response = h.interruptible_api_call(
+            agent, {"model": "gpt-5.5", "input": "generate a large artifact"}
+        )
+    finally:
+        stop.set()
+        assert worker_done.wait(1.0), "Codex worker did not exit after test cleanup"
+
+    assert response is sentinel
+    assert "stale_call_kill" not in closes
+    assert "codex_ttfb_kill" not in closes
+    assert "codex_stream_idle_kill" not in closes
+
+
+def test_idle_watchdog_disabled_falls_back_to_generic_stale_timeout(
+    tmp_path, monkeypatch
+):
+    """Disabling event-idle must not leave a post-first-byte stall unbounded."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    _use_custom_codex_backend(agent)
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 1.0
+    )
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "10")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0")
+
+    closes = _capture_request_closes(agent, monkeypatch)
+
+    stop = threading.Event()
+    worker_done = threading.Event()
+
+    def fake_one_event_then_stall(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        on_event_activity=None,
+    ):
+        try:
+            assert on_event_activity is not None
+            event_ts = time.time()
+            setattr(agent, "_codex_stream_last_event_ts", event_ts)
+            on_event_activity(event_ts)
+            deadline = time.time() + 4.0
+            while time.time() < deadline and not stop.is_set():
+                time.sleep(0.02)
+            return SimpleNamespace(ok=True)
+        finally:
+            worker_done.set()
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_one_event_then_stall)
+
+    try:
+        with pytest.raises(TimeoutError) as excinfo:
+            h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+    finally:
+        stop.set()
+        assert worker_done.wait(1.0), "Codex worker did not exit after test cleanup"
+
+    assert "did not complete before its fallback timeout" in str(excinfo.value)
+    assert "event-idle watchdog disabled" in str(excinfo.value)
+    assert "no response" not in str(excinfo.value).lower()
+    assert "stale_call_kill" in closes
+    assert "codex_ttfb_kill" not in closes
+    assert "codex_stream_idle_kill" not in closes
+
+
+def test_prior_request_events_do_not_satisfy_new_request_ttfb(tmp_path, monkeypatch):
+    """A surviving older worker cannot publish liveness into a newer request."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    _use_custom_codex_backend(agent)
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 60.0
+    )
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "1")
+
+    closes = _capture_request_closes(agent, monkeypatch)
+
+    callbacks = []
+    second_stop = threading.Event()
+    second_done = threading.Event()
+    first_response = SimpleNamespace(ok=True)
+
+    def fake_two_requests(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        on_event_activity=None,
+    ):
+        assert on_event_activity is not None
+        callbacks.append(on_event_activity)
+        if len(callbacks) == 1:
+            event_ts = time.time()
+            setattr(agent, "_codex_stream_last_event_ts", event_ts)
+            on_event_activity(event_ts)
+            return first_response
+
+        old_request_activity = callbacks[0]
+        try:
+            deadline = time.time() + 4.0
+            while time.time() < deadline and not second_stop.is_set():
+                event_ts = time.time()
+                # Simulate a daemon worker from request 1 continuing to emit.
+                setattr(agent, "_codex_stream_last_event_ts", event_ts)
+                old_request_activity(event_ts)
+                time.sleep(0.02)
+            return SimpleNamespace(ok=True)
+        finally:
+            second_done.set()
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_two_requests)
+
+    assert h.interruptible_api_call(
+        agent, {"model": "gpt-5.5", "input": "first"}
+    ) is first_response
+
+    try:
+        with pytest.raises(TimeoutError) as excinfo:
+            h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "second"})
+    finally:
+        second_stop.set()
+        assert second_done.wait(1.0), "Second Codex worker did not exit after cleanup"
+
+    assert "TTFB" in str(excinfo.value)
+    assert "codex_ttfb_kill" in closes
 
 
 def test_event_idle_kills_after_first_event_then_silence(tmp_path, monkeypatch):
@@ -297,8 +502,11 @@ def test_event_idle_kills_after_first_event_then_silence(tmp_path, monkeypatch):
 
     stop = {"flag": False}
 
-    def fake_stream(api_kwargs, client=None, on_first_delta=None):
-        agent._codex_stream_last_event_ts = time.time()
+    def fake_stream(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
+        event_ts = time.time()
+        setattr(agent, "_codex_stream_last_event_ts", event_ts)
+        assert on_event_activity is not None
+        on_event_activity(event_ts)
         deadline = time.time() + 30
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)
@@ -339,7 +547,7 @@ def test_ttfb_disabled_via_env_zero(tmp_path, monkeypatch):
 
     sentinel = SimpleNamespace(ok=True)
 
-    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+    def fake_stream(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
         # No event marker, but only briefly — well under the 60s stale timeout.
         time.sleep(2.0)
         return sentinel
@@ -372,7 +580,7 @@ def test_large_codex_request_waits_instead_of_ttfb_reconnect(tmp_path, monkeypat
 
     sentinel = SimpleNamespace(ok=True)
 
-    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+    def fake_stream(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
         # No event marker for 2s: this would trip the 1s TTFB watchdog on a
         # small request, but should be allowed for a large request.
         time.sleep(2.0)
@@ -407,7 +615,7 @@ def test_large_codex_request_can_still_ttfb_reconnect_when_capped(tmp_path, monk
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
         deadline = time.time() + 30
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)
@@ -446,7 +654,7 @@ def test_large_codex_request_strict_ttfb_env_still_reconnects(tmp_path, monkeypa
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
         deadline = time.time() + 30
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)
@@ -462,6 +670,59 @@ def test_large_codex_request_strict_ttfb_env_still_reconnects(tmp_path, monkeypa
         assert "codex_ttfb_kill" in closes
     finally:
         stop["flag"] = True
+
+
+def test_hard_ceiling_reclaims_stream_with_fresh_events(tmp_path, monkeypatch):
+    """The explicit openai-codex hard ceiling remains absolute after first byte."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 0.5
+    )
+    monkeypatch.setenv("HERMES_CODEX_HARD_TIMEOUT_SECONDS", "1")
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "10")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "1")
+
+    closes = _capture_request_closes(agent, monkeypatch)
+
+    stop = threading.Event()
+    worker_done = threading.Event()
+
+    def fake_active_stream(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        on_event_activity=None,
+    ):
+        try:
+            assert on_event_activity is not None
+            deadline = time.time() + 4.0
+            while time.time() < deadline and not stop.is_set():
+                event_ts = time.time()
+                setattr(agent, "_codex_stream_last_event_ts", event_ts)
+                on_event_activity(event_ts)
+                time.sleep(0.02)
+            raise RuntimeError("hard ceiling did not stop active stream")
+        finally:
+            worker_done.set()
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_active_stream)
+
+    try:
+        with pytest.raises(TimeoutError) as excinfo:
+            h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+    finally:
+        stop.set()
+        assert worker_done.wait(1.0), "Codex worker did not exit after test cleanup"
+
+    assert "stale_call_kill" in closes
+    assert "codex_stream_idle_kill" not in closes
+    assert "Codex Responses stream exceeded its total hard ceiling" in str(
+        excinfo.value
+    )
+    assert "threshold: 1s" in str(excinfo.value)
+    assert "no response" not in str(excinfo.value).lower()
 
 
 def test_large_codex_request_hard_ceiling_reclaims_silent_stall(tmp_path, monkeypatch):
@@ -494,7 +755,7 @@ def test_large_codex_request_hard_ceiling_reclaims_silent_stall(tmp_path, monkey
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
         # No event marker AND no event ever: the exact issue-64507 stall.
         deadline = time.time() + 120
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
@@ -542,7 +803,7 @@ def test_large_codex_request_hard_ceiling_disabled_restores_legacy(tmp_path, mon
 
     sentinel = SimpleNamespace(ok=True)
 
-    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+    def fake_stream(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
         # No event, but only briefly — well under the (here 60s) stale timeout.
         time.sleep(2.0)
         return sentinel
@@ -584,7 +845,7 @@ def test_large_codex_request_hard_ceiling_caps_raised_stale_floor(tmp_path, monk
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(api_kwargs, client=None, on_first_delta=None, on_event_activity=None):
         deadline = time.time() + 200
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1034,6 +1034,7 @@ class TestCodexStreamCallbacks:
         agent._interrupt_requested = False
 
         touch_calls = []
+        request_activity = []
         agent._touch_activity = lambda desc: touch_calls.append(desc)
 
         events = [
@@ -1054,9 +1055,13 @@ class TestCodexStreamCallbacks:
         mock_client = MagicMock()
         mock_client.responses.create.return_value = _FakeCreateStream()
 
-        agent._run_codex_stream({}, client=mock_client)
+        agent._run_codex_stream(
+            {}, client=mock_client, on_event_activity=request_activity.append
+        )
 
         assert touch_calls.count("receiving stream response") == 3
+        assert len(request_activity) == 3
+        assert request_activity == sorted(request_activity)
 
     def test_codex_remote_protocol_error_retries_then_raises(self):
         """Transport errors from ``responses.create`` retry once then re-raise.

--- a/tests/run_agent/test_wait_state_visibility.py
+++ b/tests/run_agent/test_wait_state_visibility.py
@@ -11,6 +11,7 @@ gateway's "⏳ Working — N min" heartbeat includes).
 from __future__ import annotations
 
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
@@ -83,7 +84,7 @@ def test_nonstream_wait_loop_emits_explained_notice(tmp_path, monkeypatch):
 
     seen: list = []
     agent = _make_agent(tmp_path, monkeypatch, thinking_callback=seen.append)
-    agent.api_mode = "codex_responses"
+    setattr(agent, "api_mode", "codex_responses")
     monkeypatch.setattr(agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 60.0)
 
     # Compress the 30s cadence: the loop fires the notice every 100 polls of
@@ -98,7 +99,12 @@ def test_nonstream_wait_loop_emits_explained_notice(tmp_path, monkeypatch):
 
     stop = {"flag": False}
 
-    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+    def fake_hang(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        on_event_activity=None,
+    ):
         deadline = time.time() + 10
         while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
             time.sleep(0.02)
@@ -121,3 +127,73 @@ def test_nonstream_wait_loop_emits_explained_notice(tmp_path, monkeypatch):
     reconnect_notices = [s for s in seen if "reconnecting" in s]
     assert reconnect_notices, f"expected a reconnect wait-notice, saw: {seen}"
     assert "no response from provider" in reconnect_notices[0]
+
+
+def test_active_codex_wait_notice_reports_stream_liveness(tmp_path, monkeypatch):
+    """After first byte, the periodic notice reports stream-aware limits."""
+    from agent import chat_completion_helpers as h
+
+    seen: list = []
+    agent = _make_agent(tmp_path, monkeypatch, thinking_callback=seen.append)
+    setattr(agent, "api_mode", "codex_responses")
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 60.0
+    )
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "10")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "2")
+
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent, "_abort_request_openai_client", lambda c, reason=None: None
+    )
+    monkeypatch.setattr(
+        agent, "_close_request_openai_client", lambda c, reason=None: None
+    )
+
+    stop = threading.Event()
+    worker_done = threading.Event()
+    sentinel = SimpleNamespace(ok=True)
+
+    def fake_active_stream(
+        api_kwargs,
+        client=None,
+        on_first_delta=None,
+        on_event_activity=None,
+    ):
+        try:
+            assert on_event_activity is not None
+            deadline = time.time() + 1.2
+            while time.time() < deadline and not stop.is_set():
+                event_ts = time.time()
+                setattr(agent, "_codex_stream_last_event_ts", event_ts)
+                on_event_activity(event_ts)
+                time.sleep(0.01)
+            return sentinel
+        finally:
+            worker_done.set()
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_active_stream)
+
+    original_join = threading.Thread.join
+
+    def fast_poll_join(thread, timeout=None):
+        effective_timeout = 0.005 if timeout == 0.3 else timeout
+        return original_join(thread, effective_timeout)
+
+    monkeypatch.setattr(threading.Thread, "join", fast_poll_join)
+
+    try:
+        response = h.interruptible_api_call(
+            agent, {"model": "gpt-5.5", "input": "long reasoning"}
+        )
+    finally:
+        stop.set()
+        assert worker_done.wait(1.0), "Codex worker did not exit after cleanup"
+
+    assert response is sentinel
+    active_notices = [s for s in seen if "response stream active" in s]
+    assert active_notices, f"expected an active-stream wait notice, saw: {seen}"
+    assert "without stream events" in active_notices[0]
+    assert "no response yet" not in active_notices[0]
+    assert "auto-reconnect at 60s" not in active_notices[0]


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes's generic non-streaming stale timer from aborting a healthy Codex Responses SSE stream after streaming has begun.

`codex_responses` is internally streamed but runs through `interruptible_api_call`, which also serves truly non-streaming transports. Previously, its generic wall-clock detector fired solely on total elapsed time. A long reasoning or tool-call stream could emit fresh SSE events continuously and still be killed at the 90/150-second generic deadline with the misleading error `Non-streaming API call timed out ... with no response`.

This patch gives each request private SSE-activity state:

- Before the first event, the existing TTFB and generic stale safeguards remain effective.
- After the first event, an enabled event-idle watchdog owns stream liveness, so fresh events can outlive the generic deadline.
- If event-idle monitoring is explicitly disabled, generic stale detection remains the fallback rather than leaving the request unbounded.
- The explicit OpenAI-Codex total hard ceiling remains absolute even while events flow.
- Activity from a surviving worker belonging to an older request cannot satisfy a newer request's watchdog.

## Related Issue

Related to #32156 (provider-timeout symptoms in long, tool-heavy sessions). This is a focused fix for one watchdog conflict and does not close that broader report.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py`
  - Track Codex SSE activity in request-local state rather than using the agent-global compatibility marker for watchdog decisions.
  - Hand post-first-byte liveness to event-idle monitoring only when that watchdog is enabled.
  - Preserve pre-first-byte TTFB/generic stale behavior and the explicit OpenAI-Codex hard ceiling.
  - Emit truthful stream-aware wait notices and timeout diagnostics.
- `agent/codex_runtime.py` and `run_agent.py`
  - Forward the timestamp of every SSE frame through an optional request-local activity callback.
  - Retain `_codex_stream_last_event_ts` as a diagnostic/backward-compatibility marker.
- Tests
  - Reproduce an active custom Responses stream that outlives the generic stale threshold.
  - Cover event-idle disabled fallback, cross-request stale-worker contamination, active-stream hard-ceiling enforcement, bounded worker cleanup, callback delivery for every SSE frame, and stream-aware wait notices.

## How to Test

On unpatched `main`, this regression fails despite fresh SSE activity:

```bash
scripts/run_tests.sh tests/agent/test_codex_ttfb_watchdog.py \
  -k active_responses_stream_outlives_nonstream_stale_timeout
```

On this branch, run the complete related surface:

```bash
scripts/run_tests.sh -j 4 \
  tests/agent/test_codex_ttfb_watchdog.py \
  tests/agent/test_non_stream_stale_timeout.py \
  tests/run_agent/test_openai_client_lifecycle.py \
  tests/run_agent/test_stream_stale_breaker_reset.py \
  tests/run_agent/test_wait_state_visibility.py \
  tests/run_agent/test_streaming.py \
  tests/run_agent/test_run_agent_codex_responses.py
```

Result on the rebased branch: **190 passed, 0 failed**.

Additional gates:

```text
ruff check: passed
py_compile: passed
git diff --check: passed
added-line security scan: 0 findings
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.2, Python 3.13.7

### Documentation & Housekeeping

- [x] Relevant implementation comments/docstrings are updated; no user documentation change is required
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] Cross-platform impact considered; the callback/thread timing logic is platform-independent
- [x] Tool schema update is N/A

## Risk Assessment

Low to moderate. The behavioral change is scoped to `codex_responses`, but it touches watchdog coordination across the request worker and SSE consumer. Regression coverage preserves ordinary non-Codex stale handling, no-first-byte recovery, event-idle recovery, disabled-idle fallback, explicit hard ceilings, and stale-worker isolation.

## Before / After

Before:

```text
Non-streaming API call stale for 1s (threshold 1s). Killing connection.
TimeoutError: Non-streaming API call timed out after 1s with no response
```

After: fresh SSE events keep the request alive past that generic deadline; true idle, TTFB, fallback, and hard-ceiling failures still reconnect or abort with phase-accurate diagnostics.
