### PR TITLE
feat(display): show reasoning effort and session cost

### DIFF
--- a/agent/runtime_display.py
+++ b/agent/runtime_display.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import math
+from numbers import Real
+from typing import Any
+
+_KNOWN_REASONING_EFFORTS = frozenset({"minimal", "low", "medium", "high", "xhigh", "max"})
+
+
+def effective_reasoning_effort(reasoning_config: dict[str, Any] | None) -> str:
+    """Return the live reasoning state without inventing a provider default."""
+    if not isinstance(reasoning_config, dict):
+        return "provider-default"
+    if reasoning_config.get("enabled") is False:
+        return "none"
+    effort = str(reasoning_config.get("effort") or "").strip().lower()
+    return effort if effort in _KNOWN_REASONING_EFFORTS else "provider-default"
+
+
+def format_reasoning_label(
+    reasoning_config: dict[str, Any] | None,
+    *,
+    compact: bool = False,
+) -> str:
+    """Format the effective reasoning effort for a runtime display."""
+    effort = effective_reasoning_effort(reasoning_config)
+    if compact:
+        return f"r:{'default' if effort == 'provider-default' else effort}"
+    return f"reasoning {effort}"
+
+
+def _format_usd(amount: float) -> str:
+    return f"{amount:.4f}" if amount < 0.01 else f"{amount:.2f}"
+
+
+def format_session_cost(
+    amount_usd: object,
+    status: object,
+    *,
+    compact: bool = False,
+) -> str:
+    """Format cumulative session cost while preserving billing semantics."""
+    normalized_status = str(status or "").strip().lower()
+    if normalized_status == "included":
+        return "included" if compact else "cost included"
+    unavailable = "cost n/a" if compact else "cost unavailable"
+    if normalized_status not in {"actual", "estimated"}:
+        return unavailable
+    if isinstance(amount_usd, bool) or not isinstance(amount_usd, Real):
+        return unavailable
+    amount = float(amount_usd)
+    if not math.isfinite(amount) or amount < 0:
+        return unavailable
+    prefix = "~$" if normalized_status == "estimated" else "$"
+    value = f"{prefix}{_format_usd(amount)}"
+    return value if compact else f"cost {value}"

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.runtime_display import effective_reasoning_effort
 
 
 def finalize_turn(
@@ -446,6 +447,9 @@ def finalize_turn(
         "model": agent.model,
         "provider": agent.provider,
         "base_url": agent.base_url,
+        "reasoning_effort": effective_reasoning_effort(
+            getattr(agent, "reasoning_config", None)
+        ),
         "input_tokens": agent.session_input_tokens,
         "output_tokens": agent.session_output_tokens,
         "cache_read_tokens": agent.session_cache_read_tokens,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1232,6 +1232,22 @@ display:
   #   false: Hide reasoning (default)
   show_reasoning: false
 
+  # Show the effective reasoning effort in CLI/TUI status chrome.
+  # This reports the live session setting (for example r:high or r:default),
+  # not the model's hidden reasoning text.
+  show_reasoning_effort: false
+
+  # Show truthful cumulative session billing state in CLI/TUI status chrome.
+  # Estimated cost is prefixed with ~; actual, included, and unavailable states
+  # are kept distinct. Off by default.
+  show_cost: false
+
+  # Append selected runtime metadata to final gateway replies only.
+  # Supported fields: model, reasoning_effort, cost, context_pct, cwd.
+  runtime_footer:
+    enabled: false
+    fields: [model, context_pct, cwd]
+
   # Stream tokens to the terminal as they arrive instead of waiting for the
   # full response. The response box opens on first token and text appears
   # line-by-line. Tool calls are still captured silently.

--- a/cli.py
+++ b/cli.py
@@ -4541,6 +4541,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             model_short = f"{model_short[:23]}..."
 
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
+        display_config = (getattr(self, "config", {}) or {}).get("display", {}) or {}
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
@@ -4565,6 +4566,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             "session_completion_tokens": 0,
             "session_total_tokens": 0,
             "session_api_calls": 0,
+            "reasoning_label": "",
+            "cost_label": "",
             "compressions": 0,
             "active_background_tasks": 0,
             "active_background_processes": 0,
@@ -4611,6 +4614,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         snapshot["session_completion_tokens"] = getattr(agent, "session_completion_tokens", 0) or 0
         snapshot["session_total_tokens"] = getattr(agent, "session_total_tokens", 0) or 0
         snapshot["session_api_calls"] = getattr(agent, "session_api_calls", 0) or 0
+
+        from agent.runtime_display import format_reasoning_label, format_session_cost
+
+        if display_config.get("show_reasoning_effort", False):
+            snapshot["reasoning_label"] = format_reasoning_label(
+                getattr(agent, "reasoning_config", None),
+                compact=True,
+            )
+        if display_config.get("show_cost", False):
+            snapshot["cost_label"] = format_session_cost(
+                getattr(agent, "session_estimated_cost_usd", None),
+                getattr(agent, "session_cost_status", None),
+                compact=True,
+            )
 
         compressor = getattr(agent, "context_compressor", None)
         if compressor:
@@ -5050,15 +5067,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
+            reasoning_label = snapshot.get("reasoning_label")
+            cost_label = snapshot.get("cost_label")
+            model_label = snapshot["model_short"]
+            if reasoning_label:
+                model_label = f"{model_label} {reasoning_label}"
 
             yolo_active = self._is_session_yolo_active()
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"⚕ {model_label} · {duration_label}"
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"⚕ {model_label}", percent_label]
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -5084,7 +5106,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"⚕ {model_label}", context_label, percent_label]
+            if cost_label:
+                parts.append(cost_label)
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -5121,6 +5145,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # line and produce duplicated status bar rows over long sessions.
             width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
