### PR TITLE
fix(security): reject non-ASCII auth/signature input with 401 instead of crashing (all compare_digest sites)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1236,7 +1236,13 @@ class APIServerAdapter(BasePlatformAdapter):
         auth_header = request.headers.get("Authorization", "")
         if auth_header.startswith("Bearer "):
             token = auth_header[7:].strip()
-            if hmac.compare_digest(token, self._api_key):
+            # Compare as bytes: ``hmac.compare_digest`` raises TypeError on a
+            # str containing non-ASCII characters, and ``token`` is the raw
+            # client-supplied header. A stray non-ASCII byte in the key would
+            # otherwise crash this handler (500) instead of returning a clean
+            # 401. Encoding both sides keeps the timing-safe comparison and
+            # matches web_server.py's dashboard-token check.
+            if hmac.compare_digest(token.encode(), self._api_key.encode()):
                 return None  # Auth OK
 
         logger.warning(

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -358,7 +358,9 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         provided = self._string_or_none(notification.get("clientState"))
         if provided is None:
             return False
-        return hmac.compare_digest(provided, expected)
+        # Compare as bytes: ``compare_digest`` raises TypeError on a str with
+        # non-ASCII characters, and clientState comes from the request body.
+        return hmac.compare_digest(provided.encode(), expected.encode())
 
     def _has_seen_receipt(self, receipt_key: str) -> bool:
         return receipt_key in self._seen_receipts

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -125,6 +125,20 @@ def _is_loopback_host(host: Optional[str]) -> bool:
     return host.strip().lower() in _LOOPBACK_HOSTS
 
 
+def _hmac_str_equal(provided: str, expected: str) -> bool:
+    """Timing-safe equality for two ``str`` values, tolerant of non-ASCII input.
+
+    ``hmac.compare_digest`` raises ``TypeError`` when given a ``str`` that
+    contains non-ASCII characters. The ``provided`` value here is an
+    attacker-controlled signature/token header on a public, unauthenticated
+    webhook endpoint, so a single non-ASCII byte would otherwise raise out of
+    the request handler and return a 500 instead of rejecting the request.
+    Comparing as UTF-8 bytes keeps the constant-time guarantee while making a
+    hostile header fail closed with a clean rejection.
+    """
+    return hmac.compare_digest(provided.encode(), expected.encode())
+
+
 def check_webhook_requirements() -> bool:
     """Check if webhook adapter dependencies are available."""
     return AIOHTTP_AVAILABLE
@@ -969,12 +983,12 @@ class WebhookAdapter(BasePlatformAdapter):
             expected = "sha256=" + hmac.new(
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
-            return hmac.compare_digest(gh_sig, expected)
+            return _hmac_str_equal(gh_sig, expected)
 
         # GitLab: X-Gitlab-Token = <plain secret>
         gl_token = request.headers.get("X-Gitlab-Token", "")
         if gl_token:
-            return hmac.compare_digest(gl_token, secret)
+            return _hmac_str_equal(gl_token, secret)
 
         # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
         #             X-Webhook-Timestamp = <unix seconds> (required for V2)
@@ -1017,7 +1031,7 @@ class WebhookAdapter(BasePlatformAdapter):
             expected_v2 = hmac.new(
                 secret.encode(), signed_content, hashlib.sha256
             ).hexdigest()
-            return hmac.compare_digest(v2_sig, expected_v2)
+            return _hmac_str_equal(v2_sig, expected_v2)
 
         # Generic V1 (legacy): X-Webhook-Signature = <hex HMAC-SHA256 of body>
         # (deprecated — no replay protection, since the signature only
@@ -1041,7 +1055,7 @@ class WebhookAdapter(BasePlatformAdapter):
                     "'<timestamp>.<body>').",
                     route_name,
                 )
-            return hmac.compare_digest(generic_sig, expected)
+            return _hmac_str_equal(generic_sig, expected)
 
         # No recognised signature header but secret is configured → reject
         logger.debug(
@@ -1095,7 +1109,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 version, signature = part.split(",", 1)
             except ValueError:
                 continue
-            if version == "v1" and hmac.compare_digest(signature, expected):
+            if version == "v1" and _hmac_str_equal(signature, expected):
                 return True
         return False
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1413,10 +1413,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return web.Response(status=400, text="bad mode")
 
         # Constant-time compare to avoid token-length / token-content leaks
-        # via timing. ``hmac.compare_digest`` works on str.
+        # via timing. Compare as bytes: ``compare_digest`` raises TypeError on
+        # a str with non-ASCII characters, and the token is a raw query param.
         import hmac as _hmac
 
-        if not _hmac.compare_digest(token, self._verify_token):
+        if not _hmac.compare_digest(token.encode(), self._verify_token.encode()):
             return web.Response(status=403, text="verify_token mismatch")
         if not challenge:
             return web.Response(status=400, text="missing challenge")
@@ -1509,7 +1510,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             raw_body,
             hashlib.sha256,
         ).hexdigest()
-        return hmac.compare_digest(computed.lower(), expected_hex.lower())
+        # Compare as bytes: compare_digest raises TypeError on a str with
+        # non-ASCII characters, and the signature is a raw request header.
+        return hmac.compare_digest(
+            computed.lower().encode(), expected_hex.lower().encode()
+        )
 
     # ------------------------------------------------------------------ dispatch
     def _dedup_wamid(self, wamid: str) -> bool:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3512,7 +3512,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if self._verification_token:
             header = payload.get("header") or {}
             incoming_token = str(header.get("token") or payload.get("token") or "")
-            if not incoming_token or not hmac.compare_digest(incoming_token, self._verification_token):
+            # Compare as bytes: compare_digest raises TypeError on a str with
+            # non-ASCII characters, and the token comes from the request body.
+            if not incoming_token or not hmac.compare_digest(
+                incoming_token.encode(), self._verification_token.encode()
+            ):
                 logger.warning("[Feishu] Webhook rejected: invalid verification token from %s", remote_ip)
                 self._record_webhook_anomaly(remote_ip, "401-token")
                 return web.Response(status=401, text="Invalid verification token")
@@ -3575,7 +3579,9 @@ class FeishuAdapter(BasePlatformAdapter):
             body_str = body_bytes.decode("utf-8", errors="replace")
             content = f"{timestamp}{nonce}{self._encrypt_key}{body_str}"
             computed = hashlib.sha256(content.encode("utf-8")).hexdigest()
-            return hmac.compare_digest(computed, signature)
+            # Compare as bytes: compare_digest raises TypeError on a str with
+            # non-ASCII characters, and the signature is a raw request header.
+            return hmac.compare_digest(computed.encode(), signature.encode())
         except Exception:
             logger.debug("[Feishu] Signature verification raised an exception", exc_info=True)
             return False

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -273,7 +273,9 @@ def verify_line_signature(body: bytes, signature: str, channel_secret: str) -> b
         expected = base64.b64encode(digest).decode("utf-8")
     except Exception:
         return False
-    return hmac.compare_digest(expected, signature)
+    # Compare as bytes: compare_digest raises TypeError on a str with
+    # non-ASCII characters, and the signature is a raw request header.
+    return hmac.compare_digest(expected.encode(), signature.encode())
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -692,7 +692,9 @@ class RaftAdapter(BasePlatformAdapter):
     def _validate_bridge_token(self, token: str) -> bool:
         if not self._bridge_token or not token:
             return False
-        return hmac.compare_digest(token, self._bridge_token)
+        # Compare as bytes: compare_digest raises TypeError on a str with
+        # non-ASCII characters, and the token is a raw request header.
+        return hmac.compare_digest(token.encode(), self._bridge_token.encode())
 
     async def _accept_wake(self, payload: Dict[str, Any]) -> bool:
         if not self._message_handler:

--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -257,7 +257,9 @@ class SmsAdapter(BasePlatformAdapter):
             hashlib.sha1,
         )
         computed = base64.b64encode(mac.digest()).decode("utf-8")
