### PR TITLE
feat(gateway): configure workers and add adaptive model admission

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -243,7 +243,18 @@ class _SyncAdmissionCompletionsProxy:
             permit.fail(error)
             raise
         if kwargs.get("stream"):
-            return permit.wrap_stream(response)
+            if _is_sync_stream_lifetime_carrier(response):
+                if _has_static_callable(response, "__next__") or (
+                    _has_static_callable(response, "__enter__")
+                    and _has_static_callable(response, "__exit__")
+                ):
+                    return permit.wrap_stream(response)
+                return _SyncCloseAdmissionProxy(response, permit)
+            # Some adapters and legacy tests return an opaque sentinel even
+            # when stream=True. There is no lifecycle to observe in that
+            # shape, so preserve the raw-return contract and release now.
+            permit.succeed()
+            return response
         permit.succeed()
         return response
 
@@ -277,12 +288,108 @@ class _AsyncAdmissionCompletionsProxy:
             permit.fail(error)
             raise
         if kwargs.get("stream"):
-            return permit.wrap_async_stream(response)
+            if _is_async_stream_lifetime_carrier(response):
+                if _has_static_callable(response, "__anext__") or (
+                    _has_static_callable(response, "__aenter__")
+                    and _has_static_callable(response, "__aexit__")
+                ):
+                    return permit.wrap_async_stream(response)
+                return _AsyncCloseAdmissionProxy(response, permit)
+            permit.succeed()
+            return response
         permit.succeed()
         return response
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._completions, name)
+
+
+def _has_static_callable(response: Any, name: str) -> bool:
+    """Ignore attributes fabricated dynamically by mocks or response shims."""
+
+    try:
+        inspect.getattr_static(response, name)
+        return callable(getattr(response, name))
+    except Exception:
+        return False
+
+
+def _is_sync_stream_lifetime_carrier(response: Any) -> bool:
+    """Whether a sync result exposes a boundary admission can observe."""
+
+    return (
+        _has_static_callable(response, "__next__")
+        or (
+            _has_static_callable(response, "__enter__")
+            and _has_static_callable(response, "__exit__")
+        )
+        or _has_static_callable(response, "close")
+    )
+
+
+def _is_async_stream_lifetime_carrier(response: Any) -> bool:
+    """Async counterpart; ordinary iterables and scalar sentinels are raw."""
+
+    return (
+        _has_static_callable(response, "__anext__")
+        or (
+            _has_static_callable(response, "__aenter__")
+            and _has_static_callable(response, "__aexit__")
+        )
+        or _has_static_callable(response, "aclose")
+    )
+
+
+class _SyncCloseAdmissionProxy:
+    """Delegate a close-only SDK response while releasing its permit on close."""
+
+    def __init__(self, response: Any, permit: Any) -> None:
+        self._response = response
+        self._permit = permit
+
+    def close(self) -> Any:
+        try:
+            result = self._response.close()
+        except BaseException as error:
+            self._permit.fail(error)
+            raise
+        self._permit.release()
+        return result
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._response, name)
+
+    def __del__(self) -> None:
+        try:
+            self._permit.release()
+        except BaseException:
+            pass
+
+
+class _AsyncCloseAdmissionProxy:
+    """Delegate an aclose-only SDK response with the same lifetime contract."""
+
+    def __init__(self, response: Any, permit: Any) -> None:
+        self._response = response
+        self._permit = permit
+
+    async def aclose(self) -> Any:
+        try:
+            result = await self._response.aclose()
+        except BaseException as error:
+            self._permit.fail(error)
+            raise
+        self._permit.release()
+        return result
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._response, name)
+
+    def __del__(self) -> None:
+        try:
+            self._permit.release()
+        except BaseException:
+            pass
 
 
 class _AdmissionChatProxy:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -113,6 +113,229 @@ from utils import base_url_host_matches, base_url_hostname, env_float, model_for
 logger = logging.getLogger(__name__)
 
 
+# ── Process-wide model request admission ────────────────────────────────
+# The registry is initialized lazily from config.yaml on the first real model
+# request and then retained for the lifetime of the process.  That gives the
+# main agent and every auxiliary caller one shared global budget while making
+# the documented "restart required" behavior explicit and predictable.
+_MODEL_ADMISSION_LOCK = threading.Lock()
+_MODEL_ADMISSION_REGISTRY = None
+_MODEL_ADMISSION_DEFAULTS = {
+    "enabled": False,
+    "max_in_flight": 8,
+    "per_target": 8,
+    "min_per_target": 1,
+    "queue_timeout_seconds": 600.0,
+    "additive_successes": 16,
+    "retry_after_max_seconds": 600.0,
+    "idle_state_ttl_seconds": 3600.0,
+    "max_target_states": 1024,
+}
+
+
+def _model_admission_settings_from_config():
+    from agent.model_admission import ModelAdmissionSettings
+    from hermes_cli.config import load_config
+
+    values = dict(_MODEL_ADMISSION_DEFAULTS)
+    try:
+        configured = (load_config() or {}).get("model_admission") or {}
+        if isinstance(configured, dict):
+            values.update(
+                (key, configured[key]) for key in values if key in configured
+            )
+        if not isinstance(values["enabled"], bool):
+            raise ValueError("enabled must be a boolean")
+        return ModelAdmissionSettings(**values)
+    except (TypeError, ValueError) as error:
+        logger.warning(
+            "Ignoring invalid model_admission config; admission remains disabled: %s",
+            error,
+        )
+        return ModelAdmissionSettings(**_MODEL_ADMISSION_DEFAULTS)
+    except Exception as error:
+        # A config read failure must never strand all model traffic.  The
+        # feature is opt-in, so failing open here means "disabled", not
+        # "reject requests".
+        logger.debug("Could not load model_admission config: %s", error)
+        return ModelAdmissionSettings(**_MODEL_ADMISSION_DEFAULTS)
+
+
+def _get_model_admission_registry():
+    global _MODEL_ADMISSION_REGISTRY
+    registry = _MODEL_ADMISSION_REGISTRY
+    if registry is not None:
+        return registry
+    with _MODEL_ADMISSION_LOCK:
+        registry = _MODEL_ADMISSION_REGISTRY
+        if registry is None:
+            from agent.model_admission import ModelAdmissionRegistry
+
+            registry = ModelAdmissionRegistry(_model_admission_settings_from_config())
+            _MODEL_ADMISSION_REGISTRY = registry
+    return registry
+
+
+def _reset_model_admission_registry_for_tests() -> None:
+    """Clear the lazy singleton; production code never reloads it in place."""
+
+    global _MODEL_ADMISSION_REGISTRY
+    with _MODEL_ADMISSION_LOCK:
+        _MODEL_ADMISSION_REGISTRY = None
+
+
+def acquire_model_admission(
+    provider: Optional[str],
+    base_url: Optional[str],
+    model: Optional[str],
+):
+    """Acquire one synchronous permit without retaining credentials."""
+
+    from agent.model_admission import ModelAdmissionPermit
+
+    if str(provider or "").strip().casefold() == "moa":
+        # MoA is an in-process virtual provider. Its real advisor and
+        # aggregator calls run through call_llm() below and are admitted there;
+        # taking an outer permit would double-count and can deadlock at limit 1.
+        return ModelAdmissionPermit.noop()
+    return _get_model_admission_registry().acquire(provider, base_url, model)
+
+
+async def acquire_model_admission_async(
+    provider: Optional[str],
+    base_url: Optional[str],
+    model: Optional[str],
+):
+    """Async counterpart that does not occupy a worker while queued."""
+
+    from agent.model_admission import ModelAdmissionPermit
+
+    if str(provider or "").strip().casefold() == "moa":
+        return ModelAdmissionPermit.noop()
+    return await _get_model_admission_registry().acquire_async(
+        provider, base_url, model
+    )
+
+
+class _SyncAdmissionCompletionsProxy:
+    def __init__(
+        self,
+        completions: Any,
+        *,
+        provider: Optional[str],
+        model: Optional[str],
+        base_url: Optional[str],
+    ) -> None:
+        self._completions = completions
+        self._provider = provider
+        self._model = model
+        self._base_url = base_url
+
+    def create(self, **kwargs) -> Any:
+        permit = acquire_model_admission(
+            self._provider,
+            self._base_url,
+            kwargs.get("model") or self._model,
+        )
+        try:
+            response = self._completions.create(**kwargs)
+        except BaseException as error:
+            permit.fail(error)
+            raise
+        if kwargs.get("stream"):
+            return permit.wrap_stream(response)
+        permit.succeed()
+        return response
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._completions, name)
+
+
+class _AsyncAdmissionCompletionsProxy:
+    def __init__(
+        self,
+        completions: Any,
+        *,
+        provider: Optional[str],
+        model: Optional[str],
+        base_url: Optional[str],
+    ) -> None:
+        self._completions = completions
+        self._provider = provider
+        self._model = model
+        self._base_url = base_url
+
+    async def create(self, **kwargs) -> Any:
+        permit = await acquire_model_admission_async(
+            self._provider,
+            self._base_url,
+            kwargs.get("model") or self._model,
+        )
+        try:
+            response = await self._completions.create(**kwargs)
+        except BaseException as error:
+            permit.fail(error)
+            raise
+        if kwargs.get("stream"):
+            return permit.wrap_async_stream(response)
+        permit.succeed()
+        return response
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._completions, name)
+
+
+class _AdmissionChatProxy:
+    def __init__(self, chat: Any, completions: Any) -> None:
+        self._chat = chat
+        self.completions = completions
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._chat, name)
+
+
+class _AuxiliaryAdmissionClientProxy:
+    _model_admission_wrapped = True
+
+    def __init__(self, client: Any, chat: Any) -> None:
+        self._client = client
+        self.chat = chat
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client, name)
+
+
+def _wrap_auxiliary_client(
+    client: Any,
+    *,
+    provider: Optional[str],
+    model: Optional[str],
+    base_url: Optional[str],
+    async_mode: bool,
+) -> Any:
+    """Wrap one resolved client so every SDK attempt gets its own permit."""
+
+    if client is None or getattr(client, "_model_admission_wrapped", False) is True:
+        return client
+    actual_base_url = str(getattr(client, "base_url", "") or base_url or "")
+    chat = client.chat
+    proxy_type = (
+        _AsyncAdmissionCompletionsProxy
+        if async_mode
+        else _SyncAdmissionCompletionsProxy
+    )
+    completions = proxy_type(
+        chat.completions,
+        provider=provider,
+        model=model,
+        base_url=actual_base_url,
+    )
+    return _AuxiliaryAdmissionClientProxy(
+        client,
+        _AdmissionChatProxy(chat, completions),
+    )
+
+
 # ── resolve_provider_client fall-through dedup ───────────────────────────
 # Both fall-through warning sites in resolve_provider_client (the "unknown
 # provider" and "unhandled auth_type" branches) fire on every retry of a
@@ -3434,6 +3657,11 @@ def _evict_cached_client_instance(target: Any) -> bool:
     """
     if target is None:
         return False
+    # Admission wraps only the public chat surface and keeps the cached SDK
+    # client underneath. Eviction must compare that underlying identity, not
+    # the short-lived per-call proxy.
+    if getattr(target, "_model_admission_wrapped", False) is True:
+        target = target._client
     evicted = False
     with _client_cache_lock:
         for key in list(_client_cache.keys()):
@@ -3611,6 +3839,14 @@ def _retry_same_provider_sync(
             f"Auxiliary {task or 'call'}: provider {resolved_provider} could not be rebuilt after recovery"
         )
 
+    retry_client = _wrap_auxiliary_client(
+        retry_client,
+        provider=resolved_provider,
+        model=retry_model or final_model,
+        base_url=resolved_base_url,
+        async_mode=False,
+    )
+
     retry_base = str(getattr(retry_client, "base_url", "") or "")
     retry_kwargs = _build_call_kwargs(
         resolved_provider,
@@ -3669,6 +3905,14 @@ async def _retry_same_provider_async(
         raise RuntimeError(
             f"Auxiliary {task or 'call'}: provider {resolved_provider} could not be rebuilt after recovery"
         )
+
+    retry_client = _wrap_auxiliary_client(
+        retry_client,
+        provider=resolved_provider,
+        model=retry_model or final_model,
+        base_url=resolved_base_url,
+        async_mode=True,
+    )
 
     retry_base = str(getattr(retry_client, "base_url", "") or "")
     retry_kwargs = _build_call_kwargs(
@@ -3856,6 +4100,13 @@ def _call_fallback_candidate_sync(
     fallback tuned differently from the primary is allowed its own budget
     (#62452).
     """
