### PR TITLE
fix(agent): stream Codex commentary separately from reasoning

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -743,6 +743,10 @@ def init_agent(
     # commentary when the provider later returns it as a completed interim
     # assistant message.
     agent._current_streamed_assistant_text = ""
+    # Completed interim messages delivered during the current user turn.
+    # Unlike token-stream tracking, this spans Codex continuation/tool calls so
+    # repeated commentary is not re-sent before normalization can deduplicate it.
+    agent._delivered_interim_texts: set[str] = set()
 
     # Optional current-turn user-message override used when the API-facing
     # user message intentionally differs from the persisted transcript

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -624,6 +624,7 @@ def _consume_codex_event_stream(
     model: str,
     on_text_delta=None,
     on_reasoning_delta=None,
+    on_commentary_message=None,
     on_first_delta=None,
     on_event=None,
     interrupt_check=None,
@@ -655,7 +656,11 @@ def _consume_codex_event_stream(
     * ``on_text_delta(str)`` — fires per ``response.output_text.delta``, suppressed
       once a function_call event is seen (so tool-call turns don't bleed text
       into the chat).
-    * ``on_reasoning_delta(str)`` — fires per ``response.reasoning.*.delta``.
+    * ``on_reasoning_delta(str)`` — fires per ``response.reasoning.*.delta`` and
+      ``phase=analysis`` message deltas. When no dedicated commentary callback
+      is supplied, commentary also uses this legacy fallback.
+    * ``on_commentary_message(str)`` — fires once per completed
+      ``phase=commentary`` message, before any following tool item executes.
     * ``on_first_delta()`` — one-shot, fires on the first text delta only.
     * ``on_event(event)`` — fires for every event before any other processing.
       Used for watchdog activity, debug logging, anything wire-shape-agnostic.
@@ -666,6 +671,7 @@ def _consume_codex_event_stream(
     has_tool_calls = False
     first_delta_fired = False
     active_message_phase: str | None = None
+    commentary_text_deltas: List[str] = []
     terminal_status: str = "completed"
     terminal_usage: Any = None
     terminal_response_id: str = None
@@ -710,6 +716,8 @@ def _consume_codex_event_stream(
             if item_type == "message":
                 phase = _item_field(item, "phase", None)
                 active_message_phase = phase.strip().lower() if isinstance(phase, str) else None
+                if active_message_phase == "commentary":
+                    commentary_text_deltas = []
             else:
                 active_message_phase = None
             if "function_call" in str(item_type):
@@ -718,10 +726,16 @@ def _consume_codex_event_stream(
 
         if "output_text.delta" in event_type or event_type == "response.output_text.delta":
             delta_text = _event_field(event, "delta", "")
-            is_commentary_delta = active_message_phase in {"commentary", "analysis"}
-            if delta_text and is_commentary_delta:
-                # Commentary streams through the reasoning channel, not the
-                # visible answer stream (and stays out of output_text).
+            if delta_text and active_message_phase == "commentary":
+                commentary_text_deltas.append(delta_text)
+                # Preserve CLI/backward compatibility when no first-class
+                # commentary consumer is installed.
+                if on_commentary_message is None and on_reasoning_delta is not None:
+                    try:
+                        on_reasoning_delta(delta_text)
+                    except Exception:
+                        logger.debug("Codex stream on_reasoning_delta raised", exc_info=True)
+            elif delta_text and active_message_phase == "analysis":
                 if on_reasoning_delta is not None:
                     try:
                         on_reasoning_delta(delta_text)
@@ -761,6 +775,27 @@ def _consume_codex_event_stream(
             done_item = _event_field(event, "item")
             if done_item is not None:
                 collected_output_items.append(done_item)
+                done_phase = _item_field(done_item, "phase", None)
+                done_phase = done_phase.strip().lower() if isinstance(done_phase, str) else None
+                if done_phase == "commentary" and on_commentary_message is not None:
+                    commentary_text = "".join(commentary_text_deltas).strip()
+                    if not commentary_text:
+                        content_parts = _item_field(done_item, "content", [])
+                        if isinstance(content_parts, list):
+                            commentary_text = "".join(
+                                str(_item_field(part, "text", "") or "")
+                                for part in content_parts
+                                if _item_field(part, "type", "") == "output_text"
+                            ).strip()
+                    if commentary_text:
+                        try:
+                            on_commentary_message(commentary_text)
+                        except Exception:
+                            logger.debug(
+                                "Codex stream on_commentary_message raised",
+                                exc_info=True,
+                            )
+                    commentary_text_deltas = []
             continue
 
         if event_type in _TERMINAL_EVENT_TYPES:
@@ -861,6 +896,9 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     def _on_reasoning_delta(text: str) -> None:
         agent._fire_reasoning_delta(text)
 
+    def _on_commentary_message(text: str) -> None:
+        agent._fire_streamed_codex_commentary(text)
+
     def _on_event(event: Any) -> None:
         # TTFB watchdog and activity touch — runs once per SSE event.
         agent._codex_stream_last_event_ts = time.time()
@@ -900,6 +938,11 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     model=api_kwargs.get("model"),
                     on_text_delta=_on_text_delta,
                     on_reasoning_delta=_on_reasoning_delta,
+                    on_commentary_message=(
+                        _on_commentary_message
+                        if getattr(agent, "interim_assistant_callback", None) is not None
+                        else None
+                    ),
                     on_first_delta=on_first_delta,
                     on_event=_on_event,
                     interrupt_check=_interrupt_check,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4496,21 +4496,41 @@ def run_conversation(
                     # drifts per continuation even when the visible output
                     # is identical, so including it in the comparison defeats
                     # dedup and causes message storms (#52711).
+                    last_interim_visible = (
+                        agent._interim_assistant_visible_text(last_msg)
+                        if isinstance(last_msg, dict)
+                        else ""
+                    )
+                    current_interim_visible = agent._interim_assistant_visible_text(interim_msg)
+                    if last_interim_visible or current_interim_visible:
+                        same_visible_output = last_interim_visible == current_interim_visible
+                    else:
+                        # Preserve the existing reasoning-only behavior when
+                        # neither response has text eligible for interim delivery.
+                        same_visible_output = (
+                            (last_msg.get("content") or "") == (interim_msg.get("content") or "")
+                            and (last_msg.get("reasoning") or "") == (interim_msg.get("reasoning") or "")
+                        ) if isinstance(last_msg, dict) else False
                     visible_duplicate = (
                         isinstance(last_msg, dict)
                         and last_msg.get("role") == "assistant"
                         and last_msg.get("finish_reason") == "incomplete"
-                        and (last_msg.get("content") or "") == (interim_msg.get("content") or "")
-                        and (last_msg.get("reasoning") or "") == (interim_msg.get("reasoning") or "")
+                        and same_visible_output
                     )
                     if visible_duplicate:
-                        # Update opaque state in-place so the latest
-                        # provider payload is preserved without emitting
-                        # a duplicate visible message.
-                        for _key in ("codex_reasoning_items", "codex_message_items"):
-                            _new_val = interim_msg.get(_key)
-                            if _new_val is not None:
-                                last_msg[_key] = _new_val
+                        # Update replay state in-place so the latest provider
+                        # payload is preserved without re-emitting identical
+                        # user-visible commentary.
+                        for _key in (
+                            "content",
+                            "reasoning",
+                            "reasoning_content",
+                            "reasoning_details",
+                            "codex_reasoning_items",
+                            "codex_message_items",
+                        ):
+                            if _key in interim_msg:
+                                last_msg[_key] = interim_msg[_key]
                     else:
                         messages.append(interim_msg)
                         agent._emit_interim_assistant_message(interim_msg)
@@ -4844,8 +4864,23 @@ def run_conversation(
                 # a LATER tool round.
                 agent._post_tool_empty_retried = False
 
+                previous_msg = messages[-1] if messages else None
+                current_interim_visible = agent._interim_assistant_visible_text(assistant_msg)
+                previous_interim_visible = (
+                    agent._interim_assistant_visible_text(previous_msg)
+                    if isinstance(previous_msg, dict)
+                    else ""
+                )
+                duplicate_previous_interim = (
+                    bool(current_interim_visible)
+                    and isinstance(previous_msg, dict)
+                    and previous_msg.get("role") == "assistant"
+                    and previous_msg.get("finish_reason") == "incomplete"
+                    and previous_interim_visible == current_interim_visible
+                )
                 messages.append(assistant_msg)
-                agent._emit_interim_assistant_message(assistant_msg)
+                if not duplicate_previous_interim:
+                    agent._emit_interim_assistant_message(assistant_msg)
                 try:
                     # Persist the assistant tool-call turn before any tool
                     # side effects run. If a destructive tool restarts or

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -616,6 +616,10 @@ def run_conversation(
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
 
+    # Commentary deduplication spans all provider continuations and tool calls
+    # within one user turn, but must not suppress the same phrase next turn.
+    agent._delivered_interim_texts = set()
+
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
     final_response = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -4794,15 +4794,26 @@ class AIAgent:
             visible = redact_sensitive_text(visible)
         return visible
 
+    def _interim_assistant_visible_text(self, assistant_msg: Dict[str, Any]) -> str:
+        """Return the exact assistant text eligible for interim delivery.
+
+        Prefer structured Codex commentary over top-level content. A Codex
+        response can contain both commentary and a partial/final-answer message
+        while tools are still pending; treating top-level content as progress
+        in that shape leaks the answer before the tool call runs.
+        """
+        visible = self._extract_codex_interim_visible_text(assistant_msg)
+        if visible:
+            return visible
+        content = assistant_msg.get("content")
+        return self._strip_think_blocks(content or "").strip()
+
     def _emit_interim_assistant_message(self, assistant_msg: Dict[str, Any]) -> None:
         """Surface a real mid-turn assistant commentary message to the UI layer."""
         cb = getattr(self, "interim_assistant_callback", None)
         if cb is None or not isinstance(assistant_msg, dict):
             return
-        content = assistant_msg.get("content")
-        visible = self._strip_think_blocks(content or "").strip()
-        if not visible or visible == "(empty)":
-            visible = self._extract_codex_interim_visible_text(assistant_msg)
+        visible = self._interim_assistant_visible_text(assistant_msg)
         if not visible or visible == "(empty)":
             return
         already_streamed = self._interim_content_was_streamed(visible)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4791,6 +4791,7 @@ class AIAgent:
         visible = "\n\n".join(parts).strip()
         if visible:
             visible = self._strip_think_blocks(visible).strip()
+            visible = redact_sensitive_text(visible)
         return visible
 
     def _emit_interim_assistant_message(self, assistant_msg: Dict[str, Any]) -> None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4754,6 +4754,45 @@ class AIAgent:
         )
         return bool(streamed) and streamed == visible_content
 
+    def _extract_codex_interim_visible_text(self, assistant_msg: Dict[str, Any]) -> str:
+        """Extract visible Codex Responses commentary text.
+
+        Codex Responses can keep user-facing mid-turn narration as structured
+        ``phase=commentary`` message items while final answer text remains in
+        assistant ``content``.  Non-streaming gateway surfaces need that
+        commentary through the interim assistant callback before tool calls run.
+        ``phase=analysis`` remains hidden because it is provider scratchpad.
+        """
+        items = assistant_msg.get("codex_message_items")
+        if not isinstance(items, list):
+            return ""
+
+        parts: List[str] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") != "message":
+                continue
+            phase = item.get("phase")
+            if not isinstance(phase, str) or phase.strip().lower() != "commentary":
+                continue
+            content_parts = item.get("content")
+            if not isinstance(content_parts, list):
+                continue
+            for part in content_parts:
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") != "output_text":
+                    continue
+                text = part.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+
+        visible = "\n\n".join(parts).strip()
+        if visible:
+            visible = self._strip_think_blocks(visible).strip()
+        return visible
+
     def _emit_interim_assistant_message(self, assistant_msg: Dict[str, Any]) -> None:
         """Surface a real mid-turn assistant commentary message to the UI layer."""
         cb = getattr(self, "interim_assistant_callback", None)
@@ -4761,6 +4800,8 @@ class AIAgent:
             return
         content = assistant_msg.get("content")
         visible = self._strip_think_blocks(content or "").strip()
+        if not visible or visible == "(empty)":
+            visible = self._extract_codex_interim_visible_text(assistant_msg)
         if not visible or visible == "(empty)":
             return
         already_streamed = self._interim_content_was_streamed(visible)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4754,8 +4754,11 @@ class AIAgent:
         )
         return bool(streamed) and streamed == visible_content
 
-    def _extract_codex_interim_visible_text(self, assistant_msg: Dict[str, Any]) -> str:
-        """Extract visible Codex Responses commentary text.
+    def _extract_codex_interim_visible_parts(
+        self,
+        assistant_msg: Dict[str, Any],
+    ) -> List[str]:
+        """Extract visible Codex commentary as one string per message item.
 
         Codex Responses can keep user-facing mid-turn narration as structured
         ``phase=commentary`` message items while final answer text remains in
@@ -4765,9 +4768,9 @@ class AIAgent:
         """
         items = assistant_msg.get("codex_message_items")
         if not isinstance(items, list):
-            return ""
+            return []
 
-        parts: List[str] = []
+        messages: List[str] = []
         for item in items:
             if not isinstance(item, dict):
                 continue
@@ -4779,6 +4782,7 @@ class AIAgent:
             content_parts = item.get("content")
             if not isinstance(content_parts, list):
                 continue
+            item_parts: List[str] = []
             for part in content_parts:
                 if not isinstance(part, dict):
                     continue
@@ -4786,13 +4790,20 @@ class AIAgent:
                     continue
                 text = part.get("text")
                 if isinstance(text, str) and text.strip():
-                    parts.append(text.strip())
+                    item_parts.append(text)
+            visible = "".join(item_parts).strip()
+            if visible:
+                visible = self._strip_think_blocks(visible).strip()
+                visible = redact_sensitive_text(visible)
+            if visible:
+                messages.append(visible)
+        return messages
 
-        visible = "\n\n".join(parts).strip()
-        if visible:
-            visible = self._strip_think_blocks(visible).strip()
-            visible = redact_sensitive_text(visible)
-        return visible
+    def _extract_codex_interim_visible_text(self, assistant_msg: Dict[str, Any]) -> str:
+        """Extract all visible Codex commentary for comparison/fallback."""
+        return "\n\n".join(
+            self._extract_codex_interim_visible_parts(assistant_msg)
+        ).strip()
 
     def _interim_assistant_visible_text(self, assistant_msg: Dict[str, Any]) -> str:
         """Return the exact assistant text eligible for interim delivery.
@@ -4808,17 +4819,74 @@ class AIAgent:
         content = assistant_msg.get("content")
         return self._strip_think_blocks(content or "").strip()
 
+    def _interim_text_was_delivered(self, text: str) -> bool:
+        normalized = self._normalize_interim_visible_text(text)
+        if not normalized:
+            return False
+        return normalized in getattr(self, "_delivered_interim_texts", set())
+
+    def _record_delivered_interim_text(self, text: str) -> None:
+        normalized = self._normalize_interim_visible_text(text)
+        if normalized:
+            delivered = getattr(self, "_delivered_interim_texts", None)
+            if not isinstance(delivered, set):
+                delivered = set()
+                self._delivered_interim_texts = delivered
+            delivered.add(normalized)
+
+    def _fire_streamed_codex_commentary(self, text: str) -> None:
+        """Deliver a completed live Codex commentary message immediately."""
+        cb = getattr(self, "interim_assistant_callback", None)
+        if cb is None or not isinstance(text, str):
+            return
+        visible = self._strip_think_blocks(text).strip()
+        if visible:
+            visible = redact_sensitive_text(visible)
+        if not visible or visible == "(empty)" or self._interim_text_was_delivered(visible):
+            return
+        try:
+            cb(visible, already_streamed=False)
+            self._record_delivered_interim_text(visible)
+        except Exception:
+            logger.debug("interim_assistant_callback error", exc_info=True)
+
     def _emit_interim_assistant_message(self, assistant_msg: Dict[str, Any]) -> None:
         """Surface a real mid-turn assistant commentary message to the UI layer."""
         cb = getattr(self, "interim_assistant_callback", None)
         if cb is None or not isinstance(assistant_msg, dict):
             return
-        visible = self._interim_assistant_visible_text(assistant_msg)
-        if not visible or visible == "(empty)":
+        commentary_parts = self._extract_codex_interim_visible_parts(assistant_msg)
+        undelivered_parts: List[str] = []
+        pending_keys: set[str] = set()
+        for part in commentary_parts:
+            key = self._normalize_interim_visible_text(part)
+            if (
+                not key
+                or key in pending_keys
+                or self._interim_text_was_delivered(part)
+            ):
+                continue
+            pending_keys.add(key)
+            undelivered_parts.append(part)
+        visible = (
+            "\n\n".join(undelivered_parts).strip()
+            if commentary_parts
+            else self._interim_assistant_visible_text(assistant_msg)
+        )
+        if (
+            not visible
+            or visible == "(empty)"
+            or self._interim_text_was_delivered(visible)
+        ):
             return
         already_streamed = self._interim_content_was_streamed(visible)
         try:
             cb(visible, already_streamed=already_streamed)
+            if undelivered_parts:
+                for part in undelivered_parts:
+                    self._record_delivered_interim_text(part)
+            else:
+                self._record_delivered_interim_text(visible)
         except Exception:
             logger.debug("interim_assistant_callback error", exc_info=True)
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -158,6 +158,35 @@ def _codex_commentary_message_response(text: str):
     )
 
 
+def _codex_commentary_final_tool_response(commentary: str, final_answer: str = "Done."):
+    return SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                phase="commentary",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text=commentary)],
+            ),
+            SimpleNamespace(
+                type="message",
+                phase="final_answer",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text=final_answer)],
+            ),
+            SimpleNamespace(
+                type="function_call",
+                id="fc_1",
+                call_id="call_1",
+                name="terminal",
+                arguments="{}",
+            ),
+        ],
+        usage=SimpleNamespace(input_tokens=8, output_tokens=5, total_tokens=13),
+        status="completed",
+        model="gpt-5-codex",
+    )
+
+
 def _codex_ack_message_response(text: str):
     return SimpleNamespace(
         output=[
@@ -2100,44 +2129,24 @@ def test_interim_commentary_preserves_assistant_content(monkeypatch):
     assert "I'll inspect the repo structure first." in observed["text"]
 
 
-def test_interim_commentary_uses_codex_commentary_items_when_content_is_empty(monkeypatch):
-    """Codex Responses stores commentary phase text outside content.
-
-    The gateway still needs that visible mid-turn narration to flow through the
-    interim assistant callback; otherwise Discord with streaming disabled gets
-    no natural progress commentary before tools run. Analysis/final-answer items
-    stay hidden from interim delivery.
-    """
+def test_interim_commentary_precedes_content_from_real_codex_normalization(monkeypatch):
+    """Structured commentary wins over final-answer content on tool turns."""
     agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _normalize_codex_response
+
     observed = {}
     agent.interim_assistant_callback = lambda text, *, already_streamed=False: observed.update(
         {"text": text, "already_streamed": already_streamed}
     )
 
-    agent._emit_interim_assistant_message({
-        "role": "assistant",
-        "content": "",
-        "codex_message_items": [
-            {
-                "type": "message",
-                "role": "assistant",
-                "phase": "analysis",
-                "content": [{"type": "output_text", "text": "Need inspect files."}],
-            },
-            {
-                "type": "message",
-                "role": "assistant",
-                "phase": "commentary",
-                "content": [{"type": "output_text", "text": "I'll inspect the repo first."}],
-            },
-            {
-                "type": "message",
-                "role": "assistant",
-                "phase": "final_answer",
-                "content": [{"type": "output_text", "text": "Done."}],
-            },
-        ],
-    })
+    normalized, finish_reason = _normalize_codex_response(
+        _codex_commentary_final_tool_response("I'll inspect the repo first.")
+    )
+    assert finish_reason == "tool_calls"
+    assert normalized.content == "Done."
+    agent._emit_interim_assistant_message(
+        agent._build_assistant_message(normalized, finish_reason)
+    )
 
     assert observed == {
         "text": "I'll inspect the repo first.",
@@ -2286,6 +2295,12 @@ def test_stream_delta_preserves_code_fence_newlines(monkeypatch):
 
 def test_run_conversation_codex_continues_after_commentary_phase_message(monkeypatch):
     agent = _build_agent(monkeypatch)
+    emitted = []
+    stream_events = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: emitted.append((text, already_streamed))
+    )
+    agent.stream_delta_callback = stream_events.append
     responses = [
         _codex_commentary_message_response("I'll inspect the repo structure first."),
         _codex_tool_call_response(),
@@ -2309,6 +2324,7 @@ def test_run_conversation_codex_continues_after_commentary_phase_message(monkeyp
 
     assert result["completed"] is True
     assert result["final_response"] == "Architecture summary complete."
+    assert emitted == [("I'll inspect the repo structure first.", False)]
     commentary_messages = [
         msg for msg in result["messages"]
         if msg.get("role") == "assistant" and msg.get("finish_reason") == "incomplete"
@@ -2322,6 +2338,39 @@ def test_run_conversation_codex_continues_after_commentary_phase_message(monkeyp
         if item.get("phase") == "commentary"
     )
     assert any(msg.get("role") == "tool" and msg.get("tool_call_id") == "call_1" for msg in result["messages"])
+
+
+def test_codex_commentary_emits_before_tool_and_withholds_final_answer(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    events = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: events.append(("interim", text))
+    )
+    responses = [
+        _codex_commentary_message_response("I'll inspect the repo first."),
+        _codex_commentary_final_tool_response("I'll inspect the repo first."),
+        _codex_message_response("Verified final answer."),
+    ]
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
+
+    def _fake_execute_tool_calls(assistant_message, messages, effective_task_id, *_args):
+        events.append(("tool", assistant_message.tool_calls[0].function.name))
+        messages.append({
+            "role": "tool",
+            "tool_call_id": assistant_message.tool_calls[0].id,
+            "content": '{"ok":true}',
+        })
+
+    monkeypatch.setattr(agent, "_execute_tool_calls", _fake_execute_tool_calls)
+
+    result = agent.run_conversation("analyze repo")
+
+    assert result["completed"] is True
+    assert events == [
+        ("interim", "I'll inspect the repo first."),
+        ("tool", "terminal"),
+    ]
+    assert all(text != "Done." for kind, text in events if kind == "interim")
 
 
 def test_run_conversation_codex_continues_after_ack_stop_message(monkeypatch):
@@ -2814,13 +2863,23 @@ def test_duplicate_detection_distinguishes_different_codex_reasoning(monkeypatch
         assert items[0].get("encrypted_content") == "enc_second"
 
 
-def test_duplicate_detection_distinguishes_different_codex_message_items(monkeypatch):
-    """Incomplete turns with same visible content but different message ids
-    are deduped — only one interim kept, opaque state updated in-place (#52711)."""
+def test_duplicate_detection_uses_commentary_when_hidden_reasoning_changes(monkeypatch):
+    """Identical commentary is emitted once while newer replay state wins."""
     agent = _build_agent(monkeypatch)
+    emitted = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: emitted.append(text)
+    )
     responses = [
         SimpleNamespace(
             output=[
+                SimpleNamespace(
+                    type="reasoning",
+                    id="rs_first",
+                    encrypted_content="enc_first",
+                    summary=[SimpleNamespace(text="hidden first")],
+                    status="completed",
+                ),
                 SimpleNamespace(
                     type="message",
                     id="msg_first",
@@ -2835,6 +2894,13 @@ def test_duplicate_detection_distinguishes_different_codex_message_items(monkeyp
         ),
         SimpleNamespace(
             output=[
+                SimpleNamespace(
+                    type="reasoning",
+                    id="rs_second",
+                    encrypted_content="enc_second",
+                    summary=[SimpleNamespace(text="hidden second")],
+                    status="completed",
+                ),
                 SimpleNamespace(
                     type="message",
                     id="msg_second",
@@ -2854,6 +2920,7 @@ def test_duplicate_detection_distinguishes_different_codex_message_items(monkeyp
     result = agent.run_conversation("keep going")
 
     assert result["completed"] is True
+    assert emitted == ["Still working..."]
     interim_msgs = [
         msg for msg in result["messages"]
         if msg.get("role") == "assistant"
@@ -2865,6 +2932,10 @@ def test_duplicate_detection_distinguishes_different_codex_message_items(monkeyp
     items = interim_msgs[0].get("codex_message_items")
     if items:
         assert items[0].get("id") == "msg_second"
+    assert "hidden second" in (interim_msgs[0].get("reasoning") or "")
+    reasoning_items = interim_msgs[0].get("codex_reasoning_items")
+    if reasoning_items:
+        assert reasoning_items[0].get("id") == "rs_second"
 
 
 def test_chat_messages_to_responses_input_deduplicates_reasoning_ids(monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -704,6 +704,49 @@ def test_consume_codex_stream_routes_commentary_phase_deltas_to_reasoning(monkey
     assert response.output_text == ""
 
 
+def test_consume_codex_stream_separates_commentary_from_analysis(monkeypatch):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    commentary_item = SimpleNamespace(
+        type="message",
+        phase="commentary",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="I'll inspect the repo first.")],
+    )
+    streamed = []
+    reasoning_streamed = []
+    commentary_messages = []
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", phase="commentary"),
+            ),
+            SimpleNamespace(type="response.output_text.delta", delta="I'll inspect "),
+            SimpleNamespace(type="response.output_text.delta", delta="the repo first."),
+            SimpleNamespace(type="response.output_item.done", item=commentary_item),
+            SimpleNamespace(
+                type="response.reasoning_text.delta",
+                delta="Need inspect files privately.",
+            ),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            ),
+        ]),
+        model="gpt-5-codex",
+        on_text_delta=streamed.append,
+        on_reasoning_delta=reasoning_streamed.append,
+        on_commentary_message=commentary_messages.append,
+    )
+
+    assert commentary_messages == ["I'll inspect the repo first."]
+    assert reasoning_streamed == ["Need inspect files privately."]
+    assert streamed == []
+    assert response.output == [commentary_item]
+
+
 def test_consume_codex_stream_keeps_final_answer_phase_deltas(monkeypatch):
     from agent.codex_runtime import _consume_codex_event_stream
 
@@ -724,6 +767,201 @@ def test_consume_codex_stream_keeps_final_answer_phase_deltas(monkeypatch):
 
     assert streamed == ["visible answer"]
     assert response.output_text == "visible answer"
+
+
+def test_run_codex_stream_delivers_redacted_commentary_once(monkeypatch):
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    agent = _build_agent(monkeypatch)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+    delivered = []
+    reasoning_streamed = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: delivered.append(
+            (text, already_streamed)
+        )
+    )
+    agent.reasoning_callback = reasoning_streamed.append
+    secret = "sk-" + ("A" * 32)
+    commentary_text = f"Using credential {secret}. I'll inspect the repo."
+    commentary_item = SimpleNamespace(
+        type="message",
+        phase="commentary",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text=commentary_text)],
+    )
+    function_item = SimpleNamespace(
+        type="function_call",
+        id="fc_1",
+        call_id="call_1",
+        name="terminal",
+        arguments="{}",
+    )
+
+    def _fake_create(**kwargs):
+        assert kwargs.get("stream") is True
+        return _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", phase="commentary"),
+            ),
+            SimpleNamespace(type="response.output_text.delta", delta=commentary_text),
+            SimpleNamespace(type="response.output_item.done", item=commentary_item),
+            SimpleNamespace(type="response.reasoning_text.delta", delta="Private scratchpad."),
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="function_call"),
+            ),
+            SimpleNamespace(type="response.output_item.done", item=function_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            ),
+        ])
+
+    agent.client = SimpleNamespace(responses=SimpleNamespace(create=_fake_create))
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert len(delivered) == 1
+    assert delivered[0][1] is False
+    assert secret not in delivered[0][0]
+    assert "Using credential" in delivered[0][0]
+    assert reasoning_streamed == ["Private scratchpad."]
+
+    # The completed-response fallback sees the same preserved commentary but
+    # must not enqueue it again after live delivery.
+    normalized, finish_reason = _normalize_codex_response(response)
+    agent._emit_interim_assistant_message(
+        agent._build_assistant_message(normalized, finish_reason)
+    )
+    assert len(delivered) == 1
+
+
+def test_run_codex_stream_multiple_commentary_items_are_not_reemitted(monkeypatch):
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    agent = _build_agent(monkeypatch)
+    delivered = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: delivered.append(text)
+    )
+    commentary_a = SimpleNamespace(
+        type="message",
+        phase="commentary",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="First update.")],
+    )
+    commentary_b = SimpleNamespace(
+        type="message",
+        phase="commentary",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="Second update.")],
+    )
+    function_item = SimpleNamespace(
+        type="function_call",
+        id="fc_1",
+        call_id="call_1",
+        name="terminal",
+        arguments="{}",
+    )
+
+    def _fake_create(**kwargs):
+        return _FakeCreateStream([
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", phase="commentary"),
+            ),
+            SimpleNamespace(type="response.output_text.delta", delta="First update."),
+            SimpleNamespace(type="response.output_item.done", item=commentary_a),
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="message", phase="commentary"),
+            ),
+            SimpleNamespace(type="response.output_text.delta", delta="Second update."),
+            SimpleNamespace(type="response.output_item.done", item=commentary_b),
+            SimpleNamespace(
+                type="response.output_item.added",
+                item=SimpleNamespace(type="function_call"),
+            ),
+            SimpleNamespace(type="response.output_item.done", item=function_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            ),
+        ])
+
+    agent.client = SimpleNamespace(responses=SimpleNamespace(create=_fake_create))
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    normalized, finish_reason = _normalize_codex_response(response)
+    agent._emit_interim_assistant_message(
+        agent._build_assistant_message(normalized, finish_reason)
+    )
+
+    assert delivered == ["First update.", "Second update."]
+
+
+def test_run_codex_stream_retry_deduplicates_multiple_commentary_items(monkeypatch):
+    import httpx
+
+    agent = _build_agent(monkeypatch)
+    delivered = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: delivered.append(text)
+    )
+    commentary_a = SimpleNamespace(
+        type="message",
+        phase="commentary",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="First update.")],
+    )
+    commentary_b = SimpleNamespace(
+        type="message",
+        phase="commentary",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="Second update.")],
+    )
+
+    class _DroppingStream(_FakeCreateStream):
+        def __iter__(self):
+            yield from super().__iter__()
+            raise httpx.RemoteProtocolError("connection dropped")
+
+    commentary_events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(type="message", phase="commentary"),
+        ),
+        SimpleNamespace(type="response.output_text.delta", delta="First update."),
+        SimpleNamespace(type="response.output_item.done", item=commentary_a),
+        SimpleNamespace(
+            type="response.output_item.added",
+            item=SimpleNamespace(type="message", phase="commentary"),
+        ),
+        SimpleNamespace(type="response.output_text.delta", delta="Second update."),
+        SimpleNamespace(type="response.output_item.done", item=commentary_b),
+    ]
+    calls = {"count": 0}
+
+    def _fake_create(**kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return _DroppingStream(commentary_events)
+        return _FakeCreateStream([
+            *commentary_events,
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            ),
+        ])
+
+    agent.client = SimpleNamespace(responses=SimpleNamespace(create=_fake_create))
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.status == "completed"
+    assert calls["count"] == 2
+    assert delivered == ["First update.", "Second update."]
 
 
 def test_run_codex_stream_surfaces_failed_status_in_final_response(monkeypatch):
