### PR TITLE
docs(skills): direct Hermes verification to live docs

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -36,6 +36,8 @@ People use Hermes for software development, research, system administration, dat
 
 This skill is a concise operating guide, not the complete source of truth for every Hermes feature. If a Hermes feature, command, or setting is not mentioned here, do not treat that absence as evidence that it does not exist. Check the live repository and official docs before giving a negative answer.
 
+**Use `web_search` to query `hermes-agent.nousresearch.com/docs/` for the latest documentation.** The docs site is the live source of truth and updates faster than this bundled skill or cached knowledge.
+
 Good verification targets:
 
 - CLI commands: `hermes --help`, `hermes <command> --help`, and `hermes_cli/main.py`


### PR DESCRIPTION
## What does this PR do?

Adds an explicit `web_search` directive to the bundled `hermes-agent` skill's Scope & Verification section. This tells agents how to consult the live official docs instead of relying on stale skill content or cached knowledge.

## Related Issue

Fixes #65416

## Type of Change

- [x] Documentation update

## Changes Made

- Direct agents to query `hermes-agent.nousresearch.com/docs/` with `web_search` for current documentation.

## How to Test

1. Validate `skills/autonomous-ai-agents/hermes-agent/SKILL.md` with the skill frontmatter validator.
2. Run `website/scripts/generate-skill-docs.py` and confirm the bundled skill page is generated successfully with the directive.

## Checklist

- [x] I've read the contributing guide and repository instructions.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs by issue number and equivalent wording.
- [x] This PR contains only changes related to the issue.
- [x] Relevant validation passes (`SKILL.md` frontmatter, docs generation, and `git diff --check`).
- [x] Documentation is updated at its canonical source.
- [x] Config examples, architecture docs, and tool schemas are not affected.

## Screenshots / Logs

Not applicable for this source-skill documentation change.
