### PR TITLE
fix(cli): detect hermes update running inside active session on Windows

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8982,6 +8982,74 @@ def _hermes_exe_shims(scripts_dir: Path) -> list[Path]:
     return [scripts_dir / f"{name}.exe" for name in sorted(names)]
 
 
+
+def _detect_running_inside_hermes_session(scripts_dir: Path) -> bool:
+    """Detect whether ``hermes update`` is running inside an active Hermes session.
+
+    Concurrent-instance detection excludes ancestor shims so a user-initiated
+    update from a Hermes terminal does not false-positive. When the agent
+    shells out ``hermes update``, a farther-up session shim still holds a
+    file lock (#65585). Detect a matching shim beyond the immediate launcher.
+    """
+    if not _is_windows():
+        return False
+    try:
+        import psutil
+    except Exception:
+        return False
+    shim_paths: set[str] = set()
+    for shim in _hermes_exe_shims(scripts_dir):
+        try:
+            shim_paths.add(str(shim.resolve()).lower())
+        except OSError:
+            shim_paths.add(str(shim).lower())
+    if not shim_paths:
+        return False
+    try:
+        ancestors = psutil.Process(os.getpid()).parents()
+    except Exception:
+        return False
+    for i, ancestor in enumerate(ancestors):
+        if i == 0:
+            continue
+        try:
+            anc_exe = ancestor.exe()
+        except Exception:
+            continue
+        if not anc_exe:
+            continue
+        try:
+            anc_norm = str(Path(anc_exe).resolve()).lower()
+        except (OSError, ValueError):
+            anc_norm = str(anc_exe).lower()
+        if anc_norm in shim_paths:
+            return True
+    return False
+
+
+def _format_inside_hermes_session_message(scripts_dir: Path) -> str:
+    """Clear remediation when update runs inside an active Hermes session."""
+    shim = scripts_dir / "hermes.exe"
+    return '\n'.join(
+        [
+            "✗ You are running `hermes update` from inside an active Hermes session.",
+            "",
+            f"  The session's {shim} is running and holds a file lock on the",
+            "  venv executable. Windows blocks REPLACE on a running .exe, so the",
+            "  update cannot complete while this session is active.",
+            "",
+            "  To update Hermes:",
+            "    1. Exit this Hermes session (/quit or close the terminal)",
+            "    2. Open a separate terminal (not inside Hermes)",
+            "    3. Run: hermes update",
+            "",
+            "  If you need to update without exiting the session, you can try:",
+            "    hermes update --force",
+            "  (this attempts the update anyway, but may fail mid-write)",
+        ]
+    )
+
+
 def _quarantine_running_hermes_exe(
     scripts_dir: Path, *, max_attempts: int = 4
 ) -> list[tuple[Path, Path]]:

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -88,7 +88,7 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         "--force",
         action="store_true",
         default=False,
