### PR TITLE
fix: add creationflags to tirith_security subprocess calls (Windows console flash)

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -28,6 +28,9 @@ import platform
 import shutil
 import stat
 import subprocess
+import sys
+
+from hermes_cli._subprocess_compat import windows_hide_flags
 import tarfile
 import tempfile
 import threading
@@ -318,6 +321,7 @@ def _verify_cosign(checksums_path: str, sig_path: str, cert_path: str) -> bool |
             text=True,
             timeout=15,
             stdin=subprocess.DEVNULL,
+            **({"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}),
         )
         if result.returncode == 0:
             logger.info("cosign provenance verification passed")
@@ -779,6 +783,7 @@ def check_command_security(command: str) -> dict:
             text=True,
             timeout=timeout,
             stdin=subprocess.DEVNULL,
+            **({"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}),
         )
     except OSError as exc:
         # Covers FileNotFoundError, PermissionError, exec format error.


### PR DESCRIPTION
## Summary

On Windows, `subprocess.run()` / `subprocess.Popen()` without `CREATE_NO_WINDOW` (0x08000000) spawns a visible console window (cmd.exe / conhost.exe) that flashes briefly. This affects two calls in `tools/tirith_security.py`:

1. `_verify_cosign()` — cosign provenance verification (line 321)
2. `check_command_security()` — tirith security scan (line 783)

Both calls have `stdin=subprocess.DEVNULL` and `capture_output=True`, so they're clearly non-interactive and should not show a console window.

## Fix

Add `windows_hide_flags()` creationflags on Windows, same pattern used in:
- `tools/tts_tool.py` (6 calls)
- `tools/browser_tool.py` (2 calls)
- `tools/process_registry.py`
- `tools/env_probe.py`
- `tools/lazy_deps.py`

Import from `hermes_cli._subprocess_compat`.

## Changes

- `tools/tirith_security.py`: Add import + 2 creationflags lines

## Test Plan

- [ ] Unit tests pass
- [ ] Verified on Windows: no console flash on cosign verify or tirith check
