### PR TITLE
fix: add creationflags to vision_tools SVG-to-PNG subprocess calls

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -292,6 +292,7 @@ def _rasterize_svg_to_png(svg_path: Path, out_path: Path) -> bool:
                 _subprocess.run(
                     cmd, check=True, capture_output=True, timeout=30,
                     stdin=_subprocess.DEVNULL,
+                    **({"creationflags": 0x08000000} if sys.platform == "win32" else {}),
                 )
                 if out_path.exists() and out_path.stat().st_size > 0:
                     return True


### PR DESCRIPTION
## Summary

On Windows, `subprocess.run()` without `CREATE_NO_WINDOW` (0x08000000) spawns a visible console window. `tools/vision_tools.py` has two SVG-to-PNG conversion calls (`rsvg-convert` and `inkscape`) missing this flag. Both calls have `stdin=DEVNULL` and `capture_output=True`, so they are non-interactive.

## Fix

Add `creationflags=0x08000000` on Windows. `sys` is already imported at module level.

## Changes

- `tools/vision_tools.py`: +1 line

## Test Plan

- [ ] Unit tests pass
- [ ] Verified on Windows: no console flash on SVG-to-PNG conversion
