### PR TITLE
fix(discord): expose /reasoning levels + reset|show|hide as native slash choices (salvage #55803)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4084,8 +4084,27 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_model(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/model {name}".strip())
 
-        @tree.command(name="reasoning", description="Show or change reasoning effort")
-        @discord.app_commands.describe(effort="Effort: none, minimal, low, medium, high, xhigh, max, or ultra.")
+        @tree.command(name="reasoning", description="Show/change reasoning effort, or toggle showing it")
+        @discord.app_commands.describe(effort="Pick a level, reset the override, or show/hide reasoning. Leave empty to see current.")
+        @discord.app_commands.choices(effort=[
+            # Effort levels and the reset/show/hide subcommands all arrive on the
+            # gateway's single `/reasoning <arg>` handler. Discord's native UI has
+            # no subcommand affordance for a free-text field (it just funnels the
+            # user into the `effort` box), so expose every accepted value as an
+            # explicit choice. --global persistence stays reachable by typing the
+            # command as plain text.
+            discord.app_commands.Choice(name="none — disable reasoning", value="none"),
+            discord.app_commands.Choice(name="minimal", value="minimal"),
+            discord.app_commands.Choice(name="low", value="low"),
+            discord.app_commands.Choice(name="medium", value="medium"),
+            discord.app_commands.Choice(name="high", value="high"),
+            discord.app_commands.Choice(name="xhigh", value="xhigh"),
+            discord.app_commands.Choice(name="max", value="max"),
+            discord.app_commands.Choice(name="ultra — maximum reasoning", value="ultra"),
+            discord.app_commands.Choice(name="reset — clear this session's override", value="reset"),
+            discord.app_commands.Choice(name="show — reveal reasoning in replies", value="show"),
+            discord.app_commands.Choice(name="hide — hide reasoning from replies", value="hide"),
+        ])
         async def slash_reasoning(interaction: discord.Interaction, effort: str = ""):
             await self._run_simple_slash(interaction, f"/reasoning {effort}".strip())
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "sam7894604@gmail.com": "sam7894604",  # PR #55803 salvage (discord: /reasoning slash choices)
     "bryan@users.noreply.github.com": "hydraxman",  # PR #62028 salvage (copilot xhigh) — regression-test commit authored under a bare-noreply local git identity; PR author is @hydraxman
     "antydizajn@gmail.com": "antydizajn",  # PR #36043 salvage (auxiliary: route custom:<name> through named-provider arm + Palantir Bearer auth)
     "252620095+briandevans@users.noreply.github.com": "briandevans",  # PR #64951 salvage (lmstudio: clamp max/ultra reasoning effort)


### PR DESCRIPTION
## Summary

Discord's native `/reasoning` slash UI now presents an explicit choices dropdown — effort levels plus `reset`/`show`/`hide` — instead of a free-text box that hid every subcommand and required memorizing valid values.

Salvage of #55803 by @sam7894604, cherry-picked with authorship preserved, plus a follow-up widening the choices to `max`/`ultra` (the contributor's list predates #62650).

## Changes

- `plugins/platforms/discord/adapter.py`: free-text `effort` param → `app_commands.choices` dropdown covering all 8 effort levels + `reset`/`show`/`hide` (@sam7894604; max/ultra added in follow-up). Typed-text path unchanged — `--global` persistence still reachable.
- `scripts/release.py`: AUTHOR_MAP entry.

## Validation

| | Before | After |
|---|---|---|
| Discord `/reasoning` UI | free-text box | native dropdown, 11 choices (cap is 25) |
| reset / show / hide | undiscoverable | listed |
| max / ultra | absent from contributor branch | included |

`tests/gateway/test_discord_slash_auth.py` + `tests/plugins/platforms/` — 152 passed.

Closes #55803. Refs #61110 (Telegram picker parity — separate feature).

## Infographic

![discord-reasoning-choices](https://v3b.fal.media/files/b/0aa27e6e/Q2032ueVZKQkPNdJMNrKZ_k4oe9tJH.png)
