### PR TITLE
fix(desktop): offer a retry action when branch session.create fails (#65410)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/branch-retry.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/branch-retry.test.tsx
@@ -1,0 +1,135 @@
+import { act, cleanup, render } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { textPart } from '@/lib/chat-messages'
+import { $notifications, dismissNotification } from '@/store/notifications'
+import { $messages, setCurrentCwd, setMessages } from '@/store/session'
+import type { ClientSessionState } from '../../../types'
+
+import { useSessionActions } from '.'
+
+// A backend restart mid-`session.create` silently drops the branch RPC
+// (#65410) -- requestGateway rejects. The fix offers a one-click retry
+// action on the resulting error notification instead of a dead-end toast.
+async function actRender(ui: React.ReactElement) {
+  let result: ReturnType<typeof render>
+  await act(async () => {
+    result = render(ui)
+  })
+
+  return result!
+}
+
+interface HarnessHandle {
+  branchCurrentSession: () => Promise<boolean>
+}
+
+function Harness({
+  onReady,
+  requestGateway
+}: {
+  onReady: (handle: HarnessHandle) => void
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+}) {
+  const activeSessionIdRef: MutableRefObject<string | null> = useRef('rt-active')
+  const selectedStoredSessionIdRef: MutableRefObject<string | null> = useRef('stored-active')
+  const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = useRef(new Map())
+  const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = useRef(new Map())
+  const busyRef = useRef(false)
+  const creatingSessionRef = useRef(false)
+
+  const actions = useSessionActions({
+    activeSessionId: 'rt-active',
+    activeSessionIdRef,
+    busyRef,
+    creatingSessionRef,
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    navigate: () => undefined,
+    requestGateway,
+    resetViewSync: () => undefined,
+    runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionId: 'stored-active',
+    selectedStoredSessionIdRef,
+    sessionStateByRuntimeIdRef,
+    syncSessionStateToView: () => undefined,
+    updateSessionState: (_sessionId, updater) => updater({} as ClientSessionState)
+  })
+
+  useEffect(() => {
+    onReady({
+      branchCurrentSession: (...args: Parameters<typeof actions.branchCurrentSession>) =>
+        act(async () => actions.branchCurrentSession(...args)) as Promise<boolean>
+    })
+  }, [actions.branchCurrentSession, onReady])
+
+  return null
+}
+
+describe('forkBranch retry action (#65410)', () => {
+  beforeEach(() => {
+    setMessages([
+      {
+        id: 'm1',
+        role: 'user',
+        parts: [textPart('branch me')]
+      } as never
+    ])
+    setCurrentCwd('/repo')
+    $notifications.set([])
+  })
+
+  afterEach(() => {
+    cleanup()
+    $messages.set([])
+    $notifications.set([])
+  })
+
+  it('offers a retry action that re-issues session.create with the same args after a transport failure', async () => {
+    const calls: Array<Record<string, unknown> | undefined> = []
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method !== 'session.create') return {} as never
+
+      calls.push(params)
+
+      if (calls.length === 1) {
+        throw new Error('backend restart mid-request')
+      }
+
+      return {
+        session_id: 'rt-branch',
+        stored_session_id: 'stored-branch',
+        info: {}
+      } as never
+    })
+
+    let handle!: HarnessHandle
+    await actRender(<Harness onReady={h => (handle = h)} requestGateway={requestGateway} />)
+
+    const firstResult = await handle.branchCurrentSession()
+
+    expect(firstResult).toBe(false)
+    expect(calls).toHaveLength(1)
+
+    const notification = $notifications.get()[0]
+
+    expect(notification).toBeDefined()
+    expect(notification!.kind).toBe('error')
+    expect(notification!.action).toBeDefined()
+    expect(notification!.action!.label).toBe('Retry')
+
+    // Simulate the user clicking the toast's retry button.
+    await act(async () => {
+      notification!.action!.onClick()
+    })
+
+    expect(calls).toHaveLength(2)
+    // The retry carries the identical branch payload (same messages/cwd) --
+    // no re-derivation, no chance of drifting from what the user branched.
+    expect(calls[1]).toEqual(calls[0])
+
+    dismissNotification(notification!.id)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -834,7 +834,18 @@ export function useSessionActions({
 
         return true
       } catch (err) {
-        notifyError(err, copy.branchFailed)
+        // The RPC (and its args) are still in scope here — a backend
+        // restart mid-request (auto-update, crash) silently drops the
+        // in-flight session.create with no automatic retry, and the branch
+        // intent (parent + message slice) is otherwise lost with no way to
+        // recover short of redoing the whole branch flow (#65410). Offer a
+        // one-click retry with the same args instead of a transient toast.
+        notifyError(err, copy.branchFailed, {
+          label: t.common.retry,
+          onClick: () => {
+            void forkBranch(branchMessages, parentStoredId, cwd)
+          }
+        })
 
         return false
       } finally {
@@ -851,6 +862,7 @@ export function useSessionActions({
       navigate,
       requestGateway,
       selectedStoredSessionIdRef,
+      t,
       updateSessionState
     ]
   )

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -155,14 +155,15 @@ export function notify(input: NotificationInput): string {
   return id
 }
 
-export function notifyError(error: unknown, fallback: string): string {
+export function notifyError(error: unknown, fallback: string, action?: NotificationAction): string {
   const readable = readableError(error, fallback)
 
   return notify({
     kind: 'error',
     title: fallback,
     message: readable.message,
-    detail: readable.detail
+    detail: readable.detail,
+    action
   })
 }
 


### PR DESCRIPTION
## What does this PR do?

Implements Suggested Fix Direction #1 from #65410 (the issue's own minimal, frontend-only recommendation): when a Desktop branch operation's `session.create` RPC fails (most commonly because the backend restarted mid-request — auto-update, crash, or manual restart — silently dropping the in-flight request with no automatic retry), the resulting error toast now carries a **Retry** action button that re-issues the exact same `session.create` call instead of leaving the user with a dead-end transient toast and no way to recover the branch intent short of redoing the whole flow.

## Related Issue

Fixes #65410

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/notifications.ts`: `notifyError(error, fallback, action?)` now accepts an optional third `action` parameter and threads it into the underlying `notify()` call (which already supports `action` — error/warning toasts already default to non-dismissing, `durationMs: 0`, so the action stays visible until acted on). Backward compatible — all 173 other `notifyError` call sites are unaffected (`action` defaults to `undefined`).
- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`: `forkBranch`'s `catch` block now calls `notifyError(err, copy.branchFailed, { label: t.common.retry, onClick: () => void forkBranch(branchMessages, parentStoredId, cwd) })` — the exact same args that failed are still in scope at the catch site, so retry replays the identical branch payload rather than re-deriving it.
- `apps/desktop/src/app/session/hooks/use-session-actions/branch-retry.test.tsx` (new): renders the real `useSessionActions` hook with a `requestGateway` mock that rejects on the first `session.create` call (simulating the backend-restart drop) and succeeds on the second. Asserts: (1) the first call fails and produces an error notification with an `action`, (2) invoking that action's `onClick` re-issues `session.create`, and (3) the retry's params are identical to the first attempt's (`toEqual`) — proving no drift in the replayed branch intent.

## How to Test

1. Open Desktop with a session that has conversation history.
2. Trigger a branch while the backend is mid-restart (or simulate: reject the first `session.create` call).
3. Before this fix: transient error toast, no retry, no way to recover without redoing the whole branch flow.
4. After this fix: the same error toast now has a **Retry** button; clicking it re-issues the exact branch request.

Fail-before / pass-after (this repo, this branch):

```
$ cd apps/desktop
# reverted only the notifyError-with-action call in forkBranch's catch (back to notifyError(err, copy.branchFailed))
$ npx vitest run src/app/session/hooks/use-session-actions/branch-retry.test.tsx
 FAIL ... AssertionError: expected undefined to be defined
   at notification!.action).toBeDefined()
 Tests  1 failed (1)

# restored the fix
$ npx vitest run src/app/session/hooks/use-session-actions/branch-retry.test.tsx
 Test Files  1 passed (1)
      Tests  1 passed (1)

$ npx vitest run src/app/session/hooks/use-session-actions src/store/notifications.ts
 Test Files  3 passed (3)
      Tests  27 passed (27)

$ npx tsc --noEmit -p .
(exit 0, no output)
```

Note: this PR implements direction #1 only (the issue's own "minimal" recommendation). Directions #2 (idempotent retry via request id) and #3 (persisted retry queue) are explicitly larger, separate follow-ups per the issue itself.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the relevant test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed.

## Screenshots / Logs

See the fail-before/pass-after transcript above under "How to Test".
