### PR TITLE
feat(mem0): attach conversation provenance metadata to memory writes

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -60,6 +60,29 @@ _CLIENT_ERROR_TYPES = ("MemoryNotFoundError", "ValidationError")
 # through instead of silently overriding them with the placeholder.
 _DEFAULT_USER_ID = "hermes-user"
 
+# Conversation-provenance kwargs the gateway threads through initialize()
+# (agent/agent_init.py), mapped to the metadata key each is stored under.
+# An explicit allowlist rather than a kwargs dump: initialize() also receives
+# host-local values (hermes_home, agent_workspace, ...) that must never leak
+# into a remote memory store. gateway_user_id is the platform-native id of
+# the human in the chat (Slack UID, Telegram id, ...) — distinct from the
+# memory principal, which a configured MEM0_USER_ID may override to a shared
+# store. Extend this table to record new context the gateway starts passing.
+_PROVENANCE_KWARGS = (
+    ("user_id", "gateway_user_id"),
+    ("user_id_alt", "gateway_user_id_alt"),
+    ("user_name", "user_name"),
+    ("chat_id", "chat_id"),
+    ("chat_name", "chat_name"),
+    ("chat_type", "chat_type"),
+    ("thread_id", "thread_id"),
+    ("session_title", "session_title"),
+)
+
+# Metadata travels on every add; cap each value so a pathological session
+# title or chat name can't bloat writes past Mem0's metadata size limits.
+_PROVENANCE_VALUE_MAX_CHARS = 256
+
 
 def _is_client_error(exc: Exception) -> bool:
     """True for user-caused errors (bad ID, not found) that should NOT trip circuit breaker."""
@@ -206,6 +229,8 @@ class Mem0MemoryProvider(MemoryProvider):
         self._agent_id = "hermes"
         self._rerank_default = False
         self._channel = "cli"  # gateway channel name (cli/telegram/discord/...)
+        self._session_id = ""
+        self._session_meta: Dict[str, str] = {}
         self._sync_thread = None
         self._prefetch_thread = None
         self._prefetch_query = ""
@@ -363,6 +388,12 @@ class Mem0MemoryProvider(MemoryProvider):
             _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
         )
         self._channel = kwargs.get("platform") or "cli"
+        self._session_id = session_id or ""
+        self._session_meta = {}
+        for kwarg, meta_key in _PROVENANCE_KWARGS:
+            value = kwargs.get(kwarg)
+            if value:
+                self._session_meta[meta_key] = str(value)[:_PROVENANCE_VALUE_MAX_CHARS]
         self._backend = self._create_backend()
         if self._backend and not self._atexit_registered:
             atexit.register(self._shutdown_backend)
@@ -376,10 +407,20 @@ class Mem0MemoryProvider(MemoryProvider):
         # cross-agent recall.
         return {"user_id": self._user_id}
 
-    def _write_metadata(self) -> Dict[str, Any]:
-        # Tag every write with the gateway channel so the dashboard can offer
-        # per-channel filtered views without coupling identity to the channel.
-        return {"channel": self._channel} if self._channel else {}
+    def _write_metadata(self, *, session_id: str = "") -> Dict[str, Any]:
+        # Tag every write with the gateway channel plus conversation
+        # provenance (who was in the chat, which channel/thread, which
+        # session) so a memory can be traced back to the exact conversation
+        # it came from and Mem0's metadata filters can offer per-person /
+        # per-thread views. Callers with a fresher session_id than the one
+        # captured at initialize (sync_turn is called per-turn) pass it here.
+        metadata: Dict[str, Any] = dict(self._session_meta)
+        if self._channel:
+            metadata["channel"] = self._channel
+        effective_session = session_id or self._session_id
+        if effective_session:
+            metadata["session_id"] = effective_session
+        return metadata
 
     def system_prompt_block(self) -> str:
         # Mirror the precedence in _create_backend (oss > host > platform) so
@@ -494,7 +535,7 @@ class Mem0MemoryProvider(MemoryProvider):
                     user_id=self._user_id,
                     agent_id=self._agent_id,
                     infer=True,
-                    metadata=self._write_metadata(),
+                    metadata=self._write_metadata(session_id=session_id),
                 )
                 self._record_success()
             except Exception as e:

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -529,7 +529,7 @@ class TestMem0WriteMetadata:
             provider._sync_thread.join(timeout=5.0)
         adds = [c for c in provider._backend.captured if c[0] == "add"]
         assert adds, "expected an add call from sync_turn"
-        assert adds[-1][2]["metadata"] == {"channel": "discord"}
+        assert adds[-1][2]["metadata"] == {"channel": "discord", "session_id": "s"}
 
 
 class _SentinelBackend:

