### PR TITLE
feat(gateway): add verified runtime code root contract

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2715,6 +2715,10 @@ def _configured_runtime_code_root() -> Path | None:
         return None
     if not isinstance(raw, str):
         raise ValueError("runtime.code_root must be an absolute path string")
+    if any(char in raw for char in ("\x00", "\n", "\r")):
+        raise ValueError(
+            "runtime.code_root contains control characters unsupported by service managers"
+        )
 
     path = Path(raw).expanduser()
     if not path.is_absolute():
@@ -2758,7 +2762,7 @@ def _service_definition_runtime_status(currentness_check):
         return None, False, str(exc)
 
     if runtime_info["configured"] is not None and not runtime_info["matches"]:
-        return runtime_info, False, None
+        return runtime_info, None, None
 
     try:
         return runtime_info, currentness_check(), None
@@ -2836,6 +2840,19 @@ def _systemd_watchdog_service_fields(
     if seconds <= 0:
         return "simple", ""
     return "notify", f"NotifyAccess=main\nWatchdogSec={seconds}s\n"
+
+
+def _systemd_quote_unit_value(value: str) -> str:
+    """Quote a systemd unit value while preserving literal path characters."""
+    if any(char in value for char in ("\x00", "\n", "\r")):
+        raise ValueError("systemd unit values cannot contain NUL or newlines")
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("%", "%%")
+        .replace("\t", "\\t")
+    )
+    return f'"{escaped}"'
 
 
 def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
@@ -2916,7 +2933,7 @@ Type={systemd_type}
 {systemd_watchdog_directives}User={username}
 Group={group_name}
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
-WorkingDirectory={working_dir}
+WorkingDirectory={_systemd_quote_unit_value(working_dir) if configured_runtime_root is not None else working_dir}
 Environment="HOME={home_dir}"
 Environment="USER={username}"
 Environment="LOGNAME={username}"
@@ -2957,7 +2974,7 @@ StartLimitIntervalSec=0
 [Service]
 Type={systemd_type}
 {systemd_watchdog_directives}ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
-WorkingDirectory={working_dir}
+WorkingDirectory={_systemd_quote_unit_value(working_dir) if configured_runtime_root is not None else working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
@@ -3580,7 +3597,7 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         )
     )
 
-    if not definition_current:
+    if definition_current is False:
         print("⚠ Installed gateway service definition is outdated")
         if runtime_config_error:
             print(f"  Invalid runtime deployment contract: {runtime_config_error}")
@@ -4635,9 +4652,9 @@ def launchd_status(deep: bool = False):
         _service_definition_runtime_status(launchd_plist_is_current)
     )
 
-    if definition_current:
+    if definition_current is True:
         print("✓ Service definition matches the current Hermes install")
-    else:
+    elif definition_current is False:
         print("⚠ Service definition is stale relative to the current Hermes install")
         if runtime_config_error:
             print(f"  Invalid runtime deployment contract: {runtime_config_error}")
@@ -4653,6 +4670,12 @@ def launchd_status(deep: bool = False):
             print("✗ Running Hermes code does not match runtime.code_root")
             print("  Hold restart/promotion until the interpreter is bound to the configured runtime")
 
+    runtime_mismatch = bool(
+        runtime_info
+        and runtime_info["configured"] is not None
+        and not runtime_info["matches"]
+    )
+
     if service_listed:
         if launchd_pid is not None:
             print(f"✓ Gateway is supervised by launchd (PID {launchd_pid})")
@@ -4667,7 +4690,8 @@ def launchd_status(deep: bool = False):
                 print("  Cron jobs will fire. Stop with: hermes gateway stop")
             else:
                 print("✗ No fallback process is running")
-                print("  Run: hermes gateway start")
+                if not runtime_mismatch:
+                    print("  Run: hermes gateway start")
             print("  ⚠ Auto-start at login and auto-restart on crash are NOT available.")
         else:
             print("✓ Gateway service is registered with launchd")
@@ -4677,7 +4701,8 @@ def launchd_status(deep: bool = False):
     else:
         print("✗ Gateway service is not loaded")
         print("  Service definition exists locally but launchd has not loaded it.")
-        print("  Run: hermes gateway start")
+        if not runtime_mismatch:
+            print("  Run: hermes gateway start")
         if fallback_pid:
             print(f"  Note: a detached gateway process is running (PID {fallback_pid})")
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2745,6 +2745,27 @@ def _runtime_code_root_status() -> dict[str, Path | bool | None]:
     }
 
 
+def _service_definition_runtime_status(currentness_check):
+    """Evaluate runtime provenance before generating a service definition.
+
+    A configured/imported mismatch is a distinct deployment state, not an
+    invalid declaration. Skip currentness generation in that state because the
+    generator deliberately fails closed on the same mismatch.
+    """
+    try:
+        runtime_info = _runtime_code_root_status()
+    except (ValueError, RuntimeError) as exc:
+        return None, False, str(exc)
+
+    if runtime_info["configured"] is not None and not runtime_info["matches"]:
+        return runtime_info, False, None
+
+    try:
+        return runtime_info, currentness_check(), None
+    except (ValueError, RuntimeError) as exc:
+        return runtime_info, False, str(exc)
+
+
 def _require_runtime_code_root_match() -> Path | None:
     """Fail closed when service generation runs from an unapproved code tree."""
     info = _runtime_code_root_status()
@@ -2869,7 +2890,9 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         # the long-standing system-service behavior of anchoring cwd at the
         # target user's stable HERMES_HOME rather than a caller checkout.
         if configured_runtime_root is not None:
-            working_dir = _remap_path_for_user(working_dir, home_dir)
+            # runtime.code_root is an exact deployment contract. Do not silently
+            # reinterpret a home-relative source tree for another service user.
+            working_dir = str(configured_runtime_root)
         else:
             working_dir = (
                 str(hermes_home)
@@ -3551,14 +3574,11 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         print_legacy_unit_warning()
         print()
 
-    runtime_config_error = None
-    try:
-        runtime_info = _runtime_code_root_status()
-        definition_current = systemd_unit_is_current(system=system)
-    except (ValueError, RuntimeError) as exc:
-        runtime_info = None
-        definition_current = False
-        runtime_config_error = str(exc)
+    runtime_info, definition_current, runtime_config_error = (
+        _service_definition_runtime_status(
+            lambda: systemd_unit_is_current(system=system)
+        )
+    )
 
     if not definition_current:
         print("⚠ Installed gateway service definition is outdated")
@@ -4611,14 +4631,9 @@ def launchd_status(deep: bool = False):
 
     # ── Report ──
     print(f"Launchd plist: {plist_path}")
-    runtime_config_error = None
-    try:
-        runtime_info = _runtime_code_root_status()
-        definition_current = launchd_plist_is_current()
-    except (ValueError, RuntimeError) as exc:
-        runtime_info = None
-        definition_current = False
-        runtime_config_error = str(exc)
+    runtime_info, definition_current, runtime_config_error = (
+        _service_definition_runtime_status(launchd_plist_is_current)
+    )
 
     if definition_current:
         print("✓ Service definition matches the current Hermes install")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -17,6 +17,7 @@ import textwrap
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from xml.sax.saxutils import escape as xml_escape
 
 # Ensure /bin and /usr/bin are on PATH so launchctl/systemctl are discoverable
 # when running under UV's bundled Python which ships a minimal PATH (#3849).
@@ -2819,6 +2820,7 @@ def _systemd_watchdog_service_fields(
 def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) -> str:
     python_path = get_python_path()
     working_dir = _stable_service_working_dir()
+    configured_runtime_root = _configured_runtime_code_root()
     detected_venv = _detect_venv_dir()
     venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
 
@@ -2863,10 +2865,17 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         # (e.g. /root/) to the target user's home so the service can
         # actually access them.
         python_path = _remap_path_for_user(python_path, home_dir)
-        # Anchor cwd to the target user's HERMES_HOME (stable, always exists)
-        # rather than a remapped source-checkout path that can rot. See
-        # _stable_service_working_dir() for the full rationale.
-        working_dir = str(hermes_home) if hermes_home else _remap_path_for_user(working_dir, home_dir)
+        # Preserve an explicit runtime deployment contract. Without one, keep
+        # the long-standing system-service behavior of anchoring cwd at the
+        # target user's stable HERMES_HOME rather than a caller checkout.
+        if configured_runtime_root is not None:
+            working_dir = _remap_path_for_user(working_dir, home_dir)
+        else:
+            working_dir = (
+                str(hermes_home)
+                if hermes_home
+                else _remap_path_for_user(working_dir, home_dir)
+            )
         venv_dir = _remap_path_for_user(venv_dir, home_dir)
         path_entries = [_remap_path_for_user(p, home_dir) for p in path_entries]
         path_entries.extend(_build_user_local_paths(Path(home_dir), path_entries))
@@ -3542,11 +3551,35 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         print_legacy_unit_warning()
         print()
 
-    if not systemd_unit_is_current(system=system):
+    runtime_config_error = None
+    try:
+        runtime_info = _runtime_code_root_status()
+        definition_current = systemd_unit_is_current(system=system)
+    except (ValueError, RuntimeError) as exc:
+        runtime_info = None
+        definition_current = False
+        runtime_config_error = str(exc)
+
+    if not definition_current:
         print("⚠ Installed gateway service definition is outdated")
-        print(
-            f"  Run: {'sudo ' if system else ''}hermes gateway restart{scope_flag}  # auto-refreshes the unit"
-        )
+        if runtime_config_error:
+            print(f"  Invalid runtime deployment contract: {runtime_config_error}")
+        else:
+            print(
+                f"  Run: {'sudo ' if system else ''}hermes gateway restart{scope_flag}  # auto-refreshes the unit"
+            )
+        print()
+
+    if runtime_info and runtime_info["configured"] is not None:
+        print(f"Configured runtime root: {runtime_info['configured']}")
+        print(f"Imported Hermes root: {runtime_info['imported']}")
+        if runtime_info["matches"]:
+            print("✓ Running Hermes code matches runtime.code_root")
+        else:
+            print("✗ Running Hermes code does not match runtime.code_root")
+            print(
+                "  Hold restart/promotion until the interpreter is bound to the configured runtime"
+            )
         print()
 
     status_cmd = ["status", get_service_name(), "--no-pager"]
@@ -4047,13 +4080,13 @@ def generate_launchd_plist() -> str:
 
     # Build ProgramArguments array, including --profile when using a named profile
     prog_args = [
-        f"<string>{python_path}</string>",
+        f"<string>{xml_escape(str(python_path))}</string>",
         "<string>-m</string>",
         "<string>hermes_cli.main</string>",
     ]
     if profile_arg:
         for part in profile_arg.split():
-            prog_args.append(f"<string>{part}</string>")
+            prog_args.append(f"<string>{xml_escape(part)}</string>")
     prog_args.extend(
         [
             "<string>gateway</string>",
@@ -4068,7 +4101,7 @@ def generate_launchd_plist() -> str:
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>{label}</string>
+    <string>{xml_escape(label)}</string>
 
     <key>ProgramArguments</key>
     <array>
@@ -4076,16 +4109,16 @@ def generate_launchd_plist() -> str:
     </array>
     
     <key>WorkingDirectory</key>
-    <string>{working_dir}</string>
+    <string>{xml_escape(working_dir)}</string>
     
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>{sane_path}</string>
+        <string>{xml_escape(sane_path)}</string>
         <key>VIRTUAL_ENV</key>
-        <string>{venv_dir}</string>
+        <string>{xml_escape(venv_dir)}</string>
         <key>HERMES_HOME</key>
-        <string>{hermes_home}</string>
+        <string>{xml_escape(str(hermes_home))}</string>
     </dict>
 
     <key>LimitLoadToSessionType</key>
@@ -4111,10 +4144,10 @@ def generate_launchd_plist() -> str:
     <integer>25</integer>
 
     <key>StandardOutPath</key>
-    <string>{log_dir}/gateway.log</string>
+    <string>{xml_escape(str(log_dir / 'gateway.log'))}</string>
     
     <key>StandardErrorPath</key>
-    <string>{log_dir}/gateway.error.log</string>
+    <string>{xml_escape(str(log_dir / 'gateway.error.log'))}</string>
 </dict>
 </plist>
 """

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2715,9 +2715,17 @@ def _configured_runtime_code_root() -> Path | None:
         return None
     if not isinstance(raw, str):
         raise ValueError("runtime.code_root must be an absolute path string")
-    if any(char in raw for char in ("\x00", "\n", "\r")):
+    if any(
+        ord(char) != 0x09
+        and not (
+            0x20 <= ord(char) <= 0xD7FF
+            or 0xE000 <= ord(char) <= 0xFFFD
+            or 0x10000 <= ord(char) <= 0x10FFFF
+        )
+        for char in raw
+    ):
         raise ValueError(
-            "runtime.code_root contains control characters unsupported by service managers"
+            "runtime.code_root contains characters unsupported by service managers"
         )
 
     path = Path(raw).expanduser()
@@ -3619,6 +3627,15 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
             )
         print()
 
+    runtime_actions_blocked = bool(
+        runtime_config_error
+        or (
+            runtime_info
+            and runtime_info["configured"] is not None
+            and not runtime_info["matches"]
+        )
+    )
+
     status_cmd = ["status", get_service_name(), "--no-pager"]
     if full:
         status_cmd.append("-l")
@@ -3648,7 +3665,8 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         print(
             f"✗ {_service_scope_label(system).capitalize()} gateway service is stopped"
         )
-        print(f"  Run: {'sudo ' if system else ''}hermes gateway start{scope_flag}")
+        if not runtime_actions_blocked:
+            print(f"  Run: {'sudo ' if system else ''}hermes gateway start{scope_flag}")
 
     configured_user = _read_systemd_user_from_unit(unit_path) if system else None
     if configured_user:
@@ -3670,19 +3688,21 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         print("  ⏳ Restart pending: systemd is waiting to relaunch the gateway")
     elif _systemd_unit_is_start_limited(unit_props):
         print("  ⏳ Restart pending: systemd is temporarily rate-limiting starts")
-        print(
-            f"  Run after the start-limit window expires: {'sudo ' if system else ''}hermes gateway restart{scope_flag}"
-        )
-        print(
-            f"  Or clear it manually: systemctl {'--user ' if not system else ''}reset-failed {get_service_name()}"
-        )
+        if not runtime_actions_blocked:
+            print(
+                f"  Run after the start-limit window expires: {'sudo ' if system else ''}hermes gateway restart{scope_flag}"
+            )
+            print(
+                f"  Or clear it manually: systemctl {'--user ' if not system else ''}reset-failed {get_service_name()}"
+            )
     elif active_state == "failed" and exec_main_status == str(
         GATEWAY_SERVICE_RESTART_EXIT_CODE
     ):
         print("  ⚠ Planned restart is stuck in systemd failed state (exit 75)")
-        print(
-            f"  Run: systemctl {'--user ' if not system else ''}reset-failed {get_service_name()} && {'sudo ' if system else ''}hermes gateway start{scope_flag}"
-        )
+        if not runtime_actions_blocked:
+            print(
+                f"  Run: systemctl {'--user ' if not system else ''}reset-failed {get_service_name()} && {'sudo ' if system else ''}hermes gateway start{scope_flag}"
+            )
     elif active_state == "failed" and result_code:
         print(f"  ⚠ Systemd unit result: {result_code}")
 
@@ -4670,10 +4690,13 @@ def launchd_status(deep: bool = False):
             print("✗ Running Hermes code does not match runtime.code_root")
             print("  Hold restart/promotion until the interpreter is bound to the configured runtime")
 
-    runtime_mismatch = bool(
-        runtime_info
-        and runtime_info["configured"] is not None
-        and not runtime_info["matches"]
+    runtime_actions_blocked = bool(
+        runtime_config_error
+        or (
+            runtime_info
+            and runtime_info["configured"] is not None
+            and not runtime_info["matches"]
+        )
     )
 
     if service_listed:
@@ -4690,7 +4713,7 @@ def launchd_status(deep: bool = False):
                 print("  Cron jobs will fire. Stop with: hermes gateway stop")
             else:
                 print("✗ No fallback process is running")
-                if not runtime_mismatch:
+                if not runtime_actions_blocked:
                     print("  Run: hermes gateway start")
             print("  ⚠ Auto-start at login and auto-restart on crash are NOT available.")
         else:
@@ -4701,7 +4724,7 @@ def launchd_status(deep: bool = False):
     else:
         print("✗ Gateway service is not loaded")
         print("  Service definition exists locally but launchd has not loaded it.")
-        if not runtime_mismatch:
+        if not runtime_actions_blocked:
             print("  Run: hermes gateway start")
         if fallback_pid:
             print(f"  Note: a detached gateway process is running (PID {fallback_pid})")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6647,6 +6647,11 @@ def _dispatch_via_service_manager_if_s6(
 
     if detect_service_manager() != "s6":
         return False
+    if action in ("start", "restart"):
+        # s6 lifecycle calls mutate supervised service state. Keep the guard at
+        # the dispatcher boundary so every caller, including `gateway run`'s
+        # transparent supervision redirect, fails closed before mutation.
+        _require_runtime_code_root_match()
     if profile is None:
         # _profile_suffix() returns the bare profile name for
         # HERMES_HOME=<root>/profiles/<name>, "" for the default root,
@@ -7035,6 +7040,11 @@ def _gateway_command_inner(args):
         system = getattr(args, "system", False)
         start_all = getattr(args, "all", False)
 
+        # Starting mutates the active deployment through s6, a platform service
+        # manager, or stale-process cleanup. Validate the configured runtime root
+        # before any of those paths so mismatches fail closed without mutation.
+        _require_runtime_code_root_match()
+
         # Phase 4: inside a container with s6, dispatch via the service
         # manager instead of falling through to systemd/launchd/windows.
         # `--all` isn't meaningful here (each profile has its own service
@@ -7212,12 +7222,11 @@ def _gateway_command_inner(args):
         restart_all = getattr(args, "all", False)
         service_configured = False
 
-        # ``--all`` has host-wide blast radius: s6 dispatch, service stop, and
-        # process sweeping can affect every profile. Validate before any of
-        # those mutations so an unusable deployment contract cannot take down
-        # otherwise-running gateways.
-        if restart_all:
-            _require_runtime_code_root_match()
+        # Every restart path mutates a running deployment: normal s6 dispatch
+        # and Windows restart can stop a supervised gateway just as ``--all``
+        # can. Validate before dispatching to any manager so a configured root
+        # mismatch always fails closed without service or process mutation.
+        _require_runtime_code_root_match()
 
         # Phase 4: inside a container with s6, dispatch via the service
         # manager (s6-svc -t restarts the supervised process). ``--all``

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7212,6 +7212,13 @@ def _gateway_command_inner(args):
         restart_all = getattr(args, "all", False)
         service_configured = False
 
+        # ``--all`` has host-wide blast radius: s6 dispatch, service stop, and
+        # process sweeping can affect every profile. Validate before any of
+        # those mutations so an unusable deployment contract cannot take down
+        # otherwise-running gateways.
+        if restart_all:
+            _require_runtime_code_root_match()
+
         # Phase 4: inside a container with s6, dispatch via the service
         # manager (s6-svc -t restarts the supervised process). ``--all``
         # iterates every registered profile gateway through s6; without

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3327,6 +3327,11 @@ def systemd_install(
     if system:
         _require_root_for_system_service("install")
 
+    # Validate before removing legacy units, creating directories, or touching
+    # service definitions. A failed deployment contract must leave the existing
+    # service topology unchanged.
+    _require_runtime_code_root_match()
+
     # Offer to remove legacy units (hermes.service from pre-rename installs)
     # before installing the new hermes-gateway.service. If both remain, they
     # flap-fight for the Telegram bot token on every gateway startup.
@@ -4555,6 +4560,11 @@ def _wait_for_gateway_exit(
 
 
 def launchd_restart():
+    # A restart signals or terminates the current gateway before asking launchd
+    # to relaunch it. Validate first so an invalid/mismatched deployment
+    # contract cannot disrupt a working process.
+    _require_runtime_code_root_match()
+
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
     drain_timeout = _get_restart_drain_timeout()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2684,25 +2684,91 @@ def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     return candidates
 
 
-def _stable_service_working_dir() -> str:
-    """Return a WorkingDirectory that will not disappear out from under systemd.
+def _path_is_temporary(path: Path) -> bool:
+    """Return whether *path* resolves under a system temporary directory."""
+    import tempfile
 
-    The gateway does NOT need its cwd to be the source checkout — ``ExecStart``
-    uses an absolute python interpreter and ``-m hermes_cli.main``, so module
-    resolution does not depend on cwd. Pinning ``WorkingDirectory`` to
-    ``PROJECT_ROOT`` (``Path(__file__).parent.parent``) is actively harmful:
-    when the unit is generated from a transient checkout — a ``.worktrees/``
-    dir, or a clone that ``hermes update`` later relocates/removes — the path
-    rots. systemd then fails the start at the CHDIR step (``status=200/CHDIR``,
-    "Changing to the requested working directory failed") *before* Python
-    loads, so the on-boot ``refresh_systemd_unit_if_needed()`` self-heal never
-    runs and ``Restart=always`` crash-loops forever on a dead directory.
+    resolved = path.resolve()
+    temp_roots = {
+        Path(tempfile.gettempdir()).resolve(),
+        Path("/tmp"),
+        Path("/var/tmp"),
+        Path("/private/tmp"),
+        Path("/private/var/tmp"),
+    }
+    return any(resolved == root or root in resolved.parents for root in temp_roots)
 
-    ``HERMES_HOME`` is the stable anchor: it is where config/state/logs live,
-    it never moves, and it is guaranteed to exist whenever the gateway is
-    meaningfully installed. Fall back to ``PROJECT_ROOT`` only if HERMES_HOME
-    cannot be resolved (it always can in practice).
+
+def _configured_runtime_code_root() -> Path | None:
+    """Return the declared Hermes code root for this profile, if configured.
+
+    ``runtime.code_root`` is a deployment contract, not a convenience cwd. It
+    must name an existing, absolute, non-temporary Hermes source tree. Invalid
+    declarations fail closed so service generation cannot silently point at a
+    different checkout than the operator approved.
     """
+    config = read_raw_config()
+    runtime = config.get("runtime") if isinstance(config, dict) else None
+    raw = runtime.get("code_root") if isinstance(runtime, dict) else None
+    if raw in (None, ""):
+        return None
+    if not isinstance(raw, str):
+        raise ValueError("runtime.code_root must be an absolute path string")
+
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        raise ValueError("runtime.code_root must be an absolute path")
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError(f"runtime.code_root does not exist: {path}") from exc
+    if not resolved.is_dir():
+        raise ValueError(f"runtime.code_root is not a directory: {resolved}")
+    if _path_is_temporary(resolved):
+        raise ValueError(f"runtime.code_root cannot be temporary: {resolved}")
+    if not (resolved / "hermes_cli" / "main.py").is_file():
+        raise ValueError(
+            f"runtime.code_root is not a Hermes source tree; missing hermes_cli/main.py: {resolved}"
+        )
+    return resolved
+
+
+def _runtime_code_root_status() -> dict[str, Path | bool | None]:
+    """Describe whether the configured deployment root matches imported code."""
+    configured = _configured_runtime_code_root()
+    imported = PROJECT_ROOT.resolve()
+    return {
+        "configured": configured,
+        "imported": imported,
+        "matches": None if configured is None else configured == imported,
+    }
+
+
+def _require_runtime_code_root_match() -> Path | None:
+    """Fail closed when service generation runs from an unapproved code tree."""
+    info = _runtime_code_root_status()
+    configured = info["configured"]
+    if configured is not None and not info["matches"]:
+        raise RuntimeError(
+            "runtime.code_root does not match the imported Hermes code: "
+            f"configured={configured}, imported={info['imported']}. "
+            "Run the profile-bound Hermes executable before installing, starting, or refreshing the service."
+        )
+    return configured if isinstance(configured, Path) else None
+
+
+def _stable_service_working_dir() -> str:
+    """Return a stable, explicitly declared service WorkingDirectory.
+
+    When ``runtime.code_root`` is configured, it is the profile's authoritative
+    deployment slot and must be used by service generation. Otherwise preserve
+    the standard Hermes behavior of anchoring at HERMES_HOME, never at a
+    transient source checkout.
+    """
+    configured = _require_runtime_code_root_match()
+    if configured is not None:
+        return str(configured)
+
     try:
         home = get_hermes_home()
         if home and Path(home).is_dir():
@@ -4512,11 +4578,32 @@ def launchd_status(deep: bool = False):
 
     # ── Report ──
     print(f"Launchd plist: {plist_path}")
-    if launchd_plist_is_current():
+    runtime_config_error = None
+    try:
+        runtime_info = _runtime_code_root_status()
+        definition_current = launchd_plist_is_current()
+    except (ValueError, RuntimeError) as exc:
+        runtime_info = None
+        definition_current = False
+        runtime_config_error = str(exc)
+
+    if definition_current:
         print("✓ Service definition matches the current Hermes install")
     else:
         print("⚠ Service definition is stale relative to the current Hermes install")
-        print("  Run: hermes gateway start")
+        if runtime_config_error:
+            print(f"  Invalid runtime deployment contract: {runtime_config_error}")
+        else:
+            print("  Run: hermes gateway start")
+
+    if runtime_info and runtime_info["configured"] is not None:
+        print(f"Configured runtime root: {runtime_info['configured']}")
+        print(f"Imported Hermes root: {runtime_info['imported']}")
+        if runtime_info["matches"]:
+            print("✓ Running Hermes code matches runtime.code_root")
+        else:
+            print("✗ Running Hermes code does not match runtime.code_root")
+            print("  Hold restart/promotion until the interpreter is bound to the configured runtime")
 
     if service_listed:
         if launchd_pid is not None:

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -352,15 +352,18 @@ def _legacy_startup_entry_path() -> Path:
 # ---------------------------------------------------------------------------
 
 def _stable_gateway_working_dir(project_root: Path) -> str:
-    """Return a stable cwd for detached/startup gateway runs.
+    """Return the configured runtime root or a stable cwd for Windows launches.
 
-    Mirror the POSIX service invariant: anchor at ``HERMES_HOME`` whenever it
-    exists so Scheduled Task / Startup launches do not fail at the ``cd`` step
-    after a transient checkout or worktree is moved away. Fall back to the
-    source checkout only if ``HERMES_HOME`` cannot be used yet. Preserve the
-    configured spelling instead of resolving symlinks so AppData installs backed
-    by a junction/symlink still identify themselves as AppData.
+    A declared ``runtime.code_root`` is the authoritative deployment slot and
+    must match the imported Hermes code. Without that contract, retain the
+    existing Windows behavior: anchor at ``HERMES_HOME`` when available, then
+    fall back to the source checkout. Preserve the configured home spelling so
+    AppData junctions/symlinks still identify themselves as AppData.
     """
+    configured = _require_runtime_code_root_match()
+    if configured is not None:
+        return str(configured)
+
     from hermes_cli.config import get_hermes_home
 
     try:
@@ -372,6 +375,13 @@ def _stable_gateway_working_dir(project_root: Path) -> str:
     except Exception:
         pass
     return str(project_root)
+
+
+def _require_runtime_code_root_match() -> Path | None:
+    """Validate the shared deployment contract before Windows mutations."""
+    from hermes_cli.gateway import _require_runtime_code_root_match as require_match
+
+    return require_match()
 
 
 # ---------------------------------------------------------------------------
@@ -1035,6 +1045,7 @@ def install(
     / ``systemd_install`` but isn't needed — we always reconcile.
     """
     _assert_windows()
+    _require_runtime_code_root_match()
     start_now, start_on_login = _prompt_install_choices(start_now, start_on_login)
 
     if not start_on_login:
@@ -1460,6 +1471,7 @@ def status(deep: bool = False) -> None:
 def start() -> None:
     """Start the gateway using the canonical detached Windows launch path."""
     _assert_windows()
+    _require_runtime_code_root_match()
     running_pids = _gateway_pids()
     if running_pids:
         print(f"✓ Gateway already running (PID: {', '.join(map(str, running_pids))})")
@@ -1659,6 +1671,7 @@ def restart() -> None:
     doesn't produce a running gateway.
     """
     _assert_windows()
+    _require_runtime_code_root_match()
 
     stop()
 

--- a/tests/hermes_cli/test_gateway_s6_dispatch.py
+++ b/tests/hermes_cli/test_gateway_s6_dispatch.py
@@ -378,6 +378,35 @@ def test_redirect_noop_on_host(monkeypatch: pytest.MonkeyPatch) -> None:
     assert gw._maybe_redirect_run_to_s6_supervision(_Args()) is False
 
 
+def test_redirect_validates_runtime_before_s6_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mismatched deployment contract must not mutate the s6 service."""
+    from hermes_cli import gateway as gw
+
+    rec = _stub_s6(monkeypatch, on_s6=True)
+    calls: list[str] = []
+
+    def reject_runtime() -> None:
+        calls.append("validate-runtime")
+        raise RuntimeError("runtime mismatch")
+
+    monkeypatch.setattr(gw, "_require_runtime_code_root_match", reject_runtime)
+    monkeypatch.setattr(
+        gw.os,
+        "execvp",
+        lambda *_args: pytest.fail("execvp must not run after a runtime mismatch"),
+    )
+    monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_NO_SUPERVISE", raising=False)
+
+    with pytest.raises(RuntimeError, match="runtime mismatch"):
+        gw._maybe_redirect_run_to_s6_supervision(_Args())
+
+    assert calls == ["validate-runtime"]
+    assert rec.calls == []
+
+
 def test_redirect_fires_inside_s6_container(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -574,8 +574,38 @@ class TestGeneratedSystemdUnits:
 
         unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
-        assert f"WorkingDirectory={runtime_root.resolve()}" in unit
+        assert f'WorkingDirectory="{runtime_root.resolve()}"' in unit
         assert "WorkingDirectory=/home/alice/.hermes" not in unit
+
+    def test_system_unit_escapes_configured_runtime_code_root_specifiers(
+        self, tmp_path, monkeypatch
+    ):
+        runtime_root = tmp_path / "runtime" / "slot%h"
+        (runtime_root / "hermes_cli").mkdir(parents=True)
+        (runtime_root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"runtime": {"code_root": str(runtime_root)}},
+        )
+        monkeypatch.setattr(gateway_cli, "_path_is_temporary", lambda path: False)
+        monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", runtime_root.resolve())
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_hermes_home_for_target_user",
+            lambda home: "/home/alice/.hermes",
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        escaped_root = str(runtime_root.resolve()).replace("%", "%%")
+        assert f'WorkingDirectory="{escaped_root}"' in unit
+        assert f'WorkingDirectory="{runtime_root.resolve()}"' not in unit
 
     def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
         monkeypatch.setattr(
@@ -1012,6 +1042,48 @@ class TestLaunchdServiceRecovery:
         assert str(plist_path) in output
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
+
+    def test_launchd_status_mismatch_suppresses_stale_mutation_guidance(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+        runtime_info = {
+            "configured": Path("/opt/hermes-runtime"),
+            "imported": Path("/srv/hermes"),
+            "matches": False,
+        }
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli, "_runtime_code_root_status", lambda: runtime_info
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "launchd_plist_is_current",
+            lambda: (_ for _ in ()).throw(
+                AssertionError("mismatch must skip service generation")
+            ),
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=113, stdout="", stderr="Could not find service"
+            ),
+        )
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda cleanup_stale=False: None
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_launchd_unsupported_marker_exists", lambda: False
+        )
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert "does not match runtime.code_root" in output
+        assert "Service definition is stale" not in output
+        assert "Run: hermes gateway start" not in output
 
     def test_launchd_domain_uses_user_domain(self, monkeypatch):
         # The user/<uid> domain (not gui/<uid>) is the one reachable from
@@ -1853,7 +1925,9 @@ class TestGatewaySystemServiceRouting:
 
         gateway_cli.systemd_status()
 
-        assert expected in capsys.readouterr().out
+        output = capsys.readouterr().out
+        assert expected in output
+        assert "Run:" not in output
 
     def test_gateway_status_dispatches_full_flag(self, monkeypatch):
         user_unit = SimpleNamespace(exists=lambda: True)
@@ -3649,6 +3723,18 @@ class TestServiceWorkingDirIsStable:
         with pytest.raises(ValueError, match="must be an absolute path"):
             gateway_cli._configured_runtime_code_root()
 
+    def test_configured_runtime_code_root_rejects_service_control_characters(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"runtime": {"code_root": "/srv/hermes\nWorkingDirectory=/tmp"}},
+        )
+
+        with pytest.raises(ValueError, match="control characters"):
+            gateway_cli._configured_runtime_code_root()
+
     def test_configured_runtime_code_root_rejects_existing_temporary_tree(
         self, tmp_path, monkeypatch
     ):
@@ -3732,7 +3818,7 @@ class TestServiceWorkingDirIsStable:
         )
 
         assert info == runtime_info
