### PR TITLE
fix(webhook): mark port conflict as non-retryable to stop infinite reconnect

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -33,6 +33,7 @@ Security:
 import asyncio
 import base64
 import binascii
+import errno
 import hashlib
 import hmac
 import json
@@ -287,6 +288,24 @@ class WebhookAdapter(BasePlatformAdapter):
         except OSError as exc:
             await self._runner.cleanup()
             self._runner = None
+            if getattr(exc, "errno", None) == errno.EADDRINUSE:
+                # A port conflict is a configuration error, not a transient
+                # blip — another process holds the port for its lifetime. A
+                # bare ``return False`` makes the reconnect watcher in
+                # gateway.run treat it as retryable ("No fatal error info
+                # means likely a transient issue — queue for retry") and loop
+                # forever at the backoff cap, filling errors.log and leaking
+                # the adapter's resources each retry (the same failure the
+                # api_server direct-bind path hit). Mark it non-retryable so
+                # the platform drops from the reconnect queue; recover with
+                # ``/platform resume webhook`` after changing the port.
+                self._set_fatal_error(
+                    "webhook_port_in_use",
+                    f"Port {self._port} already in use. Set a different "
+                    f"host/port under platforms.webhook.extra in config.yaml, "
+                    f"then `/platform resume webhook`.",
+                    retryable=False,
+                )
             logger.error(
                 "[webhook] Could not bind %s:%d: %s. "
                 "Set a different host or port in config.yaml under "

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -16,6 +16,7 @@ Covers:
 
 import asyncio
 import base64
+import errno
 import hashlib
 import hmac
 import json
@@ -1687,3 +1688,67 @@ class TestDualStackBind:
             await adapter.disconnect()
             blocker.close()
             await blocker.wait_closed()
+
+    @pytest.mark.asyncio
+    async def test_port_conflict_sets_non_retryable_fatal_error(self):
+        """A port conflict (EADDRINUSE) must set a non-retryable fatal error so
+        the reconnect watcher drops the platform from the retry queue instead
+        of looping indefinitely.
+
+        Previously connect() returned bare ``False`` with no fatal-error info,
+        which gateway.run treats as a transient failure ("No fatal error info
+        means likely a transient issue — queue for retry") and retries forever
+        at the backoff cap — the same infinite-reconnect symptom the api_server
+        direct-bind path was hardened against. The bind failure is injected so
+        the branch is exercised deterministically regardless of the OS's
+        dual-stack rebinding semantics.
+        """
+        port = 8099
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "port": port,
+                "routes": {"r1": {"secret": "real-secret-abc123", "prompt": "x"}},
+            },
+        )
+        adapter = WebhookAdapter(cfg)
+        eaddrinuse = OSError(errno.EADDRINUSE, "address already in use")
+        try:
+            with patch.object(adapter, "_reload_dynamic_routes"), patch(
+                "gateway.platforms.webhook.web.TCPSite"
+            ) as mock_site_cls:
+                mock_site_cls.return_value.start = AsyncMock(side_effect=eaddrinuse)
+                result = await adapter.connect()
+            assert result is False
+            assert adapter.has_fatal_error is True
+            assert adapter.fatal_error_retryable is False
+            assert adapter.fatal_error_code == "webhook_port_in_use"
+            assert str(port) in (adapter.fatal_error_message or "")
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_transient_bind_error_stays_retryable(self):
+        """A non-EADDRINUSE bind failure (e.g. a transient OSError) must NOT be
+        marked fatal — it stays a bare ``False`` so the watcher keeps retrying.
+        Only a genuine port conflict is treated as a configuration error.
+        """
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "port": 8099,
+                "routes": {"r1": {"secret": "real-secret-abc123", "prompt": "x"}},
+            },
+        )
+        adapter = WebhookAdapter(cfg)
+        transient = OSError(errno.EADDRNOTAVAIL, "cannot assign requested address")
+        try:
+            with patch.object(adapter, "_reload_dynamic_routes"), patch(
+                "gateway.platforms.webhook.web.TCPSite"
+            ) as mock_site_cls:
+                mock_site_cls.return_value.start = AsyncMock(side_effect=transient)
+                result = await adapter.connect()
+            assert result is False
+            assert adapter.has_fatal_error is False
+        finally:
+            await adapter.disconnect()


### PR DESCRIPTION
## What does this PR do?

`WebhookAdapter.connect()` binds its aiohttp listener and, on **any** `OSError`
from `site.start()`, logs and returns a bare `False`. On `EADDRINUSE` that's the
wrong signal: a port conflict is a configuration error — another process owns the
port for its lifetime — but the reconnect watcher in `gateway.run` treats a
`False` with no fatal-error info as transient:

> "No fatal error info means likely a transient issue — queue for retry"

…so it retries **forever** at the backoff cap, filling `errors.log` and
re-allocating the adapter's resources on every attempt.

This is the same failure the `api_server` direct-bind path was hardened against
(mark the port conflict non-retryable so the platform drops from the reconnect
queue). This PR applies the identical fix to the shared webhook listener: detect
`EADDRINUSE` in the bind `OSError` branch and set a non-retryable fatal error
(`webhook_port_in_use`). Other (transient) `OSError`s keep the bare-`False` path,
so they stay retryable. The operator recovers with `/platform resume webhook`
after changing the port.

## Related Issue

No separate issue. Parity fix for the shared webhook listener, mirroring the
merged `api_server` port-conflict hardening.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/webhook.py` — in `connect()`'s bind-`OSError` branch, detect
  `errno.EADDRINUSE` and call `self._set_fatal_error("webhook_port_in_use", …,
  retryable=False)` before returning `False`; non-`EADDRINUSE` errors are
  unchanged (still retryable). Adds `import errno`.
- `tests/gateway/test_webhook_adapter.py` — two regression tests (below).

## How to Test

1. `pytest tests/gateway/test_webhook_adapter.py -q` → the two new tests pass
   (`test_port_conflict_sets_non_retryable_fatal_error`,
   `test_transient_bind_error_stays_retryable`).
2. Proof the fix works — revert only the `webhook.py` change and re-run:
   `test_port_conflict_sets_non_retryable_fatal_error` fails, because `connect()`
   returns a bare `False` with `has_fatal_error == False` (the infinite-retry
   bug). With the fix it sets `fatal_error_code == "webhook_port_in_use"` and
   `fatal_error_retryable is False`.
3. The bind failure is injected (`OSError(errno.EADDRINUSE)`) so the branch is
   exercised deterministically, independent of the OS's dual-stack rebinding
   semantics.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suite (`pytest tests/gateway/test_webhook_adapter.py -q`); the two new tests pass (the one pre-existing `test_default_bind_rejects_existing_ipv6_listener` failure is unrelated — it fails on clean `main` too, due to real-bind dual-stack semantics)
- [x] I've added tests for my changes
- [x] I've tested locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation — inline rationale added; no external docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the fix keys on `errno.EADDRINUSE` (symbolic, resolves per-OS) and the tests inject the error, so both are platform-independent