### PR TITLE
fix: classify 429 quota-exhaustion errors as non-retryable for fallback

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -987,6 +987,34 @@ def _classify_by_status(
                 FailoverReason.overloaded,
                 retryable=True,
             )
+        # Quota / usage-limit exhaustion disguised as 429.  Some providers
+        # (Ollama Cloud, etc.) return HTTP 429 with body text like
+        # "you have reached your session usage limit, upgrade for higher
+        # limits" — this is NOT a transient rate limit but quota exhaustion.
+        # Without this check, the error falls through to the default
+        # rate_limit path (retryable=True), which retries the same provider
+        # 3 times then gives up — never triggering fallback_providers.
+        # Disambiguate: transient signals ("try again", "resets at") mean
+        # it's a periodic quota → rate_limit; otherwise it's billing-like
+        # exhaustion → non-retryable + should_fallback.  (#65563)
+        has_usage_limit = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
+        if has_usage_limit:
+            has_transient_signal = any(
+                p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS
+            )
+            if has_transient_signal:
+                return result_fn(
+                    FailoverReason.rate_limit,
+                    retryable=True,
+                    should_rotate_credential=True,
+                    should_fallback=True,
+                )
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
+            )
         # Distinguish an OpenRouter-aggregator upstream 429 (an upstream model
         # like DeepSeek rate-limited OpenRouter's aggregate traffic) from an
         # account-level 429 (the user's key is actually throttled). OpenRouter


### PR DESCRIPTION
## Summary

When Ollama Cloud returns HTTP 429 with body text like `"you (user) have reached your session usage limit, upgrade for higher limits"`, Hermes misclassifies it as a transient rate limit instead of quota exhaustion. The error hits the default 429 path (`rate_limit`, `retryable=True`), which retries the same provider 3 times then gives up — **never triggering the `fallback_providers` chain**.

## Root Cause

The 429 handler in `classify_api_error()` checks for:
1. Overloaded patterns (`_OVERLOADED_PATTERNS`)
2. OpenRouter upstream errors

But it does **NOT** check for quota/usage-limit exhaustion patterns (`_USAGE_LIMIT_PATTERNS`). This logic already exists in:
- The 402 path (`_classify_402`, line 1094)
- The no-status-code path (line 1369)

The 429 path was missing this check.

## Fix

Add `_USAGE_LIMIT_PATTERNS` check in the 429 handler, between the overloaded check and the OpenRouter check. Same disambiguation logic:
- Transient signals ("try again", "resets at") → `rate_limit` (retryable)
- No transient signals → `billing` (non-retryable, `should_fallback=True`)

## Changes

- `agent/error_classifier.py`: Add 28 lines — quota-exhaustion detection in 429 handler

## Test Plan

- [ ] Unit tests pass
- [ ] Verified with Ollama Cloud "session usage limit" error string
- [ ] Fallback chain triggers correctly on quota exhaustion

Fixes #65563