-        assert current is False
+        assert current is None
         assert error is None
 
     def test_service_generation_refuses_wrong_imported_code_root(self, tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -3533,6 +3533,82 @@ class TestServiceWorkingDirIsStable:
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: missing)
         assert gateway_cli._stable_service_working_dir() == str(gateway_cli.PROJECT_ROOT)
 
+    def test_configured_runtime_code_root_is_service_working_dir(self, tmp_path, monkeypatch):
+        runtime_root = tmp_path / "runtime" / "mission-ctrl"
+        (runtime_root / "hermes_cli").mkdir(parents=True)
+        (runtime_root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"runtime": {"code_root": str(runtime_root)}},
+        )
+        monkeypatch.setattr(gateway_cli, "_path_is_temporary", lambda path: False)
+        monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", runtime_root.resolve())
+
+        assert Path(gateway_cli._stable_service_working_dir()) == runtime_root.resolve()
+        assert gateway_cli._configured_runtime_code_root() == runtime_root.resolve()
+
+    @pytest.mark.parametrize("configured", ["relative/runtime", "/tmp/hermes-runtime"])
+    def test_configured_runtime_code_root_rejects_unsafe_paths(
+        self, tmp_path, monkeypatch, configured
+    ):
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"runtime": {"code_root": configured}},
+        )
+
+        with pytest.raises(ValueError, match="runtime.code_root"):
+            gateway_cli._configured_runtime_code_root()
+
+    def test_configured_runtime_code_root_requires_hermes_entrypoint(self, tmp_path, monkeypatch):
+        runtime_root = tmp_path / "runtime" / "mission-ctrl"
+        runtime_root.mkdir(parents=True)
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"runtime": {"code_root": str(runtime_root)}},
+        )
+        monkeypatch.setattr(gateway_cli, "_path_is_temporary", lambda path: False)
+
+        with pytest.raises(ValueError, match="hermes_cli/main.py"):
+            gateway_cli._configured_runtime_code_root()
+
+    def test_runtime_code_root_status_compares_config_to_imported_root(self, tmp_path, monkeypatch):
+        runtime_root = tmp_path / "runtime" / "mission-ctrl"
+        (runtime_root / "hermes_cli").mkdir(parents=True)
+        (runtime_root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"runtime": {"code_root": str(runtime_root)}},
+        )
+        monkeypatch.setattr(gateway_cli, "_path_is_temporary", lambda path: False)
+        monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", runtime_root.resolve())
+
+        info = gateway_cli._runtime_code_root_status()
+
+        assert info["configured"] == runtime_root.resolve()
+        assert info["imported"] == runtime_root.resolve()
+        assert info["matches"] is True
+
+    def test_service_generation_refuses_wrong_imported_code_root(self, tmp_path, monkeypatch):
+        runtime_root = tmp_path / "runtime" / "mission-ctrl"
+        other_root = tmp_path / "runtime" / "other-copy"
+        (runtime_root / "hermes_cli").mkdir(parents=True)
+        (runtime_root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+        other_root.mkdir(parents=True)
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"runtime": {"code_root": str(runtime_root)}},
+        )
+        monkeypatch.setattr(gateway_cli, "_path_is_temporary", lambda path: False)
+        monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", other_root.resolve())
+
+        with pytest.raises(RuntimeError, match="does not match the imported Hermes code"):
+            gateway_cli.generate_launchd_plist()
+
     def test_user_unit_workingdirectory_is_hermes_home_not_checkout(self, tmp_path, monkeypatch):
         home = tmp_path / ".hermes"
         home.mkdir()
