### PR TITLE
fix(gateway): strip /queue prefix when no agent is running (#29290 salvage)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10257,6 +10257,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "background":
             return await self._handle_background_command(event)
 
+        if canonical == "queue":
+            queue_payload = event.get_command_args().strip()
+            if not queue_payload:
+                return "Usage: /queue <prompt>"
+            try:
+                event.text = queue_payload
+            except Exception:
+                pass
+
         if canonical == "steer":
             # No active agent — /steer has no tool call to inject into.
             # Strip the prefix so downstream treats it as a normal user

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -53,6 +53,7 @@ AUTHOR_MAP = {
     "jtstothard@gmail.com": "jtstothard",  # PR #63256 salvage (gateway: multiplex secondary adapter config validation)
     "doogie@spark.local": "SAMBAS123",  # PR #64986 salvage (gateway: multiplex primary bot token scope)
     "emrekoca2003@gmail.com": "kocaemre",  # PR #36051 salvage (docs: audit round 3 code/doc reconciliation)
+    "focusedmiqa@gmail.com": "m1qaweb",  # PR #29290 salvage (gateway: strip /queue prefix when idle)
     "13574+otsune@users.noreply.github.com": "otsune",  # PR #36019 salvage (kanban: attachment toolset + CLI)
     "205466933+wesleion@users.noreply.github.com": "wesleion",  # PR #36049 salvage (telegram: per-topic free-response allowlist)
     "evefromwayback@gmail.com": "evefromwayback",  # PR #64611 salvage (agent: never load install-tree AGENTS.md as project context)

--- a/tests/gateway/test_gateway_command_dispatch_minimal.py
+++ b/tests/gateway/test_gateway_command_dispatch_minimal.py
@@ -1,0 +1,148 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_make_source(),
+        message_id="m1",
+        internal=True,
+    )
+
+
+def _session_entry() -> SessionEntry:
+    return SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter._pending_messages = {}
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = _session_entry()
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._queued_events = {}
+    runner._session_db = MagicMock()
+    runner._session_db.get_session_title.return_value = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._update_prompt_pending = {}
+    runner._busy_input_mode = "interrupt"
+    runner._draining = False
+    runner._session_run_generation = {}
+    runner._session_sources = {}
+    runner._pending_native_image_paths_by_session = {}
+    runner._background_tasks = {}
+    runner._background_task_counter = 0
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._service_tier = None
+    runner._fast_mode_by_session = {}
+    runner._goal_state_by_session = {}
+    runner._goal_runs_in_progress = set()
+    runner._goal_queued_by_session = set()
+    runner._is_telegram_topic_root_lobby = lambda _source: False
+    runner._should_send_telegram_lobby_reminder = lambda _source: False
+    runner._check_slash_access = lambda _source, _command: None
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._release_running_agent_state = lambda key: runner._running_agents.pop(key, None)
+    return runner, adapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command_text", ["/queue do this next", "/q do this next"])
+async def test_idle_queue_sends_payload_as_next_turn(command_text):
+    runner, _adapter = _make_runner()
+    captured = {}
+
+    async def fake_handle_message_with_agent(event, source, key, generation):
+        captured["text"] = event.text
+        captured["command"] = event.get_command()
+        captured["source"] = source
+        captured["key"] = key
+        captured["generation"] = generation
+        return {"final_response": "", "messages": []}
+
+    runner._handle_message_with_agent = fake_handle_message_with_agent
+
+    result = await runner._handle_message(_make_event(command_text))
+
+    assert result == {"final_response": "", "messages": []}
+    assert captured["text"] == "do this next"
+    assert captured["command"] is None
+    assert captured["source"] == _make_source()
+    assert captured["key"] == build_session_key(_make_source())
+    assert captured["generation"] == 1
+    assert runner._running_agents == {}
+
+
+@pytest.mark.asyncio
+async def test_idle_queue_without_payload_returns_usage():
+    runner, _adapter = _make_runner()
+    called = False
+
+    async def fake_handle_message_with_agent(event, source, key, generation):
+        nonlocal called
+        called = True
+        return {"final_response": "", "messages": []}
+
+    runner._handle_message_with_agent = fake_handle_message_with_agent
+
+    result = await runner._handle_message(_make_event("/queue"))
+
+    assert result == "Usage: /queue <prompt>"
+    assert called is False
+    assert runner._running_agents == {}


### PR DESCRIPTION
## Summary
`/queue <prompt>` sent while no agent is running now strips the prefix and flows as a normal prompt (empty payload → `Usage: /queue <prompt>`), mirroring `/steer`'s existing idle-path handling. Previously the raw `/queue …` text fell through dispatch verbatim.

Salvage of the surviving half of #29290 by @m1qaweb — premise re-verified on current main (`canonical == "queue"` has no idle-path branch; `/steer`'s sits right below and strips). The PR's `/footer` half already landed via #65521 (where @m1qaweb is credited as the first proposer, May 20). Authorship preserved on the queue commit.

Mid-run `/queue` (running-agent FIFO guard) is untouched.

## Changes
- `gateway/run.py`: idle-path `/queue` branch — usage message on empty payload, prefix-strip otherwise.
- `tests/gateway/test_gateway_command_dispatch_minimal.py`: 3 queue tests (`/queue` + `/q` strip, empty-payload usage).
- `scripts/release.py`: AUTHOR_MAP entry.

## Validation
| | Before | After |
|---|---|---|
| idle `/queue water plants` | raw "/queue water plants" flows onward | "water plants" runs as a prompt |
| idle `/queue` | raw text onward | usage message |
| mid-run `/queue` | FIFO enqueue | unchanged |

`scripts/run_tests.sh` → **6/6 passed** (3 new queue + 3 existing footer regression).

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa27d20/Pa81ZPhASUyHGpwW0Ioni_fEdbXkwb.png)
