### PR TITLE
fix(hooks): complete _DEFAULT_PAYLOADS for all VALID_HOOKS

### DIFF
--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -126,6 +126,31 @@ _DEFAULT_PAYLOADS = {
         "result": '{"output": "hello"}',
         "duration_ms": 42,
     },
+    # Mirrors tools/terminal_tool.py invoke_hook("transform_terminal_output")
+    # — note: no session_id kwarg at runtime, so the top-level session_id a
+    # script sees is "" there too.
+    "transform_terminal_output": {
+        "command": "echo hello",
+        "output": "hello\n",
+        "returncode": 0,
+        "task_id": "test-task",
+        "env_type": "local",
+    },
+    # Mirrors model_tools.py invoke_hook("transform_tool_result").
+    "transform_tool_result": {
+        "tool_name": "terminal",
+        "args": {"command": "echo hello"},
+        "result": '{"output": "hello"}',
+        "task_id": "test-task",
+        "session_id": "test-session",
+        "tool_call_id": "test-call",
+        "turn_id": "test-turn",
+        "api_request_id": "test-request",
+        "duration_ms": 42,
+        "status": "ok",
+        "error_type": None,
+        "error_message": None,
+    },
     "pre_llm_call": {
         "session_id": "test-session",
         "user_message": "What is the weather?",
@@ -135,6 +160,13 @@ _DEFAULT_PAYLOADS = {
         "platform": "cli",
     },
     "post_llm_call": {
+        "session_id": "test-session",
+        "model": "gpt-4",
+        "platform": "cli",
+    },
+    # Mirrors agent/turn_finalizer.py invoke_hook("transform_llm_output").
+    "transform_llm_output": {
+        "response_text": "Synthetic response for hooks test",
         "session_id": "test-session",
         "model": "gpt-4",
         "platform": "cli",
@@ -184,12 +216,122 @@ _DEFAULT_PAYLOADS = {
         "assistant_content_chars": 1200,
         "assistant_tool_call_count": 0,
     },
+    # Mirrors run_agent.py _invoke_api_request_error_hook().
+    "api_request_error": {
+        "task_id": "test-task",
+        "turn_id": "test-turn",
+        "api_request_id": "test-request",
+        "session_id": "test-session",
+        "platform": "cli",
+        "model": "claude-sonnet-4-6",
+        "provider": "anthropic",
+        "base_url": "https://api.anthropic.com",
+        "api_mode": "anthropic_messages",
+        "api_call_count": 1,
+        "api_duration": 1.234,
+        "started_at": 1700000000.0,
+        "ended_at": 1700000001.234,
+        "status_code": 500,
+        "retry_count": 0,
+        "max_retries": 2,
+        "retryable": True,
+        "reason": "server_error",
+        "error": {
+            "type": "APIError",
+            "message": "Synthetic API error for hooks test",
+        },
+        "request": {
+            "method": "POST",
+            "body": {"model": "claude-sonnet-4-6", "max_tokens": 4096},
+        },
+    },
+    # Mirrors tools/delegate_tool.py invoke_hook("subagent_start").
+    "subagent_start": {
+        "parent_session_id": "parent-sess",
+        "parent_turn_id": "test-turn",
+        "parent_subagent_id": None,
+        "child_session_id": "child-sess",
+        "child_subagent_id": "test-subagent",
+        "child_role": None,
+        "child_goal": "Synthetic goal for hooks test",
+    },
+    # Mirrors tools/delegate_tool.py invoke_hook("subagent_stop").
     "subagent_stop": {
         "parent_session_id": "parent-sess",
+        "parent_turn_id": "test-turn",
+        "child_session_id": "child-sess",
         "child_role": None,
         "child_summary": "Synthetic summary for hooks test",
         "child_status": "completed",
         "duration_ms": 1234,
+    },
+    # Mirrors gateway/run.py invoke_hook("pre_gateway_dispatch"), which
+    # passes LIVE objects: event (a MessageEvent dataclass), gateway (the
+    # GatewayRunner) and session_store.  None of them is JSON-serialisable,
+    # so _serialize_payload's json.dumps(..., default=str) reduces each to
+    # its str()/repr() — that is genuinely what a shell script sees on
+    # stdin at runtime.  The stand-ins below are repr-style strings so the
+    # synthetic shape (strings, not objects) matches production.
+    "pre_gateway_dispatch": {
+        "event": (
+            "MessageEvent(text='hello', "
+            "message_type=<MessageType.TEXT: 'text'>, "
+            "source=SessionSource(...), ...)"
+        ),
+        "gateway": "<gateway.run.GatewayRunner object at 0x0>",
+        "session_store": "<gateway.session.SessionStore object at 0x0>",
+    },
+    # Mirrors tools/approval.py _fire_approval_hook("pre_approval_request");
+    # the wrapper always adds turn_id + tool_call_id from context vars.
+    "pre_approval_request": {
+        "command": "rm -rf /tmp/scratch",
+        "description": "Recursive file deletion",
+        "pattern_key": "rm -rf",
+        "pattern_keys": ["rm -rf"],
+        "session_key": "test-session",
+        "surface": "cli",
+        "turn_id": "test-turn",
+        "tool_call_id": "test-call",
+    },
+    # Same kwargs plus choice.  (decided_by is only added on surface="smart"
+    # firings, so it is deliberately absent from this surface="cli" payload.)
+    "post_approval_response": {
+        "command": "rm -rf /tmp/scratch",
+        "description": "Recursive file deletion",
+        "pattern_key": "rm -rf",
+        "pattern_keys": ["rm -rf"],
+        "session_key": "test-session",
+        "surface": "cli",
+        "choice": "once",
+        "turn_id": "test-turn",
+        "tool_call_id": "test-call",
+    },
+    # Mirror hermes_cli/kanban_db.py _fire_kanban_lifecycle_hook() call
+    # sites; the wrapper always adds profile_name.  No session_id kwarg at
+    # runtime, so the top-level session_id a script sees is "" there too.
+    "kanban_task_claimed": {
+        "task_id": "test-task",
+        "profile_name": "default",
+        "board": "test-board",
+        "assignee": "test-agent",
+        "run_id": 1,
+    },
+    "kanban_task_completed": {
+        "task_id": "test-task",
+        "profile_name": "default",
+        "board": "test-board",
+        "assignee": "test-agent",
+        "run_id": 1,
+        "summary": "Synthetic completion summary for hooks test",
+    },
+    # Both block_task dispatch sites pass identical fields.
+    "kanban_task_blocked": {
+        "task_id": "test-task",
+        "profile_name": "default",
+        "board": "test-board",
+        "assignee": "test-agent",
+        "run_id": 1,
+        "reason": "Synthetic block reason for hooks test",
     },
 }
 

--- a/tests/hermes_cli/test_hooks_payload_parity.py
+++ b/tests/hermes_cli/test_hooks_payload_parity.py
@@ -1,0 +1,36 @@
+"""Parity guard: every hook in VALID_HOOKS has a synthetic test payload.
+
+``hermes hooks test`` / ``hermes hooks doctor`` promise that the stdin a
+script sees is identical in shape to a real runtime firing.  That promise
+only holds if ``_DEFAULT_PAYLOADS`` covers every event in ``VALID_HOOKS`` —
+uncovered events silently fall back to a generic ``{"session_id": ...}``
+payload that looks nothing like production.  This test pins the two sets
+together so adding a hook without a synthetic payload fails CI.
+"""
+
+from __future__ import annotations
+
+from hermes_cli.hooks import _DEFAULT_PAYLOADS
+from hermes_cli.plugins import VALID_HOOKS
+
+
+def test_default_payloads_cover_all_valid_hooks():
+    missing = VALID_HOOKS - set(_DEFAULT_PAYLOADS)
+    stale = set(_DEFAULT_PAYLOADS) - VALID_HOOKS
+    assert not missing, (
+        f"Hooks without a synthetic test payload (add them to "
+        f"hermes_cli.hooks._DEFAULT_PAYLOADS, mirroring the real "
+        f"invoke_hook() call site): {sorted(missing)}"
+    )
+    assert not stale, (
+        f"_DEFAULT_PAYLOADS entries for events not in VALID_HOOKS "
+        f"(remove or rename them): {sorted(stale)}"
+    )
+
+
+def test_default_payloads_are_dicts():
+    for event, payload in _DEFAULT_PAYLOADS.items():
+        assert isinstance(payload, dict), (
+            f"_DEFAULT_PAYLOADS[{event!r}] must be a kwargs dict, "
+            f"got {type(payload).__name__}"
+        )


### PR DESCRIPTION
## What & why

Follow-up promised in #65684 — `hermes hooks test`/`doctor` document that the synthetic stdin a hook script sees "is identical in shape to what it will see at runtime" (`hermes_cli/hooks.py` header comment), but `_DEFAULT_PAYLOADS` covered only 12 of 23 `VALID_HOOKS`; the rest fell back to a generic `{"session_id": "test-session"}`, so authors of e.g. gateway-dispatch or kanban-lifecycle hook scripts were testing against a shape that never occurs in production.

- Adds the 11 missing payloads, each mirrored kwarg-by-kwarg from its real dispatch site (source cited in a comment per entry): `api_request_error` (run_agent.py `_invoke_api_request_error_hook`), `transform_terminal_output`, `transform_tool_result`, `transform_llm_output`, `subagent_start`, `pre_approval_request`/`post_approval_response` (incl. the `turn_id`/`tool_call_id` kwargs `_fire_approval_hook` always injects), the three `kanban_task_*` lifecycle events (incl. the always-added `profile_name`), and `pre_gateway_dispatch`.
- Fixes the existing `subagent_stop` entry, which was missing two kwargs the real dispatch passes (`parent_turn_id`, `child_session_id` — `tools/delegate_tool.py`).
- Adds `tests/hermes_cli/test_hooks_payload_parity.py`: `set(_DEFAULT_PAYLOADS) == VALID_HOOKS` in both directions, so the catalog can't silently drift again when a hook is added or removed.

Serialization notes (verified against `agent/shell_hooks.py:_serialize_payload`, which stringifies non-JSON values via `default=str`):
- `pre_gateway_dispatch` passes live `MessageEvent`/`GatewayRunner`/`SessionStore` objects at runtime, which reach scripts as repr strings — the synthetic payload uses repr-style string stand-ins, which is what a script genuinely sees in production (explained in an inline comment).
- Hooks whose runtime firings carry no `session_id` kwarg (kanban, approval, terminal, gateway) mirror the runtime `session_id: ""` rather than inventing one.
- All 23 payloads round-trip through the real `_serialize_payload`.

One judgment call flagged for review: `post_approval_response` showcases the `surface="cli"` shape (`choice="once"`, no `decided_by`); the smart-approval surface adds `decided_by="aux_llm"` — happy to swap if that's the preferred showcase.

## Testing

- New parity tests: 2/2 pass.
- `python -m pytest tests/hermes_cli/ -k "hook" -q` → 88 passed, 5 failed, 6 skipped — the 5 failures are `test_hooks_cli.py` spawning `#!/usr/bin/env bash` scripts with chmod +x, which fails identically on pristine `main` on this Windows host (verified via stash); not caused by this change.
- Platforms: authored on Windows; data-only change plus a stdlib test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
