### PR TITLE
feat(lsp): add csharp-ls server for C# diagnostics (staging-dir dotnet install)

### DIFF
--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -94,6 +94,9 @@ INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
     },
     # Go
     "gopls": {"strategy": "go", "pkg": "golang.org/x/tools/gopls@latest", "bin": "gopls"},
+    # C# — csharp-ls is a dotnet global tool; installed via
+    # ``dotnet tool install`` into our staging dir.
+    "csharp-ls": {"strategy": "dotnet", "pkg": "csharp-ls", "bin": "csharp-ls"},
     # Rust — too heavy (hundreds of MB to bootstrap).  We do NOT
     # auto-install rust-analyzer; users install via rustup.
     "rust-analyzer": {"strategy": "manual", "pkg": "", "bin": "rust-analyzer"},
@@ -226,6 +229,8 @@ def _do_install(pkg: str) -> Optional[str]:
         )
     if strategy == "go":
         return _install_go(recipe.get("pkg", pkg), bin_name)
+    if strategy == "dotnet":
+        return _install_dotnet(recipe.get("pkg", pkg), bin_name)
     if strategy == "pip":
         return _install_pip(recipe.get("pkg", pkg), bin_name)
 
@@ -332,6 +337,42 @@ def _install_go(pkg: str, bin_name: str) -> Optional[str]:
     if bin_path.exists():
         return str(bin_path)
     logger.warning("[install] go install for %s succeeded but bin %s not found", pkg, bin_name)
