### PR TITLE
fix: replace hardcoded /tmp with tempfile.gettempdir() (fixes #52415)

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -93,10 +93,9 @@ def _resolve_home_dir() -> str:
     except Exception:
         pass
 
-    # Last resort: /tmp (writable on any POSIX system). Avoids crashing the
-    # subprocess with no HOME; callers can set HERMES_HOME explicitly if they
-    # need a different writable dir.
-    return "/tmp"
+    # Last resort: writable temp directory. Workers can override via HOME.
+    import tempfile
+    return tempfile.gettempdir()
 
 
 def _build_subprocess_env() -> dict[str, str]:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -742,7 +742,8 @@ def get_real_home(env: dict[str, str] | None = None) -> str:
         seen.add(key)
         if not _is_profile_home(candidate, profile_home):
             return candidate
-    return "/tmp"
+    import tempfile
+    return tempfile.gettempdir()
 
 
 def get_subprocess_home(env: dict[str, str] | None = None) -> str | None:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -814,7 +814,7 @@ def _env_temp_dir(env: Any) -> str:
     candidate = tempfile.gettempdir()
     if isinstance(candidate, str) and candidate.startswith("/"):
         return candidate.rstrip("/") or "/"
-    return "/tmp"
+    return tempfile.gettempdir()
 
 
 def _rpc_poll_loop(

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -684,7 +684,8 @@ class ProcessRegistry:
                     return temp_dir.rstrip("/") or "/"
             except Exception as exc:
                 logger.debug("Could not resolve environment temp dir: %s", exc)
-        return "/tmp"
+        import tempfile
+        return tempfile.gettempdir()
 
     def spawn_local(
         self,


### PR DESCRIPTION
Closes #52415

Termux/Android has no `/tmp` directory. The `get_temp_dir()` on LocalEnvironment already detects Termux via `TMPDIR` env, but 7 other sites bypass it with hardcoded `return "/tmp"`.

**Fixed 4 of 7 sites** to use `tempfile.gettempdir()`:

| File | What | 
|---|---|
| `hermes_constants.py` | `get_real_home()` fallback |
| `tools/process_registry.py` | `_env_temp_dir()` when env doesn't have a method |
| `tools/code_execution_tool.py` | `execute_code` temp dir fallback |
| `agent/copilot_acp_client.py` | ACP subprocess HOME fallback |

**Intentionally left as `/tmp`** (correct for their context):

| Site | Reason |
|---|---|
| `local.py get_temp_dir()` | Already has Termux detection + TMPDIR fallback path |
| `base.py get_temp_dir()` | Base class default for sandboxed backends (overriden by Local) |
| `browser_tool.py` | macOS-specific bypass — `TMPDIR` on macOS is per-user, `/tmp` is always available |

**Testing:** On a Termux environment, `TMPDIR` now points to the correct writable path through all resolved code paths.