### PR TITLE
usage_pricing: add prompt_cache_hit/miss_tokens as cache token fallback

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1074,12 +1074,18 @@ def normalize_usage(
         cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
         if not cache_read_tokens:
             cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
+        if not cache_read_tokens:
+            cache_read_tokens = _to_int(getattr(response_usage, "prompt_cache_hit_tokens", 0))
         cache_write_tokens = _to_int(
             getattr(details, "cache_write_tokens", 0) if details else 0
         )
         if not cache_write_tokens:
             cache_write_tokens = _to_int(
                 getattr(response_usage, "cache_creation_input_tokens", 0)
+            )
+        if not cache_write_tokens:
+            cache_write_tokens = _to_int(
+                getattr(response_usage, "prompt_cache_miss_tokens", 0)
             )
         input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
 


### PR DESCRIPTION
## What

Add `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` as generic fallbacks in the cache token extraction chain within `normalize_usage()`.

## Why

Some providers (e.g. DeepSeek direct API) expose cache statistics as top-level `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` fields rather than through `prompt_tokens_details`. The current fallback chain (`details.cached_tokens` → `cache_read_input_tokens` → `cache_creation_input_tokens`) never reaches these fields, causing both `cache_read_tokens` and `cache_write_tokens` to silently compute as 0.

This means session-level `cache_read_tokens` / `cache_write_tokens` are incorrect for affected providers, and cost estimates bill at 100% miss rate.

Closes #61871.

## How

Two `if not` guards appended to the existing fallback chain:

```python
if not cache_read_tokens:
    cache_read_tokens = _to_int(getattr(response_usage, "prompt_cache_hit_tokens", 0))
# ...
if not cache_write_tokens:
    cache_write_tokens = _to_int(getattr(response_usage, "prompt_cache_miss_tokens", 0))
```

- **Zero impact on existing providers**: the `if not` guards fire only when all earlier entries in the chain return 0.
- Follows the same pattern as the existing `cache_read_input_tokens` / `cache_creation_input_tokens` fallbacks (Port of cline/cline#10266).

## Verification

Verified in production against a direct-DeepSeek deployment: before this change `cache_write_tokens` was always 0 across all sessions; after applying the fix, real cache miss data appeared immediately.