### PR TITLE
fix(gateway): run background tasks under the profile runtime scope on multiplexed gateways (#60746 salvage)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13764,6 +13764,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         media_urls: Optional[List[str]] = None,
         media_types: Optional[List[str]] = None,
     ) -> None:
+        """Profile-scoping wrapper around the background agent task.
+
+        When multiplexing is active, resolve the inbound source's profile and
+        run the whole task inside ``_profile_runtime_scope`` so credentials
+        resolve from that profile's secret scope. Mirrors the pattern in
+        ``_run_agent``.
+        """
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return await self._run_background_task_inner(
+                prompt, source, task_id, event_message_id, media_urls, media_types,
+            )
+
+        profile_home = self._resolve_profile_home_for_source(source)
+        with _profile_runtime_scope(profile_home):
+            return await self._run_background_task_inner(
+                prompt, source, task_id, event_message_id, media_urls, media_types,
+            )
+
+    async def _run_background_task_inner(
+        self,
+        prompt: str,
+        source: "SessionSource",
+        task_id: str,
+        event_message_id: Optional[str] = None,
+        media_urls: Optional[List[str]] = None,
+        media_types: Optional[List[str]] = None,
+    ) -> None:
         """Execute a background agent task and deliver the result to the chat."""
         from run_agent import AIAgent
 

--- a/tests/gateway/test_multiplex_background_task_scope.py
+++ b/tests/gateway/test_multiplex_background_task_scope.py
@@ -1,74 +1,88 @@
 """Regression: background tasks respect profile secret scope when multiplexing.
 
-Issue #60726: /background command runs _run_background_task without a profile
-scope, causing UnscopedSecretError when multiplexing is active and credentials
-are profile-scoped.
+Issue #60726: /background spawns _run_background_task as a fire-and-forget
+asyncio task with no profile scope, so _resolve_session_agent_runtime()'s
+credential reads raise UnscopedSecretError when multiplex_profiles is on.
+The fix wraps the task body in _profile_runtime_scope, mirroring _run_agent.
 """
-import pytest
+import asyncio
+from pathlib import Path
 from unittest import mock
+
+from gateway.config import GatewayConfig
+from gateway.run import GatewayRunner
+
+
+def _make_runner(multiplex: bool) -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=multiplex)
+    return runner
 
 
 class TestBackgroundTaskProfileScope:
     """_run_background_task installs _profile_runtime_scope when multiplexing is active."""
 
-    def test_background_task_calls_inner_wrapped_in_scope_when_multiplex_active(self):
-        """When multiplex_profiles is True, _run_background_task wraps call in _profile_runtime_scope."""
-        from gateway.run import GatewayRunner
+    def test_wraps_in_profile_scope_when_multiplex_active(self):
+        runner = _make_runner(multiplex=True)
+        inner = mock.AsyncMock(return_value=None)
+        runner._run_background_task_inner = inner
 
-        config = {"multiplex_profiles": True}
-        gw = GatewayRunner(config=config)
-        gw._session_db = mock.MagicMock()
-        gw._adapter_for_source = mock.MagicMock(return_value=mock.MagicMock())
-
-        mock_inner = mock.AsyncMock(return_value=None)
-        gw._run_background_task_inner = mock_inner
-
-        import asyncio
         source = mock.MagicMock()
-        source.profile_home = "/fake/profile"
+        source.profile = "test_profile"
 