+            reasoning_label = snapshot.get("reasoning_label")
+            cost_label = snapshot.get("cost_label")
             yolo_active = self._is_session_yolo_active()
 
             if width < 52:
@@ -5130,6 +5156,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
                 ]
+                if reasoning_label:
+                    frags.insert(2, ("class:status-bar-strong", f" {reasoning_label}"))
                 if yolo_active:
                     frags.append(("class:status-bar-dim", " · "))
                     frags.append(("class:status-bar-yolo", "⚠ YOLO"))
@@ -5148,6 +5176,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
+                    if reasoning_label:
+                        frags.insert(2, ("class:status-bar-strong", f" {reasoning_label}"))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -5191,6 +5221,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                     ]
+                    if reasoning_label:
+                        frags.insert(2, ("class:status-bar-strong", f" {reasoning_label}"))
+                    if cost_label:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-strong", cost_label))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -9751,10 +9786,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         msg_count = len(self.conversation_history)
         elapsed = format_duration_compact((datetime.now() - self.session_start).total_seconds())
+        from agent.runtime_display import effective_reasoning_effort, format_session_cost
+
+        reasoning_effort = effective_reasoning_effort(
+            getattr(agent, "reasoning_config", None)
+        )
+        session_cost = format_session_cost(
+            getattr(agent, "session_estimated_cost_usd", None),
+            getattr(agent, "session_cost_status", None),
+        ).removeprefix("cost ")
 
         print("  📊 Session Token Usage")
         print(f"  {'─' * 40}")
         print(f"  Model:                     {agent.model}")
+        print(f"  Reasoning effort:            {reasoning_effort}")
         print(f"  Input tokens:              {input_tokens:>10,}")
         print(f"  Output tokens:             {output_tokens:>10,}")
         if reasoning_tokens:
@@ -9763,6 +9808,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         print(f"  Completion tokens:         {completion:>10,}")
         print(f"  Total tokens:              {total:>10,}")
         print(f"  API calls:                 {calls:>10,}")
