### PR TITLE
fix(gateway): handle silent audio and media producers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1143,10 +1143,12 @@ def _collect_auto_append_media_tags(
         if msg.get("role") not in ("tool", "function"):
             continue
         call_id = str(msg.get("tool_call_id") or msg.get("call_id") or "")
-        if tool_name_by_call_id.get(call_id) not in _AUTO_APPEND_MEDIA_TOOL_NAMES:
+        tool_name = tool_name_by_call_id.get(call_id) or str(
+            msg.get("tool_name") or msg.get("name") or ""
+        )
+        if tool_name not in _AUTO_APPEND_MEDIA_TOOL_NAMES:
             continue
         content = str(msg.get("content") or "")
-        tool_name = tool_name_by_call_id.get(call_id)
         # JSON-payload tools (image_generate) return a local-file path in a
         # known field rather than a MEDIA: tag. Extract it so delivery is
         # deterministic even when the model omits the path from its reply.
@@ -5577,6 +5579,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
 
         running_agent = self._running_agents.get(session_key)
+
+        if event.message_type == MessageType.VOICE:
+            audio_paths = list(getattr(event, "media_urls", None) or [])
+            if audio_paths:
+                text, transcripts = await self._enrich_message_with_transcription(
+                    event.text or "", audio_paths,
+                )
+                if text is None:
+                    return True
+                event.text = text
+                if transcripts:
+                    event.media_urls = []
+                    event.media_types = []
+                    if self._should_echo_stt_transcripts():
+                        echo_meta = self._thread_metadata_for_source(
+                            event.source, self._reply_anchor_for_event(event)
+                        )
+                        for transcript in transcripts:
+                            await adapter.send(
+                                event.source.chat_id,
+                                f'🎙️ "{transcript}"',
+                                metadata=echo_meta,
+                            )
 
         effective_mode = self._busy_input_mode
         busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
@@ -10810,6 +10835,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 logger.debug(
                                     "Transcript echo failed (non-fatal): %s", _echo_exc,
                                 )
+                if message_text is None:
+                    return None
                 # NOTE: Previously, when transcription failed (e.g. no STT
                 # provider configured), the gateway also emitted a hardcoded
                 # English notice via `_stt_adapter.send()`. That bypassed the
@@ -13622,7 +13649,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "reply_to": reply_anchor,
                     "metadata": thread_meta,
                 }
-                await adapter.send_voice(**send_kwargs)
+                send_result = await adapter.send_voice(**send_kwargs)
+                if send_result is not None and not getattr(send_result, "success", True):
+                    logger.warning(
+                        "Auto voice reply delivery failed: %s",
+                        getattr(send_result, "error", "send returned success=False"),
+                    )
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
         finally:
@@ -15698,7 +15730,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("Transcribing user voice: %s", path)
                 result = await asyncio.to_thread(transcribe_audio, path)
                 if result["success"]:
-                    transcript = result["transcript"]
+                    transcript = str(result.get("transcript") or "").strip()
+                    if not transcript:
+                        continue
                     successful_transcripts.append(transcript)
                     # Pass the transcript through as a plain quoted line. The
                     # earlier wording ("The user sent a voice message~ Here's
@@ -15733,7 +15767,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if user_text:
                 return f"{prefix}\n\n{user_text}", successful_transcripts
             return prefix, successful_transcripts
-        return user_text, successful_transcripts
+        return (user_text or None), successful_transcripts
 
     async def _dequeue_pending_with_transcription(
         self,

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -172,6 +172,47 @@ class TestBusySessionAck:
         agent.interrupt.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_silent_voice_queues_without_interrupting_agent(self):
+        """Valid no-speech voice must not abort active work or reach next turn."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+            user_id="user1",
+        )
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.VOICE,
+            source=source,
+            message_id="voice1",
+            media_urls=["/tmp/silent-voice.ogg"],
+            media_types=["audio/ogg"],
+        )
+        sk = build_session_key(source)
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner.adapters[source.platform] = adapter
+
+        with patch(
+            "tools.transcription_tools.transcribe_audio",
+            return_value={
+                "success": True,
+                "transcript": "",
+                "provider": "local_command",
+            },
+        ):
+            handled = await runner._handle_active_session_busy_message(event, sk)
+
+        assert handled is True
+        assert sk not in adapter._pending_messages
+        agent.interrupt.assert_not_called()
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_sends_ack_when_agent_running(self):
         """First message during busy session should get a status ack."""
         runner, sentinel = _make_runner()

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -160,6 +160,40 @@ caption
         assert tags == ["MEDIA:/tmp/voice.ogg"]
         assert voice is True
 
+    @pytest.mark.parametrize("field", ["tool_name", "name"])
+    def test_gateway_auto_append_uses_explicit_tool_result_name(self, field):
+        """Persisted tool rows may name their producer without assistant tool_calls."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {
+                "role": "tool",
+                field: "text_to_speech",
+                "content": '[[audio_as_voice]]\nMEDIA:/tmp/voice.ogg',
+            },
+        ]
+
+        tags, voice = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == ["MEDIA:/tmp/voice.ogg"]
+        assert voice is True
+
+    @pytest.mark.parametrize("field", ["tool_name", "name"])
+    def test_gateway_auto_append_rejects_unallowed_explicit_tool_name(self, field):
+        """Explicit producer metadata must not bypass automatic-delivery allowlist."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {
+                "role": "tool",
+                field: "terminal",
+                "content": "MEDIA:/tmp/private.txt",
+            },
+        ]
+
+        tags, voice = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == []
+        assert voice is False
+
     def test_gateway_auto_append_image_generate_json_path(self):
         """image_generate returns a local path in JSON (no MEDIA: tag); it is
         auto-appended so delivery doesn't depend on the model restating it."""

