### PR TITLE
echo slack clarify replies

### DIFF
--- a/docs/note-capture-implementation-audit.md
+++ b/docs/note-capture-implementation-audit.md
@@ -1,0 +1,150 @@
+# Note Capture Implementation Audit
+
+This audit tracks the current implementation status of the canonical
+note-capture and staged projection work against the requested objective.
+
+## Objective
+
+Put the canonical note-capture and projected-storage model in place across repo
+and runtime. Keep the work on a separate branch. Require PR review and user
+approval. Run full testing. Ensure the projection rules are reviewed and
+approved before runtime rollout.
+
+## Current Branch Status
+
+- Current branch: `feature/canonical-note-projection`
+- Evidence source: `git branch --show-current`
+- Status: complete
+
+## Repo Implementation Status
+
+### Canonical capture logic
+
+- File: `hermes_cli/vault_para_triage.py`
+- Status: implemented
+- Evidence:
+  - canonical capture root helpers exist
+  - capture events are written under `.hermes/note-capture/events/`
+  - per-store staged projections are written under
+    `.hermes/note-capture/staging/<store>/<entry_id>/...`
+  - projection status summary is written under
+    `.hermes/note-capture/status/latest.json`
+  - current code still routes through vault-scoped target strings rather than
+    the broader target-registry model now defined in the contract
+
+### Skill and user-facing docs
+
+- File: `optional-skills/productivity/vault-para-triage/SKILL.md`
+- Status: updated
+- Evidence:
+  - describes canonical event logging
+  - describes staged downstream projections
+  - describes source archive and feedback correction semantics
+
+### Generated website docs
+
+- File:
+  `website/docs/user-guide/skills/optional/productivity/productivity-vault-para-triage.md`
+- Status: regenerated
+- Evidence:
+  - generated page matches updated skill description and projection rules
+
+### Reviewable projection rule spec
+
+- File: `docs/note-capture-projection-contract.md`
+- Status: written
+- Evidence:
+  - defines canonical storage
+  - defines target classes:
+    `obsidian_vault`, `filesystem`
+  - defines target lifecycle states:
+    `active`, `deferred`, `pending_migration`, `unavailable`
+  - defines projected path derivation rule
+  - defines trust boundaries
+  - explicitly calls out the daily-note exception
+  - documents the reorganisation rule
+
+### Target-space review and backlog mapping
+
+- File: `docs/note-capture-target-space-review.md`
+- Status: written
+- Evidence:
+  - maps current known capture and ingress flows to current vault, non-vault,
+    and future-target lifecycle states
+  - identifies local/runtime materialization flows not yet mapped to reviewed
+    live targets
+  - identifies backlog candidates such as household-bill capture into a
+    household-finance target
+
+### Runtime rollout spec
+
+- Files:
+  - `docs/note-capture-runtime-rollout.md`
+  - `docs/note-capture-runtime-proposed-patches.md`
+- Status: written
+- Evidence:
+  - names exact runtime files to edit
+  - provides exact proposed wording for those runtime changes
+
+## Runtime Implementation Status
+
+- Status: applied
+- Evidence:
+  - live runtime skill text now describes canonical capture events plus staged
+    downstream projections
+  - live runtime memory files now describe vault and non-vault destinations as
+    downstream projected targets rather than the primary write surface
+  - live cron docs now mark daily-note handling as a special-case runtime path
+  - live `jobs.json` prompts now distinguish generic note capture from the
+    plugin-backed daily-note workflow
+- Runtime files updated:
+  - `~/HermesData/runtime/hermes-core/skills/note-taking/vault-routing/SKILL.md`
+  - `~/HermesData/runtime/hermes-core/memories/MEMORY.md`
+  - `~/HermesData/runtime/hermes-core/profiles/orchestrator/memories/MEMORY.md`
+  - `~/HermesData/runtime/hermes-core/second-brain-infra/hermes/cron-jobs.md`
+  - `~/HermesData/runtime/hermes-core/cron/jobs.json`
+
+## Testing Status
+
+### Completed checks
+
+- `scripts/run_tests.sh tests/hermes_cli/test_vault_para_triage.py tests/plugins/test_vault_triage_feedback_plugin.py`
+- `source venv/bin/activate && python website/scripts/generate-skill-docs.py`
+- `source venv/bin/activate && python -m py_compile hermes_cli/vault_para_triage.py plugins/vault_triage_feedback/__init__.py optional-skills/productivity/vault-para-triage/scripts/vault_para_triage.py`
+- `source venv/bin/activate && python optional-skills/productivity/vault-para-triage/scripts/vault_para_triage.py --help`
+
+### Proven by those checks
+
+- capture and feedback code paths are working for the covered tests
+- store path-prefix projection mapping is covered by tests
+- projection summary contract and enabled-store reporting are covered by tests
+- generated skill docs still build successfully after the source changes
+- the new/updated Python entrypoints compile cleanly
+- the helper CLI exposes the updated capture-and-projection wording
+
+### Not yet proven
+
+- live runtime behavior after runtime edits
+- broader integration behavior across external sync jobs
+- PR review gate, because no PR has been opened yet
+
+## Approval Gates
+
+### Still required from user
+
+1. Review the branch diff
+2. Approve the change set for PR submission and merge when ready
+
+### Still required after approval
+
+1. Prepare PR for review
+2. Obtain review and explicit user approval before merge
+
+## Completion Status
+
+Implementation work is complete. Review and merge gates remain open.
+
+Remaining required work:
+
+- PR review gate has not yet happened
+- merge approval has not yet happened

--- a/docs/note-capture-implementation-audit.md
+++ b/docs/note-capture-implementation-audit.md
@@ -81,10 +81,12 @@ approved before runtime rollout.
 - Files:
   - `docs/note-capture-runtime-rollout.md`
   - `docs/note-capture-runtime-proposed-patches.md`
+  - `docs/note-capture-runtime-event-schema.md`
 - Status: written
 - Evidence:
   - names exact runtime files to edit
   - provides exact proposed wording for those runtime changes
+  - defines corrected runtime event semantics for canonical capture output
 
 ## Runtime Implementation Status
 

--- a/docs/note-capture-pr-review-checklist.md
+++ b/docs/note-capture-pr-review-checklist.md
@@ -1,0 +1,83 @@
+# Note Capture PR Review Checklist
+
+Use this checklist when the canonical note-capture and staged projection work
+is ready for PR review.
+
+## Scope Check
+
+- Confirm the branch is `feature/canonical-note-projection`
+- Confirm the PR includes repo-side canonical capture logic
+- Confirm runtime edits are only included after projection-rule approval
+- Confirm daily-note behavior is either unchanged or explicitly documented as
+  a temporary exception
+
+## Contract Check
+
+- Review `docs/note-capture-projection-contract.md`
+- Review `docs/note-capture-target-space-review.md`
+- Confirm the approved target classes are:
+  `obsidian_vault`, `filesystem`
+- Confirm the approved target lifecycle states are:
+  `active`, `deferred`, `pending_migration`, `unavailable`
+- Confirm the projected path derivation rule is:
+  `<path_prefix>/<resolved-target-path>/<filename>`
+- Confirm the trust boundary rule is:
+  Hermes writes canonical capture data and staged projections; external sync
+  writes live vault, iCloud, non-vault user-space targets, and other
+  downstream stores
+- Confirm the daily-note exception is explicit and not accidental
+- Confirm the reorganisation rule preserves canonical target identities even if
+  live paths change
+
+## Repo Code Check
+
+- Review `hermes_cli/vault_para_triage.py`
+- Verify capture events are written under `.hermes/note-capture/events/`
+- Verify staged projections are written under
+  `.hermes/note-capture/staging/<store>/<entry_id>/...`
+- Verify source notes are archived under
+  `.hermes/note-capture/source-archive/<entry_id>/...`
+- Verify feedback corrections rewrite staged projections rather than pretending
+  to mutate downstream live stores directly
+
+## Docs Check
+
+- Review `optional-skills/productivity/vault-para-triage/SKILL.md`
+- Review `website/docs/user-guide/skills/optional/productivity/productivity-vault-para-triage.md`
+- Review `docs/note-capture-runtime-rollout.md`
+- Review `docs/note-capture-runtime-proposed-patches.md`
+- Review `docs/note-capture-implementation-audit.md`
+- Review `docs/note-capture-target-space-review.md`
+
+## Runtime Check
+
+After runtime edits are applied:
+
+- Review `~/HermesData/runtime/hermes-core/skills/note-taking/vault-routing/SKILL.md`
+- Review `~/HermesData/runtime/hermes-core/memories/MEMORY.md`
+- Review `~/HermesData/runtime/hermes-core/profiles/orchestrator/memories/MEMORY.md`
+- Review `~/HermesData/runtime/hermes-core/second-brain-infra/hermes/cron-jobs.md`
+- Review `~/HermesData/runtime/hermes-core/cron/jobs.json`
+- Confirm those files no longer teach direct vault writes for generic captured
+  notes
+
+## Test Evidence
+
+- Confirm focused tests passed:
+  `tests/hermes_cli/test_vault_para_triage.py`
+- Confirm focused tests passed:
+  `tests/plugins/test_vault_triage_feedback_plugin.py`
+- Confirm docs generation succeeded:
+  `source venv/bin/activate && python website/scripts/generate-skill-docs.py`
+- Confirm Python compile smoke checks succeeded:
+  `source venv/bin/activate && python -m py_compile ...`
+- Confirm helper CLI smoke check succeeded:
+  `source venv/bin/activate && python optional-skills/productivity/vault-para-triage/scripts/vault_para_triage.py --help`
+
+## Approval Gates
+
+- Reviewer approves the repo-side contract and implementation
+- User approves the projection rules
+- User approves the runtime wording changes
+- Runtime verification passes after rollout
+- Only then is the change ready to merge

--- a/docs/note-capture-projection-contract.md
+++ b/docs/note-capture-projection-contract.md
@@ -1,0 +1,297 @@
+# Note Capture Projection Contract
+
+This document defines the canonical storage mapping for Hermes note capture and
+the rules used to derive projected locations in downstream target spaces.
+
+## Purpose
+
+Hermes writes captured notes and files into canonical internal data structures
+first. Projection into user-visible stores happens later and may cross trust
+boundaries such as iCloud sync, Obsidian app state, or the broader user
+filesystem under `/Users/neilrobinson/`.
+
+The contract is:
+
+1. Hermes classifies a capture to one canonical target identity.
+2. Hermes stores canonical content and routing metadata in an event log.
+3. Hermes stages one projected artifact per enabled downstream store.
+4. External sync or projection workers materialize those staged artifacts into
+   live targets.
+
+## Current Scope
+
+This contract applies to generic captured notes and files routed through the
+canonical note-capture flow.
+
+Current runtime exception:
+
+- daily-note creation still uses a dedicated plugin-backed write path in the
+  live runtime
+
+That daily-note path should be treated as a transitional exception until it is
+migrated deliberately with its downstream consumers.
+
+## Canonical Storage
+
+For each captured item, Hermes writes:
+
+- Canonical event:
+  `.hermes/note-capture/events/<entry_id>.json`
+- Source archive:
+  `.hermes/note-capture/source-archive/<entry_id>/<original-relative-path>`
+- Projection status summary:
+  `.hermes/note-capture/status/latest.json`
+
+The canonical event is the source of truth. Projected files are derived
+artifacts.
+
+## Target Model
+
+The target model must survive target-space reorganisation. Therefore the
+contract separates:
+
+- canonical target identity
+- target class
+- logical target path
+- store-specific materialization path
+
+Recommended canonical target fields:
+
+- `target_id`: stable identifier such as
+  `vault.second_brain.resources.content_library`
+- `target_class`: one of:
+  - `obsidian_vault`
+  - `filesystem`
+- `logical_path`: reorg-friendly logical location such as
+  `resources/content_library`
+- `display_path`: current human-facing path such as
+  `4.Resources/Content Library`
+- `trust_boundary`: where live writes occur, such as
+  `external_sync`, `icloud_obsidian`, or `user_filesystem`
+- `target_status`: one of:
+  - `active`
+  - `deferred`
+  - `pending_migration`
+  - `unavailable`
+
+Current implementation note:
+
+- the repo code still uses a vault-scoped `target` string for current routing
+- the broader target-registry model in this contract is the approved direction
+  for making projection comprehensive and reorg-safe
+
+## Target Classes
+
+### 1. Current Obsidian Vault Targets
+
+This is the current live Obsidian second-brain store under the iCloud vault
+path:
+
+`/Users/neilrobinson/Library/Mobile Documents/iCloud~md~obsidian/Documents/vault`
+
+Observed current top-level target families include:
+
+- numbered PARA buckets:
+  - `1.Inbox`
+  - `2.Projects/...`
+  - `3.Areas/...`
+  - `4.Resources/...`
+  - `5.Archive/...`
+- additional live top-level families:
+  - `Interactions`
+  - `memory`
+  - `attachments`
+  - `second-brain-infra`
+  - `Projects`
+  - `Brand`
+
+Important observed nuance:
+
+- the live vault is not a perfectly normalized PARA tree
+- some concepts appear in more than one place, but the contract can still pick
+  one canonical live path and treat the others as legacy or non-canonical
+  paths
+- some top-level folders are operational or infrastructure-oriented rather than
+  classic notes, for example:
+  - `second-brain-infra`
+  - `attachments`
+  - `memory`
+
+The contract must therefore model the current vault structure as it exists,
+while still allowing future normalization and reorganisation.
+
+Trust-boundary note:
+
+- Even though this vault sits under the user home directory, it should be
+  treated as a distinct target because it is mediated by Obsidian and iCloud
+  behavior, not just ordinary filesystem writes.
+
+### 2. Non-Vault User Filesystem Targets
+
+These are live targets under `/Users/neilrobinson/` that are not the main
+Obsidian vault, including but not limited to:
+
+- `/Users/neilrobinson/HermesData/...`
+- `/Users/neilrobinson/Documents/...`
+- `/Users/neilrobinson/Downloads/...`
+- other managed working folders or filing locations
+
+This class may also include projection directories such as:
+
+- `/Users/neilrobinson/HermesData/projections/second-brain`
+- `/Users/neilrobinson/HermesData/projections/second-brain-derived`
+
+Trust-boundary note:
+
+- These are still downstream targets, but they do not share the exact sync and
+  application semantics of the live Obsidian/iCloud vault.
+
+### 3. Future Obsidian Vault Targets
+
+The contract must support planned Obsidian targets that do not exist yet.
+
+Examples:
+
+- a new vault for household operations
+- a dedicated work vault
+- a reorganized second-brain vault with different top-level buckets
+
+These targets should be registerable in the target registry before the folders
+or vaults are created, using `target_status: deferred` or
+`target_status: unavailable` until they become live.
+
+## Canonical Target Selection
+
+Hermes should classify a capture to a canonical `target_id`, not merely to a
+current folder string.
+
+Examples:
+
+- `vault.second_brain.resources.content_library`
+- `vault.second_brain.resources.interactions`
+- `vault.second_brain.areas.relationships`
+- `vault.second_brain.areas.personal.finance.invoices_and_receipts`
+- `vault.second_brain.areas.finance.property_expenses`
+- `vault.second_brain.resources.household.purchases`
+- `vault.second_brain.reviews.daily_notes`
+- `vault.second_brain.infrastructure.second_brain_infra`
+- `filesystem.hermesdata.projections.second_brain`
+- `obsidian.future.household_ops.invoices`
+
+The target registry should then resolve that canonical identity into the
+current store-specific path.
+
+Where the current vault already contains multiple plausible live locations for a
+concept, the target registry should pick one approved canonical target id and
+record any legacy or alternate live paths as aliases during migration.
+
+Current approved canonical examples from the live vault:
+
+- interaction notes:
+  - approved canonical target path: `3.Areas/Relationships`
+  - current target status: `pending_migration`
+  - current live alternatives include:
+    - top-level `Interactions`
+    - `4.Resources/Interactions`
+- invoice and receipt filing:
+  - approved canonical target path:
+    `3.Areas/Personal/Finance/Invoices and Receipts`
+  - current target status: `pending_migration`
+  - current live predecessor path:
+    `3.Areas/Personal/Invoices and receipts`
+
+## Projected Path Derivation
+
+For each enabled projection store:
+
+```text
+projected_relative_path = <store.path_prefix>/<resolved-target-path>/<filename>
+```
+
+Rules:
+
+- `store.path_prefix` may be empty.
+- `resolved-target-path` is derived from the canonical target identity through
+  the active target registry.
+- `filename` is the captured artifact filename.
+- Path separators are normalized to `/`.
+
+Current compatibility rule:
+
+- For vault-scoped targets already implemented in the repo, `resolved-target-path`
+  is currently the routed vault-relative folder string.
+
+## Staging Layout
+
+Projected artifacts are staged under:
+
+```text
+.hermes/note-capture/staging/<store>/<entry_id>/<projected-relative-path>
+```
+
+This guarantees:
+
+- one canonical event can fan out to multiple stores
+- each staged output is tied to a stable `entry_id`
+- sync jobs can reconcile by store and event id
+- Hermes never needs direct write access to the live target spaces
+
+## Status Semantics
+
+Per-store projections start in `pending` state inside the event log. Hermes
+summarizes aggregate store state in `.hermes/note-capture/status/latest.json`.
+
+Current state meanings:
+
+- `pending`: staged and waiting for external projection
+
+Future projection workers may extend this with states such as `projected`,
+`failed`, `superseded`, or store-local materialization states, but the
+canonical event remains authoritative. Canonical target lifecycle is tracked by
+`target_status`, not by per-store projection state.
+
+## Feedback and Corrections
+
+Reviewer feedback changes routing metadata and staged projections, not the live
+target space directly.
+
+- `approve`: keep the canonical target and clear feedback-needed state
+- `correct`: update the canonical target, rewrite staged projections, and
+  remove obsolete staged files
+- `ignore`: record reviewer action without changing staging
+
+Corrections preserve the same `entry_id`. The event is updated in place because
+it is the canonical record for that captured item.
+
+## Trust Boundaries
+
+Hermes is responsible for:
+
+- routing
+- canonical content rendering
+- event logging
+- staging
+- audit/status updates
+
+External sync or projection workers are responsible for:
+
+- copying staged artifacts into the live Obsidian vault
+- copying staged artifacts into non-vault user folders
+- projecting into future vaults when they exist
+- target-space migration and cleanup during reorganisation
+- projection health notifications and reconciliation
+
+## Reorganisation Rule
+
+The target space can be reorganised. Reorganisation must not require changing
+historical capture events by hand.
+
+Best-practice rule:
+
+- historical events keep their canonical `target_id`
+- the target registry is updated to map that `target_id` to a new live path
+- projection workers re-materialize from canonical staging or canonical content
+  as needed
+
+This is why the contract prefers canonical target identities over hard-coded
+folder strings.

--- a/docs/note-capture-projection-contract.md
+++ b/docs/note-capture-projection-contract.md
@@ -10,6 +10,11 @@ first. Projection into user-visible stores happens later and may cross trust
 boundaries such as iCloud sync, Obsidian app state, or the broader user
 filesystem under `/Users/neilrobinson/`.
 
+Recommended capability name:
+
+- `canonical note-capture projection flow`
+- short form: `canonical note-capture projection`
+
 The contract is:
 
 1. Hermes classifies a capture to one canonical target identity.
@@ -44,6 +49,9 @@ For each captured item, Hermes writes:
 
 The canonical event is the source of truth. Projected files are derived
 artifacts.
+
+For the corrected runtime event shape that matches this contract, see
+[`docs/note-capture-runtime-event-schema.md`](./note-capture-runtime-event-schema.md).
 
 ## Target Model
 
@@ -199,6 +207,60 @@ Current approved canonical examples from the live vault:
   - current target status: `pending_migration`
   - current live predecessor path:
     `3.Areas/Personal/Invoices and receipts`
+- raw capture fallback:
+  - `1.Inbox` is a valid canonical target when explicitly selected
+  - `Resources/_Inbox Review` remains the low-confidence fallback destination
+
+## Runtime Agent Prompt
+
+Use the following prompt text when you need the runtime agent to apply this
+capability consistently:
+
+```md
+Use the canonical note-capture projection flow for generic captured notes and
+files.
+
+Rules:
+1. Resolve the capture to one canonical target identity before choosing a live
+   path.
+2. Treat `1.Inbox` as a valid explicit canonical target when the routing
+   decision says the note should remain in inbox form.
+3. Use `Resources/_Inbox Review` as the low-confidence fallback when the route
+   is uncertain.
+4. Write a canonical capture event first, including routing metadata.
+5. Stage one projected artifact per enabled downstream store.
+6. Do not treat the live Obsidian vault or other user-space folders as the
+   primary write surface for generic note capture.
+7. Treat external sync or projection workers as responsible for materializing
+   staged artifacts into live vault or filesystem targets.
+8. Treat daily-note creation as a special-case workflow, not the generic note
+   capture model.
+
+If routing metadata is available, preserve and propagate:
+- `target_id`
+- `target_class`
+- `logical_path`
+- `display_path`
+- `resolved_target_path`
+- `target_status`
+- `trust_boundary`
+
+Capability name: canonical note-capture projection flow.
+```
+
+## Runtime Schema
+
+When implementing or reviewing runtime capture output, use the corrected event
+shape and field semantics in
+[`docs/note-capture-runtime-event-schema.md`](./note-capture-runtime-event-schema.md).
+
+In particular:
+
+- `target_id` is a stable canonical identity, not a folder path
+- `resolved_target_path` is the resolved live target-relative path, not a
+  staging path
+- `target_status` tracks target lifecycle, not projection state
+- projection state lives under the per-store projection block
 
 ## Projected Path Derivation
 