@@ -3556,6 +3632,40 @@ class TestServiceWorkingDirIsStable:
         assert m, "plist has no WorkingDirectory entry"
         assert Path(m.group(1)).resolve() == home.resolve()
         assert "/.worktrees/" not in m.group(1)
+
+    def test_launchd_currentness_honors_runtime_code_root(self, tmp_path, monkeypatch):
+        import re
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        runtime_root = tmp_path / "runtime" / "mission-ctrl"
+        (runtime_root / "hermes_cli").mkdir(parents=True)
+        (runtime_root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+        plist_path = tmp_path / "ai.hermes.gateway-mission-ctrl.plist"
+
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_path_is_temporary", lambda path: False)
+        monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", runtime_root.resolve())
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"runtime": {"code_root": str(runtime_root)}},
+        )
+
+        expected = gateway_cli.generate_launchd_plist()
+        assert re.search(
+            rf"<key>WorkingDirectory</key>\s*<string>{re.escape(str(runtime_root.resolve()))}</string>",
+            expected,
+        )
+        plist_path.write_text(expected, encoding="utf-8")
+        assert gateway_cli.launchd_plist_is_current() is True
+
+        plist_path.write_text(
+            expected.replace(str(runtime_root.resolve()), str(home.resolve()), 1),
+            encoding="utf-8",
+        )
+        assert gateway_cli.launchd_plist_is_current() is False
 
     def test_launchd_plist_keepalive_unconditional(self, tmp_path, monkeypatch):
         """KeepAlive must be unconditional <true/> so the gateway restarts on clean exits.

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -542,6 +542,33 @@ class TestGeneratedSystemdUnits:
 
         assert "/mnt/c/WINDOWS/system32" in unit
 
+    def test_system_unit_preserves_configured_runtime_code_root(self, tmp_path, monkeypatch):
+        runtime_root = tmp_path / "runtime" / "mission-ctrl"
+        (runtime_root / "hermes_cli").mkdir(parents=True)
+        (runtime_root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"runtime": {"code_root": str(runtime_root)}},
+        )
+        monkeypatch.setattr(gateway_cli, "_path_is_temporary", lambda path: False)
+        monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", runtime_root.resolve())
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_hermes_home_for_target_user",
+            lambda home: "/home/alice/.hermes",
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        assert f"WorkingDirectory={runtime_root.resolve()}" in unit
+        assert "WorkingDirectory=/home/alice/.hermes" not in unit
+
     def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
         monkeypatch.setattr(
             gateway_cli,
@@ -1763,6 +1790,56 @@ class TestGatewaySystemServiceRouting:
 
         out = capsys.readouterr().out
         assert "Planned restart is stuck in systemd failed state" in out
+
+    @pytest.mark.parametrize(
+        ("runtime_status", "expected"),
+        [
+            (
+                {
+                    "configured": Path("/opt/hermes-runtime"),
+                    "imported": Path("/srv/hermes"),
+                    "matches": False,
+                },
+                "Running Hermes code does not match runtime.code_root",
+            ),
+            (
+                ValueError("runtime.code_root does not exist: /missing"),
+                "Invalid runtime deployment contract",
+            ),
+        ],
+    )
+    def test_systemd_status_reports_runtime_code_root_contract(
+        self, monkeypatch, capsys, runtime_status, expected
+    ):
+        unit = SimpleNamespace(exists=lambda: True)
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit)
+        monkeypatch.setattr(gateway_cli, "has_conflicting_systemd_units", lambda: False)
+        monkeypatch.setattr(gateway_cli, "has_legacy_hermes_units", lambda: False)
+
+        def runtime_info():
+            if isinstance(runtime_status, Exception):
+                raise runtime_status
+            return runtime_status
+
+        monkeypatch.setattr(gateway_cli, "_runtime_code_root_status", runtime_info)
+        monkeypatch.setattr(gateway_cli, "systemd_unit_is_current", lambda system=False: True)
+        monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
+        monkeypatch.setattr(gateway_cli, "_read_systemd_unit_properties", lambda system=False: {})
+        monkeypatch.setattr(gateway_cli, "get_systemd_linger_status", lambda: (True, ""))
+
+        def fake_run_systemctl(args, **kwargs):
+            if args[0] == "status":
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            if args[0] == "is-active":
+                return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
+            raise AssertionError(f"Unexpected args: {args}")
+
+        monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
+
+        gateway_cli.systemd_status()
+
+        assert expected in capsys.readouterr().out
 
     def test_gateway_status_dispatches_full_flag(self, monkeypatch):
         user_unit = SimpleNamespace(exists=lambda: True)
@@ -3548,18 +3625,49 @@ class TestServiceWorkingDirIsStable:
         assert Path(gateway_cli._stable_service_working_dir()) == runtime_root.resolve()
         assert gateway_cli._configured_runtime_code_root() == runtime_root.resolve()
 
-    @pytest.mark.parametrize("configured", ["relative/runtime", "/tmp/hermes-runtime"])
-    def test_configured_runtime_code_root_rejects_unsafe_paths(
-        self, tmp_path, monkeypatch, configured
-    ):
+    def test_configured_runtime_code_root_rejects_relative_path(self, monkeypatch):
         monkeypatch.setattr(
             gateway_cli,
             "read_raw_config",
-            lambda: {"runtime": {"code_root": configured}},
+            lambda: {"runtime": {"code_root": "relative/runtime"}},
         )
 
-        with pytest.raises(ValueError, match="runtime.code_root"):
+        with pytest.raises(ValueError, match="must be an absolute path"):
             gateway_cli._configured_runtime_code_root()
+
+    def test_configured_runtime_code_root_rejects_existing_temporary_tree(
+        self, tmp_path, monkeypatch
+    ):
+        runtime_root = tmp_path / "hermes-runtime"
+        (runtime_root / "hermes_cli").mkdir(parents=True)
+        (runtime_root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"runtime": {"code_root": str(runtime_root)}},
+        )
+
+        with pytest.raises(ValueError, match="cannot be temporary"):
+            gateway_cli._configured_runtime_code_root()
+
+    def test_launchd_plist_escapes_configured_runtime_code_root(self, tmp_path, monkeypatch):
+        import plistlib
+
+        runtime_root = tmp_path / "runtime&slot"
+        (runtime_root / "hermes_cli").mkdir(parents=True)
+        (runtime_root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli,
+            "read_raw_config",
+            lambda: {"runtime": {"code_root": str(runtime_root)}},
+        )
+        monkeypatch.setattr(gateway_cli, "_path_is_temporary", lambda path: False)
+        monkeypatch.setattr(gateway_cli, "PROJECT_ROOT", runtime_root.resolve())
+
+        plist = gateway_cli.generate_launchd_plist()
+        parsed = plistlib.loads(plist.encode("utf-8"))
+
+        assert parsed["WorkingDirectory"] == str(runtime_root.resolve())
 
     def test_configured_runtime_code_root_requires_hermes_entrypoint(self, tmp_path, monkeypatch):
         runtime_root = tmp_path / "runtime" / "mission-ctrl"

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -563,6 +563,14 @@ class TestGeneratedSystemdUnits:
             "_hermes_home_for_target_user",
             lambda home: "/home/alice/.hermes",
         )
+        original_remap = gateway_cli._remap_path_for_user
+
+        def guarded_remap(path, home_dir):
+            if Path(path).resolve() == runtime_root.resolve():
+                raise AssertionError("configured runtime root must not be remapped")
+            return original_remap(path, home_dir)
+
+        monkeypatch.setattr(gateway_cli, "_remap_path_for_user", guarded_remap)
 
         unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
@@ -1823,7 +1831,13 @@ class TestGatewaySystemServiceRouting:
             return runtime_status
 
         monkeypatch.setattr(gateway_cli, "_runtime_code_root_status", runtime_info)
-        monkeypatch.setattr(gateway_cli, "systemd_unit_is_current", lambda system=False: True)
+
+        def should_not_generate_definition(system=False):
+            raise AssertionError("mismatch/invalid config must skip service generation")
+
+        monkeypatch.setattr(
+            gateway_cli, "systemd_unit_is_current", should_not_generate_definition
+        )
         monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
         monkeypatch.setattr(gateway_cli, "_read_systemd_unit_properties", lambda system=False: {})
         monkeypatch.setattr(gateway_cli, "get_systemd_linger_status", lambda: (True, ""))
@@ -3699,6 +3713,27 @@ class TestServiceWorkingDirIsStable:
         assert info["configured"] == runtime_root.resolve()
         assert info["imported"] == runtime_root.resolve()
         assert info["matches"] is True
+
+    def test_service_definition_status_preserves_mismatch_without_generation(self, monkeypatch):
+        runtime_info = {
+            "configured": Path("/opt/hermes-runtime"),
+            "imported": Path("/srv/hermes"),
+            "matches": False,
+        }
+        monkeypatch.setattr(
+            gateway_cli, "_runtime_code_root_status", lambda: runtime_info
+        )
+
+        def should_not_generate():
+            raise AssertionError("mismatch must skip service definition generation")
+
+        info, current, error = gateway_cli._service_definition_runtime_status(
+            should_not_generate
+        )
+
+        assert info == runtime_info
+        assert current is False
+        assert error is None
 
     def test_service_generation_refuses_wrong_imported_code_root(self, tmp_path, monkeypatch):
         runtime_root = tmp_path / "runtime" / "mission-ctrl"

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1043,20 +1043,36 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
-    def test_launchd_status_mismatch_suppresses_stale_mutation_guidance(
-        self, tmp_path, monkeypatch, capsys
+    @pytest.mark.parametrize(
+        ("runtime_status", "expected"),
+        [
+            (
+                {
+                    "configured": Path("/opt/hermes-runtime"),
+                    "imported": Path("/srv/hermes"),
+                    "matches": False,
+                },
+                "does not match runtime.code_root",
+            ),
+            (
+                ValueError("runtime.code_root does not exist: /missing"),
+                "Invalid runtime deployment contract",
+            ),
+        ],
+    )
+    def test_launchd_status_runtime_contract_suppresses_mutation_guidance(
+        self, tmp_path, monkeypatch, capsys, runtime_status, expected
     ):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
-        runtime_info = {
-            "configured": Path("/opt/hermes-runtime"),
-            "imported": Path("/srv/hermes"),
-            "matches": False,
-        }
+
+        def runtime_info():
+            if isinstance(runtime_status, Exception):
+                raise runtime_status
+            return runtime_status
+
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        monkeypatch.setattr(
-            gateway_cli, "_runtime_code_root_status", lambda: runtime_info
-        )
+        monkeypatch.setattr(gateway_cli, "_runtime_code_root_status", runtime_info)
         monkeypatch.setattr(
             gateway_cli,
             "launchd_plist_is_current",
@@ -1081,8 +1097,9 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_status()
 
         output = capsys.readouterr().out
-        assert "does not match runtime.code_root" in output
-        assert "Service definition is stale" not in output
+        assert expected in output
+        if not isinstance(runtime_status, Exception):
+            assert "Service definition is stale" not in output
         assert "Run: hermes gateway start" not in output
 
     def test_launchd_domain_uses_user_domain(self, monkeypatch):
@@ -1872,7 +1889,7 @@ class TestGatewaySystemServiceRouting:
         assert "Planned restart is stuck in systemd failed state" in out
 
     @pytest.mark.parametrize(
-        ("runtime_status", "expected"),
+        ("runtime_status", "unit_props", "expected"),
         [
             (
                 {
@@ -1880,16 +1897,21 @@ class TestGatewaySystemServiceRouting:
                     "imported": Path("/srv/hermes"),
                     "matches": False,
                 },
+                {"Result": "start-limit-hit"},
                 "Running Hermes code does not match runtime.code_root",
             ),
             (
                 ValueError("runtime.code_root does not exist: /missing"),
+                {
+                    "ActiveState": "failed",
+                    "ExecMainStatus": str(GATEWAY_SERVICE_RESTART_EXIT_CODE),
+                },
                 "Invalid runtime deployment contract",
             ),
         ],
     )
     def test_systemd_status_reports_runtime_code_root_contract(
-        self, monkeypatch, capsys, runtime_status, expected
+        self, monkeypatch, capsys, runtime_status, unit_props, expected
     ):
         unit = SimpleNamespace(exists=lambda: True)
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
@@ -1911,14 +1933,18 @@ class TestGatewaySystemServiceRouting:
             gateway_cli, "systemd_unit_is_current", should_not_generate_definition
         )
         monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
-        monkeypatch.setattr(gateway_cli, "_read_systemd_unit_properties", lambda system=False: {})
+        monkeypatch.setattr(
+            gateway_cli,
+            "_read_systemd_unit_properties",
+            lambda system=False: unit_props,
+        )
         monkeypatch.setattr(gateway_cli, "get_systemd_linger_status", lambda: (True, ""))
 
         def fake_run_systemctl(args, **kwargs):
             if args[0] == "status":
                 return SimpleNamespace(returncode=0, stdout="", stderr="")
             if args[0] == "is-active":
-                return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
+                return SimpleNamespace(returncode=3, stdout="inactive\n", stderr="")
             raise AssertionError(f"Unexpected args: {args}")
 
         monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
@@ -1928,6 +1954,7 @@ class TestGatewaySystemServiceRouting:
         output = capsys.readouterr().out
         assert expected in output
         assert "Run:" not in output
+        assert "reset-failed" not in output
 
     def test_gateway_status_dispatches_full_flag(self, monkeypatch):
         user_unit = SimpleNamespace(exists=lambda: True)
@@ -3723,16 +3750,22 @@ class TestServiceWorkingDirIsStable:
         with pytest.raises(ValueError, match="must be an absolute path"):
             gateway_cli._configured_runtime_code_root()
 
+    @pytest.mark.parametrize(
+        "bad_char",
+        ["\x00", "\x01", "\x07", "\x0b", "\x0c", "\x1b", "\n", "\r", "\ufffe", "\uffff"],
+    )
     def test_configured_runtime_code_root_rejects_service_control_characters(
-        self, monkeypatch
+        self, monkeypatch, bad_char
     ):
         monkeypatch.setattr(
             gateway_cli,
             "read_raw_config",
-            lambda: {"runtime": {"code_root": "/srv/hermes\nWorkingDirectory=/tmp"}},
+            lambda: {
+                "runtime": {"code_root": f"/srv/hermes{bad_char}WorkingDirectory=/tmp"}
+            },
         )
 
-        with pytest.raises(ValueError, match="control characters"):
+        with pytest.raises(ValueError, match="unsupported by service managers"):
             gateway_cli._configured_runtime_code_root()
 
     def test_configured_runtime_code_root_rejects_existing_temporary_tree(

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2182,6 +2182,57 @@ class TestGatewaySystemServiceRouting:
 
         assert calls == ["validate-runtime"]
 
+    def test_gateway_restart_validates_before_normal_s6_dispatch(
+        self, monkeypatch
+    ):
+        calls = []
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+
+        def reject_runtime():
+            calls.append("validate-runtime")
+            raise RuntimeError("runtime mismatch")
+
+        monkeypatch.setattr(
+            gateway_cli, "_require_runtime_code_root_match", reject_runtime
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_dispatch_via_service_manager_if_s6",
+            lambda action: calls.append("s6-dispatch") or True,
+        )
+
+        with pytest.raises(RuntimeError, match="runtime mismatch"):
+            gateway_cli.gateway_command(
+                SimpleNamespace(gateway_command="restart", system=False, all=False)
+            )
+
+        assert calls == ["validate-runtime"]
+
+    def test_gateway_start_validates_before_normal_s6_dispatch(
+        self, monkeypatch
+    ):
+        calls = []
+
+        def reject_runtime():
+            calls.append("validate-runtime")
+            raise RuntimeError("runtime mismatch")
+
+        monkeypatch.setattr(
+            gateway_cli, "_require_runtime_code_root_match", reject_runtime
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_dispatch_via_service_manager_if_s6",
+            lambda action: calls.append("s6-dispatch") or True,
+        )
+
+        with pytest.raises(RuntimeError, match="runtime mismatch"):
+            gateway_cli.gateway_command(
+                SimpleNamespace(gateway_command="start", system=False, all=False)
+            )
+
+        assert calls == ["validate-runtime"]
+
     def test_gateway_restart_does_not_fallback_to_foreground_when_launchd_restart_fails(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text("plist\n", encoding="utf-8")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -913,6 +913,57 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
+    @pytest.mark.parametrize(
+        ("runtime_status", "error_type"),
+        [
+            (
+                {
+                    "configured": Path("/opt/hermes-runtime"),
+                    "imported": Path("/srv/hermes"),
+                    "matches": False,
+                },
+                RuntimeError,
+            ),
+            (ValueError("runtime.code_root does not exist: /missing"), ValueError),
+        ],
+    )
+    def test_launchd_restart_validates_runtime_before_any_mutation(
+        self, monkeypatch, runtime_status, error_type
+    ):
+        calls = []
+
+        def runtime_info():
+            calls.append("validate-runtime")
+            if isinstance(runtime_status, Exception):
+                raise runtime_status
+            return runtime_status
+
+        monkeypatch.setattr(gateway_cli, "_runtime_code_root_status", runtime_info)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_launchd_label",
+            lambda: calls.append("get-label") or "ai.hermes.gateway",
+        )
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda: calls.append("get-pid") or 321,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: calls.append("signal-pid") or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: calls.append("launchctl"),
+        )
+
+        with pytest.raises(error_type):
+            gateway_cli.launchd_restart()
+
+        assert calls == ["validate-runtime"]
+
     def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch, capsys):
         calls = []
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
@@ -3415,6 +3466,34 @@ class TestGatewayStatusParser:
 
 class TestSystemdInstallOffersLegacyRemoval:
     """Verify that systemd_install prompts to remove legacy units first."""
+
+    def test_systemd_install_validates_runtime_before_legacy_removal(
+        self, monkeypatch
+    ):
+        calls = []
+
+        def reject_runtime():
+            calls.append("validate-runtime")
+            raise RuntimeError("runtime mismatch")
+
+        monkeypatch.setattr(
+            gateway_cli, "_require_runtime_code_root_match", reject_runtime
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "has_legacy_hermes_units",
+            lambda: calls.append("inspect-legacy") or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "remove_legacy_hermes_units",
+            lambda **kwargs: calls.append("remove-legacy"),
+        )
+
+        with pytest.raises(RuntimeError, match="runtime mismatch"):
+            gateway_cli.systemd_install(non_interactive=True)
+
+        assert calls == ["validate-runtime"]
 
     def test_install_offers_removal_when_legacy_detected(
         self, tmp_path, monkeypatch, capsys

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2136,6 +2136,52 @@ class TestGatewaySystemServiceRouting:
         assert "nohup hermes gateway" in out
         assert "install as user service" not in out
 
+    def test_gateway_restart_all_validates_before_host_wide_mutation(
+        self, monkeypatch
+    ):
+        calls = []
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+
+        def reject_runtime():
+            calls.append("validate-runtime")
+            raise RuntimeError("runtime mismatch")
+
+        monkeypatch.setattr(
+            gateway_cli, "_require_runtime_code_root_match", reject_runtime
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_dispatch_all_via_service_manager_if_s6",
+            lambda action: calls.append("s6-dispatch") or False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "systemd_stop",
+            lambda system=False: calls.append("stop-service"),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "launchd_stop",
+            lambda: calls.append("stop-launchd"),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "kill_gateway_processes",
+            lambda **kwargs: calls.append("kill-all-profiles") or 0,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda **kwargs: calls.append("wait-exit") or True,
+        )
+
+        with pytest.raises(RuntimeError, match="runtime mismatch"):
+            gateway_cli.gateway_command(
+                SimpleNamespace(gateway_command="restart", system=False, all=True)
+            )
+
+        assert calls == ["validate-runtime"]
+
     def test_gateway_restart_does_not_fallback_to_foreground_when_launchd_restart_fails(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text("plist\n", encoding="utf-8")

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -101,7 +101,7 @@ def test_build_gateway_argv_uses_base_pythonw_for_uv_venv_launcher(monkeypatch, 
     monkeypatch.setattr(gateway, "PROJECT_ROOT", project)
     monkeypatch.setattr(gateway, "get_python_path", lambda: str(venv_python))
     monkeypatch.setattr(gateway, "_profile_arg", lambda hermes_home: "")
-    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: str(hermes_home))
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hermes_home)
 
     argv, cwd, env_overlay = gateway_windows._build_gateway_argv()
 
@@ -139,7 +139,7 @@ def test_write_task_script_anchors_cmd_cd_at_hermes_home(monkeypatch, tmp_path):
     monkeypatch.setattr(gateway, "PROJECT_ROOT", project)
     monkeypatch.setattr(gateway, "get_python_path", lambda: str(python_exe))
     monkeypatch.setattr(gateway, "_profile_arg", lambda hermes_home: "")
-    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: str(hermes_home))
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hermes_home)
     monkeypatch.setattr(gateway_windows, "get_task_script_path", lambda: script_path)
 
     written = gateway_windows._write_task_script()
@@ -148,6 +148,143 @@ def test_write_task_script_anchors_cmd_cd_at_hermes_home(monkeypatch, tmp_path):
     assert written == script_path
     assert f"cd /d {gateway_windows._quote_cmd_script_arg(str(hermes_home.resolve()))}" in content
     assert f"cd /d {gateway_windows._quote_cmd_script_arg(str(project))}" not in content
+
+
+def test_write_task_script_uses_configured_runtime_code_root(monkeypatch, tmp_path):
+    runtime_root = tmp_path / "runtime-root"
+    hermes_home = tmp_path / "hermes-home"
+    python_exe = runtime_root / "venv" / "Scripts" / "python.exe"
+    (runtime_root / "hermes_cli").mkdir(parents=True)
+    (runtime_root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+    python_exe.parent.mkdir(parents=True)
+    python_exe.write_text("", encoding="utf-8")
+    hermes_home.mkdir()
+    script_path = tmp_path / "gateway.cmd"
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", runtime_root.resolve())
+    monkeypatch.setattr(gateway, "get_python_path", lambda: str(python_exe))
+    monkeypatch.setattr(gateway, "_profile_arg", lambda hermes_home: "")
+    monkeypatch.setattr(
+        gateway,
+        "read_raw_config",
+        lambda: {"runtime": {"code_root": str(runtime_root)}},
+    )
+    monkeypatch.setattr(gateway, "_path_is_temporary", lambda path: False)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: str(hermes_home))
+    monkeypatch.setattr(gateway_windows, "get_task_script_path", lambda: script_path)
+
+    gateway_windows._write_task_script()
+    cmd_content = script_path.read_text(encoding="utf-8")
+    vbs_content = script_path.with_suffix(".vbs").read_text(encoding="utf-8")
+    runtime_dir = str(runtime_root.resolve())
+    home_dir = str(hermes_home.resolve())
+
+    assert f"cd /d {gateway_windows._quote_cmd_script_arg(runtime_dir)}" in cmd_content
+    assert f"cd /d {gateway_windows._quote_cmd_script_arg(home_dir)}" not in cmd_content
+    assert f"sh.CurrentDirectory = {gateway_windows._quote_vbs_string(runtime_dir)}" in vbs_content
+    assert f"sh.CurrentDirectory = {gateway_windows._quote_vbs_string(home_dir)}" not in vbs_content
+
+
+def test_build_gateway_argv_uses_configured_runtime_code_root(monkeypatch, tmp_path):
+    runtime_root = tmp_path / "runtime-root"
+    hermes_home = tmp_path / "hermes-home"
+    python_exe = runtime_root / "venv" / "Scripts" / "python.exe"
+    (runtime_root / "hermes_cli").mkdir(parents=True)
+    (runtime_root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+    python_exe.parent.mkdir(parents=True)
+    python_exe.write_text("", encoding="utf-8")
+    hermes_home.mkdir()
+
+    monkeypatch.setattr(gateway_windows.sys, "platform", "win32")
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", runtime_root.resolve())
+    monkeypatch.setattr(gateway, "get_python_path", lambda: str(python_exe))
+    monkeypatch.setattr(gateway, "_profile_arg", lambda hermes_home: "")
+    monkeypatch.setattr(
+        gateway,
+        "read_raw_config",
+        lambda: {"runtime": {"code_root": str(runtime_root)}},
+    )
+    monkeypatch.setattr(gateway, "_path_is_temporary", lambda path: False)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hermes_home)
+
+    _argv, cwd, _env_overlay = gateway_windows._build_gateway_argv()
+
+    assert cwd == str(runtime_root.resolve())
+    assert cwd != str(hermes_home.resolve())
+
+
+def test_windows_install_validates_runtime_before_any_mutation(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(
+        gateway,
+        "_require_runtime_code_root_match",
+        lambda: calls.append("validate-runtime")
+        or (_ for _ in ()).throw(RuntimeError("runtime mismatch")),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_prompt_install_choices",
+        lambda *args: calls.append("prompt") or (False, True),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_write_task_script",
+        lambda: calls.append("write-launcher"),
+    )
+
+    with pytest.raises(RuntimeError, match="runtime mismatch"):
+        gateway_windows.install(start_now=False, start_on_login=True)
+
+    assert calls == ["validate-runtime"]
+
+
+def test_windows_start_validates_runtime_before_spawn(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(
+        gateway,
+        "_require_runtime_code_root_match",
+        lambda: calls.append("validate-runtime")
+        or (_ for _ in ()).throw(RuntimeError("runtime mismatch")),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_gateway_pids",
+        lambda: calls.append("inspect-pids") or [],
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_spawn_detached",
+        lambda: calls.append("spawn"),
+    )
+
+    with pytest.raises(RuntimeError, match="runtime mismatch"):
+        gateway_windows.start()
+
+    assert calls == ["validate-runtime"]
+
+
+def test_windows_restart_validates_runtime_before_stop(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(
+        gateway,
+        "_require_runtime_code_root_match",
+        lambda: calls.append("validate-runtime")
+        or (_ for _ in ()).throw(RuntimeError("runtime mismatch")),
+    )
+    monkeypatch.setattr(gateway_windows, "stop", lambda: calls.append("stop"))
+    monkeypatch.setattr(gateway_windows, "start", lambda: calls.append("start"))
+
+    with pytest.raises(RuntimeError, match="runtime mismatch"):
+        gateway_windows.restart()
+
+    assert calls == ["validate-runtime"]
 
 
 def _arrange_startup_fallback(monkeypatch, tmp_path, running_pids):

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -56,6 +56,31 @@ research gateway start
 That's it — three independent agents, each on its own process, restarting
 automatically on crash and on user login.
 
+## Pinning a profile to an isolated runtime tree
+
+Most installations should leave service working-directory selection at its
+default. Operators that maintain a separate, durable Hermes source tree per
+profile can declare that tree explicitly in the profile's `config.yaml`:
+
+```yaml
+runtime:
+  code_root: /srv/hermes/runtimes/research
+```
+
+`runtime.code_root` is a deployment contract, not a general-purpose current
+working directory. Hermes requires an absolute, existing, non-temporary Hermes
+source tree and verifies that the running CLI was imported from the same tree
+before it installs, starts, or refreshes the gateway service. The generated
+launchd or systemd definition uses this root as `WorkingDirectory`, and
+`hermes gateway status` reports whether the configured and imported roots
+match.
+
+If the setting is absent, service generation retains the standard behavior of
+using the profile's stable Hermes home. If the declaration is invalid or the
+CLI was launched from another Hermes checkout, service mutation fails closed;
+run the executable bound to the declared runtime rather than bypassing the
+check.
+
 ## Alternative: one gateway for all profiles (multiplexing)
 
 The model above runs **one process per profile**. That is the default and is


### PR DESCRIPTION
## Summary

- add `runtime.code_root` as an explicit deployment contract for gateway service generation
- verify the configured code root matches the imported Hermes source tree before service mutations
- apply the contract across systemd, launchd, Windows, s6, and `restart --all` paths
- expose runtime-root health and actionable, safe recovery guidance
- document multi-profile runtime-root behavior

## Safety behavior

- unset `runtime.code_root` preserves existing behavior
- invalid or mismatched configured roots fail closed before service mutation
- mismatch diagnostics do not recommend service restart until source/config alignment is restored
- systemd unit values and launchd plist values are encoded for their native formats

## Validation

- focused runtime/service tests passed
- fix + s6 dispatch suite: 28 passed
- gateway restart-loop suite: 65 passed
- gateway service test file: 213 passed; 4 unchanged pre-existing macOS systemd-preflight failures
- Ruff, Python compileall, and `git diff --check` passed
- independent final review: GO; no remaining High/Medium findings

## Operational scope

This PR changes source and tests only. No runtime promotion, profile configuration change, deployment, or service restart was performed.