@@ -2181,6 +2419,28 @@ def test_interim_commentary_redacts_secrets_from_codex_commentary_items(monkeypa
     assert len(observed) == 1
     assert secret not in observed[0]
     assert "Using credential" in observed[0]
+
+
+def test_interim_commentary_deduplicates_identical_items_in_one_response(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    observed = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: observed.append(text)
+    )
+    commentary_item = {
+        "type": "message",
+        "role": "assistant",
+        "phase": "commentary",
+        "content": [{"type": "output_text", "text": "Still working."}],
+    }
+
+    agent._emit_interim_assistant_message({
+        "role": "assistant",
+        "content": "",
+        "codex_message_items": [commentary_item, dict(commentary_item)],
+    })
+
+    assert observed == ["Still working."]
 
 
 def test_stream_delta_strips_leaked_memory_context(monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2100,6 +2100,51 @@ def test_interim_commentary_preserves_assistant_content(monkeypatch):
     assert "I'll inspect the repo structure first." in observed["text"]
 
 
+def test_interim_commentary_uses_codex_commentary_items_when_content_is_empty(monkeypatch):
+    """Codex Responses stores commentary phase text outside content.
+
+    The gateway still needs that visible mid-turn narration to flow through the
+    interim assistant callback; otherwise Discord with streaming disabled gets
+    no natural progress commentary before tools run. Analysis/final-answer items
+    stay hidden from interim delivery.
+    """
+    agent = _build_agent(monkeypatch)
+    observed = {}
+    agent.interim_assistant_callback = lambda text, *, already_streamed=False: observed.update(
+        {"text": text, "already_streamed": already_streamed}
+    )
+
+    agent._emit_interim_assistant_message({
+        "role": "assistant",
+        "content": "",
+        "codex_message_items": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "phase": "analysis",
+                "content": [{"type": "output_text", "text": "Need inspect files."}],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "phase": "commentary",
+                "content": [{"type": "output_text", "text": "I'll inspect the repo first."}],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "phase": "final_answer",
+                "content": [{"type": "output_text", "text": "Done."}],
+            },
+        ],
+    })
+
+    assert observed == {
+        "text": "I'll inspect the repo first.",
+        "already_streamed": False,
+    }
+
+
 def test_stream_delta_strips_leaked_memory_context(monkeypatch):
     agent = _build_agent(monkeypatch)
     observed = []

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2145,6 +2145,35 @@ def test_interim_commentary_uses_codex_commentary_items_when_content_is_empty(mo
     }
 
 