--- a/docs/note-capture-runtime-event-schema.md
+++ b/docs/note-capture-runtime-event-schema.md
@@ -1,0 +1,328 @@
+# Note Capture Runtime Event Schema
+
+This document defines the corrected runtime event shape for the canonical
+note-capture projection flow.
+
+Use it when aligning Hermes runtime capture code, runtime memories, and
+vault-routing instructions with the repo-side projection contract.
+
+## Design Rules
+
+Keep these meanings separate:
+
+- `target_id`: stable canonical identity
+- `resolved_target_path`: resolved live target-relative path
+- `staged_relative_path`: staged artifact location under trusted runtime storage
+- `target_status`: target lifecycle state
+- `projection.*.state`: per-store projection/materialization state
+
+Do not:
+
+- use a folder path as `target_id`
+- use a staging file path as `resolved_target_path`
+- use `staged` as `target_status`
+- collapse target lifecycle and projection state into one field
+
+## Corrected Example Event
+
+```json
+{
+  "event_id": "ce_20260713_rosmcp_001",
+  "capture_model": "canonical_event_log",
+  "event_type": "note_capture",
+  "captured_at": "2026-07-13T12:00:00Z",
+  "capture_source": "hermes-agent:slack",
+  "content_type": "knowledge_reference",
+  "content_class": "report",
+  "title": "Return on Security MCP - Cyber VC Integration Report",
+  "source": {
+    "origin": "slack",
+    "author": "NeilRobinson",
+    "original_filename": "2026-07-13 ROS MCP Cyber VC Integration Report.md"
+  },
+  "routing": {
+    "target": "3.Areas/cyber futures frontier",
+    "target_id": "vault.second_brain.areas.cyber_futures_frontier",
+    "target_class": "obsidian_vault",
+    "logical_path": "areas/cyber_futures_frontier",
+    "display_path": "3.Areas/cyber futures frontier",
+    "resolved_target_path": "3.Areas/cyber futures frontier",
+    "target_status": "active",
+    "trust_boundary": "icloud_obsidian",
+    "confidence": 0.93,
+    "reason": "Cyber VC workflow report belongs with the existing cyber futures frontier operating area."
+  },
+  "routing_review": {
+    "uncertainty": "low",
+    "alternative_targets": [
+      "4.Resources/knowledge",
+      "4.Resources/Content Library",
+      "1.Inbox"
+    ],
+    "rejected_alternatives": {
+      "4.Resources/knowledge": "Too general; this is specific to Cyber Future Frontier operating context.",
+      "4.Resources/Content Library": "Not consumable external content.",
+      "1.Inbox": "Routing confidence is high enough not to defer."
+    }
+  },
+  "canonical_content": {
+    "format": "markdown",
+    "filename": "2026-07-13 ROS MCP Cyber VC Integration Report.md"
+  },
+  "projection": {
+    "stores": {
+      "vault": {
+        "state": "pending",
+        "target_relative_path": "3.Areas/cyber futures frontier/2026-07-13 ROS MCP Cyber VC Integration Report.md",
+        "staged_relative_path": "staging/vault/ce_20260713_rosmcp_001/3.Areas/cyber futures frontier/2026-07-13 ROS MCP Cyber VC Integration Report.md"
+      },
+      "second_brain": {
+        "state": "pending",
+        "target_relative_path": "runtime-source/3.Areas/cyber futures frontier/2026-07-13 ROS MCP Cyber VC Integration Report.md",
+        "staged_relative_path": "staging/second_brain/ce_20260713_rosmcp_001/runtime-source/3.Areas/cyber futures frontier/2026-07-13 ROS MCP Cyber VC Integration Report.md"
+      }
+    }
+  },
+  "sync_contract": {
+    "capture_model": "canonical_event_log",
+    "write_policy": "trusted_staging_only",
+    "projection_status_source": "structured_status",
+    "stores": [
+      "vault",
+      "second_brain"
+    ]
+  }
+}
+```
+
+## JSON Schema
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CanonicalNoteCaptureEvent",
+  "type": "object",
+  "required": [
+    "event_id",
+    "capture_model",
+    "event_type",
+    "captured_at",
+    "title",
+    "routing",
+    "projection",
+    "sync_contract"
+  ],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 1 },
+    "capture_model": { "const": "canonical_event_log" },
+    "event_type": { "const": "note_capture" },
+    "captured_at": { "type": "string", "format": "date-time" },
+    "capture_source": { "type": "string" },
+    "content_type": { "type": "string" },
+    "content_class": { "type": "string" },
+    "title": { "type": "string", "minLength": 1 },
+    "source": {
+      "type": "object",
+      "properties": {
+        "origin": { "type": "string" },
+        "author": { "type": "string" },
+        "original_filename": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "routing": {
+      "type": "object",
+      "required": [
+        "target",
+        "target_id",
+        "target_class",
+        "logical_path",
+        "display_path",
+        "resolved_target_path",
+        "target_status",
+        "trust_boundary"
+      ],
+      "properties": {
+        "target": { "type": "string", "minLength": 1 },
+        "target_id": { "type": "string", "minLength": 1 },
+        "target_class": {
+          "type": "string",
+          "enum": ["obsidian_vault", "filesystem"]
+        },
+        "logical_path": { "type": "string", "minLength": 1 },
+        "display_path": { "type": "string", "minLength": 1 },
+        "resolved_target_path": { "type": "string", "minLength": 1 },
+        "target_status": {
+          "type": "string",
+          "enum": ["active", "deferred", "pending_migration", "unavailable"]
+        },
+        "trust_boundary": { "type": "string", "minLength": 1 },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "reason": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "routing_review": {
+      "type": "object",
+      "properties": {
+        "uncertainty": { "type": "string" },
+        "alternative_targets": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "rejected_alternatives": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "canonical_content": {
+      "type": "object",
+      "properties": {
+        "format": { "type": "string" },
+        "filename": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "projection": {
+      "type": "object",
+      "required": ["stores"],
+      "properties": {
+        "stores": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "object",
+            "required": ["state", "target_relative_path", "staged_relative_path"],
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": ["pending", "projected", "failed", "superseded"]
+              },
+              "target_relative_path": { "type": "string", "minLength": 1 },
+              "staged_relative_path": { "type": "string", "minLength": 1 }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "sync_contract": {
+      "type": "object",
+      "required": ["capture_model", "write_policy", "projection_status_source", "stores"],
+      "properties": {
+        "capture_model": { "const": "canonical_event_log" },
+        "write_policy": { "const": "trusted_staging_only" },
+        "projection_status_source": { "type": "string" },
+        "stores": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}
+```
+
+## Pydantic Model
+
+```python
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+TargetClass = Literal["obsidian_vault", "filesystem"]
+TargetStatus = Literal["active", "deferred", "pending_migration", "unavailable"]
+ProjectionState = Literal["pending", "projected", "failed", "superseded"]
+
+
+class SourceRef(BaseModel):
+    origin: Optional[str] = None
+    author: Optional[str] = None
+    original_filename: Optional[str] = None
+
+
+class RoutingMetadata(BaseModel):
+    target: str
+    target_id: str
+    target_class: TargetClass
+    logical_path: str
+    display_path: str
+    resolved_target_path: str
+    target_status: TargetStatus
+    trust_boundary: str
+    confidence: Optional[float] = Field(default=None, ge=0, le=1)
+    reason: Optional[str] = None
+
+
+class RoutingReview(BaseModel):
+    uncertainty: Optional[str] = None
+    alternative_targets: List[str] = Field(default_factory=list)
+    rejected_alternatives: Dict[str, str] = Field(default_factory=dict)
+
+
+class CanonicalContent(BaseModel):
+    format: Optional[str] = None
+    filename: Optional[str] = None
+
+
+class ProjectionStoreEntry(BaseModel):
+    state: ProjectionState
+    target_relative_path: str
+    staged_relative_path: str
+
+
+class ProjectionStateBlock(BaseModel):
+    stores: Dict[str, ProjectionStoreEntry]
+
+
+class SyncContract(BaseModel):
+    capture_model: Literal["canonical_event_log"]
+    write_policy: Literal["trusted_staging_only"]
+    projection_status_source: str
+    stores: List[str]
+
+
+class CanonicalNoteCaptureEvent(BaseModel):
+    event_id: str
+    capture_model: Literal["canonical_event_log"]
+    event_type: Literal["note_capture"]
+    captured_at: str
+    capture_source: Optional[str] = None
+    content_type: Optional[str] = None
+    content_class: Optional[str] = None
+    title: str
+    source: Optional[SourceRef] = None
+    routing: RoutingMetadata
+    routing_review: Optional[RoutingReview] = None
+    canonical_content: Optional[CanonicalContent] = None
+    projection: ProjectionStateBlock
+    sync_contract: SyncContract
+```
+
+## Runtime Prompt Addendum
+
+Use this short rule block in runtime prompts or memories when the full schema
+is too heavy:
+
+```md
+For generic note capture, preserve four separate concepts:
+- canonical identity (`target_id`)
+- resolved live target path (`resolved_target_path`)
+- staged artifact path (`staged_relative_path`)
+- projection state (`pending` / `projected` / `failed`)
+
+Do not use a folder path as `target_id`.
+Do not use a staging path as `resolved_target_path`.
+Do not use `staged` as `target_status`.
+Use `target_status` only for target lifecycle:
+`active`, `deferred`, `pending_migration`, `unavailable`.
+```

--- a/docs/note-capture-runtime-proposed-patches.md
+++ b/docs/note-capture-runtime-proposed-patches.md
@@ -5,6 +5,59 @@ after approval of the projection contract.
 
 It is intentionally concrete so approval can be based on exact wording.
 
+For the corrected runtime event shape and field semantics, see
+[`docs/note-capture-runtime-event-schema.md`](./note-capture-runtime-event-schema.md).
+
+## Runtime Agent Prompt
+
+Use this prompt block when you want Hermes-core runtime surfaces to understand
+and consistently apply the capability:
+
+```md
+Use the canonical note-capture projection flow for generic captured notes and
+files.
+
+Resolve each capture to one canonical target identity before choosing a live
+path. `1.Inbox` is a valid explicit canonical target when the routing decision
+is to keep the note as raw inbox material. `Resources/_Inbox Review` remains
+the low-confidence fallback when the route is uncertain.
+
+Write a canonical capture event first, preserve routing metadata, and stage
+one projected artifact per enabled downstream store. Do not treat the live
+Obsidian vault, `/opt/second_brain/`, or other user-space folders as the
+primary write surface for generic note capture. External sync or projection
+workers are responsible for materializing staged artifacts into live targets.
+
+Preserve and propagate routing metadata when available:
+- `target_id`
+- `target_class`
+- `logical_path`
+- `display_path`
+- `resolved_target_path`
+- `target_status`
+- `trust_boundary`
+
+Treat daily-note creation as a special-case workflow, not the generic note
+capture model.
+```
+
+Add this schema rule block where runtime prompts need a compact implementation
+guardrail:
+
+```md
+For generic note capture, preserve four separate concepts:
+- canonical identity (`target_id`)
+- resolved live target path (`resolved_target_path`)
+- staged artifact path (`staged_relative_path`)
+- projection state (`pending` / `projected` / `failed`)
+
+Do not use a folder path as `target_id`.
+Do not use a staging path as `resolved_target_path`.
+Do not use `staged` as `target_status`.
+Use `target_status` only for target lifecycle:
+`active`, `deferred`, `pending_migration`, `unavailable`.
+```
+
 ## 1. `~/HermesData/runtime/hermes-core/skills/note-taking/vault-routing/SKILL.md`
 
 ### Proposed replacement header
@@ -66,7 +119,8 @@ maps content to one canonical target identity, writes canonical capture events,
 and stages downstream projections per store. Vault, projection trees, and
 non-vault user-space targets are downstream materializations, not the primary
 write surface. Check structured projection status rather than assuming a direct
-live-path write.
+live-path write. `1.Inbox` is a valid explicit target; `Resources/_Inbox Review`
+is the low-confidence fallback.
 ```
 
 ## 3. `~/HermesData/runtime/hermes-core/profiles/orchestrator/memories/MEMORY.md`

--- a/docs/note-capture-runtime-proposed-patches.md
+++ b/docs/note-capture-runtime-proposed-patches.md
@@ -1,0 +1,144 @@
+# Note Capture Runtime Proposed Patches
+
+This document contains the proposed runtime text changes that should be applied
+after approval of the projection contract.
+
+It is intentionally concrete so approval can be based on exact wording.
+
+## 1. `~/HermesData/runtime/hermes-core/skills/note-taking/vault-routing/SKILL.md`
+
+### Proposed replacement header
+
+```md
+---
+name: vault-routing
+description: Vault routing table for the Obsidian second brain — maps content types to canonical destinations and downstream projected paths. Load this skill before saving captured content.
+platforms: [linux]
+---
+
+# Vault Routing — Content Destination Rules
+
+Load this skill whenever you need to save content related to Neil's Obsidian
+second brain.
+
+Hermes does not treat `/opt/second_brain/` as the primary write surface for
+generic captured content. The vault is one downstream projected target class.
+
+**CRITICAL:** `/opt/second_brain/` is mounted read-only from this container
+over VirtioFS. For generic note capture, Hermes should:
+
+1. decide one canonical routing target
+2. render canonical markdown content
+3. write a canonical capture event
+4. stage one projected artifact per enabled downstream store and target class
+
+External sync outside the Hermes trust boundary then projects those staged
+artifacts into the live vault, iCloud-backed Obsidian targets, broader
+user-space folders, or targets that are currently deferred in the registry.
+
+Current daily-note workflows remain a special runtime exception and may still
+use the dedicated daily-note plugin path until they are migrated explicitly.
+```
+
+### Proposed replacement for the final mistake rule
+
+```md
+4. ❌ **Don't treat the mounted vault as the generic write surface** — it is
+   read-only and downstream of canonical capture. For generic captured notes,
+   write canonical capture data and staged projections first.
+```
+
+## 2. `~/HermesData/runtime/hermes-core/memories/MEMORY.md`
+
+### Proposed replacement for the vault-routing memory line
+
+Replace:
+
+```md
+Vault routing: load vault-routing skill before saving content. YouTube→Content Library, meetings→Interactions, raw→Inbox. Stage at /opt/data/staging/.
+```
+
+With:
+
+```md
+Vault routing: load vault-routing skill before saving captured content. Hermes
+maps content to one canonical target identity, writes canonical capture events,
+and stages downstream projections per store. Vault, projection trees, and
+non-vault user-space targets are downstream materializations, not the primary
+write surface. Check structured projection status rather than assuming a direct
+live-path write.
+```
+
+## 3. `~/HermesData/runtime/hermes-core/profiles/orchestrator/memories/MEMORY.md`
+
+### Proposed replacement for the write-boundary memory line
+
+Replace:
+
+```md
+HERMES_WRITE_SAFE_ROOT=/opt/data blocks Hermes write_file/patch from /opt/second_brain/. Plugin bypasses via Python I/O — workaround: write to /opt/data/ and report.
+```
+
+With:
+
+```md
+HERMES_WRITE_SAFE_ROOT=/opt/data blocks Hermes write_file/patch from
+/opt/second_brain/. Treat `/opt/second_brain/` as one downstream projected
+target class for generic note capture. Hermes should write canonical capture
+data and staged projections under trusted runtime storage, with external sync
+responsible for projecting into the live vault and other approved user-space
+targets. The daily-note plugin remains a special-case runtime path.
+```
+
+## 4. `~/HermesData/runtime/hermes-core/second-brain-infra/hermes/cron-jobs.md`
+
+### Proposed addition near the top
+
+```md
+## Note on Trust Boundary
+
+These cron jobs include a daily-note workflow that still uses a dedicated
+plugin-backed runtime write path. That is a special case.
+
+For generic note capture and vault routing, Hermes should use the canonical
+note-capture flow: canonical event log first, staged projections second, live
+vault, iCloud-backed Obsidian targets, and non-vault user-space targets outside
+the Hermes trust boundary.
+```
+
+## 5. `~/HermesData/runtime/hermes-core/cron/jobs.json`
+
+### Proposed wording change for `Daily Morning Briefing`
+
+Add after the vault path introduction:
+
+```text
+The live vault is one projected surface for most captured notes. Do not treat
+generic captured content as direct live-path writes. Daily-note creation
+remains a special plugin-backed workflow.
+```
+
+### Proposed wording change for `Daily Memo Preparer`
+
+Add after the task description:
+
+```text
+This job is a special-case daily-note workflow. It should not be generalized
+into the generic note-capture routing path, which uses canonical capture events
+plus staged downstream projections into approved target classes.
+```
+
+## Approval Questions
+
+Applying the runtime edits above means approving these points:
+
+1. Generic captured notes use canonical event logging plus staged projections.
+2. Projected relative paths are derived as
+   `<path_prefix>/<resolved-target-path>/<filename>`.
+3. The mounted vault, projection trees, and non-vault user-space targets are
+   described to Hermes as downstream target classes with distinct trust
+   boundaries.
+4. Daily-note creation remains an explicit runtime exception for now.
+5. Future targets are represented through target registry status values
+   (`deferred`, `unavailable`, `pending_migration`) rather than a separate
+   target class.

--- a/docs/note-capture-runtime-rollout.md
+++ b/docs/note-capture-runtime-rollout.md
@@ -1,0 +1,146 @@
+# Note Capture Runtime Rollout
+
+This document records the runtime-side changes required to align Hermes-core
+with the canonical note-capture and staged projection contract defined in
+[`docs/note-capture-projection-contract.md`](./note-capture-projection-contract.md)
+and the target-space review in
+[`docs/note-capture-target-space-review.md`](./note-capture-target-space-review.md).
+
+These runtime changes should be applied only after the projection contract is
+explicitly approved.
+
+## Scope
+
+The runtime rollout is limited to communication, memory, and orchestration
+surfaces that currently describe note writes as direct writes to the projected
+vault or to a single staging mirror.
+
+It does not change the already-running external sync layer. Instead, it changes
+what Hermes-core says and expects about the trust boundaries across:
+
+- the current Obsidian vault
+- non-vault user filesystem targets
+- future targets represented through target registry status within those same
+  target classes
+
+## Runtime Files To Update
+
+### 1. `~/HermesData/runtime/hermes-core/skills/note-taking/vault-routing/SKILL.md`
+
+Current issue:
+
+- Describes content routing as staging directly to `/opt/data/staging/<vault-path>`
+- Frames the vault projection as a single downstream path
+
+Required update:
+
+- Explain that Hermes captures canonical content first and stages one projected
+  artifact per enabled store and target class
+- Keep the existing routing table
+- Replace direct-write wording with canonical event plus staged projection
+- Clarify that downstream sync projects staged files into the live vault and
+  other stores outside the trust boundary
+
+### 2. `~/HermesData/runtime/hermes-core/memories/MEMORY.md`
+
+Current issue:
+
+- The memory pointer says `Vault routing: ... Stage at /opt/data/staging/.`
+
+Required update:
+
+- Replace that line with a pointer to the canonical note-capture model
+- State that vault, projection trees, and non-vault user-space targets are
+  downstream projections with different trust boundaries
+- Reflect that future targets are represented by `target_status` rather than a
+  separate `target_class`
+- Point the agent toward structured projection status rather than assuming a
+  direct vault write
+
+### 3. `~/HermesData/runtime/hermes-core/profiles/orchestrator/memories/MEMORY.md`
+
+Current issue:
+
+- Still teaches the old write workaround model for `/opt/second_brain/`
+
+Required update:
+
+- Mirror the same canonical capture and downstream sync guidance used in the
+  main runtime memory
+
+### 4. `~/HermesData/runtime/hermes-core/second-brain-infra/hermes/cron-jobs.md`
+
+Current issue:
+
+- Documents direct daily-note creation in the mounted vault as the primary
+  write model
+
+Required update:
+
+- Clarify that daily-note creation is a special runtime path distinct from the
+  generic note-capture projection contract
+- Note that general note routing should use canonical capture and staged
+  projection into approved target classes, not direct vault writes
+
+### 5. `~/HermesData/runtime/hermes-core/cron/jobs.json`
+
+Current issue:
+
+- Morning briefing and daily memo preparer prompts still read as if the vault
+  is the primary writable source of truth
+
+Required update:
+
+- Leave the objective and daily-note workflow intact if it truly must write via
+  the daily-note plugin
+- Add wording that the live vault is one projected surface and that generic
+  note capture should prefer canonical capture plus staged projections across
+  approved target classes
+- Avoid conflating the daily-note plugin’s special-case write path with the
+  general note-routing contract
+
+## Special Case: Daily Notes
+
+Daily notes are the one runtime path that currently behaves differently from
+generic note capture.
+
+Observed current state:
+
+- `daily_memo_preparer_v2.py` writes to
+  `/opt/second_brain/4.Resources/Reviews/Daily Notes`
+- It uses the `daily_note_capture` plugin’s internal write path
+
+Rollout guidance:
+
+- Do not casually force daily notes through the new generic note-capture flow
+  unless the projection worker and downstream consumers are updated together
+- Treat daily notes as an explicit exception until there is a verified end-to-end
+  replacement for the current plugin-backed workflow
+
+## Verification After Runtime Rollout
+
+After approval and runtime edits, verify:
+
+1. Runtime skill text no longer instructs direct vault writes for generic note
+   capture.
+2. Runtime memory files describe vault, projection trees, and non-vault
+   user-space targets as downstream target classes with distinct trust
+   boundaries.
+3. Cron prompts do not teach a contradictory generic note-routing model.
+4. Existing daily-note jobs still run successfully.
+5. Projection-status files remain readable and semantically consistent with the
+   approved contract.
+
+## Approval Gate
+
+Before applying runtime edits, confirm:
+
+- The target classes are approved:
+  `obsidian_vault`, `filesystem`
+- The target lifecycle states are approved:
+  `active`, `deferred`, `pending_migration`, `unavailable`
+- The projected path derivation rule
+  `<path_prefix>/<resolved-target-path>/<filename>` is approved
+- The trust-boundary rule is approved:
+  Hermes writes canonical capture data and staging; external sync writes live
+  vault, iCloud, and non-vault user-space destinations

--- a/docs/note-capture-runtime-rollout.md
+++ b/docs/note-capture-runtime-rollout.md
@@ -5,6 +5,8 @@ with the canonical note-capture and staged projection contract defined in
 [`docs/note-capture-projection-contract.md`](./note-capture-projection-contract.md)
 and the target-space review in
 [`docs/note-capture-target-space-review.md`](./note-capture-target-space-review.md).
+Use [`docs/note-capture-runtime-event-schema.md`](./note-capture-runtime-event-schema.md)
+as the runtime output shape for canonical capture events.
 
 These runtime changes should be applied only after the projection contract is
 explicitly approved.
@@ -22,6 +24,10 @@ what Hermes-core says and expects about the trust boundaries across:
 - non-vault user filesystem targets
 - future targets represented through target registry status within those same
   target classes
+
+Use the capability name `canonical note-capture projection flow` when updating
+runtime skills, memories, and orchestration prompts so the model has one stable
+term for this behavior.
 
 ## Runtime Files To Update
 
@@ -56,6 +62,8 @@ Required update:
   separate `target_class`
 - Point the agent toward structured projection status rather than assuming a
   direct vault write
+- Clarify that `1.Inbox` is a valid explicit target while
+  `Resources/_Inbox Review` remains the low-confidence fallback
 
 ### 3. `~/HermesData/runtime/hermes-core/profiles/orchestrator/memories/MEMORY.md`
 
@@ -130,6 +138,9 @@ After approval and runtime edits, verify:
 4. Existing daily-note jobs still run successfully.
 5. Projection-status files remain readable and semantically consistent with the
    approved contract.
+6. Runtime capture events use the corrected field semantics:
+   stable `target_id`, live-relative `resolved_target_path`, lifecycle-only
+   `target_status`, and per-store projection state.
 
 ## Approval Gate
 

--- a/docs/note-capture-target-space-review.md
+++ b/docs/note-capture-target-space-review.md
@@ -1,0 +1,291 @@
+# Note Capture Target Space Review
+
+This review maps current known capture and ingress flows onto the revised target
+space model and identifies gaps for backlog work.
+
+## Target Classes In Scope
+
+### Current Obsidian Vault
+
+Observed live store:
+
+- `/Users/neilrobinson/Library/Mobile Documents/iCloud~md~obsidian/Documents/vault`
+
+Observed current top-level structures include:
+
+- `1.Inbox`
+- `2.Projects`
+- `3.Areas`
+- `4.Resources`
+- `5.Archive`
+- `Interactions`
+- `memory`
+- `attachments`
+- `second-brain-infra`
+- `Projects`
+- `Brand`
+
+Observed structural realities that should inform the contract:
+
+- the vault is not a pure PARA tree
+- some domains exist both inside and outside the numbered PARA structure
+- there are operational and code-bearing folders inside the vault
+- there are duplicate or near-duplicate concepts across current paths
+
+Examples:
+
+- interaction material currently exists in multiple live places, including:
+  - top-level `Interactions`
+  - `4.Resources/Interactions`
+  - approved canonical target: `3.Areas/Relationships`
+- household and finance concepts already exist in multiple live places:
+  - `3.Areas/household`
+  - `3.Areas/finance`
+  - `3.Areas/Personal/Finance/Invoices and Receipts`
+  - `4.Resources/Household`
+- review material already has concrete live structure:
+  - `4.Resources/Reviews/Daily Notes`
+  - `4.Resources/Reviews/Weekly Notes`
+  - `4.Resources/Reviews/Annual Notes`
+- content and knowledge targets already exist:
+  - `4.Resources/Content Library`
+  - `4.Resources/Content Queue`
+  - `4.Resources/knowledge`
+- infrastructure and attachment-like targets already exist:
+  - `second-brain-infra`
+  - `attachments`
+  - `4.Resources/attachments`
+
+### Non-Vault User Filesystem
+
+Observed live stores include:
+
+- `/Users/neilrobinson/HermesData/projections/second-brain`
+- `/Users/neilrobinson/HermesData/projections/second-brain-derived`
+- `/Users/neilrobinson/HermesData/daily-notes`
+- other user-space folders under `/Users/neilrobinson/`
+
+### Future Obsidian Targets
+
+Not yet created, but explicitly requested as part of the target model.
+
+Examples to plan for:
+
+- additional thematic vaults
+- reorganized vault structures
+- domain-specific note spaces such as household operations
+
+Modeling note:
+
+- these are still represented with `target_class: obsidian_vault`
+- their lifecycle is expressed via `target_status`, such as `deferred` or
+  `unavailable`
+
+## Current Known Capture / Ingress Flows
+
+### 1. Vault PARA triage
+
+Source:
+
+- `hermes_cli/vault_para_triage.py`
+- optional skill `vault-para-triage`
+
+Current state:
+
+- captures markdown inbox notes
+- routes to vault-scoped PARA targets
+- stages outputs per enabled store
+
+Mapped target class:
+
+- current Obsidian vault
+
+Gap:
+
+- target identity is still a vault-relative folder string, not a registry-backed
+  canonical target id
+- approved canonical choice:
+  - approved canonical target path: `3.Areas/Relationships`
+  - current target status: `pending_migration`
+  - current live alternatives:
+    - top-level `Interactions`
+    - `4.Resources/Interactions`
+
+### 2. Daily note capture
+
+Source:
+
+- runtime plugin `daily_note_capture`
+- runtime script `daily_memo_preparer_v2.py`
+
+Current state:
+
+- special-case direct daily-note workflow
+- writes to daily notes in the live second-brain vault
+
+Mapped target class:
+
+- current Obsidian vault
+
+Gap:
+
+- still bypasses the generic note-capture projection contract
+
+### 3. Meeting classification
+
+Source:
+
+- runtime plugin `google_workspace_cli`
+- tool `run_meeting_classification`
+
+Current state:
+
+- classifies calendar meetings
+- writes meeting-classification artifacts associated with the vault review area
+
+Mapped target class:
+
+- current Obsidian vault
+
+Gap:
+
+- artifacts are not yet expressed through the broader target registry model
+
+### 4. Research capture
+
+Source:
+
+- runtime plugin `research_capture`
+- Gmail-backed ingest methods
+
+Current state:
+
+- approved runtime plugin
+- newsletter ingest and local materialization
+
+Mapped target class:
+
+- currently local/runtime materialization first
+
+Gap:
+
+- no reviewed canonical mapping yet into the broader target registry across
+  vault and non-vault destinations
+
+### 5. Payments review
+
+Source:
+
+- runtime plugin `payments_review`
+- Gmail-backed invoice/payment-request ingest
+
+Current state:
+
+- captures likely invoices and payment instructions into deterministic local
+  state and materialized review artifacts
+- explicitly avoids initiating any transfer
+
+Mapped target class:
+
+- currently local/runtime materialization first
+
+Gap:
+
+- not yet mapped to a canonical household-finance or finance-review target in
+  the approved target registry
+- current live candidates already exist and should be reviewed explicitly, for
+  example:
+  - `3.Areas/Personal/Finance/Invoices and Receipts`
+  - `3.Areas/finance/Property Expenses`
+  - `4.Resources/Household/Purchases`
+
+Current approved path correction:
+
+- point-two approved canonical target path:
+  `3.Areas/Personal/Finance/Invoices and Receipts`
+- current target status: `pending_migration`
+- current live predecessor path:
+  `3.Areas/Personal/Invoices and receipts`
+
+### 6. Expense submission
+
+Source:
+
+- runtime memory points to `expense_submit.py`
+
+Current state:
+
+- operational workflow with ledger and email send
+
+Mapped target class:
+
+- non-vault operational state today
+
+Gap:
+
+- no reviewed projection target for durable note/file capture output
+
+## Backlog Candidates
+
+### High-value target registry work
+
+1. Introduce a target registry that maps stable `target_id` values to current
+   live target paths and target classes.
+2. Add reorganisation support so existing target ids survive path changes.
+3. Support planned future targets through `target_status` values such as
+   `deferred` and `unavailable` before folders exist.
+
+### Capture coverage gaps
+
+1. Household bills automated capture from email into a household-finance target.
+   Current live candidates to review:
+   - `3.Areas/Personal/Finance/Invoices and Receipts`
+     (approved canonical target path, current status `pending_migration`)
+   - `3.Areas/Personal/Invoices and receipts`
+     (current live predecessor path)
+   - `3.Areas/finance/Property Expenses`
+   - `4.Resources/Household/Purchases`
+   Recommended outcome:
+   use `3.Areas/Personal/Finance/Invoices and Receipts` as the approved
+   canonical target path and treat the current live predecessor path as a
+   migration source unless a later reorganisation promotes a different
+   approved target id.
+2. Payment-request and invoice capture from Gmail into a reviewed finance
+   workflow target rather than only local materialized review state.
+3. Research/newsletter capture into approved knowledge/library targets across
+   vault and non-vault stores.
+4. Attachment capture policy for invoices, statements, bills, and research
+   documents.
+5. Non-markdown file projection rules for PDFs, receipts, and other binary
+   assets.
+
+### Runtime/ops gaps
+
+1. Runtime wording still teaches vault-centric paths instead of the broader
+   target-space model.
+2. Daily-note capture remains a special-case direct write path.
+3. `research_capture` exists in runtime but requires reviewed enablement and
+   target mapping decisions.
+
+## Review Guidance
+
+Before runtime rollout, review and approve:
+
+1. target classes:
+   `obsidian_vault`, `filesystem`
+2. trust boundaries for each target class
+3. the move from hard-coded folder strings toward canonical `target_id`
+4. which current live vault paths become canonical when duplicates or competing
+   locations exist
+5. the initial backlog additions for household finance, payments, research, and
+   attachments
+6. target lifecycle states:
+   `active`, `deferred`, `pending_migration`, `unavailable`
+
+Current decisions already incorporated:
+
+- `3.Areas/Relationships` is the approved canonical target path for
+  interactions with `target_status: pending_migration`
+- `3.Areas/Personal/Finance/Invoices and Receipts` is the approved canonical
+  target path for the invoice-and-receipts point with
+  `target_status: pending_migration`

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3371,6 +3371,20 @@ class BasePlatformAdapter(ABC):
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Hook called when background processing completes."""
 
+    def format_intercepted_clarify_response(
+        self,
+        event: MessageEvent,
+        clarify_entry: Any,
+        response_text: str,
+    ) -> Optional[str]:
+        """Return a user-visible echo for an intercepted clarify reply.
+
+        Platforms can override this to surface the submitted reply back into
+        the channel/thread that captured it. Returning ``None`` keeps the
+        existing silent-intercept behavior.
+        """
+        return None
+
     async def _run_processing_hook(self, hook_name: str, *args: Any, **kwargs: Any) -> None:
         """Run a lifecycle hook without letting failures break message flow."""
         hook = getattr(self, hook_name, None)
@@ -4045,24 +4059,53 @@ class BasePlatformAdapter(ABC):
                         self.name, session_key,
                     )
                     try:
+                        raw_clarify_reply = (event.text or "").strip()
+                        if not raw_clarify_reply:
+                            return
+
+                        try:
+                            from tools import clarify_gateway as _clarify_mod
+                            pending_clarify = _clarify_mod.get_pending_for_session(session_key)
+                        except Exception:
+                            pending_clarify = None
+
+                        if pending_clarify is None:
+                            return
+
+                        resolved = _clarify_mod.resolve_gateway_clarify(
+                            pending_clarify.clarify_id,
+                            raw_clarify_reply,
+                        )
+                        if not resolved:
+                            return
+
                         _thread_meta = _thread_metadata_for_source(
                             event.source, _reply_anchor_for_event(event)
                         )
-                        response = await self._message_handler(event)
-                        _text, _eph_ttl = self._unwrap_ephemeral(response)
-                        if _text:
-                            _r = await self._send_with_retry(
+                        clarify_text = None
+                        try:
+                            formatter = getattr(
+                                self, "format_intercepted_clarify_response", None
+                            )
+                            if callable(formatter):
+                                clarify_text = formatter(
+                                    event,
+                                    pending_clarify,
+                                    raw_clarify_reply,
+                                )
+                        except Exception as exc:
+                            logger.warning(
+                                "[%s] clarify response formatter failed: %s",
+                                self.name,
+                                exc,
+                            )
+                        if clarify_text is not None:
+                            await self._send_with_retry(
                                 chat_id=event.source.chat_id,
-                                content=_text,
+                                content=clarify_text,
                                 reply_to=_reply_anchor_for_event(event),
                                 metadata=_mark_notify_metadata(_thread_meta),
                             )
-                            if _eph_ttl > 0 and _r.success and _r.message_id:
-                                self._schedule_ephemeral_delete(
-                                    chat_id=event.source.chat_id,
-                                    message_id=_r.message_id,
-                                    ttl_seconds=_eph_ttl,
-                                )
                     except Exception as e:
                         logger.error(
                             "[%s] Clarify text-intercept dispatch failed: %s",

--- a/hermes_cli/payments.py
+++ b/hermes_cli/payments.py
@@ -1,0 +1,471 @@
+"""Profile-scoped payment-request storage for the dashboard Payments page.
+
+The first slice is intentionally narrow:
+  * keep a durable, profile-local review queue of extracted payment requests
+  * expose source status (Gmail / Email / Uploads / Slack) for the dashboard
+  * support manual status transitions only; no payment initiation
+
+Actual ingestion/extraction can be layered on top of this store later without
+changing the dashboard contract.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from email.utils import parseaddr, parsedate_to_datetime
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any, Dict, List
+
+from hermes_constants import get_hermes_home
+from hermes_cli.config import load_env
+
+PAYMENTS_DIR = "payments"
+REQUESTS_FILE = "requests.json"
+
+PAYMENT_STATUSES = {
+    "new",
+    "needs_review",
+    "ready_to_pay",
+    "paid",
+    "ignored",
+}
+
+PAYMENT_SOURCES = (
+    ("gmail", "Gmail"),
+    ("email", "Email"),
+    ("uploads", "Uploads"),
+    ("slack", "Slack"),
+)
+
+DEFAULT_GMAIL_QUERY = (
+    'newer_than:120d (invoice OR "payment due" OR "request for payment" OR '
+    '"bank transfer" OR remittance OR billing OR statement)'
+)
+DEFAULT_GMAIL_MAX_RESULTS = 25
+
+_AMOUNT_PATTERNS = [
+    re.compile(r"\b(GBP|USD|EUR|AUD|CAD|NZD|CHF|SEK|NOK|DKK)\s?([0-9][0-9,]*(?:\.[0-9]{2})?)\b", re.I),
+    re.compile(r"([£$€])\s?([0-9][0-9,]*(?:\.[0-9]{2})?)"),
+]
+_SORT_CODE_RE = re.compile(r"\b\d{2}-\d{2}-\d{2}\b")
+_ACCOUNT_NUMBER_RE = re.compile(r"\b\d{8}\b")
+_IBAN_RE = re.compile(r"\b[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}\b")
+_SWIFT_RE = re.compile(r"\b[A-Z]{6}[A-Z0-9]{2}(?:[A-Z0-9]{3})?\b")
+_ROUTING_RE = re.compile(r"\brouting number\b[:\s]*([0-9]{9})", re.I)
+_REFERENCE_RE = re.compile(
+    r"\b(?:reference|payment reference|remittance reference)\b[:\s#-]*([A-Z0-9-]{4,})",
+    re.I,
+)
+_INVOICE_RE = re.compile(r"\b(?:invoice|inv(?:oice)? number|invoice #)\b[:\s#-]*([A-Z0-9-]{3,})", re.I)
+_DUE_RE = re.compile(
+    r"\b(?:due date|payment due|due)\b[:\s-]*("
+    r"[A-Z][a-z]{2,8}\s+\d{1,2},?\s+\d{4}"
+    r"|\d{4}-\d{2}-\d{2}"
+    r"|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}"
+    r")",
+    re.I,
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _payments_dir() -> Path:
+    return get_hermes_home() / PAYMENTS_DIR
+
+
+def _requests_path() -> Path:
+    return _payments_dir() / REQUESTS_FILE
+
+
+def _google_api_script() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "skills"
+        / "productivity"
+        / "google-workspace"
+        / "scripts"
+        / "google_api.py"
+    )
+
+
+def _empty_record(payment_id: str) -> Dict[str, Any]:
+    return {
+        "id": payment_id,
+        "source": "uploads",
+        "source_label": "Uploads",
+        "status": "new",
+        "confidence": "low",
+        "received_at": None,
+        "updated_at": None,
+        "vendor": "",
+        "title": "",
+        "amount": {"value": None, "currency": "", "display": ""},
+        "due_date": None,
+        "payee_name": "",
+        "account_holder": "",
+        "account_number": "",
+        "sort_code": "",
+        "iban": "",
+        "swift": "",
+        "routing_number": "",
+        "payment_reference": "",
+        "invoice_number": "",
+        "billing_address": "",
+        "tax_details": "",
+        "preview_text": "",
+        "warnings": [],
+        "attachments": [],
+        "original": {"label": "", "url": "", "message_id": "", "thread_id": ""},
+    }
+
+
+def _normalize_record(raw: Dict[str, Any], *, index: int) -> Dict[str, Any]:
+    record = _empty_record(str(raw.get("id") or f"payment-{index + 1}"))
+    record.update({k: v for k, v in raw.items() if k in record})
+
+    amount = raw.get("amount")
+    if isinstance(amount, dict):
+        record["amount"] = {
+            "value": amount.get("value"),
+            "currency": str(amount.get("currency") or ""),
+            "display": str(amount.get("display") or ""),
+        }
+
+    original = raw.get("original")
+    if isinstance(original, dict):
+        record["original"] = {
+            "label": str(original.get("label") or ""),
+            "url": str(original.get("url") or ""),
+            "message_id": str(original.get("message_id") or ""),
+            "thread_id": str(original.get("thread_id") or ""),
+        }
+
+    status = str(record.get("status") or "new").strip()
+    record["status"] = status if status in PAYMENT_STATUSES else "needs_review"
+
+    source = str(record.get("source") or "uploads").strip()
+    record["source"] = source or "uploads"
+    record["source_label"] = str(record.get("source_label") or source.title())
+    record["confidence"] = str(record.get("confidence") or "low")
+    record["warnings"] = [
+        str(item).strip()
+        for item in (record.get("warnings") or [])
+        if str(item).strip()
+    ]
+    record["attachments"] = [
+        str(item).strip()
+        for item in (record.get("attachments") or [])
+        if str(item).strip()
+    ]
+    return record
+
+
+def _run_google_api(args: List[str]) -> Any:
+    script = _google_api_script()
+    result = subprocess.run(
+        [sys.executable, str(script), *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        err = (result.stderr or result.stdout or "").strip() or "google_api.py failed"
+        raise RuntimeError(err)
+    stdout = result.stdout.strip()
+    if not stdout:
+        return []
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Unexpected google_api.py output: {stdout[:200]}") from exc
+
+
+def _clean_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text or "").strip()
+
+
+def _format_vendor(sender: str) -> str:
+    name, addr = parseaddr(sender or "")
+    if name.strip():
+        return name.strip().strip('"')
+    if addr:
+        return addr.split("@", 1)[0]
+    return sender.strip()
+
+
+def _parse_amount(text: str) -> Dict[str, Any]:
+    for pattern in _AMOUNT_PATTERNS:
+        match = pattern.search(text)
+        if not match:
+            continue
+        if len(match.groups()) == 2:
+            g1, g2 = match.groups()
+            symbol_currency = {"£": "GBP", "$": "USD", "€": "EUR"}
+            currency = symbol_currency.get(g1, g1.upper())
+            display = f"{currency} {g2}"
+            try:
+                value = float(g2.replace(",", ""))
+            except ValueError:
+                value = None
+            return {"value": value, "currency": currency, "display": display}
+    return {"value": None, "currency": "", "display": ""}
+
+
+def _extract_match(pattern: re.Pattern[str], text: str) -> str:
+    match = pattern.search(text)
+    if not match:
+        return ""
+    if match.lastindex:
+        return str(match.group(1) or "").strip()
+    return str(match.group(0) or "").strip()
+
+
+def _parse_received_at(value: str) -> str | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    try:
+        return parsedate_to_datetime(text).astimezone(timezone.utc).isoformat()
+    except Exception:
+        return text
+
+
+def _confidence_for(record: Dict[str, Any]) -> str:
+    score = 0
+    if record["amount"]["display"]:
+        score += 1
+    if record.get("invoice_number"):
+        score += 1
+    if record.get("payment_reference"):
+        score += 1
+    if any(
+        record.get(key)
+        for key in ("account_number", "sort_code", "iban", "swift", "routing_number")
+    ):
+        score += 2
+    if record.get("due_date"):
+        score += 1
+    if score >= 4:
+        return "high"
+    if score >= 2:
+        return "medium"
+    return "low"
+
+
+def _warnings_for(record: Dict[str, Any]) -> List[str]:
+    warnings = []
+    if not record["amount"]["display"]:
+        warnings.append("No amount detected.")
+    if not any(
+        record.get(key)
+        for key in ("account_number", "sort_code", "iban", "swift", "routing_number")
+    ):
+        warnings.append("No bank account details detected.")
+    if not record.get("payment_reference") and not record.get("invoice_number"):
+        warnings.append("No invoice or payment reference detected.")
+    return warnings
+
+
+def _build_gmail_payment_record(summary: Dict[str, Any], detail: Dict[str, Any], existing: Dict[str, Any] | None) -> Dict[str, Any]:
+    subject = str(detail.get("subject") or summary.get("subject") or "").strip()
+    body = str(detail.get("body") or "").strip()
+    snippet = str(summary.get("snippet") or "").strip()
+    combined = "\n".join(part for part in (subject, snippet, body) if part).strip()
+    vendor = _format_vendor(str(detail.get("from") or summary.get("from") or ""))
+    amount = _parse_amount(combined)
+    record = _empty_record(f"gmail:{detail['id']}")
+    record.update(
+        {
+            "source": "gmail",
+            "source_label": "Gmail",
+            "status": existing.get("status") if existing else "needs_review",
+            "received_at": _parse_received_at(str(detail.get("date") or summary.get("date") or "")),
+            "updated_at": _now_iso(),
+            "vendor": vendor,
+            "title": subject,
+            "amount": amount,
+            "due_date": _extract_match(_DUE_RE, combined) or None,
+            "payee_name": vendor,
+            "account_holder": vendor,
+            "account_number": _extract_match(_ACCOUNT_NUMBER_RE, combined),
+            "sort_code": _extract_match(_SORT_CODE_RE, combined),
+            "iban": _extract_match(_IBAN_RE, combined),
+            "swift": _extract_match(_SWIFT_RE, combined),
+            "routing_number": _extract_match(_ROUTING_RE, combined),
+            "payment_reference": _extract_match(_REFERENCE_RE, combined),
+            "invoice_number": _extract_match(_INVOICE_RE, combined),
+            "preview_text": _clean_text(body or snippet)[:1500],
+            "attachments": existing.get("attachments", []) if existing else [],
+            "original": {
+                "label": str(detail.get("from") or summary.get("from") or ""),
+                "url": f"https://mail.google.com/mail/u/0/#all/{detail['id']}",
+                "message_id": str(detail.get("id") or ""),
+                "thread_id": str(detail.get("threadId") or summary.get("threadId") or ""),
+            },
+        }
+    )
+    record["confidence"] = _confidence_for(record)
+    record["warnings"] = _warnings_for(record)
+    return record
+
+
+def _load_requests() -> List[Dict[str, Any]]:
+    path = _requests_path()
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    items = data.get("requests") if isinstance(data, dict) else data
+    if not isinstance(items, list):
+        return []
+    return [_normalize_record(item, index=i) for i, item in enumerate(items) if isinstance(item, dict)]
+
+
+def _save_requests(requests: List[Dict[str, Any]]) -> None:
+    path = _requests_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "requests": requests,
+        "updated_at": _now_iso(),
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _source_statuses() -> List[Dict[str, Any]]:
+    env = load_env()
+    home = get_hermes_home()
+
+    gmail_token = home / "google_token.json"
+    email_address = str(env.get("EMAIL_ADDRESS") or "").strip()
+    slack_token = str(env.get("SLACK_BOT_TOKEN") or "").strip()
+
+    statuses = []
+    for source_id, label in PAYMENT_SOURCES:
+        if source_id == "gmail":
+            connected = gmail_token.exists()
+            statuses.append(
+                {
+                    "id": source_id,
+                    "label": label,
+                    "connected": connected,
+                    "detail": (
+                        "Google Workspace token is present."
+                        if connected
+                        else "Connect Google Workspace to scan Gmail invoices."
+                    ),
+                }
+            )
+        elif source_id == "email":
+            connected = bool(email_address)
+            statuses.append(
+                {
+                    "id": source_id,
+                    "label": label,
+                    "connected": connected,
+                    "detail": email_address if connected else "Configure the Email channel to ingest invoices.",
+                }
+            )
+        elif source_id == "uploads":
+            statuses.append(
+                {
+                    "id": source_id,
+                    "label": label,
+                    "connected": True,
+                    "detail": "Use the Files page to stage invoice PDFs and screenshots.",
+                }
+            )
+        elif source_id == "slack":
+            connected = bool(slack_token)
+            statuses.append(
+                {
+                    "id": source_id,
+                    "label": label,
+                    "connected": connected,
+                    "detail": (
+                        "Slack bot token is configured."
+                        if connected
+                        else "Slack capture can be added once the Slack channel is configured."
+                    ),
+                }
+            )
+    return statuses
+
+
+def list_payment_requests() -> Dict[str, Any]:
+    requests = _load_requests()
+    requests.sort(
+        key=lambda item: (
+            str(item.get("received_at") or ""),
+            str(item.get("updated_at") or ""),
+            str(item.get("id") or ""),
+        ),
+        reverse=True,
+    )
+    return {
+        "sources": _source_statuses(),
+        "requests": requests,
+        "storage_path": str(_requests_path()),
+    }
+
+
+def sync_gmail_payment_requests(
+    query: str = DEFAULT_GMAIL_QUERY,
+    max_results: int = DEFAULT_GMAIL_MAX_RESULTS,
+) -> Dict[str, Any]:
+    summaries = _run_google_api(["gmail", "search", query, "--max", str(max_results)])
+    if not isinstance(summaries, list):
+        raise RuntimeError("Gmail search returned an unexpected payload")
+
+    requests = _load_requests()
+    existing_by_id = {str(record.get("id")): record for record in requests}
+    imported = 0
+    updated = 0
+
+    for summary in summaries:
+        if not isinstance(summary, dict) or not summary.get("id"):
+            continue
+        detail = _run_google_api(["gmail", "get", str(summary["id"])])
+        if not isinstance(detail, dict) or not detail.get("id"):
+            continue
+        record_id = f"gmail:{detail['id']}"
+        existing = existing_by_id.get(record_id)
+        record = _build_gmail_payment_record(summary, detail, existing)
+        if existing is None:
+            requests.append(record)
+            existing_by_id[record_id] = record
+            imported += 1
+        else:
+            existing.update(record)
+            updated += 1
+
+    _save_requests(requests)
+    return {
+        "source": "gmail",
+        "query": query,
+        "fetched": len(summaries),
+        "imported": imported,
+        "updated": updated,
+        "requests": requests,
+    }
+
+
+def update_payment_status(payment_id: str, status: str) -> Dict[str, Any]:
+    normalized_status = str(status or "").strip()
+    if normalized_status not in PAYMENT_STATUSES:
+        raise ValueError(f"Unknown payment status: {status}")
+
+    requests = _load_requests()
+    for record in requests:
+        if str(record.get("id")) == payment_id:
+            record["status"] = normalized_status
+            record["updated_at"] = _now_iso()
+            _save_requests(requests)
+            return record
+    raise KeyError(payment_id)

--- a/hermes_cli/vault_para_triage.py
+++ b/hermes_cli/vault_para_triage.py
@@ -17,6 +17,8 @@ import logging
 import os
 import re
 import shlex
+import urllib.error
+import urllib.request
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -33,6 +35,16 @@ DEFAULT_REVIEW_DIR = "Resources/_Inbox Review"
 DEFAULT_AUDIT_ROOT = ".hermes/para-triage"
 DEFAULT_CAPTURE_ROOT = ".hermes/note-capture"
 DEFAULT_CONFIG_REL_PATH = ".hermes/para-triage.yaml"
+
+_CANONICAL_ROUTING_FIELDS = (
+    "target_id",
+    "target_class",
+    "logical_path",
+    "display_path",
+    "resolved_target_path",
+    "target_status",
+    "trust_boundary",
+)
 
 
 def _utc_now() -> datetime:
@@ -86,6 +98,11 @@ def _default_config() -> dict[str, Any]:
             "low_confidence_action": "review",
             "example_limit": 8,
             "rules": [],
+            "target_resolver": {
+                "enabled": False,
+                "api_url": "",
+                "timeout_seconds": 5.0,
+            },
         },
         "projection": {
             "stores": {
@@ -429,14 +446,53 @@ def _rule_decision(
             continue
         if _rules_match(rule, title=title, body=body, tags=tags):
             reason = str(rule.get("reason") or f"matched routing rule {idx}").strip()
-            return {
+            decision = {
                 "target": target,
                 "confidence": float(rule.get("confidence", 0.95)),
                 "reason": reason,
                 "source": "rule",
                 "needs_feedback": bool(rule.get("needs_feedback", False)),
             }
+            for key in _CANONICAL_ROUTING_FIELDS:
+                value = rule.get(key)
+                if value not in (None, ""):
+                    decision[key] = value
+            return decision
     return None
+
+
+def _target_resolver_config(config: dict[str, Any]) -> dict[str, Any]:
+    routing = config.get("routing") or {}
+    resolver = routing.get("target_resolver") or {}
+    return resolver if isinstance(resolver, dict) else {}
+
+
+def _resolver_api_url(config: dict[str, Any]) -> str:
+    resolver = _target_resolver_config(config)
+    configured = str(resolver.get("api_url") or "").strip()
+    if configured:
+        return configured
+    for env_name in ("HERMES_NOTE_TARGET_RESOLVER_URL", "NOTE_CAPTURE_TARGET_RESOLVER_URL"):
+        value = os.getenv(env_name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _resolver_enabled(config: dict[str, Any]) -> bool:
+    resolver = _target_resolver_config(config)
+    if bool(resolver.get("enabled", False)):
+        return True
+    return bool(_resolver_api_url(config))
+
+
+def _resolver_timeout_seconds(config: dict[str, Any]) -> float:
+    resolver = _target_resolver_config(config)
+    try:
+        timeout = float(resolver.get("timeout_seconds", 5.0) or 5.0)
+    except (TypeError, ValueError):
+        timeout = 5.0
+    return max(timeout, 0.1)
 
 
 def _normalize_target(target: str, *, vault_path: Path, config: dict[str, Any]) -> str:
@@ -445,6 +501,7 @@ def _normalize_target(target: str, *, vault_path: Path, config: dict[str, Any]) 
         return str(config.get("review_dir") or DEFAULT_REVIEW_DIR)
     first = target.split("/", 1)[0].lower()
     allowed_roots = {str(v).split("/", 1)[0].lower() for v in (config.get("para_roots") or {}).values()}
+    allowed_roots.add(str(config.get("inbox_dir") or "Inbox").split("/", 1)[0].lower())
     allowed_roots.add(str(config.get("review_dir") or DEFAULT_REVIEW_DIR).split("/", 1)[0].lower())
     if first not in allowed_roots:
         return str(config.get("review_dir") or DEFAULT_REVIEW_DIR)
@@ -474,6 +531,123 @@ def _parse_json_object(text: str) -> dict[str, Any]:
             except json.JSONDecodeError:
                 return {}
     return {}
+
+
+def _copy_canonical_routing_fields(source: dict[str, Any], dest: dict[str, Any]) -> dict[str, Any]:
+    for key in _CANONICAL_ROUTING_FIELDS:
+        value = source.get(key)
+        if value not in (None, ""):
+            dest[key] = str(value).strip()
+    return dest
+
+
+def _normalize_resolver_decision(
+    decision: dict[str, Any],
+    *,
+    vault_path: Path,
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    canonical_target = decision.get("canonical_target") or {}
+    if not isinstance(canonical_target, dict):
+        canonical_target = {}
+    merged = dict(canonical_target)
+    for key in (
+        "target",
+        "target_id",
+        "target_class",
+        "logical_path",
+        "display_path",
+        "resolved_target_path",
+        "target_status",
+        "trust_boundary",
+    ):
+        value = decision.get(key)
+        if value not in (None, "") and key not in merged:
+            merged[key] = value
+
+    raw_target = ""
+    for key in ("resolved_target_path", "target", "display_path"):
+        candidate = str(merged.get(key) or "").strip()
+        if candidate:
+            raw_target = candidate
+            break
+
+    normalized = {
+        "target": _normalize_target(raw_target, vault_path=vault_path, config=config),
+        "confidence": float(decision.get("confidence", 0.0) or 0.0),
+        "reason": str(decision.get("reason") or "resolved by target resolver").strip() or "resolved by target resolver",
+        "source": str(decision.get("source") or "target_resolver"),
+        "needs_feedback": bool(decision.get("needs_feedback", False)),
+    }
+    return _copy_canonical_routing_fields(merged, normalized)
+
+
+def _resolver_decision(
+    *,
+    title: str,
+    body: str,
+    tags: list[str],
+    targets: list[str],
+    examples: list[dict[str, Any]],
+    config: dict[str, Any],
+    vault_path: Path,
+    state_root: Path,
+    structure: dict[str, Any],
+) -> dict[str, Any] | None:
+    if not _resolver_enabled(config):
+        return None
+
+    api_url = _resolver_api_url(config)
+    if not api_url:
+        return None
+
+    payload = {
+        "note": {
+            "title": title,
+            "tags": tags,
+            "body": body,
+            "excerpt": _excerpt(body, 1600),
+        },
+        "allowed_targets": targets,
+        "review_target": str(config.get("review_dir") or DEFAULT_REVIEW_DIR),
+        "examples": examples,
+        "vault_path": str(vault_path),
+        "state_root": str(state_root),
+        "structure": structure,
+    }
+    body_bytes = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    request = urllib.request.Request(
+        api_url,
+        method="POST",
+        data=body_bytes,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+    )
+    timeout = _resolver_timeout_seconds(config)
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        raw = response.read().decode("utf-8")
+
+    parsed: Any
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        parsed = _parse_json_object(raw)
+
+    if not isinstance(parsed, dict):
+        raise ValueError("target resolver returned a non-object")
+
+    decision = parsed
+    for wrapper_key in ("decision", "result", "data"):
+        wrapped = decision.get(wrapper_key)
+        if isinstance(wrapped, dict):
+            decision = wrapped
+            break
+
+    if not isinstance(decision, dict):
+        raise ValueError("target resolver returned a non-object decision")
+    return _normalize_resolver_decision(decision, vault_path=vault_path, config=config)
 
 
 def _llm_decision(
@@ -552,6 +726,7 @@ def _classify_note(
     state_root: Path,
     structure: dict[str, Any],
     classifier: Callable[..., dict[str, Any]] | None = None,
+    target_resolver: Callable[..., dict[str, Any] | None] | None = None,
 ) -> dict[str, Any]:
     rule_hit = _rule_decision(config, title=title, body=body, tags=tags)
     if rule_hit:
@@ -564,6 +739,35 @@ def _classify_note(
         tags=tags,
         limit=int(((config.get("routing") or {}).get("example_limit")) or 8),
     )
+
+    try:
+        resolver_decision = target_resolver(
+            title=title,
+            body=body,
+            tags=tags,
+            targets=list(structure.get("targets") or []),
+            examples=examples,
+            config=config,
+            vault_path=vault_path,
+            state_root=state_root,
+            structure=structure,
+        ) if target_resolver else _resolver_decision(
+            title=title,
+            body=body,
+            tags=tags,
+            targets=list(structure.get("targets") or []),
+            examples=examples,
+            config=config,
+            vault_path=vault_path,
+            state_root=state_root,
+            structure=structure,
+        )
+    except Exception as exc:
+        logger.warning("Vault target resolver failed: %s", exc)
+        resolver_decision = None
+
+    if isinstance(resolver_decision, dict):
+        return _normalize_resolver_decision(resolver_decision, vault_path=vault_path, config=config)
 
     try:
         decision = classifier(
@@ -598,7 +802,7 @@ def _classify_note(
         "source": str(decision.get("source") or "llm"),
         "needs_feedback": bool(decision.get("needs_feedback", False)),
     }
-    return normalized
+    return _copy_canonical_routing_fields(decision, normalized)
 
 
 def _move_note(
@@ -774,6 +978,7 @@ def run_triage(
     config_path: str | Path | None = None,
     config_override: dict[str, Any] | None = None,
     classifier: Callable[..., dict[str, Any]] | None = None,
+    target_resolver: Callable[..., dict[str, Any] | None] | None = None,
     dry_run: bool = False,
     limit: int | None = None,
 ) -> dict[str, Any]:
@@ -813,6 +1018,7 @@ def run_triage(
             state_root=state_root,
             structure=structure,
             classifier=classifier,
+            target_resolver=target_resolver,
         )
 
         target = str(decision.get("target") or config.get("review_dir") or DEFAULT_REVIEW_DIR)
@@ -903,6 +1109,10 @@ def run_triage(
             "canonical_content": rendered,
             "sync_contract": _sync_contract(config),
         }
+        for key in _CANONICAL_ROUTING_FIELDS:
+            value = decision.get(key)
+            if value not in (None, ""):
+                capture_event["routing"][key] = value
         if not dry_run:
             _json_dump(_capture_event_path(capture_root, entry_id), capture_event)
 
@@ -925,6 +1135,10 @@ def run_triage(
             "archived_path": archived_rel,
             "stores": sorted(staged_projection_paths),
         }
+        for key in _CANONICAL_ROUTING_FIELDS:
+            value = decision.get(key)
+            if value not in (None, ""):
+                event[key] = value
         processed.append(event)
         if not dry_run:
             _jsonl_append(_audit_events_path(state_root), event)

--- a/hermes_cli/vault_para_triage.py
+++ b/hermes_cli/vault_para_triage.py
@@ -1,0 +1,1443 @@
+"""PARA vault inbox triage helpers shared by the skill script and Slack plugin.
+
+The workflow is intentionally edge-scoped:
+
+* notes are read from an Obsidian-style vault inbox
+* missing YAML frontmatter is added deterministically
+* routing decisions are logged to an immutable audit trail
+* user corrections are stored as examples for future runs
+* Slack-facing commands call these helpers rather than touching core tools
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import shlex
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+import yaml
+
+from agent.skill_utils import parse_frontmatter
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REVIEW_DIR = "Resources/_Inbox Review"
+DEFAULT_AUDIT_ROOT = ".hermes/para-triage"
+DEFAULT_CAPTURE_ROOT = ".hermes/note-capture"
+DEFAULT_CONFIG_REL_PATH = ".hermes/para-triage.yaml"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _iso_now() -> str:
+    return _utc_now().isoformat().replace("+00:00", "Z")
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in (override or {}).items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _default_config() -> dict[str, Any]:
+    return {
+        "inbox_dir": "Inbox",
+        "para_roots": {
+            "projects": "Projects",
+            "areas": "Areas",
+            "resources": "Resources",
+            "archives": "Archives",
+        },
+        "review_dir": DEFAULT_REVIEW_DIR,
+        "audit": {
+            "root": DEFAULT_AUDIT_ROOT,
+        },
+        "capture": {
+            "root": DEFAULT_CAPTURE_ROOT,
+            "source_archive_dir": "source-archive",
+        },
+        "frontmatter": {
+            "title_field": "title",
+            "created_field": "created",
+            "updated_field": "updated",
+            "tags_field": "tags",
+            "triage_status_field": "para_triage_status",
+            "triage_target_field": "para_target",
+            "triage_confidence_field": "para_confidence",
+            "triage_reason_field": "para_reason",
+            "triaged_at_field": "para_triaged_at",
+        },
+        "routing": {
+            "min_confidence": 0.7,
+            "low_confidence_action": "review",
+            "example_limit": 8,
+            "rules": [],
+        },
+        "projection": {
+            "stores": {
+                "vault": {
+                    "enabled": True,
+                    "path_prefix": "",
+                },
+                "second_brain": {
+                    "enabled": True,
+                    "path_prefix": "",
+                },
+            }
+        },
+    }
+
+
+def resolve_vault_path(explicit: str | Path | None = None) -> Path:
+    """Resolve the Obsidian vault path from an explicit arg, env, or fallback."""
+    candidates: list[Path] = []
+    if explicit:
+        candidates.append(Path(explicit).expanduser())
+
+    env_path = os.getenv("OBSIDIAN_VAULT_PATH", "").strip()
+    if env_path:
+        candidates.append(Path(env_path).expanduser())
+
+    candidates.append(Path("~/Documents/Obsidian Vault").expanduser())
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate.resolve()
+
+    first = candidates[0]
+    raise FileNotFoundError(
+        f"Could not resolve Obsidian vault path. Checked: {', '.join(str(p) for p in candidates)}. "
+        f"Set OBSIDIAN_VAULT_PATH or pass --vault. First missing candidate: {first}"
+    )
+
+
+def _resolve_config_path(vault_path: Path, explicit: str | Path | None = None) -> Path:
+    if explicit:
+        return Path(explicit).expanduser().resolve()
+    return (vault_path / DEFAULT_CONFIG_REL_PATH).resolve()
+
+
+def load_config(
+    vault_path: Path,
+    *,
+    config_path: str | Path | None = None,
+    config_override: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], Path]:
+    """Load triage config from YAML and merge it with defaults."""
+    resolved_config_path = _resolve_config_path(vault_path, config_path)
+    loaded: dict[str, Any] = {}
+    if resolved_config_path.exists():
+        data = yaml.safe_load(resolved_config_path.read_text(encoding="utf-8")) or {}
+        if not isinstance(data, dict):
+            raise ValueError(f"{resolved_config_path} must contain a YAML mapping")
+        loaded = data
+    merged = _deep_merge(_default_config(), loaded)
+    if config_override:
+        merged = _deep_merge(merged, config_override)
+    return merged, resolved_config_path
+
+
+def _state_root(vault_path: Path, config: dict[str, Any]) -> Path:
+    configured = str(((config.get("audit") or {}).get("root")) or DEFAULT_AUDIT_ROOT).strip()
+    root = Path(configured).expanduser()
+    if not root.is_absolute():
+        root = vault_path / root
+    return root.resolve()
+
+
+def _capture_root(vault_path: Path, config: dict[str, Any]) -> Path:
+    configured = str(((config.get("capture") or {}).get("root")) or DEFAULT_CAPTURE_ROOT).strip()
+    root = Path(configured).expanduser()
+    if not root.is_absolute():
+        root = vault_path / root
+    return root.resolve()
+
+
+def _source_archive_root(vault_path: Path, config: dict[str, Any]) -> Path:
+    configured = str(((config.get("capture") or {}).get("source_archive_dir")) or "source-archive").strip()
+    root = Path(configured).expanduser()
+    if root.is_absolute():
+        return root.resolve()
+    return (_capture_root(vault_path, config) / configured).resolve()
+
+
+def _ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _json_load(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.warning("Could not parse %s; returning default", path)
+        return default
+
+
+def _json_dump(path: Path, payload: Any) -> None:
+    _ensure_dir(path.parent)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _jsonl_append(path: Path, payload: dict[str, Any]) -> None:
+    _ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed JSONL row in %s", path)
+                continue
+            if isinstance(item, dict):
+                rows.append(item)
+    return rows
+
+
+def _slugify(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-") or "note"
+
+
+def _extract_tags(frontmatter: dict[str, Any], field_name: str) -> list[str]:
+    raw = frontmatter.get(field_name, [])
+    if isinstance(raw, str):
+        pieces = [raw]
+    elif isinstance(raw, list):
+        pieces = raw
+    else:
+        pieces = []
+    out: list[str] = []
+    for piece in pieces:
+        text = str(piece or "").strip().lstrip("#")
+        if text and text not in out:
+            out.append(text)
+    return out
+
+
+def _extract_title(frontmatter: dict[str, Any], body: str, path: Path, *, title_field: str) -> str:
+    title = str(frontmatter.get(title_field) or "").strip()
+    if title:
+        return title
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            return stripped.lstrip("#").strip()
+    return path.stem.replace("-", " ").replace("_", " ").strip() or path.stem
+
+
+def _excerpt(text: str, limit: int = 280) -> str:
+    compact = re.sub(r"\s+", " ", text or "").strip()
+    return compact[:limit]
+
+
+def _render_note(frontmatter: dict[str, Any], body: str) -> str:
+    yaml_text = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip()
+    rendered_body = body.lstrip("\n")
+    if rendered_body:
+        return f"---\n{yaml_text}\n---\n\n{rendered_body}\n"
+    return f"---\n{yaml_text}\n---\n"
+
+
+def _unique_destination(path: Path) -> Path:
+    if not path.exists():
+        return path
+    stem = path.stem
+    suffix = path.suffix
+    for idx in range(2, 1000):
+        candidate = path.with_name(f"{stem} {idx}{suffix}")
+        if not candidate.exists():
+            return candidate
+    raise FileExistsError(f"Could not find a free destination for {path}")
+
+
+def _normalize_relative(path: Path, vault_path: Path) -> str:
+    return str(path.resolve().relative_to(vault_path.resolve())).replace("\\", "/")
+
+
+def _normalize_low_confidence_action(config: dict[str, Any]) -> str:
+    action = str(((config.get("routing") or {}).get("low_confidence_action")) or "review").strip().lower()
+    if action in {"review", "inbox", "auto-file"}:
+        return action
+    return "review"
+
+
+def _enabled_projection_stores(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    stores = (config.get("projection") or {}).get("stores") or {}
+    enabled: dict[str, dict[str, Any]] = {}
+    for store_name, store_cfg in stores.items():
+        if not isinstance(store_cfg, dict):
+            continue
+        if not store_cfg.get("enabled", True):
+            continue
+        enabled[str(store_name)] = dict(store_cfg)
+    if enabled:
+        return enabled
+    return {"vault": {"enabled": True, "path_prefix": ""}}
+
+
+def _projection_relative_path(target: str, filename: str, store_cfg: dict[str, Any]) -> str:
+    prefix = str(store_cfg.get("path_prefix") or "").strip().strip("/\\")
+    rel = "/".join(part for part in (target.strip("/\\"), filename) if part)
+    if prefix:
+        rel = f"{prefix}/{rel}"
+    return rel.replace("\\", "/")
+
+
+def _inbox_path(vault_path: Path, config: dict[str, Any]) -> Path:
+    inbox_dir = str(config.get("inbox_dir") or "Inbox").strip().strip("/\\")
+    return (vault_path / inbox_dir).resolve()
+
+
+def _available_targets(vault_path: Path, config: dict[str, Any]) -> list[str]:
+    targets: list[str] = []
+    para_roots = config.get("para_roots") or {}
+    for rel_root in para_roots.values():
+        root = (vault_path / str(rel_root)).resolve()
+        if not root.exists():
+            continue
+        targets.append(_normalize_relative(root, vault_path))
+        for candidate in sorted(p for p in root.rglob("*") if p.is_dir()):
+            targets.append(_normalize_relative(candidate, vault_path))
+
+    review_dir = str(config.get("review_dir") or DEFAULT_REVIEW_DIR).strip()
+    if review_dir and review_dir not in targets:
+        targets.append(review_dir)
+    # Preserve order but dedupe.
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in targets:
+        if item not in seen:
+            ordered.append(item)
+            seen.add(item)
+    return ordered
+
+
+def capture_structure_memory(vault_path: Path, config: dict[str, Any], *, state_root: Path | None = None) -> dict[str, Any]:
+    """Snapshot PARA folder structure so later runs have stable context."""
+    targets = _available_targets(vault_path, config)
+    snapshot = {
+        "captured_at": _iso_now(),
+        "vault_path": str(vault_path),
+        "inbox_dir": str(config.get("inbox_dir") or "Inbox"),
+        "targets": targets,
+        "para_roots": dict(config.get("para_roots") or {}),
+    }
+    if state_root is not None:
+        _json_dump(state_root / "structure.json", snapshot)
+    return snapshot
+
+
+def _load_examples(state_root: Path) -> list[dict[str, Any]]:
+    data = _json_load(state_root / "routing_examples.json", {"examples": []})
+    examples = data.get("examples", []) if isinstance(data, dict) else []
+    return [x for x in examples if isinstance(x, dict)]
+
+
+def _save_examples(state_root: Path, examples: list[dict[str, Any]]) -> None:
+    _json_dump(state_root / "routing_examples.json", {"examples": examples})
+
+
+def _keyword_overlap(needles: Iterable[str], haystack: str) -> int:
+    lowered = haystack.lower()
+    total = 0
+    for needle in needles:
+        token = str(needle or "").strip().lower()
+        if token and token in lowered:
+            total += 1
+    return total
+
+
+def _best_examples(
+    state_root: Path,
+    *,
+    title: str,
+    body: str,
+    tags: list[str],
+    limit: int,
+) -> list[dict[str, Any]]:
+    haystack = " ".join([title, body, " ".join(tags)]).lower()
+    scored: list[tuple[int, dict[str, Any]]] = []
+    for example in _load_examples(state_root):
+        signals = example.get("signals") or []
+        if isinstance(signals, str):
+            signals = [signals]
+        score = _keyword_overlap(signals, haystack)
+        if score > 0:
+            scored.append((score, example))
+    scored.sort(key=lambda item: item[0], reverse=True)
+    return [example for _score, example in scored[:limit]]
+
+
+def _rules_match(
+    rule: dict[str, Any],
+    *,
+    title: str,
+    body: str,
+    tags: list[str],
+) -> bool:
+    haystack = " ".join([title, body]).lower()
+    match_any = [str(x).strip().lower() for x in rule.get("match_any", []) if str(x).strip()]
+    match_all = [str(x).strip().lower() for x in rule.get("match_all", []) if str(x).strip()]
+    tags_any = [str(x).strip().lower().lstrip("#") for x in rule.get("tags_any", []) if str(x).strip()]
+    if match_any and not any(token in haystack for token in match_any):
+        return False
+    if match_all and not all(token in haystack for token in match_all):
+        return False
+    if tags_any and not any(tag in {t.lower() for t in tags} for tag in tags_any):
+        return False
+    return bool(match_any or match_all or tags_any)
+
+
+def _rule_decision(
+    config: dict[str, Any],
+    *,
+    title: str,
+    body: str,
+    tags: list[str],
+) -> dict[str, Any] | None:
+    for idx, rule in enumerate((config.get("routing") or {}).get("rules", []), start=1):
+        if not isinstance(rule, dict):
+            continue
+        target = str(rule.get("target") or "").strip()
+        if not target:
+            continue
+        if _rules_match(rule, title=title, body=body, tags=tags):
+            reason = str(rule.get("reason") or f"matched routing rule {idx}").strip()
+            return {
+                "target": target,
+                "confidence": float(rule.get("confidence", 0.95)),
+                "reason": reason,
+                "source": "rule",
+                "needs_feedback": bool(rule.get("needs_feedback", False)),
+            }
+    return None
+
+
+def _normalize_target(target: str, *, vault_path: Path, config: dict[str, Any]) -> str:
+    target = (target or "").strip().strip("/\\")
+    if not target:
+        return str(config.get("review_dir") or DEFAULT_REVIEW_DIR)
+    first = target.split("/", 1)[0].lower()
+    allowed_roots = {str(v).split("/", 1)[0].lower() for v in (config.get("para_roots") or {}).values()}
+    allowed_roots.add(str(config.get("review_dir") or DEFAULT_REVIEW_DIR).split("/", 1)[0].lower())
+    if first not in allowed_roots:
+        return str(config.get("review_dir") or DEFAULT_REVIEW_DIR)
+    resolved = (vault_path / target).resolve()
+    vault_resolved = vault_path.resolve()
+    if not str(resolved).startswith(str(vault_resolved) + os.sep) and resolved != vault_resolved:
+        raise ValueError(f"Target escapes the vault: {target}")
+    return target.replace("\\", "/")
+
+
+def _parse_json_object(text: str) -> dict[str, Any]:
+    raw = (text or "").strip()
+    if raw.startswith("```"):
+        raw = raw.strip("`")
+        if "\n" in raw:
+            raw = raw.split("\n", 1)[1]
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else {}
+    except json.JSONDecodeError:
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start >= 0 and end > start:
+            try:
+                parsed = json.loads(raw[start : end + 1])
+                return parsed if isinstance(parsed, dict) else {}
+            except json.JSONDecodeError:
+                return {}
+    return {}
+
+
+def _llm_decision(
+    *,
+    title: str,
+    body: str,
+    tags: list[str],
+    targets: list[str],
+    examples: list[dict[str, Any]],
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    from agent.auxiliary_client import call_llm
+
+    prompt = {
+        "task": "Route this note into the user's PARA vault.",
+        "allowed_targets": targets,
+        "review_target": str(config.get("review_dir") or DEFAULT_REVIEW_DIR),
+        "examples": examples,
+        "note": {
+            "title": title,
+            "tags": tags,
+            "excerpt": _excerpt(body, 1600),
+        },
+        "rules": [
+            "Choose exactly one target from allowed_targets.",
+            "Prefer the narrowest existing folder that fits the note.",
+            "Use the review_target when uncertain.",
+            "Return JSON only.",
+        ],
+        "response_schema": {
+            "target": "string",
+            "confidence": "number 0..1",
+            "reason": "short string",
+            "needs_feedback": "boolean",
+        },
+    }
+    response = call_llm(
+        task="monitor",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You classify personal notes into an existing PARA vault. "
+                    "Return ONLY one JSON object with keys target, confidence, reason, needs_feedback."
+                ),
+            },
+            {"role": "user", "content": json.dumps(prompt, ensure_ascii=False)},
+        ],
+        max_tokens=500,
+        temperature=0,
+    )
+    content = getattr(response.choices[0].message, "content", "") or ""
+    parsed = _parse_json_object(str(content))
+    if not parsed:
+        raise ValueError("classifier returned no JSON object")
+    return parsed
+
+
+def _fallback_decision(config: dict[str, Any], reason: str) -> dict[str, Any]:
+    return {
+        "target": str(config.get("review_dir") or DEFAULT_REVIEW_DIR),
+        "confidence": 0.0,
+        "reason": reason,
+        "source": "fallback",
+        "needs_feedback": True,
+    }
+
+
+def _classify_note(
+    *,
+    title: str,
+    body: str,
+    tags: list[str],
+    vault_path: Path,
+    config: dict[str, Any],
+    state_root: Path,
+    structure: dict[str, Any],
+    classifier: Callable[..., dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    rule_hit = _rule_decision(config, title=title, body=body, tags=tags)
+    if rule_hit:
+        return rule_hit
+
+    examples = _best_examples(
+        state_root,
+        title=title,
+        body=body,
+        tags=tags,
+        limit=int(((config.get("routing") or {}).get("example_limit")) or 8),
+    )
+
+    try:
+        decision = classifier(
+            title=title,
+            body=body,
+            tags=tags,
+            targets=list(structure.get("targets") or []),
+            examples=examples,
+            config=config,
+            vault_path=vault_path,
+            state_root=state_root,
+            structure=structure,
+        ) if classifier else _llm_decision(
+            title=title,
+            body=body,
+            tags=tags,
+            targets=list(structure.get("targets") or []),
+            examples=examples,
+            config=config,
+        )
+    except Exception as exc:
+        logger.warning("Vault note classification failed: %s", exc)
+        return _fallback_decision(config, f"classifier failed: {exc}")
+
+    if not isinstance(decision, dict):
+        return _fallback_decision(config, "classifier returned a non-object")
+
+    normalized = {
+        "target": _normalize_target(str(decision.get("target") or ""), vault_path=vault_path, config=config),
+        "confidence": float(decision.get("confidence", 0.0) or 0.0),
+        "reason": str(decision.get("reason") or "classified").strip() or "classified",
+        "source": str(decision.get("source") or "llm"),
+        "needs_feedback": bool(decision.get("needs_feedback", False)),
+    }
+    return normalized
+
+
+def _move_note(
+    source_path: Path,
+    dest_rel: str,
+    *,
+    vault_path: Path,
+    content: str,
+) -> Path:
+    dest_dir = (vault_path / dest_rel).resolve()
+    _ensure_dir(dest_dir)
+    proposed = dest_dir / source_path.name
+    if proposed.resolve() == source_path.resolve():
+        dest_path = proposed
+    else:
+        dest_path = _unique_destination(proposed)
+    dest_path.write_text(content, encoding="utf-8")
+    if source_path.resolve() != dest_path.resolve() and source_path.exists():
+        source_path.unlink()
+    return dest_path
+
+
+def _capture_event_path(capture_root: Path, entry_id: str) -> Path:
+    return capture_root / "events" / f"{entry_id}.json"
+
+
+def _projection_status_path(capture_root: Path) -> Path:
+    return capture_root / "status" / "latest.json"
+
+
+def _stage_projection_file(
+    *,
+    capture_root: Path,
+    entry_id: str,
+    store_name: str,
+    relative_path: str,
+    content: str,
+    dry_run: bool,
+) -> tuple[str, Path]:
+    staged_rel = f"staging/{store_name}/{entry_id}/{relative_path}".replace("\\", "/")
+    staged_path = capture_root / staged_rel
+    if not dry_run:
+        _ensure_dir(staged_path.parent)
+        staged_path.write_text(content, encoding="utf-8")
+    return staged_rel, staged_path
+
+
+def _archive_source_note(
+    *,
+    source_path: Path,
+    vault_path: Path,
+    capture_root: Path,
+    source_archive_root: Path,
+    entry_id: str,
+    dry_run: bool,
+) -> tuple[str, Path]:
+    archived_rel = f"source-archive/{entry_id}/{_normalize_relative(source_path, vault_path)}".replace("\\", "/")
+    archived_path = capture_root / archived_rel
+    if dry_run:
+        return archived_rel, archived_path
+    _ensure_dir(source_archive_root / entry_id / Path(_normalize_relative(source_path, vault_path)).parent)
+    _ensure_dir(archived_path.parent)
+    archived_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
+    source_path.unlink()
+    return archived_rel, archived_path
+
+
+def _sync_contract(config: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "capture_model": "canonical_event_log",
+        "write_policy": "trusted_staging_only",
+        "projection_status_source": "structured_status",
+        "stores": sorted(_enabled_projection_stores(config)),
+    }
+
+
+def _summarize_projection_status(capture_root: Path, config: dict[str, Any]) -> dict[str, Any]:
+    events_dir = capture_root / "events"
+    stores: dict[str, dict[str, int]] = {}
+    total_events = 0
+    pending_events = 0
+    needs_feedback = 0
+    if events_dir.exists():
+        for event_path in sorted(events_dir.glob("*.json")):
+            event = _json_load(event_path, {})
+            if not isinstance(event, dict):
+                continue
+            total_events += 1
+            if event.get("needs_feedback"):
+                needs_feedback += 1
+            has_pending = False
+            projection = ((event.get("projection") or {}).get("stores")) or {}
+            for store_name, store_state in projection.items():
+                state = str((store_state or {}).get("state") or "unknown")
+                bucket = stores.setdefault(store_name, {})
+                bucket[state] = bucket.get(state, 0) + 1
+                if state == "pending":
+                    has_pending = True
+            if has_pending:
+                pending_events += 1
+    summary = {
+        "captured_at": _iso_now(),
+        "sync_contract": _sync_contract(config),
+        "total_events": total_events,
+        "pending_events": pending_events,
+        "needs_feedback": needs_feedback,
+        "stores": stores,
+        "memory_hint": (
+            "Hermes captures notes into a canonical internal event log first. "
+            "Vault and second-brain outputs are downstream staged projections; "
+            "check structured status for live sync health."
+        ),
+    }
+    _json_dump(_projection_status_path(capture_root), summary)
+    return summary
+
+
+def _make_feedback_example(event: dict[str, Any], target: str, action: str) -> dict[str, Any]:
+    tokens: list[str] = []
+    for field in ("title", "excerpt"):
+        for piece in re.findall(r"[A-Za-z0-9][A-Za-z0-9/_-]+", str(event.get(field) or "")):
+            lowered = piece.lower()
+            if lowered not in tokens:
+                tokens.append(lowered)
+    for tag in event.get("tags") or []:
+        lowered = str(tag or "").strip().lower()
+        if lowered and lowered not in tokens:
+            tokens.append(lowered)
+    return {
+        "entry_id": event["entry_id"],
+        "target": target,
+        "action": action,
+        "title": event.get("title", ""),
+        "signals": tokens[:16],
+        "excerpt": event.get("excerpt", ""),
+        "tags": event.get("tags") or [],
+        "learned_at": _iso_now(),
+    }
+
+
+def _feedback_files(state_root: Path) -> tuple[Path, Path]:
+    return state_root / "feedback.jsonl", state_root / "feedback_index.json"
+
+
+def _load_feedback_index(state_root: Path) -> dict[str, Any]:
+    data = _json_load(state_root / "feedback_index.json", {})
+    return data if isinstance(data, dict) else {}
+
+
+def _save_feedback_index(state_root: Path, payload: dict[str, Any]) -> None:
+    _json_dump(state_root / "feedback_index.json", payload)
+
+
+def _audit_events_path(state_root: Path) -> Path:
+    return state_root / "audit.jsonl"
+
+
+def load_audit_events(
+    *,
+    vault_path: Path | None = None,
+    config_path: str | Path | None = None,
+    config_override: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], Path, dict[str, Any], Path]:
+    vault = resolve_vault_path(vault_path)
+    config, _resolved_config_path = load_config(vault, config_path=config_path, config_override=config_override)
+    state_root = _ensure_dir(_state_root(vault, config))
+    return _read_jsonl(_audit_events_path(state_root)), vault, config, state_root
+
+
+def run_triage(
+    *,
+    vault_path: str | Path | None = None,
+    config_path: str | Path | None = None,
+    config_override: dict[str, Any] | None = None,
+    classifier: Callable[..., dict[str, Any]] | None = None,
+    dry_run: bool = False,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Capture inbox notes into a canonical event log and stage projections."""
+    vault = resolve_vault_path(vault_path)
+    config, resolved_config_path = load_config(vault, config_path=config_path, config_override=config_override)
+    state_root = _ensure_dir(_state_root(vault, config))
+    capture_root = _ensure_dir(_capture_root(vault, config))
+    source_archive_root = _ensure_dir(_source_archive_root(vault, config))
+    structure = capture_structure_memory(vault, config, state_root=state_root)
+    inbox = _inbox_path(vault, config)
+    _ensure_dir(inbox)
+    projection_stores = _enabled_projection_stores(config)
+
+    run_id = _utc_now().strftime("%Y%m%dT%H%M%SZ")
+    min_conf = float(((config.get("routing") or {}).get("min_confidence")) or 0.7)
+    low_conf_action = _normalize_low_confidence_action(config)
+
+    processed: list[dict[str, Any]] = []
+    note_paths = sorted(inbox.rglob("*.md"))
+    if limit is not None:
+        note_paths = note_paths[: max(limit, 0)]
+
+    for note_path in note_paths:
+        raw = note_path.read_text(encoding="utf-8")
+        frontmatter, body = parse_frontmatter(raw)
+        title_field = str(((config.get("frontmatter") or {}).get("title_field")) or "title")
+        tags_field = str(((config.get("frontmatter") or {}).get("tags_field")) or "tags")
+        title = _extract_title(frontmatter, body, note_path, title_field=title_field)
+        tags = _extract_tags(frontmatter, tags_field)
+        decision = _classify_note(
+            title=title,
+            body=body,
+            tags=tags,
+            vault_path=vault,
+            config=config,
+            state_root=state_root,
+            structure=structure,
+            classifier=classifier,
+        )
+
+        target = str(decision.get("target") or config.get("review_dir") or DEFAULT_REVIEW_DIR)
+        confidence = float(decision.get("confidence", 0.0) or 0.0)
+        needs_feedback = bool(decision.get("needs_feedback", False))
+        if confidence < min_conf:
+            needs_feedback = True
+            if low_conf_action == "review":
+                target = str(config.get("review_dir") or DEFAULT_REVIEW_DIR)
+            elif low_conf_action == "inbox":
+                target = _normalize_relative(note_path.parent, vault)
+
+        frontmatter = dict(frontmatter or {})
+        fields = config.get("frontmatter") or {}
+        created_field = str(fields.get("created_field") or "created")
+        updated_field = str(fields.get("updated_field") or "updated")
+        status_field = str(fields.get("triage_status_field") or "para_triage_status")
+        target_field = str(fields.get("triage_target_field") or "para_target")
+        conf_field = str(fields.get("triage_confidence_field") or "para_confidence")
+        reason_field = str(fields.get("triage_reason_field") or "para_reason")
+        triaged_at_field = str(fields.get("triaged_at_field") or "para_triaged_at")
+
+        frontmatter.setdefault(title_field, title)
+        frontmatter.setdefault(created_field, _iso_now())
+        frontmatter[updated_field] = _iso_now()
+        frontmatter[status_field] = "needs-feedback" if needs_feedback else "captured"
+        frontmatter[target_field] = target
+        frontmatter[conf_field] = round(confidence, 3)
+        frontmatter[reason_field] = str(decision.get("reason") or "").strip()
+        frontmatter[triaged_at_field] = _iso_now()
+
+        rendered = _render_note(frontmatter, body)
+        entry_id = f"{run_id}-{uuid.uuid4().hex[:8]}"
+        path_before = _normalize_relative(note_path, vault)
+        default_store = next(iter(projection_stores))
+        staged_projection_paths: dict[str, dict[str, Any]] = {}
+        default_projected_rel = _projection_relative_path(target, note_path.name, projection_stores[default_store])
+        for store_name, store_cfg in projection_stores.items():
+            projected_rel = _projection_relative_path(target, note_path.name, store_cfg)
+            staged_rel, _staged_path = _stage_projection_file(
+                capture_root=capture_root,
+                entry_id=entry_id,
+                store_name=store_name,
+                relative_path=projected_rel,
+                content=rendered,
+                dry_run=dry_run,
+            )
+            staged_projection_paths[store_name] = {
+                "state": "pending",
+                "target_relative_path": projected_rel,
+                "staged_relative_path": staged_rel,
+            }
+        archived_rel, _archived_path = _archive_source_note(
+            source_path=note_path,
+            vault_path=vault,
+            capture_root=capture_root,
+            source_archive_root=source_archive_root,
+            entry_id=entry_id,
+            dry_run=dry_run,
+        )
+
+        capture_event = {
+            "event_id": entry_id,
+            "run_id": run_id,
+            "captured_at": _iso_now(),
+            "capture_model": "canonical_event_log",
+            "status": "needs_feedback" if needs_feedback else "projection_pending",
+            "needs_feedback": needs_feedback,
+            "content_class": "vault_note",
+            "vault_path": str(vault),
+            "config_path": str(resolved_config_path),
+            "title": title,
+            "tags": tags,
+            "source": {
+                "original_relative_path": path_before,
+                "archived_relative_path": archived_rel,
+                "filename": note_path.name,
+            },
+            "routing": {
+                "target": target,
+                "confidence": confidence,
+                "reason": str(decision.get("reason") or "").strip(),
+                "source": str(decision.get("source") or "llm"),
+            },
+            "projection": {
+                "stores": staged_projection_paths,
+            },
+            "canonical_content": rendered,
+            "sync_contract": _sync_contract(config),
+        }
+        if not dry_run:
+            _json_dump(_capture_event_path(capture_root, entry_id), capture_event)
+
+        event = {
+            "entry_id": entry_id,
+            "run_id": run_id,
+            "timestamp": _iso_now(),
+            "title": title,
+            "tags": tags,
+            "source": str(decision.get("source") or "llm"),
+            "reason": str(decision.get("reason") or "").strip(),
+            "confidence": confidence,
+            "needs_feedback": needs_feedback,
+            "path_before": path_before,
+            "path_after": default_projected_rel,
+            "target": target,
+            "status": "dry-run" if dry_run else "captured",
+            "excerpt": _excerpt(body, 300),
+            "config_path": str(resolved_config_path),
+            "archived_path": archived_rel,
+            "stores": sorted(staged_projection_paths),
+        }
+        processed.append(event)
+        if not dry_run:
+            _jsonl_append(_audit_events_path(state_root), event)
+
+    latest = {
+        "run_id": run_id,
+        "timestamp": _iso_now(),
+        "processed": len(processed),
+        "needs_feedback": sum(1 for item in processed if item["needs_feedback"]),
+        "config_path": str(resolved_config_path),
+        "vault_path": str(vault),
+    }
+    if not dry_run:
+        _json_dump(state_root / "latest_run.json", latest)
+        projection_summary = _summarize_projection_status(capture_root, config)
+    else:
+        projection_summary = {
+            "sync_contract": _sync_contract(config),
+            "total_events": len(processed),
+            "pending_events": len(processed),
+            "needs_feedback": sum(1 for item in processed if item["needs_feedback"]),
+            "stores": {store_name: {"pending": len(processed)} for store_name in projection_stores},
+        }
+
+    return {
+        "run_id": run_id,
+        "vault_path": str(vault),
+        "config_path": str(resolved_config_path),
+        "state_root": str(state_root),
+        "capture_root": str(capture_root),
+        "processed": processed,
+        "projection_status": projection_summary,
+        "counts": {
+            "processed": len(processed),
+            "needs_feedback": sum(1 for item in processed if item["needs_feedback"]),
+            "captured": sum(1 for item in processed if item["status"] == "captured"),
+        },
+        "dry_run": dry_run,
+    }
+
+
+def list_pending_feedback(
+    *,
+    vault_path: str | Path | None = None,
+    config_path: str | Path | None = None,
+    config_override: dict[str, Any] | None = None,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    events, _vault, _config, state_root = load_audit_events(
+        vault_path=vault_path,
+        config_path=config_path,
+        config_override=config_override,
+    )
+    feedback_index = _load_feedback_index(state_root)
+    pending: list[dict[str, Any]] = []
+    for event in reversed(events):
+        if not event.get("needs_feedback"):
+            continue
+        status = (feedback_index.get(event["entry_id"]) or {}).get("action")
+        if status in {"approve", "correct", "ignore"}:
+            continue
+        pending.append(event)
+        if len(pending) >= max(limit, 0):
+            break
+    return pending
+
+
+def feedback_status(
+    *,
+    vault_path: str | Path | None = None,
+    config_path: str | Path | None = None,
+    config_override: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    events, vault, config, state_root = load_audit_events(
+        vault_path=vault_path,
+        config_path=config_path,
+        config_override=config_override,
+    )
+    latest = _json_load(state_root / "latest_run.json", {})
+    feedback_log = _read_jsonl(state_root / "feedback.jsonl")
+    capture_root = _capture_root(vault, config)
+    projection_status = _json_load(_projection_status_path(capture_root), {})
+    return {
+        "vault_path": str(vault),
+        "pending": len(list_pending_feedback(vault_path=vault, config_path=config_path, config_override=config_override, limit=999999)),
+        "audited": len(events),
+        "feedback_events": len(feedback_log),
+        "latest_run": latest or None,
+        "projection_status": projection_status or None,
+    }
+
+
+def _find_event(events: list[dict[str, Any]], entry_id: str) -> dict[str, Any]:
+    for event in events:
+        if event.get("entry_id") == entry_id:
+            return event
+    raise KeyError(f"Audit entry not found: {entry_id}")
+
+
+def _load_capture_event(capture_root: Path, entry_id: str) -> dict[str, Any]:
+    payload = _json_load(_capture_event_path(capture_root, entry_id), {})
+    return payload if isinstance(payload, dict) else {}
+
+
+def _rewrite_projection_staging(
+    *,
+    vault: Path,
+    config: dict[str, Any],
+    capture_root: Path,
+    capture_event: dict[str, Any],
+    target: str,
+) -> str:
+    fields = config.get("frontmatter") or {}
+    raw = str(capture_event.get("canonical_content") or "")
+    frontmatter, body = parse_frontmatter(raw)
+    frontmatter[str(fields.get("triage_status_field") or "para_triage_status")] = "corrected"
+    frontmatter[str(fields.get("triage_target_field") or "para_target")] = target
+    frontmatter[str(fields.get("updated_field") or "updated")] = _iso_now()
+    rendered = _render_note(frontmatter, body)
+
+    projection = ((capture_event.get("projection") or {}).get("stores")) or {}
+    filename = str(((capture_event.get("source") or {}).get("filename")) or Path(str(capture_event.get("path_after") or "note.md")).name)
+    stores = _enabled_projection_stores(config)
+    relocated_path = ""
+    for store_name, store_cfg in stores.items():
+        projected_rel = _projection_relative_path(target, filename, store_cfg)
+        staged_rel, staged_path = _stage_projection_file(
+            capture_root=capture_root,
+            entry_id=str(capture_event.get("event_id") or ""),
+            store_name=store_name,
+            relative_path=projected_rel,
+            content=rendered,
+            dry_run=False,
+        )
+        old_rel = str((projection.get(store_name) or {}).get("staged_relative_path") or "")
+        if old_rel and old_rel != staged_rel:
+            old_path = capture_root / old_rel
+            if old_path.exists():
+                old_path.unlink()
+        projection[store_name] = {
+            "state": "pending",
+            "target_relative_path": projected_rel,
+            "staged_relative_path": staged_rel,
+        }
+        if not relocated_path:
+            relocated_path = projected_rel
+    capture_event["canonical_content"] = rendered
+    capture_event["status"] = "projection_pending"
+    capture_event["needs_feedback"] = False
+    capture_event["routing"] = dict(capture_event.get("routing") or {})
+    capture_event["routing"]["target"] = target
+    capture_event["projection"] = {"stores": projection}
+    _json_dump(_capture_event_path(capture_root, str(capture_event.get("event_id") or "")), capture_event)
+    _summarize_projection_status(capture_root, config)
+    return relocated_path
+
+
+def apply_feedback(
+    *,
+    action: str,
+    entry_id: str,
+    target: str | None = None,
+    reviewer: str = "user",
+    vault_path: str | Path | None = None,
+    config_path: str | Path | None = None,
+    config_override: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Persist reviewer feedback and update staged projection targets."""
+    normalized_action = str(action or "").strip().lower()
+    if normalized_action not in {"approve", "correct", "ignore"}:
+        raise ValueError("action must be one of: approve, correct, ignore")
+
+    events, vault, config, state_root = load_audit_events(
+        vault_path=vault_path,
+        config_path=config_path,
+        config_override=config_override,
+    )
+    event = _find_event(events, entry_id)
+    capture_root = _capture_root(vault, config)
+    capture_event = _load_capture_event(capture_root, entry_id)
+    resolved_target = None
+    relocated_path = None
+    if normalized_action == "correct":
+        if not target:
+            raise ValueError("correct requires a target path")
+        resolved_target = _normalize_target(target, vault_path=vault, config=config)
+        if not capture_event:
+            raise KeyError(f"Capture event not found: {entry_id}")
+        relocated_path = _rewrite_projection_staging(
+            vault=vault,
+            config=config,
+            capture_root=capture_root,
+            capture_event=capture_event,
+            target=resolved_target,
+        )
+    elif normalized_action == "approve":
+        resolved_target = str(event.get("target") or "")
+        if capture_event:
+            capture_event["needs_feedback"] = False
+            capture_event["status"] = "projection_pending"
+            _json_dump(_capture_event_path(capture_root, entry_id), capture_event)
+            _summarize_projection_status(capture_root, config)
+
+    feedback_record = {
+        "entry_id": entry_id,
+        "action": normalized_action,
+        "reviewer": reviewer,
+        "timestamp": _iso_now(),
+        "target": resolved_target,
+        "relocated_path": relocated_path,
+    }
+    _jsonl_append(state_root / "feedback.jsonl", feedback_record)
+    feedback_index = _load_feedback_index(state_root)
+    feedback_index[entry_id] = feedback_record
+    _save_feedback_index(state_root, feedback_index)
+
+    if normalized_action in {"approve", "correct"} and resolved_target:
+        examples = _load_examples(state_root)
+        new_example = _make_feedback_example(event, resolved_target, normalized_action)
+        examples = [item for item in examples if item.get("entry_id") != entry_id]
+        examples.append(new_example)
+        _save_examples(state_root, examples[-200:])
+
+    return feedback_record
+
+
+def format_pending_feedback(items: list[dict[str, Any]]) -> str:
+    if not items:
+        return "No pending PARA feedback items."
+    lines = ["Pending PARA feedback:"]
+    for item in items:
+        lines.append(
+            f"- {item['entry_id']} | {item['path_after']} | conf={item['confidence']:.2f} | {item['reason']}"
+        )
+    return "\n".join(lines)
+
+
+def format_run_report(summary: dict[str, Any]) -> str:
+    counts = summary.get("counts") or {}
+    processed = summary.get("processed") or []
+    if not processed:
+        return "[SILENT]"
+
+    lines = [
+        (
+            f"Vault PARA triage run `{summary['run_id']}`: "
+            f"{counts.get('captured', 0)} captured, {counts.get('needs_feedback', 0)} need feedback."
+        ),
+        f"Vault: {summary['vault_path']}",
+    ]
+    for item in processed[:12]:
+        lines.append(
+            f"- {item['entry_id']} | {item['path_before']} -> staged:{item['path_after']} "
+            f"(conf={item['confidence']:.2f})"
+        )
+        if item.get("needs_feedback"):
+            lines.append(
+                f"  /para-feedback approve {item['entry_id']}  |  "
+                f"/para-feedback correct {item['entry_id']} {item['target']}"
+            )
+    remaining = len(processed) - 12
+    if remaining > 0:
+        lines.append(f"...and {remaining} more item(s).")
+    lines.append("On-demand audit: /para-feedback status | /para-feedback list")
+    return "\n".join(lines)
+
+
+def _format_status(status: dict[str, Any]) -> str:
+    lines = [
+        f"Vault: {status['vault_path']}",
+        f"Audited entries: {status['audited']}",
+        f"Pending feedback: {status['pending']}",
+        f"Feedback events: {status['feedback_events']}",
+    ]
+    latest = status.get("latest_run")
+    if latest:
+        lines.append(
+            f"Latest run: {latest.get('run_id')} at {latest.get('timestamp')} "
+            f"({latest.get('processed', 0)} processed)"
+        )
+    projection = status.get("projection_status") or {}
+    if projection:
+        lines.append(
+            f"Projection status: {projection.get('pending_events', 0)} pending event(s) "
+            f"across {len(projection.get('stores') or {})} store(s)"
+        )
+    return "\n".join(lines)
+
+
+def handle_feedback_command(raw_args: str) -> str:
+    """Slash-command entrypoint used by the Slack/plugin feedback surface."""
+    argv = shlex.split(raw_args or "")
+    if not argv or argv[0] in {"help", "-h", "--help"}:
+        return (
+            "/para-feedback list [limit]\n"
+            "/para-feedback approve <entry_id>\n"
+            "/para-feedback correct <entry_id> <target>\n"
+            "/para-feedback ignore <entry_id>\n"
+            "/para-feedback status"
+        )
+
+    action = argv[0].lower()
+    try:
+        if action == "list":
+            limit = int(argv[1]) if len(argv) > 1 else 20
+            return format_pending_feedback(list_pending_feedback(limit=limit))
+        if action == "status":
+            return _format_status(feedback_status())
+        if action == "approve":
+            if len(argv) < 2:
+                return "Usage: /para-feedback approve <entry_id>"
+            record = apply_feedback(action="approve", entry_id=argv[1], reviewer="slack")
+            return f"Approved {record['entry_id']}."
+        if action == "correct":
+            if len(argv) < 3:
+                return "Usage: /para-feedback correct <entry_id> <target>"
+            record = apply_feedback(
+                action="correct",
+                entry_id=argv[1],
+                target=" ".join(argv[2:]),
+                reviewer="slack",
+            )
+            return (
+                f"Corrected {record['entry_id']} to {record.get('target')}."
+                + (f" Relocated to {record['relocated_path']}." if record.get("relocated_path") else "")
+            )
+        if action == "ignore":
+            if len(argv) < 2:
+                return "Usage: /para-feedback ignore <entry_id>"
+            record = apply_feedback(action="ignore", entry_id=argv[1], reviewer="slack")
+            return f"Ignored {record['entry_id']}."
+    except Exception as exc:
+        return f"para-feedback error: {exc}"
+
+    return "Unknown para-feedback subcommand. Use: list, approve, correct, ignore, status."
+
+
+def install_cron_wrapper(
+    *,
+    vault_path: str | Path | None = None,
+    config_path: str | Path | None = None,
+    script_name: str = "vault-para-triage-nightly.py",
+    output_format: str = "slack",
+) -> Path:
+    """Write a cron-safe launcher under ``HERMES_HOME/scripts``.
+
+    Cron script jobs are constrained to that directory, so this helper bridges
+    the optional-skill install location and the scheduler's trusted script root.
+    """
+    vault = resolve_vault_path(vault_path)
+    resolved_config = _resolve_config_path(vault, config_path)
+    scripts_dir = get_hermes_home() / "scripts"
+    _ensure_dir(scripts_dir)
+
+    clean_name = Path(script_name).name
+    if not clean_name.endswith(".py"):
+        clean_name = f"{clean_name}.py"
+    target = (scripts_dir / clean_name).resolve()
+    try:
+        target.relative_to(scripts_dir.resolve())
+    except ValueError as exc:
+        raise ValueError(f"Wrapper path escapes scripts dir: {script_name}") from exc
+
+    content = (
+        "#!/usr/bin/env python3\n"
+        "\"\"\"Cron-safe PARA vault triage launcher.\"\"\"\n\n"
+        "import sys\n\n"
+        "from hermes_cli.vault_para_triage import main\n\n\n"
+        "if __name__ == \"__main__\":\n"
+        "    raise SystemExit(main([\n"
+        f"        \"--vault\", {str(vault)!r},\n"
+        f"        \"--config\", {str(resolved_config)!r},\n"
+        "        \"run\",\n"
+        f"        \"--format\", {output_format!r},\n"
+        "    ]))\n"
+    )
+    target.write_text(content, encoding="utf-8")
+    try:
+        target.chmod(0o755)
+    except OSError:
+        pass
+    return target
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="PARA vault inbox triage helper")
+    parser.add_argument("--vault", default=None, help="Absolute path to the Obsidian vault")
+    parser.add_argument("--config", default=None, help="Path to para-triage.yaml")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = sub.add_parser(
+        "run",
+        help="Process inbox notes into canonical capture events and staged PARA projections",
+    )
+    run_parser.add_argument("--dry-run", action="store_true", help="Do not write capture or staging files")
+    run_parser.add_argument("--limit", type=int, default=None, help="Maximum inbox notes to process")
+    run_parser.add_argument(
+        "--format",
+        choices=("text", "json", "slack"),
+        default="text",
+        help="Output format",
+    )
+
+    feedback_parser = sub.add_parser("feedback", help="Review or apply feedback to prior audit entries")
+    feedback_sub = feedback_parser.add_subparsers(dest="feedback_action", required=True)
+
+    feedback_list = feedback_sub.add_parser("list", help="List pending feedback items")
+    feedback_list.add_argument("--limit", type=int, default=20)
+
+    feedback_approve = feedback_sub.add_parser("approve", help="Approve an audit entry")
+    feedback_approve.add_argument("entry_id")
+
+    feedback_correct = feedback_sub.add_parser("correct", help="Correct an audit entry target")
+    feedback_correct.add_argument("entry_id")
+    feedback_correct.add_argument("target")
+
+    feedback_ignore = feedback_sub.add_parser("ignore", help="Ignore an audit entry")
+    feedback_ignore.add_argument("entry_id")
+
+    sub.add_parser("status", help="Summarize audit and feedback state")
+
+    install_wrapper = sub.add_parser(
+        "install-wrapper",
+        help="Write a cron-safe launcher into HERMES_HOME/scripts",
+    )
+    install_wrapper.add_argument(
+        "--name",
+        default="vault-para-triage-nightly.py",
+        help="Filename to create under HERMES_HOME/scripts",
+    )
+    install_wrapper.add_argument(
+        "--format",
+        choices=("text", "json", "slack"),
+        default="slack",
+        help="Output format used by the generated nightly wrapper",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "run":
+        summary = run_triage(
+            vault_path=args.vault,
+            config_path=args.config,
+            dry_run=args.dry_run,
+            limit=args.limit,
+        )
+        if args.format == "json":
+            print(json.dumps(summary, ensure_ascii=False, indent=2))
+        else:
+            print(format_run_report(summary))
+        return 0
+
+    if args.command == "status":
+        print(_format_status(feedback_status(vault_path=args.vault, config_path=args.config)))
+        return 0
+
+    if args.command == "install-wrapper":
+        target = install_cron_wrapper(
+            vault_path=args.vault,
+            config_path=args.config,
+            script_name=args.name,
+            output_format=args.format,
+        )
+        print(str(target))
+        return 0
+
+    if args.command == "feedback":
+        if args.feedback_action == "list":
+            print(
+                format_pending_feedback(
+                    list_pending_feedback(
+                        vault_path=args.vault,
+                        config_path=args.config,
+                        limit=args.limit,
+                    )
+                )
+            )
+            return 0
+        if args.feedback_action == "approve":
+            result = apply_feedback(
+                action="approve",
+                entry_id=args.entry_id,
+                reviewer="cli",
+                vault_path=args.vault,
+                config_path=args.config,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+        if args.feedback_action == "correct":
+            result = apply_feedback(
+                action="correct",
+                entry_id=args.entry_id,
+                target=args.target,
+                reviewer="cli",
+                vault_path=args.vault,
+                config_path=args.config,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+        if args.feedback_action == "ignore":
+            result = apply_feedback(
+                action="ignore",
+                entry_id=args.entry_id,
+                reviewer="cli",
+                vault_path=args.vault,
+                config_path=args.config,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7962,6 +7962,65 @@ async def instantiate_blueprint(body: AutomationBlueprintInstantiate, profile: s
 
 
 # ---------------------------------------------------------------------------
+# Payments dashboard endpoints — profile-scoped manual-payment review queue.
+# ---------------------------------------------------------------------------
+
+
+class PaymentStatusUpdate(BaseModel):
+    status: str
+
+
+class PaymentSyncRequest(BaseModel):
+    source: str = "gmail"
+    query: Optional[str] = None
+    max_results: Optional[int] = None
+
+
+@app.get("/api/payments")
+async def list_payments(profile: Optional[str] = None):
+    from hermes_cli import payments as payments_store
+
+    with _profile_scope(profile):
+        return payments_store.list_payment_requests()
+
+
+@app.post("/api/payments/{payment_id}/status")
+async def update_payment_status(
+    payment_id: str,
+    body: PaymentStatusUpdate,
+    profile: Optional[str] = None,
+):
+    from hermes_cli import payments as payments_store
+
+    with _profile_scope(profile):
+        try:
+            return payments_store.update_payment_status(payment_id, body.status)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail="Payment request not found") from exc
+
+
+@app.post("/api/payments/sync")
+async def sync_payments(body: PaymentSyncRequest, profile: Optional[str] = None):
+    from hermes_cli import payments as payments_store
+
+    source = (body.source or "gmail").strip().lower()
+    with _profile_scope(profile):
+        try:
+            if source != "gmail":
+                raise HTTPException(status_code=400, detail=f"Unsupported payment source: {source}")
+            return payments_store.sync_gmail_payment_requests(
+                query=body.query or payments_store.DEFAULT_GMAIL_QUERY,
+                max_results=int(body.max_results or payments_store.DEFAULT_GMAIL_MAX_RESULTS),
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
 # MCP server endpoints — list / add / remove / test.
 #
 # Wraps the same config data layer the CLI uses (hermes_cli.mcp_config), so

--- a/optional-skills/productivity/vault-para-triage/SKILL.md
+++ b/optional-skills/productivity/vault-para-triage/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: vault-para-triage
+description: Capture an Obsidian inbox into a canonical capture event log, stage PARA projections for downstream stores, and learn from Slack feedback.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [obsidian, para, vault, notes, cron, slack, routing, frontmatter]
+    category: productivity
+    related_skills: [obsidian, slack-surfaces]
+---
+
+# Vault PARA Triage
+
+Use this optional skill when the user wants Hermes to clean up an Obsidian inbox
+into a PARA-organized note system on a schedule, while keeping a canonical
+capture event log, downstream staged projections, an audit trail, and a review
+loop.
+
+This skill ships a helper script, `scripts/vault_para_triage.py`, backed by the
+shared `hermes_cli.vault_para_triage` module.
+
+## What it does
+
+For each markdown note in the configured inbox folder:
+
+1. ensures YAML frontmatter exists
+2. classifies the note into a canonical PARA target folder
+3. writes canonical markdown content into a capture event log
+4. stages one projected file per enabled downstream store
+5. archives the original inbox note into the capture root
+6. writes immutable audit and status records
+7. marks uncertain routes for review and learns from later feedback
+
+The review loop is designed to pair with the bundled `vault-triage-feedback`
+plugin, which exposes `/para-feedback` inside Slack and other chat surfaces.
+
+## Default paths
+
+- Vault path: `OBSIDIAN_VAULT_PATH`, otherwise `~/Documents/Obsidian Vault`
+- Config file: `<vault>/.hermes/para-triage.yaml`
+- Audit/state root: `<vault>/.hermes/para-triage/`
+- Capture root: `<vault>/.hermes/note-capture/`
+
+The capture root is the canonical handoff point for external sync jobs. Hermes
+does not write directly into the projected vault or second-brain destinations.
+
+## Locate the helper script
+
+```bash
+SCRIPT="$(find ~/.hermes/skills -path '*/vault-para-triage/scripts/vault_para_triage.py' -print -quit)"
+```
+
+If `SCRIPT` is empty, install the skill first.
+
+## Install
+
+```bash
+hermes skills search vault-para-triage
+hermes skills install official/productivity/vault-para-triage
+```
+
+Enable the feedback plugin so `/para-feedback` is available:
+
+```bash
+hermes plugins enable vault-triage-feedback
+```
+
+## Minimal config
+
+Create `<vault>/.hermes/para-triage.yaml`:
+
+```yaml
+inbox_dir: Inbox
+para_roots:
+  projects: Projects
+  areas: Areas
+  resources: Resources
+  archives: Archives
+review_dir: Resources/_Inbox Review
+capture:
+  root: .hermes/note-capture
+  source_archive_dir: source-archive
+projection:
+  stores:
+    vault:
+      enabled: true
+      path_prefix: ""
+    second_brain:
+      enabled: true
+      path_prefix: ""
+routing:
+  min_confidence: 0.72
+  low_confidence_action: review   # one of: review, inbox, auto-file
+  rules:
+    - name: health-notes
+      match_any: ["health", "doctor", "medication"]
+      target: Areas/Health
+      confidence: 0.95
+      reason: Health-related notes belong in Areas/Health.
+    - name: taxes
+      match_any: ["tax", "hmrc", "invoice"]
+      target: Areas/Finance
+      confidence: 0.95
+```
+
+Add more explicit rules as the vault evolves. The helper also stores learned
+examples from reviewer corrections under `.hermes/para-triage/routing_examples.json`.
+
+Projection rules:
+
+- Hermes first decides one canonical logical `target`, such as `Projects/Acme`
+  or `Resources/Content Library`.
+- For each enabled store, Hermes derives the projected relative path as
+  `<path_prefix>/<target>/<filename>`.
+- Hermes stages files under
+  `.hermes/note-capture/staging/<store>/<entry_id>/<projected-relative-path>`.
+- Hermes archives the original note under
+  `.hermes/note-capture/source-archive/<entry_id>/<original-relative-path>`.
+- Hermes records the canonical event under
+  `.hermes/note-capture/events/<entry_id>.json`.
+- External sync outside the Hermes trust boundary is responsible for projecting
+  staged files into the live vault, iCloud, second brain, or other stores.
+
+Low-confidence behavior:
+
+- `review` — stage uncertain notes to `review_dir`
+- `inbox` — keep uncertain notes mapped to their inbox-relative location
+- `auto-file` — still stage uncertain notes to the predicted target, then rely on Slack corrections
+
+## Dry-run and status
+
+Preview the next triage pass:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" run --dry-run
+```
+
+Inspect audit and review state:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" status
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" feedback list --limit 20
+```
+
+Inspect canonical capture status:
+
+```bash
+cat "$OBSIDIAN_VAULT_PATH/.hermes/note-capture/status/latest.json"
+```
+
+## Overnight cron job
+
+Use a script-only cron job so the canonical capture logic runs the same way
+every night and the output can be delivered directly to Slack.
+
+First install a cron-safe launcher into `~/.hermes/scripts/`:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" install-wrapper
+```
+
+This prints the generated path, usually:
+
+```text
+~/.hermes/scripts/vault-para-triage-nightly.py
+```
+
+Then schedule that generated wrapper:
+
+```bash
+hermes cron create "0 2 * * *" \
+  --name "Vault PARA triage" \
+  --deliver slack:C0B6MV5RA06 \
+  --script ~/.hermes/scripts/vault-para-triage-nightly.py \
+  --no-agent
+```
+
+For this rollout, `slack:C0B6MV5RA06` is the explicit `#hermes-ops` channel
+target. Using the raw Slack channel ID is safer than relying on name
+resolution.
+
+If the scheduler environment on your machine does not preserve
+`OBSIDIAN_VAULT_PATH`, the generated wrapper already bakes in the absolute vault
+and config path you passed to `install-wrapper`, so cron does not need that env
+var later.
+
+If you want a different filename or output mode:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" install-wrapper \
+  --name para-nightly-review.py \
+  --format slack
+```
+
+## Slack feedback loop
+
+After the nightly run posts to Slack, review uncertain entries with:
+
+```text
+/para-feedback list
+/para-feedback approve <entry_id>
+/para-feedback correct <entry_id> Areas/Health
+/para-feedback ignore <entry_id>
+/para-feedback status
+```
+
+For an on-demand audit summary, use:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" status
+```
+
+`approve` and `correct` both teach future runs. `correct` rewrites the staged
+projection targets for the current capture event to the supplied canonical
+target path.
+
+## Notes
+
+- The helper remembers the vault structure by snapshotting available PARA
+  folders on every run into `.hermes/para-triage/structure.json`.
+- Canonical captures are logged under `.hermes/note-capture/events/`.
+- Projected store health is summarized in `.hermes/note-capture/status/latest.json`.
+- All capture audit rows are logged to `.hermes/para-triage/audit.jsonl`.
+- Reviewer actions are logged separately to `.hermes/para-triage/feedback.jsonl`.
+- This keeps the capability outside Hermes core tools while still making it
+  schedulable and auditable.

--- a/optional-skills/productivity/vault-para-triage/scripts/vault_para_triage.py
+++ b/optional-skills/productivity/vault-para-triage/scripts/vault_para_triage.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Thin wrapper for the bundled PARA triage helper.
+
+When cron runs this file directly it passes no arguments, so default to the
+nightly Slack-friendly triage run. Manual invocations still accept the full CLI.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from hermes_cli.vault_para_triage import main
+
+
+if __name__ == "__main__":
+    argv = sys.argv[1:] or ["run", "--format", "slack"]
+    raise SystemExit(main(argv))

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3072,6 +3072,18 @@ class SlackAdapter(BasePlatformAdapter):
 
         return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 
+    def format_intercepted_clarify_response(
+        self,
+        event,
+        clarify_entry,
+        response_text: str,
+    ) -> Optional[str]:
+        """Echo a submitted clarify reply back into the Slack thread."""
+        text = (response_text or "").strip()
+        if not text:
+            return None
+        return f"📝 Submitted input:\n{text}"
+
     async def _handle_slash_confirm_action(self, ack, body, action) -> None:
         """Handle a slash-confirm button click from Block Kit."""
         await ack()

--- a/plugins/vault_triage_feedback/__init__.py
+++ b/plugins/vault_triage_feedback/__init__.py
@@ -1,0 +1,14 @@
+"""Plugin slash command for reviewing PARA vault triage audit items."""
+
+from __future__ import annotations
+
+from hermes_cli.vault_para_triage import handle_feedback_command
+
+
+def register(ctx) -> None:
+    ctx.register_command(
+        "para-feedback",
+        handle_feedback_command,
+        description="Review or correct PARA vault triage audit items",
+        args_hint="list|status|approve <entry_id>|correct <entry_id> <target>|ignore <entry_id>",
+    )

--- a/plugins/vault_triage_feedback/plugin.yaml
+++ b/plugins/vault_triage_feedback/plugin.yaml
@@ -1,0 +1,4 @@
+name: vault-triage-feedback
+version: 1.0.0
+description: "Expose /para-feedback so vault triage audit items can be reviewed and corrected from Slack and other chat surfaces."
+author: Hermes Agent

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2721,6 +2721,67 @@ class TestThreadReplyHandling:
         adapter.handle_message.assert_not_called()
 
 
+class TestClarifyEcho:
+    """Test that Slack echoes intercepted clarify replies back to the thread."""
+
+    @pytest.mark.asyncio
+    async def test_clarify_reply_is_posted_back_to_thread(self):
+        from tools.clarify_gateway import clear_session, register
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent, MessageType, SendResult
+        from gateway.session import SessionSource, build_session_key
+
+        config = PlatformConfig(enabled=True, token="xoxb-test-token")
+        adapter = SlackAdapter(config)
+        adapter._app = MagicMock()
+        adapter._bot_user_id = "U_BOT"
+        adapter._running = True
+        adapter._message_handler = AsyncMock(return_value=None)
+        adapter._send_with_retry = AsyncMock(
+            return_value=SendResult(success=True, message_id="999.000")
+        )
+
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="group",
+            user_id="U_USER",
+            thread_id="123.000",
+        )
+        event = MessageEvent(
+            text="Need more info",
+            source=source,
+            message_id="123.456",
+            message_type=MessageType.TEXT,
+        )
+        session_key = build_session_key(
+            source,
+            group_sessions_per_user=True,
+            thread_sessions_per_user=False,
+        )
+        adapter._active_sessions[session_key] = asyncio.Event()
+        adapter._session_tasks[session_key] = asyncio.current_task()
+        register(
+            clarify_id="clarify-1",
+            session_key=session_key,
+            question="Which folder?",
+            choices=None,
+        )
+
+        try:
+            await adapter.handle_message(event)
+        finally:
+            clear_session(session_key)
+            adapter._active_sessions.pop(session_key, None)
+            adapter._session_tasks.pop(session_key, None)
+
+        adapter._send_with_retry.assert_awaited_once()
+        send_kwargs = adapter._send_with_retry.await_args.kwargs
+        assert send_kwargs["chat_id"] == "C123"
+        assert send_kwargs["reply_to"] == "123.456"
+        assert send_kwargs["content"] == "📝 Submitted input:\nNeed more info"
+
+
 # ---------------------------------------------------------------------------
 # TestAssistantThreadLifecycle
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_payments.py
+++ b/tests/hermes_cli/test_payments.py
@@ -1,0 +1,217 @@
+"""Tests for the dashboard Payments storage and API surface."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: home)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: home)
+    monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: home / "config.yaml")
+    monkeypatch.setattr("hermes_cli.config.get_env_path", lambda: home / ".env")
+    try:
+        import hermes_cli.payments as payments
+
+        monkeypatch.setattr(payments, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(
+            payments,
+            "load_env",
+            lambda: {},
+        )
+    except Exception:
+        pass
+    return home
+
+
+def _write_requests(home: Path, requests: list[dict]) -> None:
+    payments_dir = home / "payments"
+    payments_dir.mkdir(parents=True, exist_ok=True)
+    (payments_dir / "requests.json").write_text(
+        json.dumps({"requests": requests}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+class TestPaymentsStore:
+    def test_list_requests_reports_sources_and_normalizes_records(self, isolated_home):
+        (isolated_home / "google_token.json").write_text('{"token": "x"}', encoding="utf-8")
+        (isolated_home / ".env").write_text("EMAIL_ADDRESS=bills@example.test\n", encoding="utf-8")
+        _write_requests(
+            isolated_home,
+            [
+                {
+                    "id": "pay-1",
+                    "source": "gmail",
+                    "source_label": "Gmail",
+                    "status": "new",
+                    "confidence": "high",
+                    "received_at": "2026-07-01T10:00:00+00:00",
+                    "vendor": "Example Vendor",
+                    "title": "July invoice",
+                    "amount": {"value": 42, "currency": "GBP", "display": "GBP 42.00"},
+                }
+            ],
+        )
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        result = payments.list_payment_requests()
+
+        gmail = next(source for source in result["sources"] if source["id"] == "gmail")
+        email = next(source for source in result["sources"] if source["id"] == "email")
+        uploads = next(source for source in result["sources"] if source["id"] == "uploads")
+
+        assert gmail["connected"] is True
+        assert email["connected"] is True
+        assert uploads["connected"] is True
+        assert result["requests"][0]["vendor"] == "Example Vendor"
+        assert result["requests"][0]["amount"]["display"] == "GBP 42.00"
+
+    def test_update_status_persists_change(self, isolated_home):
+        _write_requests(
+            isolated_home,
+            [
+                {
+                    "id": "pay-1",
+                    "status": "new",
+                    "vendor": "Example Vendor",
+                }
+            ],
+        )
+
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+        updated = payments.update_payment_status("pay-1", "paid")
+
+        assert updated["status"] == "paid"
+
+        saved = json.loads((isolated_home / "payments" / "requests.json").read_text(encoding="utf-8"))
+        assert saved["requests"][0]["status"] == "paid"
+        assert saved["requests"][0]["updated_at"]
+
+    def test_sync_gmail_payment_requests_extracts_fields(self, isolated_home, monkeypatch):
+        import hermes_cli.payments as payments
+
+        importlib.reload(payments)
+
+        def fake_run_google_api(args):
+            if args[:2] == ["gmail", "search"]:
+                return [
+                    {
+                        "id": "msg-1",
+                        "threadId": "thread-1",
+                        "from": "Acme Billing <billing@acme.test>",
+                        "subject": "Invoice INV-1001",
+                        "date": "Fri, 01 Jul 2026 12:00:00 +0000",
+                        "snippet": "Amount due GBP 42.00 by 2026-07-05",
+                        "labels": ["INBOX"],
+                    }
+                ]
+            if args[:2] == ["gmail", "get"]:
+                return {
+                    "id": "msg-1",
+                    "threadId": "thread-1",
+                    "from": "Acme Billing <billing@acme.test>",
+                    "subject": "Invoice INV-1001",
+                    "date": "Fri, 01 Jul 2026 12:00:00 +0000",
+                    "body": (
+                        "Invoice number: INV-1001\n"
+                        "Amount due: GBP 42.00\n"
+                        "Due date: 2026-07-05\n"
+                        "Sort code: 12-34-56\n"
+                        "Account number: 12345678\n"
+                        "Payment reference: ACME-1001\n"
+                    ),
+                }
+            raise AssertionError(args)
+
+        monkeypatch.setattr(payments, "_run_google_api", fake_run_google_api)
+
+        result = payments.sync_gmail_payment_requests(query="invoice", max_results=5)
+
+        assert result["imported"] == 1
+        saved = payments.list_payment_requests()["requests"][0]
+        assert saved["id"] == "gmail:msg-1"
+        assert saved["vendor"] == "Acme Billing"
+        assert saved["amount"]["display"] == "GBP 42.00"
+        assert saved["sort_code"] == "12-34-56"
+        assert saved["account_number"] == "12345678"
+        assert saved["payment_reference"] == "ACME-1001"
+        assert saved["invoice_number"] == "INV-1001"
+        assert saved["confidence"] in {"medium", "high"}
+
+
+class TestPaymentsApi:
+    @pytest.fixture(autouse=True)
+    def _setup_client(self, isolated_home, monkeypatch):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", isolated_home / "state.db")
+
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def test_list_and_update_payments(self, isolated_home):
+        _write_requests(
+            isolated_home,
+            [
+                {
+                    "id": "pay-1",
+                    "source": "gmail",
+                    "source_label": "Gmail",
+                    "status": "needs_review",
+                    "vendor": "Example Vendor",
+                    "title": "July invoice",
+                }
+            ],
+        )
+
+        listed = self.client.get("/api/payments")
+        assert listed.status_code == 200
+        payload = listed.json()
+        assert payload["requests"][0]["id"] == "pay-1"
+
+        updated = self.client.post("/api/payments/pay-1/status", json={"status": "ready_to_pay"})
+        assert updated.status_code == 200
+        assert updated.json()["status"] == "ready_to_pay"
+
+    def test_update_rejects_unknown_status(self):
+        updated = self.client.post("/api/payments/missing/status", json={"status": "bogus"})
+        assert updated.status_code == 400
+
+    def test_sync_payments_endpoint(self, monkeypatch):
+        import hermes_cli.payments as payments
+
+        def fake_sync(query, max_results):
+            assert query == payments.DEFAULT_GMAIL_QUERY
+            assert max_results == payments.DEFAULT_GMAIL_MAX_RESULTS
+            return {
+                "source": "gmail",
+                "query": query,
+                "fetched": 1,
+                "imported": 1,
+                "updated": 0,
+                "requests": [],
+            }
+
+        monkeypatch.setattr(payments, "sync_gmail_payment_requests", fake_sync)
+        resp = self.client.post("/api/payments/sync", json={"source": "gmail"})
+        assert resp.status_code == 200
+        assert resp.json()["imported"] == 1

--- a/tests/hermes_cli/test_vault_para_triage.py
+++ b/tests/hermes_cli/test_vault_para_triage.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_cli import vault_para_triage as triage
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    (vault / "Inbox").mkdir(parents=True)
+    (vault / "Projects").mkdir()
+    (vault / "Areas" / "Health").mkdir(parents=True)
+    (vault / "Resources" / "Reference").mkdir(parents=True)
+    (vault / "Resources" / "_Inbox Review").mkdir(parents=True)
+    (vault / "Archives").mkdir()
+    return vault
+
+
+def test_run_triage_adds_frontmatter_moves_note_and_writes_audit(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "doctor-follow-up.md"
+    note.write_text("Need to call the doctor tomorrow about blood tests.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        config_override={
+            "routing": {
+                "rules": [
+                    {
+                        "name": "health",
+                        "match_any": ["doctor", "blood test"],
+                        "target": "Areas/Health",
+                        "confidence": 0.96,
+                        "reason": "health note",
+                    }
+                ]
+            }
+        },
+    )
+
+    staged = vault / ".hermes" / "note-capture" / "staging" / "vault" / summary["processed"][0]["entry_id"] / "Areas" / "Health" / "doctor-follow-up.md"
+    assert staged.exists()
+    content = staged.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    assert "title: doctor follow up" in content.lower()
+    assert "para_target: Areas/Health" in content
+    assert "para_triage_status: captured" in content
+
+    audit_path = vault / ".hermes" / "para-triage" / "audit.jsonl"
+    audit_rows = triage._read_jsonl(audit_path)
+    assert len(audit_rows) == 1
+    assert audit_rows[0]["path_before"] == "Inbox/doctor-follow-up.md"
+    assert audit_rows[0]["path_after"] == "Areas/Health/doctor-follow-up.md"
+    assert summary["counts"]["captured"] == 1
+    assert not note.exists()
+
+    capture_event = json.loads(
+        (vault / ".hermes" / "note-capture" / "events" / f"{summary['processed'][0]['entry_id']}.json").read_text(encoding="utf-8")
+    )
+    assert capture_event["capture_model"] == "canonical_event_log"
+    assert sorted(capture_event["projection"]["stores"]) == ["second_brain", "vault"]
+
+    structure = json.loads((vault / ".hermes" / "para-triage" / "structure.json").read_text(encoding="utf-8"))
+    assert "Areas/Health" in structure["targets"]
+
+
+def test_apply_feedback_correct_relocates_note_and_learns_example(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "clinic-plan.md"
+    note.write_text("Follow up with the clinic and update my records.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        classifier=lambda **_: {
+            "target": "Resources/Reference",
+            "confidence": 0.31,
+            "reason": "not sure",
+            "needs_feedback": True,
+        },
+    )
+
+    event = summary["processed"][0]
+    initial = (
+        vault
+        / ".hermes"
+        / "note-capture"
+        / "staging"
+        / "vault"
+        / event["entry_id"]
+        / "Resources"
+        / "_Inbox Review"
+        / "clinic-plan.md"
+    )
+    assert initial.exists()
+
+    feedback = triage.apply_feedback(
+        action="correct",
+        entry_id=event["entry_id"],
+        target="Areas/Health",
+        vault_path=vault,
+    )
+
+    corrected = (
+        vault
+        / ".hermes"
+        / "note-capture"
+        / "staging"
+        / "vault"
+        / event["entry_id"]
+        / "Areas"
+        / "Health"
+        / "clinic-plan.md"
+    )
+    assert corrected.exists()
+    assert feedback["target"] == "Areas/Health"
+    assert feedback["relocated_path"] == "Areas/Health/clinic-plan.md"
+
+    pending = triage.list_pending_feedback(vault_path=vault)
+    assert pending == []
+
+    examples_path = vault / ".hermes" / "para-triage" / "routing_examples.json"
+    examples = json.loads(examples_path.read_text(encoding="utf-8"))["examples"]
+    assert examples[0]["entry_id"] == event["entry_id"]
+    assert examples[0]["target"] == "Areas/Health"
+
+
+def test_handle_feedback_command_lists_pending_items(tmp_path, monkeypatch):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "mystery-note.md"
+    note.write_text("A note that should probably be reviewed later.\n", encoding="utf-8")
+
+    triage.run_triage(
+        vault_path=vault,
+        classifier=lambda **_: {
+            "target": "Resources/Reference",
+            "confidence": 0.2,
+            "reason": "uncertain",
+            "needs_feedback": True,
+        },
+    )
+
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+    output = triage.handle_feedback_command("list")
+    assert "Pending PARA feedback" in output
+    assert "Resources/_Inbox Review/mystery-note.md" in output
+
+
+def test_low_confidence_action_inbox_keeps_note_in_inbox(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "unsure-note.md"
+    note.write_text("Something ambiguous that should stay for review.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        config_override={
+            "routing": {
+                "min_confidence": 0.8,
+                "low_confidence_action": "inbox",
+            }
+        },
+        classifier=lambda **_: {
+            "target": "Resources/Reference",
+            "confidence": 0.22,
+            "reason": "too ambiguous",
+            "needs_feedback": True,
+        },
+    )
+
+    kept = vault / "Inbox" / "unsure-note.md"
+    assert not kept.exists()
+    content = (
+        vault
+        / ".hermes"
+        / "note-capture"
+        / "staging"
+        / "vault"
+        / summary["processed"][0]["entry_id"]
+        / "Inbox"
+        / "unsure-note.md"
+    ).read_text(encoding="utf-8")
+    assert "para_triage_status: needs-feedback" in content
+    assert "para_target: Inbox" in content
+    assert summary["processed"][0]["path_after"] == "Inbox/unsure-note.md"
+
+
+def test_feedback_status_includes_projection_summary(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "ops.md"
+    note.write_text("Review the system and route this later.\n", encoding="utf-8")
+
+    triage.run_triage(
+        vault_path=vault,
+        classifier=lambda **_: {
+            "target": "Resources/Reference",
+            "confidence": 0.9,
+            "reason": "reference",
+            "needs_feedback": False,
+        },
+    )
+
+    status = triage.feedback_status(vault_path=vault)
+    assert status["projection_status"]["sync_contract"]["capture_model"] == "canonical_event_log"
+    assert status["projection_status"]["pending_events"] == 1
+
+
+def test_format_run_report_includes_on_demand_audit_hint():
+    report = triage.format_run_report(
+        {
+            "run_id": "20260712T020000Z",
+            "vault_path": "/tmp/vault",
+            "counts": {"captured": 1, "needs_feedback": 0},
+            "processed": [
+                {
+                    "entry_id": "entry-1",
+                    "path_before": "Inbox/example.md",
+                    "path_after": "Projects/Example/example.md",
+                    "confidence": 0.95,
+                    "needs_feedback": False,
+                }
+            ],
+        }
+    )
+
+    assert "On-demand audit: /para-feedback status | /para-feedback list" in report
+
+
+def test_projection_store_path_prefix_is_applied_to_staged_relative_path(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "launch-summary.md"
+    note.write_text("OpenAI launch notes and takeaways.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        config_override={
+            "projection": {
+                "stores": {
+                    "vault": {"enabled": True, "path_prefix": ""},
+                    "second_brain": {"enabled": True, "path_prefix": "runtime-source"},
+                }
+            },
+            "routing": {
+                "rules": [
+                    {
+                        "name": "launch",
+                        "match_any": ["launch", "takeaways"],
+                        "target": "Resources/Reference",
+                        "confidence": 0.99,
+                        "reason": "reference note",
+                    }
+                ]
+            },
+        },
+    )
+
+    event_id = summary["processed"][0]["entry_id"]
+    capture_event = json.loads(
+        (vault / ".hermes" / "note-capture" / "events" / f"{event_id}.json").read_text(encoding="utf-8")
+    )
+    second_brain = capture_event["projection"]["stores"]["second_brain"]
+    assert second_brain["target_relative_path"] == "runtime-source/Resources/Reference/launch-summary.md"
+    assert second_brain["staged_relative_path"] == (
+        f"staging/second_brain/{event_id}/runtime-source/Resources/Reference/launch-summary.md"
+    )
+
+
+def test_projection_summary_includes_memory_hint_and_enabled_stores(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "capture.md"
+    note.write_text("Something to route.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        config_override={
+            "projection": {
+                "stores": {
+                    "vault": {"enabled": True, "path_prefix": ""},
+                    "second_brain": {"enabled": False, "path_prefix": "runtime-source"},
+                }
+            },
+            "routing": {
+                "rules": [
+                    {
+                        "name": "capture",
+                        "match_any": ["route"],
+                        "target": "Resources/Reference",
+                        "confidence": 0.95,
+                        "reason": "reference note",
+                    }
+                ]
+            },
+        },
+    )
+
+    projection_status = summary["projection_status"]
+    assert projection_status["sync_contract"]["stores"] == ["vault"]
+    assert "downstream staged projections" in projection_status["memory_hint"]

--- a/tests/hermes_cli/test_vault_para_triage.py
+++ b/tests/hermes_cli/test_vault_para_triage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 from hermes_cli import vault_para_triage as triage
 
@@ -184,6 +185,46 @@ def test_low_confidence_action_inbox_keeps_note_in_inbox(tmp_path):
     assert summary["processed"][0]["path_after"] == "Inbox/unsure-note.md"
 
 
+def test_explicit_inbox_target_is_allowed(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "scratch-capture.md"
+    note.write_text("Keep this as a raw inbox capture for later sorting.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        classifier=lambda **_: {
+            "target": "Inbox",
+            "confidence": 0.93,
+            "reason": "raw capture should remain in inbox",
+            "needs_feedback": False,
+        },
+    )
+
+    staged = (
+        vault
+        / ".hermes"
+        / "note-capture"
+        / "staging"
+        / "vault"
+        / summary["processed"][0]["entry_id"]
+        / "Inbox"
+        / "scratch-capture.md"
+    )
+    assert staged.exists()
+    assert summary["processed"][0]["path_after"] == "Inbox/scratch-capture.md"
+
+    capture_event = json.loads(
+        (
+            vault
+            / ".hermes"
+            / "note-capture"
+            / "events"
+            / f"{summary['processed'][0]['entry_id']}.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert capture_event["routing"]["target"] == "Inbox"
+
+
 def test_feedback_status_includes_projection_summary(tmp_path):
     vault = _make_vault(tmp_path)
     note = vault / "Inbox" / "ops.md"
@@ -295,3 +336,134 @@ def test_projection_summary_includes_memory_hint_and_enabled_stores(tmp_path):
     projection_status = summary["projection_status"]
     assert projection_status["sync_contract"]["stores"] == ["vault"]
     assert "downstream staged projections" in projection_status["memory_hint"]
+
+
+def test_target_resolver_decision_is_used_and_preserved_in_capture_event(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "lab-results.md"
+    note.write_text("Need to file these blood test notes.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        target_resolver=lambda **_: {
+            "target": "Areas/Health",
+            "confidence": 0.87,
+            "reason": "resolved by runtime target registry",
+            "source": "target_resolver",
+            "needs_feedback": False,
+            "target_id": "vault.second_brain.areas.health",
+            "logical_path": "areas/health",
+            "display_path": "4.Resources/Health and Wellbeing",
+            "resolved_target_path": "Areas/Health",
+            "target_status": "active",
+        },
+        classifier=lambda **_: (_ for _ in ()).throw(AssertionError("classifier should not run")),
+    )
+
+    event_id = summary["processed"][0]["entry_id"]
+    capture_event = json.loads(
+        (vault / ".hermes" / "note-capture" / "events" / f"{event_id}.json").read_text(encoding="utf-8")
+    )
+    routing = capture_event["routing"]
+    assert routing["target"] == "Areas/Health"
+    assert routing["target_id"] == "vault.second_brain.areas.health"
+    assert routing["logical_path"] == "areas/health"
+    assert routing["display_path"] == "4.Resources/Health and Wellbeing"
+    assert routing["resolved_target_path"] == "Areas/Health"
+    assert routing["target_status"] == "active"
+    assert summary["processed"][0]["path_after"] == "Areas/Health/lab-results.md"
+
+
+def test_http_target_resolver_uses_configured_api_before_classifier(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "launch-plan.md"
+    note.write_text("Capture these launch notes for later reference.\n", encoding="utf-8")
+    seen: dict[str, object] = {}
+
+    class _FakeResponse:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    def _fake_urlopen(request, timeout=0):
+        seen["url"] = request.full_url
+        seen["timeout"] = timeout
+        seen["payload"] = json.loads(request.data.decode("utf-8"))
+        return _FakeResponse(
+            {
+                "decision": {
+                    "resolved_target_path": "Resources/Reference",
+                    "confidence": 0.94,
+                    "reason": "api routed note",
+                    "needs_feedback": False,
+                    "target_id": "vault.second_brain.resources.reference",
+                }
+            }
+        )
+
+    with patch.object(triage.urllib.request, "urlopen", side_effect=_fake_urlopen):
+        summary = triage.run_triage(
+            vault_path=vault,
+            config_override={
+                "routing": {
+                    "target_resolver": {
+                        "enabled": True,
+                        "api_url": "http://resolver.test/v1/resolve-note-target",
+                        "timeout_seconds": 2.5,
+                    }
+                }
+            },
+            classifier=lambda **_: (_ for _ in ()).throw(AssertionError("classifier should not run")),
+        )
+
+    assert seen["url"] == "http://resolver.test/v1/resolve-note-target"
+    assert seen["timeout"] == 2.5
+    payload = seen["payload"]
+    assert payload["note"]["title"] == "launch plan"
+    assert payload["review_target"] == "Resources/_Inbox Review"
+    assert "Resources/Reference" in payload["allowed_targets"]
+    assert summary["processed"][0]["path_after"] == "Resources/Reference/launch-plan.md"
+
+
+def test_classifier_canonical_fields_are_preserved_in_capture_event(tmp_path):
+    vault = _make_vault(tmp_path)
+    note = vault / "Inbox" / "receipt.md"
+    note.write_text("HMRC invoice and payment confirmation.\n", encoding="utf-8")
+
+    summary = triage.run_triage(
+        vault_path=vault,
+        classifier=lambda **_: {
+            "target": "Areas/Health",
+            "confidence": 0.91,
+            "reason": "test classifier",
+            "needs_feedback": False,
+            "target_id": "vault.second_brain.areas.personal.finance.invoices_and_receipts",
+            "target_class": "obsidian_vault",
+            "logical_path": "areas/personal/finance/invoices_and_receipts",
+            "display_path": "3.Areas/Personal/Finance/Invoices and Receipts",
+            "resolved_target_path": "Areas/Health",
+            "target_status": "pending_migration",
+            "trust_boundary": "icloud_obsidian",
+        },
+    )
+
+    event_id = summary["processed"][0]["entry_id"]
+    capture_event = json.loads(
+        (vault / ".hermes" / "note-capture" / "events" / f"{event_id}.json").read_text(encoding="utf-8")
+    )
+    routing = capture_event["routing"]
+    assert routing["target_id"] == "vault.second_brain.areas.personal.finance.invoices_and_receipts"
+    assert routing["target_class"] == "obsidian_vault"
+    assert routing["logical_path"] == "areas/personal/finance/invoices_and_receipts"
+    assert routing["display_path"] == "3.Areas/Personal/Finance/Invoices and Receipts"
+    assert routing["resolved_target_path"] == "Areas/Health"
+    assert routing["target_status"] == "pending_migration"
+    assert routing["trust_boundary"] == "icloud_obsidian"

--- a/tests/plugins/test_vault_triage_feedback_plugin.py
+++ b/tests/plugins/test_vault_triage_feedback_plugin.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from plugins.vault_triage_feedback import register
+
+
+class _DummyContext:
+    def __init__(self):
+        self.calls = []
+
+    def register_command(self, name, handler, description="", args_hint=""):
+        self.calls.append(
+            {
+                "name": name,
+                "handler": handler,
+                "description": description,
+                "args_hint": args_hint,
+            }
+        )
+
+
+def test_register_exposes_para_feedback_command():
+    ctx = _DummyContext()
+    register(ctx)
+
+    assert len(ctx.calls) == 1
+    call = ctx.calls[0]
+    assert call["name"] == "para-feedback"
+    assert "correct <entry_id> <target>" in call["args_hint"]
+    assert callable(call["handler"])

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,6 +49,7 @@ import {
   Star,
   Terminal,
   Users,
+  Wallet,
   Webhook,
   Wrench,
   X,
@@ -81,6 +82,7 @@ import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
 import CronPage from "@/pages/CronPage";
+import PaymentsPage from "@/pages/PaymentsPage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import ProfileBuilderPage from "@/pages/ProfileBuilderPage";
 import SkillsPage from "@/pages/SkillsPage";
@@ -138,6 +140,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/models": ModelsPage,
   "/logs": LogsPage,
   "/cron": CronPage,
+  "/payments": PaymentsPage,
   "/skills": SkillsPage,
   "/plugins": PluginsPage,
   "/mcp": McpPage,
@@ -182,6 +185,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
   },
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
+  { path: "/payments", label: "Payments", icon: Wallet },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },
   { path: "/mcp", label: "MCP", icon: Plug },
@@ -218,6 +222,7 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   Database,
   Shield,
   Users,
+  Wallet,
   Wrench,
   Zap,
   Heart,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -66,6 +66,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/status",
   "/api/gateway",
   "/api/analytics",
+  "/api/payments",
   "/api/skills",
   "/api/tools/toolsets",
   "/api/config",
@@ -556,6 +557,22 @@ export const api = {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
+    }),
+
+  // Payments
+  getPayments: () =>
+    fetchJSON<PaymentsResponse>("/api/payments"),
+  syncPayments: (body?: { source?: string; query?: string; max_results?: number }) =>
+    fetchJSON<PaymentSyncResponse>("/api/payments/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body || {}),
+    }),
+  updatePaymentStatus: (id: string, status: PaymentRequest["status"]) =>
+    fetchJSON<PaymentRequest>(`/api/payments/${encodeURIComponent(id)}/status`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
     }),
 
   // Profiles
@@ -1756,6 +1773,66 @@ export interface ManagedFileWriteResponse {
   root: string | null;
   locked_root: string | null;
   can_change_path: boolean;
+}
+
+export interface PaymentSourceStatus {
+  id: string;
+  label: string;
+  connected: boolean;
+  detail: string;
+}
+
+export interface PaymentRequest {
+  id: string;
+  source: string;
+  source_label: string;
+  status: "new" | "needs_review" | "ready_to_pay" | "paid" | "ignored";
+  confidence: string;
+  received_at: string | null;
+  updated_at: string | null;
+  vendor: string;
+  title: string;
+  amount: {
+    value: number | null;
+    currency: string;
+    display: string;
+  };
+  due_date: string | null;
+  payee_name: string;
+  account_holder: string;
+  account_number: string;
+  sort_code: string;
+  iban: string;
+  swift: string;
+  routing_number: string;
+  payment_reference: string;
+  invoice_number: string;
+  billing_address: string;
+  tax_details: string;
+  preview_text: string;
+  warnings: string[];
+  attachments: string[];
+  original: {
+    label: string;
+    url: string;
+    message_id: string;
+    thread_id: string;
+  };
+}
+
+export interface PaymentsResponse {
+  sources: PaymentSourceStatus[];
+  requests: PaymentRequest[];
+  storage_path: string;
+}
+
+export interface PaymentSyncResponse {
+  source: string;
+  query: string;
+  fetched: number;
+  imported: number;
+  updated: number;
+  requests: PaymentRequest[];
 }
 
 export interface AnalyticsDailyEntry {

--- a/web/src/pages/PaymentsPage.tsx
+++ b/web/src/pages/PaymentsPage.tsx
@@ -1,0 +1,619 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  Copy,
+  ExternalLink,
+  Mail,
+  RefreshCw,
+  Wallet,
+} from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@nous-research/ui/ui/components/card";
+import { Input } from "@nous-research/ui/ui/components/input";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Toast } from "@nous-research/ui/ui/components/toast";
+import { useToast } from "@nous-research/ui/hooks/use-toast";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { api, type PaymentRequest, type PaymentsResponse } from "@/lib/api";
+import { PluginSlot } from "@/plugins";
+import { cn } from "@/lib/utils";
+
+const DATE_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+});
+
+const DATETIME_FORMAT = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const STATUS_OPTIONS: Array<{ id: PaymentRequest["status"] | "all"; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "new", label: "New" },
+  { id: "needs_review", label: "Needs review" },
+  { id: "ready_to_pay", label: "Ready to pay" },
+  { id: "paid", label: "Paid" },
+  { id: "ignored", label: "Ignored" },
+];
+
+function statusBadgeTone(status: PaymentRequest["status"]) {
+  if (status === "paid") return "success";
+  if (status === "ready_to_pay") return "warning";
+  if (status === "ignored") return "secondary";
+  return "outline";
+}
+
+function confidenceBadgeTone(confidence: string) {
+  if (confidence === "high") return "success";
+  if (confidence === "medium") return "warning";
+  return "outline";
+}
+
+function amountLabel(payment: PaymentRequest): string {
+  return payment.amount.display || "Amount missing";
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "Missing";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return DATE_FORMAT.format(date);
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "Missing";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return DATETIME_FORMAT.format(date);
+}
+
+function paymentTitle(payment: PaymentRequest): string {
+  return payment.vendor || payment.title || "Untitled payment request";
+}
+
+function searchText(payment: PaymentRequest): string {
+  return [
+    payment.vendor,
+    payment.title,
+    payment.preview_text,
+    payment.invoice_number,
+    payment.payment_reference,
+    payment.original.label,
+  ]
+    .join(" ")
+    .toLowerCase();
+}
+
+function PaymentField({
+  label,
+  value,
+  onCopy,
+}: {
+  label: string;
+  value: string;
+  onCopy?: () => void;
+}) {
+  const isMissing = !value.trim() || value === "Missing";
+  return (
+    <div className="space-y-1 border-b border-border/60 pb-3 last:border-b-0 last:pb-0">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+          {label}
+        </span>
+        {onCopy ? (
+          <Button
+            ghost
+            size="icon"
+            type="button"
+            onClick={() => void onCopy()}
+            aria-label={`Copy ${label}`}
+            disabled={isMissing}
+          >
+            <Copy className="h-3.5 w-3.5" />
+          </Button>
+        ) : null}
+      </div>
+      <p className={cn("text-sm text-foreground", isMissing && "italic text-muted-foreground")}>
+        {isMissing ? "Missing" : value}
+      </p>
+    </div>
+  );
+}
+
+export default function PaymentsPage() {
+  const { toast, showToast } = useToast();
+  const { setEnd } = usePageHeader();
+  const [data, setData] = useState<PaymentsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [sourceFilter, setSourceFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState<PaymentRequest["status"] | "all">("all");
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [savingStatus, setSavingStatus] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await api.getPayments();
+      setData(result);
+    } catch (error) {
+      showToast(`Failed to load payments: ${error}`, "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    setEnd(
+      <Button
+        ghost
+        size="icon"
+        type="button"
+        onClick={() => void load()}
+        disabled={loading}
+        aria-label="Refresh payments"
+      >
+        {loading ? <Spinner /> : <RefreshCw />}
+      </Button>,
+    );
+    return () => setEnd(null);
+  }, [load, loading, setEnd]);
+
+  const filteredRequests = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return (data?.requests || []).filter((payment) => {
+      if (sourceFilter !== "all" && payment.source !== sourceFilter) return false;
+      if (statusFilter !== "all" && payment.status !== statusFilter) return false;
+      if (needle && !searchText(payment).includes(needle)) return false;
+      return true;
+    });
+  }, [data?.requests, query, sourceFilter, statusFilter]);
+
+  useEffect(() => {
+    if (!filteredRequests.length) {
+      setSelectedId(null);
+      return;
+    }
+    if (!selectedId || !filteredRequests.some((payment) => payment.id === selectedId)) {
+      setSelectedId(filteredRequests[0].id);
+    }
+  }, [filteredRequests, selectedId]);
+
+  const selectedPayment =
+    filteredRequests.find((payment) => payment.id === selectedId) || filteredRequests[0] || null;
+
+  const copyValue = useCallback(
+    async (label: string, value: string) => {
+      if (!value.trim()) return;
+      try {
+        await navigator.clipboard.writeText(value);
+        showToast(`${label} copied`, "success");
+      } catch (error) {
+        showToast(`Failed to copy ${label}: ${error}`, "error");
+      }
+    },
+    [showToast],
+  );
+
+  const updateStatus = useCallback(
+    async (status: PaymentRequest["status"]) => {
+      if (!selectedPayment) return;
+      setSavingStatus(status);
+      try {
+        const updated = await api.updatePaymentStatus(selectedPayment.id, status);
+        setData((prev) =>
+          prev
+            ? {
+                ...prev,
+                requests: prev.requests.map((item) =>
+                  item.id === updated.id ? updated : item,
+                ),
+              }
+            : prev,
+        );
+        showToast(`Payment marked ${status.replaceAll("_", " ")}`, "success");
+      } catch (error) {
+        showToast(`Failed to update payment: ${error}`, "error");
+      } finally {
+        setSavingStatus(null);
+      }
+    },
+    [selectedPayment, showToast],
+  );
+
+  const sourceFilters = data?.sources || [];
+  const gmailSource = sourceFilters.find((source) => source.id === "gmail");
+
+  const syncGmail = useCallback(async () => {
+    setSyncing(true);
+    try {
+      const result = await api.syncPayments({ source: "gmail" });
+      showToast(
+        `Gmail sync complete: ${result.imported} imported, ${result.updated} updated`,
+        "success",
+      );
+      await load();
+    } catch (error) {
+      showToast(`Failed to sync Gmail: ${error}`, "error");
+    } finally {
+      setSyncing(false);
+    }
+  }, [load, showToast]);
+
+  return (
+    <>
+      <div className="space-y-6">
+        <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          {sourceFilters.map((source) => (
+            <Card key={source.id} className="border-border/70 bg-background/70">
+              <CardContent className="flex items-start justify-between gap-4 p-4">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-foreground">{source.label}</span>
+                    <Badge tone={source.connected ? "success" : "outline"}>
+                      {source.connected ? "Connected" : "Not connected"}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{source.detail}</p>
+                </div>
+                <Mail className="mt-0.5 h-4 w-4 text-muted-foreground" />
+              </CardContent>
+            </Card>
+          ))}
+        </section>
+
+        <section className="grid gap-6 xl:grid-cols-[21rem_minmax(0,1fr)_22rem]">
+          <Card className="min-h-[36rem] border-border/70 bg-background/80">
+            <CardHeader className="space-y-4 pb-4">
+              <div className="flex items-center justify-between gap-3">
+                <CardTitle>Queue</CardTitle>
+                <div className="flex items-center gap-2">
+                  <Badge tone="outline">{filteredRequests.length}</Badge>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => void syncGmail()}
+                    disabled={syncing || gmailSource?.connected === false}
+                  >
+                    {syncing ? <Spinner /> : "Sync Gmail"}
+                  </Button>
+                </div>
+              </div>
+              <Input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search vendor, invoice, reference..."
+              />
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={sourceFilter === "all" ? "default" : "secondary"}
+                  onClick={() => setSourceFilter("all")}
+                >
+                  All sources
+                </Button>
+                {sourceFilters.map((source) => (
+                  <Button
+                    key={source.id}
+                    type="button"
+                    size="sm"
+                    variant={sourceFilter === source.id ? "default" : "secondary"}
+                    onClick={() => setSourceFilter(source.id)}
+                  >
+                    {source.label}
+                  </Button>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {STATUS_OPTIONS.map((status) => (
+                  <Button
+                    key={status.id}
+                    type="button"
+                    size="sm"
+                    variant={statusFilter === status.id ? "default" : "secondary"}
+                    onClick={() => setStatusFilter(status.id)}
+                  >
+                    {status.label}
+                  </Button>
+                ))}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {loading ? (
+                <div className="grid min-h-48 place-items-center">
+                  <Spinner />
+                </div>
+              ) : filteredRequests.length === 0 ? (
+                <div className="space-y-3 rounded-xl border border-dashed border-border/80 bg-muted/20 p-5 text-sm text-muted-foreground">
+                  <div className="flex items-center gap-2 text-foreground">
+                    <Wallet className="h-4 w-4" />
+                    <span className="font-medium">No captured payment requests yet</span>
+                  </div>
+                  <p>
+                    Connect Gmail or Email, or stage invoice files for extraction. This queue
+                    will keep the manual-payment details once capture is wired in.
+                  </p>
+                  {data?.storage_path ? (
+                    <p className="font-mono-ui text-xs text-muted-foreground/80">
+                      Storage: {data.storage_path}
+                    </p>
+                  ) : null}
+                </div>
+              ) : (
+                filteredRequests.map((payment) => (
+                  <button
+                    key={payment.id}
+                    type="button"
+                    onClick={() => setSelectedId(payment.id)}
+                    className={cn(
+                      "w-full rounded-xl border px-4 py-3 text-left transition-colors",
+                      selectedPayment?.id === payment.id
+                        ? "border-foreground/20 bg-foreground/5"
+                        : "border-border/70 bg-background hover:bg-muted/25",
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate font-medium text-foreground">
+                          {paymentTitle(payment)}
+                        </p>
+                        <p className="truncate text-sm text-muted-foreground">
+                          {payment.title || payment.preview_text || "No source summary"}
+                        </p>
+                      </div>
+                      <Badge tone={statusBadgeTone(payment.status)}>
+                        {payment.status.replaceAll("_", " ")}
+                      </Badge>
+                    </div>
+                    <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      <Badge tone="outline">{payment.source_label}</Badge>
+                      <Badge tone={confidenceBadgeTone(payment.confidence)}>
+                        {payment.confidence} confidence
+                      </Badge>
+                      <span>{amountLabel(payment)}</span>
+                      <span>Due {formatDate(payment.due_date)}</span>
+                    </div>
+                  </button>
+                ))
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="min-h-[36rem] border-border/70 bg-background/80">
+            <CardHeader className="space-y-3 pb-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <CardTitle>{selectedPayment ? paymentTitle(selectedPayment) : "Invoice / Request"}</CardTitle>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    {selectedPayment
+                      ? selectedPayment.title || "No subject captured yet."
+                      : "Select a captured item to inspect the source and extracted fields."}
+                  </p>
+                </div>
+                {selectedPayment ? (
+                  <Badge tone={statusBadgeTone(selectedPayment.status)}>
+                    {selectedPayment.status.replaceAll("_", " ")}
+                  </Badge>
+                ) : null}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              {selectedPayment ? (
+                <>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">From</p>
+                      <p className="text-sm text-foreground">
+                        {selectedPayment.original.label || selectedPayment.vendor || "Missing"}
+                      </p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Received</p>
+                      <p className="text-sm text-foreground">{formatDateTime(selectedPayment.received_at)}</p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Amount</p>
+                      <p className="text-sm text-foreground">{amountLabel(selectedPayment)}</p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">Due date</p>
+                      <p className="text-sm text-foreground">{formatDate(selectedPayment.due_date)}</p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-xl border border-border/70 bg-muted/20 p-4">
+                    <div className="flex items-center gap-2">
+                      <AlertTriangle className="h-4 w-4 text-warning" />
+                      <p className="font-medium text-foreground">Review summary</p>
+                    </div>
+                    <p className="mt-3 whitespace-pre-wrap text-sm text-muted-foreground">
+                      {selectedPayment.preview_text || "No preview text has been captured yet."}
+                    </p>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="rounded-xl border border-border/70 bg-background p-4">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                        Attachments
+                      </p>
+                      {selectedPayment.attachments.length ? (
+                        <ul className="mt-3 space-y-2 text-sm text-foreground">
+                          {selectedPayment.attachments.map((attachment) => (
+                            <li key={attachment}>{attachment}</li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="mt-3 text-sm italic text-muted-foreground">No attachments recorded</p>
+                      )}
+                    </div>
+                    <div className="rounded-xl border border-border/70 bg-background p-4">
+                      <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+                        Warnings
+                      </p>
+                      {selectedPayment.warnings.length ? (
+                        <ul className="mt-3 space-y-2 text-sm text-foreground">
+                          {selectedPayment.warnings.map((warning) => (
+                            <li key={warning} className="flex gap-2">
+                              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+                              <span>{warning}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="mt-3 text-sm italic text-muted-foreground">
+                          No extraction warnings
+                        </p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap gap-3">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={() => window.open(selectedPayment.original.url, "_blank", "noopener,noreferrer")}
+                      disabled={!selectedPayment.original.url}
+                    >
+                      <ExternalLink className="mr-2 h-4 w-4" />
+                      Open original
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <div className="grid min-h-64 place-items-center text-sm text-muted-foreground">
+                  Select a payment request from the queue.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="min-h-[36rem] border-border/70 bg-background/80">
+            <CardHeader className="space-y-3 pb-4">
+              <CardTitle>Payment Details</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Copy these fields into your banking app. No payments are sent automatically.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {selectedPayment ? (
+                <>
+                  <PaymentField
+                    label="Payee"
+                    value={selectedPayment.payee_name}
+                    onCopy={() => copyValue("payee", selectedPayment.payee_name)}
+                  />
+                  <PaymentField
+                    label="Account holder"
+                    value={selectedPayment.account_holder}
+                    onCopy={() => copyValue("account holder", selectedPayment.account_holder)}
+                  />
+                  <PaymentField
+                    label="Account number"
+                    value={selectedPayment.account_number}
+                    onCopy={() => copyValue("account number", selectedPayment.account_number)}
+                  />
+                  <PaymentField
+                    label="Sort code"
+                    value={selectedPayment.sort_code}
+                    onCopy={() => copyValue("sort code", selectedPayment.sort_code)}
+                  />
+                  <PaymentField
+                    label="IBAN"
+                    value={selectedPayment.iban}
+                    onCopy={() => copyValue("IBAN", selectedPayment.iban)}
+                  />
+                  <PaymentField
+                    label="SWIFT"
+                    value={selectedPayment.swift}
+                    onCopy={() => copyValue("SWIFT", selectedPayment.swift)}
+                  />
+                  <PaymentField
+                    label="Routing number"
+                    value={selectedPayment.routing_number}
+                    onCopy={() => copyValue("routing number", selectedPayment.routing_number)}
+                  />
+                  <PaymentField
+                    label="Amount"
+                    value={amountLabel(selectedPayment)}
+                    onCopy={() => copyValue("amount", amountLabel(selectedPayment))}
+                  />
+                  <PaymentField
+                    label="Reference"
+                    value={selectedPayment.payment_reference}
+                    onCopy={() => copyValue("reference", selectedPayment.payment_reference)}
+                  />
+                  <PaymentField
+                    label="Invoice number"
+                    value={selectedPayment.invoice_number}
+                    onCopy={() => copyValue("invoice number", selectedPayment.invoice_number)}
+                  />
+                  <PaymentField
+                    label="Due date"
+                    value={formatDate(selectedPayment.due_date)}
+                    onCopy={() => copyValue("due date", formatDate(selectedPayment.due_date))}
+                  />
+                  <PaymentField label="Billing address" value={selectedPayment.billing_address} />
+                  <PaymentField label="Tax details" value={selectedPayment.tax_details} />
+
+                  <div className="space-y-2 pt-2">
+                    <Button
+                      type="button"
+                      className="w-full"
+                      onClick={() => void updateStatus("ready_to_pay")}
+                      disabled={savingStatus !== null || selectedPayment.status === "ready_to_pay"}
+                    >
+                      {savingStatus === "ready_to_pay" ? <Spinner /> : "Mark ready to pay"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="w-full"
+                      onClick={() => void updateStatus("paid")}
+                      disabled={savingStatus !== null || selectedPayment.status === "paid"}
+                    >
+                      {savingStatus === "paid" ? <Spinner /> : "Mark paid"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="w-full"
+                      onClick={() => void updateStatus("needs_review")}
+                      disabled={savingStatus !== null || selectedPayment.status === "needs_review"}
+                    >
+                      {savingStatus === "needs_review" ? <Spinner /> : "Needs review"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="w-full"
+                      onClick={() => void updateStatus("ignored")}
+                      disabled={savingStatus !== null || selectedPayment.status === "ignored"}
+                    >
+                      {savingStatus === "ignored" ? <Spinner /> : "Not a payment"}
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <div className="grid min-h-64 place-items-center text-sm text-muted-foreground">
+                  Payment details will appear here.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+
+      <PluginSlot name="dashboard.payments.below" />
+
+      {toast && <Toast message={toast.message} type={toast.type} onClose={toast.hide} />}
+    </>
+  );
+}

--- a/website/docs/user-guide/features/payments.md
+++ b/website/docs/user-guide/features/payments.md
@@ -1,0 +1,153 @@
+---
+sidebar_position: 16
+title: "Payments Review"
+description: "Capture invoice and payment-request details from Gmail and other sources for manual payment in your banking app."
+---
+
+# Payments Review
+
+The **Payments** page in the web dashboard is a review queue for invoices and payment requests. Hermes does **not** send money or trigger bank transfers. Instead, it captures payment details, highlights missing fields, and gives you structured values to copy into your banking app manually.
+
+## What it does
+
+- **Captures payment requests** into a profile-scoped queue
+- **Syncs Gmail** for likely invoice / payment-due messages
+- **Stores extracted fields** such as amount, due date, invoice number, payment reference, and bank details
+- **Flags uncertainty** when important details are missing or low-confidence
+- **Tracks manual review state** so you can move items from new → ready to pay → paid
+
+## Where it lives
+
+Open the [Web Dashboard](./web-dashboard.md) and select **Payments** in the sidebar.
+
+The queue is profile-scoped, like the rest of the management dashboard. If you switch profiles, you are looking at that profile's payment-request store.
+
+## Current sources
+
+### Gmail
+
+The first real ingestion path is **Gmail**.
+
+When Google Workspace is configured, the page can run **Sync Gmail**, which:
+
+1. Searches for likely invoices and payment requests
+2. Reads candidate messages through the existing Google Workspace bridge
+3. Extracts fields such as:
+   - payee
+   - amount and currency
+   - due date
+   - invoice number
+   - payment reference
+   - sort code / account number
+   - IBAN / SWIFT / routing number when present
+4. Adds or updates queue entries in the Payments store
+
+Set up Gmail/Google Workspace first:
+
+- [Google Workspace skill](../skills/bundled/productivity/productivity-google-workspace.md)
+
+### Email
+
+The page also detects whether the built-in [Email channel](../messaging/email.md) is configured. That source is currently surfaced as a connection status and review target; the real extraction path is still Gmail-first.
+
+### Uploads
+
+Uploads are supported as a staging concept today. The page points you to the [Files](./web-dashboard.md#files) workflow so invoice PDFs or screenshots can be placed under your Hermes home for later extraction/review flows.
+
+### Slack
+
+Slack appears as a source-status card so the eventual cross-channel review model is visible in one place, but Gmail is the only fully wired sync source right now.
+
+## Page layout
+
+The Payments page is split into three areas:
+
+### Queue
+
+The left column shows captured payment requests with:
+
+- vendor / sender
+- title or subject
+- amount
+- due date
+- source
+- confidence
+- review status
+
+Filters let you narrow by source, status, or free-text search.
+
+### Invoice / Request detail
+
+The middle panel shows:
+
+- sender / source metadata
+- received time
+- amount and due date
+- extracted preview text
+- attachment list
+- warnings about missing or uncertain fields
+- a link back to the original Gmail message when available
+
+### Payment details
+
+The right panel gives you copy-ready fields for your banking app:
+
+- payee
+- account holder
+- account number
+- sort code
+- IBAN
+- SWIFT
+- routing number
+- amount
+- payment reference
+- invoice number
+- due date
+- billing address
+- tax details
+
+## Manual review states
+
+Each payment request can be moved between these states:
+
+- `new`
+- `needs_review`
+- `ready_to_pay`
+- `paid`
+- `ignored`
+
+These are review-only states. Marking an item `paid` does not send anything externally.
+
+## Storage
+
+The queue is stored under your profile's Hermes home:
+
+```text
+~/.hermes/payments/requests.json
+```
+
+If you're using multiple profiles, each profile has its own `payments/requests.json`.
+
+## Safety model
+
+The Payments workflow is intentionally conservative:
+
+- Hermes does **not** initiate transfers
+- Missing details remain visible as missing
+- Low-confidence extraction is surfaced as warnings instead of hidden
+- Gmail sync updates existing entries rather than silently duplicating every read
+
+## Current limitations
+
+As of July 4, 2026:
+
+- **Gmail sync is the only fully wired ingestion path**
+- extraction is heuristic, not OCR- or attachment-parser-driven yet
+- uploads and other channels are surfaced in the UI, but not fully ingested into the queue
+- validation against a user's real invoice examples still depends on the connected mailbox and real message content
+
+## Related
+
+- [Web Dashboard](./web-dashboard.md)
+- [Google Workspace](../skills/bundled/productivity/productivity-google-workspace.md)
+- [Files](./web-dashboard.md#files)

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 15
 title: "Web Dashboard"
-description: "Browser-based administration panel for managing configuration, API keys, MCP servers, messaging pairing, webhooks, the gateway, memory, credentials, sessions, logs, analytics, cron jobs, and skills"
+description: "Browser-based administration panel for managing configuration, API keys, MCP servers, messaging pairing, payment requests, webhooks, the gateway, memory, credentials, sessions, logs, analytics, cron jobs, and skills"
 ---
 
 # Web Dashboard
@@ -228,6 +228,19 @@ Each key shows:
 
 Advanced/rarely-used keys are hidden by default behind a toggle.
 
+### Files
+
+Browse and manage files inside the dashboard without dropping to a shell.
+
+- **Browse directories** — list files under the currently selected path
+- **Navigate** — move up the directory tree or jump directly to another path
+- **Upload** — send local files into the current directory
+- **Create folder** — add directories inline
+- **Download** — fetch any file back to your machine
+- **Delete** — remove files or folders after confirmation
+
+This is the easiest staging surface for invoice PDFs, screenshots, and other payment-request artifacts you want Hermes to review later.
+
 ### Sessions
 
 Browse and inspect all agent sessions. Each row shows the session title, source platform icon (CLI, Telegram, Discord, Slack, cron), model name, message count, tool call count, and how long ago it was active. Live sessions are marked with a pulsing badge.
@@ -273,6 +286,18 @@ Create and manage scheduled cron jobs that run agent prompts on a recurring sche
 - **Edit** — open a pre-filled modal to change a job's prompt, schedule, name, or delivery target
 - **Trigger now** — immediately execute a job outside its normal schedule
 - **Delete** — permanently remove a cron job
+
+### Payments
+
+Review captured invoices and payment requests before paying them manually in your banking app.
+
+- **Sync Gmail** — search Gmail for likely invoices / payment-due messages and import or update queue entries through the existing Google Workspace bridge
+- **Queue** — review vendor, amount, due date, source, confidence, and manual status (`new`, `needs_review`, `ready_to_pay`, `paid`, `ignored`)
+- **Detail view** — inspect the source message summary, warnings, attachments, and a link back to the original Gmail message when available
+- **Copy-ready payment fields** — payee, account holder, account number, sort code, IBAN, SWIFT, routing number, amount, reference, invoice number, due date, and other extracted details
+- **Manual-review only** — the page never initiates transfers; it organizes details for you to copy into your banking app
+
+See [Payments Review](./payments.md) for the full workflow and current limitations.
 
 ### Profiles
 

--- a/website/docs/user-guide/skills/optional/productivity/productivity-vault-para-triage.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-vault-para-triage.md
@@ -1,0 +1,246 @@
+---
+title: "Vault Para Triage"
+sidebar_label: "Vault Para Triage"
+description: "Capture an Obsidian inbox into a canonical capture event log, stage PARA projections for downstream stores, and learn from Slack feedback"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Vault Para Triage
+
+Capture an Obsidian inbox into a canonical capture event log, stage PARA projections for downstream stores, and learn from Slack feedback.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/productivity/vault-para-triage` |
+| Path | `optional-skills/productivity/vault-para-triage` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `obsidian`, `para`, `vault`, `notes`, `cron`, `slack`, `routing`, `frontmatter` |
+| Related skills | [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian), [`slack-surfaces`](/docs/user-guide/skills/bundled/productivity/productivity-slack-surfaces) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Vault PARA Triage
+
+Use this optional skill when the user wants Hermes to clean up an Obsidian inbox
+into a PARA-organized note system on a schedule, while keeping a canonical
+capture event log, downstream staged projections, an audit trail, and a review
+loop.
+
+This skill ships a helper script, `scripts/vault_para_triage.py`, backed by the
+shared `hermes_cli.vault_para_triage` module.
+
+## What it does
+
+For each markdown note in the configured inbox folder:
+
+1. ensures YAML frontmatter exists
+2. classifies the note into a canonical PARA target folder
+3. writes canonical markdown content into a capture event log
+4. stages one projected file per enabled downstream store
+5. archives the original inbox note into the capture root
+6. writes immutable audit and status records
+7. marks uncertain routes for review and learns from later feedback
+
+The review loop is designed to pair with the bundled `vault-triage-feedback`
+plugin, which exposes `/para-feedback` inside Slack and other chat surfaces.
+
+## Default paths
+
+- Vault path: `OBSIDIAN_VAULT_PATH`, otherwise `~/Documents/Obsidian Vault`
+- Config file: `<vault>/.hermes/para-triage.yaml`
+- Audit/state root: `<vault>/.hermes/para-triage/`
+- Capture root: `<vault>/.hermes/note-capture/`
+
+The capture root is the canonical handoff point for external sync jobs. Hermes
+does not write directly into the projected vault or second-brain destinations.
+
+## Locate the helper script
+
+```bash
+SCRIPT="$(find ~/.hermes/skills -path '*/vault-para-triage/scripts/vault_para_triage.py' -print -quit)"
+```
+
+If `SCRIPT` is empty, install the skill first.
+
+## Install
+
+```bash
+hermes skills search vault-para-triage
+hermes skills install official/productivity/vault-para-triage
+```
+
+Enable the feedback plugin so `/para-feedback` is available:
+
+```bash
+hermes plugins enable vault-triage-feedback
+```
+
+## Minimal config
+
+Create `<vault>/.hermes/para-triage.yaml`:
+
+```yaml
+inbox_dir: Inbox
+para_roots:
+  projects: Projects
+  areas: Areas
+  resources: Resources
+  archives: Archives
+review_dir: Resources/_Inbox Review
+capture:
+  root: .hermes/note-capture
+  source_archive_dir: source-archive
+projection:
+  stores:
+    vault:
+      enabled: true
+      path_prefix: ""
+    second_brain:
+      enabled: true
+      path_prefix: ""
+routing:
+  min_confidence: 0.72
+  low_confidence_action: review   # one of: review, inbox, auto-file
+  rules:
+    - name: health-notes
+      match_any: ["health", "doctor", "medication"]
+      target: Areas/Health
+      confidence: 0.95
+      reason: Health-related notes belong in Areas/Health.
+    - name: taxes
+      match_any: ["tax", "hmrc", "invoice"]
+      target: Areas/Finance
+      confidence: 0.95
+```
+
+Add more explicit rules as the vault evolves. The helper also stores learned
+examples from reviewer corrections under `.hermes/para-triage/routing_examples.json`.
+
+Projection rules:
+
+- Hermes first decides one canonical logical `target`, such as `Projects/Acme`
+  or `Resources/Content Library`.
+- For each enabled store, Hermes derives the projected relative path as
+  `<path_prefix>/<target>/<filename>`.
+- Hermes stages files under
+  `.hermes/note-capture/staging/<store>/<entry_id>/<projected-relative-path>`.
+- Hermes archives the original note under
+  `.hermes/note-capture/source-archive/<entry_id>/<original-relative-path>`.
+- Hermes records the canonical event under
+  `.hermes/note-capture/events/<entry_id>.json`.
+- External sync outside the Hermes trust boundary is responsible for projecting
+  staged files into the live vault, iCloud, second brain, or other stores.
+
+Low-confidence behavior:
+
+- `review` — stage uncertain notes to `review_dir`
+- `inbox` — keep uncertain notes mapped to their inbox-relative location
+- `auto-file` — still stage uncertain notes to the predicted target, then rely on Slack corrections
+
+## Dry-run and status
+
+Preview the next triage pass:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" run --dry-run
+```
+
+Inspect audit and review state:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" status
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" feedback list --limit 20
+```
+
+Inspect canonical capture status:
+
+```bash
+cat "$OBSIDIAN_VAULT_PATH/.hermes/note-capture/status/latest.json"
+```
+
+## Overnight cron job
+
+Use a script-only cron job so the canonical capture logic runs the same way
+every night and the output can be delivered directly to Slack.
+
+First install a cron-safe launcher into `~/.hermes/scripts/`:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" install-wrapper
+```
+
+This prints the generated path, usually:
+
+```text
+~/.hermes/scripts/vault-para-triage-nightly.py
+```
+
+Then schedule that generated wrapper:
+
+```bash
+hermes cron create "0 2 * * *" \
+  --name "Vault PARA triage" \
+  --deliver slack:C0B6MV5RA06 \
+  --script ~/.hermes/scripts/vault-para-triage-nightly.py \
+  --no-agent
+```
+
+For this rollout, `slack:C0B6MV5RA06` is the explicit `#hermes-ops` channel
+target. Using the raw Slack channel ID is safer than relying on name
+resolution.
+
+If the scheduler environment on your machine does not preserve
+`OBSIDIAN_VAULT_PATH`, the generated wrapper already bakes in the absolute vault
+and config path you passed to `install-wrapper`, so cron does not need that env
+var later.
+
+If you want a different filename or output mode:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" install-wrapper \
+  --name para-nightly-review.py \
+  --format slack
+```
+
+## Slack feedback loop
+
+After the nightly run posts to Slack, review uncertain entries with:
+
+```text
+/para-feedback list
+/para-feedback approve <entry_id>
+/para-feedback correct <entry_id> Areas/Health
+/para-feedback ignore <entry_id>
+/para-feedback status
+```
+
+For an on-demand audit summary, use:
+
+```bash
+python3 "$SCRIPT" --vault "$OBSIDIAN_VAULT_PATH" status
+```
+
+`approve` and `correct` both teach future runs. `correct` rewrites the staged
+projection targets for the current capture event to the supplied canonical
+target path.
+
+## Notes
+
+- The helper remembers the vault structure by snapshotting available PARA
+  folders on every run into `.hermes/para-triage/structure.json`.
+- Canonical captures are logged under `.hermes/note-capture/events/`.
+- Projected store health is summarized in `.hermes/note-capture/status/latest.json`.
+- All capture audit rows are logged to `.hermes/para-triage/audit.jsonl`.
+- Reviewer actions are logged separately to `.hermes/para-triage/feedback.jsonl`.
+- This keeps the capability outside Hermes core tools while still making it
+  schedulable and auditable.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -112,6 +112,7 @@ const sidebars: SidebarsConfig = {
           label: 'Management',
           items: [
             'user-guide/features/web-dashboard',
+            'user-guide/features/payments',
             'user-guide/features/extending-the-dashboard',
             'user-guide/features/api-server',
             'user-guide/features/subscription-proxy',


### PR DESCRIPTION
## What changed
- Slack now echoes intercepted free-text clarify submissions back into the same channel/thread.
- The gateway clarify intercept resolves the pending clarify and posts a visible submission message using the platform hook.
- Added a Slack regression test covering the submitted reply echo and reply anchor.

## Why
Users were completing input requests in Slack, but the submitted text disappeared after submission. That made the interaction feel silent and left no thread-visible record of what was sent.

## Root cause
The clarify text-intercept in `gateway/platforms/base.py` resolved the pending clarify but returned without posting any user-visible message. Slack had no platform-specific echo path for these intercepted replies.

## Validation
- `python3 -m py_compile gateway/platforms/base.py plugins/platforms/slack/adapter.py tests/gateway/test_slack.py`
- Direct runtime smoke test of the Slack adapter clarify path confirmed the echoed content and thread reply anchor:
  - `📝 Submitted input:\nNeed more info`
  - `reply_to=123.456`