### PR TITLE
fix(bluebubbles): redact the password embedded in API URLs from error output

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -35,6 +35,24 @@ from gateway.platforms.helpers import strip_markdown
 
 logger = logging.getLogger(__name__)
 
+# BlueBubbles authenticates by embedding ``?password=<pw>`` in the request URL
+# (its REST/webhook API has no header-based auth path — see _api_url /
+# _webhook_register_url). httpx's ``HTTPStatusError``/``RequestError`` str()
+# includes that URL, so returning ``str(exc)`` verbatim in ``SendResult.error``
+# or a log line leaks the password. The global redactor intentionally passes
+# URL query strings through unchanged (#34029), and its webhook-access-log
+# guard only matches ``METHOD /path?...`` request-target lines — neither
+# catches the ``for url '...?password=...'`` shape an httpx error produces.
+# Mask it at the adapter boundary, mirroring telegram's
+# _redact_telegram_error_text for its token-in-URL leak.
+_BB_URL_PASSWORD_RE = re.compile(r"([?&]password=)[^&\s'\"]+", re.IGNORECASE)
+
+
+def _redact_bb_error_text(error: object) -> str:
+    """Mask the ``?password=`` value BlueBubbles carries in its API URLs."""
+    return _BB_URL_PASSWORD_RE.sub(r"\1***", str(error))
+
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -261,7 +279,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error(
-                "[bluebubbles] cannot reach server at %s: %s", self.server_url, exc
+                "[bluebubbles] cannot reach server at %s: %s", self.server_url, _redact_bb_error_text(exc)
             )
             if self.client:
                 await self.client.aclose()
@@ -493,7 +511,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             msg_id = data.get("guid") or data.get("messageGuid") or "ok"
             return SendResult(success=True, message_id=str(msg_id), raw_response=res)
         except Exception as exc:
-            return SendResult(success=False, error=str(exc))
+            return SendResult(success=False, error=_redact_bb_error_text(exc))
 
     # ------------------------------------------------------------------
     # Text sending
@@ -556,7 +574,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                     success=True, message_id=str(msg_id), raw_response=res
                 )
             except Exception as exc:
-                return SendResult(success=False, error=str(exc))
+                return SendResult(success=False, error=_redact_bb_error_text(exc))
         return last
 
     # ------------------------------------------------------------------
@@ -615,7 +633,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 error=result.get("message", "Attachment upload failed"),
             )
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=_redact_bb_error_text(e))
 
     async def send_image(
         self,

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -413,7 +413,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.warning(
                 "[bluebubbles] failed to register webhook with server: %s",
-                exc,
+                _redact_bb_error_text(exc),
             )
             return False
 
@@ -446,7 +446,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug(
                 "[bluebubbles] failed to unregister webhook (non-critical): %s",
-                exc,
+                _redact_bb_error_text(exc),
             )
         return removed
 

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -991,3 +991,31 @@ class TestBlueBubblesPasswordRedaction:
         )
         assert result.success is False
         assert "Sup3rS3cr3tPw" not in (result.error or "")
+
+
+class TestBlueBubblesWebhookErrorRedaction:
+    """The webhook register/unregister exception logs interpolate the httpx
+    error, whose URL carries ?password=<pw> — they must be redacted too."""
+
+    def test_register_webhook_failure_log_is_redacted(self, monkeypatch, caplog):
+        import logging
+        import httpx
+
+        adapter = _make_adapter(monkeypatch, password="Sup3rS3cr3tPw")
+        adapter.client = object()  # pass the "if not self.client" guard
+
+        async def _no_existing(url):
+            return []
+        adapter._find_registered_webhooks = _no_existing
+
+        async def boom(path, payload):
+            req = httpx.Request("POST", adapter._api_url(path))
+            raise httpx.HTTPStatusError(
+                "Client error", request=req, response=httpx.Response(401, request=req)
+            )
+        adapter._api_post = boom
+
+        with caplog.at_level(logging.WARNING):
+            ok = asyncio.get_event_loop().run_until_complete(adapter._register_webhook())
+        assert ok is False
+        assert "Sup3rS3cr3tPw" not in caplog.text

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -934,3 +934,60 @@ class TestBlueBubblesWebhookRegistration:
             adapter._unregister_webhook()
         )
         assert ok is False