+    return None
+
+
+def _install_dotnet(pkg: str, bin_name: str) -> Optional[str]:
+    """Install a dotnet global tool with ``--tool-path`` = <staging>."""
+    dotnet = shutil.which("dotnet")
+    if dotnet is None:
+        logger.info("[install] cannot install %s: dotnet not on PATH", pkg)
+        return None
+    staging = hermes_lsp_bin_dir()
+    try:
+        logger.info("[install] dotnet tool install %s --tool-path %s", pkg, staging)
+        proc = subprocess.run(
+            [dotnet, "tool", "install", pkg, "--tool-path", str(staging)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            stdin=subprocess.DEVNULL,
+        )
+        if proc.returncode != 0:
+            logger.warning(
+                "[install] dotnet tool install failed for %s: %s",
+                pkg,
+                (proc.stderr or proc.stdout or "").strip()[:500],
+            )
+            return None
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.warning("[install] dotnet tool install errored for %s: %s", pkg, e)
+        return None
+    for bin_path in _native_binary_candidates(staging / bin_name):
+        if bin_path.exists():
+            return str(bin_path)
+    logger.warning(
+        "[install] dotnet tool install for %s succeeded but bin %s not found", pkg, bin_name
+    )
     return None
 
 

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -594,6 +594,22 @@ def _spawn_prisma(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
+def _spawn_csharp_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+    bin_path = _resolve_override(ctx, "csharp-ls") or _which("csharp-ls")
+    if bin_path is None:
+        from agent.lsp.install import try_install
+        bin_path = try_install("csharp-ls", ctx.install_strategy)
+        if bin_path is None:
+            return None
+    return SpawnSpec(
+        command=[bin_path],
+        workspace_root=root,
+        cwd=root,
+        env=ctx.env_overrides.get("csharp-ls", {}),
+        initialization_options=ctx.init_overrides.get("csharp-ls", {}),
+    )
+
+
 def _spawn_kotlin_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "kotlin-language-server") or _which(
         "kotlin-language-server"
@@ -935,6 +951,40 @@ def _root_prisma(file_path: str, workspace: str) -> Optional[str]:
     )
 
 
+def _root_csharp(file_path: str, workspace: str) -> Optional[str]:
+    # .sln/.csproj have project-specific names, so nearest_root's
+    # exact-name matching can't find them — walk up with globs.
+    # Unity projects are gated off: their .csproj files are generated
+    # by the Unity editor and are stale/absent in headless checkouts,
+    # so csharp-ls would resolve nothing useful.
+    try:
+        cur = os.path.dirname(os.path.abspath(file_path))
+    except (OSError, ValueError):
+        return None
+    ceiling = os.path.dirname(workspace) if workspace else None
+    fallback: Optional[str] = None
+    for _ in range(64):
+        if os.path.exists(os.path.join(cur, "ProjectSettings", "ProjectVersion.txt")):
+            return None  # Unity project
+        try:
+            entries = os.listdir(cur)
+        except OSError:
+            entries = []
+        if any(
+            e.endswith((".sln", ".slnx")) and not e.startswith("._") for e in entries
+        ):
+            return cur
+        if fallback is None and (
+            any(e.endswith(".csproj") for e in entries) or "global.json" in entries
+        ):
+            fallback = cur
+        parent = os.path.dirname(cur)
+        if parent == cur or (ceiling and cur == ceiling):
+            break
+        cur = parent
+    return fallback or (workspace or None)
+
+
 def _root_kotlin(file_path: str, workspace: str) -> Optional[str]:
     return _root_or_workspace(
         file_path,
@@ -1137,6 +1187,13 @@ SERVERS: List[ServerDef] = [
         resolve_root=_root_prisma,
         build_spawn=_spawn_prisma,
         description="Prisma — built-in language server",
+    ),
+    ServerDef(
+        server_id="csharp-ls",
+        extensions=(".cs", ".csx"),
+        resolve_root=_root_csharp,
+        build_spawn=_spawn_csharp_ls,
+        description="C# — csharp-ls (Roslyn-based)",
     ),
     ServerDef(
         server_id="kotlin-language-server",

--- a/tests/agent/lsp/test_csharp_root.py
+++ b/tests/agent/lsp/test_csharp_root.py
@@ -1,0 +1,87 @@
+"""Root resolution for the csharp-ls server.
+
+``_root_csharp`` can't use ``nearest_root`` because .sln/.csproj files
+have project-specific names (exact-name matching can't find them), so
+it walks up with suffix matching.  These tests pin the contract:
+
+  - .sln directory wins over a nearer .csproj directory (solution-level
+    load gives csharp-ls cross-project resolution).
+  - .csproj / global.json is the fallback root when no .sln exists.
+  - macOS resource-fork litter (``._foo.sln``) is ignored.
+  - Unity projects (``ProjectSettings/ProjectVersion.txt``) gate the
+    server OFF — their .csproj files are editor-generated and stale or
+    absent in headless checkouts.
+  - No marker at all falls back to the workspace root.
+"""
+from __future__ import annotations
+
+
+def _resolve(file_path, workspace):
+    from agent.lsp.servers import _root_csharp
+    return _root_csharp(str(file_path), str(workspace))
+
+
+def test_sln_dir_wins_over_nearer_csproj(tmp_path):
+    (tmp_path / "app.sln").write_text("")
+    proj = tmp_path / "App"
+    proj.mkdir()
+    (proj / "App.csproj").write_text("")
+    src = proj / "Program.cs"
+    src.write_text("class C {}")
+    assert _resolve(src, tmp_path) == str(tmp_path)
+
+
+def test_csproj_fallback_without_sln(tmp_path):
+    proj = tmp_path / "App"
+    proj.mkdir()
+    (proj / "App.csproj").write_text("")
+    src = proj / "Program.cs"
+    src.write_text("class C {}")
+    assert _resolve(src, tmp_path) == str(proj)
+
+
+def test_macos_resource_fork_sln_ignored(tmp_path):
+    (tmp_path / "._app.sln").write_text("")
+    proj = tmp_path / "App"
+    proj.mkdir()
+    (proj / "App.csproj").write_text("")
+    src = proj / "Program.cs"
+    src.write_text("class C {}")
+    assert _resolve(src, tmp_path) == str(proj)
+
+
+def test_unity_project_gated_off(tmp_path):
+    ps = tmp_path / "ProjectSettings"
+    ps.mkdir()
+    (ps / "ProjectVersion.txt").write_text("m_EditorVersion: 2022.3.0f1")
+    (tmp_path / "app.sln").write_text("")
+    scripts = tmp_path / "Assets" / "Scripts"
+    scripts.mkdir(parents=True)
+    src = scripts / "Foo.cs"
+    src.write_text("class Foo {}")
+    assert _resolve(src, tmp_path) is None
+
+
+def test_no_marker_falls_back_to_workspace(tmp_path):
+    sub = tmp_path / "loose"
+    sub.mkdir()
+    src = sub / "Script.cs"
+    src.write_text("class C {}")
+    assert _resolve(src, tmp_path) == str(tmp_path)
+
+
+def test_slnx_recognized(tmp_path):
+    (tmp_path / "app.slnx").write_text("")
+    proj = tmp_path / "App"
+    proj.mkdir()
+    (proj / "App.csproj").write_text("")
+    src = proj / "Program.cs"
+    src.write_text("class C {}")
+    assert _resolve(src, tmp_path) == str(tmp_path)
+
+
+def test_registry_matches_cs_files():
+    from agent.lsp.servers import find_server_for_file
+    srv = find_server_for_file("/some/where/Foo.cs")
+    assert srv is not None
+    assert srv.server_id == "csharp-ls"

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -135,6 +135,41 @@ def test_install_pip_finds_windows_scripts_launcher(tmp_path, monkeypatch):
     assert (install_mod.hermes_lsp_bin_dir() / "fake-language-server.exe").exists()
 
 
+def test_install_dotnet_uses_staging_dir_and_finds_windows_executable(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from agent.lsp import install as install_mod
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        executable = install_mod.hermes_lsp_bin_dir() / "csharp-ls.exe"
+        executable.write_text("launcher\n")
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        install_mod.shutil,
+        "which",
+        lambda command: "/usr/bin/dotnet" if command == "dotnet" else None,
+    )
+
+    resolved = install_mod._install_dotnet("csharp-ls", "csharp-ls")
+
+    staging = install_mod.hermes_lsp_bin_dir()
+    assert captured["cmd"] == [
+        "/usr/bin/dotnet",
+        "tool",
+        "install",
+        "csharp-ls",
+        "--tool-path",
+        str(staging),
+    ]
+    assert resolved == str(staging / "csharp-ls.exe")
+
+
 # ---------------------------------------------------------------------------
 # Fix 2: ``hermes lsp status`` surfaces shellcheck-missing for bash
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/lsp.md
+++ b/website/docs/user-guide/features/lsp.md
@@ -66,6 +66,7 @@ agent sees a syntax-clean file with semantic problems as
 | Svelte | `svelte-language-server` | npm |
 | Astro | `@astrojs/language-server` | npm |
 | Go | `gopls` | `go install` |
+| C# | `csharp-ls` | `dotnet tool install` |
 | Rust | `rust-analyzer` | manual (rustup) |
 | C / C++ | `clangd` | manual (LLVM) |
 | Bash / Zsh | `bash-language-server` | npm |
@@ -189,7 +190,8 @@ When `install_strategy: auto`, Hermes installs binaries into
 `<HERMES_HOME>/lsp/bin/`. NPM packages land in
 `<HERMES_HOME>/lsp/node_modules/` with bin symlinks one level up.
 Go binaries come from `go install` with `GOBIN` pointed at the
-staging dir.
+staging dir. .NET tools come from `dotnet tool install` with
+`--tool-path` pointed at the staging dir.
 
 Nothing is ever installed to `/usr/local/`, `~/.local/`, or any other
 shared location — the staging dir is fully Hermes-owned and is


### PR DESCRIPTION
## What & why

`LANGUAGE_BY_EXT` maps `.cs`/`.csx` to `csharp` (`agent/lsp/servers.py:63-64`), but `SERVERS` has no C# entry — C# edits get no LSP diagnostics at all. This registers [csharp-ls](https://github.com/razzmatazz/csharp-language-server) (Roslyn-based, MIT) so `patch`/`write_file` on C# files surface real compiler diagnostics.

- **`csharp-ls` ServerDef** for `.cs`/`.csx` with spawn builder and binary override support.
- **Root resolver** with C#-specific semantics that `nearest_root` can't express (sln/csproj names are project-specific, so exact-name markers don't work):
  - nearest `.sln`/`.slnx` directory wins over a nearer `.csproj` (solution-level load gives cross-project resolution),
  - `.csproj`/`global.json` directory is the fallback, then workspace root,
  - macOS `._*.sln` resource-fork litter is ignored,
  - **Unity projects are gated off** (detected via `ProjectSettings/ProjectVersion.txt`): their `.csproj` files are editor-generated and stale/absent in headless checkouts, so spawning a Roslyn server there burns memory for zero diagnostics.
- **New `dotnet` install strategy**: `dotnet tool install <pkg> --tool-path <HERMES_HOME>/lsp/bin` — binaries stay in the Hermes-owned staging dir per the isolation contract in `agent/lsp/install.py:3-6` and the "Installation locations" section of `website/docs/user-guide/features/lsp.md`. Nothing touches the user's global dotnet tool location.
- Docs: server table row + install-locations paragraph in `lsp.md`.

## How to test

```bash
# unit tests (CI-parity wrapper)
scripts/run_tests.sh tests/agent/lsp -q

# manual: install + status (requires dotnet SDK on PATH)
hermes lsp install csharp-ls
hermes lsp list | grep csharp

# manual end-to-end: in any .NET solution, edit a .cs file to
# `return "not an int";` in an int-returning method — the edit result's
# lsp_diagnostics field shows: Cannot implicitly convert type 'string' to 'int'
```

Note: on large multi-project solutions the first diagnostics take ~60–90s (Roslyn solution load); small projects respond in seconds. Later checks in the same session are instant since the server stays warm.

## Test evidence

- `tests/agent/lsp/test_csharp_root.py` — 7 new tests pinning the root-resolution contract (sln-over-csproj, slnx, Unity gate, `._` litter, workspace fallback, registry match).
- Full LSP suite on this base via `scripts/run_tests.sh tests/agent/lsp -q`: **166 passed, 0 failed**.
- End-to-end through `LSPClient`: auto-install landed csharp-ls 0.26.0 in `<HERMES_HOME>/lsp/bin/`; a deliberate `return "not an int"` produced `Cannot implicitly convert type 'string' to 'int'` (CS0029) on both a scratch solution and a real 30-project solution.

## Platforms tested

- **Linux (Ubuntu, x86_64, .NET SDK 10)**: full manual + automated verification as above.
- **Windows/macOS**: not manually tested. `scripts/check-windows-footguns.py` passes on all three touched Python files; the install path reuses the existing `_native_binary_candidates` helper for `.exe` resolution, uses `shutil.which`, `pathlib`, no POSIX-only primitives; the root resolver is pure `os.path`. csharp-ls itself ships cross-platform via NuGet.

## Related

- **PR #41056** — adds csharp-ls + fsautocomplete but installs with `dotnet tool install -g`, which its sweeper review flagged as violating the staging-dir isolation contract (suggested fix: `--tool-path` + docs). This PR is the `--tool-path` shape that review asked for, C#-only, plus the Unity gate and sln-over-csproj root preference that #41056's `_root_dotnet` doesn't have (first marker wins there, so a nested csproj shadows the solution). Opened as a **draft** deliberately: if #41056 gets updated to address its review, happy to close this one — or its author is welcome to lift any of this (root-resolver semantics, tests, docs) into that PR.