### PR TITLE
fix(desktop): bound numeric config fields so compression ratios can't go out of range (fixes #65703)

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -22,10 +22,12 @@ import { CONTROL_TEXT, EMPTY_SELECT_VALUE, FIELD_DESCRIPTIONS, FIELD_LABELS } fr
 import { FallbackModelsField } from './fallback-models-field'
 import { fieldCopyForSchemaKey } from './field-copy'
 import {
+  clampToBounds,
   enumOptionsFor,
   getNested,
   isExternalMemoryProvider,
   prettyName,
+  resolveNumberBounds,
   sectionFieldEntries,
   setNested
 } from './helpers'
@@ -152,18 +154,27 @@ function ConfigField({
   }
 
   if (schema.type === 'number') {
+    const bounds = resolveNumberBounds(schemaKey, schema)
+
     return row(
       <Input
         className={CONTROL_TEXT}
+        max={bounds.max}
+        min={bounds.min}
         onChange={e => {
           const raw = e.target.value
           const n = raw === '' ? 0 : Number(raw)
 
           if (!Number.isNaN(n)) {
-            onChange(n)
+            // Clamp here too: a bare `min`/`max` on a number input only blocks
+            // the spinner, not typed out-of-range values (#65703). The empty
+            // input's 0 fallback needs it as well, for a field whose minimum
+            // is positive (e.g. compression.target_ratio).
+            onChange(clampToBounds(n, bounds))
           }
         }}
         placeholder={c.notSet}
+        step={bounds.step}
         type="number"
         value={value === undefined || value === null ? '' : String(value)}
       />

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -285,6 +285,30 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'updates.non_interactive_local_changes': ['stash', 'discard']
 }
 
+export interface NumberBounds {
+  max?: number
+  min?: number
+  step?: number
+}
+
+// Numeric config fields that represent a bounded quantity. The generic number
+// input has no intrinsic range, so a field like compression.target_ratio would
+// otherwise accept negatives or values > 1.0 (#65703). The field renderer
+// applies these to the input AND clamps typed values. Backend-supplied bounds
+// on the schema take precedence over these fallbacks.
+//
+// Ranges mirror the runtime contract, not the nominal [0, 1] of a ratio:
+//   - compression.threshold: fraction of the context window that triggers a
+//     compression pass (`hermes_cli/config.py`, default 0.50) — any fraction.
+//   - compression.target_ratio: clamped to 0.10-0.80 by the runtime
+//     (`agent/context_compressor.py`: `max(0.10, min(summary_target_ratio, 0.80))`)
+//     and documented as 0.10-0.80 in the context-compression developer guide.
+//     Enforcing it here stops the UI saving a value the runtime discards.
+export const NUMBER_BOUNDS: Record<string, NumberBounds> = {
+  'compression.threshold': { min: 0, max: 1, step: 0.05 },
+  'compression.target_ratio': { min: 0.1, max: 0.8, step: 0.05 }
+}
+
 export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   model: 'Default Model',
   modelContextLength: 'Context Window',

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -4,10 +4,12 @@ import type { HermesConfigRecord } from '@/types/hermes'
 
 import { defineFieldCopy, fieldCopyForSchemaKey, schemaKeyToFieldCopyKey } from './field-copy'
 import {
+  clampToBounds,
   enumOptionsFor,
   getNested,
   isExternalMemoryProvider,
   providerGroup,
+  resolveNumberBounds,
   sectionFieldEntries,
   setNested,
   stripToolsetLabel,
@@ -332,6 +334,73 @@ describe('settings helpers', () => {
 
     it('hides declared keys absent from both schema and config', () => {
       expect(sectionFieldEntries({}, {}).get('memory') ?? []).toHaveLength(0)
+    })
+  })
+
+  describe('resolveNumberBounds', () => {
+    it('declares bounds for the compression ratio fields (#65703)', () => {
+      expect(resolveNumberBounds('compression.threshold')).toEqual({ min: 0, max: 1, step: 0.05 })
+    })
+
+    it('bounds target_ratio to the runtime-enforced 0.10-0.80 window', () => {
+      // agent/context_compressor.py: max(0.10, min(summary_target_ratio, 0.80))
+      expect(resolveNumberBounds('compression.target_ratio')).toEqual({ min: 0.1, max: 0.8, step: 0.05 })
+    })
+
+    it('returns empty bounds for an unbounded field so it renders unchanged', () => {
+      expect(resolveNumberBounds('memory.memory_char_limit')).toEqual({})
+    })
+
+    it('lets backend-supplied schema bounds win over the declared fallback', () => {
+      expect(resolveNumberBounds('compression.threshold', { min: 0.1, max: 0.9, step: 0.01 })).toEqual({
+        min: 0.1,
+        max: 0.9,
+        step: 0.01
+      })
+    })
+
+    it('falls back to declared bounds for edges the schema omits', () => {
+      expect(resolveNumberBounds('compression.threshold', { max: 0.8 })).toEqual({
+        min: 0,
+        max: 0.8,
+        step: 0.05
+      })
+    })
+
+    it('ignores non-finite schema bounds', () => {
+      expect(resolveNumberBounds('compression.threshold', { min: Number.NaN, max: Infinity })).toEqual({
+        min: 0,
+        max: 1,
+        step: 0.05
+      })
+    })
+  })
+
+  describe('clampToBounds', () => {
+    it('clamps below min and above max', () => {
+      const bounds = { min: 0, max: 1 }
+
+      expect(clampToBounds(-0.5, bounds)).toBe(0)
+      expect(clampToBounds(1.5, bounds)).toBe(1)
+    })
+
+    it('leaves in-range values untouched', () => {
+      expect(clampToBounds(0.5, { min: 0, max: 1 })).toBe(0.5)
+    })
+
+    it('applies only the declared edge when the other is absent', () => {
+      expect(clampToBounds(-3, { min: 0 })).toBe(0)
+      expect(clampToBounds(-3, { max: 10 })).toBe(-3)
+    })
+
+    it('returns the value unchanged when no bounds are declared', () => {
+      expect(clampToBounds(42, {})).toBe(42)
+    })
+
+    it('raises the empty-input 0 fallback to a positive minimum', () => {
+      // The number field writes 0 when the input is cleared; for a field with
+      // min > 0 that value is itself out of range and must be clamped.
+      expect(clampToBounds(0, resolveNumberBounds('compression.target_ratio'))).toBe(0.1)
     })
   })
 })

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -1,7 +1,8 @@
 import { asText, normalize } from '@/lib/text'
 import type { ConfigFieldSchema, HermesConfigRecord, ToolsetInfo } from '@/types/hermes'
 
-import { BUILTIN_PERSONALITIES, ENUM_OPTIONS, PROVIDER_GROUPS, SECTIONS } from './constants'
+import type { NumberBounds } from './constants'
+import { BUILTIN_PERSONALITIES, ENUM_OPTIONS, NUMBER_BOUNDS, PROVIDER_GROUPS, SECTIONS } from './constants'
 
 // Canonical implementations live in @/lib/text; re-exported here so the many
 // settings/capabilities call sites keep their import path.
@@ -257,6 +258,59 @@ function commandProviderNames(config: HermesConfigRecord, section: 'tts' | 'stt'
   }
 
   return [...names]
+}
+
+// Resolve the effective numeric bounds for a `type: 'number'` field.
+// Backend-supplied bounds on the schema win; otherwise fall back to the
+// desktop-declared NUMBER_BOUNDS. Only finite numbers are carried through,
+// so an unbounded field yields `{}` and renders exactly as before.
+export function resolveNumberBounds(
+  schemaKey: string,
+  schema?: Pick<ConfigFieldSchema, 'max' | 'min' | 'step'>
+): NumberBounds {
+  const declared = NUMBER_BOUNDS[schemaKey]
+
+  const pick = (fromSchema: number | undefined, fallback: number | undefined) =>
+    typeof fromSchema === 'number' && Number.isFinite(fromSchema)
+      ? fromSchema
+      : typeof fallback === 'number' && Number.isFinite(fallback)
+        ? fallback
+        : undefined
+
+  const bounds: NumberBounds = {}
+  const min = pick(schema?.min, declared?.min)
+  const max = pick(schema?.max, declared?.max)
+  const step = pick(schema?.step, declared?.step)
+
+  if (min !== undefined) {
+    bounds.min = min
+  }
+
+  if (max !== undefined) {
+    bounds.max = max
+  }
+
+  if (step !== undefined) {
+    bounds.step = step
+  }
+
+  return bounds
+}
+
+// Clamp a value into `[min, max]` when either edge is declared. A field with
+// no bounds is returned unchanged.
+export function clampToBounds(n: number, bounds: NumberBounds): number {
+  let v = n
+
+  if (typeof bounds.min === 'number' && v < bounds.min) {
+    v = bounds.min
+  }
+
+  if (typeof bounds.max === 'number' && v > bounds.max) {
+    v = bounds.max
+  }
+
+  return v
 }
 
 export function enumOptionsFor(

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1,7 +1,13 @@
 export interface ConfigFieldSchema {
   category?: string
   description?: string
+  // Optional numeric bounds for `type: 'number'` fields. The backend may
+  // supply these; when absent the desktop falls back to NUMBER_BOUNDS so a
+  // bounded ratio (e.g. compression.target_ratio) can't be set out of range.
+  max?: number
+  min?: number
   options?: unknown[]
+  step?: number
   type?: 'boolean' | 'list' | 'number' | 'select' | 'string' | 'text'
 }
 


### PR DESCRIPTION
## What does this PR do?

The desktop settings render **every** `type: 'number'` config field through one generic `<Input type="number">` in `config-settings.tsx` that carries no `min`/`max`/`step`. So `compression.threshold` and `compression.target_ratio` accept negatives and values above their valid range, exactly as reported.

**Repro (code-level, addressing `needs-repro`):** on current `main` the number branch is

```tsx
<Input type="number" onChange={e => { const n = raw === '' ? 0 : Number(raw); if (!Number.isNaN(n)) onChange(n) }} .../>
```

(`apps/desktop/src/app/settings/config-settings.tsx:154-171`) — no bound anywhere, so `-0.5` / `1.5` flow straight into config for any numeric field.

The fix declares bounds per field, applies them to the input, **and clamps in `onChange`**. That second half is what actually enforces the bound: a bare `min`/`max` on an HTML number input only constrains the spinner arrows and native validation, so a user can still *type* `-5` or `1.5`.

Bounds mirror the **runtime contract**, not the nominal `[0, 1]` of a ratio:

- `compression.target_ratio` → `0.10-0.80`, matching the runtime clamp `max(0.10, min(summary_target_ratio, 0.80))` at `agent/context_compressor.py:1331` and the documented range at `website/docs/developer-guide/context-compression-and-caching.md:104`. Saving `0.05` from the UI would otherwise be silently normalized away by the runtime.
- `compression.threshold` → `0-1` (fraction of the context window that triggers compression; `hermes_cli/config.py`, default `0.50`).

Fields without declared bounds resolve to `{}`; `undefined` `min`/`max`/`step` are omitted by React, so every other numeric field renders and behaves **exactly as before**.

### Note on the "slider" wording

The issue calls these sliders; the actual control is a number input. The suggested fix is implemented on that control, plus the typed-value clamp so the bound holds regardless of how the value is entered.

### Notes for reviewers

- This branch was rebuilt from scratch onto current `main` (`19527db731`) after the previous head went stale, so it is a fresh commit rather than a rebase of the old ones.
- Both points from the earlier review are addressed: `target_ratio` now uses the runtime's `0.10-0.80` rather than `0-1`, and the `0` written when the input is cleared is clamped too, with a regression test for a field whose `min > 0`.
- **Collision warning:** PR #65406 (`feat/personality-labels-i18n`) edits the same 9-line import block in `apps/desktop/src/app/settings/helpers.test.ts`, about 2 lines from this PR's edit, which is inside git's 3-line context. Whichever of the two lands second will need a trivial rebase of that import list. No pre-merge was attempted.

## Related Issue

Fixes #65703

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/types/hermes.ts` — add optional `min` / `max` / `step` to `ConfigFieldSchema` so the backend can declare bounds in future.
- `apps/desktop/src/app/settings/constants.ts` — new `NumberBounds` type and `NUMBER_BOUNDS` map declaring `compression.threshold` (`0-1`, step `0.05`) and `compression.target_ratio` (`0.10-0.80`, step `0.05`). Extensible: add a key to bound another numeric field.
- `apps/desktop/src/app/settings/helpers.ts` — `resolveNumberBounds(schemaKey, schema)` merges schema-supplied bounds (which win, when finite) over the declared fallback; `clampToBounds(n, bounds)` clamps into range.
- `apps/desktop/src/app/settings/config-settings.tsx` — the number field applies `min`/`max`/`step` to the input and clamps the value in `onChange`, including the `0` fallback written for a cleared input.
- `apps/desktop/src/app/settings/helpers.test.ts` — 11 new cases covering both helpers.

## How to Test

1. Open desktop Settings and go to the Compression section.
2. Type `-0.5` into **Target Ratio**, then `1.5`. Before: both are saved verbatim. After: they clamp to `0.10` and `0.80`. `compression.threshold` clamps to `0` / `1`.
3. Clear the Target Ratio field entirely. Before: `0` is written, which is out of range. After: it clamps to `0.10`.
4. Check any other numeric field (e.g. `memory.memory_char_limit`): no `min`/`max`/`step` attributes, behavior unchanged.
5. Automated: `cd apps/desktop && npx vitest run --project ui src/app/settings/helpers.test.ts` → 41 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **N/A**: this is a TypeScript-only change under `apps/desktop`, no Python touched. The JS/TS equivalents were run instead, listed below.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5, arm64)

**Verification actually run** (from `apps/desktop`):

- `npm run typecheck` (`tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit`) → clean, exit 0.
- `npx vitest run --project ui src/app/settings/helpers.test.ts` → **41 passed** (1 file).
- `npx vitest run --project ui src/app/settings` → **165 passed, 2 failed** (18 files).
- `npx vitest run --project ui` (full renderer suite) → **1594 passed, 1 skipped, 2 failed** (195 files).
- `npx vitest run --project electron` → **458 passed, 1 skipped** (45 files).
- `npm run lint` → **0 errors**; 9 pre-existing `no-restricted-globals` warnings, none in the files touched here.
- `npm run fix` (`eslint --fix` + `prettier --write`) → produced no changes to the diff.
- `git diff --check` → clean.

The 2 failures in both `--project ui` runs are the same two, both in `src/app/settings/billing/index.test.tsx` (`rejects auto-refill amounts outside the billing bounds` and `disables buy controls while polling and renders the settled outcome`). Confirmed pre-existing by stashing this branch's changes and re-running that file against clean `main`: still **2 failed / 16 passed**.

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — **N/A**: no new user-facing behavior beyond enforcing an already-documented range. `website/docs/developer-guide/context-compression-and-caching.md` already states `0.10-0.80` for `target_ratio`; this change makes the UI honor it.
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A**: no config keys added or renamed, only UI-side bounds on existing keys.
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — **N/A**: no architecture or workflow change.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure renderer-side TypeScript, no platform-specific paths or APIs.
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — **N/A**: no tool behavior changed.

## Screenshots / Logs

Not attached: the change is an input constraint, and its effect is shown more precisely by the unit tests above than by a screenshot of a number field.
