### PR TITLE
feat(agent): permit upfront scope clarification in steering guidance

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -292,9 +292,10 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "Keep working until the task is actually complete. Do not stop with a summary of "
     "what you plan to do next time. If you have tools available that can accomplish "
     "the task, use them instead of telling the user what you would do.\n"
-    "Every response should either (a) contain tool calls that make progress, or "
-    "(b) deliver a final result to the user. Responses that only describe intentions "
-    "without acting are not acceptable."
+    "Every response should either (a) contain tool calls that make progress, "
+    "(b) deliver a final result to the user, or (c) ask the user a genuinely "
+    "blocking question about intent or scope that only they can answer. Responses "
+    "that only describe intentions without acting are not acceptable."
 )
 
 # Model name substrings that trigger tool-use enforcement guidance.
@@ -329,7 +330,14 @@ TASK_COMPLETION_GUIDANCE = (
     "approach, ask the user). NEVER substitute plausible-looking fabricated "
     "output (made-up data, invented file contents, synthesised API responses) "
     "for results you couldn't actually produce. Reporting a blocker honestly "
-    "is always better than inventing a result."
+    "is always better than inventing a result.\n"
+    "Clarifying scope is progress, not stopping. Tools can retrieve facts, but "
+    "they cannot decide what the user wants: when an open-ended build/change "
+    "request leaves goal, scale, or constraints unstated, ask ONE upfront "
+    "clarifying question (use the clarify tool if available) instead of filling "
+    "the gaps with ambitious assumptions. If you cannot ask, state your "
+    "assumptions explicitly and build the SMALLEST version that satisfies the "
+    "request — the user can always ask for more."
 )
 
 # Universal parallel-tool-call guidance — applied to ALL models.
@@ -412,8 +420,10 @@ OPENAI_MODEL_EXECUTION_GUIDANCE = (
     "- 'Is port 443 open?' → check THIS machine (don't ask 'open where?')\n"
     "- 'What OS am I running?' → check the live system (don't use user profile)\n"
     "- 'What time is it?' → run `date` (don't guess)\n"
-    "Only ask for clarification when the ambiguity genuinely changes what tool "
-    "you would call.\n"
+    "For quick factual questions, only ask for clarification when the ambiguity "
+    "genuinely changes what tool you would call. This rule is about lookups — it "
+    "does NOT apply to open-ended build/change requests, where intent and scope "
+    "ambiguity is resolved by asking the user (see <missing_context>).\n"
     "</act_dont_ask>\n"
     "\n"
     "<prerequisite_checks>\n"
@@ -436,8 +446,15 @@ OPENAI_MODEL_EXECUTION_GUIDANCE = (
     "- If required context is missing, do NOT guess or hallucinate an answer.\n"
     "- Use the appropriate lookup tool when missing information is retrievable "
     "(search_files, web_search, read_file, etc.).\n"
-    "- Ask a clarifying question only when the information cannot be retrieved by tools.\n"
-    "- If you must proceed with incomplete information, label assumptions explicitly.\n"
+    "- Ask a clarifying question when the information cannot be retrieved by tools, "
+    "OR when the ambiguity is about the user's intent, scope, or preference — a "
+    "decision only the user can make. Tools can fill in facts; they cannot decide "
+    "what the user actually wants. On an open-ended build/change request, prefer "
+    "one upfront clarifying question (goal, scale, constraints) over building on "
+    "maximal assumptions.\n"
+    "- If you must proceed with incomplete information, label assumptions explicitly "
+    "and default to the SMALLEST solution that satisfies the request, not the most "
+    "ambitious one.\n"
     "</missing_context>"
 )
 


### PR DESCRIPTION
## Problem

The completion-steering prompt blocks currently leave the agent **no acceptable way to ask a clarifying question**, even when the request is fundamentally underspecified:

- `TOOL_USE_ENFORCEMENT_GUIDANCE` (injected for gpt/gemini/grok/glm/qwen/deepseek) says every response must either **(a)** make tool calls or **(b)** deliver a final result. A blocking question about intent or scope fits neither — it is literally classified *"not acceptable"*.
- `TASK_COMPLETION_GUIDANCE` (universal, every session) pushes *"keep working until the task is actually complete"* with no carve-out for requests where "complete" is undefined.
- `OPENAI_MODEL_EXECUTION_GUIDANCE`'s `<missing_context>` permits questions only when information *"cannot be retrieved by tools"* — but intent/scope/preference ambiguity is never tool-retrievable (the model can always fill gaps from its own priors), so the permission never fires. `<act_dont_ask>` then generalizes a lookup heuristic (*"only ask when the ambiguity changes what tool you would call"*) to all requests.

**Net effect:** on a vague open-ended request, the model fills every gap with maximal assumptions instead of asking.

## Real-world observation (deepseek-v4-flash, CLI)

A one-line request — *"buatkan saya trading platform"* (build me a trading platform) — produced overnight: 67 files, 13 modules, ~22k lines, 40+ heavy deps (torch, xgboost, redis, celery…), Grafana/Terraform/K8s configs. Every API call was a stub; tests only asserted imports. The clarify tool was available the whole time and was never called — session transcripts show asking was never even considered. The same pattern reproduced on smaller requests ("build me an inventory system" → 8-feature spec invented in one reasoning pass).

## Change

Adds a narrow, explicit carve-out to each of the three blocks (no behavior removed):

1. **enforcement**: valid responses are now (a) tool calls, (b) final result, **or (c) a genuinely blocking question about intent or scope that only the user can answer**.
2. **task completion**: *"Clarifying scope is progress, not stopping"* — on an open-ended build/change request with goal/scale/constraints unstated, ask **ONE** bundled upfront question (clarify tool if available); if asking is impossible, state assumptions explicitly and build the **SMALLEST** version that satisfies the request.
3. **missing_context / act_dont_ask**: intent/scope/preference ambiguity is ask-worthy even though tools could "fill" it; `act_dont_ask` is scoped to the factual lookups its examples describe.

Wording is deliberately tight — these blocks ship in every session's cached system prompt.

## Testing

- `tests/agent/test_prompt_builder.py`: 164 passed
- `tests/agent/ -k system_prompt`: 29 passed
- Live check (deepseek-v4-flash, interactive CLI): with the patched prompt plus a matching skill rule, the same class of vague request ("buatkan saya sistem kasir") produced one bundled clarify question before any file was written, then a scope-matched ~900-line deliverable. (The prompt change alone reduces the prohibition; pairing it with workspace-level guidance gave the most reliable behavior — the carve-out is the necessary first step since the current text actively forbids asking.)

## Notes

- No config surface change; pure prompt-text edit.
- Related in spirit to the clarify-tool UX issues (#65113, #53666) but orthogonal: those fix the tool's plumbing, this fixes the steering that prevents the tool from being invoked at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)