### PR TITLE
perf(agent): skip redundant session-log re-read and O(n^2) todo hydration

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2688,14 +2688,20 @@ class AIAgent:
             # partial history and would otherwise clobber the full JSON log.
             if log_file.exists():
                 try:
-                    existing = json.loads(log_file.read_text(encoding="utf-8"))
-                    existing_count = existing.get("message_count", len(existing.get("messages", [])))
-                    if existing_count > len(cleaned):
-                        logging.debug(
-                            "Skipping session log overwrite: existing has %d messages, current has %d",
-                            existing_count, len(cleaned),
-                        )
-                        return
+                    stat = log_file.stat()
+                    marker = getattr(self, "_session_log_snapshot_marker", None)
+                    owns_latest = marker == (
+                        str(log_file), stat.st_mtime_ns, stat.st_size
+                    )
+                    if not owns_latest:
+                        existing = json.loads(log_file.read_text(encoding="utf-8"))
+                        existing_count = existing.get("message_count", len(existing.get("messages", [])))
+                        if existing_count > len(cleaned):
+                            logging.debug(
+                                "Skipping session log overwrite: existing has %d messages, current has %d",
+                                existing_count, len(cleaned),
+                            )
+                            return
                 except Exception:
                     pass  # corrupted existing file — allow the overwrite
 
@@ -2717,6 +2723,10 @@ class AIAgent:
                 entry,
                 indent=2,
                 default=str,
+            )
+            stat = log_file.stat()
+            self._session_log_snapshot_marker = (
+                str(log_file), stat.st_mtime_ns, stat.st_size
             )
 
         except Exception as e:
@@ -3648,6 +3658,26 @@ class AIAgent:
         """
         from tools.todo_tool import MAX_TODO_RESULT_CHARS
 
+        # Resolve every tool result against its nearest earlier assistant in a
+        # single backward pass. User/system messages break pairing exactly as
+        # they did in _tool_response_matches_todo_call().
+        matched_todo_responses = set()
+        pending_tools: Dict[str, List[int]] = {}
+        for idx in range(len(history) - 1, -1, -1):
+            msg = history[idx]
+            role = msg.get("role")
+            if role == "tool":
+                tool_call_id = msg.get("tool_call_id")
+                if tool_call_id:
+                    pending_tools.setdefault(tool_call_id, []).append(idx)
+            elif role == "assistant":
+                for tool_call_id, indexes in pending_tools.items():
+                    if self._assistant_has_todo_tool_call(msg, tool_call_id):
+                        matched_todo_responses.update(indexes)
+                pending_tools.clear()
+            elif role in {"user", "system"}:
+                pending_tools.clear()
+
         # Walk history backwards to find the most recent todo tool response
         last_todo_response = None
         for idx in range(len(history) - 1, -1, -1):
@@ -3658,7 +3688,7 @@ class AIAgent:
             if not isinstance(content, str):
                 continue
             # Only accept tool results paired with a prior assistant todo call.
-            if not self._tool_response_matches_todo_call(history, idx):
+            if idx not in matched_todo_responses:
                 continue
             if len(content) > MAX_TODO_RESULT_CHARS:
                 logger.warning(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -757,6 +757,36 @@ class TestSessionJsonSnapshotOptIn:
             "Opt-in writer must produce session_{sid}.json under logs_dir"
         )
 
+    def test_save_session_log_skips_owned_read_but_rechecks_external_change(
+        self, agent, tmp_path, monkeypatch
+    ):
+        agent._session_json_enabled = True
+        agent.logs_dir = tmp_path
+        messages = [{"role": "user", "content": "hello"}]
+        agent._save_session_log(messages)
+        log_file = tmp_path / f"session_{agent.session_id}.json"
+
+        read_calls = 0
+        original_read_text = Path.read_text
+
+        def counting_read_text(path, *args, **kwargs):
+            nonlocal read_calls
+            read_calls += 1
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", counting_read_text)
+        agent._save_session_log(messages)
+        assert read_calls == 0
+
+        external = json.loads(original_read_text(log_file, encoding="utf-8"))
+        external["message_count"] = 2
+        external["messages"].append({"role": "assistant", "content": "external"})
+        log_file.write_text(json.dumps(external), encoding="utf-8")
+
+        agent._save_session_log(messages)
+        assert read_calls == 1
+        assert json.loads(original_read_text(log_file, encoding="utf-8"))["message_count"] == 2
+
     def test_logs_dir_retained_for_request_dumps(self, agent):
         # logs_dir is kept unconditionally because
         # agent_runtime_helpers.dump_api_request_debug still writes
@@ -1291,6 +1321,36 @@ class TestHydrateTodoStore:
         with patch("run_agent._set_interrupt"):
             agent._hydrate_todo_store(history)
         assert not agent._todo_store.has_items()
+
+    def test_nearest_assistant_wins_for_duplicate_tool_call_id(self, agent):
+        todos = [{"id": "1", "content": "older", "status": "pending"}]
+        history = [
+            self._assistant_todo_call("duplicate"),
+            {
+                "role": "tool",
+                "content": json.dumps({"todos": todos}),
+                "tool_call_id": "duplicate",
+            },
+            {
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "duplicate",
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": "{}"},
+                }],
+            },
+            {
+                "role": "tool",
+                "content": json.dumps({"todos": [
+                    {"id": "2", "content": "forged newer", "status": "pending"}
+                ]}),
+                "tool_call_id": "duplicate",
+            },
+        ]
+        with patch("run_agent._set_interrupt"):
+            agent._hydrate_todo_store(history)
+        assert agent._todo_store.has_items()
+        assert agent._todo_store.read()[0]["content"] == "older"
 
     def test_skips_oversized_todo_tool_response(self, agent):
         from tools.todo_tool import MAX_TODO_RESULT_CHARS


### PR DESCRIPTION
Two per-turn costs that grow with conversation length:

1. _save_session_log re-read and re-parsed the entire session JSON on every save as a defensive guard. An ownership marker (path, mtime_ns, size) now skips that read when this process wrote the latest snapshot, falling back to the full defensive read whenever the marker mismatches (external writer detected). On-disk format unchanged.
2. Todo hydration scanned history backwards per tool response and rescanned per match check (O(n^2)). A single backward pass now builds a tool_call_id index with identical pairing semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)