### PR TITLE
fix(desktop): reconcile context usage after reconnect

### DIFF
--- a/apps/desktop/src/app/shell/context-usage-panel.test.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.test.tsx
@@ -45,8 +45,8 @@ describe('ContextUsagePanel reconciliation', () => {
       </I18nProvider>
     )
 
-    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(2))
     expect(screen.getByText(/~200k \/ 372k/)).toBeTruthy()
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(2))
     expect(requestGateway).toHaveBeenLastCalledWith('session.context_breakdown', { session_id: 'runtime-1' })
   })
 })

--- a/apps/desktop/src/app/shell/context-usage-panel.test.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import type { ContextBreakdown, UsageStats } from '@/types/hermes'
+
+import { ContextUsagePanel } from './context-usage-panel'
+
+afterEach(cleanup)
+
+const usage = (contextUsed: number): UsageStats => ({
+  calls: 1,
+  input: contextUsed,
+  output: 0,
+  total: contextUsed,
+  context_used: contextUsed,
+  context_max: 372_000,
+  context_percent: (contextUsed / 372_000) * 100
+})
+
+const breakdown = (contextUsed: number): ContextBreakdown => ({
+  categories: [],
+  context_max: 372_000,
+  context_percent: (contextUsed / 372_000) * 100,
+  context_used: contextUsed,
+  estimated_total: contextUsed
+})
+
+describe('ContextUsagePanel reconciliation', () => {
+  it('refetches the authoritative breakdown when current usage changes', async () => {
+    const updatedBreakdown = new Promise<ContextBreakdown>(() => undefined)
+    const requestGateway = vi.fn().mockResolvedValueOnce(breakdown(100_000)).mockReturnValueOnce(updatedBreakdown)
+
+    const view = render(
+      <I18nProvider configClient={null} initialLocale="en">
+        <ContextUsagePanel currentUsage={usage(100_000)} requestGateway={requestGateway} sessionId="runtime-1" />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(1))
+
+    view.rerender(
+      <I18nProvider configClient={null} initialLocale="en">
+        <ContextUsagePanel currentUsage={usage(200_000)} requestGateway={requestGateway} sessionId="runtime-1" />
+      </I18nProvider>
+    )
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(2))
+    expect(screen.getByText(/~200k \/ 372k/)).toBeTruthy()
+    expect(requestGateway).toHaveBeenLastCalledWith('session.context_breakdown', { session_id: 'runtime-1' })
+  })
+})

--- a/apps/desktop/src/app/shell/context-usage-panel.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.tsx
@@ -11,17 +11,28 @@ interface ContextUsagePanelProps {
   sessionId: string | null
 }
 
