### PR TITLE
fix: detect in-stream error chunks in SSE streaming path (#65631)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2409,6 +2409,20 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # Usage comes in the final chunk with empty choices
                 if hasattr(chunk, "usage") and chunk.usage:
                     usage_obj = chunk.usage
+                # Some OpenAI-compatible providers (DeepInfra, etc.)
+                # return validation errors as in-stream error chunks:
+                # choices=None with error_type/error_message in
+                # model_extra.  Without this check the error is
+                # silently dropped and the stream ends empty →
+                # EmptyStreamError → misleading "empty stream" message
+                # and pointless retries on the same bad request. (#65631)
+                _err_type = getattr(chunk, "error_type", None)
+                _err_msg = getattr(chunk, "error_message", None)
+                if _err_type or _err_msg:
+                    raise RuntimeError(
+                        f"Provider in-stream error"
+                        f" ({_err_type or 'unknown'}): {_err_msg or chunk}"
+                    )
                 continue
 
             delta = chunk.choices[0].delta


### PR DESCRIPTION
## Summary

When an OpenAI-compatible provider returns an **error inside a streaming HTTP-200 response** — a single SSE chunk whose `choices` is `None` and whose provider-specific `error_type` / `error_message` fields carry a `400 BadRequestError` — the streaming loop silently drops the error chunk. The stream ends empty, raising `EmptyStreamError` ("Provider returned an empty stream with no finish_reason"), and all retries hit the identical error. The real error (e.g. context-length 400) is never surfaced.

## Root Cause

In `agent/chat_completion_helpers.py`, the streaming loop skips any chunk with no `choices`:

```python
if not chunk.choices:
    # usage / model-name only chunk
    ...
    continue  # <-- error-bearing chunk is silently dropped here
```

`error_type` / `error_message` are non-standard fields (exposed by the OpenAI SDK via `model_extra`), so they are never inspected.

## Fix

Check for `error_type` / `error_message` on chunks with no `choices` before skipping. When found, raise `RuntimeError` with the provider's error message so the error classifier can properly handle it (classify as format_error → non-retryable → trigger fallback).

## Changes

- `agent/chat_completion_helpers.py`: Add 14 lines — error detection in streaming loop

## Test Plan

- [ ] Unit tests pass
- [ ] Verified with DeepInfra-style in-stream error chunk (choices=None, error_type="validation_error")
- [ ] Error is properly classified by error_classifier (not treated as empty stream)

Fixes #65631
