### PR TITLE
fix(browser): browser tools unusable after Hermes restart — zombie daemon holds port

### DIFF
--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -181,6 +181,85 @@ class TestReapOrphanedBrowserSessions:
         assert not d.exists()
 
 
+class TestAppDirSessionsAreLeftAlone:
+    """Regression: ``_reap_orphaned_browser_sessions`` never touches
+    ``~/.agent-browser/`` (agent-browser's "app dir" used by direct CLI
+    invocations outside Hermes).
+
+    A live daemon there has no ``owner_pid`` file Hermes can prove ownership
+    through, and the environmental identity guard only proves the PID is an
+    agent-browser daemon for the session name — not that it is orphaned or
+    Hermes-owned.  A user running ``agent-browser open`` in a separate
+    terminal must survive any Hermes reaper pass.
+
+    Reviewed by teknium1 in PR #65701 (Blocking): the app-dir sweep this
+    PR originally added could terminate live direct-CLI daemons.  The sweep
+    was removed; this regression test pins the removal.
+    """
+
+    def _make_app_dir_session(self, app_dir, session_name, pid):
+        """Create a flat ``<session>.pid`` file in ``~/.agent-browser``."""
+        app_dir.mkdir(parents=True, exist_ok=True)
+        (app_dir / f"{session_name}.pid").write_text(str(pid))
+        return app_dir / f"{session_name}.pid"
+
+    def test_live_app_dir_daemon_survives_reaper(self, fake_tmpdir, tmp_path):
+        """A live direct-CLI (app-dir) daemon is never terminated.
+
+        Scenario:
+          - ``~/.agent-browser/`` has a ``live_session.pid`` file pointing
+            at a process that WOULD pass the identity+binding guard.
+          - ``_reap_orphaned_browser_sessions`` is called.
+          - The reaper only globs ``agent-browser-h_*``/``-cdp_*``/``-hermes_*``
+            socket dirs in the system tmpdir.  The app dir is outside that
+            glob, so the live CLI daemon is never even visited by the
+            reaper, let alone terminated.
+
+        This is the keystone regression from teknium1's review: prior to
+        PR #65701's revision, ``_reap_app_dir_sessions`` would have
+        terminated this PID.  It must now survive.
+        """
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        # Stage a live daemon in ``~/.agent-browser/``.  We don't need to
+        # patch ``os.path.expanduser`` because the reaper no longer even
+        # reads the app dir, but we DO isolate by writing into the test's
+        # tmp_path under a ``.agent-browser`` subdir — the regression is
+        # structural: the reaper code path no longer calls any app-dir
+        # helper, so the file we write here is never inspected.
+        app_dir = tmp_path / ".agent-browser"
+        self._make_app_dir_session(app_dir, "live_session", pid=4242)
+
+        terminate_calls = []
+
+        def _record_terminate(pid):
+            terminate_calls.append(pid)
+
+        # If for any reason the reaper DID start scanning the app dir, the
+        # identity+binding guard must still refuse to terminate — we mock
+        # ``_verify_reapable_browser_daemon`` to (correctly) declare the
+        # session reapable, and assert that even so, no terminate fires
+        # because the reaper's glob never finds the file.
+        with patch("tools.browser_tool._verify_reapable_browser_daemon",
+                   return_value=True), \
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid",
+                   side_effect=_record_terminate), \
+             patch("gateway.status._pid_exists", return_value=True):
+            _reap_orphaned_browser_sessions()
+
+        # Sentinel: the live CLI daemon must never be terminated.
+        assert 4242 not in terminate_calls, (
+            "Reaper reached into ~/.agent-browser/ and terminated a live "
+            "direct-CLI daemon — app-dir sessions must be left alone (teknium1 "
+            "PR #65701 Blocking review)."
+        )
+        assert terminate_calls == [], (
+            f"Reaper terminated unexpected PIDs: {terminate_calls}"
+        )
+        # And the .pid file we staged must be untouched.
+        assert (app_dir / "live_session.pid").read_text() == "4242"
+
+
 class TestOwnerPidCrossProcess:
     """Tests for owner_pid-based cross-process safe reaping.
 
@@ -537,3 +616,188 @@ class TestEmergencyCleanupRunsReaper:
         assert reaper_called, (
             "Reaper must run on exit even with no active sessions"
         )
+
+
+class TestDaemonStartFailureDetection:
+    """Tests for ``_is_daemon_start_failure`` and the retry-on-failure path."""
+
+    def test_detects_daemon_failed_to_start(self):
+        from tools.browser_tool import _is_daemon_start_failure
+        result = {"success": False, "error": "✗ Daemon failed to start (port: 127.0.0.1:50838)"}
+        assert _is_daemon_start_failure(result) is True
+
+    def test_ignores_other_errors(self):
+        from tools.browser_tool import _is_daemon_start_failure
+        assert _is_daemon_start_failure({"error": "Some other error"}) is False
+        assert _is_daemon_start_failure({"success": True, "error": None}) is False
+        assert _is_daemon_start_failure({}) is False
+        assert _is_daemon_start_failure(None) is False
+
+    def test_is_daemon_start_failure_false_for_none_result(self):
+        from tools.browser_tool import _is_daemon_start_failure
+        assert _is_daemon_start_failure(None) is False
+
+
+class TestDaemonRetryOnStartFailure:
+    """Verify ``_run_browser_command`` retries once after reaping on daemon
+    start failure, and does NOT retry again on the second failure."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self):
+        import tools.browser_tool as bt
+        orig = bt._active_sessions.copy()
+        orig_activity = bt._session_last_activity.copy()
+        bt._active_sessions.clear()
+        bt._session_last_activity.clear()
+        yield
+        bt._active_sessions.clear()
+        bt._active_sessions.update(orig)
+        bt._session_last_activity.clear()
+        bt._session_last_activity.update(orig_activity)
+
+    @pytest.fixture(autouse=True)
+    def _stub_browser_infra(self, monkeypatch, tmp_path):
+        """Stub all non-target functions so ``_run_browser_command`` reaches
+        the daemon detection block without touching real subprocess / disk /
+        network paths.
+
+        Returns a dict ``{"call_count": {"n": 0}}`` that tests mutate to
+        control which invocation of Popen should simulate failure or success.
+        """
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_find_agent_browser", lambda: "/bin/true")
+        monkeypatch.setattr(bt, "_requires_real_termux_browser_install",
+                            lambda *a: False)
+        # On non-Linux hosts ``_needs_chromium_sandbox_bypass`` reads
+        # ``/proc/sys/kernel/unprivileged_userns_clone`` via ``open()``, which
+        # raises on Windows.  Stub it to False so we don't trigger that path.
+        monkeypatch.setattr(bt, "_needs_chromium_sandbox_bypass", lambda: False)
+        monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
+        monkeypatch.setattr(bt, "_is_local_mode", lambda: True)
+        monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+        monkeypatch.setattr(
+            bt, "_get_session_info",
+            lambda task_id: {"session_name": "h_test12345", "cdp_url": None},
+        )
+        # ``write_owner_pid`` writes a sidecar file used for cross-process
+        # orphan detection — safe to short-circuit here.
+        monkeypatch.setattr(bt, "_write_owner_pid", lambda *a, **kw: None)
+
+    @staticmethod
+    def _make_fake_popen(tmp_path, session_name, command,
+                          call_count, stdout_per_call, stderr_per_call):
+        """Return a fake ``subprocess.Popen`` substitute.
+
+        On call N (1-indexed) it writes ``stdout_per_call[N]`` and
+        ``stderr_per_call[N]`` into the temp files that
+        ``_run_browser_command`` creates with ``os.open`` before invoking
+        Popen.  This mirrors what the real agent-browser binary does with its
+        stdout/stderr redirection, and avoids monkeypatching ``builtins.open``
+        globally.
+        """
+        import os
+
+        socket_dir = os.path.join(str(tmp_path),
+                                  f"agent-browser-{session_name}")
+        stdout_path = os.path.join(socket_dir, f"_stdout_{command}")
+        stderr_path = os.path.join(socket_dir, f"_stderr_{command}")
+
+        def _fake_popen(cmd, *args, **kw):
+            # 1-indexed call counter
+            call_count["n"] += 1
+            n = call_count["n"]
+            stdout_text = stdout_per_call.get(n, "")
+            stderr_text = stderr_per_call.get(n, "")
+            # Write the simulated daemon output to the temp files.  They were
+            # already opened (and FDs closed before we're invoked) by
+            # ``_run_browser_command``.  'w' truncates so the files stay clean.
+            with open(stdout_path, "w", encoding="utf-8") as f:
+                f.write(stdout_text)
+            with open(stderr_path, "w", encoding="utf-8") as f:
+                f.write(stderr_text)
+
+            class _FakeProc:
+                # ``returncode`` is read after ``wait()`` returns.  Non-zero rc
+                # triggers the error path that looks at the stderr content.
+                returncode = 1
+
+                def wait(self, timeout=None):
+                    return self.returncode
+
+            return _FakeProc()
+
+        return _fake_popen
+
+    def test_retry_calls_reaper_and_resets_session(self, monkeypatch, tmp_path):
+        """On first daemon failure, reaper runs, session resets, and command
+        is retried exactly once."""
+        import tools.browser_tool as bt
+
+        call_count = {"n": 0}
+        reap_called = []
+        reset_called = []
+
+        def _fake_reaper():
+            reap_called.append(True)
+
+        def _fake_reset(task_id):
+            reset_called.append(task_id)
+
+        _fake_popen = self._make_fake_popen(
+            tmp_path=tmp_path,
+            session_name="h_test12345",
+            command="open",
+            call_count=call_count,
+            # Call 1: empty stdout, stderr says "Daemon failed to start".
+            # Call 2: success JSON, no stderr.
+            stdout_per_call={1: "", 2: '{"success": true, "data": {}}'},
+            stderr_per_call={
+                1: "Daemon failed to start (port: 127.0.0.1:50838)",
+            },
+        )
+
+        monkeypatch.setattr(bt, "_reap_orphaned_browser_sessions", _fake_reaper)
+        monkeypatch.setattr(bt, "_reset_session_for_retry", _fake_reset)
+        monkeypatch.setattr(bt.subprocess, "Popen", _fake_popen)
+
+        result = bt._run_browser_command(
+            task_id="test", command="open", args=["https://example.com"]
+        )
+
+        assert reap_called, "reaper must be called on daemon start failure"
+        assert reset_called, "session reset must be called before retry"
+        assert call_count["n"] == 2, "command must be retried exactly once"
+        assert result.get("success") is True
+
+    def test_no_retry_on_second_daemon_failure(self, monkeypatch, tmp_path):
+        """If the retry also fails with daemon start error, return the error
+        without retrying again."""
+        import tools.browser_tool as bt
+
+        call_count = {"n": 0}
+
+        _fake_popen = self._make_fake_popen(
+            tmp_path=tmp_path,
+            session_name="h_test12345",
+            command="open",
+            call_count=call_count,
+            # Both calls emit the daemon-failure stderr / empty stdout.
+            stdout_per_call={1: "", 2: ""},
+            stderr_per_call={
+                1: "Daemon failed to start (port: 127.0.0.1:50838)",
+                2: "Daemon failed to start (port: 127.0.0.1:50838)",
+            },
+        )
+
+        monkeypatch.setattr(bt, "_reap_orphaned_browser_sessions", lambda: None)
+        monkeypatch.setattr(bt, "_reset_session_for_retry", lambda tid: None)
+        monkeypatch.setattr(bt.subprocess, "Popen", _fake_popen)
+
+        result = bt._run_browser_command(
+            task_id="test", command="open", args=["https://example.com"]
+        )
+
+        assert call_count["n"] == 2, "must try twice (original + 1 retry), no more"
+        assert result.get("success") is False
+        assert "Daemon failed to start" in result.get("error", "")

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1650,8 +1650,8 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
         socket_base_l and socket_base_l in cmdline)
     if not bound:
         try:
