### PR TITLE
feat(slack): render structured worker progress

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -56,6 +56,12 @@ from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
+from gateway.worker_progress import (
+    WORKER_PROGRESS_QUEUE_KIND,
+    WorkerProgressNotice,
+    notice_from_worker_progress_event,
+    render_worker_progress_notice,
+)
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -17721,7 +17727,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             require_platform_override_for={Platform.MATTERMOST},
         )
         _thinking_enabled = _thinking_mode != "off"
-        needs_progress_queue = tool_progress_enabled or _thinking_enabled
+        worker_progress_enabled = source.platform == Platform.SLACK
+        needs_progress_queue = (
+            tool_progress_enabled or _thinking_enabled or worker_progress_enabled
+        )
 
 
         # Queue for progress messages (thread-safe)
@@ -17729,6 +17738,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
+        worker_progress_seen = [False]
+        worker_progress_last_notice: List[Optional[WorkerProgressNotice]] = [None]
+        worker_progress_last_delivery: List[Optional[threading.Event]] = [None]
         # True when the previously enqueued progress line was a terminal
         # fenced code block — consecutive terminal calls then drop the
         # repeated "💻 terminal" header and render back-to-back blocks.
@@ -17811,6 +17823,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return
             if not progress_queue or not _run_still_current():
                 return
+
+            if worker_progress_enabled:
+                notice = notice_from_worker_progress_event(
+                    event_type,
+                    args=args,
+                    kwargs=kwargs,
+                )
+                if notice is not None:
+                    worker_progress_seen[0] = True
+                    worker_progress_last_notice[0] = notice
+                    delivery = (
+                        threading.Event()
+                        if notice.status in {"complete", "blocked"}
+                        else None
+                    )
+                    worker_progress_last_delivery[0] = delivery
+                    if delivery is not None:
+                        progress_queue.put(
+                            (WORKER_PROGRESS_QUEUE_KIND, notice, delivery)
+                        )
+                    else:
+                        progress_queue.put((WORKER_PROGRESS_QUEUE_KIND, notice))
+                    return
 
             # First-touch onboarding: the first time a tool takes longer than
             # _LONG_TOOL_THRESHOLD_S during a run that's streaming every tool
@@ -18029,6 +18064,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _progress_thread_id == source.thread_id
             else {"thread_id": _progress_thread_id}
         ) if _progress_thread_id else None
+        if (
+            _progress_metadata is not None
+            and source.platform == Platform.SLACK
+            and getattr(source, "scope_id", None)
+        ):
+            _progress_metadata = dict(_progress_metadata)
+            _progress_metadata["slack_team_id"] = str(source.scope_id)
         _progress_metadata = _non_conversational_metadata(_progress_metadata, platform=source.platform)
         _progress_reply_to = (
             event_message_id
@@ -18232,12 +18274,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 progress_lines = groups[-1]
                 return True
 
+            async def _send_or_edit_progress_text(text: str) -> None:
+                nonlocal progress_msg_id, can_edit
+                if can_edit and progress_msg_id is not None:
+                    result = await _edit_progress_message(progress_msg_id, text)
+                    if result.success:
+                        return
+                    _err = (getattr(result, "error", "") or "").lower()
+                    if getattr(result, "retryable", False):
+                        logger.debug(
+                            "[%s] Transient edit failure — keeping can_edit=True",
+                            adapter.name,
+                        )
+                        return
+                    if "flood" in _err or "retry after" in _err:
+                        logger.info(
+                            "[%s] Progress edit flood control, backing off",
+                            adapter.name,
+                        )
+                    else:
+                        can_edit = False
+
+                result = await _send_progress_text(text)
+                if result.success and result.message_id:
+                    progress_msg_id = str(result.message_id)
+                    can_edit = True
+
             while True:
                 try:
                     if not _run_still_current():
                         while not progress_queue.empty():
                             try:
-                                progress_queue.get_nowait()
+                                raw = progress_queue.get_nowait()
+                                if (
+                                    isinstance(raw, tuple)
+                                    and len(raw) >= 3
+                                    and hasattr(raw[2], "set")
+                                ):
+                                    raw[2].set()
                             except Exception:
                                 break
                         return
@@ -18255,6 +18329,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _agent_for_interrupt, "is_interrupted", False
                         ):
                             # Drop this event and continue draining.