-        help="Windows: proceed with the update even when another hermes.exe is detected. The concurrent process will likely cause WinError 32 warnings. Does NOT bypass the venv-process guard (see --force-venv).",
+        help="Windows: proceed even when another hermes.exe or an active parent Hermes session is detected. The running process will likely cause WinError 32 warnings and may leave a reboot-deferred .exe replacement. Does NOT bypass the venv-process guard (see --force-venv).",
     )
     update_parser.add_argument(
         "--force-venv",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5161,6 +5161,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
     if _m()._is_windows() and not getattr(args, "force", False):
         scripts_dir = _m()._venv_scripts_dir()
         if scripts_dir is not None:
+            # Inside an active Hermes session the ancestor hermes.exe holds a
+            # lock on the venv shim (#65585). Concurrent-instance detection
+            # deliberately skips ancestors; this check covers that gap.
+            if _m()._detect_running_inside_hermes_session(scripts_dir):
+                print(_m()._format_inside_hermes_session_message(scripts_dir))
+                sys.exit(2)
             concurrent = _m()._detect_concurrent_hermes_instances(scripts_dir)
             if concurrent:
                 print(_format_concurrent_instances_message(concurrent, scripts_dir))

--- a/tests/hermes_cli/test_update_inside_session.py
+++ b/tests/hermes_cli/test_update_inside_session.py
@@ -1,0 +1,283 @@
+"""Tests for issue #65585 — ``hermes update`` should detect it's running
+inside an active Hermes session on Windows and fail fast with a clear
+message instead of proceeding to a confusing mid-update failure.
+
+These tests force ``_is_windows`` to return ``True`` via patching so the
+Windows-specific code paths can be exercised on any host.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import main as cli_main
+from hermes_cli import update_cmd
+
+
+# --------------------------------------------------------------------------- #
+# _detect_running_inside_hermes_session
+# --------------------------------------------------------------------------- #
+
+
+def _make_ancestor_proc(pid: int, exe: str):
+    """Build a duck-typed psutil Process stand-in for an ancestor."""
+    proc = MagicMock()
+    proc.pid = pid
+    proc.exe.return_value = exe
+    return proc
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_inside_session_detected_when_great_grandparent_is_shim(_winp, tmp_path):
+    """Grandparent hermes.exe → update is inside a session.
+
+    Topology: hermes.exe (session, PID S) → python.exe (agent, PID A)
+              → hermes.exe (update launcher, PID L) → python.exe (us, PID me)
+
+    The parent (L) is the launcher for *this* update — skip it.
+    The grandparent (A) is python.exe — not a shim.
+    The great-grandparent (S) is the session hermes.exe — a shim → detected.
+    """
+    scripts_dir = tmp_path
+    shim = scripts_dir / "hermes.exe"
+    shim.write_bytes(b"")
+    me = os.getpid()
+    launcher_pid = me + 100
+    agent_pid = me + 200
+    session_pid = me + 300
+
+    ancestors = [
+        _make_ancestor_proc(launcher_pid, str(shim)),         # parent — skip
+        _make_ancestor_proc(agent_pid, r"C:\Python\python.exe"),  # grandparent
+        _make_ancestor_proc(session_pid, str(shim)),          # great-grandparent — shim!
+    ]
+
+    fake_current = MagicMock()
+    fake_current.parents.return_value = ancestors
+    fake_psutil = types.SimpleNamespace(
+        Process=lambda pid=None: fake_current,
+        process_iter=lambda attrs: iter([]),
+    )
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        result = cli_main._detect_running_inside_hermes_session(scripts_dir)
+
+    assert result is True
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_not_inside_session_when_only_launcher_is_shim(_winp, tmp_path):
+    """Only the parent launcher is a shim → user invoked from separate terminal.
+
+    Topology: bash.exe (PID B) → hermes.exe (launcher, PID L) → python.exe (us)
+
+    The parent (L) is the launcher — skip it.
+    The grandparent (B) is bash — not a shim → not inside a session.
+    """
+    scripts_dir = tmp_path
+    shim = scripts_dir / "hermes.exe"
+    shim.write_bytes(b"")
+    me = os.getpid()
+    launcher_pid = me + 100
+    bash_pid = me + 200
+
+    ancestors = [
+        _make_ancestor_proc(launcher_pid, str(shim)),         # parent — skip
+        _make_ancestor_proc(bash_pid, r"C:\Windows\System32\bash.exe"),  # not a shim
+    ]
+
+    fake_current = MagicMock()
+    fake_current.parents.return_value = ancestors
+    fake_psutil = types.SimpleNamespace(
+        Process=lambda pid=None: fake_current,
+        process_iter=lambda attrs: iter([]),
+    )
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        result = cli_main._detect_running_inside_hermes_session(scripts_dir)
+
+    assert result is False
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_not_inside_session_when_no_shim_ancestors(_winp, tmp_path):
+    """No ancestors are shims at all → separate terminal, not inside session."""
+    scripts_dir = tmp_path
+    shim = scripts_dir / "hermes.exe"
+    shim.write_bytes(b"")
+    me = os.getpid()
+
+    ancestors = [
+        _make_ancestor_proc(me + 1, r"C:\Windows\System32\cmd.exe"),
+        _make_ancestor_proc(me + 2, r"C:\Windows\System32\explorer.exe"),
+    ]
+
+    fake_current = MagicMock()
+    fake_current.parents.return_value = ancestors
+    fake_psutil = types.SimpleNamespace(
+        Process=lambda pid=None: fake_current,
+        process_iter=lambda attrs: iter([]),
+    )
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        result = cli_main._detect_running_inside_hermes_session(scripts_dir)
+
+    assert result is False
+
+
+@patch.object(cli_main, "_is_windows", return_value=False)
+def test_inside_session_check_is_noop_off_windows(_winp, tmp_path):
+    """Off Windows, the check is a no-op (returns False)."""
+    assert cli_main._detect_running_inside_hermes_session(tmp_path) is False
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_inside_session_no_psutil_returns_false(_winp, tmp_path):
+    """Without psutil, the check returns False (best-effort, never raises)."""
+    scripts_dir = tmp_path
+    (scripts_dir / "hermes.exe").write_bytes(b"")
+
+    with patch.dict(sys.modules, {"psutil": None}):
+        result = cli_main._detect_running_inside_hermes_session(scripts_dir)
+
+    assert result is False
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_inside_session_no_shims_returns_false(_winp, tmp_path):
+    """With no shim files present, the check returns False."""
+    # Don't create any .exe files
+    with patch.dict(sys.modules, {"psutil": types.SimpleNamespace()}):
+        result = cli_main._detect_running_inside_hermes_session(tmp_path)
+
+    assert result is False
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_inside_session_parents_raises_returns_false(_winp, tmp_path):
+    """If psutil.Process().parents() raises, the check returns False."""
+    scripts_dir = tmp_path
+    (scripts_dir / "hermes.exe").write_bytes(b"")
+
+    fake_current = MagicMock()
+    fake_current.parents.side_effect = OSError("access denied")
+    fake_psutil = types.SimpleNamespace(
+        Process=lambda pid=None: fake_current,
+    )
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        result = cli_main._detect_running_inside_hermes_session(scripts_dir)
+
+    assert result is False
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_inside_session_ancestor_exe_unreadable_does_not_crash(_winp, tmp_path):
+    """If an ancestor's .exe() raises, that ancestor is skipped (no crash)."""
+    scripts_dir = tmp_path
+    shim = scripts_dir / "hermes.exe"
+    shim.write_bytes(b"")
+    me = os.getpid()
+
+    bad_ancestor = MagicMock()
+    bad_ancestor.exe.side_effect = OSError("access denied")
+
+    good_ancestor = _make_ancestor_proc(me + 300, str(shim))
+
+    ancestors = [
+        _make_ancestor_proc(me + 100, str(shim)),  # parent — skip
+        bad_ancestor,                               # exe raises — skip
+        good_ancestor,                              # shim — detected
+    ]
+
+    fake_current = MagicMock()
+    fake_current.parents.return_value = ancestors
+    fake_psutil = types.SimpleNamespace(
+        Process=lambda pid=None: fake_current,
+    )
+    with patch.dict(sys.modules, {"psutil": fake_psutil}):
+        result = cli_main._detect_running_inside_hermes_session(scripts_dir)
+
+    assert result is True
+
+
+# --------------------------------------------------------------------------- #
+# _format_inside_hermes_session_message
+# --------------------------------------------------------------------------- #
+
+
+def test_format_message_explains_issue_and_remediation(tmp_path):
+    """The message should explain the problem and how to fix it."""
+    msg = cli_main._format_inside_hermes_session_message(tmp_path)
+
+    # Explains the problem
+    assert "inside" in msg.lower()
+    assert "file lock" in msg.lower() or "lock" in msg.lower()
+
+    # Names the shim
+    assert str(tmp_path / "hermes.exe") in msg
+
+    # Provides remediation steps
+    assert "/quit" in msg or "exit" in msg.lower()
+    assert "hermes update" in msg
+    assert "separate terminal" in msg.lower()
+
+    # Mentions --force escape hatch
+    assert "--force" in msg
+
+
+def test_format_message_is_user_friendly(tmp_path):
+    """The message should not contain raw WinError or technical jargon."""
+    msg = cli_main._format_inside_hermes_session_message(tmp_path)
+
+    # No raw error codes
+    assert "WinError" not in msg
+    assert "os error" not in msg
+    # No traceback-style content
+    assert "Traceback" not in msg
+
+
+# --------------------------------------------------------------------------- #
+# _cmd_update_impl integration
+# --------------------------------------------------------------------------- #
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_update_impl_exits_before_mutation_inside_session(
+    _winp, tmp_path, capsys, monkeypatch
+):
+    """The command guard should fail with code 2 before backup or mutation."""
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(cli_main, "_venv_scripts_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        cli_main, "_detect_running_inside_hermes_session", lambda _path: True
+    )
+    backup = MagicMock(side_effect=AssertionError("backup must not run"))
+    monkeypatch.setattr(cli_main, "_run_pre_update_backup", backup)
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._cmd_update_impl(types.SimpleNamespace(force=False, yes=False), False)
+
+    assert exc_info.value.code == 2
+    assert "inside an active Hermes session" in capsys.readouterr().out
+    backup.assert_not_called()
+
+
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_update_impl_force_bypasses_inside_session_guard(_winp, monkeypatch):
+    """--force skips the shim guard and reaches the first mutation boundary."""
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    detect = MagicMock(side_effect=AssertionError("guard must be bypassed"))
+    monkeypatch.setattr(cli_main, "_detect_running_inside_hermes_session", detect)
+    monkeypatch.setattr(
+        cli_main,
+        "_run_pre_update_backup",
+        MagicMock(side_effect=RuntimeError("past shim guard")),
+    )
+
+    with pytest.raises(RuntimeError, match="past shim guard"):
+        update_cmd._cmd_update_impl(types.SimpleNamespace(force=True, yes=False), False)
+
+    detect.assert_not_called()


### PR DESCRIPTION
## Summary

When the agent shells out `hermes update` via the terminal tool on Windows, the active session's `hermes.exe` remains in the update process ancestry and keeps the venv shim locked. The existing concurrent-instance detector deliberately excludes ancestor shims so a normal update does not report its own launcher, allowing this distinct nested-session case to proceed until it fails during file replacement.

This PR adds an early Windows-only guard. `_detect_running_inside_hermes_session()` skips the immediate update launcher and checks remaining ancestors for a matching venv shim. A match means the update is nested inside another live Hermes session, so the command exits with a clear remediation message before backup or file mutation.

## What changed

- Added `_detect_running_inside_hermes_session()` with best-effort `psutil` ancestry handling.
- Added `_format_inside_hermes_session_message()` with separate-terminal remediation and an explicit `--force` escape hatch.
- Integrated the guard before concurrent-process detection and all update mutation.
- Clarified `hermes update --force` help for active parent sessions.
- Added helper, failure-path, message, command-integration, and `--force` regression tests.

## Process topologies

```text
Separate terminal:
  bash.exe → hermes.exe (update launcher) → python.exe (update)
  immediate launcher is skipped; no other shim ancestor → DETECTED=False

Nested active session:
  hermes.exe (session) → python.exe (agent)
    → hermes.exe (update launcher) → python.exe (update)
  immediate launcher is skipped; session shim remains → DETECTED=True
```

## Verification

Rebased onto authoritative Nous `main` commit `7fd419e5e6a0ac53f934a69226262c41ba130a2c`.

```text
pytest tests/hermes_cli/test_update_inside_session.py \
       tests/hermes_cli/test_update_concurrent_quarantine.py -q

37 passed in 3.86s
```

```text
ruff check hermes_cli/main.py \
           hermes_cli/subcommands/update.py \
           tests/hermes_cli/test_update_inside_session.py

All checks passed!
```

- `git diff --check`: passed
- static security scan: no secret, shell, eval/exec, unsafe-pickle, or SQL-formatting findings
- native Windows control topology: `DETECTED=False`
- native Windows nested-session topology: `DETECTED=True`
- independent final diff review: passed with no security concerns or logic errors

## Platforms tested

- Windows 10, native process tree through git-bash/MSYS
- Python 3.11.15

Closes #65585
