### PR TITLE
fix(gateway): preserve external routing handoffs

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1246,6 +1246,76 @@ class SessionStore:
             self._routing_generation,
         )
 
+    def _protect_external_routing_handoffs(
+        self, data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Keep externally-created live routes from being overwritten by stale memory.
+
+        Script-only watchdogs and other out-of-band maintenance can atomically
+        end a gateway session and repoint ``gateway_routing``/``sessions.json``
+        while the gateway process is still alive.  Until the next inbound
+        message, this SessionStore may still hold the old in-memory
+        ``SessionEntry``.  A later full-index save from that stale snapshot must
+        not clobber the newer durable route back to the ended session.
+        """
+        db = getattr(self, "_db", None)
+        if not db or not data:
+            return data
+        loader = getattr(db, "load_gateway_routing_entries", None)
+        if not callable(loader):
+            return data
+        try:
+            current_rows = loader(scope=self._routing_scope())
+        except Exception:
+            return data
+
+        protected = dict(data)
+        for key, entry in list(data.items()):
+            if not isinstance(entry, dict):
+                continue
+            incoming_sid = entry.get("session_id")
+            if not incoming_sid:
+                continue
+            try:
+                incoming_row = db.get_session(str(incoming_sid))
+            except Exception:
+                continue
+            if not (incoming_row and incoming_row.get("end_reason") is not None):
+                continue
+
+            current_json = current_rows.get(key)
+            if not current_json:
+                continue
+            try:
+                current_entry = json.loads(current_json)
+            except Exception:
+                continue
+            if not isinstance(current_entry, dict):
+                continue
+            current_sid = current_entry.get("session_id")
+            if not current_sid or current_sid == incoming_sid:
+                continue
+            try:
+                current_row = db.get_session(str(current_sid))
+            except Exception:
+                continue
+            if current_row and current_row.get("end_reason") is None:
+                end_reason = (
+                    incoming_row.get("end_reason")
+                    if isinstance(incoming_row, dict)
+                    else None
+                )
+                logger.warning(
+                    "gateway.session: preserving newer durable route %r -> %s; "
+                    "stale in-memory entry still points at ended %s (%r)",
+                    key,
+                    current_sid,
+                    incoming_sid,
+                    end_reason,
+                )
+                protected[key] = current_entry
+        return protected
+
     def _persist_routing_data(self, data: Dict[str, Any], generation: int) -> None:
         """Serialize all whole-index writers through one durable write lock."""
         save_lock = getattr(self, "_save_lock", None)
@@ -1255,6 +1325,7 @@ class SessionStore:
         with save_lock:
             if generation <= getattr(self, "_persisted_routing_generation", 0):
                 return
+            data = self._protect_external_routing_handoffs(data)
             db_saved = False
             _db = getattr(self, "_db", None)
             if _db:

--- a/tests/gateway/test_session_store_lock_io.py
+++ b/tests/gateway/test_session_store_lock_io.py
@@ -365,6 +365,47 @@ def test_save_serialization_snapshots_latest_routing_index(tmp_path):
     assert json.loads(persisted[key_b])["session_id"] == entry_b.session_id
 
 
+def test_external_handoff_route_survives_stale_in_memory_save(tmp_path):
+    """A watchdog-created clean route must not be clobbered by stale gateway memory."""
+    db = _db_with_rows(
+        {
+            "old-ended": {
+                "id": "old-ended",
+                "end_reason": "context_guard_handoff",
+            },
+            "new-live": {
+                "id": "new-live",
+                "end_reason": None,
+            },
+        }
+    )
+    key = "agent:main:telegram:dm:12345"
+    current_route = {
+        "session_key": key,
+        "session_id": "new-live",
+        "created_at": datetime.now().isoformat(),
+        "updated_at": datetime.now().isoformat(),
+        "platform": "telegram",
+        "chat_type": "dm",
+        "origin": _source().to_dict(),
+    }
+    db.load_gateway_routing_entries.return_value = {key: json.dumps(current_route)}
+    persisted: dict[str, str] = {}
+
+    def replace(entries, *, scope):
+        nonlocal persisted
+        persisted = dict(entries)
+
+    db.replace_gateway_routing_entries.side_effect = replace
+    store = _make_store(tmp_path, db)
+    stale = _seed_entry(store, key, "old-ended")
+
+    store._save_entries()
+
+    assert json.loads(persisted[key])["session_id"] == "new-live"
+    assert stale.session_id == "old-ended"
+
+
 def test_recovery_rejects_other_profile_row(tmp_path, monkeypatch):
     """The lock-free recovery path must retain the canonical profile guard."""
     source = _source()


### PR DESCRIPTION
## Summary
- Prevent stale in-memory gateway SessionStore snapshots from overwriting newer durable routes created by out-of-band watchdogs/maintenance.
- Preserve a durable live route when a full-index save still points back at an ended session.
- Add regression coverage for an external context-guard handoff route surviving a stale in-memory save.

## Test Plan
- [x] `scripts/run_tests.sh tests/gateway/test_session_store_lock_io.py -q`