+def test_interim_commentary_redacts_secrets_from_codex_commentary_items(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+    observed = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: observed.append(text)
+    )
+    secret = "sk-" + ("A" * 32)
+
+    agent._emit_interim_assistant_message({
+        "role": "assistant",
+        "content": "",
+        "codex_message_items": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "phase": "commentary",
+                "content": [
+                    {"type": "output_text", "text": f"Using credential {secret}."}
+                ],
+            },
+        ],
+    })
+
+    assert len(observed) == 1
+    assert secret not in observed[0]
+    assert "Using credential" in observed[0]
+
+
 def test_stream_delta_strips_leaked_memory_context(monkeypatch):
     agent = _build_agent(monkeypatch)
     observed = []


### PR DESCRIPTION
## What does this PR do?

This PR gives Codex `phase="commentary"` a first-class, user-visible streaming path without exposing private reasoning.

It **supersedes #60453** while preserving David Robertson's two original commits and authorship. On top of that work, it adds the lifecycle, deduplication, fallback, and security fixes found during adversarial review against current `main`.

The user-visible contract is intentionally narrow:

| Codex event / phase | Hermes destination | Visibility |
| --- | --- | --- |
| `phase="commentary"` | existing `interim_assistant_callback` | visible progress narration |
| `response.reasoning_text.*` / reasoning summaries | existing reasoning callback | controlled by `show_reasoning` |
| `phase="analysis"` | reasoning-only path | never promoted to commentary |
| `phase="final_answer"` | normal assistant stream | final response |