+    fb_client = _wrap_auxiliary_client(
+        fb_client,
+        provider=fb_label,
+        model=fb_model,
+        base_url=None,
+        async_mode=False,
+    )
     fb_timeout = _fallback_entry_timeout(task, fb_label)
     if fb_timeout is not None and fb_timeout != effective_timeout:
         logger.info(
@@ -3881,6 +4132,13 @@ def _call_fallback_candidate_sync(
         if fb_provider not in {"auto", "", None} and _refresh_provider_credentials(fb_provider):
             retry_client, retry_model = _get_cached_client(fb_provider, fb_model)
             if retry_client is not None:
+                retry_client = _wrap_auxiliary_client(
+                    retry_client,
+                    provider=fb_provider,
+                    model=retry_model or fb_model,
+                    base_url=fb_base,
+                    async_mode=False,
+                )
                 retry_kwargs = _build_call_kwargs(
                     fb_provider, retry_model or fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
@@ -3922,6 +4180,13 @@ async def _call_fallback_candidate_async(
     reasoning_config: Optional[dict],
 ) -> Optional[Any]:
     """Async mirror of :func:`_call_fallback_candidate_sync`."""
+    fb_client = _wrap_auxiliary_client(
+        fb_client,
+        provider=fb_label,
+        model=fb_model,
+        base_url=None,
+        async_mode=True,
+    )
     fb_timeout = _fallback_entry_timeout(task, fb_label)
     if fb_timeout is not None and fb_timeout != effective_timeout:
         logger.info(
@@ -3948,6 +4213,13 @@ async def _call_fallback_candidate_async(
             retry_client, retry_model = _get_cached_client(
                 fb_provider, fb_model, async_mode=True)
             if retry_client is not None:
+                retry_client = _wrap_auxiliary_client(
+                    retry_client,
+                    provider=fb_provider,
+                    model=retry_model or fb_model,
+                    base_url=fb_base,
+                    async_mode=True,
+                )
                 retry_kwargs = _build_call_kwargs(
                     fb_provider, retry_model or fb_model, messages,
                     temperature=temperature, max_tokens=max_tokens,
@@ -7041,6 +7313,13 @@ def call_llm(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
+    client = _wrap_auxiliary_client(
+        client,
+        provider=resolved_provider,
+        model=final_model,
+        base_url=resolved_base_url,
+        async_mode=False,
+    )
     effective_timeout = _effective_aux_timeout(task, timeout)
 
     # Log what we're about to do — makes auxiliary operations visible
@@ -7243,6 +7522,13 @@ def call_llm(
                 is_vision=(task == "vision"),
             )
             if refreshed_client is not None:
+                refreshed_client = _wrap_auxiliary_client(
+                    refreshed_client,
+                    provider=resolved_provider or "nous",
+                    model=refreshed_model or final_model,
+                    base_url=resolved_base_url,
+                    async_mode=False,
+                )
                 logger.info(
                     "Auxiliary %s: refreshed Nous runtime credentials after paid account check, retrying",
                     task or "call",
@@ -7274,6 +7560,13 @@ def call_llm(
                 is_vision=(task == "vision"),
             )
             if refreshed_client is not None:
+                refreshed_client = _wrap_auxiliary_client(
+                    refreshed_client,
+                    provider=resolved_provider or "nous",
+                    model=refreshed_model or final_model,
+                    base_url=resolved_base_url,
+                    async_mode=False,
+                )
                 logger.info("Auxiliary %s: refreshed Nous runtime credentials after 401, retrying",
                             task or "call")
                 if refreshed_model and refreshed_model != kwargs.get("model"):
@@ -7663,6 +7956,13 @@ async def async_call_llm(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
+    client = _wrap_auxiliary_client(
+        client,
+        provider=resolved_provider,
+        model=final_model,
+        base_url=resolved_base_url,
+        async_mode=True,
+    )
     effective_timeout = _effective_aux_timeout(task, timeout)
 
     # Pass the client's actual base_url (not just resolved_base_url) so
@@ -7805,6 +8105,13 @@ async def async_call_llm(
                 is_vision=(task == "vision"),
             )
             if refreshed_client is not None:
+                refreshed_client = _wrap_auxiliary_client(
+                    refreshed_client,
+                    provider=resolved_provider or "nous",
+                    model=refreshed_model or final_model,
+                    base_url=resolved_base_url,
+                    async_mode=True,
+                )
                 logger.info(
                     "Auxiliary %s (async): refreshed Nous runtime credentials after paid account check, retrying",
                     task or "call",
@@ -7835,6 +8142,13 @@ async def async_call_llm(
                 is_vision=(task == "vision"),
             )
             if refreshed_client is not None:
+                refreshed_client = _wrap_auxiliary_client(
+                    refreshed_client,
+                    provider=resolved_provider or "nous",
+                    model=refreshed_model or final_model,
+                    base_url=resolved_base_url,
+                    async_mode=True,
+                )
                 logger.info("Auxiliary %s (async): refreshed Nous runtime credentials after 401, retrying",
                             task or "call")
                 if refreshed_model and refreshed_model != kwargs.get("model"):

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -15,6 +15,7 @@ sites unchanged.  Symbols that tests patch on ``run_agent`` (e.g.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import math
@@ -55,6 +56,28 @@ _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
 # billing reasons keep their own 60s cooldown (set above); this is the
 # narrower non-rate-limit case.  See issue #24996.
 _FALLBACK_EXHAUSTED_COOLDOWN_S = 5.0
+
+
+def _acquire_model_admission(agent, api_kwargs: dict):
+    """Use the process-wide registry shared with all auxiliary model calls."""
+
+    from agent.auxiliary_client import acquire_model_admission
+
+    return acquire_model_admission(
+        getattr(agent, "provider", None),
+        getattr(agent, "base_url", None),
+        api_kwargs.get("model") or getattr(agent, "model", None),
+    )
+
+
+@contextlib.contextmanager
+def _admitted_anthropic_stream(agent, api_kwargs: dict, request_client):
+    """Hold one permit through Anthropic manager exit and stream close."""
+
+    permit = _acquire_model_admission(agent, api_kwargs)
+    with permit:
+        with request_client.messages.stream(**api_kwargs) as stream:
+            yield stream
 
 
 def _ra():
@@ -385,51 +408,56 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
     interrupt, abort, cancellation, and close semantics stay in the callers —
     this helper only issues the request.
     """
-    if agent.api_mode == "codex_responses":
-        request_client = make_client("codex_stream_request")
-        return agent._run_codex_stream(
-            api_kwargs,
-            client=request_client,
-            on_first_delta=getattr(agent, "_codex_on_first_delta", None),
-        )
-    if agent.api_mode == "anthropic_messages":
-        # #67142: use a request-local Anthropic client so the stale/interrupt
-        # watchdog aborts sockets from the stranger thread while the worker
-        # owns the SDK close — never closing the shared client mid-flight.
-        request_client = make_client(
-            "anthropic_messages_request", kind="anthropic_messages"
-        )
-        return agent._anthropic_messages_create(api_kwargs, client=request_client)
-    if agent.api_mode == "bedrock_converse":
-        # Bedrock uses boto3 directly — no OpenAI client needed.
-        # normalize_converse_response produces an OpenAI-compatible
-        # SimpleNamespace so the rest of the agent loop can treat
-        # bedrock responses like chat_completions responses.
-        from agent.bedrock_adapter import (
-            _get_bedrock_runtime_client,
-            invalidate_runtime_client,
-            is_stale_connection_error,
-            normalize_converse_response,
-        )
-        region = api_kwargs.pop("__bedrock_region__", "us-east-1")
-        api_kwargs.pop("__bedrock_converse__", None)
-        client = _get_bedrock_runtime_client(region)
-        try:
-            raw_response = client.converse(**api_kwargs)
-        except Exception as _bedrock_exc:
-            # Evict the cached client on stale-connection failures
-            # so the outer retry loop builds a fresh client/pool.
-            if is_stale_connection_error(_bedrock_exc):
-                invalidate_runtime_client(region)
-            raise
-        return normalize_converse_response(raw_response)
-    if agent.provider == "moa":
-        # MoA is a virtual chat-completions provider backed by the
-        # in-process MoAClient facade. Do not rebuild a request-local
-        # OpenAI client from the virtual runtime metadata.
-        return agent.client.chat.completions.create(**api_kwargs)
-    request_client = make_client("chat_completion_request")
-    return request_client.chat.completions.create(**api_kwargs)
+    permit = _acquire_model_admission(agent, api_kwargs)
+    try:
+        if agent.api_mode == "codex_responses":
+            request_client = make_client("codex_stream_request")
+            response = agent._run_codex_stream(
+                api_kwargs,
+                client=request_client,
+                on_first_delta=getattr(agent, "_codex_on_first_delta", None),
+            )
+        elif agent.api_mode == "anthropic_messages":
+            # #67142: use a request-local Anthropic client so the stale/interrupt
+            # watchdog aborts sockets from the stranger thread while the worker
+            # owns the SDK close — never closing the shared client mid-flight.
+            request_client = make_client(
+                "anthropic_messages_request", kind="anthropic_messages"
+            )
+            response = agent._anthropic_messages_create(
+                api_kwargs, client=request_client
+            )
+        elif agent.api_mode == "bedrock_converse":
+            # Bedrock uses boto3 directly — no OpenAI client needed.
+            from agent.bedrock_adapter import (
+                _get_bedrock_runtime_client,
+                invalidate_runtime_client,
+                is_stale_connection_error,
+                normalize_converse_response,
+            )
+
+            region = api_kwargs.pop("__bedrock_region__", "us-east-1")
+            api_kwargs.pop("__bedrock_converse__", None)
+            client = _get_bedrock_runtime_client(region)
+            try:
+                raw_response = client.converse(**api_kwargs)
+            except Exception as bedrock_error:
+                if is_stale_connection_error(bedrock_error):
+                    invalidate_runtime_client(region)
+                raise
+            response = normalize_converse_response(raw_response)
+        elif agent.provider == "moa":
+            # The virtual outer MoA call gets a no-op permit. Real advisor and
+            # aggregator requests are admitted independently in call_llm().
+            response = agent.client.chat.completions.create(**api_kwargs)
+        else:
+            request_client = make_client("chat_completion_request")
+            response = request_client.chat.completions.create(**api_kwargs)
+    except BaseException as error:
+        permit.fail(error)
+        raise
+    permit.succeed()
+    return response
 
 
 def should_use_direct_api_call(agent) -> bool:
@@ -2087,7 +2115,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
                 final_response = (_summary_result.content or "").strip()
             else:
-                summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary").chat.completions.create(**summary_kwargs)
+                with _acquire_model_admission(agent, summary_kwargs):
+                    summary_response = agent._ensure_primary_openai_client(
+                        reason="iteration_limit_summary"
+                    ).chat.completions.create(**summary_kwargs)
                 _summary_result = agent._get_transport().normalize_response(summary_response)
                 final_response = (_summary_result.content or "").strip()
 
@@ -2130,7 +2161,10 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 if summary_extra_body:
                     summary_kwargs["extra_body"] = summary_extra_body
 
-                summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary_retry").chat.completions.create(**summary_kwargs)
+                with _acquire_model_admission(agent, summary_kwargs):
+                    summary_response = agent._ensure_primary_openai_client(
+                        reason="iteration_limit_summary_retry"
+                    ).chat.completions.create(**summary_kwargs)
                 _retry_result = agent._get_transport().normalize_response(summary_response)
                 final_response = (_retry_result.content or "").strip()
 
@@ -2679,7 +2713,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # ``request_client_holder["diag"]`` for closure access.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
-        stream = request_client.chat.completions.create(**stream_kwargs)
+        admission_permit = _acquire_model_admission(agent, stream_kwargs)
+        try:
+            stream = request_client.chat.completions.create(**stream_kwargs)
+        except BaseException as error:
+            admission_permit.fail(error)
+            raise
         # Claim the delta sink for THIS attempt (#65991). If a prior attempt's
         # stream is somehow still alive (a stale-stream reconnect whose socket
         # abort raced), this claim supersedes it so its late chunks are fenced
@@ -2701,6 +2740,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # the same.  A genuine provider stream (SDK ``Stream`` object,
         # generator) exposes no ``choices`` attribute, so it is left untouched.
         if hasattr(stream, "choices"):
+            admission_permit.succeed()
             logger.info(
                 "Streaming request returned a final response object instead of "
                 "an iterator; switching %s/%s to non-streaming for this session.",
@@ -2728,6 +2768,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     _fire_first_delta()
                     agent._fire_stream_delta(content)
             return stream
+
+        # The permit belongs to the complete response lifecycle, not merely
+        # the SDK's create() call. Exhaustion, iteration errors, and explicit
+        # close are all reported by this proxy.
+        stream = admission_permit.wrap_stream(stream)
 
         # Capture rate limit headers from the initial HTTP response.
         # The OpenAI SDK Stream object exposes the underlying httpx
@@ -2922,6 +2967,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if hasattr(chunk, "usage") and chunk.usage:
                 usage_obj = chunk.usage
 
+        # A superseding attempt or user interrupt can break before iterator
+        # exhaustion. Close explicitly so capacity is released before retry or
+        # backoff rather than waiting for garbage collection.
+        if not admission_permit.is_finished:
+            stream.close()
+
         if _stream_attempt_was_cancelled(stream_attempt_id):
             raise _httpx.RemoteProtocolError(
                 f"stream attempt {stream_attempt_id} was superseded"
@@ -3101,8 +3152,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         sanitize_anthropic_kwargs(
             api_kwargs, log_prefix=getattr(agent, "log_prefix", "")
         )
-        # Use the Anthropic SDK's streaming context manager
-        with request_client.messages.stream(**api_kwargs) as stream:
+        # Use the Anthropic SDK's streaming context manager. Stacking the
+        # permit around it holds capacity until context exit, including the
+        # final-message snapshot and any close-time transport error.
+        with _admitted_anthropic_stream(
+            agent, api_kwargs, request_client
+        ) as stream:
             # The Anthropic SDK exposes the raw httpx response on
             # ``stream.response``.  Snapshot diagnostic headers
             # immediately so they survive a stream that dies before the

--- a/agent/model_admission.py
+++ b/agent/model_admission.py
@@ -1,0 +1,1192 @@
+"""Process-wide admission control for outbound model requests.
+
+The controller deliberately knows nothing about a particular model SDK.  A
+caller acquires a permit immediately before starting a request and completes
+it when the response (including a streaming response) is finished.  Keeping
+that boundary here lets every transport share the same global and per-target
+limits without holding a worker thread for async callers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import math
+import threading
+import time
+from collections import deque
+from collections.abc import AsyncIterator, Callable, Iterator
+from dataclasses import dataclass
+from datetime import timezone
+from email.utils import parsedate_to_datetime
+from typing import Any, Generic, TypeVar
+from urllib.parse import urlsplit, urlunsplit
+
+__all__ = [
+    "ModelAdmissionCancelled",
+    "ModelAdmissionPermit",
+    "ModelAdmissionRegistry",
+    "ModelAdmissionSettings",
+    "ModelAdmissionTimeout",
+    "ModelTarget",
+    "normalize_model_target",
+]
+
+
+class ModelAdmissionTimeout(TimeoutError):
+    """Raised when a request cannot enter before its queue deadline."""
+
+
+class ModelAdmissionCancelled(RuntimeError):
+    """Raised when a queued synchronous request is cancelled."""
+
+
+@dataclass(frozen=True, slots=True)
+class ModelTarget:
+    """A credential-free key for one provider endpoint and model."""
+
+    provider: str
+    base_url: str
+    model: str
+
+
+def _normalize_base_url(base_url: str | None) -> str:
+    raw = "" if base_url is None else str(base_url).strip()
+    if not raw:
+        return ""
+
+    # urlsplit only recognizes a network location when a scheme or ``//`` is
+    # present.  The latter also lets us safely strip credentials from the
+    # scheme-less endpoint forms accepted by some custom providers.
+    has_scheme = "://" in raw
+    try:
+        parsed = urlsplit(raw if has_scheme else f"//{raw}")
+        scheme = parsed.scheme.casefold() if has_scheme else ""
+        host = (parsed.hostname or "").casefold().rstrip(".")
+    except ValueError:
+        # Admission must not make an already-invalid transport URL leak its
+        # credentials through a parser exception.  A short digest keeps bad
+        # endpoints isolated from each other while remaining safe to snapshot.
+        digest = hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()
+        return f"invalid-url:{digest[:16]}"
+
+    if host:
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        try:
+            port = parsed.port
+        except ValueError:
+            # An invalid port must not make diagnostics echo the original URL,
+            # which may contain credentials.  The transport will report the
+            # malformed endpoint separately when it attempts the request.
+            port = None
+        if port is not None and not (
+            (scheme == "https" and port == 443) or (scheme == "http" and port == 80)
+        ):
+            host = f"{host}:{port}"
+
+    path = parsed.path.rstrip("/")
+    if scheme:
+        return urlunsplit((scheme, host, path, "", ""))
+    if host:
+        return f"{host}{path}"
+
+    # Non-network schemes (for example a local test adapter) have no hostname.
+    # urlunsplit still removes any query and fragment from their key.
+    return urlunsplit((parsed.scheme.casefold(), "", path, "", ""))
+
+
+def normalize_model_target(
+    provider: str | None,
+    base_url: str | None,
+    model: str | None,
+) -> ModelTarget:
+    """Return a stable target key that never retains URL credentials."""
+
+    return ModelTarget(
+        provider=("" if provider is None else str(provider)).strip().casefold(),
+        base_url=_normalize_base_url(base_url),
+        model=("" if model is None else str(model)).strip().casefold(),
+    )
+
+
+def _snapshot_base_url(base_url: str) -> str:
+    """Render only an endpoint origin; route paths may contain credentials."""
+
+    if not base_url:
+        return ""
+    if base_url.startswith("invalid-url:"):
+        return "invalid-url"
+    has_scheme = "://" in base_url
+    try:
+        parsed = urlsplit(base_url if has_scheme else f"//{base_url}")
+        host = parsed.netloc if has_scheme else (parsed.netloc or parsed.hostname or "")
+    except ValueError:
+        return "opaque-endpoint"
+    if has_scheme and host:
+        return f"{parsed.scheme.casefold()}://{host}"
+    if host:
+        return host
+    return "opaque-endpoint"
+
+
+def _snapshot_route_id(base_url: str) -> str:
+    if not base_url:
+        return ""
+    return hashlib.sha256(base_url.encode("utf-8", errors="replace")).hexdigest()[:16]
+
+
+@dataclass(frozen=True, slots=True)
+class ModelAdmissionSettings:
+    """Limits and recovery policy for :class:`ModelAdmissionRegistry`."""
+
+    enabled: bool = True
+    max_in_flight: int = 64
+    per_target: int = 8
+    min_per_target: int = 1
+    queue_timeout_seconds: float = 120.0
+    additive_successes: int = 16
+    retry_after_max_seconds: float = 600.0
+    idle_state_ttl_seconds: float = 3600.0
+    max_target_states: int = 1024
+    wait_poll_seconds: float = 0.1
+
+    def __post_init__(self) -> None:
+        positive_ints = {
+            "max_in_flight": self.max_in_flight,
+            "per_target": self.per_target,
+            "min_per_target": self.min_per_target,
+            "additive_successes": self.additive_successes,
+            "max_target_states": self.max_target_states,
+        }
+        for name, value in positive_ints.items():
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if self.min_per_target > self.per_target:
+            raise ValueError("min_per_target cannot exceed per_target")
+
+        non_negative = {
+            "queue_timeout_seconds": self.queue_timeout_seconds,
+            "retry_after_max_seconds": self.retry_after_max_seconds,
+            "idle_state_ttl_seconds": self.idle_state_ttl_seconds,
+        }
+        for name, value in non_negative.items():
+            if not math.isfinite(float(value)) or value < 0:
+                raise ValueError(f"{name} must be finite and non-negative")
+        if (
+            not math.isfinite(float(self.wait_poll_seconds))
+            or self.wait_poll_seconds <= 0
+        ):
+            raise ValueError("wait_poll_seconds must be finite and positive")
+
+
+@dataclass(slots=True)
+class _TargetState:
+    limit: int
+    last_used: float
+    in_flight: int = 0
+    queued: int = 0
+    notified: int = 0
+    congestion_epoch: int = 0
+    successes_toward_increase: int = 0
+    blocked_until: float = 0.0
+    rate_limit_events: int = 0
+    rate_limit_streak: int = 0
+
+
+@dataclass(eq=False, slots=True)
+class _Waiter:
+    target: ModelTarget
+    state: _TargetState
+    deadline: float | None
+    sync_event: threading.Event
+    loop: asyncio.AbstractEventLoop | None = None
+    event: asyncio.Event | None = None
+    active: bool = True
+    notified: bool = False
+    first_check: bool = True
+    terminal_error: BaseException | None = None
+
+
+def _iter_error_chain(error: BaseException) -> Iterator[BaseException]:
+    pending: list[BaseException] = [error]
+    seen: set[int] = set()
+    while pending and len(seen) < 12:
+        current = pending.pop(0)
+        identity = id(current)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        yield current
+        for linked in (current.__cause__, current.__context__):
+            if isinstance(linked, BaseException):
+                pending.append(linked)
+
+
+def _status_code(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_attr(value: Any, name: str, default: Any = None) -> Any:
+    try:
+        return getattr(value, name, default)
+    except Exception:
+        return default
+
+
+def _is_rate_limit_error(error: BaseException) -> bool:
+    for current in _iter_error_chain(error):
+        if _status_code(_safe_attr(current, "status_code")) == 429:
+            return True
+        response = _safe_attr(current, "response")
+        if _status_code(_safe_attr(response, "status_code")) == 429:
+            return True
+        class_name = type(current).__name__.casefold().replace("_", "")
+        if "ratelimit" in class_name or class_name == "toomanyrequestserror":
+            return True
+    return False
+
+
+def _header_value(headers: Any, name: str) -> Any:
+    if headers is None:
+        return None
+    getter = _safe_attr(headers, "get")
+    if callable(getter):
+        for candidate in (name, name.casefold(), name.upper()):
+            try:
+                value = getter(candidate)
+            except Exception:
+                continue
+            if value is not None:
+                return value
+    items = _safe_attr(headers, "items")
+    if callable(items):
+        try:
+            for key, value in items():
+                if str(key).casefold() == name.casefold():
+                    return value
+        except Exception:
+            pass
+    return None
+
+
+def _retry_after_value(error: BaseException) -> Any:
+    for current in _iter_error_chain(error):
+        direct = _safe_attr(current, "retry_after")
+        if direct is not None:
+            return direct
+        response = _safe_attr(current, "response")
+        value = _header_value(_safe_attr(response, "headers"), "Retry-After")
+        if value is not None:
+            return value
+        value = _header_value(_safe_attr(current, "headers"), "Retry-After")
+        if value is not None:
+            return value
+    return None
+
+
+def _parse_retry_after(value: Any, wall_now: float, maximum: float) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        delay = float(value)
+    else:
+        rendered = str(value).strip()
+        try:
+            delay = float(rendered)
+        except ValueError:
+            try:
+                parsed = parsedate_to_datetime(rendered)
+            except (TypeError, ValueError, OverflowError):
+                return None
+            if parsed is None:
+                return None
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            try:
+                delay = parsed.timestamp() - wall_now
+            except (OverflowError, OSError, ValueError):
+                return None
+    if not math.isfinite(delay):
+        return None
+    return min(max(delay, 0.0), maximum)
+
+
+class ModelAdmissionRegistry:
+    """Thread-safe global and per-model request admission registry."""
+
+    def __init__(
+        self,
+        settings: ModelAdmissionSettings | None = None,
+        *,
+        monotonic: Callable[[], float] = time.monotonic,
+        wall_clock: Callable[[], float] = time.time,
+    ) -> None:
+        self.settings = settings or ModelAdmissionSettings()
+        self._monotonic = monotonic
+        self._wall_clock = wall_clock
+        self._condition = threading.Condition(threading.RLock())
+        self._states: dict[ModelTarget, _TargetState] = {}
+        self._waiters: deque[_Waiter] = deque()
+        self._notified_waiters: set[_Waiter] = set()
+        self._in_flight = 0
+        self._notified = 0
+
+    def acquire(
+        self,
+        provider: str | None,
+        base_url: str | None,
+        model: str | None,
+        *,
+        timeout: float | None = None,
+        cancel_check: Callable[[], bool] | None = None,
+    ) -> ModelAdmissionPermit:
+        """Synchronously wait for and return a request permit."""
+
+        if not self.settings.enabled:
+            return ModelAdmissionPermit.noop()
+        target = normalize_model_target(provider, base_url, model)
+        deadline = self._deadline(timeout)
+
+        with self._condition:
+            waiter = self._enqueue_locked(target, deadline=deadline)
+        try:
+            while True:
+                if cancel_check is not None and cancel_check():
+                    error = ModelAdmissionCancelled("Model admission was cancelled")
+                    with self._condition:
+                        self._remove_waiter_locked(waiter, terminal_error=error)
+                        self._dispatch_waiters_locked()
+                    raise error
+                with self._condition:
+                    now = self._monotonic()
+                    if not waiter.active:
+                        raise waiter.terminal_error or ModelAdmissionCancelled(
+                            "Model admission waiter is no longer active"
+                        )
+                    if not waiter.first_check and self._deadline_expired(waiter, now):
+                        error = ModelAdmissionTimeout("Model admission timed out")
+                        self._remove_waiter_locked(waiter, terminal_error=error)
+                        self._dispatch_waiters_locked(now)
+                        raise error
+                    if not waiter.notified and self._has_reservable_capacity_locked(
+                        waiter.state, now
+                    ):
+                        self._dispatch_waiters_locked(now)
+                    if waiter.notified and self._can_admit_locked(waiter, now):
+                        return self._admit_locked(waiter, now)
+                    if waiter.notified:
+                        self._revoke_notification_locked(waiter)
+                        self._dispatch_waiters_locked(now)
+                    waiter.first_check = False
+                    remaining = None if deadline is None else deadline - now
+                    if remaining is not None and remaining <= 0:
+                        error = ModelAdmissionTimeout("Model admission timed out")
+                        self._remove_waiter_locked(waiter, terminal_error=error)
+                        self._dispatch_waiters_locked(now)
+                        raise error
+                    waiter.sync_event.clear()
+                    wait_for = self.settings.wait_poll_seconds
+                    if remaining is not None:
+                        wait_for = min(wait_for, remaining)
+                waiter.sync_event.wait(timeout=wait_for)
+        except BaseException:
+            with self._condition:
+                self._remove_waiter_locked(waiter)
+                self._dispatch_waiters_locked()
+            raise
+
+    async def acquire_async(
+        self,
+        provider: str | None,
+        base_url: str | None,
+        model: str | None,
+        *,
+        timeout: float | None = None,
+        cancel_check: Callable[[], bool] | None = None,
+    ) -> ModelAdmissionPermit:
+        """Asynchronously wait without occupying a worker thread."""
+
+        if not self.settings.enabled:
+            return ModelAdmissionPermit.noop()
+        target = normalize_model_target(provider, base_url, model)
+        deadline = self._deadline(timeout)
+        loop = asyncio.get_running_loop()
+        event = asyncio.Event()
+
+        with self._condition:
+            waiter = self._enqueue_locked(
+                target,
+                deadline=deadline,
+                loop=loop,
+                event=event,
+            )
+        try:
+            while True:
+                if cancel_check is not None and cancel_check():
+                    error = ModelAdmissionCancelled("Model admission was cancelled")
+                    with self._condition:
+                        self._remove_waiter_locked(waiter, terminal_error=error)
+                        self._dispatch_waiters_locked()
+                    raise error
+                with self._condition:
+                    now = self._monotonic()
+                    if not waiter.active:
+                        raise waiter.terminal_error or ModelAdmissionCancelled(
+                            "Model admission waiter is no longer active"
+                        )
+                    if not waiter.first_check and self._deadline_expired(waiter, now):
+                        error = ModelAdmissionTimeout("Model admission timed out")
+                        self._remove_waiter_locked(waiter, terminal_error=error)
+                        self._dispatch_waiters_locked(now)
+                        raise error
+                    if not waiter.notified and self._has_reservable_capacity_locked(
+                        waiter.state, now
+                    ):
+                        self._dispatch_waiters_locked(now)
+                    if waiter.notified and self._can_admit_locked(waiter, now):
+                        return self._admit_locked(waiter, now)
+                    if waiter.notified:
+                        self._revoke_notification_locked(waiter)
+                        self._dispatch_waiters_locked(now)
+                    waiter.first_check = False
+                    remaining = None if deadline is None else deadline - now
+                    if remaining is not None and remaining <= 0:
+                        error = ModelAdmissionTimeout("Model admission timed out")
+                        self._remove_waiter_locked(waiter, terminal_error=error)
+                        self._dispatch_waiters_locked(now)
+                        raise error
+                    event.clear()
+                    wait_for = self.settings.wait_poll_seconds
+                    if remaining is not None:
+                        wait_for = min(wait_for, remaining)
+                try:
+                    await asyncio.wait_for(event.wait(), timeout=wait_for)
+                except TimeoutError:
+                    pass
+        except BaseException:
+            with self._condition:
+                self._remove_waiter_locked(waiter)
+                self._dispatch_waiters_locked()
+            raise
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return bounded, credential-free diagnostics for observability."""
+
+        with self._condition:
+            now = self._monotonic()
+            self._prune_stale_waiters_locked(now, scan_all=True)
+            self._dispatch_waiters_locked(now)
+            self._cleanup_idle_locked(now)
+            targets = [
+                {
+                    "provider": target.provider,
+                    "base_url": _snapshot_base_url(target.base_url),
+                    "route_id": _snapshot_route_id(target.base_url),
+                    "model": target.model,
+                    "limit": state.limit,
+                    "in_flight": state.in_flight,
+                    "queued": state.queued,
+                    "congestion_epoch": state.congestion_epoch,
+                    "successes_toward_increase": state.successes_toward_increase,
+                    "blocked_for_seconds": max(0.0, state.blocked_until - now),
+                    "rate_limit_events": state.rate_limit_events,
+                }
+                for target, state in sorted(
+                    self._states.items(),
+                    key=lambda item: (
+                        item[0].provider,
+                        item[0].base_url,
+                        item[0].model,
+                    ),
+                )
+            ]
+            return {
+                "enabled": self.settings.enabled,
+                "global": {
+                    "in_flight": self._in_flight,
+                    "max_in_flight": self.settings.max_in_flight,
+                    "queued": len(self._waiters),
+                },
+                "targets": targets,
+            }
+
+    def _deadline(self, timeout: float | None) -> float | None:
+        duration = self.settings.queue_timeout_seconds if timeout is None else timeout
+        duration = float(duration)
+        if math.isnan(duration):
+            raise ValueError("timeout must not be NaN")
+        if math.isinf(duration):
+            if duration > 0:
+                return None
+            duration = 0.0
+        return self._monotonic() + max(0.0, duration)
+
+    def _enqueue_locked(
+        self,
+        target: ModelTarget,
+        *,
+        deadline: float | None,
+        loop: asyncio.AbstractEventLoop | None = None,
+        event: asyncio.Event | None = None,
+    ) -> _Waiter:
+        now = self._monotonic()
+        self._cleanup_idle_locked(now)
+        state = self._states.get(target)
+        if state is None:
+            state = _TargetState(limit=self.settings.per_target, last_used=now)
+            self._states[target] = state
+        state.queued += 1
+        state.last_used = now
+        waiter = _Waiter(
+            target=target,
+            state=state,
+            deadline=deadline,
+            sync_event=threading.Event(),
+            loop=loop,
+            event=event,
+        )
+        self._waiters.append(waiter)
+        # Enqueuing behind a blocked/saturated target (or a full global pool)
+        # cannot make any waiter newly eligible.  Avoid rescanning the whole
+        # queue on every such enqueue; the next capacity/state transition or
+        # the waiter's bounded poll will dispatch eligible work.
+        if self._has_reservable_capacity_locked(state, now):
+            self._dispatch_waiters_locked(now)
+        return waiter
+
+    def _has_reservable_capacity_locked(
+        self,
+        state: _TargetState,
+        now: float,
+    ) -> bool:
+        return (
+            self._in_flight + self._notified < self.settings.max_in_flight
+            and now >= state.blocked_until
+            and state.in_flight + state.notified < state.limit
+        )
+
+    def _can_admit_locked(self, waiter: _Waiter, now: float) -> bool:
+        return (
+            waiter.active
+            and waiter.notified
+            and self._in_flight < self.settings.max_in_flight
+            and waiter.state.in_flight < waiter.state.limit
+            and now >= waiter.state.blocked_until
+        )
+
+    def _admit_locked(self, waiter: _Waiter, now: float) -> ModelAdmissionPermit:
+        self._remove_waiter_locked(waiter)
+        waiter.state.in_flight += 1
+        waiter.state.last_used = now
+        self._in_flight += 1
+        self._dispatch_waiters_locked(now)
+        return ModelAdmissionPermit(
+            registry=self,
+            target=waiter.target,
+            congestion_epoch=waiter.state.congestion_epoch,
+        )
+
+    def _remove_waiter_locked(
+        self,
+        waiter: _Waiter,
+        *,
+        terminal_error: BaseException | None = None,
+        wake: bool = False,
+    ) -> None:
+        if not waiter.active:
+            return
+        try:
+            self._waiters.remove(waiter)
+        except ValueError:
+            waiter.active = False
+            return
+        waiter.active = False
+        if waiter.notified:
+            self._revoke_notification_locked(waiter)
+        waiter.state.queued = max(0, waiter.state.queued - 1)
+        waiter.state.last_used = self._monotonic()
+        if terminal_error is not None:
+            waiter.terminal_error = terminal_error
+        if wake:
+            self._signal_waiter_locked(waiter)
+
+    def _revoke_notification_locked(self, waiter: _Waiter) -> None:
+        if not waiter.notified:
+            return
+        waiter.notified = False
+        waiter.state.notified = max(0, waiter.state.notified - 1)
+        self._notified = max(0, self._notified - 1)
+        self._notified_waiters.discard(waiter)
+
+    @staticmethod
+    def _deadline_expired(waiter: _Waiter, now: float) -> bool:
+        return waiter.deadline is not None and now >= waiter.deadline
+
+    @staticmethod
+    def _loop_closed(waiter: _Waiter) -> bool:
+        if waiter.loop is None:
+            return False
+        try:
+            return waiter.loop.is_closed()
+        except Exception:
+            return True
+
+    def _drop_stale_waiter_locked(self, waiter: _Waiter, now: float) -> bool:
+        if not waiter.active:
+            return True
+        if self._loop_closed(waiter):
+            self._remove_waiter_locked(waiter)
+            return True
+        if not waiter.first_check and self._deadline_expired(waiter, now):
+            self._remove_waiter_locked(
+                waiter,
+                terminal_error=ModelAdmissionTimeout("Model admission timed out"),
+                wake=True,
+            )
+            return True
+        return False
+
+    def _prune_stale_waiters_locked(self, now: float, *, scan_all: bool) -> None:
+        candidates = self._waiters if scan_all else self._notified_waiters
+        for waiter in tuple(candidates):
+            self._drop_stale_waiter_locked(waiter, now)
+
+    def _signal_waiter_locked(self, waiter: _Waiter) -> bool:
+        if waiter.loop is None or waiter.event is None:
+            waiter.sync_event.set()
+            return True
+        if self._loop_closed(waiter):
+            return False
+        try:
+            waiter.loop.call_soon_threadsafe(waiter.event.set)
+            return True
+        except RuntimeError:
+            return False
+
+    def _dispatch_waiters_locked(self, now: float | None = None) -> None:
+        now = self._monotonic() if now is None else now
+        # Already-signalled waiters are at most max_in_flight, so this stale
+        # check stays bounded even when the queue contains thousands of tasks.
+        self._prune_stale_waiters_locked(now, scan_all=False)
+        available = self.settings.max_in_flight - self._in_flight - self._notified
+        if available <= 0:
+            return
+
+        for waiter in tuple(self._waiters):
+            if available <= 0:
+                break
+            if waiter.notified or self._drop_stale_waiter_locked(waiter, now):
+                continue
+            state = waiter.state
+            if now < state.blocked_until:
+                continue
+            if state.in_flight + state.notified >= state.limit:
+                continue
+
+            waiter.notified = True
+            state.notified += 1
+            self._notified += 1
+            self._notified_waiters.add(waiter)
+            if self._signal_waiter_locked(waiter):
+                available -= 1
+            else:
+                self._remove_waiter_locked(waiter)
+
+    def _revoke_target_notifications_locked(self, state: _TargetState) -> None:
+        for waiter in tuple(self._notified_waiters):
+            if waiter.state is state:
+                self._revoke_notification_locked(waiter)
+
+    def _complete(
+        self,
+        target: ModelTarget,
+        congestion_epoch: int,
+        *,
+        succeeded: bool,
+        error: BaseException | None,
+    ) -> None:
+        try:
+            is_rate_limit = error is not None and _is_rate_limit_error(error)
+            retry_after = (
+                _parse_retry_after(
+                    _retry_after_value(error),
+                    self._wall_clock(),
+                    self.settings.retry_after_max_seconds,
+                )
+                if is_rate_limit and error is not None
+                else None
+            )
+        except Exception:
+            # A non-standard SDK exception must never prevent capacity release.
+            is_rate_limit = False
+            retry_after = None
+
+        with self._condition:
+            now = self._monotonic()
+            state = self._states.get(target)
+            self._in_flight = max(0, self._in_flight - 1)
+            if state is None:
+                self._dispatch_waiters_locked(now)
+                return
+            state.in_flight = max(0, state.in_flight - 1)
+            state.last_used = now
+
+            if is_rate_limit:
+                state.rate_limit_events += 1
+                new_congestion_epoch = congestion_epoch == state.congestion_epoch
+                if new_congestion_epoch:
+                    state.rate_limit_streak += 1
+                    state.limit = max(
+                        self.settings.min_per_target,
+                        state.limit // 2,
+                    )
+                    state.congestion_epoch += 1
+                    state.successes_toward_increase = 0
+                delay = retry_after
+                if delay is None and new_congestion_epoch:
+                    delay = min(
+                        self.settings.retry_after_max_seconds,
+                        float(2 ** min(state.rate_limit_streak - 1, 6)),
+                    )
+                if delay is not None:
+                    state.blocked_until = max(state.blocked_until, now + delay)
+                self._revoke_target_notifications_locked(state)
+            elif succeeded and congestion_epoch == state.congestion_epoch:
+                state.rate_limit_streak = 0
+                if state.limit < self.settings.per_target:
+                    state.successes_toward_increase += 1
+                    if (
+                        state.successes_toward_increase
+                        >= self.settings.additive_successes
+                    ):
+                        state.limit += 1
+                        state.successes_toward_increase = 0
+
+            self._cleanup_idle_locked(now)
+            self._dispatch_waiters_locked(now)
+
+    def _cleanup_idle_locked(self, now: float) -> None:
+        idle = [
+            (target, state)
+            for target, state in self._states.items()
+            if state.in_flight == 0
+            and state.queued == 0
+            and state.notified == 0
+            and now >= state.blocked_until
+        ]
+        ttl = self.settings.idle_state_ttl_seconds
+        for target, state in idle:
+            if now - state.last_used >= ttl:
+                self._states.pop(target, None)
+
+        overflow = len(self._states) - self.settings.max_target_states
+        if overflow <= 0:
+            return
+        remaining_idle = sorted(
+            (
+                (target, state)
+                for target, state in self._states.items()
+                if state.in_flight == 0
+                and state.queued == 0
+                and state.notified == 0
+                and now >= state.blocked_until
+            ),
+            key=lambda item: item[1].last_used,
+        )
+        for target, _state in remaining_idle[:overflow]:
+            self._states.pop(target, None)
+
+
+_T = TypeVar("_T")
+
+
+class ModelAdmissionPermit:
+    """An idempotent permit whose lifetime covers the complete response."""
+
+    def __init__(
+        self,
+        *,
+        registry: ModelAdmissionRegistry | None,
+        target: ModelTarget | None,
+        congestion_epoch: int,
+    ) -> None:
+        self._registry = registry
+        self._target = target
+        self._congestion_epoch = congestion_epoch
+        self._finish_lock = threading.Lock()
+        self._finished = False
+        self._stream_owned = False
+
+    @classmethod
+    def noop(cls) -> ModelAdmissionPermit:
+        return cls(registry=None, target=None, congestion_epoch=0)
+
+    @property
+    def is_noop(self) -> bool:
+        return self._registry is None
+
+    @property
+    def is_finished(self) -> bool:
+        with self._finish_lock:
+            return self._finished
+
+    def succeed(self) -> None:
+        self._finish(succeeded=True, error=None)
+
+    def fail(self, error: BaseException) -> None:
+        if not isinstance(error, BaseException):
+            raise TypeError("error must be an exception")
+        self._finish(succeeded=False, error=error)
+
+    def release(self) -> None:
+        """Release without treating an early cancellation as a success."""
+
+        self._finish(succeeded=False, error=None)
+
+    def _finish(
+        self,
+        *,
+        succeeded: bool,
+        error: BaseException | None,
+        defer_if_stream_owned: bool = False,
+    ) -> None:
+        with self._finish_lock:
+            if self._finished:
+                return
+            if defer_if_stream_owned and self._stream_owned:
+                return
+            self._finished = True
+        if self._registry is not None and self._target is not None:
+            self._registry._complete(
+                self._target,
+                self._congestion_epoch,
+                succeeded=succeeded,
+                error=error,
+            )
+
+    def _claim_stream_ownership(self) -> None:
+        with self._finish_lock:
+            if self._finished:
+                raise RuntimeError("Cannot wrap a stream with a finished permit")
+            if self._stream_owned:
+                raise RuntimeError("A permit can own only one stream")
+            self._stream_owned = True
+
+    def wrap_stream(self, stream: Any) -> _PermitStream[_T]:
+        self._claim_stream_ownership()
+        try:
+            return _PermitStream(stream, self)
+        except BaseException as error:
+            self.fail(error)
+            raise
+
+    # A descriptive alias is useful at integration sites that handle both
+    # sync and async SDKs in the same function.
+    wrap_sync_stream = wrap_stream
+
+    def wrap_async_stream(self, stream: Any) -> _PermitAsyncStream[_T]:
+        self._claim_stream_ownership()
+        try:
+            return _PermitAsyncStream(stream, self)
+        except BaseException as error:
+            self.fail(error)
+            raise
+
+    def __enter__(self) -> ModelAdmissionPermit:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: Any,
+    ) -> bool:
+        if exc is None:
+            self._finish(
+                succeeded=True,
+                error=None,
+                defer_if_stream_owned=True,
+            )
+        else:
+            self.fail(exc)
+        return False
+
+    async def __aenter__(self) -> ModelAdmissionPermit:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: Any,
+    ) -> bool:
+        if exc is None:
+            self._finish(
+                succeeded=True,
+                error=None,
+                defer_if_stream_owned=True,
+            )
+        else:
+            self.fail(exc)
+        return False
+
+    def __del__(self) -> None:
+        try:
+            self.release()
+        except BaseException:
+            pass
+
+
+class _PermitStream(Generic[_T]):
+    """Iterator proxy that releases its permit at the real stream boundary."""
+
+    def __init__(self, stream: Any, permit: ModelAdmissionPermit) -> None:
+        self._stream = stream
+        self._entered_stream: Any = None
+        self._context_entered = False
+        self._exhausted = False
+        self._pending_error: BaseException | None = None
+        self._permit = permit
+        try:
+            self._iterator: Iterator[_T] | None = iter(stream)
+        except TypeError:
+            # Some SDKs return a context manager whose entered value is the
+            # iterable stream.  Defer iterator construction until __enter__.
+            if not callable(_safe_attr(stream, "__enter__")):
+                raise
+            self._iterator = None
+
+    def __iter__(self) -> _PermitStream[_T]:
+        return self
+
+    def _active_stream(self) -> Any:
+        return (
+            self._entered_stream if self._entered_stream is not None else self._stream
+        )
+
+    def _record_error(self, error: BaseException) -> None:
+        if self._context_entered:
+            if self._pending_error is None:
+                self._pending_error = error
+        else:
+            self._permit.fail(error)
+
+    def __next__(self) -> _T:
+        try:
+            if self._iterator is None:
+                self._iterator = iter(self._stream)
+            return next(self._iterator)
+        except StopIteration:
+            self._exhausted = True
+            if not self._context_entered:
+                self._permit.succeed()
+            raise
+        except BaseException as error:
+            self._record_error(error)
+            raise
+
+    def close(self) -> None:
+        try:
+            target = self._active_stream()
+            close = _safe_attr(target, "close")
+            if callable(close):
+                close()
+        except BaseException as error:
+            self._record_error(error)
+            raise
+        else:
+            # A manager can still fail in __exit__ (including with a 429), so
+            # only the manager exit owns completion once context entry began.
+            if not self._context_entered:
+                self._permit.release()
+
+    def __enter__(self) -> _PermitStream[_T]:
+        self._context_entered = True
+        enter = _safe_attr(self._stream, "__enter__")
+        try:
+            entered = enter() if callable(enter) else self._stream
+            self._entered_stream = entered
+            if callable(enter):
+                self._iterator = iter(entered)
+            return self
+        except BaseException as error:
+            self._permit.fail(error)
+            raise
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: Any,
+    ) -> bool:
+        suppressed = False
+        try:
+            exit_method = _safe_attr(self._stream, "__exit__")
+            if callable(exit_method):
+                suppressed = bool(exit_method(exc_type, exc, traceback))
+            else:
+                target = self._active_stream()
+                close = _safe_attr(target, "close")
+                if callable(close):
+                    close()
+        except BaseException as close_error:
+            self._pending_error = None
+            self._permit.fail(close_error)
+            raise
+        if exc is not None:
+            self._permit.fail(exc)
+        elif self._pending_error is not None:
+            self._permit.fail(self._pending_error)
+        elif self._exhausted:
+            self._permit.succeed()
+        else:
+            self._permit.release()
+        self._pending_error = None
+        return suppressed
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._active_stream(), name)
+
+    def __del__(self) -> None:
+        # This is a safety net for consumers that abandon a stream without
+        # closing it.  Explicit close/context management remains deterministic.
+        try:
+            self._permit.release()
+        except BaseException:
+            pass
+
+
+class _PermitAsyncStream(Generic[_T]):
+    """Async iterator proxy with the same lifetime rules as `_PermitStream`."""
+
+    def __init__(
+        self,
+        stream: Any,
+        permit: ModelAdmissionPermit,
+    ) -> None:
+        self._stream = stream
+        self._entered_stream: Any = None
+        self._context_entered = False
+        self._exhausted = False
+        self._pending_error: BaseException | None = None
+        self._permit = permit
+        iterator_factory = _safe_attr(stream, "__aiter__")
+        if callable(iterator_factory):
+            self._iterator: AsyncIterator[_T] | None = iterator_factory()
+        elif callable(_safe_attr(stream, "__aenter__")):
+            # As with sync SDKs, an async stream manager may only expose the
+            # iterator returned from its context entry.
+            self._iterator = None
+        else:
+            raise TypeError("stream is not an async iterable or context manager")
+
+    def __aiter__(self) -> _PermitAsyncStream[_T]:
+        return self
+
+    def _active_stream(self) -> Any:
+        return (
+            self._entered_stream if self._entered_stream is not None else self._stream
+        )
+
+    def _record_error(self, error: BaseException) -> None:
+        if self._context_entered:
+            if self._pending_error is None:
+                self._pending_error = error
+        else:
+            self._permit.fail(error)
+
+    async def __anext__(self) -> _T:
+        try:
+            if self._iterator is None:
+                raise TypeError("async stream context must be entered before iteration")
+            return await self._iterator.__anext__()
+        except StopAsyncIteration:
+            self._exhausted = True
+            if not self._context_entered:
+                self._permit.succeed()
+            raise
+        except BaseException as error:
+            self._record_error(error)
+            raise
+
+    async def aclose(self) -> None:
+        try:
+            target = self._active_stream()
+            aclose = _safe_attr(target, "aclose")
+            close = _safe_attr(target, "close")
+            if callable(aclose):
+                await aclose()
+            elif callable(close):
+                result = close()
+                if hasattr(result, "__await__"):
+                    await result
+        except BaseException as error:
+            self._record_error(error)
+            raise
+        else:
+            # As in the sync wrapper, __aexit__ owns the final outcome after
+            # context entry because it can still surface a rate-limit error.
+            if not self._context_entered:
+                self._permit.release()
+
+    async def __aenter__(self) -> _PermitAsyncStream[_T]:
+        self._context_entered = True
+        enter = _safe_attr(self._stream, "__aenter__")
+        try:
+            entered = await enter() if callable(enter) else self._stream
+            self._entered_stream = entered
+            if callable(enter):
+                self._iterator = entered.__aiter__()
+            return self
+        except BaseException as error:
+            self._permit.fail(error)
+            raise
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: Any,
+    ) -> bool:
+        suppressed = False
+        try:
+            exit_method = _safe_attr(self._stream, "__aexit__")
+            if callable(exit_method):
+                suppressed = bool(await exit_method(exc_type, exc, traceback))
+            else:
+                target = self._active_stream()
+                aclose = _safe_attr(target, "aclose")
+                close = _safe_attr(target, "close")
+                if callable(aclose):
+                    await aclose()
+                elif callable(close):
+                    result = close()
+                    if hasattr(result, "__await__"):
+                        await result
+        except BaseException as close_error:
+            self._pending_error = None
+            self._permit.fail(close_error)
+            raise
+        if exc is not None:
+            self._permit.fail(exc)
+        elif self._pending_error is not None:
+            self._permit.fail(self._pending_error)
+        elif self._exhausted:
+            self._permit.succeed()
+        else:
+            self._permit.release()
+        self._pending_error = None
+        return suppressed
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._active_stream(), name)
+
+    def __del__(self) -> None:
+        try:
+            self._permit.release()
+        except BaseException:
+            pass

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -614,6 +614,17 @@ session_reset:
 # local runtime lease registry cannot be read or locked.
 max_concurrent_sessions: null
 
+# Number of gateway-owned worker threads available for synchronous agent turns.
+# Raising this can reduce cross-session queueing when many long turns are active,
+# but increases memory use, tool concurrency, and upstream provider pressure.
+# Must be a positive integer; invalid values fall back to 10. There is no fixed
+# upper bound, so size this conservatively for available memory, tool capacity,
+# and provider limits. The pool is created lazily, so restart the gateway after
+# changing this value. This is separate from max_concurrent_sessions, which
+# limits admission across all chat surfaces.
+gateway:
+  agent_executor_workers: 10
+
 # When true, group/channel chats use one session per participant when the platform
 # provides a user ID. This is the secure default and prevents users in the same
 # room from sharing context, interrupts, and token costs. Set false only if you

--- a/contributors/emails/StellarisW@users.noreply.github.com
+++ b/contributors/emails/StellarisW@users.noreply.github.com
@@ -1,0 +1,2 @@
+StellarisW
+# PR #65740

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -23,6 +23,9 @@ from utils import is_truthy_value
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_AGENT_EXECUTOR_WORKERS = 10
+
+
 def _coerce_bool(value: Any, default: bool = True) -> bool:
     """Coerce bool-ish config values, preserving a caller-provided default."""
     if value is None:
@@ -187,6 +190,35 @@ def coerce_systemd_watchdog_seconds(
             _SYSTEMD_WATCHDOG_MAX_SECONDS,
         )
         return 0
+    return parsed
+
+
+def _coerce_positive_int(
+    value: Any,
+    key: str,
+    default: int,
+) -> int:
+    """Coerce a required positive integer, falling back on invalid input."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        parsed = None
+    else:
+        try:
+            if isinstance(value, float) and not value.is_integer():
+                raise ValueError(value)
+            parsed = int(value)
+        except (TypeError, ValueError):
+            parsed = None
+    if parsed is None or parsed <= 0:
+        logger.warning(
+            "Ignoring invalid %s=%r (expected %s); using %d",
+            key,
+            value,
+            "a positive integer",
+            default,
+        )
+        return default
     return parsed
 
 
@@ -900,6 +932,11 @@ class GatewayConfig:
     # dict with: name, platform, profile, and optional guild_id/chat_id/thread_id.
     profile_routes: list = field(default_factory=list)
 
+    # Worker threads that run synchronous agent turns without blocking the
+    # gateway event loop. Applied when the pool is created; restart to change.
+    # Keep new fields at the end to preserve positional-constructor compatibility.
+    agent_executor_workers: int = DEFAULT_AGENT_EXECUTOR_WORKERS
+
     def __post_init__(self) -> None:
         self.systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(
             self.systemd_watchdog_seconds
@@ -1014,6 +1051,7 @@ class GatewayConfig:
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "max_concurrent_sessions": self.max_concurrent_sessions,
+            "agent_executor_workers": self.agent_executor_workers,
             "multiplex_profiles": self.multiplex_profiles,
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
@@ -1077,7 +1115,7 @@ class GatewayConfig:
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
         multiplex_profiles = data.get("multiplex_profiles")
-        nested_gateway = data.get("gateway") if isinstance(data.get("gateway"), dict) else {}
+        nested_gateway = _coerce_dict(data.get("gateway"))
         if "systemd_watchdog_seconds" in data:
             systemd_watchdog_raw = data.get("systemd_watchdog_seconds")
             systemd_watchdog_key = "systemd_watchdog_seconds"
@@ -1087,7 +1125,7 @@ class GatewayConfig:
         systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(
             systemd_watchdog_raw, systemd_watchdog_key
         )
-        if multiplex_profiles is None and isinstance(nested_gateway, dict):
+        if multiplex_profiles is None:
             # Also honor gateway.multiplex_profiles written by
             # ``hermes config set gateway.multiplex_profiles true``.
             multiplex_profiles = nested_gateway.get("multiplex_profiles")
@@ -1112,6 +1150,17 @@ class GatewayConfig:
         max_concurrent_sessions = _coerce_optional_positive_int(
             max_concurrent_raw,
             max_concurrent_key,
+        )
+        if "agent_executor_workers" in data:
+            agent_executor_workers_raw = data.get("agent_executor_workers")
+            agent_executor_workers_key = "agent_executor_workers"
+        else:
+            agent_executor_workers_raw = nested_gateway.get("agent_executor_workers")
+            agent_executor_workers_key = "gateway.agent_executor_workers"
+        agent_executor_workers = _coerce_positive_int(
+            agent_executor_workers_raw,
+            agent_executor_workers_key,
+            DEFAULT_AGENT_EXECUTOR_WORKERS,
         )
         unauthorized_dm_behavior = _normalize_unauthorized_dm_behavior(
             data.get("unauthorized_dm_behavior"),
@@ -1148,6 +1197,7 @@ class GatewayConfig:
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
             systemd_watchdog_seconds=systemd_watchdog_seconds,
             max_concurrent_sessions=max_concurrent_sessions,
+            agent_executor_workers=agent_executor_workers,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
@@ -1307,6 +1357,8 @@ def load_gateway_config() -> GatewayConfig:
                     gw_data["systemd_watchdog_seconds"] = gateway_section[
                         "systemd_watchdog_seconds"
                     ]
+                if "agent_executor_workers" in gateway_section:
+                    gw_data["agent_executor_workers"] = gateway_section["agent_executor_workers"]
 
             if "max_concurrent_sessions" in yaml_cfg:
                 gw_data["max_concurrent_sessions"] = yaml_cfg["max_concurrent_sessions"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1902,6 +1902,7 @@ if not _configured_cwd or _configured_cwd in CWD_PLACEHOLDERS:
 
 from gateway.config import (
     ChannelOverride,
+    DEFAULT_AGENT_EXECUTOR_WORKERS,
     Platform,
     _BUILTIN_PLATFORM_VALUES,
     GatewayConfig,
@@ -16443,8 +16444,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 raise RuntimeError("Gateway is shutting down; executor unavailable")
             executor = getattr(self, "_executor", None)
             if executor is None or getattr(executor, "_shutdown", False):
+                workers = getattr(
+                    getattr(self, "config", None),
+                    "agent_executor_workers",
+                    DEFAULT_AGENT_EXECUTOR_WORKERS,
+                )
                 executor = concurrent.futures.ThreadPoolExecutor(
-                    max_workers=10,
+                    max_workers=workers,
                     thread_name_prefix="hermes-gateway",
                 )
                 self._executor = executor

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1004,6 +1004,21 @@ DEFAULT_CONFIG = {
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,
+    # Process-wide admission control for outbound model API requests. This is
+    # opt-in for compatibility; once enabled it bounds both primary turns and
+    # auxiliary calls (compression, vision, MoA advisors/aggregator, etc.).
+    # The registry is created lazily and retained, so changes require restart.
+    "model_admission": {
+        "enabled": False,
+        "max_in_flight": 8,
+        "per_target": 8,
+        "min_per_target": 1,
+        "queue_timeout_seconds": 600.0,
+        "additive_successes": 16,
+        "retry_after_max_seconds": 600.0,
+        "idle_state_ttl_seconds": 3600.0,
+        "max_target_states": 1024,
+    },
     # Soft LRU cap on in-memory TUI/desktop/dashboard sessions. When more than
     # this many are live, the gateway evicts the least-recently-active DETACHED
     # sessions (no live client) so accumulated agents don't pile up under memory

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3006,6 +3006,13 @@ DEFAULT_CONFIG = {
         # crash/restart, as before.
         "delivery_ledger": True,
 
+        # Worker threads used to run synchronous agent turns without blocking
+        # the messaging event loop. Higher values admit more simultaneous
+        # turns but increase memory use and upstream provider pressure. The
+        # pool is created lazily, so changing this setting requires a gateway
+        # restart. Must be a positive integer.
+        "agent_executor_workers": 10,
+
         # Seconds the gateway waits for a single messaging platform to finish
         # connecting during startup (and on reconnect). Discord in particular
         # can blow past the old fixed 30s when an account has many slash

--- a/tests/agent/test_model_admission.py
+++ b/tests/agent/test_model_admission.py
@@ -1,0 +1,727 @@
+"""Behavior tests for process-wide model request admission."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from email.utils import format_datetime
+from types import SimpleNamespace
+
+import pytest
+
+from agent.model_admission import (
+    ModelAdmissionCancelled,
+    ModelAdmissionRegistry,
+    ModelAdmissionSettings,
+    ModelAdmissionTimeout,
+    normalize_model_target,
+)
+
+
+class _Clock:
+    def __init__(self, *, monotonic: float = 100.0, wall: float = 1_800_000_000.0):
+        self.monotonic_value = monotonic
+        self.wall_value = wall
+
+    def monotonic(self) -> float:
+        return self.monotonic_value
+
+    def wall(self) -> float:
+        return self.wall_value
+
+    def advance(self, seconds: float) -> None:
+        self.monotonic_value += seconds
+        self.wall_value += seconds
+
+
+class _RateLimitError(Exception):
+    status_code = 429
+
+    def __init__(self, retry_after=None):
+        super().__init__("rate limited")
+        headers = {} if retry_after is None else {"Retry-After": retry_after}
+        self.response = SimpleNamespace(status_code=429, headers=headers)
+
+
+def _settings(**overrides) -> ModelAdmissionSettings:
+    values = {
+        "enabled": True,
+        "max_in_flight": 8,
+        "per_target": 4,
+        "min_per_target": 1,
+        "queue_timeout_seconds": 2.0,
+        "additive_successes": 2,
+        "retry_after_max_seconds": 600.0,
+        "idle_state_ttl_seconds": 3600.0,
+        "max_target_states": 256,
+        "wait_poll_seconds": 0.01,
+    }
+    values.update(overrides)
+    return ModelAdmissionSettings(**values)
+
+
+def _target_snapshot(registry: ModelAdmissionRegistry, model: str) -> dict:
+    return next(
+        target for target in registry.snapshot()["targets"] if target["model"] == model
+    )
+
+
+def _wait_until(predicate, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return bool(predicate())
+
+
+def test_normalize_model_target_removes_credentials_and_preserves_route_path():
+    target = normalize_model_target(
+        " OpenAI ",
+        "HTTPS://user:super-secret@API.Example.COM:443/v1/deployments/GPT/?token=leak#part",
+        " GPT-5 ",
+    )
+
+    assert target.provider == "openai"
+    assert target.base_url == "https://api.example.com/v1/deployments/GPT"
+    assert target.model == "gpt-5"
+    assert "super-secret" not in repr(target)
+    assert "token" not in repr(target)
+
+
+def test_concurrent_admission_never_exceeds_global_or_per_target_limits():
+    registry = ModelAdmissionRegistry(_settings(max_in_flight=8, per_target=3))
+    lock = threading.Lock()
+    global_active = 0
+    target_active: dict[str, int] = {}
+    observed_global = 0
+    observed_target: dict[str, int] = {}
+
+    def worker(index: int) -> None:
+        nonlocal global_active, observed_global
+        model = f"model-{index % 4}"
+        with registry.acquire("provider", "https://api.example.com/v1", model):
+            with lock:
+                global_active += 1
+                target_active[model] = target_active.get(model, 0) + 1
+                observed_global = max(observed_global, global_active)
+                observed_target[model] = max(
+                    observed_target.get(model, 0), target_active[model]
+                )
+            time.sleep(0.005)
+            with lock:
+                global_active -= 1
+                target_active[model] -= 1
+
+    with ThreadPoolExecutor(max_workers=64) as pool:
+        futures = [pool.submit(worker, index) for index in range(64)]
+        for future in futures:
+            future.result(timeout=10)
+
+    assert observed_global <= 8
+    assert observed_global >= 4
+    assert all(value <= 3 for value in observed_target.values())
+    assert registry.snapshot()["global"]["in_flight"] == 0
+
+
+def test_ready_waiters_are_fifo_within_the_same_target():
+    registry = ModelAdmissionRegistry(_settings(max_in_flight=1, per_target=1))
+    owner = registry.acquire("p", "https://one.example/v1", "m")
+    admitted: list[int] = []
+    threads: list[threading.Thread] = []
+
+    def wait_for_turn(index: int) -> None:
+        with registry.acquire("p", "https://one.example/v1", "m"):
+            admitted.append(index)
+
+    for index in range(4):
+        thread = threading.Thread(target=wait_for_turn, args=(index,), daemon=True)
+        thread.start()
+        threads.append(thread)
+        assert _wait_until(
+            lambda expected=index + 1: registry.snapshot()["global"]["queued"]
+            == expected
+        )
+
+    owner.succeed()
+    for thread in threads:
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+
+    assert admitted == [0, 1, 2, 3]
+
+
+def test_retry_after_target_does_not_head_of_line_block_another_target():
+    registry = ModelAdmissionRegistry(
+        _settings(max_in_flight=1, per_target=1, wait_poll_seconds=0.01)
+    )
+    limiter = registry.acquire("p", "https://api.example/v1", "blocked")
+    limiter.fail(_RateLimitError("60"))
+
+    cancel = threading.Event()
+    blocked_error: list[BaseException] = []
+
+    def wait_on_blocked_target() -> None:
+        try:
+            registry.acquire(
+                "p",
+                "https://api.example/v1",
+                "blocked",
+                cancel_check=cancel.is_set,
+            )
+        except BaseException as exc:
+            blocked_error.append(exc)
+
+    waiter = threading.Thread(target=wait_on_blocked_target, daemon=True)
+    waiter.start()
+    assert _wait_until(lambda: registry.snapshot()["global"]["queued"] == 1)
+
+    healthy = registry.acquire("p", "https://api.example/v1", "healthy", timeout=0.2)
+    healthy.succeed()
+    cancel.set()
+    waiter.join(timeout=2)
+
+    assert not waiter.is_alive()
+    assert len(blocked_error) == 1
+    assert isinstance(blocked_error[0], ModelAdmissionCancelled)
+
+
+def test_timeout_and_cancellation_remove_waiters_without_leaking_capacity():
+    registry = ModelAdmissionRegistry(_settings(max_in_flight=1, per_target=1))
+    owner = registry.acquire("p", "https://api.example/v1", "m")
+
+    with pytest.raises(ModelAdmissionTimeout, match="timed out"):
+        registry.acquire("p", "https://api.example/v1", "m", timeout=0.02)
+    assert registry.snapshot()["global"]["queued"] == 0
+
+    cancel = threading.Event()
+    seen: list[BaseException] = []
+
+    def cancelled_waiter() -> None:
+        try:
+            registry.acquire(
+                "p",
+                "https://api.example/v1",
+                "m",
+                cancel_check=cancel.is_set,
+            )
+        except BaseException as exc:
+            seen.append(exc)
+
+    thread = threading.Thread(target=cancelled_waiter, daemon=True)
+    thread.start()
+    assert _wait_until(lambda: registry.snapshot()["global"]["queued"] == 1)
+    cancel.set()
+    thread.join(timeout=2)
+    owner.release()
+
+    assert len(seen) == 1
+    assert isinstance(seen[0], ModelAdmissionCancelled)
+    assert registry.snapshot()["global"] == {
+        "in_flight": 0,
+        "max_in_flight": 1,
+        "queued": 0,
+    }
+
+
+def test_async_task_cancellation_removes_waiter_and_future_acquire_works():
+    async def scenario() -> None:
+        registry = ModelAdmissionRegistry(_settings(max_in_flight=1, per_target=1))
+        owner = registry.acquire("p", "https://api.example/v1", "m")
+        task = asyncio.create_task(
+            registry.acquire_async("p", "https://api.example/v1", "m")
+        )
+        for _ in range(100):
+            if registry.snapshot()["global"]["queued"] == 1:
+                break
+            await asyncio.sleep(0.005)
+        assert registry.snapshot()["global"]["queued"] == 1
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert registry.snapshot()["global"]["queued"] == 0
+
+        owner.succeed()
+        permit = await registry.acquire_async(
+            "p", "https://api.example/v1", "m", timeout=0.2
+        )
+        permit.succeed()
+        assert registry.snapshot()["global"]["in_flight"] == 0
+
+    asyncio.run(scenario())
+
+
+def test_same_epoch_rate_limits_reduce_once_then_additive_success_recovers():
+    clock = _Clock()
+    registry = ModelAdmissionRegistry(
+        _settings(per_target=4, additive_successes=2),
+        monotonic=clock.monotonic,
+        wall_clock=clock.wall,
+    )
+    permits = [registry.acquire("p", "https://api.example/v1", "m") for _ in range(4)]
+
+    permits[0].fail(_RateLimitError("10"))
+    permits[1].fail(_RateLimitError("20"))
+    permits[2].succeed()
+    permits[3].succeed()
+
+    state = _target_snapshot(registry, "m")
+    assert state["limit"] == 2
+    assert state["congestion_epoch"] == 1
+    assert state["successes_toward_increase"] == 0
+    assert state["blocked_for_seconds"] == pytest.approx(20.0)
+
+    clock.advance(20)
+    for _ in range(2):
+        registry.acquire("p", "https://api.example/v1", "m").succeed()
+
+    state = _target_snapshot(registry, "m")
+    assert state["limit"] == 3
+    assert state["successes_toward_increase"] == 0
+
+
+def test_new_epoch_rate_limit_can_reduce_again():
+    clock = _Clock()
+    registry = ModelAdmissionRegistry(
+        _settings(per_target=4),
+        monotonic=clock.monotonic,
+        wall_clock=clock.wall,
+    )
+
+    registry.acquire("p", "https://api.example/v1", "m").fail(_RateLimitError("1"))
+    clock.advance(1)
+    registry.acquire("p", "https://api.example/v1", "m").fail(_RateLimitError("1"))
+
+    state = _target_snapshot(registry, "m")
+    assert state["limit"] == 1
+    assert state["congestion_epoch"] == 2
+
+
+def test_same_epoch_rate_limits_do_not_multiply_fallback_cooldown():
+    clock = _Clock()
+    registry = ModelAdmissionRegistry(
+        _settings(per_target=4),
+        monotonic=clock.monotonic,
+        wall_clock=clock.wall,
+    )
+    permits = [registry.acquire("p", "https://api.example/v1", "m") for _ in range(4)]
+
+    for permit in permits:
+        permit.fail(_RateLimitError())
+
+    state = _target_snapshot(registry, "m")
+    assert state["limit"] == 2
+    assert state["congestion_epoch"] == 1
+    assert state["blocked_for_seconds"] == pytest.approx(1.0)
+
+
+def test_retry_after_http_date_is_parsed_and_capped():
+    clock = _Clock()
+    registry = ModelAdmissionRegistry(
+        _settings(per_target=4, retry_after_max_seconds=90),
+        monotonic=clock.monotonic,
+        wall_clock=clock.wall,
+    )
+    retry_at = format_datetime(
+        datetime.fromtimestamp(clock.wall() + 120, tz=timezone.utc), usegmt=True
+    )
+
+    registry.acquire("p", "https://api.example/v1", "dated").fail(
+        _RateLimitError(retry_at)
+    )
+
+    state = _target_snapshot(registry, "dated")
+    assert state["blocked_for_seconds"] == pytest.approx(90.0)
+
+
+def test_blocked_state_survives_zero_ttl_and_target_capacity_cleanup():
+    clock = _Clock()
+    registry = ModelAdmissionRegistry(
+        _settings(
+            max_in_flight=1,
+            per_target=1,
+            idle_state_ttl_seconds=0,
+            max_target_states=1,
+        ),
+        monotonic=clock.monotonic,
+        wall_clock=clock.wall,
+    )
+    registry.acquire("p", "https://api.example/v1", "blocked").fail(
+        _RateLimitError("60")
+    )
+
+    assert _target_snapshot(registry, "blocked")["blocked_for_seconds"] == 60
+    with pytest.raises(ModelAdmissionTimeout):
+        registry.acquire("p", "https://api.example/v1", "blocked", timeout=0)
+
+    registry.acquire("p", "https://api.example/v1", "healthy").succeed()
+    assert {target["model"] for target in registry.snapshot()["targets"]} == {"blocked"}
+
+    clock.advance(60)
+    assert len(registry.snapshot()["targets"]) <= 1
+
+
+def test_sync_stream_holds_permit_until_exhaustion_and_release_is_idempotent():
+    registry = ModelAdmissionRegistry(_settings(max_in_flight=1, per_target=1))
+    permit = registry.acquire("p", "https://api.example/v1", "stream")
+    stream = permit.wrap_stream(iter(["a", "b"]))
+
+    assert registry.snapshot()["global"]["in_flight"] == 1
+    assert next(stream) == "a"
+    assert registry.snapshot()["global"]["in_flight"] == 1
+    assert next(stream) == "b"
+    with pytest.raises(StopIteration):
+        next(stream)
+
+    permit.succeed()
+    permit.release()
+    assert registry.snapshot()["global"]["in_flight"] == 0
+
+
+def test_permit_context_transfers_lifetime_to_sync_stream():
+    registry = ModelAdmissionRegistry(_settings(max_in_flight=1, per_target=1))
+
+    with registry.acquire("p", "https://api.example/v1", "stream") as permit:
+        stream = permit.wrap_stream(iter(["a", "b"]))
+
+    assert registry.snapshot()["global"]["in_flight"] == 1
+    assert list(stream) == ["a", "b"]
+    assert registry.snapshot()["global"]["in_flight"] == 0
+
+
+def test_sync_stream_context_manager_can_defer_iterator_creation_until_entry():
+    registry = ModelAdmissionRegistry(_settings(max_in_flight=1, per_target=1))
+
+    class StreamManager:
+        def __enter__(self):
+            return iter(["a", "b"])
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    stream = registry.acquire(
+        "p", "https://api.example/v1", "managed-stream"
+    ).wrap_stream(StreamManager())
+
+    with stream as entered:
+        assert list(entered) == ["a", "b"]
+    assert registry.snapshot()["global"]["in_flight"] == 0
+
+
+def test_sync_stream_context_exit_rate_limit_overrides_exhaustion_success():
+    registry = ModelAdmissionRegistry(_settings(per_target=4))
+
+    class StreamManager:
+        def __enter__(self):
+            return iter(["a"])
+
+        def __exit__(self, exc_type, exc, traceback):
+            raise _RateLimitError("30")
+
+    stream = registry.acquire(
+        "p", "https://api.example/v1", "managed-stream-exit"
+    ).wrap_stream(StreamManager())
+
+    with pytest.raises(_RateLimitError):
+        with stream as entered:
+            assert list(entered) == ["a"]
+            entered.close()
+
+    state = _target_snapshot(registry, "managed-stream-exit")
+    assert state["limit"] == 2
+    assert state["rate_limit_events"] == 1
+    assert state["blocked_for_seconds"] > 0
+
+
+def test_stream_iteration_rate_limit_updates_aimd_and_releases_permit():
+    registry = ModelAdmissionRegistry(_settings(per_target=4))
+
+    def failing_stream():
+        yield "first"
+        raise _RateLimitError("15")
+
+    stream = registry.acquire(
+        "p", "https://api.example/v1", "stream-error"
+    ).wrap_stream(failing_stream())
+
+    assert next(stream) == "first"
+    with pytest.raises(_RateLimitError):
+        next(stream)
+
+    state = _target_snapshot(registry, "stream-error")
+    assert registry.snapshot()["global"]["in_flight"] == 0
+    assert state["limit"] == 2
+    assert state["blocked_for_seconds"] > 0
+
+
+def test_async_stream_holds_permit_until_exhaustion():
+    async def scenario() -> None:
+        registry = ModelAdmissionRegistry(_settings(max_in_flight=1, per_target=1))
+
+        async def chunks():
+            yield "a"
+            yield "b"
+
+        permit = await registry.acquire_async(
+            "p", "https://api.example/v1", "async-stream"
+        )
+        stream = permit.wrap_async_stream(chunks())
+
+        assert registry.snapshot()["global"]["in_flight"] == 1
+        assert [item async for item in stream] == ["a", "b"]
+        assert registry.snapshot()["global"]["in_flight"] == 0
+
+    asyncio.run(scenario())
+
+
+def test_async_permit_context_transfers_lifetime_to_stream():
+    async def scenario() -> None:
+        registry = ModelAdmissionRegistry(_settings(max_in_flight=1, per_target=1))
+
+        async def chunks():
+            yield "a"
+            yield "b"
+
+        async with await registry.acquire_async(
+            "p", "https://api.example/v1", "async-stream"
+        ) as permit:
+            stream = permit.wrap_async_stream(chunks())
+
+        assert registry.snapshot()["global"]["in_flight"] == 1
+        assert [item async for item in stream] == ["a", "b"]
+        assert registry.snapshot()["global"]["in_flight"] == 0
+
+    asyncio.run(scenario())
+
+
+def test_async_stream_context_manager_can_defer_iterator_creation_until_entry():
+    async def scenario() -> None:
+        registry = ModelAdmissionRegistry(_settings(max_in_flight=1, per_target=1))
+
+        async def chunks():
+            yield "a"
+
+        class StreamManager:
+            async def __aenter__(self):
+                return chunks()
+
+            async def __aexit__(self, exc_type, exc, traceback):
+                return False
+
+        permit = await registry.acquire_async(
+            "p", "https://api.example/v1", "managed-async-stream"
+        )
+        stream = permit.wrap_async_stream(StreamManager())
+        async with stream as entered:
+            assert [item async for item in entered] == ["a"]
+        assert registry.snapshot()["global"]["in_flight"] == 0
+
+    asyncio.run(scenario())
+
+
+def test_async_stream_context_exit_rate_limit_overrides_exhaustion_success():
+    async def scenario() -> None:
+        registry = ModelAdmissionRegistry(_settings(per_target=4))
+
+        async def chunks():
+            yield "a"
+
+        class StreamManager:
+            async def __aenter__(self):
+                return chunks()
+
+            async def __aexit__(self, exc_type, exc, traceback):
+                raise _RateLimitError("30")
+
+        permit = await registry.acquire_async(
+            "p", "https://api.example/v1", "managed-async-stream-exit"
+        )
+        stream = permit.wrap_async_stream(StreamManager())
+        with pytest.raises(_RateLimitError):
+            async with stream as entered:
+                assert [item async for item in entered] == ["a"]
+                await entered.aclose()
+
+        state = _target_snapshot(registry, "managed-async-stream-exit")
+        assert state["limit"] == 2
+        assert state["rate_limit_events"] == 1
+        assert state["blocked_for_seconds"] > 0
+
+    asyncio.run(scenario())
+
+
+def test_async_waiter_notifications_are_bounded_by_queue_size():
+    async def scenario() -> None:
+        registry = ModelAdmissionRegistry(
+            _settings(max_in_flight=1, per_target=1, wait_poll_seconds=0.05)
+        )
+        owner = registry.acquire("p", "https://api.example/v1", "owner")
+        loop = asyncio.get_running_loop()
+        original_call = loop.call_soon_threadsafe
+        wake_calls = 0
+
+        def counted_call(callback, *args, context=None):
+            nonlocal wake_calls
+            wake_calls += 1
+            return original_call(callback, *args, context=context)
+
+        setattr(loop, "call_soon_threadsafe", counted_call)
+        tasks: list[asyncio.Task] = []
+        try:
+
+            async def worker(index: int) -> None:
+                permit = await registry.acquire_async(
+                    "p", "https://api.example/v1", f"model-{index % 4}"
+                )
+                permit.succeed()
+
+            waiter_count = 32
+            tasks = [
+                asyncio.create_task(worker(index)) for index in range(waiter_count)
+            ]
+            for _ in range(100):
+                if registry.snapshot()["global"]["queued"] == waiter_count:
+                    break
+                await asyncio.sleep(0.001)
+            assert registry.snapshot()["global"]["queued"] == waiter_count
+
+            owner.succeed()
+            await asyncio.gather(*tasks)
+            assert wake_calls <= waiter_count * 3
+        finally:
+            setattr(loop, "call_soon_threadsafe", original_call)
+            owner.release()
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    asyncio.run(scenario())
+
+
+def test_reported_closed_async_loop_waiter_does_not_block_sync_admission():
+    async def scenario() -> None:
+        registry = ModelAdmissionRegistry(
+            _settings(max_in_flight=1, per_target=1, wait_poll_seconds=0.01)
+        )
+        owner = registry.acquire("p", "https://api.example/v1", "owner")
+        waiting = asyncio.create_task(
+            registry.acquire_async("p", "https://api.example/v1", "orphan")
+        )
+        for _ in range(100):
+            if registry.snapshot()["global"]["queued"] == 1:
+                break
+            await asyncio.sleep(0.001)
+
+        loop = asyncio.get_running_loop()
+        original_is_closed = loop.is_closed
+        setattr(loop, "is_closed", lambda: True)
+        failure = None
+        healthy = None
+        try:
+            owner.succeed()
+            healthy = registry.acquire(
+                "p", "https://api.example/v1", "healthy", timeout=0.05
+            )
+        except BaseException as error:
+            failure = error
+        finally:
+            setattr(loop, "is_closed", original_is_closed)
+            if healthy is not None:
+                healthy.succeed()
+            waiting.cancel()
+            await asyncio.gather(waiting, return_exceptions=True)
+        if failure is not None:
+            raise failure
+        assert registry.snapshot()["global"]["queued"] == 0
+
+    asyncio.run(scenario())
+
+
+def test_expired_async_waiter_is_pruned_before_sync_admission():
+    async def scenario() -> None:
+        clock = _Clock()
+        registry = ModelAdmissionRegistry(
+            _settings(max_in_flight=1, per_target=1),
+            monotonic=clock.monotonic,
+            wall_clock=clock.wall,
+        )
+        owner = registry.acquire("p", "https://api.example/v1", "owner")
+        expired = asyncio.create_task(
+            registry.acquire_async("p", "https://api.example/v1", "expired", timeout=5)
+        )
+        for _ in range(100):
+            if registry.snapshot()["global"]["queued"] == 1:
+                break
+            await asyncio.sleep(0.001)
+
+        clock.advance(5)
+        healthy = None
+        try:
+            owner.succeed()
+            healthy = registry.acquire(
+                "p", "https://api.example/v1", "healthy", timeout=0
+            )
+        finally:
+            if healthy is not None:
+                healthy.succeed()
+        with pytest.raises(ModelAdmissionTimeout):
+            await expired
+        assert registry.snapshot()["global"]["queued"] == 0
+
+    asyncio.run(scenario())
+
+
+def test_bounded_idle_cleanup_and_snapshot_never_expose_url_secrets():
+    registry = ModelAdmissionRegistry(
+        _settings(max_target_states=2, idle_state_ttl_seconds=3600)
+    )
+    for index in range(3):
+        registry.acquire(
+            "provider",
+            f"https://user:password-{index}@api{index}.example/v1?api_key=secret-{index}",
+            f"model-{index}",
+        ).succeed()
+
+    snapshot = registry.snapshot()
+    rendered = repr(snapshot)
+
+    assert len(snapshot["targets"]) <= 2
+    assert "password" not in rendered
+    assert "api_key" not in rendered
+    assert "secret" not in rendered
+    assert all(target["in_flight"] == 0 for target in snapshot["targets"])
+
+
+def test_snapshot_hashes_route_path_instead_of_exposing_it():
+    registry = ModelAdmissionRegistry(_settings())
+    registry.acquire(
+        "provider",
+        "https://api.example/v1/tenant-secret-value/deployments/model?key=query-secret",
+        "model",
+    ).succeed()
+
+    target = _target_snapshot(registry, "model")
+    rendered = repr(target)
+    assert target["base_url"] == "https://api.example"
+    assert target["route_id"]
+    assert "tenant-secret-value" not in rendered
+    assert "query-secret" not in rendered
+
+
+def test_disabled_registry_returns_noop_permits_without_tracking_state():
+    registry = ModelAdmissionRegistry(_settings(enabled=False))
+
+    with registry.acquire(
+        "p", "https://user:secret@api.example/v1?token=secret", "m"
+    ) as permit:
+        assert permit.is_noop
+
+    assert registry.snapshot() == {
+        "enabled": False,
+        "global": {"in_flight": 0, "max_in_flight": 8, "queued": 0},
+        "targets": [],
+    }

--- a/tests/agent/test_model_admission_integration.py
+++ b/tests/agent/test_model_admission_integration.py
@@ -266,6 +266,62 @@ def test_auxiliary_sync_stream_holds_permit_until_exhaustion(monkeypatch):
     )
 
 
+def test_auxiliary_opaque_stream_sentinel_is_returned_raw(monkeypatch):
+    permit = _RecordingPermit()
+    monkeypatch.setattr(aux, "acquire_model_admission", lambda *_args: permit)
+    sentinel = "RAW_STREAM"
+    client = SimpleNamespace(
+        base_url="https://api.example.test/v1",
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **_kwargs: sentinel)
+        ),
+    )
+    wrapped = aux._wrap_auxiliary_client(
+        client,
+        provider="custom",
+        model="m",
+        base_url=None,
+        async_mode=False,
+    )
+
+    response = wrapped.chat.completions.create(model="m", stream=True)
+
+    assert response is sentinel
+    assert permit.events == ["succeed"]
+
+
+def test_auxiliary_async_opaque_stream_sentinel_is_returned_raw(monkeypatch):
+    permit = _RecordingPermit()
+    sentinel = object()
+
+    async def acquire(*_args):
+        return permit
+
+    async def create(**_kwargs):
+        return sentinel
+
+    monkeypatch.setattr(aux, "acquire_model_admission_async", acquire)
+    client = SimpleNamespace(
+        base_url="https://api.example.test/v1",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+    )
+    wrapped = aux._wrap_auxiliary_client(
+        client,
+        provider="custom",
+        model="m",
+        base_url=None,
+        async_mode=True,
+    )
+
+    async def exercise():
+        return await wrapped.chat.completions.create(model="m", stream=True)
+
+    response = asyncio.run(exercise())
+
+    assert response is sentinel
+    assert permit.events == ["succeed"]
+
+
 def test_auxiliary_async_attempt_has_its_own_permit(monkeypatch):
     first_permit = _RecordingPermit()
     second_permit = _RecordingPermit()

--- a/tests/agent/test_model_admission_integration.py
+++ b/tests/agent/test_model_admission_integration.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent import auxiliary_client as aux
+from agent import chat_completion_helpers as chat
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    aux._reset_model_admission_registry_for_tests()
+    yield
+    aux._reset_model_admission_registry_for_tests()
+
+
+class _RecordingPermit:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+        self.is_finished = False
+
+    def succeed(self) -> None:
+        if not self.is_finished:
+            self.events.append("succeed")
+            self.is_finished = True
+
+    def fail(self, error: BaseException) -> None:
+        if not self.is_finished:
+            self.events.append(("fail", error))
+            self.is_finished = True
+
+    def release(self) -> None:
+        if not self.is_finished:
+            self.events.append("release")
+            self.is_finished = True
+
+    def wrap_stream(self, stream):
+        permit = self
+
+        class _Stream:
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                try:
+                    return next(stream)
+                except StopIteration:
+                    permit.succeed()
+                    raise
+                except BaseException as error:
+                    permit.fail(error)
+                    raise
+
+            def close(self):
+                close = getattr(stream, "close", None)
+                if callable(close):
+                    close()
+                permit.release()
+
+        return _Stream()
+
+    def wrap_async_stream(self, stream):
+        permit = self
+
+        class _AsyncStream:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                try:
+                    return await stream.__anext__()
+                except StopAsyncIteration:
+                    permit.succeed()
+                    raise
+                except BaseException as error:
+                    permit.fail(error)
+                    raise
+
+        return _AsyncStream()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, _traceback):
+        if exc is None:
+            self.succeed()
+        else:
+            self.fail(exc)
+        return False
+
+
+def test_model_admission_is_safe_by_default_and_requires_explicit_enablement():
+    config = DEFAULT_CONFIG["model_admission"]
+
+    assert config["enabled"] is False
+    assert config["max_in_flight"] > 0
+    assert config["per_target"] > 0
+    assert config["min_per_target"] <= config["per_target"]
+
+
+def test_model_admission_config_is_loaded_once_per_process(monkeypatch):
+    enabled = dict(DEFAULT_CONFIG["model_admission"])
+    enabled.update({"enabled": True, "max_in_flight": 3, "per_target": 2})
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config", lambda: {"model_admission": enabled}
+    )
+
+    first = aux._get_model_admission_registry()
+    assert first.settings.enabled is True
+    assert first.settings.max_in_flight == 3
+    assert first.settings.per_target == 2
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model_admission": {"enabled": False}},
+    )
+    assert aux._get_model_admission_registry() is first
+
+
+def test_main_nonstreaming_attempt_reports_success(monkeypatch):
+    permit = _RecordingPermit()
+    monkeypatch.setattr(chat, "_acquire_model_admission", lambda *_args: permit)
+    response = SimpleNamespace(id="ok")
+    client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **_kwargs: response)
+        )
+    )
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        model="m",
+    )
+
+    assert (
+        chat._dispatch_nonstreaming_api_request(
+            agent, {"model": "m", "messages": []}, make_client=lambda *_a, **_k: client
+        )
+        is response
+    )
+    assert permit.events == ["succeed"]
+
+
+def test_main_nonstreaming_429_is_reported_before_retry(monkeypatch):
+    permit = _RecordingPermit()
+    monkeypatch.setattr(chat, "_acquire_model_admission", lambda *_args: permit)
+
+    class RateLimitError(RuntimeError):
+        status_code = 429
+
+    error = RateLimitError("busy")
+    client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda **_kwargs: (_ for _ in ()).throw(error)
+            )
+        )
+    )
+    agent = SimpleNamespace(
+        api_mode="chat_completions",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        model="m",
+    )
+
+    with pytest.raises(RateLimitError):
+        chat._dispatch_nonstreaming_api_request(
+            agent,
+            {"model": "m", "messages": []},
+            make_client=lambda *_a, **_k: client,
+        )
+
+    assert permit.events == [("fail", error)]
+
+
+def test_main_anthropic_permit_covers_manager_exit(monkeypatch):
+    events: list[str] = []
+    permit = _RecordingPermit()
+    monkeypatch.setattr(chat, "_acquire_model_admission", lambda *_args: permit)
+
+    class StreamManager:
+        def __enter__(self):
+            events.append("stream-enter")
+            return iter(["event"])
+
+        def __exit__(self, _exc_type, _exc, _traceback):
+            events.append("stream-exit")
+            assert permit.events == []
+
+    client = SimpleNamespace(
+        messages=SimpleNamespace(stream=lambda **_kwargs: StreamManager())
+    )
+
+    with chat._admitted_anthropic_stream(
+        SimpleNamespace(), {"model": "m"}, client
+    ) as stream:
+        assert list(stream) == ["event"]
+        assert permit.events == []
+        events.append("body")
+
+    assert events == ["stream-enter", "body", "stream-exit"]
+    assert permit.events == ["succeed"]
+
+
+def test_main_anthropic_close_429_is_reported(monkeypatch):
+    permit = _RecordingPermit()
+    monkeypatch.setattr(chat, "_acquire_model_admission", lambda *_args: permit)
+
+    class RateLimitError(RuntimeError):
+        status_code = 429
+
+    error = RateLimitError("close rate limited")
+
+    class StreamManager:
+        def __enter__(self):
+            return iter(())
+
+        def __exit__(self, _exc_type, _exc, _traceback):
+            raise error
+
+    client = SimpleNamespace(
+        messages=SimpleNamespace(stream=lambda **_kwargs: StreamManager())
+    )
+
+    with pytest.raises(RateLimitError):
+        with chat._admitted_anthropic_stream(SimpleNamespace(), {"model": "m"}, client):
+            pass
+
+    assert permit.events == [("fail", error)]
+
+
+def test_auxiliary_sync_stream_holds_permit_until_exhaustion(monkeypatch):
+    permit = _RecordingPermit()
+    acquire = MagicMock(return_value=permit)
+    monkeypatch.setattr(aux, "acquire_model_admission", acquire)
+    raw_stream = iter(["a", "b"])
+    client = SimpleNamespace(
+        base_url="https://user:secret@example.test/v1?api_key=hidden",
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **_kwargs: raw_stream)
+        ),
+    )
+    wrapped = aux._wrap_auxiliary_client(
+        client,
+        provider="openrouter",
+        model="m",
+        base_url=None,
+        async_mode=False,
+    )
+
+    stream = wrapped.chat.completions.create(model="m", stream=True)
+    assert permit.events == []
+    assert next(stream) == "a"
+    assert permit.events == []
+    assert list(stream) == ["b"]
+    assert permit.events == ["succeed"]
+    acquire.assert_called_once_with(
+        "openrouter",
+        "https://user:secret@example.test/v1?api_key=hidden",
+        "m",
+    )
+
+
+def test_auxiliary_async_attempt_has_its_own_permit(monkeypatch):
+    first_permit = _RecordingPermit()
+    second_permit = _RecordingPermit()
+    permits = [first_permit, second_permit]
+
+    async def acquire(*_args):
+        return permits.pop(0)
+
+    monkeypatch.setattr(aux, "acquire_model_admission_async", acquire)
+
+    class RateLimitError(RuntimeError):
+        status_code = 429
+
+    calls = 0
+
+    async def create(**_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RateLimitError("busy")
+        return SimpleNamespace(id="ok")
+
+    client = SimpleNamespace(
+        base_url="https://api.example.test/v1",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+    )
+    wrapped = aux._wrap_auxiliary_client(
+        client,
+        provider="custom",
+        model="m",
+        base_url=None,
+        async_mode=True,
+    )
+
+    async def exercise():
+        with pytest.raises(RateLimitError):
+            await wrapped.chat.completions.create(model="m")
+        assert first_permit.events
+        assert first_permit.events[0][0] == "fail"
+        return await wrapped.chat.completions.create(model="m")
+
+    response = asyncio.run(exercise())
+
+    assert response.id == "ok"
+    assert second_permit.events == ["succeed"]
+    # One failed permit was fully released before the second attempt entered.
+    # ``permits`` is empty only if acquisition happened independently twice.
+    assert permits == []
+
+
+def test_virtual_moa_outer_request_does_not_enter_registry(monkeypatch):
+    registry = MagicMock()
+    monkeypatch.setattr(aux, "_get_model_admission_registry", lambda: registry)
+
+    permit = aux.acquire_model_admission("moa", "in-process://moa", "preset")
+
+    assert permit.is_noop
+    registry.acquire.assert_not_called()

--- a/tests/agent/test_model_admission_integration.py
+++ b/tests/agent/test_model_admission_integration.py
@@ -269,7 +269,9 @@ def test_auxiliary_sync_stream_holds_permit_until_exhaustion(monkeypatch):
 def test_auxiliary_opaque_stream_sentinel_is_returned_raw(monkeypatch):
     permit = _RecordingPermit()
     monkeypatch.setattr(aux, "acquire_model_admission", lambda *_args: permit)
-    sentinel = "RAW_STREAM"
+    # Ordinary iterables do not expose a stream lifecycle boundary. Wrapping
+    # them would still alter the adapter's raw-return contract.
+    sentinel = ["RAW_STREAM"]
     client = SimpleNamespace(
         base_url="https://api.example.test/v1",
         chat=SimpleNamespace(

--- a/tests/gateway/test_agent_executor_workers_config.py
+++ b/tests/gateway/test_agent_executor_workers_config.py
@@ -1,0 +1,73 @@
+"""Gateway agent executor worker-count configuration tests."""
+
+import logging
+import threading
+from pathlib import Path
+
+import yaml
+
+from gateway.config import GatewayConfig, load_gateway_config
+from gateway.run import GatewayRunner
+
+
+def test_agent_executor_workers_defaults_to_ten():
+    assert GatewayConfig().agent_executor_workers == 10
+
+
+def test_agent_executor_workers_accepts_positive_integer_string():
+    config = GatewayConfig.from_dict({"agent_executor_workers": "14"})
+
+    assert config.agent_executor_workers == 14
+    assert config.to_dict()["agent_executor_workers"] == 14
+
+
+def test_agent_executor_workers_accepts_large_positive_integer():
+    config = GatewayConfig.from_dict({"agent_executor_workers": 10_000})
+
+    assert config.agent_executor_workers == 10_000
+    assert config.to_dict()["agent_executor_workers"] == 10_000
+
+
+def test_agent_executor_workers_invalid_values_fall_back_to_ten(caplog):
+    caplog.set_level(logging.WARNING, logger="gateway.config")
+
+    for invalid in (0, -1, True, 1.5, "many"):
+        assert GatewayConfig.from_dict(
+            {"agent_executor_workers": invalid}
+        ).agent_executor_workers == 10
+
+    assert any(
+        "Ignoring invalid agent_executor_workers" in record.message
+        for record in caplog.records
+    )
+
+
+def test_load_gateway_config_bridges_nested_agent_executor_workers(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"gateway": {"agent_executor_workers": 6}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    config = load_gateway_config()
+
+    assert config.agent_executor_workers == 6
+
+
+def test_gateway_executor_uses_configured_worker_count():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(agent_executor_workers=3)
+    runner._executor_lock = threading.Lock()
+    runner._executor = None
+    runner._executor_closing = False
+
+    executor = runner._get_executor()
+    try:
+        assert executor._max_workers == 3
+    finally:
+        runner._shutdown_executor()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1742,6 +1742,38 @@ and provider limits. Use
 `max_concurrent_sessions` separately to bound admission across
 CLI, TUI/dashboard, and messaging surfaces.
 
+To prevent a busy gateway from overwhelming the upstream model API, enable the
+process-wide model admission controller:
+
+```yaml
+model_admission:
+  enabled: true
+  max_in_flight: 8          # all primary and auxiliary model requests combined
+  per_target: 8             # initial cap per provider endpoint and model
+  min_per_target: 1         # lower bound after rate-limit backoff
+  queue_timeout_seconds: 600
+  additive_successes: 16    # successes required before raising a reduced cap
+  retry_after_max_seconds: 600
+  idle_state_ttl_seconds: 3600
+  max_target_states: 1024
+```
+
+The feature defaults to `enabled: false`. When enabled, it covers primary
+non-streaming calls, full Chat Completions and Anthropic streaming lifecycles,
+and auxiliary work such as compression, vision, and the real MoA advisor and
+aggregator requests. Each retry acquires a fresh permit, so capacity is not held
+during retry backoff. HTTP 429 responses reduce the affected target's limit and
+honor `Retry-After` (capped by `retry_after_max_seconds`); sustained successful
+requests restore capacity gradually. Streaming requests keep their permit until
+the iterator ends or closes.
+
+Targets are keyed by provider, normalized endpoint, and model. URL credentials,
+query strings, and fragments are excluded from admission diagnostics. The
+registry is process-local; it coordinates all callers inside one Hermes process,
+not multiple gateway hosts. **Restart Hermes after changing any
+`model_admission` setting** because the registry and its limits are initialized
+once per process.
+
 Control whether shared chats keep one conversation per room or one conversation per participant:
 
 ```yaml

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1703,7 +1703,7 @@ For separate natural mid-turn assistant updates without progressive token editin
 The master `streaming.enabled` switch is `false` by default — nothing streams until you flip it. Once enabled, streaming is decided **per platform**: Telegram ships with `display.platforms.telegram.streaming: true` (streams) and Discord with `display.platforms.discord.streaming: false` (does not). So after enabling streaming, Telegram streams out of the box and Discord stays on whole-message replies until you change its toggle. You can adjust these per-platform switches from the dashboard's **Channels** toggles or directly in `~/.hermes/config.yaml`.
 :::
 
-## Group Chat Session Isolation
+## Gateway Concurrency and Session Isolation
 
 Limit how many chat sessions can actively be open across CLI, TUI/dashboard,
 and messaging gateway:
@@ -1723,6 +1723,24 @@ The cap is enforced with a local runtime lease file and is best-effort: Hermes
 fails open if the registry cannot be read or locked so users are not stranded.
 It is intended for a single host/profile runtime, not a shared `$HERMES_HOME`
 mounted across multiple machines.
+
+Control how many synchronous agent turns the messaging gateway can execute at
+once:
+
+```yaml
+gateway:
+  agent_executor_workers: 10  # positive integer; restart required
+```
+
+Each active turn occupies one worker while it calls the model and tools. Raising
+the value can reduce queueing when many chats are active, but also increases
+memory use, tool concurrency, and upstream provider pressure. This pool is
+created lazily and is not resized in place, so restart the gateway after changing
+the value. There is no fixed upper bound; non-positive or malformed values fall
+back to `10`. Size the pool conservatively for available memory, tool capacity,
+and provider limits. Use
+`max_concurrent_sessions` separately to bound admission across
+CLI, TUI/dashboard, and messaging surfaces.
 
 Control whether shared chats keep one conversation per room or one conversation per participant:
 


### PR DESCRIPTION
## Availability Impact

This addresses a release-critical high-concurrency failure mode. Raising Gateway worker capacity can otherwise turn local queueing into an uncontrolled burst of model API requests. A provider-side 429 storm then occupies workers, expands every session backlog, and makes the Gateway effectively unavailable even though the process remains alive.

This PR makes local executor capacity configurable and adds an opt-in, process-wide model admission controller that bounds outbound pressure, reacts to provider rate limits, and covers primary and auxiliary model traffic.

## What Does This PR Do?

It adds two separate controls:

1. `gateway.agent_executor_workers` controls how many synchronous messaging turns the Gateway executes locally. The backward-compatible default remains `10`.
2. `model_admission` bounds actual model API attempts globally and per provider endpoint/model target.

These remain separate from `max_concurrent_sessions`, which limits active conversations across Hermes surfaces.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] ✅ Tests
- [x] 📝 Documentation update

## Configurable Gateway Executor

- Adds `GatewayConfig.agent_executor_workers` with a default of `10`.
- Accepts positive integers without imposing an artificial upper bound.
- Warns and falls back to `10` for malformed or non-positive values.
- Passes the resolved value to the Gateway-owned `ThreadPoolExecutor` when it is lazily created.
- Keeps `max_concurrent_sessions` as an independent admission control.

## Shared Model Admission Registry

- Adds one lazily initialized registry shared by primary agent turns and auxiliary model callers.
- Enforces a static process-wide in-flight cap plus an adaptive per-target cap.
- Keys targets by normalized provider, credential-free endpoint, and model.
- Preserves FIFO ordering for same-target waiters while avoiding cross-target head-of-line blocking.
- Supports synchronous and asynchronous acquisition, bounded queue waits, cancellation cleanup, and stale event-loop cleanup.
- Retains blocked target state through TTL/cap cleanup and bounds idle state by TTL and maximum target count.
- Wakes only the bounded number of waiters that available global/target capacity can serve, avoiding thundering-herd scans.

## Adaptive Rate-Limit Control

- Detects HTTP 429 across SDK exception and response shapes.
- Parses numeric and HTTP-date `Retry-After` values and caps provider-requested cooldowns.
- Uses multiplicative decrease on the affected target once per congestion epoch.
- Restores capacity gradually after sustained successes.
- Uses bounded exponential fallback cooldown when the provider omits `Retry-After`.

The global cap remains stable; only the affected provider endpoint/model target adapts.

## Complete Request-Lifetime Accounting

- Primary non-streaming model attempts acquire and finish one permit.
- Chat Completions and Anthropic streams retain their permit through exhaustion, explicit close, context-manager exit, cancellation, or error.
- A late stream-exit 429 is recorded before release.
- Every retry, provider fallback, credential refresh, and MoA advisor/aggregator network request receives a fresh permit.
- Permits are not held across retry backoff.
- The virtual in-process MoA outer call is excluded to avoid double-counting; its real advisor and aggregator calls remain admitted.
- Auxiliary calls including compression, vision, title generation, web extraction, and MoA fan-out share the same process-wide budget.

## Safe Diagnostics

- URL user information, query strings, and fragments are stripped from target keys.
- Diagnostics expose only the endpoint origin and a short hashed route ID; secret-bearing route paths are not retained.
- The controller stores no model prompt, response body, tool payload, or conversation content.

## Concurrency Controls

| Control | Scope | Default | Purpose |
|---|---|---:|---|
| `max_concurrent_sessions` | Hermes runtime | unlimited | Bounds active conversations |
| `gateway.agent_executor_workers` | Messaging Gateway | `10` | Bounds local synchronous turn workers |
| `model_admission.max_in_flight` | One Hermes process | `8` when enabled | Bounds all actual model API attempts |
| `model_admission.per_target` | Endpoint + model | `8` when enabled | Initial target-specific pressure limit |

Raising executor workers improves local throughput only when memory, tools, and upstream quotas can support it. Model admission prevents that local setting from becoming unbounded provider fan-out.

## Configuration

```yaml
gateway:
  agent_executor_workers: 10

model_admission:
  enabled: false
  max_in_flight: 8
  per_target: 8
  min_per_target: 1
  queue_timeout_seconds: 600
  additive_successes: 16
  retry_after_max_seconds: 600
  idle_state_ttl_seconds: 3600
  max_target_states: 1024
```

`model_admission` is disabled by default for compatibility. High-concurrency Gateway deployments should enable and size it against their provider quotas. Both controls are initialized lazily and require a Hermes restart after changes.

Invalid admission configuration logs a warning and fails open with admission disabled rather than stranding all model traffic.

## Operational Boundaries

- The registry coordinates one Hermes process; it is not a distributed quota service across hosts.
- A low global cap protects provider availability but can increase local queue latency.
- A high executor count still increases thread count, memory use, tool concurrency, and context switching.
- Only HTTP 429 changes adaptive target capacity; unrelated transport failures release permits without being classified as congestion.
- Adaptive limits are not persisted across restart.

## How to Test

Remote canonical run on `8c6ab1108eadc322cacaf2ed2778e5dbf7bfbafe`:

```bash
scripts/run_tests.sh -j 64 \
  tests/agent/test_model_admission.py \
  tests/agent/test_model_admission_integration.py \
  tests/agent/test_auxiliary_client.py \
  tests/agent/test_cron_inline_api_call_62151.py \
  tests/agent/test_turn_finalizer_iteration_limit_exit.py \
  tests/agent/test_stream_single_writer_guard.py \
  tests/agent/test_moa_trace_streamed_capture.py \
  tests/run_agent/test_moa_streaming.py \
  tests/gateway/test_agent_executor_workers_config.py \
  tests/hermes_cli/test_config_validation.py \
  tests/hermes_cli/test_config.py \
  -q
```

Result: **11 files, 612 passed, 0 failed, 64 workers**.

Coverage includes global/per-target ceilings, FIFO fairness, cross-target progress, sync/async timeout and cancellation, bounded waiter notification, AIMD epochs, numeric/HTTP-date `Retry-After`, blocked-state retention, full stream ownership, opaque raw-stream compatibility, late exit 429 handling, primary and auxiliary per-attempt acquisition, fallback/refresh/MoA accounting, secret-free diagnostics, default-disabled configuration, and executor construction.

Additional checks passed: Ruff, Python compilation, and `git diff --check`.

## Infographic

![Gateway executor configuration flow: validated worker capacity, separate session admission, runtime pool creation, restart behavior, and capacity trade-offs](https://raw.githubusercontent.com/StellarisW/hermes-agent/5eb0228d17fa5013581b8b127eb67b32bc821295/pr-65740-gateway-executor-and-attribution.png)

The executor diagram now forms the local-execution layer of a three-boundary design:

```mermaid
flowchart LR
    A[Active conversations] -->|max_concurrent_sessions| B[Gateway turn workers]
    B -->|agent_executor_workers| C[Process-wide model admission]
    C -->|global cap| D{Provider target}
    D -->|per-target AIMD| E[Model API]
    E -->|429 + Retry-After| D
```
