### PR TITLE
fix(api_server): run the cron-fire token verifier off the event loop

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4257,12 +4257,29 @@ class APIServerAdapter(BasePlatformAdapter):
         token = auth[7:].strip() if auth.startswith("Bearer ") else ""
 
         cfg = load_config()
-        claims = get_fire_verifier()(
+        verifier = get_fire_verifier()
+        verify_kwargs = dict(
             token=token,
             expected_audience=cfg_get(cfg, "cron", "chronos", "expected_audience", default=""),
             jwks_or_key=cfg_get(cfg, "cron", "chronos", "nas_jwks_url", default="") or None,
             issuer=cfg_get(cfg, "cron", "chronos", "portal_url", default="") or None,
         )
+        try:
+            if asyncio.iscoroutinefunction(verifier):
+                claims = await verifier(**verify_kwargs)
+            else:
+                # The verifier resolves the NAS signing key from a JWKS URL,
+                # which is a synchronous HTTP GET on a cache miss (cold client
+                # or a rotated kid) — keep that blocking I/O off the event loop
+                # so a slow or rate-limited portal can't stall every other
+                # adapter sharing this loop. Same hardening the platform HTTP
+                # event verifier already got.
+                claims = await asyncio.to_thread(verifier, **verify_kwargs)
+        except Exception:
+            # Fail closed: a crashing verifier must never admit a fire — this
+            # is the only inbound that can trigger remote job execution.
+            logger.exception("cron fire: verifier crashed; rejecting token")
+            claims = None
         if claims is None:
             logger.warning(
                 "cron fire: rejected invalid token: %s",

--- a/tests/gateway/test_cron_fire_webhook.py
+++ b/tests/gateway/test_cron_fire_webhook.py
@@ -233,3 +233,95 @@ async def test_fire_does_not_require_api_server_key(adapter, monkeypatch):
             break
         await asyncio.sleep(0.01)
     assert spy.fired == ["j9"]
+
+
+@pytest.mark.asyncio
+async def test_sync_verifier_runs_off_the_event_loop(adapter, monkeypatch):
+    """The verifier resolves the signing key from a JWKS URL — a synchronous
+    HTTP GET on a cache miss. It must run via asyncio.to_thread, NOT inline on
+    the event loop, or a slow/rate-limited portal stalls every other adapter
+    sharing the loop. Proof: the sync verifier executes on a worker thread, not
+    the loop thread.
+    """
+    loop_thread_id = threading.get_ident()
+    seen = {}
+
+    def blocking_verifier(**kw):
+        seen["thread_id"] = threading.get_ident()
+        return {"purpose": "cron_fire"}
+
+    spy = _SpyProvider()
+    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: blocking_verifier,
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/api/cron/fire",
+                              headers={"Authorization": "Bearer good"},
+                              json={"job_id": "off-loop"})
+        assert resp.status == 202
+
+    # If the verifier had run inline on the loop, its thread id would equal the
+    # loop thread's; to_thread puts it on a distinct worker thread.
+    assert seen["thread_id"] != loop_thread_id
+
+
+@pytest.mark.asyncio
+async def test_crashing_verifier_fails_closed_401(adapter, monkeypatch):
+    """A verifier that raises must be treated as a rejection (401), never admit
+    the fire, and never surface as a 500 — this is the only inbound that can
+    trigger remote job execution, so it fails closed.
+    """
+    spy = _SpyProvider()
+    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+
+    def exploding_verifier(**kw):
+        raise RuntimeError("JWKS endpoint unreachable")
+
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: exploding_verifier,
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/api/cron/fire",
+                              headers={"Authorization": "Bearer boom"},
+                              json={"job_id": "abc123"})
+        assert resp.status == 401
+
+    await asyncio.sleep(0.05)
+    assert spy.fired == []
+
+
+@pytest.mark.asyncio
+async def test_async_verifier_is_awaited(adapter, monkeypatch):
+    """A coroutine verifier (a future async escape-hatch) is awaited directly
+    rather than dispatched to a thread — a valid async verify still fires.
+    """
+    spy = _SpyProvider()
+    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+
+    async def async_verifier(**kw):
+        return {"purpose": "cron_fire", "aud": "agent:x"}
+
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: async_verifier,
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/api/cron/fire",
+                              headers={"Authorization": "Bearer good"},
+                              json={"job_id": "async-ok"})
+        assert resp.status == 202
+
+    for _ in range(50):
+        if spy.fired:
+            break
+        await asyncio.sleep(0.01)
+    assert spy.fired == ["async-ok"]


### PR DESCRIPTION
## What does this PR do?

`_handle_cron_fire` (POST `/api/cron/fire`) authenticated the NAS-minted fire
JWT by calling the fire-verifier **inline on the event loop**. That verifier
resolves the NAS signing key from a JWKS URL, which is a **synchronous HTTP GET
on a cache miss** — a cold `PyJWKClient`, or a rotated `kid` the cached client
doesn't yet know. A slow or rate-limited portal therefore stalls the whole
asyncio event loop and starves every other adapter sharing it.

This is the same class of bug already fixed for the platform HTTP event verifier
(run sync verifiers off-loop, fail closed). `#64641` documented the exact
production symptom for this path — relay 504s concentrated on high-job-count
instances — and cut the fetch frequency by caching the `PyJWKClient` per URL, but
the residual cache-miss fetch still ran **inline** on the loop. This PR closes
that residual gap on the cron-fire handler.

The verifier now:
- runs a synchronous verifier via `asyncio.to_thread` so its blocking JWKS fetch
  stays off the event loop (the JWK-client cache is already `threading.Lock`-guarded,
  so worker-thread access is safe);
- awaits a coroutine verifier directly (forward-compatible with an async
  escape-hatch verifier);
- **fails closed** — a verifier that raises is treated as a `401` rejection and
  never admits the fire, since this is the only inbound that can trigger remote
  job execution.

## Related Issue

No separate issue. Follow-up hardening to the merged JWKS-cache fix (`#64641`) and
parity with the platform-verifier off-loop change on the sibling handler.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` — in `_handle_cron_fire`, dispatch the
  fire-verifier off the event loop: `await` for coroutine verifiers, `asyncio.to_thread`
  for sync ones, wrapped in a fail-closed `try/except` that rejects with `401` if the
  verifier raises.
- `tests/gateway/test_cron_fire_webhook.py` — three regression tests (below).

## How to Test

1. `pytest tests/gateway/test_cron_fire_webhook.py -q` → **10 passed**.
2. Reproduction / proof the fix works — revert only the `api_server.py` change and
   re-run: the two new regression tests fail, confirming they pin the fix:
   - `test_sync_verifier_runs_off_the_event_loop` — a sync verifier is expected to
     execute on a worker thread, not the loop thread. Without the fix it runs inline
     on the loop thread → **fails**.
   - `test_crashing_verifier_fails_closed_401` — a verifier that raises must yield
     `401` with no fire. Without the fail-closed guard the exception surfaces as a
     `500` → **fails**.
   - `test_async_verifier_is_awaited` — a coroutine verifier is awaited and still
     fires (async-path coverage).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suite (`pytest tests/gateway/test_cron_fire_webhook.py -q`) and all tests pass
- [x] I've added tests for my changes
- [x] I've tested locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/inline rationale) — code comment added; no external docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure asyncio dispatch change, no OS-specific code)