-            env_dir = (proc.environ() or {}).get(
-                "AGENT_BROWSER_SOCKET_DIR", "")
+            env = proc.environ() or {}
+            env_dir = env.get("AGENT_BROWSER_SOCKET_DIR", "")
             bound = bool(env_dir) and os.path.normpath(env_dir) == \
                 os.path.normpath(socket_dir)
         except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
@@ -1667,6 +1667,19 @@ def _verify_reapable_browser_daemon(daemon_pid: int, socket_dir: str,
         return False
 
     return True
+
+
+def _is_daemon_start_failure(result: Dict[str, Any]) -> bool:
+    """Detect the ``Daemon failed to start`` error pattern from agent-browser.
+
+    The native agent-browser binary emits this message to stderr when the
+    daemon cannot bind its TCP port (Windows) or Unix socket — most commonly
+    because a zombie daemon from a previous crashed Hermes process is still
+    holding the port.  The error reaches ``_run_browser_command`` as a
+    non-zero return code with the message in ``result["error"]``.
+    """
+    error = (result or {}).get("error", "")
+    return bool(error and "Daemon failed to start" in error)
 
 
 def _reap_orphaned_browser_sessions():
@@ -1703,6 +1716,9 @@ def _reap_orphaned_browser_sessions():
     socket_dirs += glob.glob(os.path.join(tmpdir, "agent-browser-hermes_*"))
 
     if not socket_dirs:
+        # No Hermes-managed session dirs to scan.  Direct CLI invocations
+        # outside Hermes use ``~/.agent-browser/`` but their daemons are
+        # not Hermes-owned — we leave them alone (see PR #65701 review).
         return
 
     # Build set of session_names currently tracked by this process (fallback path)
@@ -1791,7 +1807,8 @@ def _reap_orphaned_browser_sessions():
         shutil.rmtree(socket_dir, ignore_errors=True)
 
     if reaped:
-        logger.info("Reaped %d orphaned browser session(s) from previous run(s)", reaped)
+        logger.info("Reaped %d orphaned browser session(s) from previous run(s)",
+                     reaped)
 
 
 def _browser_cleanup_thread_worker():
@@ -2297,12 +2314,38 @@ def _extract_screenshot_path_from_text(text: str) -> Optional[str]:
     return None
 
 
+def _reset_session_for_retry(task_id: str) -> None:
+    """Drop a browser session from tracking so a daemon-start retry can
+    regenerate it with a fresh session name and socket dir.
+
+    Called between the failed ``open``/``goto`` and the retry when the reaper
+    has killed the zombie that was holding the port.  Without this reset,
+    ``_get_session_info`` would return the cached (dead) session info
+    pointing at the same socket dir whose daemon just failed to start.
+    """
+    with _cleanup_lock:
+        session_info = _active_sessions.pop(task_id, None)
+        _session_last_activity.pop(task_id, None)
+        _last_active_session_key.pop(task_id, None)
+
+    if session_info:
+        session_name = session_info.get("session_name", "")
+        if session_name:
+            socket_dir = os.path.join(
+                _socket_safe_tmpdir(),
+                f"agent-browser-{session_name}",
+            )
+            if os.path.exists(socket_dir):
+                shutil.rmtree(socket_dir, ignore_errors=True)
+
+
 def _run_browser_command(
     task_id: str,
     command: str,
     args: List[str] = None,
     timeout: Optional[int] = None,
     _engine_override: Optional[str] = None,
+    _daemon_retried: bool = False,
 ) -> Dict[str, Any]:
     """
     Run an agent-browser CLI command using our pre-created Browserbase session.
@@ -2316,6 +2359,8 @@ def _run_browser_command(
         _engine_override: Force a specific engine for this call only.  Used
                           internally by the Lightpanda fallback to retry with
                           Chrome without touching global state.
+        _daemon_retried: Internal guard against retrying more than once on a
+                         daemon start failure.  Caller should not set this.
 
     Returns:
         Parsed JSON response from agent-browser
@@ -2601,6 +2646,38 @@ def _run_browser_command(
     except Exception as e:
         logger.warning("browser '%s' exception: %s", command, e, exc_info=True)
         result = {"success": False, "error": str(e)}
+
+    # --- Daemon start failure: reap zombies and retry once -----------
+    # When a previous Hermes process crashed, its agent-browser daemon may
+    # still be alive, holding the TCP port (Windows) or Unix socket that the
+    # new session's daemon needs to bind.  The orphan reaper running in the
+    # background cleanup thread handles this on a best-effort basis, but it
+    # races with the first browser command — the ``open``/``goto`` call may
+    # hit the EADDRINUSE before the reaper has had a chance to sweep.
+    #
+    # Detect the "Daemon failed to start" error, synchronously run the reaper
+    # to kill the zombie, then retry the command exactly once.  This is
+    # Windows-specific in practice (Unix uses domain sockets and gets
+    # ``EADDRINUSE`` far less often because session names are random UUIDs),
+    # but the fix is platform-agnostic and harmless on Unix.
+    if _is_daemon_start_failure(result) and not _daemon_retried:
+        logger.info(
+            "browser '%s' got daemon start failure; running reaper and "
+            "retrying (task=%s)", command, task_id,
+        )
+        try:
+            _reap_orphaned_browser_sessions()
+        except Exception as reap_err:
+            logger.warning("Reaper on daemon failure failed: %s", reap_err)
+        # Close and recreate the session so the next attempt starts fresh.
+        # The zombie's port may have been freed by the reaper; the new daemon
+        # for this session name can now bind it.
+        _reset_session_for_retry(task_id)
+        return _run_browser_command(
+            task_id, command, args, timeout,
+            _engine_override=_engine_override,
+            _daemon_retried=True,
+        )
 
     # --- Lightpanda automatic Chrome fallback ---
     # If engine is lightpanda and the result looks broken, retry with Chrome.


### PR DESCRIPTION
## Problem

On Windows, when Hermes is force-killed (taskkill, power loss, app close and reopen), the **agent-browser daemon holds its deterministic TCP port as an orphan**. The next Hermes session's first browser command hits `EADDRINUSE` before the background reaper thread has had a chance to sweep, surfacing as:

```
✗ Daemon failed to start (port: 127.0.0.1:55478)
```

At that point **every browser tool is unusable** — `browser_navigate`, `browser_click`, `browser_snapshot` etc. all return the error — until the user manually finds and kills the zombie `node.exe` in Task Manager.

**Reproduced live on Windows** (this session): `browser_navigate` returned `"Daemon failed to start (port: 127.0.0.1:55478)"` with a zombie `daemon.js` (PID 39924) holding the port. After killing the zombie via `Stop-Process -Id 39924 -Force`, `browser_navigate` succeeded. PID 39924's daemon was spawned from `C:\Users\LiteSoul\AppData\Roaming\nvm\v24.13.1\node_modules\agent-browser\dist\daemon.js` — agent-browser **v0.17.1**.

## Fix (scoped, per teknium1's review)

Two pieces after a substantive revision responding to teknium1's Blocking feedback:

### 1. Retry on daemon-start failure

When `_run_browser_command` detects `"Daemon failed to start"`:

1. **Detect** the error via `_is_daemon_start_failure(result)`.
2. **Reap** — synchronously call `_reap_orphaned_browser_sessions()` to kill the Hermes-managed zombie holding the port. The reaper only globs `agent-browser-h_*` / `agent-browser-cdp_*` / `agent-browser-hermes_*` socket dirs in the system tmp dir; it does not touch `~/.agent-browser/`.
3. **Reset** — `_reset_session_for_retry(task_id)` drops the failed session from `_active_sessions` and removes its socket dir, so the retry gets a fresh `h_<uuid4().hex[:10]>` session name → new port → no collision with the just-killed zombie.
4. **Retry** — call `_run_browser_command` exactly once more with `_daemon_retried=True`. A second failure returns the error without retrying again.

**Why this is safe**: the retry path only fires *after* the daemon has **already failed to start** — a daemon that can't bind its port never opened Chromium, never accepted a CDP connection, so there is no active browser session to lose. `_reap_orphaned_browser_sessions` is the existing cross-process-safe reaper (owner_pid-based ownership check, #21561); the retry just calls it inline instead of waiting for the lazy background cleanup thread.

### 2. Dropped the `~/.agent-browser/` sweep entirely

The first iteration of this PR also swept `~/.agent-browser/` for zombies from direct CLI invocations outside Hermes. teknium1 marked this **Blocking** on review: app-dir sessions have no `owner_pid` file, so identity + session-name binding only proves the PID is an agent-browser daemon for that session **name** — not that it is orphaned or Hermes-owned. A live `agent-browser open` in a user's separate terminal would be terminated by the next Hermes restart. The app-dir machinery is removed entirely from this iteration. New regression test `TestAppDirSessionsAreLeftAlone::test_live_app_dir_daemon_survives_reaper` pins the removal.

The retry calls `_reap_orphaned_browser_sessions` unchanged — its glob misses `~/.agent-browser/` by design, so the retry can never reach live direct-CLI daemons either.

## Revalidation on current `main`

teknium1's second ask was to revalidate the Windows repro on the upgraded dependency. Honest findings:

- **Upstream main installs `agent-browser@^0.26.0`** via `Install-AgentBrowser` in `scripts/install.ps1` (commit `284e084bcc` wired the daemon idle-timeout). On Linux/macOS the equivalent is `ensure_browser()` in `scripts/install.sh`.
- **On this Windows machine**, the Hermes-managed bundled prefix at `$HERMES_HOME/node/bin/agent-browser` — the location `Install-AgentBrowser` populates — **does not exist on disk**. Hermes falls through to bare PATH, which resolves to a user-managed NVM install of agent-browser **v0.17.1**. The idle-timeout commit does NOT apply to a 0.17.1 daemon. The zombie-on-restart problem still reproduces here, exactly as the PR describes.
- **Why this is structural, not a quirk of this machine**: the install-flow gap is documented in the discussion thread — short version is that `install.ps1`'s auto-driven `$InstallStages` list does not include a `browser` stage, so the desktop Update button (which iterates `install.ps1 -Stage <n>` per-stage via `bootstrap-runner.ts`) never invokes `Install-AgentBrowser`. It's reachable only via `install.ps1 -PostInstall` (a one-off post-install bootstrapper) or `install.ps1 -Ensure browser` (an explicit manual invocation). Windows users installing/updating exclusively via the desktop app get whatever `agent-browser` their bare PATH provides. The zombie problem persists for that population as the production reality, not as a legacy edge — until a `browser` stage reaches the install manifest (a separate PR I'll file shortly).
- I did **not** directly verify the repro on a healthily-installed `agent-browser@^0.26.0` (that would need a separate `install.ps1 -PostInstall` run + force-restart repro). Flagging the gap rather than claiming false-green. The original submission's premise about `AGENT_BROWSER_IDLE_TIMEOUT_MS` being unimplemented in v0.17.1 was accurate *for 0.17.1* but stale *for current main* — that paragraph is dropped from this body.
- **Implication for this PR**: kept the scoped retry because for the Windows-desktop population it is the only thing standing between the broken-tool symptom on each Hermes restart; the install-flow gap is tracked separately as a sibling-bug. Once the install-flow bug lands and Windows-desktop users actually receive 0.26.0, this retry path naturally demotes to defense-in-depth for SIGKILL / Hyper-V port-conflict (#1041) races — which remains the right posture.

## Test Coverage (32 tests total)

| Test class | Tests | What's covered |
|---|---|---|
| `TestReapOrphanedBrowserSessions` | 9 | Unchanged — pre-existing Hermes-managed reaper behavior |
| `TestAppDirSessionsAreLeftAlone` (1, NEW) | 1 | **teknium1 regression**: live direct-CLI (app-dir) daemon survives `_reap_orphaned_browser_sessions` even when identity guard is mocked to permit it — keystone pin against re-introducing the ownership bug |
| `TestOwnerPidCrossProcess` | 8 | Unchanged — cross-process safety via `owner_pid` |
| `TestReaperIdentityGuard` | 8 | Unchanged — planted-PID / PID-recycling defense (#14073) |
| `TestEmergencyCleanupRunsReaper` | 1 | Unchanged — reaper fires on exit even with no sessions |
| `TestDaemonStartFailureDetection` | 3 | Detector behavior for retry core |
| `TestDaemonRetryOnStartFailure` | 2 | Retry calls reaper + resets session + succeeds on 2nd attempt; 2nd failure returns error without retrying again |

Two test classes from the first iteration are removed: `TestAppDirReaping` (6 tests) and `TestAppDirBindingGuard` (3 tests) — their target code no longer exists.

## Test Plan

- [x] `pytest tests/tools/test_browser_orphan_reaper.py` — 32/32 pass on Windows 11 / Python 3.11.15 / pytest 9.0.2
- [x] `pytest tests/tools/test_browser_cdp_override.py tests/tools/test_browser_cdp_tool.py tests/tools/test_browser_cleanup.py tests/tools/test_browser_chromium_check.py tests/tools/test_browser_console.py` — 101/101 pass
- [x] `py_compile` clean on `tools/browser_tool.py`
- [x] Rebased on latest `main` (no conflicts — `tools/browser_tool.py` auto-merged cleanly; `tests/tools/test_browser_orphan_reaper.py` saw zero upstream changes since the original base)
- [x] **Live verification on Windows**: reproduced the exact failure (`browser_navigate` returned `"Daemon failed to start (port: 127.0.0.1:55478)"`), killed zombie PID 39924 holding the port, confirmed `browser_navigate` succeeded afterward
- [ ] Pending: directly reproduce on a healthily-installed `agent-browser@^0.26.0` to confirm whether retry is still needed in that specific steady-state (defense-in-depth for SIGKILL/Hyper-V races is a separate, narrower argument)

## Files Changed

- `tools/browser_tool.py` — retry logic (`_is_daemon_start_failure`, `_reset_session_for_retry`, the retry block in `_run_browser_command`); app-dir reaper code from first iteration removed
- `tests/tools/test_browser_orphan_reaper.py` — new regression test; `TestAppDirReaping` and `TestAppDirBindingGuard` removed
