### PR TITLE
perf(gateway): reuse loaded config for timestamp check

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19078,7 +19078,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent_history, observed_group_context = _build_gateway_agent_history(
                 history,
                 channel_prompt=channel_prompt,
-                inject_timestamps=_message_timestamps_enabled(_load_gateway_config()),
+                inject_timestamps=_message_timestamps_enabled(user_config),
             )
 
             # FTS write-corruption guard (#50502): when message persistence


### PR DESCRIPTION
_message_timestamps_enabled(_load_gateway_config()) triggered a second full config load (cache lookup, deep copy, overlay, normalization) inside the per-message turn-building path. Reuses the user_config already loaded at the start of the turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)