### PR TITLE
fix(delegate): non-blocking executor shutdown on interrupt

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -913,6 +913,71 @@ class TestSubagentCostRollup(unittest.TestCase):
         parent.session_cost_source = "none"
         return parent
 
+    def test_batch_interrupt_does_not_wait_for_running_children(self):
+        parent = self._make_parent_with_cost_counters(starting_cost=0.0)
+        parent._interrupt_requested = False
+        release = threading.Event()
+        both_started = threading.Event()
+        started = 0
+        started_lock = threading.Lock()
+        children = [MagicMock(), MagicMock()]
+        for child in children:
+            child._delegate_role = "leaf"
+            child.session_id = "child"
+
+        def build_child(**kwargs):
+            child = children[kwargs["task_index"]]
+            with parent._active_children_lock:
+                parent._active_children.append(child)
+            return child
+
+        def run_child(task_index, goal, child, parent_agent):
+            nonlocal started
+            with started_lock:
+                started += 1
+                if started == 2:
+                    both_started.set()
+            try:
+                release.wait(5)
+                return {
+                    "task_index": task_index,
+                    "status": "interrupted",
+                    "summary": None,
+                    "api_calls": 0,
+                    "duration_seconds": 0,
+                    "_child_role": "leaf",
+                }
+            finally:
+                with parent._active_children_lock:
+                    if child in parent._active_children:
+                        parent._active_children.remove(child)
+
+        outcome = {}
+
+        def invoke():
+            outcome["result"] = delegate_task(
+                tasks=[{"goal": "A"}, {"goal": "B"}],
+                parent_agent=parent,
+            )
+
+        with patch("tools.delegate_tool._build_child_agent", side_effect=build_child), \
+             patch("tools.delegate_tool._run_single_child", side_effect=run_child):
+            worker = threading.Thread(target=invoke)
+            worker.start()
+            self.assertTrue(both_started.wait(2))
+            parent._interrupt_requested = True
+            worker.join(timeout=1.5)
+            self.assertFalse(worker.is_alive(), "delegate shutdown waited for running children")
+            self.assertIn("results", json.loads(outcome["result"]))
+            for child in children:
+                child.interrupt.assert_called_once()
+            release.set()
+
+        deadline = time.time() + 2
+        while parent._active_children and time.time() < deadline:
+            time.sleep(0.01)
+        self.assertEqual(parent._active_children, [])
+
     def test_single_child_cost_folded_into_parent(self):
         parent = self._make_parent_with_cost_counters(starting_cost=0.10)
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2576,7 +2576,9 @@ def delegate_task(
             # normally, but if the parent is interrupted while a child is
             # wedged, the abandoned worker must not block interpreter exit.
             from tools.daemon_pool import DaemonThreadPoolExecutor
-            with DaemonThreadPoolExecutor(max_workers=max_children) as executor:
+            executor = DaemonThreadPoolExecutor(max_workers=max_children)
+            interrupted = False
+            try:
                 futures = {}
                 for i, t, child in children:
                     future = executor.submit(
@@ -2603,8 +2605,15 @@ def delegate_task(
                         # Parent interrupted — collect whatever finished and
                         # abandon the rest.  Children already received the
                         # interrupt signal; we just can't wait forever.
+                        interrupted = True
                         for f in pending:
                             idx = futures[f]
+                            child = _child_by_index.get(idx)
+                            try:
+                                if child and hasattr(child, "interrupt"):
+                                    child.interrupt("Parent agent interrupted")
+                            except Exception:
+                                logger.debug("Failed to interrupt delegated child")
                             if f.done():
                                 try:
                                     entry = f.result()
@@ -2621,6 +2630,7 @@ def delegate_task(
                                         ),
                                     }
                             else:
+                                cancelled_before_start = f.cancel()
                                 entry = {
                                     "task_index": idx,
                                     "status": "interrupted",
@@ -2632,6 +2642,21 @@ def delegate_task(
                                         _child_by_index.get(idx), "_delegate_role", None
                                     ),
                                 }
+                                if cancelled_before_start:
+                                    try:
+                                        if child and hasattr(child, "close"):
+                                            child.close()
+                                    except Exception:
+                                        logger.debug("Failed to close queued interrupted child")
+                                    try:
+                                        lock = getattr(parent_agent, "_active_children_lock", None)
+                                        if lock:
+                                            with lock:
+                                                parent_agent._active_children.remove(child)
+                                        else:
+                                            parent_agent._active_children.remove(child)
+                                    except (AttributeError, ValueError):
+                                        pass
                             results.append(entry)
                             completed_count += 1
                         break
@@ -2686,6 +2711,8 @@ def delegate_task(
                                 )
                             except Exception as e:
                                 logger.debug("Spinner update_text failed: %s", e)
+            finally:
+                executor.shutdown(wait=not interrupted, cancel_futures=interrupted)
 
             # Sort by task_index so results match input order
             results.sort(key=lambda r: r["task_index"])


### PR DESCRIPTION
An interrupt during delegated child execution hit the executor context manager exit, which blocks on shutdown(wait=True) until all running children finish — the parent appeared hung. Interrupts now signal each child, cancel queued futures, and shut the executor down without waiting (wait=not interrupted, cancel_futures=interrupted); running children remain tracked in _active_children until their normal cleanup completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)