### PR TITLE
fix: add creationflags to plugins subprocess calls (Windows console flash)

### DIFF
--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -307,6 +307,7 @@ def decode_to_pcm(path: str, *, timeout: float = 30.0) -> Optional[bytes]:
     requirement of the voice path (see ``VoiceReceiver.pcm_to_wav``).
     """
     import subprocess
+    import sys
 
     try:
         proc = subprocess.run(
@@ -321,6 +322,7 @@ def decode_to_pcm(path: str, *, timeout: float = 30.0) -> Optional[bytes]:
             capture_output=True,
             timeout=timeout,
             stdin=subprocess.DEVNULL,
+            **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
         logger.warning("decode_to_pcm failed for %s: %s", path, e)

--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -546,7 +546,8 @@ class RaftAdapter(BasePlatformAdapter):
         env = {**os.environ, "RAFT_CHANNEL_TOKEN": self._bridge_token}
         try:
             self._bridge_process = subprocess.Popen(
-                cmd, env=env, stdin=subprocess.DEVNULL
+                cmd, env=env, stdin=subprocess.DEVNULL,
+                **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
             )
             logger.info("[raft] Spawned bridge pid=%d profile=%s endpoint=%s", self._bridge_process.pid, profile, endpoint)
         except Exception:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -348,12 +348,14 @@ def _probe_voice_duration_seconds(path: str) -> Optional[int]:
     try:
         import shutil
         import subprocess
+        import sys
 
         if shutil.which("ffprobe"):
             proc = subprocess.run(
                 ["ffprobe", "-v", "error", "-show_entries", "format=duration",
                  "-of", "default=noprint_wrappers=1:nokey=1", path],
                 capture_output=True, text=True, timeout=5,
+                **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
             )
             if proc.returncode == 0:
                 return _coerce_duration_seconds(proc.stdout.strip())


### PR DESCRIPTION
## Summary

On Windows, `subprocess.run()` / `subprocess.Popen()` without `CREATE_NO_WINDOW` (0x08000000) spawns a visible console window (cmd.exe / conhost.exe) that flashes briefly. Three plugins have non-interactive subprocess calls missing this flag:

1. `plugins/platforms/telegram/adapter.py` — ffprobe duration check (line 353)
2. `plugins/platforms/discord/voice_mixer.py` — ffmpeg PCM decode (line 312)
3. `plugins/platforms/raft/adapter.py` — raft bridge Popen (line 548)

All three have `stdin=DEVNULL` and `capture_output=True` (or are Popen with no interactive I/O), so they should not show a console window.

## Fix

Add `creationflags=0x08000000` on Windows, same pattern used in:
- `tools/tts_tool.py` (6 calls)
- `tools/browser_tool.py` (2 calls)
- `tools/tirith_security.py` (2 calls)
- `tools/env_probe.py`
- `tools/lazy_deps.py`

## Changes

- `plugins/platforms/telegram/adapter.py`: +2 lines
- `plugins/platforms/discord/voice_mixer.py`: +2 lines
- `plugins/platforms/raft/adapter.py`: +2 lines

## Test Plan

- [ ] Unit tests pass
- [ ] Verified on Windows: no console flash on ffprobe, ffmpeg, raft bridge
