### PR TITLE
docs: clarify Telegram goal scoping

### DIFF
--- a/website/docs/user-guide/features/goals.md
+++ b/website/docs/user-guide/features/goals.md
@@ -51,6 +51,36 @@ What you'll see:
 
 Works identically on the CLI and every gateway platform (Telegram, Discord, Slack, Matrix, Signal, WhatsApp, SMS, iMessage, Webhook, API server, and the web dashboard).
 
+:::note The command is singular
+The built-in command is `/goal`, not `/goals`.
+:::
+
+## Scope and parallel goals
+
+:::tip Yes — multiple `/goal` loops can run in parallel
+The one-goal limit is **per session**, not global. If Telegram Topic A and Telegram Topic B are separate sessions, each can have its own active `/goal`, and both loops can run at the same time. Using a separate repository for each topic is the safest setup.
+:::
+
+A standing goal is scoped to one **Hermes session**, not to the whole gateway, Telegram bot, profile, or machine. Goal state is stored under `goal:<session_id>`. "One standing goal per session" therefore means:
+
+| Where commands are sent | Result |
+|---|---|
+| Topic A: `/goal Work on Repo A`<br/>Topic B: `/goal Work on Repo B` | **Both goals remain active and can run concurrently.** Neither overwrites the other. |
+| Topic A: `/goal First task`, then Topic A: `/goal Second task` | The second goal replaces the first because both commands target the same session. |
+| Different Telegram chats or channels | Each chat session can have its own active goal. |
+
+- Running `/goal <new text>` in the **same session** replaces that session's existing goal and clears its subgoals.
+- Goals in **other sessions** are unaffected and can remain active at the same time.
+- `/goal` drives that session's primary agent in a multi-turn loop. It does **not** automatically create a delegated child agent, but that does not prevent other sessions from running their own `/goal` loops in parallel. The agent may also call `delegate_task` when delegation is available and the task benefits from it.
+
+On Telegram, each forum topic or private-chat topic has its own session key because the topic's `thread_id` is part of the key. You can therefore run a different `/goal` in each topic without one topic overwriting another. Those topic sessions can make progress concurrently, subject to your gateway resources, provider rate limits, and delegation concurrency settings. The top-level `max_concurrent_sessions` setting can cap active sessions; `null` or `0` leaves them unlimited.
+
+:::warning Session isolation is not filesystem isolation
+The goal and conversation state are separate, but the session key contains no project or working-directory component. Two topics that modify the same repository can still collide on files, branches, builds, or deployments. Use separate Git worktrees (or serialize the work) when parallel topic goals touch the same repository.
+:::
+
+Within one topic/session, use `/subgoal` to add acceptance criteria to the current goal. If you need multiple independent jobs from the same topic, use separate Telegram topics, `/background`, or the multi-agent Kanban workflow instead of setting a second `/goal`.
+
 ## Completion contracts
 
 A bare `/goal <text>` works fine, but a *vague* goal makes for vague judging — the judge can only check what you told it to want. Codex's `/goal` guidance makes the same point: a durable objective works best when it names **what done means, how to prove it, what not to break, what's in scope, and when to stop**. Hermes adapts this as an optional **completion contract** layered on top of the existing goal loop.

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -686,6 +686,14 @@ platforms:
 3. Each topic maps to an isolated session key: `agent:main:telegram:dm:{chat_id}:{thread_id}`
 4. Messages in each topic have their own conversation history, memory flush, and context window
 
+:::tip Run multiple goals in parallel across topics
+**Yes: you can run one active `/goal` in Topic A and another active `/goal` in Topic B at the same time.** Each topic is a separate Hermes session, so setting or replacing a goal in one topic does not affect any other topic. For example, Topic A can run `/goal Work on Repo A` while Topic B simultaneously runs `/goal Work on Repo B`.
+
+The one-goal restriction applies only **within the same topic/session**. The command is singular (`/goal`, not `/goals`). `/goal` runs that topic session's primary-agent continuation loop; it does not automatically spawn a delegated child agent, but multiple topic loops can still execute concurrently. Concurrency remains subject to `max_concurrent_sessions` (`null` or `0` means unlimited).
+:::
+
+Topic sessions isolate conversation and goal state, not shared repository files. Separate repositories are safe; when parallel goals must modify the same repository, use separate Git worktrees or serialize the work. See [Persistent Goals](/user-guide/features/goals#scope-and-parallel-goals).
+
 ### Root DM handling
 
 By default, messages sent to the root DM (outside any topic) are processed


### PR DESCRIPTION
## Summary

**Telegram supports multiple active `/goal` loops in parallel when they are in separate topics/sessions.** The one-goal limit is per session, not global.

This documentation update now explicitly:
- shows that Topic A can run `/goal Work on Repo A` while Topic B simultaneously runs `/goal Work on Repo B`
- distinguishes parallel topic sessions from replacing a goal inside the same topic
- clarifies that `/goal` not automatically spawning a delegated child does **not** prevent multiple topic goal loops from running concurrently
- documents `max_concurrent_sessions` (`null` or `0` = unlimited)
- warns that session isolation is not filesystem isolation; separate repos are safe, while the same repo should use worktrees or serialized writes
- notes that the built-in command is singular: `/goal`

## Verification
- `cd website && npm run build`
- Docusaurus production build completed successfully for `en` and `zh-Hans`