+                            if (
+                                isinstance(raw, tuple)
+                                and len(raw) >= 3
+                                and hasattr(raw[2], "set")
+                            ):
+                                raw[2].set()
                             await asyncio.sleep(0)
                             continue
                     except Exception:
@@ -18266,6 +18346,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if progress_lines:
                             progress_lines[-1] = f"{base_msg} (×{count + 1})"
                         msg = progress_lines[-1] if progress_lines else base_msg
+                    elif (
+                        isinstance(raw, tuple)
+                        and len(raw) >= 2
+                        and raw[0] == WORKER_PROGRESS_QUEUE_KIND
+                        and isinstance(raw[1], WorkerProgressNotice)
+                    ):
+                        _worker_done = raw[2] if len(raw) >= 3 else None
+                        try:
+                            msg = render_worker_progress_notice(raw[1])
+                            progress_lines = [msg]
+                            await _send_or_edit_progress_text(msg)
+                            _last_edit_ts = time.monotonic()
+                            await asyncio.sleep(0.3)
+                            if _run_still_current():
+                                await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
+                        finally:
+                            if hasattr(_worker_done, "set"):
+                                _worker_done.set()
+                        continue
                     elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                         # Content bubble just landed on the platform — close off
                         # the current tool-progress bubble so the next tool
@@ -18346,6 +18445,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 and getattr(_flood_result, "message_id", None)
                             ):
                                 _cleanup_msg_ids.append(str(_flood_result.message_id))
+                            if getattr(_flood_result, "success", False) and getattr(
+                                _flood_result, "message_id", None
+                            ):
+                                progress_msg_id = str(_flood_result.message_id)
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message
@@ -18388,6 +18491,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 if progress_lines:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
                                     await _roll_progress_overflow_if_needed()
+                            elif (
+                                isinstance(raw, tuple)
+                                and len(raw) >= 2
+                                and raw[0] == WORKER_PROGRESS_QUEUE_KIND
+                                and isinstance(raw[1], WorkerProgressNotice)
+                            ):
+                                _worker_done = raw[2] if len(raw) >= 3 else None
+                                try:
+                                    _worker_text = render_worker_progress_notice(raw[1])
+                                    progress_lines = [_worker_text]
+                                    await _send_or_edit_progress_text(_worker_text)
+                                finally:
+                                    if hasattr(_worker_done, "set"):
+                                        _worker_done.set()
                             elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                                 # Content-bubble marker during drain: close off
                                 # the current progress bubble and start a fresh
@@ -19826,6 +19943,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if needs_progress_queue:
             progress_task = asyncio.create_task(send_progress_messages())
 
+        async def _enqueue_worker_progress_notice_and_wait(
+            notice: WorkerProgressNotice,
+        ) -> None:
+            """Queue a worker-progress card update and wait until it is delivered."""
+            if not progress_queue or not progress_task or progress_task.done():
+                return
+            delivered = threading.Event()
+            progress_queue.put((WORKER_PROGRESS_QUEUE_KIND, notice, delivered))
+            await _wait_for_worker_progress_delivery(delivered)
+
+        async def _wait_for_worker_progress_delivery(
+            delivered: threading.Event | None,
+        ) -> None:
+            if delivered is None:
+                return
+            try:
+                await asyncio.wait_for(asyncio.to_thread(delivered.wait), timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.debug(
+                    "Timed out waiting for worker-progress card update to flush"
+                )
+
         # Start the tool-call log writer when tool_progress == "log".
         log_task = None
         if log_mode_enabled:
@@ -20044,6 +20183,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _long_running_mode == "generic"
                     else f"⏳ Working — {_elapsed_mins} min{_status_detail}"
                 )
