### PR TITLE
feat(plugins): add pre_transcription hook and STT prompt threading

### DIFF
--- a/agent/transcription_provider.py
+++ b/agent/transcription_provider.py
@@ -190,4 +190,9 @@ class TranscriptionProvider(abc.ABC):
                 ignore this argument.
             **extra: Forward-compat parameters future schema versions
                 may expose. Implementations should ignore unknown keys.
+                The dispatcher currently forwards ``prompt`` here when a
+                transcription prompt is set (via the ``stt.prompt`` config
+                key or a ``pre_transcription`` hook) — prompt-capable
+                providers may use it as a vocabulary/context hint; others
+                should ignore it.
         """

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1033,6 +1033,30 @@ platform_toolsets:
 stt:
   enabled: true
   # provider: "local"          # auto-detected if omitted
+  # Optional static transcription prompt: vocabulary/context hints for
+  # prompt-capable backends. Composition is deterministic: this config value
+  # is the base, then `pre_transcription` hooks run in registration order with
+  # last-writer-wins semantics per field.
+  #
+  # Privacy: the final prompt is sent to the configured STT provider alongside
+  # the audio. Do not include secrets or session context you would not send to
+  # that provider.
+  #
+  # Length / truncation contract: Hermes forwards the final prompt unchanged;
+  # it does not silently truncate by characters or tokens because limits and
+  # tokenizers differ by provider/model. Keep hints concise (Whisper-family
+  # models commonly allow about 224 prompt tokens). The backend SDK/API owns
+  # validation, truncation, or rejection beyond its model-specific limit.
+  #
+  # Provider behavior:
+  #   local (faster-whisper)  -> `initial_prompt`, forwarded unchanged
+  #   openai / groq          -> `prompt`, forwarded unchanged
+  #   mistral                -> `prompt`, forwarded unchanged
+  #   deepinfra              -> OpenAI-compatible `prompt`, unchanged
+  #   local_command/xai/
+  #   elevenlabs             -> unsupported; DEBUG log, then continue
+  #   plugin providers       -> `prompt` in `**extra`; plugin owns limits
+  # prompt: "Hermes, Teknium, Nous Research, kanban"
   local:
     model: "base"              # tiny | base | small | medium | large-v3 | turbo
     # language: ""             # auto-detect; set to "en", "es", "fr", etc. to force

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16545,7 +16545,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         for path in audio_paths:
             try:
                 logger.debug("Transcribing user voice: %s", path)
-                result = await asyncio.to_thread(transcribe_audio, path)
+                result = await asyncio.to_thread(
+                    transcribe_audio, path, None, "gateway",
+                )
                 if result["success"]:
                     transcript = result["transcript"]
                     successful_transcripts.append(transcript)

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -184,6 +184,14 @@ _DEFAULT_PAYLOADS = {
         "assistant_content_chars": 1200,
         "assistant_tool_call_count": 0,
     },
+    "pre_transcription": {
+        "file_path": "/tmp/voice-message.ogg",
+        "provider": "local",
+        "model": "base",
+        "language": "en",
+        "prompt": None,
+        "source": "gateway",
+    },
     "subagent_stop": {
         "parent_session_id": "parent-sess",
         "child_role": None,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -187,6 +187,17 @@ VALID_HOOKS: Set[str] = {
     #   decided_by: "aux_llm"  -- only on surface="smart"
     "pre_approval_request",
     "post_approval_response",
+    # Pre-transcription transform hook. Fired by the STT dispatcher
+    # (tools.transcription_tools.transcribe_audio) after provider resolution
+    # and BEFORE any backend — built-in, command-type, or plugin-registered —
+    # is invoked. Callbacks receive keyword args:
+    #   file_path, provider, model, language, prompt, source
+    # and may return None (unchanged) or a dict mutating any of
+    # ``prompt`` / ``language`` / ``model``. Results are applied in
+    # registration order, last-writer-wins per field. ``file_path`` is
+    # read-only — attempts to change it are logged and dropped. The static
+    # ``stt.prompt`` config value is the base; hook results mutate on top.
+    "pre_transcription",
     # Kanban task lifecycle hooks. Fired by hermes_cli.kanban_db when a task
     # transitions state, AFTER the change is committed to the board DB (so the
     # hook always sees durable state and a slow plugin can never hold the

--- a/tests/tools/test_pre_transcription_hook.py
+++ b/tests/tools/test_pre_transcription_hook.py
@@ -1,0 +1,580 @@
+"""Tests for the ``pre_transcription`` plugin hook and STT prompt threading
+(issue #64168) wired into ``tools.transcription_tools.transcribe_audio``.
+
+Covers:
+
+1. Fixture plugin returning a prompt → the backend call receives
+   ``initial_prompt`` (faster-whisper) / ``prompt`` (OpenAI, Groq, Mistral).
+   The API boundary is stubbed — no live model is loaded or called.
+2. Two hooks → last-writer-wins per field, in registration order.
+3. Hook returning the read-only ``file_path`` field → dropped with a log.
+4. No hook registered → invoke_hook is never called and the backend
+   dispatch kwargs are identical to a control run (no prompt/language keys
+   on the wire).
+5. ``stt.prompt`` config alone → threaded without any hook.
+6. Config + hook → hook wins (config is the base, hooks mutate on top).
+7. Unsupported backend (xAI, ElevenLabs) → DEBUG note and the call
+   proceeds without the prompt.
+8. Plugin-registered providers receive the prompt via the ABC's ``**extra``
+   kwargs — no signature change.
+
+Mirrors the ``transform_tool_result`` hook test conventions from
+``tests/test_transform_tool_result_hook.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import hermes_cli.plugins as plugins_mod
+from tools import transcription_tools
+
+
+PROMPT = "Hermes, Teknium, Nous Research, kanban"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_audio(tmp_path):
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"fake audio data")
+    return str(audio)
+
+
+def _fake_hooks(monkeypatch, results):
+    """Install fake has_hook/invoke_hook returning *results* and capture kwargs."""
+    captured = {}
+
+    def _invoke(hook_name, **kw):
+        captured["hook_name"] = hook_name
+        captured["kwargs"] = kw
+        return list(results)
+
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: True)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _invoke)
+    return captured
+
+
+def _no_hooks(monkeypatch):
+    """No hook registered: has_hook is False and invoke_hook must not fire."""
+    def _boom(hook_name, **kw):  # pragma: no cover - the assert is the point
+        raise AssertionError(
+            "invoke_hook must not be called when has_hook() is False"
+        )
+
+    monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda name: False)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _boom)
+
+
+def _dispatch_ctx(stt_config, provider):
+    """Patch config load + provider resolution around transcribe_audio."""
+    return (
+        patch("tools.transcription_tools._load_stt_config", return_value=stt_config),
+        patch("tools.transcription_tools._get_provider", return_value=provider),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hook registration surface
+# ---------------------------------------------------------------------------
+
+
+def test_pre_transcription_in_valid_hooks():
+    assert "pre_transcription" in plugins_mod.VALID_HOOKS
+
+
+# ---------------------------------------------------------------------------
+# Prompt threading into backends (API boundary stubbed)
+# ---------------------------------------------------------------------------
+
+
+class TestPromptThreading:
+    def test_hook_prompt_reaches_faster_whisper_initial_prompt(
+        self, monkeypatch, tmp_path,
+    ):
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [{"prompt": PROMPT}])
+
+        mock_segment = MagicMock()
+        mock_segment.text = "hello"
+        mock_info = MagicMock(language="en", duration=1.0)
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([mock_segment], mock_info)
+
+        cfg_patch, prov_patch = _dispatch_ctx({"provider": "local"}, "local")
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("tools.transcription_tools._load_local_whisper_model",
+                   return_value=mock_model), \
+             patch("tools.transcription_tools._local_model", None):
+            result = transcription_tools.transcribe_audio(audio)
+
+        assert result["success"] is True
+        _, kwargs = mock_model.transcribe.call_args
+        assert kwargs["initial_prompt"] == PROMPT
+
+    def test_hook_prompt_and_language_reach_openai(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+        _fake_hooks(monkeypatch, [{"prompt": PROMPT, "language": "en"}])
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "hello"
+
+        cfg_patch, prov_patch = _dispatch_ctx({"provider": "openai"}, "openai")
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client):
+            result = transcription_tools.transcribe_audio(audio)
+
+        assert result["success"] is True
+        _, kwargs = mock_client.audio.transcriptions.create.call_args
+        assert kwargs["prompt"] == PROMPT
+        assert kwargs["language"] == "en"
+
+    def test_hook_prompt_reaches_groq(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+        _fake_hooks(monkeypatch, [{"prompt": PROMPT}])
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "hello"
+
+        cfg_patch, prov_patch = _dispatch_ctx({"provider": "groq"}, "groq")
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client):
+            result = transcription_tools.transcribe_audio(audio)
+
+        assert result["success"] is True
+        _, kwargs = mock_client.audio.transcriptions.create.call_args
+        assert kwargs["prompt"] == PROMPT
+
+    def test_prompt_reaches_mistral(self, monkeypatch, tmp_path):
+        """Unit-level: _transcribe_mistral forwards prompt to the SDK call."""
+        audio = _make_audio(tmp_path)
+        monkeypatch.setenv("MISTRAL_API_KEY", "mk-test")
+        # Never attempt a lazy install in tests.
+        monkeypatch.setattr("tools.lazy_deps.ensure", lambda *a, **kw: None)
+
+        mistral_cls = MagicMock()
+        mock_client = mistral_cls.return_value.__enter__.return_value
+        mock_client.audio.transcriptions.complete.return_value = SimpleNamespace(
+            text="hello",
+        )
+        fake_mistralai = SimpleNamespace(client=SimpleNamespace(Mistral=mistral_cls))
+        monkeypatch.setitem(sys.modules, "mistralai", fake_mistralai)
+        monkeypatch.setitem(sys.modules, "mistralai.client", fake_mistralai.client)
+
+        result = transcription_tools._transcribe_mistral(
+            audio, "voxtral-mini-latest", prompt=PROMPT,
+        )
+
+        assert result["success"] is True
+        _, kwargs = mock_client.audio.transcriptions.complete.call_args
+        assert kwargs["prompt"] == PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Hook merge mechanics
+# ---------------------------------------------------------------------------
+
+
+class TestHookMergeMechanics:
+    def test_two_hooks_last_writer_wins_per_field(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        # Two hooks in registration order: the second overwrites ``prompt``
+        # but leaves ``language`` untouched — last-writer-wins PER FIELD.
+        _fake_hooks(
+            monkeypatch,
+            [{"prompt": "first", "language": "ja"}, {"prompt": "second"}],
+        )
+
+        backend = MagicMock(return_value={"success": True, "transcript": "hi"})
+        cfg_patch, prov_patch = _dispatch_ctx({"provider": "openai"}, "openai")
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._transcribe_openai", backend):
+            transcription_tools.transcribe_audio(audio)
+
+        _, kwargs = backend.call_args
+        assert kwargs["prompt"] == "second"
+        assert kwargs["language"] == "ja"
+
+    def test_hook_model_override_flows_to_backend(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [{"model": "gpt-4o-transcribe"}])
+
+        backend = MagicMock(return_value={"success": True, "transcript": "hi"})
+        cfg_patch, prov_patch = _dispatch_ctx({"provider": "openai"}, "openai")
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._transcribe_openai", backend):
+            transcription_tools.transcribe_audio(audio)
+
+        args, _ = backend.call_args
+        assert args[1] == "gpt-4o-transcribe"
+
+    def test_file_path_mutation_dropped_with_log(
+        self, monkeypatch, tmp_path, caplog,
+    ):
+        audio = _make_audio(tmp_path)
+        _fake_hooks(
+            monkeypatch,
+            [{"file_path": "/evil/other.ogg", "prompt": PROMPT}],
+        )
+
+        backend = MagicMock(return_value={"success": True, "transcript": "hi"})
+        cfg_patch, prov_patch = _dispatch_ctx({"provider": "openai"}, "openai")
+        with caplog.at_level(logging.WARNING, logger="tools.transcription_tools"), \
+             cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._transcribe_openai", backend):
+            transcription_tools.transcribe_audio(audio)
+
+        args, kwargs = backend.call_args
+        # Original file_path untouched, valid fields still applied.
+        assert args[0] == audio
+        assert kwargs["prompt"] == PROMPT
+        assert "read-only" in caplog.text
+
+    def test_non_string_field_values_ignored(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [{"prompt": 123, "language": ["en"]}])
+
+        backend = MagicMock(return_value={"success": True, "transcript": "hi"})
+        cfg_patch, prov_patch = _dispatch_ctx({"provider": "openai"}, "openai")
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._transcribe_openai", backend):
+            transcription_tools.transcribe_audio(audio)
+
+        _, kwargs = backend.call_args
+        assert kwargs["prompt"] is None
+        assert kwargs["language"] is None
+
+    def test_hook_receives_expected_kwargs(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        captured = _fake_hooks(monkeypatch, [])
+
+        backend = MagicMock(return_value={"success": True, "transcript": "hi"})
+        cfg_patch, prov_patch = _dispatch_ctx(
+            {"provider": "openai", "prompt": "config base"}, "openai",
+        )
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._transcribe_openai", backend):
+            transcription_tools.transcribe_audio(
+                audio, model="whisper-1", source="gateway",
+            )
+
+        assert captured["hook_name"] == "pre_transcription"
+        kw = captured["kwargs"]
+        assert kw["file_path"] == audio
+        assert kw["provider"] == "openai"
+        assert kw["model"] == "whisper-1"
+        # Config is the base — the hook sees the static stt.prompt value.
+        assert kw["prompt"] == "config base"
+        assert kw["source"] == "gateway"
+
+
+# ---------------------------------------------------------------------------
+# No-hook path stays identical
+# ---------------------------------------------------------------------------
+
+
+class TestNoHookPath:
+    def test_no_hook_dispatch_kwargs_identical_to_control(
+        self, monkeypatch, tmp_path,
+    ):
+        audio = _make_audio(tmp_path)
+        _no_hooks(monkeypatch)  # invoke_hook raises if ever called
+
+        backend = MagicMock(return_value={"success": True, "transcript": "hi"})
+        cfg_patch, prov_patch = _dispatch_ctx({"provider": "openai"}, "openai")
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._transcribe_openai", backend):
+            transcription_tools.transcribe_audio(audio)
+
+        args, kwargs = backend.call_args
+        assert args == (audio, "whisper-1")
+        # No prompt/language reach the backend — same effective dispatch as
+        # a control run without the hook plumbing.
+        assert kwargs == {"language": None, "prompt": None}
+
+    def test_no_hook_openai_wire_call_has_no_prompt_or_language(
+        self, monkeypatch, tmp_path,
+    ):
+        """Wire-level control: with prompt/language unset, the OpenAI SDK
+        call carries exactly the same kwargs as before this feature."""
+        audio = _make_audio(tmp_path)
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "hello"
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("openai.OpenAI", return_value=mock_client):
+            transcription_tools._transcribe_openai(audio, "whisper-1")
+
+        _, kwargs = mock_client.audio.transcriptions.create.call_args
+        assert set(kwargs) == {"model", "file", "response_format"}
+
+
+# ---------------------------------------------------------------------------
+# stt.prompt config key
+# ---------------------------------------------------------------------------
+
+
+class TestSttPromptConfig:
+    def test_config_prompt_alone_is_threaded(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        _no_hooks(monkeypatch)
+
+        backend = MagicMock(return_value={"success": True, "transcript": "hi"})
+        cfg_patch, prov_patch = _dispatch_ctx(
+            {"provider": "openai", "prompt": PROMPT}, "openai",
+        )
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._transcribe_openai", backend):
+            transcription_tools.transcribe_audio(audio)
+
+        _, kwargs = backend.call_args
+        assert kwargs["prompt"] == PROMPT
+
+    def test_hook_prompt_wins_over_config_prompt(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        _fake_hooks(monkeypatch, [{"prompt": "hook wins"}])
+
+        backend = MagicMock(return_value={"success": True, "transcript": "hi"})
+        cfg_patch, prov_patch = _dispatch_ctx(
+            {"provider": "openai", "prompt": "config base"}, "openai",
+        )
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._transcribe_openai", backend):
+            transcription_tools.transcribe_audio(audio)
+
+        _, kwargs = backend.call_args
+        assert kwargs["prompt"] == "hook wins"
+
+    def test_final_prompt_is_not_silently_truncated(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        long_prompt = "domain-vocabulary " * 300
+        _fake_hooks(monkeypatch, [{"prompt": long_prompt}])
+
+        backend = MagicMock(return_value={"success": True, "transcript": "hi"})
+        cfg_patch, prov_patch = _dispatch_ctx(
+            {"provider": "openai", "prompt": "config base"}, "openai",
+        )
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._transcribe_openai", backend):
+            transcription_tools.transcribe_audio(audio)
+
+        _, kwargs = backend.call_args
+        assert kwargs["prompt"] == long_prompt
+
+    def test_blank_config_prompt_ignored(self, monkeypatch, tmp_path):
+        audio = _make_audio(tmp_path)
+        _no_hooks(monkeypatch)
+
+        backend = MagicMock(return_value={"success": True, "transcript": "hi"})
+        cfg_patch, prov_patch = _dispatch_ctx(
+            {"provider": "openai", "prompt": "   "}, "openai",
+        )
+        with cfg_patch, prov_patch, \
+             patch("tools.transcription_tools._transcribe_openai", backend):
+            transcription_tools.transcribe_audio(audio)
+
+        _, kwargs = backend.call_args
+        assert kwargs["prompt"] is None
+
+
+# ---------------------------------------------------------------------------
+# Backends without prompt support
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedBackends:
+    def test_xai_logs_debug_and_proceeds_without_prompt(
+        self, monkeypatch, tmp_path, caplog,
+    ):
+        audio = _make_audio(tmp_path)
+        monkeypatch.setattr(
+            "tools.xai_http.resolve_xai_http_credentials",
+            lambda: {"api_key": "xk-test", "base_url": None},
+        )
+        monkeypatch.setattr(
+            "tools.xai_http.hermes_xai_user_agent", lambda: "test-ua",
+        )
+
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"text": "hello", "language": "en", "duration": 1.0}
+        fake_requests = SimpleNamespace(post=MagicMock(return_value=response))
+        monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+        with caplog.at_level(logging.DEBUG, logger="tools.transcription_tools"), \
+             patch("tools.transcription_tools._load_stt_config", return_value={}):
+            result = transcription_tools._transcribe_xai(
+                audio, "grok-stt", prompt=PROMPT,
+            )
+
+        assert result["success"] is True
+        assert "does not support transcription prompts" in caplog.text
+        _, kwargs = fake_requests.post.call_args
+        assert "prompt" not in kwargs["data"]
+
+    def test_elevenlabs_logs_debug_and_proceeds_without_prompt(
+        self, monkeypatch, tmp_path, caplog,
+    ):
+        audio = _make_audio(tmp_path)
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "el-test")
+
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"text": "hello"}
+        fake_requests = SimpleNamespace(post=MagicMock(return_value=response))
+        monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+        with caplog.at_level(logging.DEBUG, logger="tools.transcription_tools"), \
+             patch("tools.transcription_tools._load_stt_config", return_value={}):
+            result = transcription_tools._transcribe_elevenlabs(
+                audio, "scribe_v2", prompt=PROMPT,
+            )
+
+        assert result["success"] is True
+        assert "does not support transcription prompts" in caplog.text
+        _, kwargs = fake_requests.post.call_args
+        assert "prompt" not in kwargs["data"]
+
+
+# ---------------------------------------------------------------------------
+# Plugin-registered providers (TranscriptionProvider ABC)
+# ---------------------------------------------------------------------------
+
+
+class TestPluginProviderThreading:
+    @pytest.fixture(autouse=True)
+    def _reset_registry(self):
+        from agent import transcription_registry
+        transcription_registry._reset_for_tests()
+        yield
+        transcription_registry._reset_for_tests()
+
+    def _register_fake_provider(self):
+        from agent import transcription_registry
+        from agent.transcription_provider import TranscriptionProvider
+
+        class _FakeProvider(TranscriptionProvider):
+            def __init__(self):
+                self.last_call = None
+
+            @property
+            def name(self):
+                return "openrouter"
+
+            def transcribe(self, file_path, **kw):
+                self.last_call = {"file_path": file_path, "kwargs": dict(kw)}
+                return {"success": True, "transcript": "hi", "provider": "openrouter"}
+
+        provider = _FakeProvider()
+        transcription_registry.register_provider(provider)
+        return provider
+
+    def test_plugin_provider_receives_prompt_via_extra_kwargs(
+        self, monkeypatch, tmp_path,
+    ):
+        audio = _make_audio(tmp_path)
+        provider = self._register_fake_provider()
+        _fake_hooks(monkeypatch, [{"prompt": PROMPT, "language": "en"}])
+
+        cfg_patch, prov_patch = _dispatch_ctx(
+            {"provider": "openrouter"}, "openrouter",
+        )
+        with cfg_patch, prov_patch:
+            result = transcription_tools.transcribe_audio(audio)
+
+        assert result["success"] is True
+        assert provider.last_call["kwargs"]["prompt"] == PROMPT
+        assert provider.last_call["kwargs"]["language"] == "en"
+
+    def test_plugin_provider_sees_no_prompt_key_when_unset(
+        self, monkeypatch, tmp_path,
+    ):
+        audio = _make_audio(tmp_path)
+        provider = self._register_fake_provider()
+        _no_hooks(monkeypatch)
+
+        cfg_patch, prov_patch = _dispatch_ctx(
+            {"provider": "openrouter"}, "openrouter",
+        )
+        with cfg_patch, prov_patch:
+            transcription_tools.transcribe_audio(audio)
+
+        # Byte-identical no-prompt path: the key is not even sent.
+        assert "prompt" not in provider.last_call["kwargs"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with a real fixture plugin (real PluginManager mechanics)
+# ---------------------------------------------------------------------------
+
+
+def test_real_fixture_plugins_thread_prompt_in_registration_order(
+    monkeypatch, tmp_path,
+):
+    """Two callbacks registered by a real plugin, applied in registration
+    order with last-writer-wins — verified against the faster-whisper
+    backend stub receiving ``initial_prompt``."""
+    import os
+    from pathlib import Path
+
+    import yaml
+
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    plugin_dir = hermes_home / "plugins" / "stt_vocab"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text("name: stt_vocab\n", encoding="utf-8")
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        '    ctx.register_hook("pre_transcription", '
+        'lambda **kw: {"prompt": "loser", "language": "en"})\n'
+        '    ctx.register_hook("pre_transcription", '
+        f'lambda **kw: {{"prompt": "{PROMPT}"}})\n',
+        encoding="utf-8",
+    )
+    cfg_path = hermes_home / "config.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["stt_vocab"]}}),
+        encoding="utf-8",
+    )
+
+    old_manager = plugins_mod._plugin_manager
+    plugins_mod._plugin_manager = plugins_mod.PluginManager()
+    try:
+        plugins_mod.discover_plugins()
+
+        audio = _make_audio(tmp_path)
+        mock_segment = MagicMock()
+        mock_segment.text = "hello"
+        mock_info = MagicMock(language="en", duration=1.0)
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([mock_segment], mock_info)
+
+        with patch("tools.transcription_tools._load_stt_config",
+                   return_value={"provider": "local"}), \
+             patch("tools.transcription_tools._get_provider",
+                   return_value="local"), \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("tools.transcription_tools._load_local_whisper_model",
+                   return_value=mock_model), \
+             patch("tools.transcription_tools._local_model", None):
+            result = transcription_tools.transcribe_audio(audio)
+    finally:
+        plugins_mod._plugin_manager = old_manager
+
+    assert result["success"] is True
+    _, kwargs = mock_model.transcribe.call_args
+    assert kwargs["initial_prompt"] == PROMPT  # last writer won
+    assert kwargs["language"] == "en"  # earlier hook's field preserved

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -760,7 +760,9 @@ class TestTranscribeRecording:
 
         assert result["success"] is True
         assert result["transcript"] == "hello world"
-        mock_transcribe.assert_called_once_with("/tmp/test.wav", model="whisper-1")
+        mock_transcribe.assert_called_once_with(
+            "/tmp/test.wav", model="whisper-1", source="voice_mode",
+        )
 
     def test_filters_whisper_hallucination(self):
         mock_transcribe = MagicMock(return_value={
@@ -806,7 +808,7 @@ class TestTranscribeRecording:
 
         seen_paths = []
 
-        def fake_transcribe(path, model=None):
+        def fake_transcribe(path, model=None, source=None):
             seen_paths.append(path)
             assert model == "base"
             assert path != str(wav_path)
@@ -844,7 +846,7 @@ class TestTranscribeRecording:
         monkeypatch.setattr("tools.voice_mode._TEMP_DIR", str(temp_dir))
         monkeypatch.setattr("tools.transcription_tools.MAX_FILE_SIZE", 70 * 1024)
 
-        def fake_transcribe(path, model=None):
+        def fake_transcribe(path, model=None, source=None):
             return {"success": False, "transcript": "", "error": "provider rejected audio"}
 
         with patch("tools.transcription_tools.transcribe_audio", side_effect=fake_transcribe):

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -623,6 +623,8 @@ def _transcribe_command_stt(
     config: Dict[str, Any],
     stt_config: Dict[str, Any],
     model_override: Optional[str] = None,
+    language_override: Optional[str] = None,
+    prompt: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Transcribe via a user-declared ``stt.providers.<name>: type: command``.
 
@@ -643,6 +645,12 @@ def _transcribe_command_stt(
     Returns the standard transcribe-response envelope (``success``,
     ``transcript``, ``provider``, ``error``).
     """
+    if prompt:
+        logger.debug(
+            "Command STT provider '%s' does not support transcription "
+            "prompts — proceeding without the prompt.", provider_name,
+        )
+
     command_template = str(config.get("command") or "").strip()
     if not command_template:
         return {
@@ -663,8 +671,10 @@ def _transcribe_command_stt(
 
     timeout = _get_command_stt_timeout(config)
     output_format = _get_command_stt_output_format(config)
+    # Language: hook override > provider config > stt.language > default.
     language = (
-        config.get("language")
+        language_override
+        or config.get("language")
         or stt_config.get("language")
         or DEFAULT_COMMAND_STT_LANGUAGE
     )
@@ -897,6 +907,7 @@ def _dispatch_to_plugin_provider(
     *,
     model: Optional[str] = None,
     language: Optional[str] = None,
+    prompt: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Route the call to a plugin-registered transcription provider, or
     return None.
@@ -1001,11 +1012,19 @@ def _dispatch_to_plugin_provider(
         }
 
     logger.info("Transcribing with plugin STT provider '%s'...", key)
+    # Plugin providers receive the transcription prompt via the ABC's
+    # existing ``**extra`` kwargs — no signature change needed. The key is
+    # only sent when a prompt is actually set so providers that predate it
+    # see byte-identical calls on the no-prompt path.
+    extra_kwargs: Dict[str, Any] = {}
+    if prompt is not None:
+        extra_kwargs["prompt"] = prompt
     try:
         result = plugin_provider.transcribe(
             file_path,
             model=model,
             language=language,
+            **extra_kwargs,
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning(
@@ -1031,6 +1050,102 @@ def _dispatch_to_plugin_provider(
     # Stamp provider if the plugin forgot to.
     result.setdefault("provider", key)
     return result
+
+
+# ---------------------------------------------------------------------------
+# pre_transcription plugin hook (issue #64168 — STT prompt/vocab threading)
+# ---------------------------------------------------------------------------
+
+
+# Fields a pre_transcription hook may mutate. ``file_path`` is deliberately
+# absent — it is read-only; attempts to change it are logged and dropped.
+_PRE_TRANSCRIPTION_MUTABLE_FIELDS = ("prompt", "language", "model")
+
+
+def _apply_pre_transcription_hook(
+    *,
+    file_path: str,
+    provider: str,
+    model: Optional[str],
+    language: Optional[str],
+    prompt: Optional[str],
+    source: Optional[str],
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Fire the ``pre_transcription`` plugin hook and merge its results.
+
+    Mirrors the ``transform_*`` hook mechanics from
+    ``model_tools.handle_function_call`` (``transform_tool_result``): gated
+    on ``has_hook`` so the no-hook dispatch path never builds hook kwargs,
+    and fail-open — any hook-plumbing error leaves the dispatch untouched.
+    ``invoke_hook`` returns results in registration order; each dict result
+    is applied field-by-field on top of the previous ones, so the last hook
+    to write a field wins (last-writer-wins per field).
+
+    Model values are accepted as-is: the dispatcher has no catalog-level
+    validation today, so a hook-set model flows through the exact same
+    per-backend normalization/auto-correction (``_normalize_local_model``,
+    the Groq/OpenAI cross-corrections) a caller-supplied model would, and
+    otherwise errors at the backend as it would today.
+
+    Returns ``(model, language_override, prompt)``. ``language_override``
+    is ``None`` unless a hook explicitly set ``language`` — backends keep
+    their existing config/env language resolution when no hook overrides
+    it.
+    """
+    try:
+        from hermes_cli.plugins import has_hook, invoke_hook
+
+        # No-hook short-circuit: keep the no-plugin dispatch path
+        # byte-identical (no kwargs built, no invoke_hook call).
+        if not has_hook("pre_transcription"):
+            return model, None, prompt
+
+        hook_results = invoke_hook(
+            "pre_transcription",
+            file_path=file_path,
+            provider=provider,
+            model=model,
+            language=language,
+            prompt=prompt,
+            source=source,
+        )
+        overrides: Dict[str, Any] = {}
+        for hook_result in hook_results:
+            if not isinstance(hook_result, dict):
+                continue
+            for key, value in hook_result.items():
+                if key == "file_path":
+                    # file_path is read-only for hooks — log and drop.
+                    logger.warning(
+                        "pre_transcription hook attempted to change "
+                        "file_path (read-only) — ignoring the attempt."
+                    )
+                    continue
+                if key not in _PRE_TRANSCRIPTION_MUTABLE_FIELDS:
+                    logger.debug(
+                        "pre_transcription hook returned unsupported field "
+                        "%r — ignoring.", key,
+                    )
+                    continue
+                if not isinstance(value, str):
+                    logger.debug(
+                        "pre_transcription hook returned non-string value "
+                        "%r for field %r — ignoring.", value, key,
+                    )
+                    continue
+                overrides[key] = value
+
+        if "model" in overrides:
+            model = overrides["model"]
+        if "prompt" in overrides:
+            # Hook results win over the static ``stt.prompt`` config value —
+            # config is the base, hooks mutate on top. An empty string
+            # clears the config prompt.
+            prompt = overrides["prompt"] or None
+        return model, overrides.get("language") or None, prompt
+    except Exception as _hook_err:  # noqa: BLE001 — hook plumbing is fail-open
+        logger.debug("pre_transcription hook error: %s", _hook_err)
+        return model, None, prompt
 
 
 # ---------------------------------------------------------------------------
@@ -1132,7 +1247,13 @@ def _load_local_whisper_model(model_name: str):
         return WhisperModel(model_name, device="cpu", compute_type="int8")
 
 
-def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_local(
+    file_path: str,
+    model_name: str,
+    *,
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
+) -> Dict[str, Any]:
     """Transcribe using faster-whisper (local, free)."""
     global _local_model, _local_model_name
 
@@ -1147,15 +1268,20 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             _local_model = _load_local_whisper_model(model_name)
             _local_model_name = model_name
 
-        # Language: config.yaml (stt.local.language) > env var > auto-detect.
+        # Language: hook override > config.yaml (stt.local.language) >
+        # env var > auto-detect.
         _forced_lang = (
-            (_load_stt_config().get("local") or {}).get("language")
+            language
+            or (_load_stt_config().get("local") or {}).get("language")
             or os.getenv(LOCAL_STT_LANGUAGE_ENV)
             or None
         )
         transcribe_kwargs = {"beam_size": 5}
         if _forced_lang:
             transcribe_kwargs["language"] = _forced_lang
+        if prompt:
+            # faster-whisper's vocabulary/context hint parameter.
+            transcribe_kwargs["initial_prompt"] = prompt
 
         try:
             segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
@@ -1218,8 +1344,20 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
         return None, f"Failed to convert audio for local STT: {details}"
 
 
-def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_local_command(
+    file_path: str,
+    model_name: str,
+    *,
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
+) -> Dict[str, Any]:
     """Run the configured local STT command template and read back a .txt transcript."""
+    if prompt:
+        logger.debug(
+            "STT provider 'local_command' does not support transcription "
+            "prompts — proceeding without the prompt."
+        )
+
     command_template = _get_local_command_template()
     if not command_template:
         return {
@@ -1230,9 +1368,11 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             ),
         }
 
-    # Language: config.yaml (stt.local.language) > env var > "en" default.
+    # Language: hook override > config.yaml (stt.local.language) > env var
+    # > "en" default.
     language = (
-        (_load_stt_config().get("local") or {}).get("language")
+        language
+        or (_load_stt_config().get("local") or {}).get("language")
         or os.getenv(LOCAL_STT_LANGUAGE_ENV)
         or DEFAULT_LOCAL_STT_LANGUAGE
     )
@@ -1294,7 +1434,13 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_groq(
+    file_path: str,
+    model_name: str,
+    *,
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
+) -> Dict[str, Any]:
     """Transcribe using Groq Whisper API (free tier available)."""
     api_key = get_env_value("GROQ_API_KEY")
     if not api_key:
@@ -1312,11 +1458,19 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
         client = OpenAI(api_key=api_key, base_url=GROQ_BASE_URL, timeout=30, max_retries=0)
         try:
+            # Only send prompt/language when set so the no-hook, no-config
+            # request stays byte-identical to today's.
+            extra_params: Dict[str, Any] = {}
+            if prompt:
+                extra_params["prompt"] = prompt
+            if language:
+                extra_params["language"] = language
             with open(file_path, "rb") as audio_file:
                 transcription = client.audio.transcriptions.create(
                     model=model_name,
                     file=audio_file,
                     response_format="text",
+                    **extra_params,
                 )
 
             transcript_text = str(transcription).strip()
@@ -1353,6 +1507,8 @@ def _transcribe_openai(
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
     provider_label: str = "openai",
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Transcribe via the OpenAI ``audio.transcriptions.create`` SDK shape.
 
@@ -1383,11 +1539,19 @@ def _transcribe_openai(
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
         client = OpenAI(api_key=api_key, base_url=base_url, timeout=30, max_retries=0)
         try:
+            # Only send prompt/language when set so the no-hook, no-config
+            # request stays byte-identical to today's.
+            extra_params: Dict[str, Any] = {}
+            if prompt:
+                extra_params["prompt"] = prompt
+            if language:
+                extra_params["language"] = language
             with open(file_path, "rb") as audio_file:
                 transcription = client.audio.transcriptions.create(
                     model=model_name,
                     file=audio_file,
                     response_format="text" if model_name == "whisper-1" else "json",
+                    **extra_params,
                 )
 
             transcript_text = _extract_transcript_text(transcription)
@@ -1419,7 +1583,13 @@ def _transcribe_openai(
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_mistral(
+    file_path: str,
+    model_name: str,
+    *,
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
+) -> Dict[str, Any]:
     """Transcribe using Mistral Voxtral Transcribe API.
 
     Uses the ``mistralai`` Python SDK to call ``/v1/audio/transcriptions``.
@@ -1437,11 +1607,20 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
             pass
         from mistralai.client import Mistral
 
+        # Only send prompt/language when set so the no-hook, no-config
+        # request stays byte-identical to today's.
+        extra_params: Dict[str, Any] = {}
+        if prompt:
+            extra_params["prompt"] = prompt
+        if language:
+            extra_params["language"] = language
+
         with Mistral(api_key=api_key) as client:
             with open(file_path, "rb") as audio_file:
                 result = client.audio.transcriptions.complete(
                     model=model_name,
                     file={"content": audio_file, "file_name": Path(file_path).name},
+                    **extra_params,
                 )
 
             transcript_text = _extract_transcript_text(result)
@@ -1463,7 +1642,13 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_xai(
+    file_path: str,
+    model_name: str,
+    *,
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
+) -> Dict[str, Any]:
     """Transcribe using xAI Grok STT API.
 
     Uses the ``POST /v1/stt`` REST endpoint with multipart/form-data.
@@ -1471,6 +1656,12 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
     Requires ``XAI_API_KEY`` environment variable.
     """
     from tools.xai_http import resolve_xai_http_credentials
+
+    if prompt:
+        logger.debug(
+            "STT provider 'xai' does not support transcription prompts — "
+            "proceeding without the prompt."
+        )
 
     creds = resolve_xai_http_credentials()
     api_key = str(creds.get("api_key") or "").strip()
@@ -1489,8 +1680,11 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
         or creds.get("base_url")
         or XAI_STT_BASE_URL
     ).strip().rstrip("/")
+    # Language: hook override > config.yaml (stt.xai.language) > env var
+    # > "en" default.
     language = str(
-        xai_config.get("language")
+        language
+        or xai_config.get("language")
         or os.getenv("HERMES_LOCAL_STT_LANGUAGE")
         or DEFAULT_LOCAL_STT_LANGUAGE
     ).strip()
@@ -1570,8 +1764,20 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_elevenlabs(
+    file_path: str,
+    model_name: str,
+    *,
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
+) -> Dict[str, Any]:
     """Transcribe using ElevenLabs Scribe STT API."""
+    if prompt:
+        logger.debug(
+            "STT provider 'elevenlabs' does not support transcription "
+            "prompts — proceeding without the prompt."
+        )
+
     api_key = get_env_value("ELEVENLABS_API_KEY")
     if not api_key:
         return {"success": False, "transcript": "", "error": "ELEVENLABS_API_KEY not set"}
@@ -1583,7 +1789,10 @@ def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
         or get_env_value("ELEVENLABS_STT_BASE_URL")
         or ELEVENLABS_STT_BASE_URL
     ).strip().rstrip("/")
-    language_code = str(elevenlabs_config.get("language_code") or "").strip()
+    # Language: hook override > config.yaml (stt.elevenlabs.language_code).
+    language_code = str(
+        language or elevenlabs_config.get("language_code") or ""
+    ).strip()
     tag_audio_events = is_truthy_value(elevenlabs_config.get("tag_audio_events", False))
     diarize = is_truthy_value(elevenlabs_config.get("diarize", False))
 
@@ -1656,7 +1865,13 @@ def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_deepinfra(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_deepinfra(
+    file_path: str,
+    model_name: str,
+    *,
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
+) -> Dict[str, Any]:
     """Resolve DeepInfra credentials/model, then delegate to the OpenAI handler.
 
     DeepInfra's STT endpoint is OpenAI-compatible, so the actual SDK
@@ -1701,6 +1916,8 @@ def _transcribe_deepinfra(file_path: str, model_name: str) -> Dict[str, Any]:
         api_key=api_key,
         base_url=base_url,
         provider_label="deepinfra",
+        language=language,
+        prompt=prompt,
     )
 
 
@@ -1709,7 +1926,11 @@ def _transcribe_deepinfra(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
+def transcribe_audio(
+    file_path: str,
+    model: Optional[str] = None,
+    source: Optional[str] = None,
+) -> Dict[str, Any]:
     """
     Transcribe an audio file using the configured STT provider.
 
@@ -1720,6 +1941,9 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
     Args:
         file_path: Absolute path to the audio file to transcribe.
         model:     Override the model. If None, uses config or provider default.
+        source:    Optional caller-surface label (e.g. ``"gateway"``,
+                   ``"voice_mode"``) forwarded to the ``pre_transcription``
+                   plugin hook for observability. Not used for dispatch.
 
     Returns:
         dict with keys:
@@ -1744,49 +1968,92 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
 
     provider = _get_provider(stt_config)
 
+    # Optional static transcription prompt (``stt.prompt`` in config.yaml):
+    # vocabulary/context hints threaded to prompt-capable backends.
+    # Ordering: config is the base; pre_transcription hook results mutate on
+    # top, in registration order, so the last hook to set a field wins.
+    # Hermes deliberately does not truncate the final prompt: provider/model
+    # tokenizers and limits differ, so the configured backend owns validation,
+    # truncation, or rejection. The user-facing config example documents the
+    # per-provider behavior and privacy boundary.
+    prompt = stt_config.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        prompt = None
+
+    # pre_transcription plugin hook — fires after provider resolution and
+    # BEFORE any backend (built-in, command-type, or plugin-registered) is
+    # invoked. Hooks may mutate prompt/language/model; file_path is
+    # read-only. The helper short-circuits on has_hook() so the no-hook
+    # dispatch path stays byte-identical. ``language`` stays None unless a
+    # hook overrides it — backends keep their own config/env resolution.
+    model, language, prompt = _apply_pre_transcription_hook(
+        file_path=file_path,
+        provider=provider,
+        model=model,
+        language=_get_stt_section(stt_config, provider).get("language"),
+        prompt=prompt,
+        source=source,
+    )
+
     if provider == "local":
         local_cfg = stt_config.get("local") or {}
         model_name = _normalize_local_model(
             model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
         )
-        return _transcribe_local(file_path, model_name)
+        return _transcribe_local(
+            file_path, model_name, language=language, prompt=prompt,
+        )
 
     if provider == "local_command":
         local_cfg = stt_config.get("local") or {}
         model_name = _normalize_local_command_model(
             model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
         )
-        return _transcribe_local_command(file_path, model_name)
+        return _transcribe_local_command(
+            file_path, model_name, language=language, prompt=prompt,
+        )
 
     if provider == "groq":
         model_name = model or DEFAULT_GROQ_STT_MODEL
-        return _transcribe_groq(file_path, model_name)
+        return _transcribe_groq(
+            file_path, model_name, language=language, prompt=prompt,
+        )
 
     if provider == "openai":
         openai_cfg = stt_config.get("openai") or {}
         model_name = model or openai_cfg.get("model", DEFAULT_STT_MODEL)
-        return _transcribe_openai(file_path, model_name)
+        return _transcribe_openai(
+            file_path, model_name, language=language, prompt=prompt,
+        )
 
     if provider == "mistral":
         mistral_cfg = stt_config.get("mistral") or {}
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
-        return _transcribe_mistral(file_path, model_name)
+        return _transcribe_mistral(
+            file_path, model_name, language=language, prompt=prompt,
+        )
 
     if provider == "xai":
         # xAI Grok STT doesn't use a model parameter — pass through for logging
         model_name = model or "grok-stt"
-        return _transcribe_xai(file_path, model_name)
+        return _transcribe_xai(
+            file_path, model_name, language=language, prompt=prompt,
+        )
 
     if provider == "elevenlabs":
         elevenlabs_cfg = stt_config.get("elevenlabs") or {}
         model_name = model or elevenlabs_cfg.get("model_id", DEFAULT_ELEVENLABS_STT_MODEL)
-        return _transcribe_elevenlabs(file_path, model_name)
+        return _transcribe_elevenlabs(
+            file_path, model_name, language=language, prompt=prompt,
+        )
 
     if provider == "deepinfra":
         di_config = stt_config.get("deepinfra")  # may be None (YAML null)
         di_config = di_config if isinstance(di_config, dict) else {}
         model_name = model or di_config.get("model") or ""
-        return _transcribe_deepinfra(file_path, model_name)
+        return _transcribe_deepinfra(
+            file_path, model_name, language=language, prompt=prompt,
+        )
 
     # User-declared command-type provider
     # (``stt.providers.<name>: type: command``). Fires after the built-in
@@ -1802,6 +2069,8 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             command_provider_config,
             stt_config,
             model_override=model,
+            language_override=language,
+            prompt=prompt,
         )
 
     # Plugin-registered STT backend (e.g. OpenRouter, SenseAudio,
@@ -1818,7 +2087,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
     # forwards ``language`` from there. Top-level ``model`` argument
     # overrides any config-set model.
     plugin_cfg = stt_config.get(provider, {}) if isinstance(stt_config.get(provider), dict) else {}
-    plugin_language = plugin_cfg.get("language")
+    plugin_language = language or plugin_cfg.get("language")
     plugin_model = model or plugin_cfg.get("model")
     plugin_result = _dispatch_to_plugin_provider(
         file_path,
@@ -1826,6 +2095,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         stt_config,
         model=plugin_model,
         language=plugin_language,
+        prompt=prompt,
     )
     if plugin_result is not None:
         return plugin_result

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -893,7 +893,7 @@ def transcribe_recording(wav_path: str, model: Optional[str] = None) -> Dict[str
     if _should_chunk_for_transcription(wav_path, MAX_FILE_SIZE):
         result = _transcribe_wav_in_chunks(wav_path, model=model, max_file_size=MAX_FILE_SIZE)
     else:
-        result = transcribe_audio(wav_path, model=model)
+        result = transcribe_audio(wav_path, model=model, source="voice_mode")
 
     # Filter out Whisper hallucinations (common on silent/near-silent audio)
     if result.get("success") and is_whisper_hallucination(result.get("transcript", "")):
@@ -932,7 +932,7 @@ def _transcribe_wav_in_chunks(
 
         logger.info("Transcribing oversized WAV in %d chunks: %s", len(chunk_paths), wav_path)
         for index, chunk_path in enumerate(chunk_paths, start=1):
-            result = transcribe_audio(chunk_path, model=model)
+            result = transcribe_audio(chunk_path, model=model, source="voice_mode")
             if not result.get("success"):
                 error = result.get("error", "Unknown transcription error")
                 return {

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1621,6 +1621,7 @@ stt:
   enabled: true                # Auto-transcribe inbound voice messages (default: true)
   echo_transcripts: true       # Post raw transcripts back to the chat as 🎙️ "..." (default: true)
   provider: "local"            # "local" | "groq" | "openai" | "mistral"
+  # prompt: "Hermes, Teknium, Nous Research, kanban"   # Static vocabulary hint (see below)
   local:
     model: "base"              # tiny, base, small, medium, large-v3
   openai:
@@ -1646,6 +1647,39 @@ STT_OPENAI_MODEL=whisper-1
 GROQ_BASE_URL=https://api.groq.com/openai/v1
 STT_OPENAI_BASE_URL=https://api.openai.com/v1
 ```
+
+### Transcription prompt (vocabulary hints)
+
+`stt.prompt` is an optional static hint passed to prompt-capable STT backends. Use it for proper nouns, product names, and jargon that Whisper-family models otherwise mis-hear:
+
+```yaml
+stt:
+  provider: "local"
+  prompt: "Hermes, Teknium, Nous Research, kanban, Ollama"
+```
+
+**Composition.** The config value is the base. Plugins that register the [`pre_transcription`](/user-guide/features/hooks#pre_transcription) hook run in registration order and mutate on top of it, last-writer-wins per field. A hook returning an empty string for `prompt` clears the config prompt for that request. Hooks may also override `language` and `model`; `file_path` is read-only and any attempt to change it is logged and dropped. With no hook registered and no `stt.prompt` set, the outgoing request is identical to previous releases.
+
+**Provider support.**
+
+| Provider | Prompt parameter | Behavior |
+|----------|-----------------|----------|
+| `local` (faster-whisper) | `initial_prompt` | Forwarded unchanged to the local model |
+| `openai` | `prompt` | Forwarded unchanged in the transcription request |
+| `groq` | `prompt` | Forwarded unchanged in the transcription request |
+| `mistral` | `prompt` | Forwarded unchanged in the transcription request |
+| `deepinfra` | `prompt` | OpenAI-compatible path, forwarded unchanged |
+| `xai` | not supported | Logged at DEBUG, the request proceeds without the prompt |
+| `elevenlabs` | not supported | Logged at DEBUG, the request proceeds without the prompt |
+| `local_command` | not supported | Logged at DEBUG, the request proceeds without the prompt |
+| `stt.providers.<name>` with `type: command` | not supported | Logged at DEBUG, the request proceeds without the prompt |
+| Plugin-registered providers | `prompt` in the `transcribe(**extra)` kwargs | Only sent when a prompt is set, so providers that predate this key see unchanged calls |
+
+**Length.** Hermes forwards the final prompt unchanged and never silently truncates it. Token limits differ by provider and model; Whisper-family models commonly accept about 224 prompt tokens. The backend SDK or API owns validation, truncation, and rejection beyond its own limit, so keep hints short and specific.
+
+:::warning Prompts are uploaded with your audio
+The final prompt is sent to the configured STT provider alongside the audio file. Keep secrets and session-derived context out of `stt.prompt` and out of anything a `pre_transcription` hook returns, especially when the provider is a hosted API rather than local `faster-whisper`.
+:::
 
 ## Voice Mode (CLI)
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -392,6 +392,7 @@ def register(ctx):
 | [`pre_gateway_dispatch`](#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch | `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow |
 | [`pre_approval_request`](#pre_approval_request) | An approval decision is requested, including smart-mode auto decisions | ignored |
 | [`post_approval_response`](#post_approval_response) | An approval decision is made (or a prompt times out) | ignored |
+| [`pre_transcription`](#pre_transcription) | Before an audio file is sent to any STT backend | `{"prompt"/"language"/"model": str}` to modify the request, `None` to leave unchanged |
 | [`transform_tool_result`](#transform_tool_result) | After any tool returns, before the result is handed back to the model | `str` to replace the result, `None` to leave unchanged |
 | [`transform_terminal_output`](#transform_terminal_output) | Inside the `terminal` tool, before truncation/ANSI-strip/redact | `str` to replace the raw output, `None` to leave unchanged |
 | [`transform_llm_output`](#transform_llm_output) | After the tool-calling loop completes, before the final response is delivered | `str` to replace the response text, `None`/empty to leave unchanged |
@@ -1147,6 +1148,53 @@ def log_decision(command, choice, session_key, **kwargs):
 def register(ctx):
     ctx.register_hook("post_approval_response", log_decision)
 ```
+
+---
+
+### `pre_transcription`
+
+Fires inside the STT dispatcher (`tools.transcription_tools.transcribe_audio`) **after** the provider has been resolved and **before** any backend is invoked, whether that backend is built-in, a `type: command` provider, or a plugin-registered provider. Lets a plugin steer the transcription request itself instead of only observing the transcript afterwards.
+
+**Callback signature:**
+
+```python
+def my_callback(
+    file_path: str,
+    provider: str,
+    model: str | None,
+    language: str | None,
+    prompt: str | None,
+    source: str | None,
+    **kwargs,
+) -> dict | None:
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `file_path` | `str` | Absolute path to the audio file about to be transcribed. Read-only. |
+| `provider` | `str` | Resolved STT provider (`local`, `groq`, `openai`, `mistral`, `xai`, `elevenlabs`, `deepinfra`, `local_command`, a command provider name, or a plugin provider name). |
+| `model` | `str \| None` | Model resolved so far, or `None` when the backend default applies. |
+| `language` | `str \| None` | Language from the provider's config section, or `None`. |
+| `prompt` | `str \| None` | The static [`stt.prompt`](/user-guide/configuration#transcription-prompt-vocabulary-hints) value, or `None`. |
+| `source` | `str \| None` | Caller surface label (`gateway`, `voice_mode`, …). Observability only, not used for dispatch. |
+
+**Return value:** a `dict` with any of `"prompt"`, `"language"`, `"model"` mapped to strings, or `None` to leave the request unchanged. Non-string values, unknown keys, and `file_path` are ignored (`file_path` attempts are logged as a warning). Results are applied in **registration order, last-writer-wins per field**, on top of the `stt.prompt` config value. Returning `""` for `prompt` clears the configured prompt for that request.
+
+**Use cases:** Inject a per-user or per-chat vocabulary list before the audio is uploaded, force `language` from the caller's locale, downgrade `model` for long recordings, route noisy sources to a different model.
+
+```python
+VOCAB = "Hermes, Teknium, Nous Research, kanban"
+
+def add_vocab(provider, prompt, source, **kwargs):
+    if source != "gateway":
+        return None
+    return {"prompt": f"{prompt}. {VOCAB}" if prompt else VOCAB}
+
+def register(ctx):
+    ctx.register_hook("pre_transcription", add_vocab)
+```
+
+Not every backend accepts a prompt. `local` maps it to faster-whisper's `initial_prompt`; `openai`, `groq`, `mistral`, and `deepinfra` send it as `prompt`; `xai`, `elevenlabs`, `local_command`, and `type: command` providers log at DEBUG and transcribe without it. See the [provider support table](/user-guide/configuration#transcription-prompt-vocabulary-hints) for the full matrix and the privacy boundary. Hook-plumbing errors are fail-open: the dispatch continues with the unmodified request.
 
 ---
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -201,6 +201,7 @@ Plugins can register callbacks for these lifecycle events. See the **[Event Hook
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`, `/clear`, idle rotation) |
 | [`subagent_stop`](/user-guide/features/hooks#subagent_stop) | Once per child after `delegate_task` finishes |
 | [`pre_gateway_dispatch`](/user-guide/features/hooks#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch. Return `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow. |
+| [`pre_transcription`](/user-guide/features/hooks#pre_transcription) | Before an audio file is sent to any STT backend. Return `{"prompt" \| "language" \| "model": "..."}` to modify the request, `None` to leave it unchanged. |
 
 ## Plugin types
 


### PR DESCRIPTION
## What & why

Fixes #64168 — plugins can now influence the request sent to the STT backend (most importantly the model prompt / vocabulary hint) via a `pre_transcription` hook, plus an optional static `stt.prompt` config key on the same plumbing.

- `hermes_cli/plugins.py`: `pre_transcription` added to `VALID_HOOKS` with the contract documented (mutable: `prompt`/`language`/`model`; `file_path` read-only — writes are logged and dropped; results applied in registration order, last-writer-wins per field, the per-field analogue of the `transform_*` convention).
- `tools/transcription_tools.py`: `_apply_pre_transcription_hook()` fired before any backend — built-in or plugin-registered. Gated on `has_hook` so the no-hook path builds no kwargs and stays byte-identical; the whole seam is fail-open (hook-plumbing errors leave dispatch untouched), mirroring the `transform_tool_result` seam in `model_tools.py`.
- Prompt threading: faster-whisper `initial_prompt`; OpenAI/Groq `prompt`; Mistral `prompt` on `transcriptions.complete`; DeepInfra inherits via the shared OpenAI-compatible handler; xAI/ElevenLabs/command providers log a DEBUG note and proceed; plugin providers receive it via the ABC's existing `**extra` (no signature change — the `prompt` key is only sent when set, so pre-existing providers see byte-identical calls on the no-prompt path).
- Config ordering: `stt.prompt` is the base, hooks mutate on top (hook sees the config value and wins).
- `hermes_cli/hooks.py`: synthetic payload so `hermes hooks test/doctor` cover the new event.
- Model values are accepted as-is: the dispatcher has no catalog-level validation today; a hook-set model flows through the same per-backend normalization (`_normalize_local_model`, Groq/OpenAI cross-corrections) as a caller-supplied one.

Open questions flagged for review:
1. The hook currently also fires when the provider resolves to `none` (observers see it; mutations are moot) — happy to skip it instead if preferred.
2. Mistral SDK `prompt` acceptance was verified at the stubbed call boundary per the issue spec; if the live SDK rejects it, it surfaces through the existing error envelope.
3. DeepInfra gets prompt threading implicitly (shared OpenAI handler) — the issue named OpenAI/Groq/Mistral; flag if it should DEBUG-and-drop instead.

## Testing

- New `tests/tools/test_pre_transcription_hook.py` — **20 tests**: fixture plugin → `initial_prompt`/`prompt` verified at the stubbed SDK/HTTP boundary; two hooks → last-writer-wins per field (including via a real `PluginManager` fixture plugin); `file_path` write dropped + logged; no-hook control run with an invoke-must-not-fire guard plus wire-kwargs equality; `stt.prompt` alone; config + hook (hook wins); xAI/ElevenLabs DEBUG-and-proceed; plugin `**extra` threading with no `prompt` key when unset.
- Affected sweep (`test_transcription*.py` ×4, `test_managed_media_gateways.py`, `test_plugins.py`, both transform-hook suites, `TestTranscribeRecording`): **380 passed, 1 skipped** (pre-existing skip). Remaining failures in the wider voice suite are pre-existing on clean `main` (AF_UNIX-on-Windows tests, shell-script hook tests) — verified via stash.
- Platforms: authored and tested on Windows; no platform-specific behavior added.

## Docs

The user-facing docs are now included, so `stt.prompt` and the new hook are no longer undocumented:

- `website/docs/user-guide/configuration.md`: the `stt` YAML block gains the commented `prompt` key, plus a new **Transcription prompt (vocabulary hints)** subsection under Speech-to-Text covering composition order (config is the base, hooks mutate on top in registration order, last-writer-wins per field, empty string clears), a per-provider support table (`initial_prompt` / `prompt` / unsupported-and-DEBUG / plugin `**extra`), the length contract (forwarded unchanged, never silently truncated, backend owns rejection), and a `:::warning` on the privacy boundary (the final prompt is uploaded to the provider alongside the audio).
- `website/docs/user-guide/features/hooks.md`: `pre_transcription` added to the Quick reference table and a full `### pre_transcription` section (callback signature, parameter table, return-value semantics, use cases, example plugin), modelled on `transform_tool_result`.
- `website/docs/user-guide/features/plugins.md`: the mirrored row in the "Available hooks" table.

Verified with `npm run lint:diagrams` (0 errors, 365 files) and a full `npm run build` in `website/` (both locales SUCCESS; the new anchors and cross-links resolve in the generated HTML, no new broken-anchor warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
