### PR TITLE
fix(desktop): make remote backend updates terminal-state driven

### DIFF
--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -373,6 +373,7 @@ describe('applyBackendUpdate recovery', () => {
     checkHermesUpdateSpy.mockReset()
     updateHermesSpy.mockReset()
     getActionStatusSpy.mockReset()
+    $backendUpdateStatus.set(null)
     $backendUpdateApply.set({
       applying: false,
       stage: 'idle',
@@ -390,16 +391,14 @@ describe('applyBackendUpdate recovery', () => {
   })
 
   it('waits for the backend to return after the restart drops the connection, then clears the overlay', async () => {
-    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
-    getActionStatusSpy.mockRejectedValue(new Error('ECONNREFUSED'))
-    checkHermesUpdateSpy.mockResolvedValue({
-      install_method: 'git',
-      current_version: '0.16.0',
-      behind: 0,
-      update_available: false,
-      can_apply: true,
-      update_command: 'hermes update',
-      message: null
+    const actionId = 'd'.repeat(32)
+    updateHermesSpy.mockResolvedValue({ action_id: actionId, ok: true, name: 'update', pid: 1 })
+    getActionStatusSpy.mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValueOnce({
+      exit_code: null,
+      lines: [`=== hermes-update completed ${actionId} ===`],
+      name: 'update',
+      pid: null,
+      running: false
     })
 
     const promise = applyBackendUpdate()
@@ -412,7 +411,8 @@ describe('applyBackendUpdate recovery', () => {
   })
 
   it('surfaces backend update action log lines while the action is running', async () => {
-    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    const actionId = 'e'.repeat(32)
+    updateHermesSpy.mockResolvedValue({ action_id: actionId, ok: true, name: 'update', pid: 1 })
     getActionStatusSpy
       .mockResolvedValueOnce({
         exit_code: null,
@@ -422,15 +422,13 @@ describe('applyBackendUpdate recovery', () => {
         running: true
       })
       .mockRejectedValueOnce(new Error('ECONNREFUSED'))
-    checkHermesUpdateSpy.mockResolvedValue({
-      install_method: 'git',
-      current_version: '0.16.0',
-      behind: 0,
-      update_available: false,
-      can_apply: true,
-      update_command: 'hermes update',
-      message: null
-    })
+      .mockResolvedValueOnce({
+        exit_code: null,
+        lines: [`=== hermes-update completed ${actionId} ===`],
+        name: 'update',
+        pid: null,
+        running: false
+      })
 
     const promise = applyBackendUpdate()
     await vi.advanceTimersByTimeAsync(1500)
@@ -445,18 +443,323 @@ describe('applyBackendUpdate recovery', () => {
     await promise
   })
 
+  it('keeps waiting past the old 45-second cutoff while the update action is running', async () => {
+    const actionId = 'f'.repeat(32)
+    updateHermesSpy.mockResolvedValue({ action_id: actionId, ok: true, name: 'hermes-update', pid: 1 })
+
+    for (let attempt = 0; attempt < 31; attempt += 1) {
+      getActionStatusSpy.mockResolvedValueOnce({
+        exit_code: null,
+        lines: ['=== hermes-update started now ===', `step ${attempt}`],
+        name: 'hermes-update',
+        pid: 1,
+        running: true
+      })
+    }
+
+    getActionStatusSpy.mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValueOnce({
+      exit_code: null,
+      lines: [`=== hermes-update completed ${actionId} ===`],
+      name: 'hermes-update',
+      pid: null,
+      running: false
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(46500)
+
+    expect($backendUpdateApply.get().applying).toBe(true)
+    expect($backendUpdateApply.get().stage).toBe('pull')
+
+    await vi.advanceTimersByTimeAsync(5000)
+    await expect(promise).resolves.toMatchObject({ ok: true })
+  })
+
+  it('treats a successful no-op as complete without waiting for a restart', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: ['stale output from another run', '=== hermes-update started now ===', '✓ Already up to date!'],
+      name: 'hermes-update',
+      pid: 1,
+      running: false
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+    const result = await promise
+
+    expect(result.ok).toBe(true)
+    expect($backendUpdateApply.get().stage).toBe('idle')
+  })
+
+  it('treats a successful dependency repair as complete without waiting for a restart', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: ['=== hermes-update started now ===', '✓ Dependencies repaired!', '✓ Update complete!'],
+      name: 'hermes-update',
+      pid: 1,
+      running: false
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect($backendUpdateApply.get().stage).toBe('idle')
+  })
+
+  it('trusts the current action exit code without parsing its output', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: ['✓ Already up to date!'],
+      name: 'hermes-update',
+      pid: 1,
+      running: false
+    })
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
+  })
+
+  it('waits for current-action completion proof after the backend restarts', async () => {
+    const actionId = 'a'.repeat(32)
+    updateHermesSpy.mockResolvedValue({ action_id: actionId, ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValueOnce({
+        exit_code: null,
+        lines: ['Update complete!', `=== hermes-update completed ${'c'.repeat(32)} ===`],
+        name: 'hermes-update',
+        pid: null,
+        running: false
+      })
+      .mockResolvedValueOnce({
+        exit_code: null,
+        lines: ['Update complete!', `=== hermes-update completed ${actionId} ===`],
+        name: 'hermes-update',
+        pid: null,
+        running: false
+      })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(5000)
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts its terminal receipt when a verbose update pushes the start marker out of the log tail', async () => {
+    const actionId = 'b'.repeat(32)
+    updateHermesSpy.mockResolvedValue({ action_id: actionId, ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValueOnce({
+      exit_code: null,
+      lines: ['final build output', 'Update complete!', `=== hermes-update completed ${actionId} ===`],
+      name: 'hermes-update',
+      pid: null,
+      running: false
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(5000)
+
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(getActionStatusSpy).toHaveBeenCalledWith('hermes-update', 2000)
+  })
+
+  it('proves a pre-action-ID backend reached its requested commit after restart', async () => {
+    $backendUpdateStatus.set({
+      behind: 2,
+      commits: [{ at: 1, author: 'Nous', sha: 'requested-target', summary: 'target' }],
+      fetchedAt: 1,
+      supported: true,
+      targetSha: 'backend:0.18.2',
+      updateAvailable: true
+    })
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValue({
+      exit_code: null,
+      lines: ['verbose output', 'Update complete!'],
+      name: 'hermes-update',
+      pid: null,
+      running: false
+    })
+    checkHermesUpdateSpy
+      .mockResolvedValueOnce({
+        behind: null,
+        can_apply: true,
+        commits: [],
+        current_version: '0.18.2',
+        install_method: 'git',
+        message: 'offline',
+        update_available: false,
+        update_command: 'hermes update'
+      })
+      .mockResolvedValueOnce({
+        behind: 1,
+        can_apply: true,
+        commits: [{ at: 2, author: 'Nous', sha: 'newer-commit', summary: 'newer' }],
+        current_version: '0.18.2',
+        install_method: 'git',
+        message: null,
+        update_available: true,
+        update_command: 'hermes update'
+      })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(5000)
+
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(checkHermesUpdateSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('proves a fast pre-action-ID packaged update by its changed version', async () => {
+    $backendUpdateStatus.set({
+      behind: 1,
+      commits: [],
+      fetchedAt: 1,
+      supported: true,
+      targetSha: 'backend:0.18.2',
+      updateAvailable: true
+    })
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: null,
+      lines: ['verbose output without a retained start marker'],
+      name: 'hermes-update',
+      pid: null,
+      running: false
+    })
+    checkHermesUpdateSpy.mockResolvedValue({
+      behind: -1,
+      can_apply: true,
+      commits: [],
+      current_version: '0.18.3',
+      install_method: 'pip',
+      message: null,
+      update_available: true,
+      update_command: 'hermes update'
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(checkHermesUpdateSpy).toHaveBeenCalledWith(true)
+  })
+
+  it('resumes action polling after a transient status failure', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce({
+        exit_code: null,
+        lines: ['=== hermes-update started now ===', 'still running'],
+        name: 'hermes-update',
+        pid: 1,
+        running: true
+      })
+      .mockResolvedValueOnce({
+        exit_code: 0,
+        lines: ['=== hermes-update started now ===', 'Update complete!'],
+        name: 'hermes-update',
+        pid: 1,
+        running: false
+      })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(5000)
+    await expect(promise).resolves.toMatchObject({ ok: true })
+    expect(getActionStatusSpy).toHaveBeenCalledTimes(3)
+  })
+
+  it('restores the fixed action deadline after reconnecting', async () => {
+    updateHermesSpy.mockResolvedValue({ action_id: 'a'.repeat(32), ok: true, name: 'hermes-update', pid: 1 })
+    const running = {
+      exit_code: null,
+      lines: ['still running'],
+      name: 'hermes-update',
+      pid: 1,
+      running: true
+    }
+
+    for (let attempt = 0; attempt < 119; attempt += 1) {
+      getActionStatusSpy.mockResolvedValueOnce(running)
+    }
+    getActionStatusSpy.mockRejectedValueOnce(new Error('ECONNRESET')).mockResolvedValue(running)
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000 + 1500)
+
+    await expect(promise).resolves.toMatchObject({ error: 'apply-failed', ok: false })
+    expect($backendUpdateApply.get().stage).toBe('error')
+  })
+
+  it('shares one in-flight update between concurrent apply requests', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 0,
+      lines: ['=== hermes-update started now ===', '✓ Already up to date!'],
+      name: 'hermes-update',
+      pid: 1,
+      running: false
+    })
+
+    const first = applyBackendUpdate()
+    const second = applyBackendUpdate()
+
+    expect(second).toBe(first)
+    await vi.advanceTimersByTimeAsync(1500)
+    await Promise.all([first, second])
+    expect(updateHermesSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails closed when the update action never reaches a terminal state', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: null,
+      lines: ['=== hermes-update started now ===', 'still running'],
+      name: 'hermes-update',
+      pid: 1,
+      running: true
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000 + 1500)
+    await expect(promise).resolves.toMatchObject({ ok: false, error: 'apply-failed' })
+    expect($backendUpdateApply.get().stage).toBe('error')
+  })
+
+  it('fails immediately when the update action exits nonzero', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'hermes-update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({
+      exit_code: 1,
+      lines: ['=== hermes-update started now ===', 'update failed'],
+      name: 'hermes-update',
+      pid: 1,
+      running: false
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(1500)
+    await expect(promise).resolves.toMatchObject({ ok: false, error: 'apply-failed' })
+    expect(checkHermesUpdateSpy).not.toHaveBeenCalled()
+    expect($backendUpdateApply.get().stage).toBe('error')
+  })
+
   it('surfaces an error when the backend never comes back after the restart', async () => {
     updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
     getActionStatusSpy.mockRejectedValue(new Error('ECONNREFUSED'))
     checkHermesUpdateSpy.mockRejectedValue(new Error('ECONNREFUSED'))
 
     const promise = applyBackendUpdate()
-    await vi.advanceTimersByTimeAsync(70000)
+    await vi.advanceTimersByTimeAsync(250000)
     const result = await promise
 
     expect(result.ok).toBe(false)
     expect($backendUpdateApply.get().stage).toBe('error')
-  })
+  }, 10000)
 })
 
 describe('startUpdatePoller', () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -465,24 +465,9 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
   }
 }
 
-const BACKEND_RETURN_POLL_MS = 1500
-const BACKEND_RETURN_MAX_ATTEMPTS = 40
-
-async function waitForBackendReturn(): Promise<boolean> {
-  for (let attempt = 0; attempt < BACKEND_RETURN_MAX_ATTEMPTS; attempt += 1) {
-    await new Promise(resolve => globalThis.setTimeout(resolve, BACKEND_RETURN_POLL_MS))
-
-    try {
-      await checkHermesUpdate()
-
-      return true
-    } catch {
-      continue
-    }
-  }
-
-  return false
-}
+const BACKEND_ACTION_POLL_MS = 1500
+const BACKEND_ACTION_MAX_MS = 6 * 60 * 1000
+const BACKEND_RETURN_MAX_MS = 4 * 60 * 1000
 
 function finishBackendApply(returned: boolean): DesktopUpdateApplyResult {
   if (returned) {
@@ -525,7 +510,32 @@ function ingestBackendActionStatus(status: Awaited<ReturnType<typeof getActionSt
   })
 }
 
-export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
+function completedAfterRestart(
+  status: Awaited<ReturnType<typeof getActionStatus>>,
+  actionId: string | undefined
+): boolean {
+  return !!actionId && status.lines.some(line => line === `=== hermes-update completed ${actionId} ===`)
+}
+
+function legacyBackendReachedTarget(
+  status: BackendUpdateCheckResponse,
+  targetSha: string | undefined,
+  previousVersion: string | undefined
+): boolean {
+  if (status.behind === 0) {
+    return true
+  }
+
+  if (previousVersion && status.current_version !== previousVersion) {
+    return true
+  }
+
+  return !!targetSha && !!status.commits?.length && !status.commits.some(commit => commit.sha === targetSha)
+}
+
+let backendUpdateInFlight: Promise<DesktopUpdateApplyResult> | null = null
+
+async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   dismissNotification(UPDATE_TOAST_ID)
   $backendUpdateApply.set({
     ...IDLE,
@@ -535,6 +545,11 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   })
 
   try {
+    const previousStatus = $backendUpdateStatus.get()
+    const requestedTargetSha = previousStatus?.commits?.at(0)?.sha
+    const previousVersion = previousStatus?.targetSha?.startsWith('backend:')
+      ? previousStatus.targetSha.slice('backend:'.length)
+      : undefined
     const started = await updateHermes()
 
     if (!started.ok) {
@@ -553,41 +568,67 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
     })
 
     let last: Awaited<ReturnType<typeof getActionStatus>> | null = null
+    // Backups, dependency repair, and builds can legitimately take several
+    // minutes. Keep the generous cap only as a guard against a stuck action.
+    const actionDeadline = Date.now() + BACKEND_ACTION_MAX_MS
+    let deadline = actionDeadline
+    let reconnecting = false
 
-    for (let attempt = 0; attempt < 30; attempt += 1) {
-      await new Promise(resolve => globalThis.setTimeout(resolve, 1500))
+    while (Date.now() < deadline) {
+      await new Promise(resolve => globalThis.setTimeout(resolve, BACKEND_ACTION_POLL_MS))
 
       try {
-        last = await getActionStatus(started.name, 200)
+        last = await getActionStatus(started.name, 2000)
         ingestBackendActionStatus(last)
       } catch {
-        // The dashboard restarts mid-update, dropping this connection — expected, not a failure.
-        $backendUpdateApply.set({
-          ...$backendUpdateApply.get(),
-          applying: true,
-          stage: 'restart',
-          message: translateNow('updates.applyStatus.restarting')
-        })
+        if (!reconnecting) {
+          reconnecting = true
+          deadline = Date.now() + BACKEND_RETURN_MAX_MS
+          $backendUpdateApply.set({
+            ...$backendUpdateApply.get(),
+            applying: true,
+            stage: 'restart',
+            message: translateNow('updates.applyStatus.restarting')
+          })
+        }
 
-        return finishBackendApply(await waitForBackendReturn())
+        continue
       }
 
-      if (last && !last.running) {
+      if (last.running) {
+        if (reconnecting) {
+          reconnecting = false
+          deadline = actionDeadline
+          $backendUpdateApply.set({
+            ...$backendUpdateApply.get(),
+            applying: true,
+            stage: 'pull',
+            message: translateNow('updates.applyStatus.pulling')
+          })
+        }
+
+        continue
+      }
+
+      if (last.exit_code === 0 || (last.exit_code === null && completedAfterRestart(last, started.action_id))) {
+        return finishBackendApply(true)
+      }
+
+      if (!started.action_id && last.exit_code === null) {
+        try {
+          const status = await checkHermesUpdate(true)
+
+          if (legacyBackendReachedTarget(status, requestedTargetSha, previousVersion)) {
+            return finishBackendApply(true)
+          }
+        } catch {
+          continue
+        }
+      }
+
+      if (last.exit_code !== null) {
         break
       }
-    }
-
-    const ok = !!last && (last.exit_code ?? 1) === 0
-
-    if (ok) {
-      $backendUpdateApply.set({
-        ...$backendUpdateApply.get(),
-        applying: true,
-        stage: 'restart',
-        message: translateNow('updates.applyStatus.restarting')
-      })
-
-      return finishBackendApply(await waitForBackendReturn())
     }
 
     $backendUpdateApply.set({
@@ -611,6 +652,18 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
 
     return { ok: false, error: 'apply-failed', message }
   }
+}
+
+export function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
+  if (backendUpdateInFlight) {
+    return backendUpdateInFlight
+  }
+
+  backendUpdateInFlight = runBackendUpdate().finally(() => {
+    backendUpdateInFlight = null
+  })
+
+  return backendUpdateInFlight
 }
 
 function ingestProgress(payload: DesktopUpdateProgress): void {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -811,6 +811,8 @@ export interface ActionResponse {
   name: string
   ok: boolean
   pid: number
+  action_id?: string
+  already_running?: boolean
 }
 
 export interface ActionStatusResponse {

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6472,7 +6472,7 @@ def _update_via_zip(args):
         print("  Code and Python deps are updated, but the dashboard/TUI may")
         print("  be in a mixed state until the Node deps are rebuilt.")
     else:
-        print("✓ Update complete!")
+        _print_update_completion("✓ Update complete!")
     try:
         _print_curator_first_run_notice()
     except Exception as e:
@@ -9608,6 +9608,13 @@ def _discard_lockfile_churn(git_cmd, repo_root):
         pass
 
 
+def _print_update_completion(message: str) -> None:
+    print(message)
+    action_id = os.environ.get("HERMES_ACTION_ID", "")
+    if len(action_id) == 32 and all(char in "0123456789abcdef" for char in action_id):
+        print(f"=== hermes-update completed {action_id} ===")
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version.
 
@@ -9727,7 +9734,7 @@ def _cmd_update_pip(args):
         print("✗ Update failed")
         sys.exit(1)
 
-    print("✓ Update complete! Restart hermes to use the new version.")
+    _print_update_completion("✓ Update complete! Restart hermes to use the new version.")
 
 
 def _cmd_update_impl(args, gateway_mode: bool):
@@ -10059,11 +10066,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 healthy_after, detail_after = _venv_core_imports_healthy()
                 if healthy_after:
                     print("✓ Dependencies repaired!")
+                    _print_update_completion("✓ Update complete!")
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
-                print("✓ Already up to date!")
+                _print_update_completion("✓ Already up to date!")
             _resume_windows_gateways_after_update(_windows_gateway_resume)
             return
 
@@ -10569,7 +10577,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("  Code and Python deps are updated, but the dashboard/TUI may")
             print("  be in a mixed state until the Node deps are rebuilt.")
         else:
-            print("✓ Update complete!")
+            _print_update_completion("✓ Update complete!")
 
         # Curator first-run heads-up. Only prints when curator is enabled AND
         # has never run — i.e. the window where the ticker would otherwise

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3231,6 +3231,7 @@ _ACTION_LOG_FILES: Dict[str, str] = {
 # report liveness and exit code without shelling out to ``ps``.
 _ACTION_PROCS: Dict[str, subprocess.Popen] = {}
 _ACTION_COMMANDS: Dict[str, Tuple[str, ...]] = {}
+_ACTION_IDS: Dict[str, str] = {}
 
 # ``name`` → completed synthetic action result for actions the server handled
 # without spawning a subprocess (for example, unsupported Docker updates).
@@ -3251,6 +3252,7 @@ def _record_completed_action(name: str, message: str, exit_code: int = 1) -> Non
             log_file.write(b"\n")
     _ACTION_PROCS.pop(name, None)
     _ACTION_COMMANDS.pop(name, None)
+    _ACTION_IDS.pop(name, None)
     _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": None}
 
 
@@ -3266,7 +3268,12 @@ def _dashboard_spawn_executable() -> str:
     return exe
 
 
-def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
+def _spawn_hermes_action(
+    subcommand: List[str],
+    name: str,
+    *,
+    env_overrides: Optional[Dict[str, str]] = None,
+) -> subprocess.Popen:
     """Spawn ``hermes <subcommand>`` detached and record the Popen handle.
 
     Uses the running interpreter's ``hermes_cli.main`` module so the action
@@ -3287,7 +3294,11 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
         "stdin": subprocess.DEVNULL,
         "stdout": log_file,
         "stderr": subprocess.STDOUT,
-        "env": {**os.environ, "HERMES_NONINTERACTIVE": "1"},
+        "env": {
+            **os.environ,
+            "HERMES_NONINTERACTIVE": "1",
+            **(env_overrides or {}),
+        },
     }
     if sys.platform == "win32":
         popen_kwargs["creationflags"] = windows_detach_flags()
@@ -3302,6 +3313,11 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     _ACTION_RESULTS.pop(name, None)
     _ACTION_COMMANDS[name] = tuple(subcommand)
     _ACTION_PROCS[name] = proc
+    action_id = (env_overrides or {}).get("HERMES_ACTION_ID")
+    if action_id:
+        _ACTION_IDS[name] = action_id
+    else:
+        _ACTION_IDS.pop(name, None)
     return proc
 
 
@@ -3581,8 +3597,26 @@ async def update_hermes():
             "update_command": recommended_update_command_for_method(install_method),
         }
 
+    existing = _ACTION_PROCS.get("hermes-update")
+    if existing is not None and existing.poll() is None:
+        response = {
+            "ok": True,
+            "pid": existing.pid,
+            "name": "hermes-update",
+            "already_running": True,
+        }
+        action_id = _ACTION_IDS.get("hermes-update")
+        if action_id:
+            response["action_id"] = action_id
+        return response
+
+    action_id = secrets.token_hex(16)
     try:
-        proc = _spawn_hermes_action(["update"], "hermes-update")
+        proc = _spawn_hermes_action(
+            ["update"],
+            "hermes-update",
+            env_overrides={"HERMES_ACTION_ID": action_id},
+        )
     except Exception as exc:
         _log.exception("Failed to spawn hermes update")
         raise HTTPException(status_code=500, detail=f"Failed to start update: {exc}")
@@ -3590,6 +3624,7 @@ async def update_hermes():
         "ok": True,
         "pid": proc.pid,
         "name": "hermes-update",
+        "action_id": action_id,
     }
 
 
@@ -3999,6 +4034,7 @@ async def get_action_status(name: str, lines: int = 200):
             _ACTION_RESULTS[name] = {"exit_code": exit_code, "pid": pid}
             _ACTION_PROCS.pop(name, None)
             _ACTION_COMMANDS.pop(name, None)
+            _ACTION_IDS.pop(name, None)
 
     return {
         "name": name,

--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -19,8 +19,28 @@ from hermes_cli.main import (
     _finalize_update_output,
     _install_hangup_protection,
     _log_only_write,
+    _print_update_completion,
     _run_logged_subprocess,
 )
+
+
+def test_update_completion_includes_bounded_action_identity(monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_ACTION_ID", "a" * 32)
+
+    _print_update_completion("✓ Update complete!")
+
+    assert capsys.readouterr().out.splitlines() == [
+        "✓ Update complete!",
+        f"=== hermes-update completed {'a' * 32} ===",
+    ]
+
+
+def test_update_completion_rejects_untrusted_action_identity(monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_ACTION_ID", "not-safe\nforged")
+
+    _print_update_completion("✓ Update complete!")
+
+    assert capsys.readouterr().out == "✓ Update complete!\n"
 
 
 # -----------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1976,11 +1976,12 @@ class TestWebServerEndpoints:
 
         calls = []
 
-        def fake_spawn(subcommand, name):
-            calls.append((subcommand, name))
+        def fake_spawn(subcommand, name, *, env_overrides=None):
+            calls.append((subcommand, name, env_overrides))
             return Proc()
 
         monkeypatch.setattr(web_server, "detect_install_method", lambda _root: "git")
+        monkeypatch.setattr(web_server.secrets, "token_hex", lambda _size: "a" * 32)
         monkeypatch.setattr(web_server, "_spawn_hermes_action", fake_spawn)
         web_server._ACTION_PROCS.pop("hermes-update", None)
         web_server._ACTION_RESULTS.pop("hermes-update", None)
@@ -1988,8 +1989,48 @@ class TestWebServerEndpoints:
         resp = self.client.post("/api/hermes/update")
 
         assert resp.status_code == 200
-        assert resp.json() == {"ok": True, "pid": 12345, "name": "hermes-update"}
-        assert calls == [(["update"], "hermes-update")]
+        assert resp.json() == {
+            "ok": True,
+            "pid": 12345,
+            "name": "hermes-update",
+            "action_id": "a" * 32,
+        }
+        assert calls == [
+            (["update"], "hermes-update", {"HERMES_ACTION_ID": "a" * 32})
+        ]
+
+    def test_update_hermes_reuses_running_action(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        class Proc:
+            pid = 24680
+
+            def poll(self):
+                return None
+
+        monkeypatch.setattr(web_server, "detect_install_method", lambda _root: "git")
+        monkeypatch.setattr(
+            web_server,
+            "_spawn_hermes_action",
+            lambda *_args: pytest.fail("must not spawn a duplicate update"),
+        )
+        web_server._ACTION_PROCS["hermes-update"] = Proc()
+        web_server._ACTION_IDS["hermes-update"] = "b" * 32
+
+        try:
+            resp = self.client.post("/api/hermes/update")
+        finally:
+            web_server._ACTION_PROCS.pop("hermes-update", None)
+            web_server._ACTION_IDS.pop("hermes-update", None)
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "ok": True,
+            "pid": 24680,
+            "name": "hermes-update",
+            "already_running": True,
+            "action_id": "b" * 32,
+        }
 
     def test_action_status_reaps_completed_process(self, monkeypatch):
         import hermes_cli.web_server as web_server


### PR DESCRIPTION
## Summary

Unifies the complementary remote-backend updater fixes from #47362 and #59190 on current `main`:

- keep polling a reachable `running: true` action beyond the old ~45 second budget, with a fixed six-minute action deadline;
- share one in-flight apply promise in the renderer and reuse an already-running update action in the dashboard process;
- give each new backend update an `action_id` and emit a matching terminal receipt before restart;
- after restart, accept only the receipt for the action the Desktop started, so appended or truncated logs cannot create false success or false failure;
- preserve upgrades from older backends without `action_id` by proving the requested Git commit, an up-to-date check, or a packaged-version transition;
- recover from transient polling failures without extending the fixed action deadline indefinitely;
- preserve current-main action-log ingestion and fail closed when completion cannot be proven.

The no-op, dependency-repair, pip, ZIP, and normal update success paths now emit the same bounded terminal receipt when invoked by the dashboard.

## Runtime evidence

Observed on a real macOS remote Desktop/backend update before this patch:

1. `hermes update` started and its configured full backup copied 629.4 MB in 50.1 seconds, already exceeding the Desktop's old 30 x 1.5 second action budget.
2. The Desktop reported failure while that detached action continued.
3. The same action later printed `Update complete`, restarted the service, and stopped the dashboard as designed.
4. A follow-up invocation returned `Already up to date` with exit code 0 and no restart, exercising the second false-failure path.
5. The dashboard subsequently returned healthy on its normal status endpoint.

No credentials, session material, user content, or raw logs are included here.

## Tests

- focused updater UI suite: 38/38 passed;
- full Desktop UI suite, serial supported mode: 167/167 files and 1316/1316 tests passed;
- Desktop TypeScript typecheck passed;
- Desktop ESLint passed with zero errors (15 pre-existing warnings outside this diff);
- Prettier and `git diff --check` passed;
- Python compile checks passed;
- update-output suite: 23/23 passed;
- focused update/action-status endpoint suite: 7/7 passed;
- mandatory `openclaw-autoreview` with Codex: clean, zero actionable findings.

Regression coverage includes:

- action still running beyond 45 seconds;
- fixed timeout after transient reconnects;
- no-op and dependency-repair success without restart;
- exact action receipt after restart, including verbose truncated logs;
- rejection of a receipt from another update action;
- pre-action-ID Git and packaged-backend upgrades;
- fast restarts where no failed poll is observed;
- inconclusive/offline legacy checks failing closed;
- concurrent renderer apply requests;
- explicit nonzero action exit;
- duplicate update POST within one dashboard process.

## Relationship to existing work

This is a current-main consolidation of:

- #47362 by @MarkVLK: long-running action/restart confirmation;
- #59190 by @doncazper: no-restart terminal success and stale-log hardening.

Both authors are credited in the commit. This PR does not assume either existing PR should be closed; maintainers can choose whether to merge one independently or use this combined successor.

Fixes #47359.
Fixes #58764.
Addresses #59237.

## Known boundary

Dashboard-side action reuse is process-local. A future CLI-level cross-process lock would be needed to guarantee exclusion when multiple independently running profile backends target the same checkout. This patch does not claim that broader guarantee.