-        # Mock _profile_runtime_scope
-        from gateway.run import _profile_runtime_scope
-        with mock.patch("gateway.run._profile_runtime_scope") as mock_scope:
-            mock_scope.return_value.__enter__ = mock.MagicMock()
-            mock_scope.return_value.__exit__ = mock.MagicMock()
-
+        with mock.patch.object(
+            GatewayRunner,
+            "_resolve_profile_home_for_source",
+            return_value=Path("/fake/profile"),
+        ), mock.patch("gateway.run._profile_runtime_scope") as scope:
+            scope.return_value.__enter__ = mock.MagicMock()
+            scope.return_value.__exit__ = mock.MagicMock(return_value=False)
             asyncio.run(
-                gw._run_background_task(
-                    prompt="test",
-                    source=source,
-                    task_id="test_task",
+                runner._run_background_task(
+                    prompt="test", source=source, task_id="bg_test"
                 )
             )
 
-            # _profile_runtime_scope should have been called with profile_home
-            mock_scope.assert_called_once_with("/fake/profile")
-            mock_inner.assert_called_once()
+        scope.assert_called_once_with(Path("/fake/profile"))
+        inner.assert_awaited_once()
 
-    def test_background_task_calls_inner_direct_when_multiplex_disabled(self):
-        """When multiplex_profiles is False, _run_background_task calls inner directly."""
-        from gateway.run import GatewayRunner
+    def test_calls_inner_directly_when_multiplex_disabled(self):
+        runner = _make_runner(multiplex=False)
+        inner = mock.AsyncMock(return_value=None)
+        runner._run_background_task_inner = inner
 
-        config = {"multiplex_profiles": False}
-        gw = GatewayRunner(config=config)
-        gw._session_db = mock.MagicMock()
-        gw._adapter_for_source = mock.MagicMock(return_value=mock.MagicMock())
-
-        mock_inner = mock.AsyncMock(return_value=None)
-        gw._run_background_task_inner = mock_inner
-
-        import asyncio
-        source = mock.MagicMock()
-
-        with mock.patch("gateway.run._profile_runtime_scope") as mock_scope:
+        with mock.patch("gateway.run._profile_runtime_scope") as scope:
             asyncio.run(
-                gw._run_background_task(
-                    prompt="test",
-                    source=source,
-                    task_id="test_task",
+                runner._run_background_task(
+                    prompt="test", source=mock.MagicMock(), task_id="bg_test"
                 )
             )
 
-            # _profile_runtime_scope should NOT have been called
-            mock_scope.assert_not_called()
-            mock_inner.assert_called_once()
+        scope.assert_not_called()
+        inner.assert_awaited_once()
+
+    def test_inner_receives_all_arguments(self):
+        runner = _make_runner(multiplex=True)
+        inner = mock.AsyncMock(return_value=None)
+        runner._run_background_task_inner = inner
+        source = mock.MagicMock()
+
+        with mock.patch.object(
+            GatewayRunner,
+            "_resolve_profile_home_for_source",
+            return_value=Path("/fake/profile"),
+        ), mock.patch("gateway.run._profile_runtime_scope") as scope:
+            scope.return_value.__enter__ = mock.MagicMock()
+            scope.return_value.__exit__ = mock.MagicMock(return_value=False)
+            asyncio.run(
+                runner._run_background_task(
+                    prompt="p",
+                    source=source,
+                    task_id="t",
+                    event_message_id="m1",
+                    media_urls=["u"],
+                    media_types=["image"],
+                )
+            )
+
+        inner.assert_awaited_once_with("p", source, "t", "m1", ["u"], ["image"])

--- a/tests/gateway/test_multiplex_background_task_scope.py
+++ b/tests/gateway/test_multiplex_background_task_scope.py
@@ -1,0 +1,74 @@
+"""Regression: background tasks respect profile secret scope when multiplexing.
+
+Issue #60726: /background command runs _run_background_task without a profile
+scope, causing UnscopedSecretError when multiplexing is active and credentials
+are profile-scoped.
+"""
+import pytest
+from unittest import mock
+
+
+class TestBackgroundTaskProfileScope:
+    """_run_background_task installs _profile_runtime_scope when multiplexing is active."""
+
+    def test_background_task_calls_inner_wrapped_in_scope_when_multiplex_active(self):
+        """When multiplex_profiles is True, _run_background_task wraps call in _profile_runtime_scope."""
+        from gateway.run import GatewayRunner
+
+        config = {"multiplex_profiles": True}
+        gw = GatewayRunner(config=config)
+        gw._session_db = mock.MagicMock()
+        gw._adapter_for_source = mock.MagicMock(return_value=mock.MagicMock())
+
+        mock_inner = mock.AsyncMock(return_value=None)
+        gw._run_background_task_inner = mock_inner
+
+        import asyncio
+        source = mock.MagicMock()
+        source.profile_home = "/fake/profile"
+
+        # Mock _profile_runtime_scope
+        from gateway.run import _profile_runtime_scope
+        with mock.patch("gateway.run._profile_runtime_scope") as mock_scope:
+            mock_scope.return_value.__enter__ = mock.MagicMock()
+            mock_scope.return_value.__exit__ = mock.MagicMock()
+
+            asyncio.run(
+                gw._run_background_task(
+                    prompt="test",
+                    source=source,
+                    task_id="test_task",
+                )
+            )
+
+            # _profile_runtime_scope should have been called with profile_home
+            mock_scope.assert_called_once_with("/fake/profile")
+            mock_inner.assert_called_once()
+
+    def test_background_task_calls_inner_direct_when_multiplex_disabled(self):
+        """When multiplex_profiles is False, _run_background_task calls inner directly."""
+        from gateway.run import GatewayRunner
+
+        config = {"multiplex_profiles": False}
+        gw = GatewayRunner(config=config)
+        gw._session_db = mock.MagicMock()
+        gw._adapter_for_source = mock.MagicMock(return_value=mock.MagicMock())
+
+        mock_inner = mock.AsyncMock(return_value=None)
+        gw._run_background_task_inner = mock_inner
+
+        import asyncio
+        source = mock.MagicMock()
+
+        with mock.patch("gateway.run._profile_runtime_scope") as mock_scope:
+            asyncio.run(
+                gw._run_background_task(
+                    prompt="test",
+                    source=source,
+                    task_id="test_task",
+                )
+            )
+
+            # _profile_runtime_scope should NOT have been called
+            mock_scope.assert_not_called()
+            mock_inner.assert_called_once()


### PR DESCRIPTION
## Summary

`/background` tasks no longer crash with `UnscopedSecretError` on multiplexed gateways: `_run_background_task` now wraps its body in `_profile_runtime_scope`, mirroring the per-turn agent wrapper, so credential reads resolve from the routed profile's secret scope. Closes #60726.

Salvages PR #60746 by @liuhao1024 — the same bug class as the api_server default-listener fix that merged in #65700, at the call site flagged during that review (`_run_background_task` is spawned fire-and-forget from `_handle_background_command` with no scope; the per-turn scope at `_run_agent` never covers it). Root cause chain traced by @ptbsare in the issue.

## Changes

- `gateway/run.py`: `_run_background_task` becomes a scoping wrapper — multiplex on → resolve the source's profile home and run the task body inside `_profile_runtime_scope`; multiplex off → direct call, unchanged.
- `tests/gateway/test_multiplex_background_task_scope.py`: 3 regression tests (scope wrap under multiplex, direct call when off, full argument passthrough).

Dropped from the original PR: the second commit's `GatewayRunner.__init__` dict-coercion hack — it existed only so the PR's tests could pass a dict as config. Tests rewritten on the established `object.__new__` bare-runner pattern instead; no production-code test accommodation.

## Validation

| Check | Result |
|---|---|
| `test_multiplex_background_task_scope.py` | 3/3 passed |
| `tests/gateway/ -k background` | 79 passed, 0 failed |
| Live E2E (real secret scopes, real profile `.env`) | baseline confirmed: unscoped read raises `UnscopedSecretError` with multiplex active; through the fixed wrapper the scope is installed inside the task body and the profile's `OPENROUTER_BASE_URL` resolves |
| ruff | clean |

Contributor commit cherry-picked with authorship preserved; merge via rebase.

## Infographic

![background-task-scope](https://v3b.fal.media/files/b/0aa27e0d/XbkMvJHQBCmhgC0gy5XV9_hcaRK5GR.png)