--- a/tests/gateway/test_send_voice_reply_notify.py
+++ b/tests/gateway/test_send_voice_reply_notify.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 
@@ -114,3 +114,18 @@ async def test_voice_reply_marks_existing_thread_metadata_without_mutation(monke
         event.source, runner._reply_anchor_for_event(event)
     )
     assert "notify" not in fresh
+
+
+@pytest.mark.asyncio
+async def test_voice_reply_logs_unsuccessful_send_result(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    _fake_tts_call(monkeypatch)
+
+    send_voice = AsyncMock(return_value=SendResult(success=False, error="chat unavailable"))
+    runner = _runner_with_adapter(send_voice)
+
+    with caplog.at_level("WARNING"):
+        await runner._send_voice_reply(_make_event(), "Hello there.")
+
+    assert "Auto voice reply delivery failed" in caplog.text
+    assert "chat unavailable" in caplog.text

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -185,3 +185,42 @@ async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
     # Success path: the transcript passes through as a plain quoted line, with
     # no "voice message" meta-commentary that the LLM would echo back.
     assert "queued voice transcript" in result
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_drops_successful_empty_voice_transcript():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._has_setup_skill = lambda: False
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/silent-voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={
+            "success": True,
+            "transcript": "  \n",
+            "provider": "local_command",
+        },
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is None


### PR DESCRIPTION
## Summary

- Drop successful empty STT transcripts as valid no-speech before invoking the agent.
- Transcribe voice follow-ups before busy-session handling, so pending silence is discarded without interrupting active work.
- Recover allowed media producers from explicit tool-result `tool_name` / `name` when the paired assistant `tool_calls` row is absent.
- Log unsuccessful auto voice-reply `SendResult` values instead of silently ignoring them.

## Generic symptoms

Command-backed STT can exit successfully with an empty transcript for silence. Fresh silent voice previously reached the LLM as a quoted empty string, while silent voice received during an active turn could queue and interrupt that turn.

Post-stream media extraction also required a paired assistant tool-call row. Persisted/reconstructed tool results that retained explicit producer metadata but lost that row could therefore fail to auto-deliver valid generated media.

## Security invariant

Automatic file delivery remains fail-closed: explicit tool-result metadata only identifies the producer; producer must still match `_AUTO_APPEND_MEDIA_TOOL_NAMES`, and path matching plus delivery-path filtering remain unchanged. Arbitrary tools such as `terminal` cannot auto-deliver files.

## Test evidence

Strict RED observed before implementation:

- `tests/gateway/test_stt_config.py`: 1 failed, 7 passed (`'"  \\n"' is None`)
- `tests/gateway/test_busy_session_ack.py`: 1 failed, 26 passed (silent voice queued/interrupted)
- `tests/gateway/test_media_extraction.py`: 2 failed, 17 passed (explicit `tool_name` / `name` ignored); arbitrary producer cases passed
- `tests/gateway/test_send_voice_reply_notify.py`: 1 failed, 2 passed (unsuccessful send result not logged)

GREEN:

```text
scripts/run_tests.sh tests/gateway/test_stt_config.py tests/gateway/test_busy_session_ack.py tests/gateway/test_media_extraction.py tests/gateway/test_send_voice_reply_notify.py -q
57 passed, 0 failed

scripts/run_tests.sh tests/gateway/test_telegram_audio_vs_voice.py tests/gateway/test_stt_transcript_echo_config.py tests/gateway/test_voice_command.py tests/gateway/test_tts_media_routing.py tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_voice_duration.py -q
250 passed, 0 failed

scripts/run_tests.sh tests/gateway/test_run_tool_media_re.py tests/gateway/test_media_metadata_contract.py tests/gateway/test_platform_base.py -q
237 passed, 0 failed

uv run ruff check gateway/run.py tests/gateway/test_stt_config.py tests/gateway/test_busy_session_ack.py tests/gateway/test_media_extraction.py tests/gateway/test_send_voice_reply_notify.py
All checks passed

.venv/bin/python -m py_compile gateway/run.py tests/gateway/test_stt_config.py tests/gateway/test_busy_session_ack.py tests/gateway/test_media_extraction.py tests/gateway/test_send_voice_reply_notify.py
passed

git diff --check
passed
```

`ruff format --check` was also inspected but not used as a gate: current `gateway/run.py` and touched legacy test files are already not ruff-formatted on `main`; formatting whole files would create a large unrelated diff.
