### PR TITLE
fix(kanban): close parent log handle after spawn and validate max_spawn

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -827,9 +827,26 @@ class GatewayKanbanWatchersMixin:
         interval = max(interval, 1.0)  # sanity floor — tighter than this is a footgun
 
         # Read max_spawn config to limit concurrent kanban tasks
-        max_spawn = kanban_cfg.get("max_spawn", None)
-        if max_spawn is not None:
-            logger.info(f"kanban dispatcher: max_spawn={max_spawn}")
+        raw_max_spawn = kanban_cfg.get("max_spawn", None)
+        max_spawn = None
+        if raw_max_spawn is not None:
+            try:
+                max_spawn = int(raw_max_spawn)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "kanban dispatcher: invalid kanban.max_spawn=%r; ignoring",
+                    raw_max_spawn,
+                )
+                max_spawn = None
+            else:
+                if max_spawn < 1:
+                    logger.warning(
+                        "kanban dispatcher: kanban.max_spawn=%r is below 1; ignoring",
+                        raw_max_spawn,
+                    )
+                    max_spawn = None
+                else:
+                    logger.info(f"kanban dispatcher: max_spawn={max_spawn}")
 
         # Cap the number of simultaneously running tasks so slow workers
         # (local LLMs, resource-constrained hosts) don't pile up and time

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8236,11 +8236,10 @@ def _default_spawn(
             "`hermes` executable not found on PATH. "
             "Install Hermes Agent or activate its venv before running the kanban dispatcher."
         )
-    # NOTE: we intentionally do NOT close log_f here — we want Popen's
-    # child process to keep writing after this function returns.  The
-    # handle is kept alive by the child's inheritance.  The parent's
-    # reference goes out of scope and is GC'd, but the OS-level FD stays
-    # open in the child until the child exits.
+    # Popen duplicated/inherited the handle for the child. Release the
+    # parent copy immediately so long-lived Windows dispatchers do not leak
+    # one handle per spawned worker.
+    log_f.close()
     return proc.pid
 
 

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -8,6 +8,10 @@ that GatewayRunner picks them up via the MRO (behavior-neutral relocation).
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 
@@ -67,3 +71,53 @@ def test_singleton_dispatcher_lock_is_exclusive(tmp_path):
     h3, st3 = _acquire_singleton_lock(lock)
     assert st3 == "held" and h3 is not None
     _release_singleton_lock(h3)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("raw_max_spawn", "expected"), [("4", 4), (0, None)])
+async def test_dispatcher_normalizes_positive_max_spawn(
+    tmp_path, monkeypatch, raw_max_spawn, expected
+):
+    """YAML strings become ints and values below one are ignored."""
+    import gateway.kanban_watchers as watchers
+    from hermes_cli import kanban_db as kb
+
+    runner = SimpleNamespace(_running=True, _kanban_dispatcher_lock_handle=None)
+    captured = {}
+
+    class _Conn:
+        def close(self):
+            pass
+
+    async def no_sleep(_delay):
+        pass
+
+    def dispatch_once(_conn, **kwargs):
+        captured.update(kwargs)
+        runner._running = False
+        return SimpleNamespace(spawned=[])
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "auto_decompose": False,
+                "max_spawn": raw_max_spawn,
+            }
+        },
+    )
+    monkeypatch.setattr(watchers, "_acquire_singleton_lock", lambda _path: (None, "unavailable"))
+    monkeypatch.setattr(watchers.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(kb, "kanban_home", lambda: tmp_path)
+    monkeypatch.setattr(kb, "kanban_db_path", lambda _slug=None: Path(tmp_path / "kanban.db"))
+    monkeypatch.setattr(kb, "list_boards", lambda **_kwargs: [{"slug": "default"}])
+    monkeypatch.setattr(kb, "connect", lambda **_kwargs: _Conn())
+    monkeypatch.setattr(kb, "dispatch_once", dispatch_once)
+    monkeypatch.setattr(kb, "reap_worker_zombies", lambda: [])
+    monkeypatch.setattr(kb, "has_spawnable_ready", lambda _conn: False)
+    monkeypatch.setattr(kb, "has_spawnable_review", lambda _conn: False)
+
+    await GatewayKanbanWatchersMixin._kanban_dispatcher_watcher(runner)
+
+    assert captured["max_spawn"] == expected

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3113,6 +3113,7 @@ class TestSharedBoardPaths:
             def __init__(self, cmd, **kwargs):
                 captured["cmd"] = cmd
                 captured["env"] = kwargs.get("env", {})
+                captured["stdout"] = kwargs["stdout"]
                 self.pid = 4242
 
         monkeypatch.setattr("subprocess.Popen", _FakePopen)
@@ -3144,6 +3145,7 @@ class TestSharedBoardPaths:
         )
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
         assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
+        assert captured["stdout"].closed is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
1. The dispatcher opened each worker log file and left the parent-side handle open after Popen succeeded, leaking one Windows handle per spawned worker in a long-lived gateway. The parent copy now closes right after Popen; the child keeps its inherited handle.
2. kanban.max_spawn was passed straight from YAML; a quoted value like "4" raised TypeError inside dispatch_once and silently aborted every dispatch tick (ready queue non-empty, zero workers spawned). The value is now normalized to a positive int with the same validation pattern as max_in_progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)