### PR TITLE
fix(lmstudio): clamp max/ultra reasoning effort to the server ceiling (salvage #64951)

### DIFF
--- a/agent/lmstudio_reasoning.py
+++ b/agent/lmstudio_reasoning.py
@@ -20,6 +20,17 @@ _LM_VALID_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}
 # Map them onto the OpenAI-compatible request vocabulary.
 _LM_EFFORT_ALIASES = {"off": "none", "on": "medium"}
 
+# Hermes' generic effort ladder grew past LM Studio's vocabulary ("max",
+# "ultra"). Clamp the stronger generic levels onto LM Studio's ceiling: left
+# alone they miss _LM_VALID_EFFORTS, keep the initialized "medium" default and
+# are thereby conflated with unparseable input, so asking for more reasoning
+# yields less than "xhigh". Mirrors the ceiling clamp every other provider
+# applies (see agent/transports/codex.py).
+#
+# Deliberately separate from _LM_EFFORT_ALIASES: that mapping is also applied
+# to the model's published allowed_options, which must not be rewritten.
+_LM_EFFORT_CLAMP = {"max": "xhigh", "ultra": "xhigh"}
+
 
 def resolve_lmstudio_effort(
     reasoning_config: Optional[dict],
@@ -39,6 +50,7 @@ def resolve_lmstudio_effort(
         else:
             raw = (reasoning_config.get("effort") or "").strip().lower()
             raw = _LM_EFFORT_ALIASES.get(raw, raw)
+            raw = _LM_EFFORT_CLAMP.get(raw, raw)
             if raw in _LM_VALID_EFFORTS:
                 effort = raw
     if allowed_options:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "antydizajn@gmail.com": "antydizajn",  # PR #36043 salvage (auxiliary: route custom:<name> through named-provider arm + Palantir Bearer auth)
+    "252620095+briandevans@users.noreply.github.com": "briandevans",  # PR #64951 salvage (lmstudio: clamp max/ultra reasoning effort)
     "kar.iskakov@gmail.com": "karfly",  # PR #64012 salvage (gateway: surface extended reasoning efforts)
     "kimyeon30@naver.com": "rlaehddus302",  # PR #61985 salvage (gateway: secondary-adapter auth callback profile)
     "agungsubastian1963@gmail.com": "aguung",  # PR #64461 salvage (gateway: multiplex secret_scope for authz/Slack/webhooks)

--- a/tests/agent/test_lmstudio_reasoning.py
+++ b/tests/agent/test_lmstudio_reasoning.py
@@ -1,0 +1,97 @@
+"""Reasoning-effort resolution for LM Studio.
+
+Covers the contract that Hermes' generic effort ladder must stay monotonic
+once it is mapped onto LM Studio's narrower vocabulary: a stronger requested
+level may resolve to an equal-or-stronger LM Studio level, never a weaker one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.lmstudio_reasoning import resolve_lmstudio_effort
+from hermes_constants import VALID_REASONING_EFFORTS
+
+# Rank of each value LM Studio accepts, weakest to strongest. Used to assert
+# the resolved ladder never inverts.
+_LM_RANK = {"minimal": 0, "low": 1, "medium": 2, "high": 3, "xhigh": 4}
+
+
+@pytest.mark.parametrize("effort", ["max", "ultra"])
+def test_strong_efforts_clamp_to_lmstudio_ceiling(effort):
+    """"max"/"ultra" exceed LM Studio's vocabulary and clamp to its ceiling.
+
+    Without the clamp they miss the valid set, keep the "medium" default and
+    resolve *below* "xhigh" -- more requested reasoning yielding less.
+    """
+    assert resolve_lmstudio_effort({"enabled": True, "effort": effort}, None) == "xhigh"
+
+
+def test_effort_ladder_is_monotonic():
+    """Resolving Hermes' canonical ladder never produces an inversion."""
+    resolved = [
+        resolve_lmstudio_effort({"enabled": True, "effort": effort}, None)
+        for effort in VALID_REASONING_EFFORTS
+    ]
+    ranks = [_LM_RANK[value] for value in resolved]
+    assert ranks == sorted(ranks), dict(zip(VALID_REASONING_EFFORTS, resolved))
+
+
+@pytest.mark.parametrize(
+    "effort,expected",
+    [
+        ("minimal", "minimal"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "xhigh"),
+    ],
+)
+def test_levels_within_lmstudio_vocabulary_are_unchanged(effort, expected):
+    """Negative control: the clamp must not disturb levels LM Studio knows."""
+    assert resolve_lmstudio_effort({"enabled": True, "effort": effort}, None) == expected
+
+
+def test_unparseable_effort_still_falls_back_to_medium():
+    """Negative control: clamping must not change the unrecognized-input path.
+
+    This is the behaviour "max"/"ultra" were previously conflated with.
+    """
+    assert resolve_lmstudio_effort({"enabled": True, "effort": "banana"}, None) == "medium"
+
+
+def test_disabled_reasoning_still_resolves_to_none():
+    """Negative control: the clamp sits after the enabled=False short-circuit."""
+    assert resolve_lmstudio_effort({"enabled": False, "effort": "max"}, None) == "none"
+
+
+@pytest.mark.parametrize("effort", ["max", "ultra"])
+def test_clamped_effort_is_still_checked_against_allowed_options(effort):
+    """A clamped value stays subject to the model's published allowed set.
+
+    "max" resolves to "xhigh"; a model that does not publish "xhigh" gets the
+    field omitted (``None``) so LM Studio applies the model's own default --
+    exactly how a directly-requested "xhigh" already behaves.
+    """
+    assert (
+        resolve_lmstudio_effort(
+            {"enabled": True, "effort": effort}, ["off", "minimal", "low"]
+        )
+        is None
+    )
+    assert (
+        resolve_lmstudio_effort(
+            {"enabled": True, "effort": effort}, ["low", "medium", "high", "xhigh"]
+        )
+        == "xhigh"
+    )
+
+
+def test_clamp_does_not_rewrite_published_allowed_options():
+    """The clamp must not leak into allowed_options normalization.
+
+    A model publishing "max" is not claiming LM Studio's request vocabulary
+    accepts it; allowed_options passes through untouched, so a resolved
+    "xhigh" that the model does not publish is still omitted.
+    """
+    assert resolve_lmstudio_effort({"enabled": True, "effort": "max"}, ["max"]) is None


### PR DESCRIPTION
## Summary

Requesting `max` or `ultra` reasoning from an LM Studio model now clamps to `xhigh` (the server's ceiling) instead of silently inverting to `medium`.

Salvage of #64951 by @briandevans, cherry-picked onto current main with authorship preserved.

Root cause: `_LM_VALID_EFFORTS` mirrored the canonical effort ladder when written, but the #62650 sweep that added `max`/`ultra` missed this module — so the two highest levels failed the membership test and kept the `medium` initializer, conflated with unrecognized input. Every other provider clamps to its ceiling (codex `_effort_clamp`, anthropic adapter); LM Studio was the sole outlier.

## Changes

- `agent/lmstudio_reasoning.py`: `_LM_EFFORT_CLAMP = {"max": "xhigh", "ultra": "xhigh"}` applied after alias lookup, before the validity check (@briandevans)
- `tests/agent/test_lmstudio_reasoning.py`: regression test — clamp behavior + monotonicity over the canonical ladder, negative controls (@briandevans)
- `scripts/release.py`: AUTHOR_MAP entry

## Validation

| requested | before | after |
|---|---|---|
| `xhigh` | `xhigh` | `xhigh` |
| `max` | `medium` (inversion) | `xhigh` |
| `ultra` | `medium` (inversion) | `xhigh` |
| invalid | `medium` | `medium` |

`tests/agent/test_lmstudio_reasoning.py` + `tests/agent/transports/test_chat_completions.py`: 101 passed.

Closes #64951.

## Infographic

![lmstudio-effort-clamp](https://v3b.fal.media/files/b/0aa27df4/Mmrc0cnSJXccr_N2T2Bzf_i9HhmuWJ.png)