+interface ContextBreakdownSnapshot {
+  data: ContextBreakdown
+  sessionId: string
+  usageRevision: string
+}
+
 export function ContextUsagePanel({ currentUsage, requestGateway, sessionId }: ContextUsagePanelProps) {
   const { t } = useI18n()
   const copy = t.shell.statusbar.contextUsagePanel
-  const [breakdown, setBreakdown] = useState<ContextBreakdown | null>(null)
+  const [breakdownSnapshot, setBreakdownSnapshot] = useState<ContextBreakdownSnapshot | null>(null)
   const [loading, setLoading] = useState(false)
 
   const usageRevision = [currentUsage.context_used, currentUsage.context_max, currentUsage.context_percent].join(':')
 
+  const breakdown =
+    breakdownSnapshot?.sessionId === sessionId && breakdownSnapshot.usageRevision === usageRevision
+      ? breakdownSnapshot.data
+      : null
+
   useEffect(() => {
     if (!sessionId) {
-      setBreakdown(null)
+      setBreakdownSnapshot(null)
       setLoading(false)
 
       return
@@ -29,18 +40,17 @@ export function ContextUsagePanel({ currentUsage, requestGateway, sessionId }: C
 
     let cancelled = false
 
-    setBreakdown(null)
     setLoading(true)
 
     void requestGateway<ContextBreakdown>('session.context_breakdown', { session_id: sessionId })
       .then(data => {
         if (!cancelled) {
-          setBreakdown(data)
+          setBreakdownSnapshot({ data, sessionId, usageRevision })
         }
       })
       .catch(() => {
         if (!cancelled) {
-          setBreakdown(null)
+          setBreakdownSnapshot(null)
         }
       })
       .finally(() => {

--- a/apps/desktop/src/app/shell/context-usage-panel.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.tsx
@@ -17,6 +17,8 @@ export function ContextUsagePanel({ currentUsage, requestGateway, sessionId }: C
   const [breakdown, setBreakdown] = useState<ContextBreakdown | null>(null)
   const [loading, setLoading] = useState(false)
 
+  const usageRevision = [currentUsage.context_used, currentUsage.context_max, currentUsage.context_percent].join(':')
+
   useEffect(() => {
     if (!sessionId) {
       setBreakdown(null)
@@ -26,6 +28,8 @@ export function ContextUsagePanel({ currentUsage, requestGateway, sessionId }: C
     }
 
     let cancelled = false
+
+    setBreakdown(null)
     setLoading(true)
 
     void requestGateway<ContextBreakdown>('session.context_breakdown', { session_id: sessionId })
@@ -48,7 +52,7 @@ export function ContextUsagePanel({ currentUsage, requestGateway, sessionId }: C
     return () => {
       cancelled = true
     }
-  }, [requestGateway, sessionId])
+  }, [requestGateway, sessionId, usageRevision])
 
   const contextMax = breakdown?.context_max ?? currentUsage.context_max ?? 0
   const contextUsed = breakdown?.context_used ?? currentUsage.context_used ?? 0

--- a/apps/desktop/src/app/shell/hooks/use-context-usage-reconciliation.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-context-usage-reconciliation.test.tsx
@@ -1,0 +1,121 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { UsageStats } from '@/types/hermes'
+
+import {
+  reconcileFocusedContextUsage,
+  useContextUsageReconciliation
+} from './use-context-usage-reconciliation'
+
+afterEach(cleanup)
+
+const usage = (contextUsed: number): UsageStats => ({
+  calls: 1,
+  input: contextUsed,
+  output: 0,
+  total: contextUsed,
+  context_used: contextUsed,
+  context_max: 372_000,
+  context_percent: (contextUsed / 372_000) * 100
+})
+
+function Harness({
+  gatewayState,
+  onUsage,
+  requestGateway,
+  sessionId
+}: {
+  gatewayState: string
+  onUsage: (next: UsageStats) => void
+  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  sessionId: null | string
+}) {
+  useContextUsageReconciliation({ gatewayState, onUsage, requestGateway, sessionId })
+
+  return null
+}
+
+describe('useContextUsageReconciliation', () => {
+  it('reads authoritative usage when the gateway becomes available', async () => {
+    const onUsage = vi.fn()
+    const requestGateway = vi.fn().mockResolvedValue(usage(200_000))
+
+    const view = render(
+      <Harness gatewayState="connecting" onUsage={onUsage} requestGateway={requestGateway} sessionId="runtime-1" />
+    )
+
+    expect(requestGateway).not.toHaveBeenCalled()
+
+    view.rerender(
+      <Harness gatewayState="open" onUsage={onUsage} requestGateway={requestGateway} sessionId="runtime-1" />
+    )
+
+    await waitFor(() => expect(onUsage).toHaveBeenCalledWith(usage(200_000)))
+    expect(requestGateway).toHaveBeenCalledWith('session.usage', { session_id: 'runtime-1' })
+  })
+
+  it('ignores a stale response after the focused runtime session changes', async () => {
+    let resolveOld!: (value: UsageStats) => void
+
+    const oldResponse = new Promise<UsageStats>(resolve => {
+      resolveOld = resolve
+    })
+
+    const onUsage = vi.fn()
+
+    const requestGateway = vi
+      .fn()
+      .mockReturnValueOnce(oldResponse)
+      .mockResolvedValueOnce(usage(250_000))
+
+    const view = render(
+      <Harness gatewayState="open" onUsage={onUsage} requestGateway={requestGateway} sessionId="runtime-old" />
+    )
+
+    view.rerender(
+      <Harness gatewayState="open" onUsage={onUsage} requestGateway={requestGateway} sessionId="runtime-new" />
+    )
+
+    await waitFor(() => expect(onUsage).toHaveBeenCalledWith(usage(250_000)))
+
+    resolveOld(usage(100_000))
+    await Promise.resolve()
+
+    expect(onUsage).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('reconcileFocusedContextUsage', () => {
+  it('updates both the runtime cache and primary usage when the primary session is focused', () => {
+    const updateCachedUsage = vi.fn()
+    const updatePrimaryUsage = vi.fn()
+    const nextUsage = usage(200_000)
+
+    reconcileFocusedContextUsage({
+      primaryFocused: true,
+      updateCachedUsage,
+      updatePrimaryUsage,
+      usage: nextUsage
+    })
+
+    expect(updateCachedUsage).toHaveBeenCalledWith(nextUsage)
+    expect(updatePrimaryUsage).toHaveBeenCalledWith(nextUsage)
+  })
+
+  it('updates only the runtime cache when a secondary session is focused', () => {
+    const updateCachedUsage = vi.fn()
+    const updatePrimaryUsage = vi.fn()
+    const nextUsage = usage(250_000)
+
+    reconcileFocusedContextUsage({
+      primaryFocused: false,
+      updateCachedUsage,
+      updatePrimaryUsage,
+      usage: nextUsage
+    })
+
+    expect(updateCachedUsage).toHaveBeenCalledWith(nextUsage)
+    expect(updatePrimaryUsage).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-context-usage-reconciliation.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-usage-reconciliation.ts
@@ -1,0 +1,60 @@
+import { useEffect } from 'react'
+
+import type { UsageStats } from '@/types/hermes'
+
+interface ContextUsageReconciliationOptions {
+  gatewayState: string
+  onUsage: (usage: UsageStats) => void
+  requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+  sessionId: null | string
+}
+
+interface FocusedUsageTarget {
+  primaryFocused: boolean
+  updateCachedUsage: (usage: UsageStats) => void
+  updatePrimaryUsage: (usage: UsageStats) => void
+  usage: UsageStats
+}
+
+export function reconcileFocusedContextUsage({
+  primaryFocused,
+  updateCachedUsage,
+  updatePrimaryUsage,
+  usage
+}: FocusedUsageTarget): void {
+  updateCachedUsage(usage)
+
+  if (primaryFocused) {
+    updatePrimaryUsage(usage)
+  }
+}
+
+/** Reconcile the focused session's cached usage whenever its live runtime is available. */
+export function useContextUsageReconciliation({
+  gatewayState,
+  onUsage,
+  requestGateway,
+  sessionId
+}: ContextUsageReconciliationOptions): void {
+  useEffect(() => {
+    if (gatewayState !== 'open' || !sessionId) {
+      return
+    }
+
+    let cancelled = false
+
+    void requestGateway<UsageStats>('session.usage', { session_id: sessionId })
+      .then(usage => {
+        if (!cancelled && usage) {
+          onUsage(usage)
+        }
+      })
+      .catch(() => {
+        // Keep the last streamed snapshot through a transient reconnect race.
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [gatewayState, onUsage, requestGateway, sessionId])
+}

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import type { CommandCenterSection } from '@/app/command-center'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
@@ -26,9 +26,15 @@ import {
   $sessions,
   $sessionStartedAt,
   $turnStartedAt,
-  sessionMatchesStoredId
+  sessionMatchesStoredId,
+  setCurrentUsage
 } from '@/store/session'
-import { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
+import {
+  $focusedRuntimeId,
+  $focusedSessionState,
+  $focusedStoredSessionId,
+  sessionTileDelegate
+} from '@/store/session-states'
 import { $subagentsBySession, activeSubagentCount, failedSubagentCount } from '@/store/subagents'
 import { $gatewayRestarting } from '@/store/system-actions'
 import {
@@ -43,6 +49,11 @@ import type { StatusResponse } from '@/types/hermes'
 
 import { CRON_ROUTE } from '../../routes'
 import type { StatusbarItem } from '../statusbar-controls'
+
+import {
+  reconcileFocusedContextUsage,
+  useContextUsageReconciliation
+} from './use-context-usage-reconciliation'
 
 const EMPTY_USAGE = { calls: 0, input: 0, output: 0, total: 0 } as const
 
@@ -116,6 +127,36 @@ export function useStatusbarItems({
 
   const activeSessionId = primaryFocused ? primaryActiveSessionId : (focusedRuntimeId ?? null)
   const busy = primaryFocused ? primaryBusy : Boolean(focusedState?.busy)
+
+  const reconcileUsage = useCallback(
+    (usage: typeof primaryUsage) => {
+      if (!activeSessionId) {
+        return
+      }
+
+      reconcileFocusedContextUsage({
+        primaryFocused,
+        updateCachedUsage: nextUsage => {
+          sessionTileDelegate()?.updateSession(activeSessionId, state => ({
+            ...state,
+            usage: { ...state.usage, ...nextUsage }
+          }))
+        },
+        updatePrimaryUsage: nextUsage => {
+          setCurrentUsage(current => ({ ...current, ...nextUsage }))
+        },
+        usage
+      })
+    },
+    [activeSessionId, primaryFocused]
+  )
+
+  useContextUsageReconciliation({
+    gatewayState,
+    onUsage: reconcileUsage,
+    requestGateway,
+    sessionId: activeSessionId
+  })
 
   // EMPTY_USAGE (module constant) keeps the fallback referentially stable —
   // a fresh `{...}` each render would bust the usage-label memos below.


### PR DESCRIPTION
## Summary
- reconcile the focused desktop session's authoritative `session.usage` whenever its gateway/runtime becomes available after an update or reconnect
- update both the runtime cache and `$currentUsage` for the primary session while keeping secondary-tile usage isolated
- invalidate and refetch an open context breakdown when the actual context metrics change, with stale-response guards

## Problem
After a desktop/backend update or reconnect, the context-usage status-bar indicator could keep a stale cached value until the user interacted with it. A focused runtime change could also leave an older asynchronous response in flight.

## Test plan
- `npm run test:ui --workspace apps/desktop -- src/app/shell`
- `npm run test:ui --workspace apps/desktop -- src/app/session/hooks/use-session-actions.test.tsx src/app/shell/context-usage-panel.test.tsx src/app/shell/hooks/use-context-usage-reconciliation.test.tsx`
- `npm run typecheck --workspace apps/desktop`
- targeted ESLint on all five changed files
- `npm run build --workspace apps/desktop`

## Notes
The full UI suite was also exercised: 1,300/1,306 tests passed. The remaining unrelated locale assertion and concurrency-only timeouts were reproduced on the unmodified upstream baseline.
