### PR TITLE
fix(model_tools): 网关平台中MCP工具不可用的问题修复

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -392,6 +392,15 @@ def _compute_tool_definitions(
         for ts_name in get_all_toolsets():
             tools_to_include.update(resolve_toolset(ts_name))
 
+    # Auto-include MCP toolsets so all platforms (CLI, gateway, etc.)
+    # can use configured MCP servers. MCP toolsets are dynamically
+    # registered at runtime (not in toolsets.py), so they'd otherwise
+    # be invisible to platforms with a hardcoded toolset list.
+    mcp_ts_names = [ts for ts in registry.get_registered_toolset_names()
+                    if ts.startswith("mcp-")]
+    for ts_name in mcp_ts_names:
+        tools_to_include.update(resolve_toolset(ts_name))
+
     # Always apply disabled toolsets as a subtraction step at the end.
     # This ensures that even if a composite toolset (like hermes-cli)
     # is enabled, any tools belonging to a disabled toolset are strictly


### PR DESCRIPTION
## 背景

修复 #65662: MCP tools not available in gateway/messaging platform agents (QQ, Telegram, etc.)

## 根因分析

在  中，当  被显式设置时（网关平台如 QQ、Telegram、Discord 均如此），只会从这些指定的 toolset 中解析工具。MCP 工具被动态注册到  toolset 中，但这些 dynamic toolset 不属于任何平台 toolset 定义，因此网关平台的 agent 无法看到或调用  工具。

CLI 模式不受影响，因为它没有设置  过滤器，默认会包含所有 toolset。

## 修复方式

在  第393行之后（enabled_toolsets 解析块之后、disabled_toolsets 过滤之前），添加自动发现并包含所有  开头的 toolset：



将 MCP toolsets 放在 enabled_toolsets 解析之后、disabled_toolsets 过滤之前，这样用户仍然可以通过 disabled_toolsets 显式禁用 MCP 工具集。

## 验证

- [x] 代码变更已在本地验证
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更 — 仅添加，不修改现有逻辑
- [x] disabled_toolsets 仍可正常排除 MCP 工具

Closes #65662