### PR TITLE
fix(desktop): apply terminal config before cron ticks

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -54,6 +54,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from hermes_cli import __version__, __release_date__
 from hermes_cli.config import (
+    apply_terminal_config_to_env,
     cfg_get,
     DEFAULT_CONFIG,
     OPTIONAL_ENV_VARS,
@@ -152,6 +153,14 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     real gateway on the same HERMES_HOME — whichever process grabs the lock
     first wins the tick.
     """
+    try:
+        apply_terminal_config_to_env()
+    except Exception:
+        _log.exception(
+            "Desktop cron scheduler disabled: terminal config could not be resolved"
+        )
+        return
+
     from cron.scheduler_provider import resolve_cron_scheduler
 
     provider = resolve_cron_scheduler()

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -7788,6 +7788,69 @@ class TestDesktopCronTicker:
         with self._client():
             assert called.wait(3.0), "expected cron tick under HERMES_DESKTOP=1"
 
+    def test_ticker_applies_terminal_config_before_first_tick(
+        self, monkeypatch, _isolate_hermes_home
+    ):
+        import threading
+        import cron.scheduler as sched
+
+        config_path = Path(os.environ["HERMES_HOME"]) / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "terminal": {
+                        "backend": "docker",
+                        "docker_volumes": ["/host/project:/workspace:rw"],
+                        "docker_extra_args": ["--network=none"],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_DOCKER_VOLUMES", raising=False)
+        monkeypatch.delenv("TERMINAL_DOCKER_EXTRA_ARGS", raising=False)
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+
+        called = threading.Event()
+        observed = {}
+
+        def capture_terminal_env(*_args, **_kwargs):
+            observed["backend"] = os.environ.get("TERMINAL_ENV")
+            observed["volumes"] = os.environ.get("TERMINAL_DOCKER_VOLUMES")
+            observed["extra_args"] = os.environ.get("TERMINAL_DOCKER_EXTRA_ARGS")
+            called.set()
+
+        monkeypatch.setattr(sched, "tick", capture_terminal_env)
+
+        with self._client():
+            assert called.wait(3.0), "expected cron tick under HERMES_DESKTOP=1"
+
+        assert observed == {
+            "backend": "docker",
+            "volumes": '["/host/project:/workspace:rw"]',
+            "extra_args": '["--network=none"]',
+        }
+
+    def test_ticker_does_not_run_when_terminal_config_bridge_fails(
+        self, monkeypatch, _isolate_hermes_home
+    ):
+        import threading
+        import cron.scheduler as sched
+        from hermes_cli import web_server
+
+        called = threading.Event()
+        monkeypatch.setattr(sched, "tick", lambda *_a, **_k: called.set())
+        monkeypatch.setattr(
+            web_server,
+            "apply_terminal_config_to_env",
+            MagicMock(side_effect=RuntimeError("invalid terminal config")),
+        )
+
+        web_server._start_desktop_cron_ticker(threading.Event(), interval=0)
+
+        assert not called.is_set(), "cron must not fall back to host execution"
+
     def test_ticker_skipped_without_desktop(self, monkeypatch, _isolate_hermes_home):
         import threading
         import cron.scheduler as sched


### PR DESCRIPTION
## What does this PR do?

Desktop-spawned backends now apply Hermes' existing terminal config-to-environment bridge before starting the cron ticker. This keeps `terminal.backend` and its backend-specific settings effective for scheduled jobs when the user configured them only in `config.yaml` (for example, `terminal.backend: docker`) and no legacy `TERMINAL_*` values exist in `.env`.

If terminal config cannot be resolved, the Desktop cron ticker now fails closed instead of silently continuing with the local host backend.

## Related Issue

Fixes #65696

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Root Cause

`_start_desktop_cron_ticker()` started the scheduler without running the terminal bridge used by other entry points. Because terminal tools select their backend from `TERMINAL_ENV`, a Desktop process started from a config-only setup could reach its first cron tick with that variable unset and execute locally.

The fix reuses `hermes_cli.config.apply_terminal_config_to_env()` rather than introducing another config parser or duplicating the existing mapping.

## Changes Made

- `hermes_cli/web_server.py`
  - Apply the shared terminal config bridge before resolving or starting the Desktop cron scheduler.
  - Disable the ticker if the bridge raises, preventing an implicit host fallback.
- `tests/hermes_cli/test_web_server.py`
  - Add an integration-style regression test using a temporary real `HERMES_HOME/config.yaml` and the first actual Desktop lifespan tick.
  - Cover Docker backend, volume, and extra-argument propagation.
  - Verify a bridge failure prevents the scheduler from ticking.

## How to Test

1. Configure a temporary `HERMES_HOME/config.yaml` with `terminal.backend: docker`, `docker_volumes`, and `docker_extra_args`, without setting `TERMINAL_*` variables.
2. Start the Desktop web-server lifespan with `HERMES_DESKTOP=1` and observe the first scheduler tick.
3. Confirm the tick sees `TERMINAL_ENV=docker` plus the JSON-encoded Docker settings, and confirm a bridge exception prevents any tick.

Automated command:

```bash
scripts/run_tests.sh tests/hermes_cli/test_web_server.py tests/tools/test_terminal_config_env_sync.py tests/cron/test_scheduler_provider.py -q
```

Result after rebasing onto `007cd1513`: **452 passed, 0 failed**.

The regression test was also run against the pre-fix implementation and failed with all three terminal environment values unset.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Python 3.11.15

Full-suite note: `scripts/run_tests.sh` completed 2,037 files with **41,840 passed and 25 failed**. The failures are in 13 untouched files plus two browser-test timeouts, primarily existing macOS `/tmp` normalization, `systemctl`, service-permission, browser isolation, and unrelated credential tests. The affected Desktop cron/config suites above pass in full.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing behavior or configuration shape changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; existing keys only
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the bridge is shared and platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changed

## Risk Assessment

Low. The change is scoped to the Desktop cron startup path and reuses the bridge already used by other Hermes entry points. No config keys or tool schemas change. The main behavior change is deliberate fail-closed handling if existing terminal config cannot be loaded.

## Screenshots / Logs

```text
=== Summary: 3 files, 452 tests passed, 0 failed (100% complete) ===
All checks passed!  # ruff
```
