### PR TITLE
fix(gateway): stop truncate_message hanging on a pathologically small max_length

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5694,6 +5694,17 @@ class BasePlatformAdapter(ABC):
                 # the whole budget — leaves split_at at 0, so ``remaining``
                 # never shrinks and the while-loop spins forever appending
                 # empty chunks (an unbounded hang / OOM).
+                #
+                # Length contract for a degenerate budget: a codepoint is the
+                # smallest indivisible unit, so when the budget is smaller than
+                # one codepoint (e.g. max_length=1 with a 2-unit surrogate pair
+                # under utf16_len) the emitted chunk WILL exceed max_length by
+                # that one codepoint. That is intentional — emitting the
+                # codepoint whole preserves the content, whereas the only
+                # alternatives are dropping it (data loss) or looping forever.
+                # Real callers never hit this: platform caps are hundreds/
+                # thousands, and the relay path normalizes a 0/negative
+                # descriptor bound to 4096 (see gateway/relay/descriptor.py).
                 split_at = max(1, _cp_limit)
 
             # Avoid splitting inside an inline code span (`...`).

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5661,7 +5661,10 @@ class BasePlatformAdapter(ABC):
             # a potential closing fence, and the chunk indicator.
             headroom = max_length - INDICATOR_RESERVE - _len(prefix) - _len(FENCE_CLOSE)
             if headroom < 1:
-                headroom = max_length // 2
+                # Floor at 1 so a pathologically small max_length (0 or 1 —
+                # e.g. a relay capability descriptor whose max_message_length
+                # is 0/1) can't make headroom 0 and stall the loop below.
+                headroom = max(1, max_length // 2)
 
             # Everything remaining fits in one final chunk
             if _len(prefix) + _len(remaining) <= max_length - INDICATOR_RESERVE:
@@ -5685,7 +5688,13 @@ class BasePlatformAdapter(ABC):
             if split_at < _cp_limit // 2:
                 split_at = region.rfind(" ")
             if split_at < 1:
-                split_at = _cp_limit
+                # Consume at least one codepoint. Without the max(1, …) floor,
+                # a zero _cp_limit — reachable when max_length is 0/1, or under
+                # utf16_len when the next char is a surrogate pair wider than
+                # the whole budget — leaves split_at at 0, so ``remaining``
+                # never shrinks and the while-loop spins forever appending
+                # empty chunks (an unbounded hang / OOM).
+                split_at = max(1, _cp_limit)
 
             # Avoid splitting inside an inline code span (`...`).
             # If the text before split_at has an odd number of unescaped

--- a/gateway/relay/descriptor.py
+++ b/gateway/relay/descriptor.py
@@ -80,6 +80,19 @@ class CapabilityDescriptor:
         raw = json.loads(data)
         known = {f for f in cls.__dataclass_fields__}  # type: ignore[attr-defined]
         filtered = {k: v for k, v in raw.items() if k in known}
+        # Normalize the chunking bound at the trust boundary. A connector may
+        # advertise max_message_length 0 ("no limit"), and a buggy/hostile one
+        # may send 0 or a negative; either is a degenerate value that would flow
+        # straight into the adapter's MAX_MESSAGE_LENGTH and truncate_message().
+        # Map it to the documented 4096 default (docs/relay-connector-contract.md;
+        # mirrors from_platform_entry's `or 4096`) so from_json never yields a
+        # descriptor that can't chunk a real message.
+        if "max_message_length" in filtered:
+            try:
+                if int(filtered["max_message_length"]) <= 0:
+                    filtered["max_message_length"] = 4096
+            except (TypeError, ValueError):
+                filtered["max_message_length"] = 4096
         return cls(**filtered)
 
     @classmethod

--- a/tests/gateway/relay/test_descriptor.py
+++ b/tests/gateway/relay/test_descriptor.py
@@ -46,6 +46,38 @@ def test_from_json_ignores_unknown_keys():
     assert restored == d
 
 
+def test_from_json_normalizes_zero_max_message_length_to_default():
+    """A connector may advertise max_message_length 0 ("no limit"). from_json
+    must normalize it to the documented 4096 default so the receiver never
+    carries a degenerate chunking bound into truncate_message()."""
+    raw = (
+        '{"contract_version": 1, "platform": "x", "label": "X", '
+        '"max_message_length": 0, "supports_draft_streaming": false, '
+        '"supports_edit": false, "supports_threads": false, '
+        '"markdown_dialect": "plain", "len_unit": "chars"}'
+    )
+    d = CapabilityDescriptor.from_json(raw)
+    assert d.max_message_length == 4096
+
+
+def test_from_json_normalizes_negative_max_message_length_to_default():
+    """A buggy/hostile connector sending a negative bound is normalized too."""
+    raw = (
+        '{"contract_version": 1, "platform": "x", "label": "X", '
+        '"max_message_length": -5, "supports_draft_streaming": false, '
+        '"supports_edit": false, "supports_threads": false, '
+        '"markdown_dialect": "plain", "len_unit": "chars"}'
+    )
+    d = CapabilityDescriptor.from_json(raw)
+    assert d.max_message_length == 4096
+
+
+def test_from_json_keeps_a_real_positive_bound():
+    """A normal positive bound is passed through unchanged."""
+    d = CapabilityDescriptor.from_json(_telegram_descriptor(max_message_length=2000).to_json())
+    assert d.max_message_length == 2000
+
+
 def test_from_json_fills_optional_defaults():
     """Optional fields (emoji/platform_hint/pii_safe) fall back to defaults."""
     minimal = (

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1651,6 +1651,28 @@ class TestTruncateMessage:
         assert chunks
         assert "😀" in "".join(chunks)
 
+    def test_sub_codepoint_budget_emits_whole_codepoints_without_data_loss(self):
+        """Length contract for a budget too small to fit one codepoint.
+
+        A codepoint is indivisible, so with max_length=1 and utf16_len a 2-unit
+        emoji cannot fit — the loop emits it whole rather than dropping it or
+        spinning. The documented, intentional consequence is that such a chunk
+        EXCEEDS max_length by that one codepoint; in return every codepoint is
+        preserved (no data loss) and the call terminates.
+        """
+        import re
+
+        from gateway.platforms.base import utf16_len
+
+        chunks = self._truncate_with_timeout("😀😀😀", 1, len_fn=utf16_len)
+        assert chunks
+        bodies = [re.sub(r"\s*\(\d+/\d+\)$", "", c) for c in chunks]
+        # No data loss: all three emojis survive across the chunks.
+        assert "".join(bodies).count("😀") == 3
+        # Contract: a chunk carrying a 2-unit emoji necessarily exceeds the
+        # 1-unit budget — assert that explicitly so the behavior is pinned.
+        assert any(utf16_len(b) > 1 for b in bodies)
+
     def test_code_block_first_chunk_closed(self):
         adapter = self._adapter()
         msg = "Before\n```python\n" + "x = 1\n" * 100 + "```\nAfter"

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1603,6 +1603,54 @@ class TestTruncateMessage:
         assert "(1/" in chunks[0]
         assert f"({len(chunks)}/{len(chunks)})" in chunks[-1]
 
+    @staticmethod
+    def _truncate_with_timeout(content, max_length, *, len_fn=None, timeout=3.0):
+        """Run truncate_message on a worker thread; fail if it doesn't return.
+
+        Guards against the regression where a pathologically small max_length
+        made the split loop never consume any input and spin forever.
+        """
+        import threading
+
+        box: dict = {}
+
+        def _run():
+            box["result"] = BasePlatformAdapter.truncate_message(
+                content, max_length, len_fn=len_fn
+            )
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+        t.join(timeout=timeout)
+        assert not t.is_alive(), (
+            f"truncate_message hung (infinite loop) for max_length={max_length}"
+        )
+        return box["result"]
+
+    def test_pathological_small_max_length_terminates(self):
+        # max_length 0 and 1 previously drove the split loop into an unbounded
+        # hang (headroom -> 0, split_at -> 0, remaining never shrinks). It must
+        # terminate and preserve every character across the chunks.
+        import re
+
+        for max_length in (0, 1, 2):
+            chunks = self._truncate_with_timeout("abcdefghij", max_length)
+            assert chunks, f"no chunks for max_length={max_length}"
+            reassembled = "".join(
+                re.sub(r"\s*\(\d+/\d+\)$", "", c) for c in chunks
+            )
+            for ch in "abcdefghij":
+                assert ch in reassembled, f"char {ch!r} lost at max_length={max_length}"
+
+    def test_pathological_small_max_length_utf16_terminates(self):
+        # Under utf16_len (Telegram), a surrogate-pair emoji is 2 units wide, so
+        # a budget below that maps to zero codepoints — the same stall vector.
+        from gateway.platforms.base import utf16_len
+
+        chunks = self._truncate_with_timeout("😀😀😀😀😀", 1, len_fn=utf16_len)
+        assert chunks
+        assert "😀" in "".join(chunks)
+
     def test_code_block_first_chunk_closed(self):
         adapter = self._adapter()
         msg = "Before\n```python\n" + "x = 1\n" * 100 + "```\nAfter"


### PR DESCRIPTION
## Summary

`truncate_message()` can no longer hang on a pathologically small `max_length` (0/1), and a relay connector advertising `max_message_length <= 0` is normalized to the documented 4096 default at the descriptor trust boundary.

Salvages #65288 by @Drexuxux (both substantive commits cherry-picked, authorship preserved). Root cause: with a degenerate budget, `headroom` and `split_at` both floored at 0, so the split loop never consumed any input and spun forever appending empty chunks — an unbounded hang/OOM in the base platform adapter's chunking path. Reachable via a relay capability descriptor with `max_message_length: 0`.

## Changes

- `gateway/platforms/base.py`: floor `headroom` and `split_at` at 1 so the loop always consumes at least one codepoint (degenerate-budget contract documented inline).
- `gateway/relay/descriptor.py`: `from_json` normalizes a 0/negative/non-int `max_message_length` to 4096 (mirrors `from_platform_entry`'s `or 4096`).
- Tests: thread-with-timeout hang guards for `max_length` 0/1/2 in chars and utf16 (surrogate-pair) units; descriptor normalization for 0, negative, and pass-through positive bounds.

## Validation

| | Before | After |
|---|---|---|
| `truncate_message("abcdefghij", 1)` | hangs forever (repro'd on main, killed at 5s) | terminates, all chars preserved across chunks |
| utf16 emoji with budget 1 | hangs | terminates |
| Descriptor `max_message_length: 0` / `-7` | flows into adapter as-is | normalized to 4096 |
| tests/gateway/test_platform_base.py + relay/test_descriptor.py | — | 202/202 pass |

## Infographic

![truncate-loop-rescue](https://v3b.fal.media/files/b/0aa27cf5/jYvISm_oSRfkbjef4RMVy_HdfENxIq.png)