+        print(f"  Session cost:                {session_cost}")
         print(f"  Session duration:          {elapsed:>10}")
         print(f"  {'─' * 40}")
         print(f"  Current context:  {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12146,6 +12146,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    reasoning_effort=agent_result.get("reasoning_effort"),
+                    estimated_cost_usd=agent_result.get("estimated_cost_usd"),
+                    cost_status=agent_result.get("cost_status"),
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -94,6 +94,9 @@ def format_runtime_footer(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    estimated_cost_usd: object = None,
+    cost_status: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -115,6 +118,14 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "reasoning_effort":
+            effort = str(reasoning_effort or "").strip()
+            if effort:
+                parts.append(f"reasoning {effort}")
+        elif field == "cost":
+            from agent.runtime_display import format_session_cost
+
+            parts.append(format_session_cost(estimated_cost_usd, cost_status))
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -130,6 +141,9 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    estimated_cost_usd: object = None,
+    cost_status: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -145,5 +159,8 @@ def build_footer_line(
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
+        reasoning_effort=reasoning_effort,
+        estimated_cost_usd=estimated_cost_usd,
+        cost_status=cost_status,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1872,7 +1872,8 @@ DEFAULT_CONFIG = {
         # iteration/budget limit.  Replaces the bare "(empty)" sentinel so the
         # failure isn't silent from the UI's perspective.  Set false to suppress.
         "turn_completion_explainer": True,
-        "show_cost": False,       # Show $ cost in the status bar (off by default)
+        "show_reasoning_effort": False,  # Show live reasoning effort in status chrome
+        "show_cost": False,       # Show truthful session cost/status in status chrome
         "skin": "default",
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent

--- a/tests/agent/test_runtime_display.py
+++ b/tests/agent/test_runtime_display.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from agent.runtime_display import (
+    effective_reasoning_effort,
+    format_reasoning_label,
+    format_session_cost,
+)
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (None, "provider-default"),
+        ({}, "provider-default"),
+        ({"enabled": False}, "none"),
+        ({"enabled": True}, "provider-default"),
+        ({"enabled": True, "effort": "minimal"}, "minimal"),
+        ({"enabled": True, "effort": "low"}, "low"),
+        ({"enabled": True, "effort": "medium"}, "medium"),
+        ({"enabled": True, "effort": "high"}, "high"),
+        ({"enabled": True, "effort": "xhigh"}, "xhigh"),
+        ({"enabled": True, "effort": "max"}, "max"),
+        ({"enabled": True, "effort": " HIGH "}, "high"),
+        ({"enabled": True, "effort": "turbo"}, "provider-default"),
+    ],
+)
+def test_effective_reasoning_effort_normalizes_runtime_config(config, expected):
+    assert effective_reasoning_effort(config) == expected
+
+
+@pytest.mark.parametrize(
+    ("config", "compact", "expected"),
+    [
+        ({"enabled": False}, False, "reasoning none"),
+        ({"enabled": True, "effort": "high"}, False, "reasoning high"),
+        (None, False, "reasoning provider-default"),
+        ({"enabled": False}, True, "r:none"),
+        ({"enabled": True, "effort": "high"}, True, "r:high"),
+        (None, True, "r:default"),
+    ],
+)
+def test_format_reasoning_label_has_full_and_compact_forms(config, compact, expected):
+    assert format_reasoning_label(config, compact=compact) == expected
+
+
+@pytest.mark.parametrize(
+    ("amount", "status", "compact", "expected"),
+    [
+        (0.001234, "actual", False, "cost $0.0012"),
+        (0.1234, "actual", False, "cost $0.12"),
+        (123.456, "actual", False, "cost $123.46"),
+        (0.001234, "estimated", False, "cost ~$0.0012"),
+        (0.1234, "estimated", True, "~$0.12"),
+        (0, "included", False, "cost included"),
+        (0, "included", True, "included"),
+        (None, "unknown", False, "cost unavailable"),
+        (None, "unknown", True, "cost n/a"),
+    ],
+)
+def test_format_session_cost_preserves_billing_semantics(amount, status, compact, expected):
+    assert format_session_cost(amount, status, compact=compact) == expected
+
+
+@pytest.mark.parametrize(
+    "amount",
+    [None, "not-a-number", -1, math.inf, -math.inf, math.nan],
+)
+def test_format_session_cost_rejects_invalid_amounts(amount):
+    assert format_session_cost(amount, "estimated") == "cost unavailable"
+
+
+def test_format_session_cost_rejects_unknown_status_even_with_zero_amount():
+    assert format_session_cost(0, "unknown") == "cost unavailable"

--- a/tests/agent/test_turn_finalizer_runtime_metadata.py
+++ b/tests/agent/test_turn_finalizer_runtime_metadata.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.turn_finalizer import finalize_turn
+
+
+class _MetadataAgent:
+    def __init__(self, reasoning_config):
+        self.max_iterations = 10
+        self.iteration_budget = SimpleNamespace(remaining=9, used=1, max_total=10)
+        self.quiet_mode = True
+        self.model = "openai/gpt-5.6-sol"
+        self.provider = "openai"
+        self.base_url = ""
+        self.session_id = "metadata-session"
+        self.reasoning_config = reasoning_config
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=42)
+        self.session_input_tokens = 100
+        self.session_output_tokens = 20
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_reasoning_tokens = 5
+        self.session_prompt_tokens = 100
+        self.session_completion_tokens = 20
+        self.session_total_tokens = 120
+        self.session_estimated_cost_usd = 0.1234
+        self.session_cost_status = "estimated"
+        self.session_cost_source = "official_docs_snapshot"
+        self._tool_guardrail_halt_decision = None
+        self._interrupt_message = None
+        self._response_was_previewed = False
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self.valid_tool_names = []
+
+    def _save_trajectory(self, *_args, **_kwargs):
+        pass
+
+    def _cleanup_task_resources(self, *_args, **_kwargs):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, messages):
+        pass
+
+    def _persist_session(self, messages, conversation_history):
+        pass
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **_kwargs):
+        pass
+
+
+def _finalize(monkeypatch, reasoning_config):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    return finalize_turn(
+        _MetadataAgent(reasoning_config),
+        final_response="done",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=[{"role": "assistant", "content": "done"}],
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="task",
+        original_user_message="task",
+        _should_review_memory=False,
+        _turn_exit_reason="completed",
+    )
+
+
+@pytest.mark.parametrize(
+    ("reasoning_config", "expected"),
+    [
+        ({"enabled": True, "effort": "high"}, "high"),
+        ({"enabled": False}, "none"),
+        (None, "provider-default"),
+    ],
+)
+def test_finalize_turn_exposes_effective_reasoning_effort(monkeypatch, reasoning_config, expected):
+    result = _finalize(monkeypatch, reasoning_config)
+
+    assert result["reasoning_effort"] == expected
+    assert result["estimated_cost_usd"] == 0.1234
+    assert result["cost_status"] == "estimated"
+    assert result["cost_source"] == "official_docs_snapshot"

