### PR TITLE
fix: add creationflags to remaining tts_tool subprocess calls

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -734,6 +734,7 @@ def _terminate_command_tts_process_tree(proc: subprocess.Popen) -> None:
                 stderr=subprocess.DEVNULL,
                 timeout=5,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
         except Exception:
             proc.kill()
@@ -2012,7 +2013,7 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
         "--device", device,
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL, creationflags=windows_hide_flags())
     if result.returncode != 0:
         stderr = result.stderr.strip()
         # Filter out the "OK:" line from stderr
@@ -2096,6 +2097,7 @@ def _resolve_piper_voice_path(voice: str, download_dir: Path) -> str:
              "--download-dir", str(download_dir)],
             capture_output=True, text=True, timeout=300,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(


### PR DESCRIPTION
## Summary

Three subprocess calls in `tools/tts_tool.py` were missing `CREATE_NO_WINDOW` (0x08000000), causing console window flashes on Windows:

1. **Line 731** — `taskkill` process tree termination (`_terminate_command_tts_process_tree`)
2. **Line 2015** — NeuTTS synthesis call
3. **Line 2094** — Piper voice download call

All three have `stdin=DEVNULL` and `capture_output=True`, so they are non-interactive. `windows_hide_flags()` is already imported at line 55.

## Context

PR #64081 previously covered `tts_tool.py` lines 2002 and 2087 (ffmpeg conversion calls), but missed these three calls. This PR closes the remaining gap.

## Changes

- `tools/tts_tool.py`: +3 lines, -1 line

## Test Plan

- [ ] Unit tests pass
- [ ] Verified on Windows: no console flash on taskkill, NeuTTS synthesis, or Piper download