+
+
+class TestBlueBubblesPasswordRedaction:
+    """BlueBubbles carries its auth password in the request URL query string
+    (?password=<pw>), so httpx errors — whose str() includes that URL — must be
+    masked before they reach SendResult.error or a log line."""
+
+    def test_redact_masks_password_query_param(self):
+        import httpx
+
+        from gateway.platforms.bluebubbles import _redact_bb_error_text
+
+        req = httpx.Request(
+            "POST", "http://mac.local:1234/api/v1/message/text?password=Sup3rS3cr3tPw"
+        )
+        try:
+            httpx.Response(401, request=req).raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            out = _redact_bb_error_text(exc)
+        assert "Sup3rS3cr3tPw" not in out
+        assert "password=***" in out
+
+    def test_redact_masks_url_encoded_and_ampersand_forms(self):
+        from gateway.platforms.bluebubbles import _redact_bb_error_text
+
+        out = _redact_bb_error_text(
+            "for url 'http://h/api/v1/webhook?guid=x&password=a%2Fb%2Bc'"
+        )
+        assert "a%2Fb%2Bc" not in out
+        assert "guid=x" in out  # non-secret query params are left intact
+
+    def test_redact_preserves_benign_error(self):
+        from gateway.platforms.bluebubbles import _redact_bb_error_text
+
+        assert _redact_bb_error_text("Connection timeout after 30s") == (
+            "Connection timeout after 30s"
+        )
+
+    def test_send_result_error_is_redacted(self, monkeypatch):
+        """A failed send must not return the password in SendResult.error."""
+        import httpx
+
+        adapter = _make_adapter(monkeypatch, password="Sup3rS3cr3tPw")
+
+        async def boom(path, payload):
+            req = httpx.Request("POST", adapter._api_url(path))
+            raise httpx.HTTPStatusError(
+                "Client error", request=req, response=httpx.Response(401, request=req)
+            )
+
+        adapter._api_post = boom
+        adapter.client = object()  # bypass the "Not connected" guard
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter.send("+15551234567", "hi")
+        )
+        assert result.success is False
+        assert "Sup3rS3cr3tPw" not in (result.error or "")


### PR DESCRIPTION
## What does this PR do?

BlueBubbles authenticates by putting `?password=<pw>` in the **request URL** — its REST/webhook API has no header-based auth path (see `_api_url`). httpx raises `HTTPStatusError` / `RequestError` whose `str()` includes that URL, so every path that logged or returned the raw exception leaked the password on **any** BlueBubbles API failure (server offline, wrong-password `401`, chat-not-found `404`, timeout):

- the three send paths that returned `SendResult(error=str(exc))`,
- the `connect()` "cannot reach server" log,
- the `_register_webhook` / `_unregister_webhook` failure logs (the *status* logs already used the redacted `_webhook_register_url_for_log`, but the *exception* logs interpolated the raw error).

The global secret redactor does not catch this: it intentionally passes URL query strings through unchanged (#34029, to preserve OAuth callbacks / magic links / presigned URLs), and the webhook-access-log guard added in #31690 only matches `METHOD /path?... HTTP/1.1` request-target lines. Neither masks the `for url '...?password=...'` shape an httpx error produces. Verified end-to-end: a failed `_api_post` returns `SendResult.error` containing the password, and it survives `redact_sensitive_text(..., force=True)`.

Same class as Telegram's token-in-URL leak (#58594). Add an adapter-local `_redact_bb_error_text` (mirroring `_redact_telegram_error_text`) and route **every** BlueBubbles error/log site through it — without touching the global "web URLs pass through" behavior.

## Related Issue

Fixes # — no existing issue. Parity sibling of the merged Telegram transport-error redaction (#58594); complements #31690 (inbound webhook access-log / registration URL) with the outbound send/connect/register error paths it did not cover.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `gateway/platforms/bluebubbles.py`:
  - Add `_redact_bb_error_text(error)` + `_BB_URL_PASSWORD_RE` — mask a `?password=`/`&password=` value (raw or URL-encoded) in any error string.
  - Route all error/log sites through it: the 3 `SendResult(error=str(exc/e))` send failures, the `connect()` unreachable log, and the `_register_webhook` / `_unregister_webhook` failure logs.
- `tests/gateway/test_bluebubbles.py`:
  - `TestBlueBubblesPasswordRedaction` (4 tests) + `TestBlueBubblesWebhookErrorRedaction` (1 test).

## How to Test

1. `pytest tests/gateway/test_bluebubbles.py -q` → 65 passed (60 existing + 5 new).
2. New coverage:
   - the redactor masks `?password=` (raw, URL-encoded, and `&password=` forms) while leaving non-secret query params (`guid=x`) and benign errors intact;
   - a failed `send()` (mocked `_api_post` raising an `HTTPStatusError` built from the real `_api_url`) returns a `SendResult` whose `.error` has no password;
   - a failed `_register_webhook` no longer writes the password into its log (asserted via `caplog`).
3. Re-run any of these against the pre-fix code (return/log `str(exc)` verbatim) to confirm the password leaks there.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — the helper carries an inline rationale — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string masking, no OS-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

### Security

Closes a credential leak: the BlueBubbles auth password, embedded in the API request URL, reached `SendResult.error` and logs on any API failure. Masked at the adapter boundary (mirroring the existing Telegram token-in-URL redaction); the global URL-passthrough behavior other features rely on is unchanged.

## Screenshots / Logs

Before (send failure, current code):

```
SendResult.error = Client error '401 Unauthorized' for url
  'http://mac.local:1234/api/v1/message/text?password=Sup3rS3cr3tPw'
```

After (this branch):

```
SendResult.error = Client error '401 Unauthorized' for url
  'http://mac.local:1234/api/v1/message/text?password=***'
```