This means gateways can keep `show_reasoning: false` and still show polished Codex progress updates, matching the commentary/final channel split used by Codex clients.

## Related issue and PRs

- Canonical commentary leak/routing family: #24933
- Supersedes: #60453
- Related alternative implementations: #59831, #62396

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security hardening (redaction is preserved on the new visible route)
- [ ] 📝 Documentation update
- [x] ✅ Tests (adds lifecycle, fallback, compatibility, and regression coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Why this supersedes #60453

#60453 found the correct user-facing seam and added the first safe extraction path. This PR retains those commits, including think-block stripping and secret redaction, then fixes cases that could otherwise duplicate, delay, omit, or misclassify commentary:

- emits completed commentary items immediately instead of waiting for the entire response;
- prefers `final_answer` content when a response contains both commentary and final text;
- keeps `analysis` and reasoning events off the visible commentary rail;
- supports delta, text-done, and output-item-done fallbacks;
- tracks multiple output items independently;
- deduplicates incomplete-to-tool transitions and transport retries;
- handles identical commentary items without collapsing distinct occurrences;
- prevents aggregate fallbacks from re-emitting items already delivered live;
- preserves the legacy CLI reasoning fallback when no interim callback exists;
- does not mutate phase-bearing replay items used for continuation/prompt-cache behavior.

Related design work:

- #59831 explores moving this routing into the Codex runtime and raised the finalized-event and interleaved-item robustness cases covered here.
- #62396 proposes a new persisted end-to-end `Working` UI protocol. That can still be evaluated independently; this PR deliberately uses Hermes' existing interim-assistant contract to keep the change backward-compatible and scoped.

## Routing design

```mermaid
flowchart LR
    SSE["Codex Responses SSE"] --> Kind{"Event / output phase"}
    Kind -->|"phase=commentary"| Item["Assemble one output item"]
    Item --> Safe["Strip think blocks<br/>Redact sensitive text"]
    Safe --> Interim["interim_assistant_callback"]
    Kind -->|"reasoning events<br/>or phase=analysis"| Reasoning["reasoning_callback"]
    Kind -->|"phase=final_answer"| Final["normal stream_delta_callback"]
    Interim --> Gateway["Gateway progress message"]
    Reasoning --> Thinking["Shown only when reasoning is enabled"]
    Final --> Reply["Assistant final response"]
```

Commentary is emitted at the earliest authoritative lifecycle boundary:

```mermaid
sequenceDiagram
    participant C as Codex SSE
    participant H as Hermes runtime
    participant G as Gateway
    C->>H: commentary deltas
    C->>H: commentary output_item.done
    H->>H: strip think blocks + redact + deduplicate
    H-->>G: interim commentary
    C->>H: function call / tool transition
    H-->>G: existing tool progress
    C->>H: final_answer deltas
    H-->>G: normal final response stream
```

## Implementation notes

- `agent/codex_runtime.py` exposes a commentary callback alongside the existing reasoning and final-stream callbacks.
- `agent/conversation_loop.py` and `agent/agent_init.py` wire that callback through the existing interim assistant delivery path.
- `run_agent.py` owns per-turn delivery state so retries and response fallbacks remain idempotent.
- The wire fixtures use the actual Responses API event shapes, including `response.reasoning_text.delta`.
- No configuration migration or new public gateway protocol is required.

## Safety and compatibility

- Commentary is sanitized before any user-facing callback: `<think>` content is removed and `redact_sensitive_text()` is applied.
- `phase="analysis"` is never promoted to the visible path.
- `show_reasoning: false` continues to hide reasoning; it no longer hides commentary.
- Callers that do not provide the new commentary callback retain the previous CLI behavior.
- Final-answer streaming and tool execution remain on their existing rails.
- The patch is additive at callback boundaries and does not alter stored Codex message-item phases.

## Verification

Rebased onto `main` at `53adb3fd9750376b520100b0f90b737da802d1e1`; reviewed head: `48a48b85ca9a8a935d75590136fbd4cae51c1af6`.

Focused local proof: **521 passed, 0 failed**.

```text
scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py
# 102 passed

scripts/run_tests.sh tests/run_agent/test_provider_parity.py -k 'codex or commentary or message_items'
# 38 passed

scripts/run_tests.sh tests/agent/test_redact.py
# 149 passed

scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/agent/test_codex_responses_adapter.py -k 'codex or commentary or analysis'
# 87 passed

scripts/run_tests.sh tests/gateway -k 'commentary or interim or progress'
# 145 passed across 479 discovered gateway files
```

Also passed:

- Ruff on all changed Python files (one pre-existing invalid-`noqa` warning at `run_agent.py:107`)
- `compileall` on all changed Python files
- `git diff --check`
- adversarial review of security, lifecycle, compatibility, and fallback/dedup behavior, with all >=95%-confidence findings fixed and regression-tested

Not claimed here: a live external Codex provider or messaging-platform smoke. The deterministic stream fixtures exercise the same event lifecycle without consuming credentials or sending messages.

## Review guide

1. Start with the callback contract in `agent/codex_runtime.py`.
2. Check callback wiring in `agent/agent_init.py` and `agent/conversation_loop.py`.
3. Review per-turn delivery/dedup logic in `run_agent.py`.
4. Use the named regression tests in `tests/run_agent/test_run_agent_codex_responses.py` to verify each lifecycle edge case.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing PRs and documented the three overlapping approaches above
- [x] This PR contains only changes related to Codex commentary routing and its tests
- [ ] I've run `pytest tests/ -q` locally — the 39k-test repository suite is left to canonical CI; 521 focused tests pass locally
- [x] I've added tests for the behavior and regressions
- [x] Tested on macOS (focused deterministic Python suites)

### Documentation and housekeeping

- [x] Relevant documentation is N/A; the callback and lifecycle contracts are documented in code and this PR
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are N/A; no contributor workflow changed
- [x] Cross-platform impact considered; the change is platform-neutral Python callback/state logic
- [x] Tool descriptions/schemas are N/A; no tool behavior or schema changed

### Behavioral acceptance

- [x] Original #60453 commits and authorship preserved
- [x] Commentary visible without enabling reasoning
- [x] Analysis/reasoning remains private
- [x] Final-answer streaming unchanged
- [x] Secret redaction covered by regression tests
- [x] Multi-item, fallback, retry, and dedup cases covered
- [x] Current `main` rebase and focused validation complete

Credit: David Robertson (@davidrobertson) for the original #60453 diagnosis and safe extraction path.
