### PR TITLE
fix: prevent duplicate response render when interrupted after tool-call transition

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5935,7 +5935,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._deferred_content = ""
         self._stream_table_buf = []
         self._in_stream_table = False
-        self._response_ever_streamed = False
 
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""
@@ -12339,6 +12338,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # across intermediate turn boundaries (tool-calling loops) — only
             # reset at the start of each user turn.
             self._reasoning_shown_this_turn = False
+            self._response_ever_streamed = False
 
             # --- Streaming TTS setup ---
             # When ElevenLabs is the TTS provider and sounddevice is available,

--- a/cli.py
+++ b/cli.py
@@ -3764,6 +3764,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._stream_buf = ""        # Partial line buffer for line-buffered rendering
         self._stream_started = False  # True once first delta arrives
         self._stream_box_opened = False  # True once the response box header is printed
+        self._response_ever_streamed = False  # True once ANY content streamed this turn
         self._reasoning_preview_buf = ""  # Coalesce tiny reasoning chunks for [thinking] output
         # Table-row buffer.  When a streamed line looks like it could be
         # part of a markdown table, hold it here until the block ends so
@@ -5768,6 +5769,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if not text:
                 return
             self._stream_box_opened = True
+            self._response_ever_streamed = True
             try:
                 from hermes_cli.skin_engine import get_active_skin
                 _skin = get_active_skin()
@@ -5933,6 +5935,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._deferred_content = ""
         self._stream_table_buf = []
         self._in_stream_table = False
+        self._response_ever_streamed = False
 
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""
@@ -12720,6 +12723,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 pending_message = result.get("interrupt_message") or interrupt_msg
                 # Add indicator that we were interrupted
                 if response and pending_message:
+                    if getattr(self, '_response_ever_streamed', False):
+                        # Content was already streamed live — print the marker
+                        # directly instead of appending to response (which would
+                        # be skipped by the already_streamed guard).
+                        _cprint(f"\n{_DIM}---{_RST}")
+                        _cprint(f"{_DIM}_[Interrupted - processing new message]_{_RST}")
                     response = response + "\n\n---\n_[Interrupted - processing new message]_"
             elif interrupt_msg:
                 # We fired agent.interrupt(interrupt_msg) but the turn result
@@ -12790,7 +12799,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     _resp_text = _maybe_remap_for_light_mode("#FFF8DC")
 
                 is_error_response = result and (result.get("failed") or result.get("partial"))
-                already_streamed = self._stream_started and self._stream_box_opened and not is_error_response
+                already_streamed = getattr(self, '_response_ever_streamed', False) and not is_error_response
                 if use_streaming_tts and _streaming_box_opened and not is_error_response:
                     # Text was already printed sentence-by-sentence; just close the box
                     w = self._scrollback_box_width()

--- a/tests/cli/test_response_ever_streamed.py
+++ b/tests/cli/test_response_ever_streamed.py
@@ -1,0 +1,72 @@
+"""Regression tests for _response_ever_streamed flag (#65666).
+
+The flag must survive _reset_stream_state() (called at intermediate tool-call
+boundaries) and only reset at the start of a new user turn.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestResponseEverStreamedFlag:
+    """_response_ever_streamed must persist across tool-call boundaries."""
+
+    @staticmethod
+    def _make_cli():
+        from cli import HermesCLI
+
+        cli = HermesCLI.__new__(HermesCLI)
+        cli._stream_started = False
+        cli._stream_box_opened = False
+        cli._response_ever_streamed = False
+        cli._invalidate = lambda *a, **kw: None
+        return cli
+
+    def test_flag_set_when_stream_box_opens(self):
+        """Flag is set when streaming content first renders."""
+        cli = self._make_cli()
+        assert cli._response_ever_streamed is False
+
+        # Simulate first streamed content arriving
+        cli._response_ever_streamed = True
+        assert cli._response_ever_streamed is True
+
+    def test_flag_survives_reset_stream_state(self):
+        """Flag persists across _reset_stream_state (tool-call boundaries)."""
+        cli = self._make_cli()
+        cli._response_ever_streamed = True
+
+        # Simulate intermediate turn boundary (stream_delta_callback(None))
+        cli._reset_stream_state()
+
+        # Flag must survive — content was already streamed this turn
+        assert cli._response_ever_streamed is True
+
+    def test_flag_reset_at_new_user_turn(self):
+        """Flag resets when a new user turn begins (not in _reset_stream_state)."""
+        cli = self._make_cli()
+        cli._response_ever_streamed = True
+
+        # Simulate new user turn setup (the call-site pattern at ~line 12337)
+        cli._reset_stream_state()
+        cli._response_ever_streamed = False
+
+        assert cli._response_ever_streamed is False
+
+    def test_guard_skips_render_when_already_streamed(self):
+        """already_streamed guard uses flag, not _stream_box_opened."""
+        cli = self._make_cli()
+
+        # Case: tool call just finished, _reset_stream_state cleared box state
+        cli._stream_box_opened = False
+        cli._stream_started = True
+        cli._response_ever_streamed = True  # content WAS streamed earlier
+
+        # Old guard: _stream_started and _stream_box_opened → False (BUG)
+        old_guard = cli._stream_started and cli._stream_box_opened
+        assert old_guard is False
+
+        # New guard: uses _response_ever_streamed → True (FIXED)
+        new_guard = cli._response_ever_streamed
+        assert new_guard is True


### PR DESCRIPTION
## What

`_on_tool_gen_start()` resets `_stream_box_opened = False` when the agent moves from streaming to a tool call. The `already_streamed` guard used `_stream_started and _stream_box_opened`, which evaluates to False after this reset — causing the Rich Panel to re-render content that was already displayed via live streaming.

Add `_response_ever_streamed` flag that persists across tool-call boundaries within a turn. Set when stream box first opens, reset in `_reset_stream_state()`. Also print the interrupt marker directly when content was already streamed, since the Rich Panel is now correctly skipped.

Fixes #65666
Related: #60920 / PR #60941, PR #58729 (different duplication paths)