--- a/tests/cli/test_cli_runtime_metadata_status.py
+++ b/tests/cli/test_cli_runtime_metadata_status.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+from cli import HermesCLI
+
+
+def _cli(*, reasoning_config, amount=0.1234, status="estimated"):
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.model = "openai/gpt-5.6-sol"
+    cli_obj.session_start = datetime.now() - timedelta(minutes=14, seconds=32)
+    cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
+    cli_obj.config = {
+        "display": {
+            "show_reasoning_effort": True,
+            "show_cost": True,
+        }
+    }
+    cli_obj.agent = SimpleNamespace(
+        model=cli_obj.model,
+        provider="openai",
+        base_url="",
+        reasoning_config=reasoning_config,
+        session_estimated_cost_usd=amount,
+        session_cost_status=status,
+        session_cost_source="official_docs_snapshot",
+        session_input_tokens=10000,
+        session_output_tokens=5000,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_prompt_tokens=10000,
+        session_completion_tokens=5000,
+        session_total_tokens=15000,
+        session_api_calls=7,
+        context_compressor=SimpleNamespace(
+            last_prompt_tokens=50000,
+            context_length=200_000,
+            compression_count=0,
+        ),
+    )
+    return cli_obj
+
+
+def test_status_bar_shows_live_reasoning_and_estimated_cost_when_enabled():
+    text = _cli(
+        reasoning_config={"enabled": True, "effort": "medium"},
+    )._build_status_bar_text(width=120)
+
+    assert "r:medium" in text
+    assert "~$0.12" in text
+
+
+def test_status_bar_shows_subscription_cost_as_included():
+    text = _cli(
+        reasoning_config={"enabled": False},
+        amount=0.0,
+        status="included",
+    )._build_status_bar_text(width=120)
+
+    assert "r:none" in text
+    assert "included" in text
+    assert "$0.00" not in text
+
+
+def test_narrow_status_bar_keeps_reasoning_and_drops_cost():
+    text = _cli(
+        reasoning_config={"enabled": True, "effort": "high"},
+        status="actual",
+    )._build_status_bar_text(width=60)
+
+    assert "r:high" in text
+    assert "$0.12" not in text
+
+
+def test_status_bar_hides_runtime_metadata_when_flags_are_disabled():
+    cli_obj = _cli(reasoning_config={"enabled": True, "effort": "high"})
+    cli_obj.config["display"].update(
+        show_reasoning_effort=False,
+        show_cost=False,
+    )
+
+    text = cli_obj._build_status_bar_text(width=120)
+
+    assert "r:high" not in text
+    assert "$" not in text
+
+
+def test_rich_status_bar_fragments_match_plain_runtime_metadata(monkeypatch):
+    cli_obj = _cli(reasoning_config={"enabled": True, "effort": "high"})
+    cli_obj._status_bar_visible = True
+    cli_obj._model_picker_state = None
+    monkeypatch.setattr(cli_obj, "_get_tui_terminal_width", lambda: 120)
+
+    rendered = "".join(text for _, text in cli_obj._get_status_bar_fragments())
+
+    assert "r:high" in rendered
+    assert "~$0.12" in rendered