+                if worker_progress_enabled and progress_queue and worker_progress_seen[0]:
+                    _heartbeat_notice = (
+                        worker_progress_last_notice[0]
+                        or WorkerProgressNotice(phase="preparing", status="active")
+                    )
+                    progress_queue.put(
+                        (
+                            WORKER_PROGRESS_QUEUE_KIND,
+                            _heartbeat_notice,
+                        )
+                    )
+                    continue
                 try:
                     _notify_res = None
                     if _heartbeat_msg_id:
@@ -20596,6 +20747,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:
+            if (
+                worker_progress_enabled
+                and progress_queue
+                and worker_progress_seen[0]
+                and worker_progress_last_notice[0] is not None
+                and worker_progress_last_notice[0].status in {"complete", "blocked"}
+                and _run_still_current()
+            ):
+                try:
+                    _agent_for_interrupt = agent_holder[0] if agent_holder else None
+                    if not (
+                        _agent_for_interrupt is not None
+                        and getattr(_agent_for_interrupt, "is_interrupted", False)
+                    ):
+                        await _wait_for_worker_progress_delivery(
+                            worker_progress_last_delivery[0]
+                        )
+                except Exception:
+                    pass
+            if (
+                worker_progress_enabled
+                and progress_queue
+                and worker_progress_seen[0]
+                and (
+                    worker_progress_last_notice[0] is None
+                    or worker_progress_last_notice[0].status not in {"complete", "blocked"}
+                )
+                and _run_still_current()
+            ):
+                try:
+                    _final_status = "blocked"
+                    _response_obj = locals().get("response")
+                    if isinstance(_response_obj, dict) and not _response_obj.get("failed"):
+                        _final_status = "complete"
+                    await _enqueue_worker_progress_notice_and_wait(
+                        WorkerProgressNotice(
+                            phase=_final_status,
+                            status=_final_status,
+                        )
+                    )
+                except Exception:
+                    pass
             # Stop progress sender, interrupt monitor, and notification task
             if progress_task:
                 progress_task.cancel()