--- a/tests/plugins/memory/test_mem0_write_metadata.py
+++ b/tests/plugins/memory/test_mem0_write_metadata.py
@@ -1,0 +1,117 @@
+"""Tests for conversation-provenance metadata on Mem0 writes."""
+
+import json
+
+from plugins.memory.mem0 import (
+    Mem0MemoryProvider,
+    _PROVENANCE_KWARGS,
+    _PROVENANCE_VALUE_MAX_CHARS,
+)
+
+
+class CaptureBackend:
+    """Backend stub that records add() calls."""
+
+    def __init__(self):
+        self.adds = []
+
+    def add(self, messages, *, user_id, agent_id, infer, metadata):
+        self.adds.append({
+            "messages": messages, "user_id": user_id,
+            "agent_id": agent_id, "infer": infer, "metadata": metadata,
+        })
+        return {"status": "PENDING", "event_id": "evt-1"}
+
+    def close(self):
+        pass
+
+
+GATEWAY_KWARGS = {
+    "platform": "slack",
+    "user_id": "U0AAAA1",
+    "user_id_alt": "alt-42",
+    "user_name": "Ada Lovelace",
+    "chat_id": "C0BBBB2",
+    "chat_name": "customer-care",
+    "chat_type": "channel",
+    "thread_id": "1784193622.582189",
+    "session_title": "Login issue triage",
+    # Host-local init kwargs that must never reach remote metadata:
+    "hermes_home": "/home/user/.hermes",
+    "agent_identity": "default",
+    "agent_workspace": "hermes",
+    "gateway_session_key": "agent:main:slack:channel:C0BBBB2:1784193622.582189",
+}
+
+
+def _provider(init_kwargs=None, session_id="sess-1"):
+    provider = Mem0MemoryProvider()
+    provider.initialize(session_id, **(init_kwargs or {}))
+    provider._backend = CaptureBackend()
+    return provider
+
+
+class TestWriteProvenanceMetadata:
+
+    def test_tool_add_carries_conversation_provenance(self):
+        provider = _provider(GATEWAY_KWARGS)
+        result = json.loads(provider.handle_tool_call("mem0_add", {"content": "fact"}))
+        assert "error" not in result
+        metadata = provider._backend.adds[0]["metadata"]
+        assert metadata["gateway_user_id"] == "U0AAAA1"
+        assert metadata["gateway_user_id_alt"] == "alt-42"
+        assert metadata["user_name"] == "Ada Lovelace"
+        assert metadata["chat_id"] == "C0BBBB2"
+        assert metadata["chat_name"] == "customer-care"
+        assert metadata["chat_type"] == "channel"
+        assert metadata["thread_id"] == "1784193622.582189"
+        assert metadata["session_title"] == "Login issue triage"
+        assert metadata["channel"] == "slack"
+        assert metadata["session_id"] == "sess-1"
+
+    def test_host_local_kwargs_never_leak(self):
+        provider = _provider(GATEWAY_KWARGS)
+        provider.handle_tool_call("mem0_add", {"content": "fact"})
+        metadata = provider._backend.adds[0]["metadata"]
+        allowed = {meta_key for _, meta_key in _PROVENANCE_KWARGS} | {"channel", "session_id"}
+        assert set(metadata) <= allowed
+        assert "hermes_home" not in metadata
+        assert "gateway_session_key" not in metadata
+
+    def test_cli_defaults_stay_minimal(self):
+        provider = _provider({}, session_id="sess-cli")
+        provider.handle_tool_call("mem0_add", {"content": "fact"})
+        metadata = provider._backend.adds[0]["metadata"]
+        assert metadata == {"channel": "cli", "session_id": "sess-cli"}
+
+    def test_values_are_stringified_and_truncated(self):
+        kwargs = dict(GATEWAY_KWARGS, user_id=123456789, session_title="x" * 1000)
+        provider = _provider(kwargs)
+        provider.handle_tool_call("mem0_add", {"content": "fact"})
+        metadata = provider._backend.adds[0]["metadata"]
+        assert metadata["gateway_user_id"] == "123456789"
+        assert len(metadata["session_title"]) == _PROVENANCE_VALUE_MAX_CHARS
+
+    def test_sync_turn_prefers_per_call_session_id(self):
+        provider = _provider(GATEWAY_KWARGS, session_id="sess-old")
+        provider.sync_turn("hello", "hi there", session_id="sess-new")
+        provider._sync_thread.join(timeout=5.0)
+        metadata = provider._backend.adds[0]["metadata"]
+        assert metadata["session_id"] == "sess-new"
+        assert metadata["thread_id"] == "1784193622.582189"
+
+    def test_sync_turn_falls_back_to_initialize_session_id(self):
+        provider = _provider(GATEWAY_KWARGS, session_id="sess-init")
+        provider.sync_turn("hello", "hi there")
+        provider._sync_thread.join(timeout=5.0)
+        assert provider._backend.adds[0]["metadata"]["session_id"] == "sess-init"
+
+    def test_reinitialize_replaces_stale_provenance(self):
+        provider = _provider(GATEWAY_KWARGS)
+        provider.initialize("sess-2", platform="telegram", user_id="tg-7")
+        provider._backend = CaptureBackend()
+        provider.handle_tool_call("mem0_add", {"content": "fact"})
+        metadata = provider._backend.adds[0]["metadata"]
+        assert metadata["gateway_user_id"] == "tg-7"
+        assert metadata["channel"] == "telegram"
+        assert "chat_id" not in metadata


