### PR TITLE
fix: make Claude Code Keychain lookup configurable

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -885,6 +885,16 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
         return None
 
     try:
+        from hermes_cli.config import load_config
+
+        anthropic_config = (load_config() or {}).get("anthropic")
+    except Exception:
+        anthropic_config = None
+    if isinstance(anthropic_config, dict) and not anthropic_config.get("use_claude_code_keychain", True):
+        logger.debug("Keychain: Claude Code macOS Keychain access disabled by config.yaml")
+        return None
+
+    try:
         # Read the "Claude Code-credentials" generic password entry
         result = subprocess.run(
             ["security", "find-generic-password",

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -138,7 +138,17 @@ model:
 #     models:
 #       gpt-5.4:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
-
+#
+# =============================================================================
+# Anthropic Credential Discovery
+# =============================================================================
+# Claude Code stores OAuth credentials in the macOS Keychain. Set this false
+# when Hermes runs under a sandbox or service account whose login Keychain is
+# unavailable. The default is true.
+#
+# anthropic:
+#   use_claude_code_keychain: false
+#
 # =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1508,6 +1508,12 @@ DEFAULT_CONFIG = {
         "cache_ttl": "5m",
     },
 
+    # Anthropic credential discovery settings.
+    "anthropic": {
+        # Check Claude Code's macOS Keychain entry for OAuth credentials.
+        "use_claude_code_keychain": True,
+    },
+
     # OpenRouter-specific settings.
     # response_cache: enable OpenRouter response caching (X-OpenRouter-Cache header).
     #   When enabled, identical requests return cached responses for free (zero billing).

--- a/tests/agent/test_anthropic_keychain.py
+++ b/tests/agent/test_anthropic_keychain.py
@@ -69,7 +69,9 @@ class TestReadClaudeCodeCredentialsFromKeychain:
             )
             assert _read_claude_code_credentials_from_keychain() is None
 
-    def test_parses_valid_keychain_entry(self):
+    def test_parses_valid_keychain_entry(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
         with patch("agent.anthropic_adapter.platform.system", return_value="Darwin"), \
              patch("agent.anthropic_adapter.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
@@ -84,12 +86,37 @@ class TestReadClaudeCodeCredentialsFromKeychain:
                 stderr="",
             )
             creds = _read_claude_code_credentials_from_keychain()
-            assert creds is not None
-            assert creds["accessToken"] == "kc-access-token-abc"
-            assert creds["refreshToken"] == "kc-refresh-token-xyz"
-            assert creds["expiresAt"] == 9999999999999
-            assert creds["source"] == "macos_keychain"
 
+        assert creds is not None
+        assert creds["accessToken"] == "kc-access-token-abc"
+        assert creds["refreshToken"] == "kc-refresh-token-xyz"
+        assert creds["expiresAt"] == 9999999999999
+        assert creds["source"] == "macos_keychain"
+
+    def test_config_can_disable_keychain_and_use_json_credentials(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "anthropic:\n  use_claude_code_keychain: false\n"
+        )
+        json_cred_file = tmp_path / ".claude" / ".credentials.json"
+        json_cred_file.parent.mkdir(parents=True)
+        json_cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": "json-fallback-token",
+                "refreshToken": "json-refresh",
+                "expiresAt": 9999999999999,
+            }
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        with patch("agent.anthropic_adapter.platform.system", return_value="Darwin"), \
+             patch("agent.anthropic_adapter.subprocess.run") as mock_run:
+            creds = read_claude_code_credentials()
+
+        assert creds is not None
+        assert creds["accessToken"] == "json-fallback-token"
+        assert creds["source"] == "claude_code_credentials_file"
+        mock_run.assert_not_called()
 
 class TestReadClaudeCodeCredentialsPriority:
     """Bug 4: Keychain must be checked before the JSON file."""


### PR DESCRIPTION
## Summary
- Replace the rejected public environment flag with `anthropic.use_claude_code_keychain` in `config.yaml`.
- Preserve the default macOS Keychain lookup and the JSON credentials-file fallback.
- Document the setting and cover the config-backed disable path.

Supersedes #42205.

## Testing
- `python -m pytest -q -o addopts= tests/agent/test_anthropic_keychain.py tests/hermes_cli/test_config.py` — 174 passed.
- Full suite completed with 41 existing failures across unrelated files; the affected Anthropic/credential-pool baseline failures reproduce on unmodified upstream.