--- a/gateway/worker_progress.py
+++ b/gateway/worker_progress.py
@@ -1,0 +1,184 @@
+"""Structured gateway worker-progress contract and safe renderer."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+from urllib.parse import parse_qsl, urlsplit
+
+
+WORKER_PROGRESS_EVENT = "worker.progress"
+WORKER_PROGRESS_QUEUE_KIND = "__worker_progress__"
+
+WORKER_PHASES = frozenset(
+    {
+        "preparing",
+        "inspecting",
+        "drafting",
+        "editing",
+        "validating",
+        "visual_verification",
+        "complete",
+        "blocked",
+    }
+)
+WORKER_STATUSES = frozenset({"active", "complete", "blocked"})
+_DELEGATED_COMPLETE_STATUSES = frozenset({"complete", "completed", "ok", "success"})
+_DELEGATED_BLOCKED_STATUSES = frozenset({"error", "failed", "timeout"})
+_SECRET_QUERY_KEYS = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "apikey",
+        "auth",
+        "key",
+        "password",
+        "secret",
+        "sig",
+        "signature",
+        "token",
+    }
+)
+_SECRET_KEY_RE = re.compile(
+    r"(?:api[_-]?key|access[_-]?token|auth[_-]?token|bearer|password|secret|signature|token)",
+    re.IGNORECASE,
+)
+_SECRET_VALUE_RE = re.compile(
+    r"(?:"
+    r"\b(?:api[_-]?key|access[_-]?token|auth[_-]?token|bearer|password|secret|token)\b\s*[:=]"
+    r"|sk-[A-Za-z0-9_-]{12,}"
+    r"|xox[baprs]-[A-Za-z0-9-]{10,}"
+    r")",
+    re.IGNORECASE,
+)
+
+_PHASE_TEXT = {
+    "preparing": "Preparing the workspace",
+    "inspecting": "Inspecting the request",
+    "drafting": "Drafting the change",
+    "editing": "Editing files",
+    "validating": "Validating the result",
+    "visual_verification": "Checking the browser view",
+    "complete": "Work complete",
+    "blocked": "Blocked",
+}
+
+
+@dataclass(frozen=True)
+class WorkerProgressNotice:
+    """Trusted, bounded worker-progress state for human-facing gateways."""
+
+    phase: str = "preparing"
+    status: str = "active"
+    preview_url: str | None = None
+
+
+def _payload_mapping(args: Any, kwargs: Mapping[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    if isinstance(args, Mapping):
+        payload.update(args)
+    progress = kwargs.get("progress")
+    if isinstance(progress, Mapping):
+        payload.update(progress)
+    payload.update(kwargs)
+    return payload
+
+
+def _safe_token(value: Any, allowed: frozenset[str], default: str) -> str:
+    token = str(value or "").strip().lower().replace("-", "_")
+    return token if token in allowed else default
+
+
+def sanitize_preview_url(value: Any) -> str | None:
+    """Return a Slack-safe HTTPS preview URL, or None for untrusted input."""
+    url = str(value or "").strip()
+    if not url or len(url) > 512:
+        return None
+    if any(ch.isspace() or ch in "<>`" for ch in url):
+        return None
+    if _SECRET_VALUE_RE.search(url):
+        return None
+    try:
+        parsed = urlsplit(url)
+    except Exception:
+        return None
+    if parsed.scheme.lower() != "https" or not parsed.hostname:
+        return None
+    if parsed.username or parsed.password:
+        return None
+    if parsed.fragment:
+        return None
+    if _SECRET_KEY_RE.search(parsed.path):
+        return None
+    for key, _value in parse_qsl(parsed.query, keep_blank_values=True):
+        normalized_key = key.strip().lower()
+        if normalized_key in _SECRET_QUERY_KEYS or _SECRET_KEY_RE.search(key):
+            return None
+        if _SECRET_VALUE_RE.search(str(_value or "")):
+            return None
+    return url
+
+
+def notice_from_worker_progress_event(
+    event_type: str,
+    *,
+    args: Any = None,
+    kwargs: Mapping[str, Any] | None = None,
+) -> WorkerProgressNotice | None:
+    """Parse trusted worker-progress events into a renderable notice.
+
+    This intentionally ignores free-form text such as previews, task prompts,
+    tool names, stdout, paths, and logs. The only accepted external data is a
+    finite phase/status plus an optional sanitized HTTPS preview URL.
+    """
+    kwargs = kwargs or {}
+    payload = _payload_mapping(args, kwargs)
+
+    if event_type == WORKER_PROGRESS_EVENT:
+        phase = _safe_token(payload.get("phase"), WORKER_PHASES, "preparing")
+        status = _safe_token(payload.get("status"), WORKER_STATUSES, "active")
+    elif event_type == "subagent.start":
+        phase = "preparing"
+        status = "active"
+    elif event_type == "subagent.complete":
+        delegated_status = (
+            str(payload.get("status") or "").strip().lower().replace("-", "_")
+        )
+        if delegated_status in _DELEGATED_BLOCKED_STATUSES:
+            phase = "blocked"
+            status = "blocked"
+        elif delegated_status in _DELEGATED_COMPLETE_STATUSES or not delegated_status:
+            phase = "complete"
+            status = "complete"
+        else:
+            phase = "complete"
+            status = "complete"
+    else:
+        return None
+
+    if phase in {"complete", "blocked"}:
+        status = phase
+    elif status in {"complete", "blocked"}:
+        phase = status
+
+    return WorkerProgressNotice(
+        phase=phase,
+        status=status,
+        preview_url=sanitize_preview_url(payload.get("preview_url")),
+    )
+
+
+def render_worker_progress_notice(notice: WorkerProgressNotice) -> str:
+    """Render a canned, human-readable Slack/gateway progress card."""
+    phase_text = _PHASE_TEXT.get(notice.phase, _PHASE_TEXT["preparing"])
+    if notice.status == "blocked":
+        header = "⚠️ Worker progress"
+    elif notice.status == "complete":
+        header = "✅ Worker progress"
+    else:
+        header = "⏳ Worker progress"
+
+    lines = [header, phase_text]
+    if notice.preview_url and notice.status in {"complete", "blocked"}:
+        lines.append(f"<{notice.preview_url}|Open preview>")
+    return "\n".join(lines)

--- a/tests/gateway/test_worker_progress.py
+++ b/tests/gateway/test_worker_progress.py
@@ -1,0 +1,426 @@
+import importlib
+import sys
+import time
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
+from gateway.worker_progress import (
+    WORKER_PROGRESS_EVENT,
+    notice_from_worker_progress_event,
+    render_worker_progress_notice,
+)
+from tools.delegate_tool import _build_child_progress_callback
+
+
+class SlackWorkerProgressAdapter(BasePlatformAdapter):
+    def __init__(self, *, fail_first_edit: bool = False):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.SLACK)
+        self.sent = []
+        self.edits = []
+        self.typing = []
+        self._next_id = 1
+        self._fail_first_edit = fail_first_edit
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        message_id = f"msg-{self._next_id}"
+        self._next_id += 1
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+                "message_id": message_id,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def edit_message(
+        self,
+        chat_id,
+        message_id,
+        content,
+        *,
+        finalize=False,
+        metadata=None,
+    ) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "metadata": metadata,
+            }
+        )
+        if self._fail_first_edit:
+            self._fail_first_edit = False
+            return SendResult(success=False, error="message not found")
+        return SendResult(success=True, message_id=message_id)
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        self.typing.append({"chat_id": chat_id, "metadata": metadata})
+
+    async def stop_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+class StructuredWorkerAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+        self._interrupt_requested = False
+
+    @property
+    def is_interrupted(self) -> bool:
+        return self._interrupt_requested
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        cb(
+            WORKER_PROGRESS_EVENT,
+            args={
+                "phase": "inspecting",
+                "status": "active",
+                "text": "raw task text API_KEY=should-not-render",
+                "log_path": "/tmp/worker.log",
+            },
+        )
+        time.sleep(0.35)
+        cb(
+            WORKER_PROGRESS_EVENT,
+            args={
+                "phase": "validating",
+                "status": "active",
+                "command": "pytest --token=should-not-render",
+                "preview": "terminal output should-not-render",
+            },
+        )
+        time.sleep(0.35)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class DelegatedWorkerAgent(StructuredWorkerAgent):
+    relayed_events = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.__class__.relayed_events = []
+
+        def parent_progress(event_type, tool_name=None, preview=None, args=None, **kwargs):
+            self.__class__.relayed_events.append((event_type, tool_name, preview, args))
+            self.tool_progress_callback(event_type, tool_name, preview, args, **kwargs)
+
+        child_progress = _build_child_progress_callback(
+            0,
+            "Rotate API_KEY=should-not-render and inspect /tmp/worker.log",
+            SimpleNamespace(tool_progress_callback=parent_progress),
+            task_count=1,
+            subagent_id="child-1",
+            session_ref={"session_id": "child-session-1"},
+        )
+        child_progress("subagent.start")
+        time.sleep(0.35)
+        child_progress(
+            "tool.started",
+            "terminal",
+            "cat /tmp/worker.log",
+            {"command": "cat /tmp/worker.log && echo API_KEY=should-not-render"},
+        )
+        time.sleep(0.35)
+        child_progress("subagent.complete", status="completed")
+        time.sleep(0.1)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class PreviewCompleteWorkerAgent(StructuredWorkerAgent):
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback(
+            WORKER_PROGRESS_EVENT,
+            args={"phase": "editing", "status": "active"},
+        )
+        time.sleep(0.35)
+        self.tool_progress_callback(
+            WORKER_PROGRESS_EVENT,
+            args={
+                "phase": "complete",
+                "status": "complete",
+                "preview_url": "https://example.com/preview/123",
+                "text": "API_KEY=should-not-render",
+            },
+        )
+        time.sleep(0.1)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner._draining = False
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    return runner
+
+
+async def _run_once(
+    monkeypatch,
+    tmp_path,
+    agent_cls,
+    adapter,
+    *,
+    source=None,
+    event_message_id="1700000000.000100",
+):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "off")
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = agent_cls
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "fake"},
+    )
+    source = source or SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="channel",
+        thread_id="1700000000.000100",
+        scope_id="T123",
+    )
+    return await runner._run_agent(
+        message="please run worker",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-worker-progress",
+        session_key="agent:main:slack:channel:C123:1700000000.000100",
+        event_message_id=event_message_id,
+    )
+
+
+def _rendered(adapter):
+    return "\n".join([*(c["content"] for c in adapter.sent), *(c["content"] for c in adapter.edits)])
+
+
+@pytest.mark.parametrize(
+    "payload, expected",
+    [
+        ({"phase": "editing", "status": "active"}, "Editing files"),
+        ({"phase": "complete", "preview_url": "https://example.com/preview/123"}, "<https://example.com/preview/123|Open preview>"),
+        ({"phase": "complete", "preview_url": "http://example.com/preview/123"}, "Open preview"),
+        ({"phase": "complete", "preview_url": "https://example.com/?token=secret"}, "Open preview"),
+        ({"phase": "complete", "preview_url": "https://example.com/?authToken=secret"}, "Open preview"),
+        ({"phase": "complete", "preview_url": "https://example.com/?next=sk-abcdefghijklmnopqrstuvwxyz"}, "Open preview"),
+        ({"phase": "complete", "preview_url": "https://example.com/preview/API_KEY=secret"}, "Open preview"),
+        ({"phase": "complete", "preview_url": "https://example.com/preview/token/123"}, "Open preview"),
+        ({"phase": "complete", "preview_url": "https://example.com/preview#token=secret"}, "Open preview"),
+        ({"phase": "rm -rf", "status": "cat /tmp/log"}, "Preparing the workspace"),
+    ],
+)
+def test_worker_progress_contract_renders_only_allowlisted_fields(payload, expected):
+    notice = notice_from_worker_progress_event(WORKER_PROGRESS_EVENT, args=payload)
+    rendered = render_worker_progress_notice(notice)
+    if expected.startswith("<https://"):
+        assert expected in rendered
+    elif expected == "Open preview":
+        assert expected not in rendered
+    else:
+        assert expected in rendered
+
+
+def test_worker_progress_contract_ignores_raw_text_and_secret_shapes():
+    notice = notice_from_worker_progress_event(
+        WORKER_PROGRESS_EVENT,
+        args={
+            "phase": "validating",
+            "status": "active",
+            "text": "run pytest with API_KEY=should-not-render",
+            "command": "cat /tmp/worker.log",
+            "preview_url": "https://example.com/?api_key=secret",
+        },
+    )
+    rendered = render_worker_progress_notice(notice)
+    assert "Validating the result" in rendered
+    assert "pytest" not in rendered
+    assert "/tmp/worker.log" not in rendered
+    assert "API_KEY" not in rendered
+    assert "should-not-render" not in rendered
+    assert "Open preview" not in rendered
+
+
+@pytest.mark.parametrize(
+    "delegated_status, expected, unexpected",
+    [
+        ("completed", "Work complete", "Blocked"),
+        ("timeout", "Blocked", "Work complete"),
+        ("error", "Blocked", "Work complete"),
+        ("failed", "Blocked", "Work complete"),
+    ],
+)
+def test_delegated_subagent_complete_statuses_render_only_canned_terminal_states(
+    delegated_status,
+    expected,
+    unexpected,
+):
+    notice = notice_from_worker_progress_event(
+        "subagent.complete",
+        kwargs={
+            "status": delegated_status,
+            "summary": "API_KEY=should-not-render",
+            "preview": "cat /tmp/worker.log",
+            "error": "timeout with secret token=should-not-render",
+        },
+    )
+    rendered = render_worker_progress_notice(notice)
+
+    assert expected in rendered
+    assert unexpected not in rendered
+    assert "API_KEY" not in rendered
+    assert "/tmp/worker.log" not in rendered
+    assert "token=should-not-render" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_structured_worker_progress_uses_one_slack_thread_card_without_raw_leakage(monkeypatch, tmp_path):
+    adapter = SlackWorkerProgressAdapter()
+    result = await _run_once(monkeypatch, tmp_path, StructuredWorkerAgent, adapter)
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["metadata"] == {
+        "thread_id": "1700000000.000100",
+        "slack_team_id": "T123",
+    }
+    assert adapter.edits
+    assert all(edit["message_id"] == adapter.sent[0]["message_id"] for edit in adapter.edits)
+    rendered = _rendered(adapter)
+    assert "Inspecting the request" in rendered
+    assert "Validating the result" in rendered
+    assert "Work complete" in rendered
+    assert "pytest" not in rendered
+    assert "/tmp/worker.log" not in rendered
+    assert "terminal output" not in rendered
+    assert "API_KEY" not in rendered
+    assert "should-not-render" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_delegated_subagent_relay_opens_safe_worker_card(monkeypatch, tmp_path):
+    adapter = SlackWorkerProgressAdapter()
+    result = await _run_once(monkeypatch, tmp_path, DelegatedWorkerAgent, adapter)
+
+    assert result["final_response"] == "done"
+    assert [event[0] for event in DelegatedWorkerAgent.relayed_events[:3]] == [
+        "subagent.start",
+        "subagent.tool",
+        "subagent.complete",
+    ]
+    assert len(adapter.sent) == 1
+    assert adapter.edits
+    assert adapter.edits[-1]["message_id"] == adapter.sent[0]["message_id"]
+    assert "Work complete" in adapter.edits[-1]["content"]
+    rendered = _rendered(adapter)
+    assert "Preparing the workspace" in rendered
+    assert "Work complete" in rendered
+    assert "Rotate API_KEY" not in rendered
+    assert "cat /tmp/worker.log" not in rendered
+    assert "should-not-render" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_worker_progress_complete_notice_can_render_safe_preview_url(monkeypatch, tmp_path):
+    adapter = SlackWorkerProgressAdapter()
+    await _run_once(monkeypatch, tmp_path, PreviewCompleteWorkerAgent, adapter)
+
+    rendered = _rendered(adapter)
+    assert "<https://example.com/preview/123|Open preview>" in rendered
+    assert "API_KEY" not in rendered
+    assert "should-not-render" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_worker_progress_dm_fallback_keeps_event_thread_and_slack_team(monkeypatch, tmp_path):
+    adapter = SlackWorkerProgressAdapter()
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="D123",
+        chat_type="dm",
+        thread_id=None,
+        scope_id="T999",
+    )
+    await _run_once(
+        monkeypatch,
+        tmp_path,
+        StructuredWorkerAgent,
+        adapter,
+        source=source,
+        event_message_id="1711111111.000200",
+    )
+
+    assert adapter.sent[0]["metadata"] == {
+        "thread_id": "1711111111.000200",
+        "slack_team_id": "T999",
+    }
+    assert all(
+        edit["metadata"] == {
+            "thread_id": "1711111111.000200",
+            "slack_team_id": "T999",
+        }
+        for edit in adapter.edits
+    )
+
+
+@pytest.mark.asyncio
+async def test_worker_progress_edit_failure_replaces_card_and_continues_editing_replacement(monkeypatch, tmp_path):
+    adapter = SlackWorkerProgressAdapter(fail_first_edit=True)
+    await _run_once(monkeypatch, tmp_path, StructuredWorkerAgent, adapter)
+
+    assert [sent["message_id"] for sent in adapter.sent] == ["msg-1", "msg-2"]
+    assert adapter.edits[0]["message_id"] == "msg-1"
+    assert adapter.edits[-1]["message_id"] == "msg-2"
+    assert adapter.sent[1]["metadata"] == {
+        "thread_id": "1700000000.000100",
+        "slack_team_id": "T123",
+    }
+    assert adapter.edits[-1]["metadata"] == {
+        "thread_id": "1700000000.000100",
+        "slack_team_id": "T123",
+    }

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -50,6 +50,12 @@ Mode — all at once.
 4. Skip ahead to **Step 6: Install App to Workspace**. The manifest
    handled scopes, events, and slash commands for you.
 
+:::caution Reinstall after manifest changes
+After you save a generated manifest, reinstall the Slack app to the workspace
+when Slack prompts you. Agent view, event subscriptions, scopes, and slash
+commands do not fully take effect until the reinstall completes.
+:::
+
 ### Option B: From scratch (manual)
 
 1. Go to [https://api.slack.com/apps](https://api.slack.com/apps)
@@ -267,6 +273,39 @@ identify a Messages-tab DM and receive the user's active Slack context with a
 turn. Hermes only supplies that context as a label; it does not read the viewed
 channel's history.
 
+### Long-running worker progress in Agent view
+
+In Slack Agent view, long-running delegated or worker-backed work uses one
+editable progress message in the originating thread. Hermes updates that single
+message as the worker moves through safe structured phases, then marks it
+complete or blocked. The card intentionally does **not** show raw shell
+commands, terminal previews, subprocess stdout, log paths, task prompts, goals,
+or secret-shaped strings.
+
+Delegated in-process Hermes subagents can open the card through the existing
+delegation relay. External profile subprocess workers currently cannot emit
+internal phases automatically through the gateway. Until that bridge exists,
+Slack still shows the safe start/heartbeat/final behavior for worker progress
+surfaces that reach the gateway, but it will not claim detailed internal
+subprocess phases it did not receive.
+
+External emitters that integrate with the gateway worker-progress receiving
+surface must use this contract:
+
+```json
+{
+  "event_type": "worker.progress",
+  "phase": "preparing | inspecting | drafting | editing | validating | visual_verification | complete | blocked",
+  "status": "active | complete | blocked",
+  "preview_url": "https://example.com/optional-preview"
+}
+```
+
+Only the finite `phase` and `status` values are rendered. `preview_url` is
+optional and is rendered only for `complete` or `blocked` states, only when it
+is an HTTPS URL without credentials, fragments, or secret-looking path/query
+content. Any other payload fields are treated as untrusted and ignored.
+
 ### Refreshing slash commands after updates
 
 When Hermes adds new commands (e.g. after `hermes update`), regenerate
@@ -282,7 +321,8 @@ Then in Slack:
 2. **Features → App Manifest → Edit**
 3. Paste the new contents of `~/.hermes/slack-manifest.json`
 4. **Save**. Slack will prompt to reinstall the app if scopes or slash
-   commands changed.
+   commands changed. Complete that reinstall before testing the updated
+   Agent view or command surface.
 
 ### Legacy `/hermes <subcommand>` still works
 


### PR DESCRIPTION
## Summary
- add a bounded structured worker-progress contract for Slack gateway runs
- render one editable, thread-scoped progress card with optional sanitized HTTPS preview links
- preserve safe Slack Agent View routing and document the external-emitter contract

## Verification
- `scripts/run_tests.sh tests/gateway/test_worker_progress.py tests/hermes_cli/test_slack_cli.py tests/gateway/test_slack.py`

## Limitation
External worker subprocesses must emit structured `worker.progress` phase/status events to gain per-phase updates; this PR intentionally does not forward worker stdout or raw tool output.