### PR DESCRIPTION
## What does this PR do?

Mem0 memory **writes** now carry full **conversation provenance** in metadata. Previously every memory was written with only `{"channel": "slack"}` — even though the gateway already threads the complete conversation context into `MemoryProvider.initialize()` (`agent/agent_init.py`): who the human in the chat is, which chat/channel, which thread, which session. The Mem0 plugin dropped all of it, so a memory could not be traced back to who said it or which thread it came from, and Mem0's metadata filters couldn't offer per-person / per-thread views.

After this change, both write paths (the per-turn `sync_turn` and the `mem0_add` tool) attach:

```json
{
  "gateway_user_id": "U0B6740445P",
  "user_name": "Harvey Coster",
  "chat_id": "C06N440N3EV",
  "chat_name": "customer-care",
  "chat_type": "channel",
  "thread_id": "1784193622.582189",
  "session_title": "Login issue triage",
  "channel": "slack",
  "session_id": "20260716_133000_abc123"
}
```

(Slack example — works identically for Telegram, Discord, WhatsApp, etc.; absent context keys are simply omitted, so bare CLI sessions still write `{"channel": "cli", "session_id": …}`.)

Why this approach:
- **Explicit allowlist** (`_PROVENANCE_KWARGS`), never a kwargs dump — `initialize()` also receives host-local values (`hermes_home`, `agent_workspace`, …) that must never leak into a remote memory store. New gateway context = one row in the table.
- `gateway_user_id` is deliberately distinct from the memory principal (`self._user_id`), which a configured `MEM0_USER_ID` may override to merge gateways into one store — so attribution survives a shared-store design.
- Values are stringified and capped at 256 chars so a pathological session title can't bloat every add past metadata size limits.
- `sync_turn()` passes its per-call `session_id`, so turn-level writes stay accurate if the session rotates after `initialize()`.
- **Read path untouched** — recall stays scoped to `user_id` only, exactly as before.

This modifies the existing in-tree `mem0` provider (bug-fix/enhancement to an existing provider); it does **not** add a new `plugins/memory/` backend.

## Related Issue

No existing issue — behavior gap found while working with Mem0 metadata filters. Happy to open a tracking issue if maintainers prefer.

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/mem0/__init__.py` — add `_PROVENANCE_KWARGS` allowlist + `_PROVENANCE_VALUE_MAX_CHARS`; capture `session_id` and provenance into `self._session_meta` in `initialize()`; expand `_write_metadata()` to merge provenance + channel + session id and accept a per-call `session_id`; pass `session_id` through from `sync_turn()`.
- `tests/plugins/memory/test_mem0_write_metadata.py` — new file, 7 tests (full-context capture on both write paths, host-local kwargs can never leak, CLI minimal case, stringify+truncate, per-call vs initialize session id, re-initialize replaces stale provenance).
- `tests/plugins/memory/test_mem0_v3.py` — update one assertion for the intended new behavior (`session_id` now included in write metadata).

3 files changed, +164/−6.

## How to Test

1. Configure Mem0 and run Hermes via a gateway (e.g. Slack): `hermes` and exchange a few turns.
2. Inspect a written memory's metadata (Mem0 dashboard or v2 API) — it now includes `gateway_user_id`, `user_name`, `chat_id/name/type`, `thread_id`, `session_title`, `channel`, `session_id`.
3. Confirm a bare CLI session writes only `{"channel": "cli", "session_id": …}` (no gateway keys leak).
4. Run the tests:
   ```
   pytest tests/plugins/memory/ -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(mem0): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the memory-plugin suite and all tests pass — `pytest tests/plugins/memory/ -q` → **457 passed, 1 skipped**
- [x] I've added tests for my changes (7 new tests + 1 updated assertion)
- [x] I've tested on my platform: macOS 15 (Sequoia, Darwin 24.6)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior is documented in code docstrings on `_PROVENANCE_KWARGS` / `_write_metadata`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure dict-building, no OS-specific calls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (`mem0_add` input schema unchanged; only emitted metadata changes)

## Screenshots / Logs

Full memory-plugin suite, run before opening this PR:

```
$ pytest tests/plugins/memory/ -q
457 passed, 1 skipped in 91.78s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