--- a/tests/cli/test_cli_usage_runtime_metadata.py
+++ b/tests/cli/test_cli_usage_runtime_metadata.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from cli import HermesCLI
+
+
+def _cli(*, reasoning_config, amount, status):
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.model = "openai/gpt-5.6-sol"
+    cli_obj.provider = None
+    cli_obj.base_url = ""
+    cli_obj.api_key = ""
+    cli_obj.session_start = datetime.now() - timedelta(minutes=5)
+    cli_obj.conversation_history = [{"role": "user", "content": "hello"}]
+    cli_obj.verbose = False
+    cli_obj._print_nous_credits_block = lambda: False
+    cli_obj.agent = SimpleNamespace(
+        model=cli_obj.model,
+        provider=None,
+        base_url="",
+        reasoning_config=reasoning_config,
+        session_estimated_cost_usd=amount,
+        session_cost_status=status,
+        session_cost_source="official_docs_snapshot",
+        session_input_tokens=1000,
+        session_output_tokens=200,
+        session_reasoning_tokens=50,
+        session_prompt_tokens=1000,
+        session_completion_tokens=200,
+        session_total_tokens=1200,
+        session_api_calls=2,
+        get_rate_limit_state=lambda: None,
+        context_compressor=SimpleNamespace(
+            last_prompt_tokens=1200,
+            context_length=200_000,
+            compression_count=0,
+        ),
+    )
+    return cli_obj
+
+
+@pytest.mark.parametrize(
+    ("reasoning_config", "amount", "status", "effort", "cost"),
+    [
+        (
+            {"enabled": True, "effort": "high"},
+            0.1234,
+            "estimated",
+            "high",
+            "~$0.12",
+        ),
+        ({"enabled": False}, 0.0, "included", "none", "included"),
+        (None, None, "unknown", "provider-default", "unavailable"),
+    ],
+)
+def test_usage_reports_live_reasoning_and_honest_session_cost(
+    capsys,
+    reasoning_config,
+    amount,
+    status,
+    effort,
+    cost,
+):
+    _cli(
+        reasoning_config=reasoning_config,
+        amount=amount,
+        status=status,
+    )._show_usage()
+
+    output = capsys.readouterr().out
+    assert f"Reasoning effort:            {effort}" in output
+    assert f"Session cost:                {cost}" in output

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -147,6 +147,43 @@ def test_format_footer_unknown_field_silently_ignored():
     assert out == "gpt-5.4 · 50%"
 
 
+def test_format_footer_supports_reasoning_and_estimated_cost():
+    out = format_runtime_footer(
+        model="openai/gpt-5.6-sol",
+        context_tokens=50,
+        context_length=100,
+        cwd="/x",
+        reasoning_effort="high",
+        estimated_cost_usd=0.1234,
+        cost_status="estimated",
+        fields=("model", "reasoning_effort", "cost", "context_pct"),
+    )
+
+    assert out == "gpt-5.6-sol · reasoning high · cost ~$0.12 · 50%"
+
+
+def test_format_footer_preserves_included_and_unavailable_cost_states():
+    included = format_runtime_footer(
+        model="m",
+        context_tokens=0,
+        context_length=None,
+        estimated_cost_usd=0,
+        cost_status="included",
+        fields=("cost",),
+    )
+    unavailable = format_runtime_footer(
+        model="m",
+        context_tokens=0,
+        context_length=None,
+        estimated_cost_usd=None,
+        cost_status="unknown",
+        fields=("cost",),
+    )
+
+    assert included == "cost included"
+    assert unavailable == "cost unavailable"
+
+
 # ---------------------------------------------------------------------------
 # resolve_footer_config
 # ---------------------------------------------------------------------------

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5588,6 +5588,26 @@ def test_session_info_includes_session_title(monkeypatch):
     assert info["title"] == "Dashboard title"
 
 
+def test_session_info_includes_runtime_metadata_display_flags(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {
+            "display": {
+                "show_reasoning_effort": True,
+                "show_cost": True,
+            }
+        },
+    )
+
+    info = server._session_info(
+        types.SimpleNamespace(tools=[], model="test/model", provider="openai")
+    )
+
+    assert info["show_reasoning_effort"] is True
+    assert info["show_cost"] is True
+
+
 def test_session_info_includes_install_warning_for_pip(monkeypatch):
     """pip installs surface install_warning; git installs don't (issue: pip/brew deprecation)."""
     monkeypatch.setattr("hermes_cli.config.detect_install_method", lambda: "pip")