-        return hmac.compare_digest(computed, signature)
+        # Compare as bytes: compare_digest raises TypeError on a str with
+        # non-ASCII characters, and the signature is a raw request header.
+        return hmac.compare_digest(computed.encode(), signature.encode())
 
     @staticmethod
     def _port_variant_url(url: str) -> str | None:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -526,6 +526,27 @@ class TestAuth:
         assert result is not None
         assert result.status == 401
 
+    def test_non_ascii_bearer_token_returns_401_not_500(self):
+        """A non-ASCII byte in the bearer token must be rejected with 401, not
+        crash the handler: hmac.compare_digest raises TypeError on a str with
+        non-ASCII characters, and the token is raw client input."""
+        config = PlatformConfig(enabled=True, extra={"key": "sk-test123"})
+        adapter = APIServerAdapter(config)
+        mock_request = MagicMock()
+        mock_request.headers = {"Authorization": "Bearer ské-not-the-key"}
+        result = adapter._check_auth(mock_request)  # must not raise
+        assert result is not None
+        assert result.status == 401
+
+    def test_non_ascii_key_config_still_authenticates(self):
+        """A non-ASCII configured key must still match its exact value byte for
+        byte (bytes comparison keeps this working)."""
+        config = PlatformConfig(enabled=True, extra={"key": "sk-tést-kéy"})
+        adapter = APIServerAdapter(config)
+        mock_request = MagicMock()
+        mock_request.headers = {"Authorization": "Bearer sk-tést-kéy"}
+        assert adapter._check_auth(mock_request) is None
+
 
 # ---------------------------------------------------------------------------
 # Concurrency cap (gateway.api_server.max_concurrent_runs) — #7483

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -316,8 +316,30 @@ class TestMSGraphNotifications:
 
         assert calls, "hmac.compare_digest was never called; clientState check is not timing-safe"
         provided, expected = calls[0]
