### PR TITLE
feat(cron): configure reasoning per job

### DIFF
--- a/apps/desktop/src/app/cron/cron-job-model.test.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.test.ts
@@ -35,12 +35,13 @@ describe('cronEditorUpdates', () => {
   it('omits prompt when saving a script-only job with an empty prompt', () => {
     expect(
       cronEditorUpdates(
-        { deliver: 'local', name: 'Weekly', prompt: '', schedule: '0 9 * * 1' },
+        { deliver: 'local', name: 'Weekly', prompt: '', reasoningEffort: 'inherit', schedule: '0 9 * * 1' },
         { scriptOnlyJob: true }
       )
     ).toEqual({
       deliver: 'local',
       name: 'Weekly',
+      reasoning_effort: null,
       schedule: '0 9 * * 1'
     })
   })
@@ -48,9 +49,25 @@ describe('cronEditorUpdates', () => {
   it('includes prompt when the user typed one on a script-only job', () => {
     expect(
       cronEditorUpdates(
-        { deliver: 'email', name: 'Weekly', prompt: 'note', schedule: '0 9 * * 1' },
+        { deliver: 'email', name: 'Weekly', prompt: 'note', reasoningEffort: 'high', schedule: '0 9 * * 1' },
         { scriptOnlyJob: true }
       ).prompt
     ).toBe('note')
+  })
+
+  it('sets and clears a per-job reasoning override explicitly', () => {
+    expect(
+      cronEditorUpdates(
+        { deliver: 'local', name: 'Daily', prompt: 'run', reasoningEffort: 'xhigh', schedule: '0 9 * * *' },
+        { scriptOnlyJob: false }
+      ).reasoning_effort
+    ).toBe('xhigh')
+
+    expect(
+      cronEditorUpdates(
+        { deliver: 'local', name: 'Daily', prompt: 'run', reasoningEffort: 'inherit', schedule: '0 9 * * *' },
+        { scriptOnlyJob: false }
+      ).reasoning_effort
+    ).toBeNull()
   })
 })

--- a/apps/desktop/src/app/cron/cron-job-model.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.ts
@@ -38,6 +38,7 @@ export interface CronEditorSaveValues {
   deliver: string
   name: string
   prompt: string
+  reasoningEffort: string
   schedule: string
 }
 
@@ -46,7 +47,8 @@ export function cronEditorUpdates(values: CronEditorSaveValues, options: { scrip
   const updates: CronJobUpdates = {
     deliver: values.deliver,
     name: values.name,
-    schedule: values.schedule.trim()
+    schedule: values.schedule.trim(),
+    reasoning_effort: values.reasoningEffort === 'inherit' ? null : values.reasoningEffort
   }
 
   const trimmedPrompt = values.prompt.trim()

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -61,6 +61,18 @@ const DEFAULT_DELIVER = 'local'
 
 const DELIVERY_VALUES: readonly string[] = ['local', 'telegram', 'discord', 'slack', 'email']
 
+const REASONING_VALUES: readonly string[] = [
+  'inherit',
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra'
+]
+
 const SCHEDULE_OPTIONS: ReadonlyArray<ScheduleOption> = [
   { expr: '0 9 * * *', value: 'daily' },
   { expr: '0 9 * * 1-5', value: 'weekdays' },
@@ -101,6 +113,14 @@ function jobScheduleExpr(job: CronJob): string {
 
 function jobDeliver(job: CronJob): string {
   return asText(job.deliver) || DEFAULT_DELIVER
+}
+
+function jobReasoningEffort(job: CronJob): string {
+  if (job.reasoning_effort === false) {
+    return 'none'
+  }
+
+  return asText(job.reasoning_effort).trim()
 }
 
 function cronParts(expr: string): null | string[] {
@@ -391,7 +411,8 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
         prompt: values.prompt,
         schedule: values.schedule,
         name: values.name || undefined,
-        deliver: values.deliver || DEFAULT_DELIVER
+        deliver: values.deliver || DEFAULT_DELIVER,
+        reasoning_effort: values.reasoningEffort === 'inherit' ? null : values.reasoningEffort
       })
 
       updateCronJobs(rows => [...rows, created])
@@ -550,6 +571,7 @@ function CronJobDetail({
   const isPaused = state === 'paused'
   const deliver = jobDeliver(job)
   const prompt = jobPrompt(job)
+  const reasoningEffort = jobReasoningEffort(job)
 
   return (
     <PanelDetail>
@@ -574,7 +596,10 @@ function CronJobDetail({
             { label: c.frequencyLabel, value: jobScheduleDisplay(job) },
             { label: c.last.replace(/:$/, ''), value: formatTime(job.last_run_at) },
             { label: c.next.replace(/:$/, ''), value: formatTime(job.next_run_at) },
-            { label: c.deliverLabel, value: c.deliveryLabels[deliver] ?? deliver }
+            { label: c.deliverLabel, value: c.deliveryLabels[deliver] ?? deliver },
+            ...(reasoningEffort
+              ? [{ label: c.reasoningLabel, value: c.reasoningLabels[reasoningEffort] ?? reasoningEffort }]
+              : [])
           ]}
         />
 
@@ -717,6 +742,7 @@ function CronEditorDialog({
   const [schedule, setSchedule] = useState('')
   const [schedulePreset, setSchedulePreset] = useState('daily')
   const [deliver, setDeliver] = useState(DEFAULT_DELIVER)
+  const [reasoningEffort, setReasoningEffort] = useState('inherit')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<null | string>(null)
 
@@ -730,6 +756,7 @@ function CronEditorDialog({
     setSchedule(initial ? jobScheduleExpr(initial) : (SCHEDULE_OPTIONS[0].expr ?? ''))
     setSchedulePreset(initial ? scheduleOptionForExpr(jobScheduleExpr(initial)).value : 'daily')
     setDeliver(initial ? jobDeliver(initial) : DEFAULT_DELIVER)
+    setReasoningEffort(initial ? jobReasoningEffort(initial) || 'inherit' : 'inherit')
     setError(null)
     setSaving(false)
   }, [initial, open])
@@ -781,6 +808,7 @@ function CronEditorDialog({
         deliver,
         name: name.trim(),
         prompt: prompt.trim(),
+        reasoningEffort,
         schedule: schedule.trim()
       })
     } catch (err) {
@@ -857,6 +885,21 @@ function CronEditorDialog({
             </Field>
           </div>
 
+          <Field htmlFor="cron-reasoning" label={c.reasoningLabel}>
+            <Select onValueChange={setReasoningEffort} value={reasoningEffort}>
+              <SelectTrigger className="h-9 rounded-md" id="cron-reasoning">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {REASONING_VALUES.map(value => (
+                  <SelectItem key={value} value={value}>
+                    {c.reasoningLabels[value] ?? value}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+
           {schedulePreset === 'custom' ? (
             <Field htmlFor="cron-schedule" label={c.customScheduleLabel}>
               <Input
@@ -932,6 +975,7 @@ interface EditorValues {
   deliver: string
   name: string
   prompt: string
+  reasoningEffort: string
   schedule: string
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1495,6 +1495,18 @@ export const en: Translations = {
     promptPlaceholder: 'Summarize my unread Slack threads and email me the top 5...',
     frequencyLabel: 'Frequency',
     deliverLabel: 'Deliver to',
+    reasoningLabel: 'Reasoning effort',
+    reasoningLabels: {
+      inherit: 'Inherit model/global setting',
+      none: 'Off',
+      minimal: 'Minimal',
+      low: 'Low',
+      medium: 'Medium',
+      high: 'High',
+      xhigh: 'Extra High',
+      max: 'Max',
+      ultra: 'Ultra'
+    },
     customScheduleLabel: 'Custom schedule',
     customPlaceholder: '0 9 * * * or weekdays at 9am',
     customHint: 'Cron expression, or phrases like "every hour" or "weekdays at 9am".',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1418,6 +1418,18 @@ export const ja = defineLocale({
     promptPlaceholder: '実行ごとにエージェントが行う内容は？',
     frequencyLabel: '頻度',
     deliverLabel: '配信先',
+    reasoningLabel: '推論強度',
+    reasoningLabels: {
+      inherit: 'モデルまたはグローバル設定を継承',
+      none: 'オフ',
+      minimal: '最小',
+      low: '低',
+      medium: '中',
+      high: '高',
+      xhigh: '特高',
+      max: '最大',
+      ultra: 'ウルトラ'
+    },
     customScheduleLabel: 'カスタムスケジュール',
     customPlaceholder: '0 9 * * * または weekdays at 9am',
     customHint: 'Cron 式、または「every hour」「weekdays at 9am」のようなフレーズ。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1226,6 +1226,8 @@ export interface Translations {
     promptPlaceholder: string
     frequencyLabel: string
     deliverLabel: string
+    reasoningLabel: string
+    reasoningLabels: Record<string, string>
     customScheduleLabel: string
     customPlaceholder: string
     customHint: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1371,6 +1371,18 @@ export const zhHant = defineLocale({
     promptPlaceholder: '代理每次執行時應做什麼？',
     frequencyLabel: '頻率',
     deliverLabel: '傳遞至',
+    reasoningLabel: '推理強度',
+    reasoningLabels: {
+      inherit: '繼承模型或全域設定',
+      none: '關閉',
+      minimal: '最少',
+      low: '低',
+      medium: '中',
+      high: '高',
+      xhigh: '特高',
+      max: '最大',
+      ultra: '超強'
+    },
     customScheduleLabel: '自訂排程',
     customPlaceholder: '0 9 * * * 或 weekdays at 9am',
     customHint: 'Cron 表達式，或類似「每小時」「工作日上午 9 點」的短語。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1673,6 +1673,18 @@ export const zh: Translations = {
     promptPlaceholder: '总结我未读的 Slack 话题，并把前 5 条邮件发给我…',
     frequencyLabel: '频率',
     deliverLabel: '投递至',
+    reasoningLabel: '推理强度',
+    reasoningLabels: {
+      inherit: '继承模型或全局设置',
+      none: '关闭',
+      minimal: '最少',
+      low: '低',
+      medium: '中',
+      high: '高',
+      xhigh: '特高',
+      max: '最大',
+      ultra: '超强'
+    },
     customScheduleLabel: '自定义排程',
     customPlaceholder: '0 9 * * * 或 weekdays at 9am',
     customHint: 'Cron 表达式，或类似"每小时""工作日上午 9 点"的短语。',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -560,6 +560,7 @@ export interface CronJob {
   next_run_at?: null | string
   no_agent?: boolean
   prompt?: null | string
+  reasoning_effort?: boolean | null | string
   schedule?: CronJobSchedule
   schedule_display?: null | string
   script?: null | string
@@ -570,6 +571,7 @@ export interface CronJobCreatePayload {
   deliver?: string
   name?: string
   prompt: string
+  reasoning_effort?: boolean | null | string
   schedule: string
 }
 
@@ -584,6 +586,7 @@ export interface CronJobUpdates {
   enabled?: boolean
   name?: string
   prompt?: string
+  reasoning_effort?: boolean | null | string
   schedule?: string
 }
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -981,6 +981,31 @@ def _normalize_job_optional_text(value: Any, *, strip_trailing_slash: bool = Fal
     return text or None
 
 
+def normalize_job_reasoning_effort(value: Any) -> Union[str, bool, None]:
+    """Validate and canonicalize a per-job reasoning override.
+
+    ``None`` means inherit the global/per-model reasoning configuration.
+    Disabled aliases accepted by the shared parser are persisted as ``False``;
+    enabled levels are persisted using the parser's canonical lower-case form.
+    """
+    if value is None:
+        return None
+
+    from hermes_constants import VALID_REASONING_EFFORTS, parse_reasoning_effort
+
+    parsed = parse_reasoning_effort(value)
+    if parsed is None:
+        accepted = ", ".join(("none", *VALID_REASONING_EFFORTS))
+        raise ValueError(
+            f"Invalid cron reasoning_effort {value!r}. Expected one of: "
+            f"{accepted}; false also disables reasoning, and null inherits "
+            "the global setting."
+        )
+    if not parsed.get("enabled"):
+        return False
+    return str(parsed["effort"])
+
+
 def _compute_provider_model_snapshots(
     *,
     provider: Any,
@@ -1048,6 +1073,7 @@ def create_job(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    reasoning_effort: Any = None,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
@@ -1071,6 +1097,9 @@ def create_job(
         model: Optional per-job model override
         provider: Optional per-job provider override
         base_url: Optional per-job base URL override
+        reasoning_effort: Optional per-job reasoning override. ``None`` inherits
+                          the global/per-model setting; ``False`` or ``none``
+                          explicitly disables reasoning for this job.
         script: Optional path to a script whose stdout feeds the job. With
                 ``no_agent=True`` the script IS the job — its stdout is
                 delivered verbatim. Without ``no_agent``, its stdout is
@@ -1123,6 +1152,7 @@ def create_job(
     normalized_model = _normalize_job_optional_text(model)
     normalized_provider = _normalize_job_optional_text(provider)
     normalized_base_url = _normalize_job_optional_text(base_url, strip_trailing_slash=True)
+    normalized_reasoning_effort = normalize_job_reasoning_effort(reasoning_effort)
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
@@ -1220,6 +1250,8 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    if normalized_reasoning_effort is not None:
+        job["reasoning_effort"] = normalized_reasoning_effort
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
     # global cron.mirror_delivery config, default off).
@@ -1294,7 +1326,8 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
     # Block mutation of immutable fields. ``id`` in particular is a filesystem
     # path component under OUTPUT_DIR — letting an update change it leaks
     # path-escape values into output writes/deletes.
-    bad_fields = _IMMUTABLE_JOB_FIELDS.intersection(updates or {})
+    updates = dict(updates or {})
+    bad_fields = _IMMUTABLE_JOB_FIELDS.intersection(updates)
     if bad_fields:
         raise ValueError(
             f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}"
@@ -1314,6 +1347,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            if "reasoning_effort" in updates:
+                updates["reasoning_effort"] = normalize_job_reasoning_effort(
+                    updates["reasoning_effort"]
+                )
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3108,9 +3108,32 @@ def run_job(
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc
 
-        reasoning_config = resolve_reasoning_config(
-            _cfg if isinstance(_cfg, dict) else {}, str(model)
-        )
+        # A valid job override wins for this run only. Missing/null and malformed
+        # hand-edited legacy values inherit the effective per-model/global policy
+        # for the model that actually survived provider-auth fallback.
+        reasoning_config = None
+        if "reasoning_effort" in job and job.get("reasoning_effort") is not None:
+            from cron.jobs import normalize_job_reasoning_effort
+            from hermes_constants import parse_reasoning_effort
+
+            try:
+                job_effort = normalize_job_reasoning_effort(
+                    job.get("reasoning_effort")
+                )
+            except ValueError as exc:
+                logger.warning(
+                    "Job '%s': ignoring invalid reasoning_effort and inheriting "
+                    "configured reasoning: %s",
+                    job_id,
+                    exc,
+                )
+            else:
+                reasoning_config = parse_reasoning_effort(job_effort)
+
+        if reasoning_config is None:
+            reasoning_config = resolve_reasoning_config(
+                _cfg if isinstance(_cfg, dict) else {}, str(model)
+            )
 
         # Provider/model-drift fail-closed guard (#44585).
         #

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -163,6 +163,13 @@ def cron_list(show_all: bool = False):
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
+        if "reasoning_effort" in job and job.get("reasoning_effort") is not None:
+            effort = (
+                "none"
+                if job.get("reasoning_effort") is False
+                else job["reasoning_effort"]
+            )
+            print(f"    Reasoning: {effort}")
 
         # Execution history
         last_status = job.get("last_status")
@@ -310,6 +317,7 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        reasoning_effort=getattr(args, "reasoning_effort", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -326,6 +334,13 @@ def cron_create(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
+    if job_data.get("reasoning_effort") is not None:
+        effort = (
+            "none"
+            if job_data["reasoning_effort"] is False
+            else job_data["reasoning_effort"]
+        )
+        print(f"  Reasoning: {effort}")
     print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
     return 0
@@ -361,7 +376,7 @@ def cron_edit(args):
             if skill not in final_skills:
                 final_skills.append(skill)
 
-    result = _cron_api(
+    update_kwargs = dict(
         action="update",
         job_id=args.job_id,
         schedule=getattr(args, "schedule", None),
@@ -374,6 +389,12 @@ def cron_edit(args):
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", None),
     )
+    reasoning_effort = getattr(args, "reasoning_effort", None)
+    if reasoning_effort is not None:
+        update_kwargs["reasoning_effort"] = (
+            None if reasoning_effort == "inherit" else reasoning_effort
+        )
+    result = _cron_api(**update_kwargs)
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
         return 1
@@ -392,6 +413,13 @@ def cron_edit(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    if updated.get("reasoning_effort") is not None:
+        effort = (
+            "none"
+            if updated["reasoning_effort"] is False
+            else updated["reasoning_effort"]
+        )
+        print(f"  Reasoning: {effort}")
     return 0
 
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 from typing import Callable
 
 from hermes_cli.subcommands._shared import add_accept_hooks_flag
+from hermes_constants import VALID_REASONING_EFFORTS
+
+
+_CRON_REASONING_CHOICES = ("none", *VALID_REASONING_EFFORTS)
 
 
 def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
@@ -69,6 +73,11 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_create.add_argument(
         "--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
+    )
+    cron_create.add_argument(
+        "--reasoning-effort",
+        choices=_CRON_REASONING_CHOICES,
+        help="Override reasoning effort for this job only",
     )
 
     # cron edit
@@ -133,6 +142,11 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_edit.add_argument(
         "--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--reasoning-effort",
+        choices=(*_CRON_REASONING_CHOICES, "inherit"),
+        help="Set the job reasoning override; 'inherit' clears it",
     )
 
     # lifecycle actions

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10314,6 +10314,7 @@ class CronJobCreate(BaseModel):
     model: Optional[str] = None
     provider: Optional[str] = None
     base_url: Optional[str] = None
+    reasoning_effort: Any = None
     script: Optional[str] = None
     context_from: Optional[Any] = None
     enabled_toolsets: Optional[List[str]] = None
@@ -10636,6 +10637,7 @@ def _create_cron_job_sync(body: CronJobCreate, profile: str = "default"):
             model=_cron_optional_text(body.model),
             provider=_cron_optional_text(body.provider),
             base_url=_cron_optional_text(body.base_url, strip_trailing_slash=True),
+            reasoning_effort=body.reasoning_effort,
             script=script,
             context_from=context_from,
             enabled_toolsets=_cron_string_list(body.enabled_toolsets),

--- a/tests/cron/test_cron_reasoning_effort.py
+++ b/tests/cron/test_cron_reasoning_effort.py
@@ -1,0 +1,241 @@
+"""Per-job cron reasoning override contracts."""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_store(tmp_path, monkeypatch):
+    from cron import jobs
+
+    monkeypatch.setattr(jobs, "CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr(jobs, "JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+@contextmanager
+def captured_cron_agents(home):
+    """Run the real scheduler path while replacing external/runtime edges."""
+    runtime = {
+        "provider": "test-provider",
+        "api_key": None,
+        "base_url": "https://example.invalid/v1",
+        "api_mode": "chat_completions",
+    }
+    fake_db = MagicMock()
+    with patch("cron.scheduler._hermes_home", home), patch(
+        "cron.scheduler._resolve_origin", return_value=None
+    ), patch("hermes_cli.env_loader.load_hermes_dotenv"), patch(
+        "hermes_cli.env_loader.reset_secret_source_cache"
+    ), patch("hermes_state.SessionDB", return_value=fake_db), patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", return_value=runtime
+    ), patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), patch(
+        "run_agent.AIAgent"
+    ) as agent_class:
+        agent = MagicMock()
+        agent.run_conversation.return_value = {"final_response": "synthetic result"}
+        agent_class.return_value = agent
+        yield agent_class
+
+
+def _agent_job(job_id: str, **overrides):
+    return {
+        "id": job_id,
+        "name": f"Synthetic {job_id}",
+        "prompt": "Produce a synthetic result.",
+        "model": "test-model",
+        "provider": "test-provider",
+        "deliver": "local",
+        **overrides,
+    }
+
+
+def test_create_update_clear_and_persistence_reload(isolated_store):
+    from cron.jobs import create_job, get_job, load_jobs, update_job
+
+    job = create_job(
+        prompt="Produce a synthetic result.",
+        schedule="every 1h",
+        name="Synthetic reasoning job",
+        model="test-model",
+        provider="test-provider",
+        reasoning_effort="HIGH",
+    )
+    assert job["reasoning_effort"] == "high"
+    assert get_job(job["id"])["reasoning_effort"] == "high"
+    assert load_jobs()[0]["reasoning_effort"] == "high"
+
+    renamed = update_job(job["id"], {"name": "Synthetic renamed job"})
+    assert renamed["reasoning_effort"] == "high"
+
+    disabled = update_job(job["id"], {"reasoning_effort": "none"})
+    assert disabled["reasoning_effort"] is False
+    assert get_job(job["id"])["reasoning_effort"] is False
+
+    cleared = update_job(job["id"], {"reasoning_effort": None})
+    assert cleared["reasoning_effort"] is None
+    assert get_job(job["id"])["reasoning_effort"] is None
+
+
+def test_old_record_without_reasoning_loads_without_rewrite(isolated_store):
+    from cron.jobs import get_job
+
+    jobs_file = isolated_store / "cron" / "jobs.json"
+    jobs_file.parent.mkdir(parents=True)
+    original = {
+        "jobs": [
+            {
+                "id": "legacy-job",
+                "name": "Legacy synthetic job",
+                "prompt": "Produce a synthetic result.",
+                "enabled": True,
+                "schedule_display": "every 1h",
+            }
+        ],
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    jobs_file.write_text(json.dumps(original, indent=2), encoding="utf-8")
+
+    loaded = get_job("legacy-job")
+    assert "reasoning_effort" not in loaded
+    assert json.loads(jobs_file.read_text(encoding="utf-8")) == original
+
+
+@pytest.mark.parametrize("value", ["turbo", "", True, 42])
+def test_invalid_values_fail_with_shared_vocabulary(isolated_store, value):
+    from cron.jobs import create_job
+
+    with pytest.raises(ValueError) as exc_info:
+        create_job(
+            prompt="Produce a synthetic result.",
+            schedule="every 1h",
+            reasoning_effort=value,
+        )
+    message = str(exc_info.value)
+    assert "Invalid cron reasoning_effort" in message
+    assert "none, minimal, low, medium, high, xhigh, max, ultra" in message
+
+
+def test_scheduled_execution_uses_job_override(isolated_store):
+    from cron.jobs import create_job
+    from cron.scheduler import run_one_job
+
+    (isolated_store / "config.yaml").write_text(
+        "model: test-model\nagent:\n  reasoning_effort: low\n",
+        encoding="utf-8",
+    )
+    job = create_job(
+        prompt="Produce a synthetic result.",
+        schedule="every 1h",
+        name="Synthetic scheduled job",
+        model="test-model",
+        provider="test-provider",
+        reasoning_effort="xhigh",
+        deliver="local",
+    )
+
+    with captured_cron_agents(isolated_store) as agent_class:
+        assert run_one_job(job) is True
+
+    assert agent_class.call_args.kwargs["reasoning_config"] == {
+        "enabled": True,
+        "effort": "xhigh",
+    }
+
+
+def test_manual_run_uses_same_job_override(isolated_store):
+    from cron.jobs import create_job
+    from tools.cronjob_tools import cronjob
+
+    (isolated_store / "config.yaml").write_text(
+        "model: test-model\nagent:\n  reasoning_effort: low\n",
+        encoding="utf-8",
+    )
+    job = create_job(
+        prompt="Produce a synthetic result.",
+        schedule="every 1h",
+        name="Synthetic manual job",
+        model="test-model",
+        provider="test-provider",
+        reasoning_effort="high",
+        deliver="local",
+    )
+
+    with captured_cron_agents(isolated_store) as agent_class:
+        result = json.loads(cronjob(action="run", job_id=job["id"]))
+
+    assert result["success"] is True
+    assert result["job"]["executed"] is True
+    assert result["job"]["reasoning_effort"] == "high"
+    assert agent_class.call_args.kwargs["reasoning_config"] == {
+        "enabled": True,
+        "effort": "high",
+    }
+
+
+def test_job_override_precedes_per_model_and_stays_isolated(isolated_store):
+    from cron.scheduler import run_job
+
+    (isolated_store / "config.yaml").write_text(
+        "model: test-model\n"
+        "agent:\n"
+        "  reasoning_effort: medium\n"
+        "  reasoning_overrides:\n"
+        "    test-model: high\n",
+        encoding="utf-8",
+    )
+    jobs = [
+        _agent_job("inherit"),
+        _agent_job("disabled", reasoning_effort=False),
+        _agent_job("explicit", reasoning_effort="ultra"),
+        _agent_job("inherit-again", reasoning_effort=None),
+        # A hand-edited legacy record may contain an invalid/unhashable value.
+        # It must inherit rather than crashing the scheduler.
+        _agent_job("invalid-legacy", reasoning_effort=[]),
+    ]
+
+    with captured_cron_agents(isolated_store) as agent_class:
+        for job in jobs:
+            assert run_job(job)[0] is True
+
+    configs = [call.kwargs["reasoning_config"] for call in agent_class.call_args_list]
+    assert configs == [
+        {"enabled": True, "effort": "high"},
+        {"enabled": False},
+        {"enabled": True, "effort": "ultra"},
+        {"enabled": True, "effort": "high"},
+        {"enabled": True, "effort": "high"},
+    ]
+
+
+def test_no_agent_job_preserves_override_without_constructing_llm(isolated_store):
+    from cron.jobs import create_job, get_job
+    from cron.scheduler import run_job
+
+    job = create_job(
+        prompt="",
+        schedule="every 1h",
+        name="Synthetic script-only job",
+        script="synthetic-check.py",
+        no_agent=True,
+        reasoning_effort="ultra",
+        deliver="local",
+    )
+    assert get_job(job["id"])["reasoning_effort"] == "ultra"
+
+    with patch(
+        "cron.scheduler._run_job_script_with_claim_heartbeat",
+        return_value=(True, "synthetic output"),
+    ), patch("run_agent.AIAgent") as agent_class:
+        success, _doc, final_response, error = run_job(job)
+
+    assert success is True
+    assert final_response == "synthetic output"
+    assert error is None
+    agent_class.assert_not_called()

--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -39,3 +39,13 @@ def test_cronjob_schema_required_array_unchanged():
     from tools.cronjob_tools import CRONJOB_SCHEMA
 
     assert CRONJOB_SCHEMA["parameters"]["required"] == ["action"]
+
+
+def test_cronjob_schema_exposes_per_job_reasoning_contract():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    field = CRONJOB_SCHEMA["parameters"]["properties"]["reasoning_effort"]
+    assert field["type"] == ["string", "boolean", "null"]
+    assert "minimal, low, medium, high, xhigh, max, ultra" in field["description"]
+    assert "null" in field["description"]
+    assert "false" in field["description"]

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -19,6 +19,73 @@ def tmp_cron_dir(tmp_path, monkeypatch):
 
 
 class TestCronCommandLifecycle:
+    def test_create_list_edit_and_clear_reasoning(self, tmp_cron_dir, capsys):
+        cron_command(
+            Namespace(
+                cron_command="create",
+                schedule="every 1h",
+                prompt="Produce a synthetic result",
+                name="Synthetic CLI job",
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                script=None,
+                workdir=None,
+                no_agent=False,
+                reasoning_effort="high",
+            )
+        )
+        job = list_jobs()[0]
+        assert job["reasoning_effort"] == "high"
+
+        cron_command(Namespace(cron_command="list", all=True))
+        assert "Reasoning: high" in capsys.readouterr().out
+
+        cron_command(
+            Namespace(
+                cron_command="edit",
+                job_id=job["id"],
+                schedule=None,
+                prompt=None,
+                name=None,
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                clear_skills=False,
+                add_skills=None,
+                remove_skills=None,
+                script=None,
+                workdir=None,
+                no_agent=None,
+                reasoning_effort="none",
+            )
+        )
+        assert get_job(job["id"])["reasoning_effort"] is False
+
+        cron_command(
+            Namespace(
+                cron_command="edit",
+                job_id=job["id"],
+                schedule=None,
+                prompt=None,
+                name=None,
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                clear_skills=False,
+                add_skills=None,
+                remove_skills=None,
+                script=None,
+                workdir=None,
+                no_agent=None,
+                reasoning_effort="inherit",
+            )
+        )
+        assert get_job(job["id"])["reasoning_effort"] is None
+
     def test_pause_resume_run(self, tmp_cron_dir, capsys):
         job = create_job(prompt="Check server status", schedule="every 1h")
 

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -51,6 +51,7 @@ def test_cron_create_options():
         "--name", "daily", "--deliver", "origin", "--repeat", "3",
         "--skill", "a", "--skill", "b", "--no-agent",
         "--workdir", "/tmp/x",
+        "--reasoning-effort", "high",
     ])
     assert ns.schedule == "0 9 * * *"
     assert ns.prompt == "daily task prompt"
@@ -60,6 +61,7 @@ def test_cron_create_options():
     assert ns.skills == ["a", "b"]
     assert ns.no_agent is True
     assert ns.workdir == "/tmp/x"
+    assert ns.reasoning_effort == "high"
 
 
 def test_cron_edit_no_agent_tristate():
@@ -68,6 +70,16 @@ def test_cron_edit_no_agent_tristate():
     assert parser.parse_args(["cron", "edit", "j", "--no-agent"]).no_agent is True
     assert parser.parse_args(["cron", "edit", "j", "--agent"]).no_agent is False
     assert parser.parse_args(["cron", "edit", "j"]).no_agent is None
+
+
+def test_cron_edit_reasoning_can_set_or_clear_override():
+    parser = _build()
+    assert parser.parse_args(
+        ["cron", "edit", "j", "--reasoning-effort", "ultra"]
+    ).reasoning_effort == "ultra"
+    assert parser.parse_args(
+        ["cron", "edit", "j", "--reasoning-effort", "inherit"]
+    ).reasoning_effort == "inherit"
 
 
 def test_cron_dispatch_func_is_injected_handler():

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -265,6 +265,7 @@ async def test_create_cron_job_normalizes_representative_core_fields(
             schedule="every 1h",
             name="full-core-mapping",
             base_url="https://example.invalid/v1/",
+            reasoning_effort="high",
             script=str(scripts_dir / "collect-status.py"),
             no_agent=True,
         ),
@@ -273,6 +274,7 @@ async def test_create_cron_job_normalizes_representative_core_fields(
 
     assert job["name"] == "full-core-mapping"
     assert job["base_url"] == "https://example.invalid/v1"
+    assert job["reasoning_effort"] == "high"
     assert job["script"] == "collect-status.py"
     assert job["no_agent"] is True
 
@@ -376,6 +378,7 @@ async def test_update_cron_job_normalizes_dashboard_core_fields(isolated_profile
         web_server.CronJobUpdate(
             updates={
                 "base_url": "https://example.invalid/v1/",
+                "reasoning_effort": False,
                 "script": str(scripts_dir / "collect.py"),
                 "context_from": "",
                 "no_agent": True,
@@ -385,9 +388,17 @@ async def test_update_cron_job_normalizes_dashboard_core_fields(isolated_profile
     )
 
     assert updated["base_url"] == "https://example.invalid/v1"
+    assert updated["reasoning_effort"] is False
     assert updated["script"] == "collect.py"
     assert updated["context_from"] is None
     assert updated["no_agent"] is True
+
+    cleared = await web_server.update_cron_job(
+        job["id"],
+        web_server.CronJobUpdate(updates={"reasoning_effort": None}),
+        profile="worker_alpha",
+    )
+    assert cleared["reasoning_effort"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -264,6 +264,53 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_reasoning_create_list_update_and_clear(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Produce a synthetic result",
+                schedule="every 1h",
+                name="Synthetic reasoning tool job",
+                reasoning_effort="high",
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["reasoning_effort"] == "high"
+
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["reasoning_effort"] == "high"
+
+        disabled = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                reasoning_effort=False,
+            )
+        )
+        assert disabled["job"]["reasoning_effort"] is False
+
+        cleared = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                reasoning_effort=None,
+            )
+        )
+        assert cleared["job"]["reasoning_effort"] is None
+
+    def test_invalid_reasoning_value_returns_clear_tool_error(self):
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="Produce a synthetic result",
+                schedule="every 1h",
+                reasoning_effort="turbo",
+            )
+        )
+        assert result["success"] is False
+        assert "Invalid cron reasoning_effort" in result["error"]
+        assert "none, minimal, low, medium, high, xhigh, max, ultra" in result["error"]
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -16,6 +16,8 @@ from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
 
+_UNSET = object()
+
 # Import from cron module (will be available when properly installed)
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -578,6 +580,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "model": job.get("model"),
         "provider": job.get("provider"),
         "base_url": job.get("base_url"),
+        "reasoning_effort": job.get("reasoning_effort"),
         "schedule": job.get("schedule_display") or "?",
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
@@ -670,6 +673,7 @@ def cronjob(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    reasoning_effort: Any = _UNSET,
     reason: Optional[str] = None,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
@@ -744,6 +748,9 @@ def cronjob(
                 model=_normalize_optional_job_value(model),
                 provider=_normalize_optional_job_value(provider),
                 base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
+                reasoning_effort=(
+                    None if reasoning_effort is _UNSET else reasoning_effort
+                ),
                 script=_normalize_optional_job_value(script),
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,
@@ -875,6 +882,8 @@ def cronjob(
                 updates["provider"] = _normalize_optional_job_value(provider)
             if base_url is not None:
                 updates["base_url"] = _normalize_optional_job_value(base_url, strip_trailing_slash=True)
+            if reasoning_effort is not _UNSET:
+                updates["reasoning_effort"] = reasoning_effort
             # Re-validate the EFFECTIVE provider/base_url on EVERY update, not
             # only when this update supplies provider/base_url. A job persisted
             # before this guard (or written directly to the jobs store) may
@@ -1037,6 +1046,16 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 },
                 "required": ["model"]
             },
+            "reasoning_effort": {
+                "type": ["string", "boolean", "null"],
+                "description": (
+                    "Optional per-job reasoning override. Accepted enabled levels: "
+                    "minimal, low, medium, high, xhigh, max, ultra. Use 'none' "
+                    "or false to disable reasoning explicitly. Omit on create/update "
+                    "to preserve the current setting; pass null on update to clear "
+                    "the override and inherit the per-model/global configuration."
+                ),
+            },
             "script": {
                 "type": "string",
                 "description": f"Optional path to a script that runs each tick. In the default mode its stdout is injected into the agent's prompt as context (data-collection / change-detection pattern). With no_agent=True, the script IS the job and its stdout is delivered verbatim (classic watchdog pattern). Relative paths resolve under {display_hermes_home()}/scripts/. ``.sh``/``.bash`` extensions run via bash, everything else via Python. On update, pass empty string to clear."
@@ -1134,6 +1153,11 @@ registry.register(
         model=_mo[1],
         provider=_mo[0] or args.get("provider"),
         base_url=args.get("base_url"),
+        reasoning_effort=(
+            args["reasoning_effort"]
+            if "reasoning_effort" in args
+            else _UNSET
+        ),
         reason=args.get("reason"),
         script=args.get("script"),
         context_from=args.get("context_from"),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2114,6 +2114,7 @@ export interface CronJobMutation {
   provider?: string | null;
   model?: string | null;
   base_url?: string | null;
+  reasoning_effort?: string | boolean | null;
   script?: string | null;
   no_agent?: boolean;
   context_from?: string[] | null;
@@ -2140,6 +2141,7 @@ export interface CronJob {
   model?: string | null;
   provider?: string | null;
   base_url?: string | null;
+  reasoning_effort?: string | boolean | null;
   no_agent?: boolean | null;
   context_from?: string[] | string | null;
   enabled_toolsets?: string[] | null;

--- a/web/src/lib/cron-job.test.ts
+++ b/web/src/lib/cron-job.test.ts
@@ -19,6 +19,7 @@ function form(overrides: Partial<CronJobFormState> = {}): CronJobFormState {
     provider: "",
     model: "",
     base_url: "",
+    reasoning_effort: "",
     script: "",
     no_agent: false,
     context_from: "",
@@ -63,6 +64,7 @@ describe("buildCronJobPayload", () => {
       provider: null,
       model: null,
       base_url: null,
+      reasoning_effort: null,
       script: null,
       no_agent: false,
       context_from: null,
@@ -118,6 +120,18 @@ describe("cronJobFormFromJob", () => {
 
     expect(cronJobFormFromJob(job)).toMatchObject({
       schedule: "2026-02-03T14:00:00+08:00",
+    });
+  });
+
+  it("round-trips explicit and disabled reasoning overrides", () => {
+    expect(
+      cronJobFormFromJob({ id: "explicit", enabled: true, reasoning_effort: "xhigh" }),
+    ).toMatchObject({ reasoning_effort: "xhigh" });
+    expect(
+      cronJobFormFromJob({ id: "disabled", enabled: true, reasoning_effort: false }),
+    ).toMatchObject({ reasoning_effort: "none" });
+    expect(buildCronJobPayload(form({ reasoning_effort: "high" }))).toMatchObject({
+      reasoning_effort: "high",
     });
   });
 });

--- a/web/src/lib/cron-job.ts
+++ b/web/src/lib/cron-job.ts
@@ -9,6 +9,7 @@ export interface CronJobFormState {
   provider: string;
   model: string;
   base_url: string;
+  reasoning_effort: string;
   script: string;
   no_agent: boolean;
   context_from: string;
@@ -58,6 +59,7 @@ export function buildCronJobPayload(form: CronJobFormState): CronJobMutation {
     provider: optionalText(form.provider),
     model: optionalText(form.model),
     base_url: optionalText(form.base_url, true),
+    reasoning_effort: optionalText(form.reasoning_effort),
     script: optionalText(form.script),
     no_agent: Boolean(form.no_agent),
     context_from: contextFrom.length > 0 ? contextFrom : null,
@@ -86,6 +88,8 @@ export function cronJobFormFromJob(job: CronJob): CronJobFormState {
     provider: asString(job.provider),
     model: asString(job.model),
     base_url: asString(job.base_url),
+    reasoning_effort:
+      job.reasoning_effort === false ? "none" : asString(job.reasoning_effort),
     script: asString(job.script),
     no_agent: Boolean(job.no_agent),
     context_from: listToText(job.context_from),

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -46,6 +46,7 @@ import { PluginSlot } from "@/plugins";
 import { Segmented } from "@nous-research/ui/ui/components/segmented";
 import { AutomationBlueprints } from "@/components/AutomationBlueprints";
 import { cn, themedBody } from "@/lib/utils";
+import { EFFORT_OPTIONS } from "@/lib/reasoning-effort";
 
 function formatTime(iso?: string | null): string {
   if (!iso) return "—";
@@ -138,6 +139,7 @@ function emptyCronJobForm(): CronJobEditorState {
     provider: "",
     model: "",
     base_url: "",
+    reasoning_effort: "",
     script: "",
     no_agent: false,
     context_from: "",
@@ -246,14 +248,31 @@ function CronAdvancedFields({
           </div>
         </div>
 
-        <div className="grid gap-1">
-          <Label htmlFor={`${idPrefix}-base-url`}>Base URL override</Label>
-          <Input
-            id={`${idPrefix}-base-url`}
-            placeholder="https://api.example.com/v1"
-            value={form.base_url}
-            onChange={(e) => update("base_url", e.target.value)}
-          />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div className="grid gap-1">
+            <Label htmlFor={`${idPrefix}-base-url`}>Base URL override</Label>
+            <Input
+              id={`${idPrefix}-base-url`}
+              placeholder="https://api.example.com/v1"
+              value={form.base_url}
+              onChange={(e) => update("base_url", e.target.value)}
+            />
+          </div>
+          <div className="grid gap-1">
+            <Label htmlFor={`${idPrefix}-reasoning`}>Reasoning effort</Label>
+            <Select
+              id={`${idPrefix}-reasoning`}
+              value={form.reasoning_effort}
+              onValueChange={(v) => update("reasoning_effort", v)}
+            >
+              <SelectOption value="">Inherit model/global setting</SelectOption>
+              {EFFORT_OPTIONS.map((option) => (
+                <SelectOption key={option.value} value={option.value}>
+                  {option.label}
+                </SelectOption>
+              ))}
+            </Select>
+          </div>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 items-end">
@@ -994,6 +1013,10 @@ export default function CronPage() {
           const jobKey = getJobKey(job);
           const mode = getJobMode(job);
           const modelDisplay = getModelDisplay(job);
+          const reasoningDisplay =
+            job.reasoning_effort === false
+              ? "none"
+              : asText(job.reasoning_effort);
           const toolsets = Array.isArray(job.enabled_toolsets)
             ? job.enabled_toolsets.filter(Boolean)
             : [];
@@ -1026,6 +1049,11 @@ export default function CronPage() {
                     {modelDisplay && (
                       <Badge tone="outline" title={modelDisplay}>
                         model
+                      </Badge>
+                    )}
+                    {reasoningDisplay && (
+                      <Badge tone="outline" title={`Reasoning: ${reasoningDisplay}`}>
+                        reasoning: {reasoningDisplay}
                       </Badge>
                     )}
                     {toolsets.length > 0 && (

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -59,9 +59,16 @@ Jobs are stored in `~/.hermes/cron/jobs.json` with atomic write semantics (write
   "created_at": "2025-01-01T00:00:00Z",
   "model": null,
   "provider": null,
+  "reasoning_effort": "high",
   "script": null
 }
 ```
+
+`reasoning_effort` is optional. Missing or `null` inherits the existing
+per-model/global reasoning configuration, while `false` means reasoning is
+explicitly disabled. Older records need no migration. The scheduler passes the
+effective value into the newly constructed agent for each run, which prevents
+one job's override from affecting another job.
 
 ### Job Lifecycle States
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -49,7 +49,16 @@ hermes cron create "every 1h" "Use both skills and combine the result" \
   --skill blogwatcher \
   --skill maps \
   --name "Skill combo"
+hermes cron create "every 1d" "Summarize the daily report" \
+  --name "Daily report" \
+  --reasoning-effort high
 ```
+
+`--reasoning-effort` sets the reasoning level for that job only. Accepted
+values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, and
+`ultra`. Jobs without an override keep using the model/global reasoning
+configuration. Clear an existing override with
+`hermes cron edit <job_id> --reasoning-effort inherit`.
 
 ### Through natural conversation
 
@@ -588,7 +597,21 @@ cronjob(action="run", job_id="...")
 cronjob(action="remove", job_id="...")
 ```
 
-For `update`, pass `skills=[]` to remove all attached skills.
+For `update`, pass `skills=[]` to remove all attached skills. Pass
+`reasoning_effort=null` to clear a per-job reasoning override, or `false` /
+`"none"` to disable reasoning explicitly for that job:
+
+```python
+cronjob(
+    action="update",
+    job_id="<job_id>",
+    reasoning_effort="high",
+)
+```
+
+The override affects scheduled runs and manual `run` actions equally. A
+script-only job with `no_agent=true` stores the field but does not start an
+agent or model call.
 
 ## Toolsets available to cron jobs
 

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -666,7 +666,8 @@ the `cronjob` tool, the `hermes cron` CLI (`list`, `add`, `edit`,
 
 - **Schedules:** duration (`"30m"`, `"2h"`), "every" phrase
   (`"every monday 9am"`), 5-field cron (`"0 9 * * *"`), or ISO timestamp.
-- **Per-job knobs:** `skills`, `model`/`provider` override, `script`
+- **Per-job knobs:** `skills`, `model`/`provider` override,
+  `reasoning_effort` (missing/null inherits global; `false` disables), `script`
   (pre-run data collection; `no_agent=True` makes the script the whole
   job), `context_from` (chain job A's output into job B), `workdir`
   (run in a specific dir with its `AGENTS.md` / `CLAUDE.md` loaded),


### PR DESCRIPTION
## Summary

Adds an optional `reasoning_effort` override to each cron job, so scheduled work can choose its own quality/latency tradeoff without mutating global agent configuration.

Runtime precedence is:

1. valid per-job override
2. per-model reasoning policy for the model that actually survives provider-auth fallback
3. global reasoning policy
4. provider/model default

## Behavior

- Missing or `null` inherits the configured policy.
- `false` / `none` explicitly disables reasoning.
- Supported levels come from the canonical parser: `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`.
- Invalid new writes are rejected with a clear error.
- Malformed hand-edited/legacy stored values warn and inherit instead of crashing the scheduler.
- `hermes cron edit <job_id> --reasoning-effort inherit` clears an override.
- Script-only (`no_agent`) jobs preserve the field but never construct an agent, so it has no runtime effect.
- Each run receives its own `reasoning_config`; no job can leak its override into another job or global config.

## Surfaces

The field round-trips through cron storage, scheduler execution, the `cronjob` tool, standalone CLI, authenticated dashboard API, web UI, desktop UI/types/translations, and cron documentation.

Existing jobs require no migration and retain their current behavior.

## Current-main compatibility

This is rebased onto current `main` and preserves the newer auth-fallback ordering: reasoning is resolved only after the actual fallback model is known. It also covers the gaps called out on earlier proposals: all current effort levels, raw YAML/JSON `false`, malformed-record fallback, standalone CLI set/clear, and both web and desktop surfaces.

Related: #7382, #63327, #23524.

## Validation

- 829 Python tests collected and passed across `tests/cron`, cron tool, CLI parser/lifecycle, and dashboard profile API suites
- Web + desktop cron model Vitest: 16 passed
- Web TypeScript typecheck: passed
- Desktop renderer + Electron TypeScript typechecks: passed
- ESLint on every changed frontend file: passed
- Ruff on changed Python files: passed
- `py_compile`: passed
- `git diff --check`: passed
- Added-line private identifier, IP, credential-literal, and control-character scans: zero hits

- [x] Tested on Ubuntu 26.04 (x86_64)