@@ -9413,6 +9433,20 @@ class _BareAgent:
     independent of the `if comp:` context-percent block."""
 
     model = "x"
+
+
+def test_get_usage_includes_session_cost_metadata(monkeypatch):
+    import tools.async_delegation as ad_mod
+
+    monkeypatch.setattr(ad_mod, "active_count", lambda: 0)
+    agent = _BareAgent()
+    agent.session_estimated_cost_usd = 0.1234
+    agent.session_cost_status = "estimated"
+
+    usage = server._get_usage(agent)
+
+    assert usage["cost_usd"] == 0.1234
+    assert usage["cost_status"] == "estimated"
 
 
 def test_get_usage_includes_active_subagents(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3244,6 +3244,12 @@ def _get_usage(agent) -> dict:
         "total": g("session_total_tokens"),
         "calls": g("session_api_calls"),
     }
+    session_cost = getattr(agent, "session_estimated_cost_usd", None)
+    if isinstance(session_cost, (int, float)) and not isinstance(session_cost, bool):
+        usage["cost_usd"] = float(session_cost)
+    usage["cost_status"] = str(
+        getattr(agent, "session_cost_status", "unknown") or "unknown"
+    )
     comp = getattr(agent, "context_compressor", None)
     if comp:
         # context_used is the *current-window* occupancy. Do NOT fall back to
@@ -3365,7 +3371,8 @@ def _session_info(agent, session: dict | None = None) -> dict:
     session_key = str(
         (session or {}).get("session_key") or getattr(agent, "session_id", "") or ""
     )
-    cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
+    display_cfg = _load_cfg().get("display") or {}
+    cfg_personality = display_cfg.get("personality") or ""
     personality = (session or {}).get("personality", cfg_personality)
     reasoning_config = getattr(agent, "reasoning_config", None)
     reasoning_effort = ""
@@ -3401,6 +3408,10 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "model": getattr(agent, "model", ""),
         "provider": getattr(agent, "provider", ""),
         "reasoning_effort": reasoning_effort,
+        "show_reasoning_effort": bool(
+            display_cfg.get("show_reasoning_effort", False)
+        ),
+        "show_cost": bool(display_cfg.get("show_cost", False)),
         "service_tier": service_tier,
         "fast": service_tier == "priority",
         "yolo": yolo,

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -100,9 +100,41 @@ const baseProps = {
   statusColor: DEFAULT_THEME.color.ok,
   t: DEFAULT_THEME,
   turnStartedAt: null,
-  usage: { context_max: 200_000, context_percent: 25, context_used: 50_000, total: 50_000 },
+  usage: {
+    calls: 0,
+    context_max: 200_000,
+    context_percent: 25,
+    context_used: 50_000,
+    input: 0,
+    output: 0,
+    total: 50_000
+  },
   voiceLabel: ''
 }
+
+describe('StatusRule session cost', () => {
+  it('renders truthful session cost when enabled', () => {
+    const element = StatusRule({
+      ...baseProps,
+      cols: 160,
+      showCost: true,
+      usage: { ...baseProps.usage, cost_status: 'estimated', cost_usd: 0.1234 }
+    })
+
+    expect(textContent(element)).toContain('~$0.12')
+  })
+
+  it('hides session cost when disabled', () => {
+    const element = StatusRule({
+      ...baseProps,
+      cols: 160,
+      showCost: false,
+      usage: { ...baseProps.usage, cost_status: 'estimated', cost_usd: 0.1234 }
+    })
+
+    expect(textContent(element)).not.toContain('~$0.12')
+  })
+})
 
 describe('StatusRule background-subagent indicator', () => {
   it('renders ⛓ N on a wide terminal when subagents are running', () => {

--- a/ui-tui/src/__tests__/statusRule.test.ts
+++ b/ui-tui/src/__tests__/statusRule.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
 import type { StatusBarSegments } from '../components/appChrome.js'
-import { busyIndicatorWidth, statusBarSegments, statusRuleWidths } from '../components/appChrome.js'
+import {
+  busyIndicatorWidth,
+  formatSessionCost,
+  statusBarSegments,
+  statusRuleWidths
+} from '../components/appChrome.js'
 
 describe('statusRuleWidths', () => {
   it('keeps the status rule within the terminal width', () => {
@@ -101,6 +106,21 @@ describe('statusBarSegments', () => {
       expect(visible).toBeLessThanOrEqual(prevCount)
       prevCount = visible
     }
+  })
+})
+
+describe('formatSessionCost', () => {
+  it('preserves actual, estimated, included, and unavailable billing states', () => {
+    expect(formatSessionCost(0.1234, 'estimated')).toBe('~$0.12')
+    expect(formatSessionCost(0.005, 'actual')).toBe('$0.0050')
+    expect(formatSessionCost(undefined, 'included')).toBe('included')
+    expect(formatSessionCost(undefined, 'unknown')).toBe('cost n/a')
+    expect(formatSessionCost(1, 'exact')).toBe('cost n/a')
+  })
+
+  it('does not render invalid numeric amounts as money', () => {
+    expect(formatSessionCost(Number.NaN, 'estimated')).toBe('cost n/a')
+    expect(formatSessionCost(-1, 'actual')).toBe('cost n/a')
   })
 })
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -213,6 +213,27 @@ function ctxBar(pct: number | undefined, w = 10) {
   return '█'.repeat(filled) + '░'.repeat(w - filled)
 }
 
+export function formatSessionCost(amount: number | undefined, status: string | undefined): string {
+  const normalized = (status ?? '').trim().toLowerCase()
+
+  if (normalized === 'included') {
+    return 'included'
+  }
+
+  if (
+    (normalized !== 'actual' && normalized !== 'estimated') ||
+    typeof amount !== 'number' ||
+    !Number.isFinite(amount) ||
+    amount < 0
+  ) {
+    return 'cost n/a'
+  }
+
+  const value = amount < 0.01 ? amount.toFixed(4) : amount.toFixed(2)
+
+  return `${normalized === 'estimated' ? '~' : ''}$${value}`
+}
+
 // `minLeftContent` is the display width of the high-priority left segments
 // (status indicator + model + context). Reserving it makes the cwd/branch
 // segment on the right yield FIRST on narrow terminals, instead of squeezing
@@ -411,6 +432,7 @@ export function StatusRule({
   model,
   modelFast,
   modelReasoningEffort,
+  showCost,
   indicatorStyle = 'kaomoji',
   notice,
   usage,
@@ -528,6 +550,8 @@ export function StatusRule({
     subagentCount === 1 ? '↩ resumes when subagent finishes' : `↩ resumes when ${subagentCount} subagents finish`
 
   const showResumeHint = !busy && subagentCount > 0 && fits(SEP + stringWidth(resumeHintText))
+  const costText = showCost ? formatSessionCost(usage.cost_usd, usage.cost_status) : ''
+  const showSessionCost = !!costText && fits(SEP + stringWidth(costText))
   // Dev-gated readout (HERMES_DEV_CREDITS), lowest priority,
   // so it consumes tail budget LAST and drops first on a narrow terminal.
   const showDevCredits = !!devCreditsText && fits(SEP + stringWidth(devCreditsText))
@@ -643,6 +667,12 @@ export function StatusRule({
           <Text color={t.color.muted} dim wrap="truncate-end">
             {' │ '}
             {resumeHintText}
+          </Text>
+        ) : null}
+        {showSessionCost ? (
+          <Text color={t.color.muted} wrap="truncate-end">
+            {' │ '}
+            {costText}
           </Text>
         ) : null}
         {showDevCredits ? (
@@ -779,6 +809,7 @@ interface StatusRuleProps {
   model: string
   modelFast?: boolean
   modelReasoningEffort?: string
+  showCost?: boolean
   indicatorStyle?: IndicatorStyle
   notice?: Notice | null
   sessionStartedAt?: null | number

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -482,10 +482,11 @@ const StatusRulePane = memo(function StatusRulePane({
         liveSessionCount={ui.liveSessionCount}
         model={ui.info?.model ?? ''}
         modelFast={ui.info?.fast || ui.info?.service_tier === 'priority'}
-        modelReasoningEffort={ui.info?.reasoning_effort}
+        modelReasoningEffort={ui.info?.show_reasoning_effort ? ui.info.reasoning_effort : undefined}
         notice={ui.notice}
         onSessionCountClick={() => patchOverlayState({ sessions: true })}
         sessionStartedAt={status.sessionStartedAt}
+        showCost={ui.info?.show_cost}
         status={ui.status}
         statusColor={status.statusColor}
         t={ui.theme}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -323,7 +323,7 @@ export interface SessionUsageResponse {
   context_max?: number
   context_percent?: number
   context_used?: number
-  cost_status?: 'estimated' | 'exact'
+  cost_status?: 'actual' | 'estimated' | 'included' | 'unknown'
   cost_usd?: number
   credits_lines?: string[]
   input?: number

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -160,6 +160,8 @@ export interface SessionInfo {
   reasoning_effort?: string
   release_date?: string
   service_tier?: string
+  show_cost?: boolean
+  show_reasoning_effort?: boolean
   skills: Record<string, string[]>
   system_prompt?: string
   tools: Record<string, string[]>

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -63,21 +63,22 @@ The welcome banner shows your model, terminal backend, working directory, availa
 A persistent status bar sits above the input area, updating in real time:
 
 ```
- ⚕ claude-sonnet-4-20250514 │ 12.4K/200K │ [██████░░░░] 6% │ $0.06 │ 15m
+ ⚕ claude-sonnet-4-20250514 r:high │ 12.4K/200K │ [██████░░░░] 6% │ ~$0.06 │ 15m
 ```
 
 | Element | Description |
 |---------|-------------|
 | Model name | Current model (truncated if longer than 26 chars) |
+| Reasoning effort | Effective live level (`r:high`, `r:none`, or `r:default`) when `display.show_reasoning_effort` is enabled |
 | Token count | Context tokens used / max context window |
 | Context bar | Visual fill indicator with color-coded thresholds |
-| Cost | Estimated session cost (or `n/a` for unknown/zero-priced models) |
+| Cost | Truthful cumulative state when `display.show_cost` is enabled: actual `$`, estimated `~$`, `included`, or `cost n/a` |
 | 🗜️ N | **Context compression count** — how many times the running session has been auto-compressed. Appears once the first compression fires. |
 | ▶ N | **Active background tasks** — how many `/background` prompts are still running in the current session. Appears whenever at least one task is in flight. |
 | Duration | Elapsed session time |
 | ⚠ YOLO | **YOLO mode warning** — shown whenever `HERMES_YOLO_MODE` is on (either `hermes --yolo` at launch or `/yolo` toggled mid-session). Mirrors the banner-line warning so you can't forget you're in auto-approve mode. |
 
-The bar adapts to terminal width — full layout at ≥ 76 columns, compact at 52–75, minimal (model + duration, plus the YOLO badge when active) below 52.
+The bar adapts to terminal width — full layout at ≥ 76 columns, compact at 52–75, minimal (model + duration, plus the YOLO badge when active) below 52. Reasoning effort and cost are off by default; enable them with `display.show_reasoning_effort: true` and `display.show_cost: true`. The Ink TUI uses the same settings and drops the low-priority cost segment first when space is tight.
 
 **Context color coding:**
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1469,13 +1469,14 @@ display:
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
   show_reasoning: false   # Show model reasoning/thinking above each response (toggle with /reasoning show|hide)
+  show_reasoning_effort: false  # Show the effective reasoning level in CLI/TUI status chrome
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
-  show_cost: false        # Show estimated $ cost in the CLI status bar
+  show_cost: false        # Show actual/estimated/included/unavailable session cost in CLI/TUI status chrome
   timestamps: false       # When true, prefixes user and assistant labels with [HH:MM] timestamps in the CLI / TUI transcript
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
     enabled: false
-    fields: ["model", "context_pct", "cwd"]
+    fields: ["model", "reasoning_effort", "cost", "context_pct", "cwd"]
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
@@ -1538,13 +1539,13 @@ Tool progress requires a gateway adapter that can display progress updates safel
 
 ### Runtime-metadata footer (gateway only)
 
-When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The current footer can show the model, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
+When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The footer can show the model, effective reasoning effort, truthful session cost/status, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # supported fields: model, context_pct, cwd
+    fields: ["model", "reasoning_effort", "cost", "context_pct", "cwd"]
 ```
 
 The `/footer` slash command toggles this at runtime in any session.
@@ -1552,10 +1553,10 @@ The `/footer` slash command toggles this at runtime in any session.
 Example footer appended to a Telegram/Discord/Slack reply:
 
 ```
-— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+claude-opus-4.8 · reasoning high · cost ~$0.04 · 6% · ~/project
 ```
 
-Only the **final** message of a turn gets the footer; interim updates stay clean.
+Only the **final** message of a turn gets the footer; interim updates stay clean. Estimated values use `~$`, actual values use `$`, subscription-backed usage shows `cost included`, and unknown pricing shows `cost unavailable` instead of fabricating `$0`.
 
 ### Per-platform progress overrides
 


### PR DESCRIPTION
## Summary

- add shared truthful formatting for effective reasoning effort and cumulative session cost/status
- expose opt-in reasoning and cost metadata in classic CLI status, `/usage`, Gateway/Discord runtime footers, and Ink TUI status chrome
- document `display.show_reasoning_effort`, `display.show_cost`, and runtime footer fields

## Behavior / compatibility

- all new status chrome remains off by default
- cost states remain distinct: actual `$`, estimated `~$`, included, and unavailable
- unsupported statuses and invalid amounts never fabricate `$0`
- gateway footer fields are opt-in and only affect final messages

## Validation

- `scripts/run_tests.sh tests/agent/test_runtime_display.py tests/agent/test_turn_finalizer_runtime_metadata.py tests/cli/test_cli_runtime_metadata_status.py tests/cli/test_cli_usage_runtime_metadata.py tests/cli/test_cli_status_bar.py tests/gateway/test_runtime_footer.py tests/test_tui_gateway_server.py -q` — 457 passed
- `VITEST_MAX_THREADS=1 VITEST_MIN_THREADS=1 npm run check` in `ui-tui` — build/typecheck passed; 1,127 passed, 4 skipped
- changed-file ESLint — passed
- staged added-line security scan — no findings
- independent review — passed with no security concerns or logic errors

## Risk and rollback

Risk: Medium — touches shared runtime metadata and multiple presentation surfaces, but behavior is opt-in and covered by focused plus full TUI regression suites.

Rollback plan:
- revert this commit; defaults and wire payloads return to their prior behavior.