-        assert provided == "expected-client-state"
-        assert expected == "expected-client-state"
+        assert provided == b"expected-client-state"
+        assert expected == b"expected-client-state"
+
+    @pytest.mark.anyio
+    async def test_non_ascii_client_state_rejected_without_raising(self):
+        """A non-ASCII clientState (attacker-controlled request body) must be
+        rejected with 403, not crash the handler: hmac.compare_digest raises
+        TypeError on a str containing non-ASCII characters."""
+        adapter = _make_adapter()
+        payload = {
+            "value": [
+                {
+                    "id": "notif-nonascii",
+                    "subscriptionId": "sub-1",
+                    "changeType": "updated",
+                    "resource": "communications/onlineMeetings/meeting-x",
+                    "clientState": "ské-not-the-secret",
+                }
+            ]
+        }
+        response = await adapter._handle_notification(
+            _FakeRequest(json_payload=payload)
+        )
+        assert response.status == 403
 
     @pytest.mark.anyio
     async def test_duplicate_notification_deduped(self):

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -166,6 +166,40 @@ class TestValidateSignature:
         req = _mock_request(headers={})  # no sig headers at all
         assert adapter._validate_signature(req, b"{}", "my-secret") is False
 
+    def test_non_ascii_signature_headers_reject_without_raising(self):
+        """The signature headers are attacker-controlled on a public, unauth
+        endpoint. A non-ASCII byte in one must be rejected (False), not crash
+        the handler: hmac.compare_digest raises TypeError on a non-ASCII str."""
+        adapter = _make_adapter()
+        body = b'{"action": "opened"}'
+        secret = "webhook-secret-42"
+        hostile = "ské-not-a-valid-signature"
+        for header in (
+            "X-Hub-Signature-256",
+            "X-Gitlab-Token",
+            "X-Webhook-Signature",
+        ):
+            req = _mock_request(headers={header: hostile})
+            # Must return False, never raise.
+            assert adapter._validate_signature(req, body, secret) is False
+
+    def test_non_ascii_generic_v2_signature_rejected(self):
+        """V2 branch (timestamp-bound) also rejects a non-ASCII signature."""
+        adapter = _make_adapter()
+        req = _mock_request(headers={
+            "X-Webhook-Signature-V2": "ské-bad",
+            "X-Webhook-Timestamp": str(int(time.time())),
+        })
+        assert adapter._validate_signature(req, b"{}", "secret") is False
+
+    def test_non_ascii_secret_still_validates_a_matching_token(self):
+        """A non-ASCII configured secret must still match its exact GitLab
+        token value byte for byte (bytes comparison keeps this working)."""
+        adapter = _make_adapter()
+        secret = "gl-tökén-välue"
+        req = _mock_request(headers={"X-Gitlab-Token": secret})
+        assert adapter._validate_signature(req, b"{}", secret) is True
+
     def test_validate_no_secret_allows_all(self):
         """When the secret is empty/falsy, the validator is never even called
         by the handler (secret check is 'if secret and secret != _INSECURE...').

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -192,6 +192,18 @@ class TestValidateSignature:
         })
         assert adapter._validate_signature(req, b"{}", "secret") is False
 
+    def test_non_ascii_svix_signature_rejected(self):
+        """The Svix branch also runs its `v1,<sig>` comparison through the
+        hardened helper: a valid svix-id + fresh timestamp reaches the compare,
+        and a non-ASCII signature must reject rather than raise."""
+        adapter = _make_adapter()
+        req = _mock_request(headers={
+            "svix-id": "msg_2xabc",
+            "svix-timestamp": str(int(time.time())),  # inside the replay window
+            "svix-signature": "v1,ské-not-a-valid-base64-sig",
+        })
+        assert adapter._validate_signature(req, b'{"x":1}', "shh-secret") is False
+
     def test_non_ascii_secret_still_validates_a_matching_token(self):
         """A non-ASCII configured secret must still match its exact GitLab
         token value byte for byte (bytes comparison keeps this working)."""

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -354,6 +354,22 @@ class TestWebhookVerify:
         assert response.status == 403
 
     @pytest.mark.asyncio
+    async def test_verify_rejects_non_ascii_token_without_raising(self):
+        """A non-ASCII verify_token (raw query param) must be rejected with
+        403, not crash the handler: hmac.compare_digest raises TypeError on a
+        str containing non-ASCII characters."""
+        adapter = _make_adapter(verify_token="shared-secret-123")
+        request = _verify_request({
+            "hub.mode": "subscribe",
+            "hub.verify_token": "ské-not-the-secret",
+            "hub.challenge": "abc-12345",
+        })
+
+        response = await adapter._handle_verify(request)
+
+        assert response.status == 403
+
+    @pytest.mark.asyncio
     async def test_verify_rejects_wrong_mode(self):
         adapter = _make_adapter(verify_token="shared-secret-123")
         request = _verify_request({

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -596,7 +596,10 @@ def _rpc_server_loop(
                     continue
 
                 if not rpc_token or not secrets.compare_digest(
-                    str(request.get("token") or ""), rpc_token
+                    # Compare as bytes: compare_digest raises TypeError on a
+                    # str with non-ASCII characters, and the token comes from
+                    # sandbox-script-supplied JSON.
+                    str(request.get("token") or "").encode(), rpc_token.encode()
                 ):
                     resp = json.dumps({"error": "Unauthorized RPC request"})
                     conn.sendall((resp + "\n").encode())
@@ -881,7 +884,10 @@ def _rpc_poll_loop(
                     continue
 
                 if not rpc_token or not secrets.compare_digest(
-                    str(request.get("token") or ""), rpc_token
+                    # Compare as bytes: compare_digest raises TypeError on a
+                    # str with non-ASCII characters, and the token comes from
+                    # sandbox-script-supplied JSON.
+                    str(request.get("token") or "").encode(), rpc_token.encode()
                 ):
                     logger.debug("Unauthorized RPC request in %s", req_file)
                     env.execute(f"rm -f {quoted_req_file}", cwd="/", timeout=5)


### PR DESCRIPTION
## Summary

A non-ASCII byte in any attacker-controlled auth/signature input now yields a clean 401/403/False instead of crashing the handler with a 500 — across the API server, the webhook adapter, and every sibling `compare_digest` call site that feeds it raw request input.

Salvages #65305 and #65307 by @Drexuxux (3 commits cherry-picked, authorship preserved). Root cause: `hmac.compare_digest` (and `secrets.compare_digest`) raise `TypeError` when given a `str` containing non-ASCII characters. Bearer tokens, signature headers, verify tokens, and clientState values are raw client input — several of these sit on public, unauthenticated endpoints.

## Changes

- `gateway/platforms/api_server.py`: bearer-token check compares as bytes (@Drexuxux)
- `gateway/platforms/webhook.py`: `_hmac_str_equal()` helper; all 5 signature branches (GitHub, GitLab, generic V1/V2, Svix) routed through it (@Drexuxux)
- Sibling-site widening (ours, same bug class — never merge incomplete fixes):
  - `gateway/platforms/msgraph_webhook.py`: clientState from request body
  - `gateway/platforms/whatsapp_cloud.py`: `hub.verify_token` query param + `X-Hub-Signature-256` (the old comment claimed compare_digest "works on str" — not for non-ASCII)
  - `plugins/platforms/{feishu,raft,line,sms}`: verification tokens + signature headers
  - `tools/code_execution_tool.py`: sandbox RPC token (both server loops)
- Tests: non-ASCII reject + positive-path (non-ASCII secrets still self-match) for api_server, webhook (incl. Svix v1), msgraph, whatsapp_cloud

## Validation

| | Before | After |
|---|---|---|
| `Bearer ské-…` to API server | TypeError → 500 | 401 |
| Non-ASCII webhook signature header | TypeError out of unauthenticated endpoint | False → clean reject |
| Non-ASCII msgraph clientState / WhatsApp verify token | TypeError | 403 |
| Legit non-ASCII configured secrets | worked | still match byte-for-byte |
| Targeted suites (api_server, webhook, msgraph, whatsapp_cloud, raft, code_execution) | — | 574/574 pass |
| E2E: all 9 sites called with hostile `ské-` input via real imports | — | rejected cleanly, no raise |

## Infographic

![timing-safe-bytes](https://v3b.fal.media/files/b/0aa27d1d/6s2dVzBkuCSbkP1aIG5bx_WCGPjE4Y.png)
