### PR TITLE
Harden queued gateway delivery for shared local models

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -883,7 +883,8 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     so both the tool-call path and the final-response path share one builder.
     """
     assistant_tool_calls = getattr(assistant_message, "tool_calls", None)
-    reasoning_text = agent._extract_reasoning(assistant_message)
+    _persist_reasoning = getattr(agent, "_persist_reasoning", True)
+    reasoning_text = agent._extract_reasoning(assistant_message) if _persist_reasoning else None
     _from_structured = bool(reasoning_text)
 
     # Fallback: extract inline <think> blocks from content when no structured
@@ -954,9 +955,11 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     }
 
     raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
+    if not _persist_reasoning:
+        raw_reasoning_content = None
     if raw_reasoning_content is None and hasattr(assistant_message, "model_extra"):
         model_extra = getattr(assistant_message, "model_extra", None) or {}
-        if isinstance(model_extra, dict) and "reasoning_content" in model_extra:
+        if _persist_reasoning and isinstance(model_extra, dict) and "reasoning_content" in model_extra:
             raw_reasoning_content = model_extra["reasoning_content"]
     if raw_reasoning_content is not None:
         msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
@@ -999,7 +1002,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     if "reasoning_content" not in msg and reasoning_text:
         msg["reasoning_content"] = reasoning_text
 
-    if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
+    if _persist_reasoning and hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
         # Pass reasoning_details back unmodified so providers (OpenRouter,
         # Anthropic, OpenAI) can maintain reasoning continuity across turns.
         # Each provider may include opaque fields (signature, encrypted_content)
@@ -1025,13 +1028,13 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # replay the latest assistant message unchanged. See
     # agent/transports/anthropic.py and agent/anthropic_adapter.py.
     ordered_blocks = getattr(assistant_message, "anthropic_content_blocks", None)
-    if ordered_blocks:
+    if _persist_reasoning and ordered_blocks:
         msg["anthropic_content_blocks"] = ordered_blocks
 
     # Codex Responses API: preserve encrypted reasoning items for
     # multi-turn continuity. These get replayed as input on the next turn.
     codex_items = getattr(assistant_message, "codex_reasoning_items", None)
-    if codex_items:
+    if _persist_reasoning and codex_items:
         msg["codex_reasoning_items"] = codex_items
 
     # Codex Responses API: preserve exact assistant message items (with

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -803,7 +803,14 @@ def run_conversation(
 
             # For ALL assistant messages, pass reasoning back to the API
             # This ensures multi-turn reasoning context is preserved
-            agent._copy_reasoning_content_for_api(msg, api_msg)
+            if getattr(agent, "_persist_reasoning", True):
+                agent._copy_reasoning_content_for_api(msg, api_msg)
+            else:
+                for reasoning_field in (
+                    "reasoning_content", "reasoning_details",
+                    "codex_reasoning_items", "anthropic_content_blocks",
+                ):
+                    api_msg.pop(reasoning_field, None)
 
             # Remove 'reasoning' field - it's for trajectory storage only
             # We've copied it to 'reasoning_content' for the API above
@@ -1767,6 +1774,30 @@ def run_conversation(
 
                     _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None
                     _trunc_has_tool_calls = bool(getattr(_trunc_msg, "tool_calls", None)) if _trunc_msg else False
+
+                    # Local Qwen profiles use a hard broker clamp. Hitting it
+                    # is a controlled terminal limit, not permission to hold
+                    # or immediately reacquire the shared model for synthetic
+                    # continuation prompts.
+                    if (
+                        (agent.provider or "").strip().lower() == "lmstudio"
+                        and getattr(response, "id", "") != PARTIAL_STREAM_STUB_ID
+                    ):
+                        partial_response = agent._strip_think_blocks(
+                            _trunc_content or ""
+                        ).strip()
+                        limit_error = "Response reached the configured Qwen output limit"
+                        agent._cleanup_task_resources(effective_task_id)
+                        agent._persist_session(messages, conversation_history)
+                        return {
+                            "final_response": partial_response or limit_error,
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "partial": True,
+                            "error": limit_error,
+                            "length_limited": True,
+                        }
 
                     # ── Detect thinking-budget exhaustion ──────────────
                     # When the model spends ALL output tokens on reasoning
@@ -4667,7 +4698,47 @@ def run_conversation(
                     except Exception:
                         pass
 
+                _tool_result_start = len(messages)
                 agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+
+                # A successful TTS tool call is terminal. The audio itself is
+                # the answer; another model pass can only waste the shared Qwen
+                # slot and risks replacing the media-only result with empty text.
+                _tts_ids = {
+                    tc.id for tc in assistant_message.tool_calls
+                    if tc.function.name == "text_to_speech"
+                }
+                for _tool_msg in messages[_tool_result_start:]:
+                    if (
+                        _tool_msg.get("role") != "tool"
+                        or _tool_msg.get("tool_call_id") not in _tts_ids
+                    ):
+                        continue
+                    _tts_content = _tool_msg.get("content")
+                    if not isinstance(_tts_content, str):
+                        continue
+                    try:
+                        _tts_result = json.loads(_tts_content)
+                    except (TypeError, ValueError):
+                        continue
+                    _media_tag = _tts_result.get("media_tag")
+                    if not (_tts_result.get("success") and _media_tag):
+                        continue
+                    _tts_call_id = str(_tool_msg.get("tool_call_id") or "tts")
+                    _tool_msg["content"] = json.dumps({
+                        "success": True,
+                        "delivered_tts": True,
+                        "tool_call_id": _tts_call_id,
+                    })
+                    agent._cleanup_task_resources(effective_task_id)
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": f"[[media_outbox:{_tts_call_id}]]\n{_media_tag}",
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": True,
+                        "terminal_tts": True,
+                    }
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -726,6 +726,12 @@ agent:
   # Controls how much "thinking" the model does before responding.
   # Options: "xhigh" (max), "high", "medium", "low", "minimal", "none" (disable)
   reasoning_effort: "medium"
+
+  # Persist and replay hidden reasoning fields in conversation history.
+  # Disable for local profiles where scratchpads can be very large and the
+  # provider does not require reasoning continuity. Usage metrics are still
+  # retained and inline <think> blocks are still stripped from visible text.
+  persist_reasoning: true
   
   # Predefined personalities (use with /personality command)
   personalities:

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Gateway developers and maintainers
 > **Source files:** `gateway/session.py` (~1444 lines), `gateway/run.py` (~16800 lines), `gateway/config.py`
-> **Last updated:** 2026-06-16
+> **Last updated:** 2026-07-16
 
 ## Overview
 
@@ -444,8 +444,8 @@ or `/restart`.
 
 The message queuing system handles two scenarios:
 
-1. **Interrupt follow-ups** — When a user sends multiple messages while the agent is
-   processing, subsequent messages are queued as single-slot pending messages.
+1. **Busy-input follow-ups** — With `busy_input_mode: queue`, messages received during
+   an active turn enter a bounded FIFO. Contiguous plain text may be batched at drain time.
 2. **`/queue` FIFO** — Explicit `/queue` commands that must each produce their own full
    agent turn, in order, without merging.
 
@@ -453,12 +453,12 @@ The message queuing system handles two scenarios:
 
 ```
 adapter._pending_messages: Dict[session_key, MessageEvent]
-    └── Single "next-up" slot per session. Overwritten on repeat sends
-        (burst collapse). Shared with photo-burst follow-ups.
+    └── Single "next-up" slot per session. Shared with photo-burst
+        follow-ups and the FIFO head.
 
 self._queued_events: Dict[session_key, List[MessageEvent]]
-    └── Overflow buffer. Each /queue invocation appends here when the
-        slot is occupied. Promoted one-at-a-time after each drain.
+    └── Overflow buffer. Busy follow-ups and explicit /queue events append
+        here when the slot is occupied. Promoted after each drain.
 ```
 
 ### Enqueue (`_enqueue_fifo`)
@@ -488,15 +488,44 @@ Called at the drain site after the slot was consumed. If there's an overflow ite
 
 `_queue_depth(session_key, adapter)` returns `len(overflow) + (1 if slot occupied else 0)`.
 
+### Bounded Busy-Text Batching (`_batch_queued_text_events`)
+
+Immediately after dequeue, Hermes may combine the FIFO head with following plain-text events:
+
+- At most 10 messages and 8,000 source characters enter one next turn.
+- Order is explicit in `[Queued message N]` blocks.
+- Batching stops before slash commands, explicit `/queue` events, or any event with media.
+- Explicit `/queue` events carry `_explicit_queue` metadata so stripping the command prefix
+  cannot accidentally make them batchable.
+- The first non-batchable event remains at the overflow head for the next turn.
+
+The queue cap remains 32 pending events per session, preventing unbounded memory growth when
+a gateway receives a burst behind a long-running turn.
+
 ### Clearing
 
 Queued events for a session are cleared on `/new` and `/reset` (via `_handle_reset_command`).
 
 ### FIFO Invariant
 
-Each `/queue` invocation produces exactly one full agent turn, in FIFO order, with no
-merging. The single-slot `_pending_messages` + overflow `_queued_events` design ensures
-that repeated sends during an active turn don't cause out-of-order processing.
+Each explicit `/queue` invocation produces exactly one full agent turn, in FIFO order, with
+no merging. Ordinary busy-mode text preserves arrival order but may share one bounded next
+turn. Commands and media always preserve their own event boundary.
+
+### Terminal TTS and Media Outbox
+
+A successful `text_to_speech` call ends the agent loop without another model request. The
+gateway collects current-turn `MEDIA:` tags before its empty-response return, so interrupted
+or media-only turns cannot orphan completed audio.
+
+Before platform delivery, terminal TTS is staged in profile-local `media_outbox.sqlite3`
+under a session/tool-call/path key. Successful delivery records the platform message ID;
+acknowledged keys are skipped and pending rows retry before the next inbound event. Only a
+compact TTS marker remains in in-memory conversation history.
+
+For profiles with `agent.persist_reasoning: false`, gateway-created agents neither persist nor
+replay hidden `reasoning_content`, `reasoning_details`, or provider-specific reasoning carriers.
+Visible content and usage metrics are unchanged.
 
 ---
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6,13 +6,16 @@ and implement the required methods.
 """
 
 import asyncio
+import hashlib
 import inspect
 import ipaddress
+import json
 import logging
 import os
 import random
 import re
 import socket as _socket
+import sqlite3
 import subprocess
 import sys
 import time
@@ -961,6 +964,99 @@ _CACHE_DIR_IMPORT_DEFAULTS = {
 }
 
 _HERMES_HOME = get_hermes_home()
+
+_MEDIA_OUTBOX_DB = _HERMES_HOME / "media_outbox.sqlite3"
+
+
+def _media_outbox_connect() -> sqlite3.Connection:
+    _MEDIA_OUTBOX_DB.parent.mkdir(parents=True, exist_ok=True)
+    db = sqlite3.connect(str(_MEDIA_OUTBOX_DB), timeout=5.0)
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS media_outbox (
+            delivery_key TEXT PRIMARY KEY,
+            session_key TEXT NOT NULL,
+            tool_call_id TEXT NOT NULL,
+            platform TEXT NOT NULL,
+            chat_id TEXT NOT NULL,
+            thread_id TEXT,
+            media_path TEXT NOT NULL,
+            is_voice INTEGER NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            attempts INTEGER NOT NULL DEFAULT 0,
+            message_id TEXT,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL
+        )
+        """
+    )
+    return db
+
+
+def _media_outbox_delivery_key(session_key: str, tool_call_id: str, media_path: str) -> str:
+    path_digest = hashlib.sha256(media_path.encode("utf-8", "replace")).hexdigest()[:16]
+    return f"{session_key}:{tool_call_id}:{path_digest}"
+
+
+def _media_outbox_stage(
+    *,
+    session_key: str,
+    tool_call_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: str | None,
+    media_path: str,
+    is_voice: bool,
+) -> tuple[str, bool]:
+    key = _media_outbox_delivery_key(session_key, tool_call_id, media_path)
+    now = time.time()
+    with _media_outbox_connect() as db:
+        db.execute(
+            """
+            INSERT OR IGNORE INTO media_outbox (
+                delivery_key, session_key, tool_call_id, platform, chat_id,
+                thread_id, media_path, is_voice, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                key, session_key, tool_call_id, platform, str(chat_id),
+                str(thread_id) if thread_id else None, media_path,
+                int(is_voice), now, now,
+            ),
+        )
+        row = db.execute(
+            "SELECT status FROM media_outbox WHERE delivery_key = ?", (key,)
+        ).fetchone()
+        if not row or row[0] == "delivered":
+            return key, False
+        db.execute(
+            "UPDATE media_outbox SET attempts = attempts + 1, updated_at = ? "
+            "WHERE delivery_key = ?",
+            (now, key),
+        )
+    return key, True
+
+
+def _media_outbox_ack(delivery_key: str, message_id: str | None) -> None:
+    with _media_outbox_connect() as db:
+        db.execute(
+            "UPDATE media_outbox SET status = 'delivered', message_id = ?, "
+            "updated_at = ? WHERE delivery_key = ?",
+            (str(message_id) if message_id else None, time.time(), delivery_key),
+        )
+
+
+def _media_outbox_pending(platform: str, chat_id: str) -> list[tuple]:
+    with _media_outbox_connect() as db:
+        return db.execute(
+            """
+            SELECT delivery_key, media_path, is_voice, thread_id
+            FROM media_outbox
+            WHERE platform = ? AND chat_id = ? AND status = 'pending'
+            ORDER BY created_at
+            """,
+            (platform, str(chat_id)),
+        ).fetchall()
 _HERMES_ROOT = get_default_hermes_root()
 MEDIA_DELIVERY_ALLOW_DIRS_ENV = "HERMES_MEDIA_ALLOW_DIRS"
 MEDIA_DELIVERY_TRUST_RECENT_ENV = "HERMES_MEDIA_TRUST_RECENT_FILES"
@@ -1500,15 +1596,22 @@ def _path_lacks_deliverable_extension(path: str) -> bool:
     return not Path(path).suffix
 
 
+_MEDIA_OUTBOX_DIRECTIVE_RE = re.compile(
+    r"\[\[media_outbox:(?P<key>[^\]\r\n]+)\]\]", re.IGNORECASE
+)
+
+
 def _strip_media_tag_directives(text: str) -> str:
     """Remove MEDIA: tags and [[audio_as_voice]] / [[as_document]] markers."""
     if (
         "MEDIA:" not in text
         and "[[audio_as_voice]]" not in text
         and "[[as_document]]" not in text
+        and "[[media_outbox:" not in text.lower()
     ):
         return text
     cleaned = text.replace("[[audio_as_voice]]", "").replace("[[as_document]]", "")
+    cleaned = _MEDIA_OUTBOX_DIRECTIVE_RE.sub("", cleaned)
 
     def _strip_extensionless(match: re.Match) -> str:
         path = _normalize_media_tag_path(match.group("path"))
@@ -4805,6 +4908,44 @@ class BasePlatformAdapter(ABC):
             max_ms = 2500
         return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
 
+    async def _replay_pending_media_outbox(
+        self,
+        event: MessageEvent,
+        metadata: dict | None,
+    ) -> None:
+        """Retry durable media for this chat before processing new input."""
+        platform_name = _platform_name(self.platform)
+        try:
+            pending = _media_outbox_pending(platform_name, event.source.chat_id)
+        except Exception as exc:
+            logger.warning("[%s] Media outbox read failed: %s", self.name, exc)
+            return
+        for delivery_key, media_path, is_voice, thread_id in pending:
+            if not Path(media_path).exists():
+                logger.warning("[%s] Media outbox file is missing: %s", self.name, media_path)
+                continue
+            replay_metadata = dict(metadata or {})
+            if thread_id and not replay_metadata.get("thread_id"):
+                replay_metadata["thread_id"] = thread_id
+            try:
+                ext = Path(media_path).suffix.lower()
+                if should_send_media_as_audio(self.platform, ext, is_voice=bool(is_voice)):
+                    result = await self.send_voice(
+                        chat_id=event.source.chat_id,
+                        audio_path=media_path,
+                        metadata=replay_metadata or None,
+                    )
+                else:
+                    result = await self.send_document(
+                        chat_id=event.source.chat_id,
+                        file_path=media_path,
+                        metadata=replay_metadata or None,
+                    )
+                if getattr(result, "success", False):
+                    _media_outbox_ack(delivery_key, getattr(result, "message_id", None))
+            except Exception as exc:
+                logger.warning("[%s] Media outbox replay failed: %s", self.name, exc)
+
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
         # Track delivery outcomes for the processing-complete hook
@@ -4830,6 +4971,7 @@ class BasePlatformAdapter(ABC):
         # never spawned, so no "typing…" / "is thinking…" status is shown.
         # typing_task stays None; _stop_typing_refresh already no-ops on None.
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        await self._replay_pending_media_outbox(event, _thread_metadata)
         typing_task: Optional[asyncio.Task] = None
         if getattr(self.config, "typing_indicator", True):
             _keep_typing_kwargs: Dict[str, Any] = {"metadata": _thread_metadata}
@@ -4890,6 +5032,10 @@ class BasePlatformAdapter(ABC):
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
             if response:
+                outbox_match = _MEDIA_OUTBOX_DIRECTIVE_RE.search(response)
+                outbox_tool_call_id = (
+                    outbox_match.group("key").strip() if outbox_match else None
+                )
                 # Capture [[as_document]] before extract_media strips it, so the
                 # dispatch partition below can route image-extension files
                 # through send_document instead of send_multiple_images. Used
@@ -5087,7 +5233,24 @@ class BasePlatformAdapter(ABC):
                 for media_path, is_voice in _non_image_media:
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)
+                    delivery_key = None
                     try:
+                        if outbox_tool_call_id:
+                            delivery_key, should_send = _media_outbox_stage(
+                                session_key=session_key,
+                                tool_call_id=outbox_tool_call_id,
+                                platform=_platform_name(self.platform),
+                                chat_id=event.source.chat_id,
+                                thread_id=event.source.thread_id,
+                                media_path=media_path,
+                                is_voice=is_voice,
+                            )
+                            if not should_send:
+                                logger.info(
+                                    "[%s] Skipping delivered media outbox item %s",
+                                    self.name, delivery_key,
+                                )
+                                continue
                         ext = Path(media_path).suffix.lower()
                         if should_send_media_as_audio(self.platform, ext, is_voice=is_voice):
                             media_result = await self.send_voice(
@@ -5110,6 +5273,11 @@ class BasePlatformAdapter(ABC):
 
                         if not media_result.success:
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
+                        elif delivery_key:
+                            _media_outbox_ack(
+                                delivery_key, getattr(media_result, "message_id", None)
+                            )
+                        _record_delivery(media_result)
                     except Exception as media_err:
                         logger.warning("[%s] Error sending media: %s", self.name, media_err)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11775,10 +11775,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 response = ""
 
-            # Auto voice reply: send TTS audio before the text response
+            # Auto voice reply: send TTS audio before the text response.
+            # Profiles can opt into voice replacing the text body entirely via
+            # voice.suppress_text_reply. This keeps companion-style bots from
+            # leaking visible transcripts when the model forgets to call TTS.
             _already_sent = bool(agent_result.get("already_sent"))
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
-                await self._send_voice_reply(event, response)
+                _voice_sent = await self._send_voice_reply(event, response)
+                if self._should_suppress_text_after_voice_reply(event):
+                    if _voice_sent:
+                        logger.info(
+                            "Suppressing text response after successful voice reply: platform=%s chat=%s",
+                            _platform_name, source.chat_id or "unknown",
+                        )
+                    else:
+                        logger.warning(
+                            "Suppressing text response because voice-only reply was requested but voice delivery failed: platform=%s chat=%s",
+                            _platform_name, source.chat_id or "unknown",
+                        )
+                    response = ""
 
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
@@ -12738,7 +12753,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Return whether inbound voice/STT transcripts should be echoed to chat."""
         return bool(getattr(self.config, "stt_echo_transcripts", True))
 
-    async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
+    def _should_suppress_text_after_voice_reply(self, event: MessageEvent) -> bool:
+        """Return whether auto-TTS should replace the text response."""
+        try:
+            cfg = _load_gateway_config()
+            voice_cfg = cfg.get("voice") or {}
+            return bool(voice_cfg.get("suppress_text_reply", False))
+        except Exception as exc:
+            logger.debug("voice.suppress_text_reply check failed: %s", exc)
+            return False
+
+    async def _send_voice_reply(self, event: MessageEvent, text: str) -> bool:
         """Generate TTS audio and send as a voice message before the text reply."""
         import uuid as _uuid
         audio_path = None
@@ -12748,7 +12773,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             tts_text = _strip_markdown_for_tts(text[:4000])
             if not tts_text:
-                return
+                return False
 
             # Telegram's adapter only sends native voice bubbles for OGG/Opus.
             # Other platforms keep the existing MP3 default.
@@ -12772,7 +12797,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             actual_path = result.get("file_path", audio_path)
             if not result.get("success") or not os.path.isfile(actual_path):
                 logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
-                return
+                return False
 
             adapter = self._adapter_for_source(event.source)
 
@@ -12783,6 +12808,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     and hasattr(adapter, "is_in_voice_channel")
                     and adapter.is_in_voice_channel(guild_id)):
                 await adapter.play_in_voice_channel(guild_id, actual_path)
+                return True
             elif adapter and hasattr(adapter, "send_voice"):
                 reply_anchor = self._reply_anchor_for_event(event)
                 thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
@@ -12804,9 +12830,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "reply_to": reply_anchor,
                     "metadata": thread_meta,
                 }
-                await adapter.send_voice(**send_kwargs)
+                send_result = await adapter.send_voice(**send_kwargs)
+                return bool(getattr(send_result, "success", True))
+            return False
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
+            return False
         finally:
             for p in {audio_path, actual_path} - {None}:
                 try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3177,8 +3177,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _load_voice_modes(self) -> Dict[str, str]:
         try:
-            data = json.loads(self._VOICE_MODE_PATH.read_text())
-        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            # utf-8-sig: external writers (e.g. Windows PowerShell 5.1
+            # Set-Content -Encoding UTF8) may prefix a BOM, which plain
+            # json.loads rejects.
+            data = json.loads(self._VOICE_MODE_PATH.read_text(encoding="utf-8-sig"))
+        except FileNotFoundError:
+            return {}
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(
+                "Failed to load voice modes from %s (%s) — treating all chats "
+                "as voice mode off until the file is fixed or /voice is re-run.",
+                self._VOICE_MODE_PATH, e,
+            )
             return {}
 
         if not isinstance(data, dict):
@@ -3199,6 +3209,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 continue
             result[key] = mode
+        if result:
+            logger.info(
+                "Loaded %d persisted voice mode entr%s: %s",
+                len(result), "y" if len(result) == 1 else "ies",
+                ", ".join(f"{k}={v}" for k, v in sorted(result.items())),
+            )
         return result
 
     def _save_voice_modes(self) -> None:
@@ -11780,7 +11796,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # voice.suppress_text_reply. This keeps companion-style bots from
             # leaking visible transcripts when the model forgets to call TTS.
             _already_sent = bool(agent_result.get("already_sent"))
-            if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
+            # Dedup must only see THIS turn's messages: agent_messages includes
+            # the full session history, and a text_to_speech call from an older
+            # turn would otherwise suppress the mechanical voice reply forever.
+            _turn_offset = agent_result.get("history_offset", len(history))
+            _turn_messages = (
+                agent_messages[_turn_offset:]
+                if len(agent_messages) > _turn_offset else []
+            )
+            if self._should_send_voice_reply(event, response, _turn_messages, already_sent=_already_sent):
                 _voice_sent = await self._send_voice_reply(event, response)
                 if self._should_suppress_text_after_voice_reply(event):
                     if _voice_sent:
@@ -11794,6 +11818,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _platform_name, source.chat_id or "unknown",
                         )
                     response = ""
+            elif (
+                response
+                and not response.startswith("Error:")
+                and self._voice_reply_requested(event)
+                and self._should_suppress_text_after_voice_reply(event)
+                and not (event.message_type == MessageType.VOICE and not _already_sent)
+            ):
+                # The agent delivered TTS media itself this turn (the dedup
+                # above), but a voice-only chat must still never show prose:
+                # keep only the media directive lines for the adapter to
+                # upload and drop any visible transcript around them.
+                _media_only = self._media_directives_only(response)
+                if _media_only != response:
+                    logger.info(
+                        "Voice-only chat: stripping %d chars of visible text around agent media directives: platform=%s chat=%s",
+                        len(response) - len(_media_only),
+                        _platform_name, source.chat_id or "unknown",
+                    )
+                    response = _media_only
 
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
@@ -12704,10 +12747,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> bool:
         """Decide whether the runner should send a TTS voice reply.
 
+        ``agent_messages`` must be the CURRENT turn's messages only (slice by
+        ``history_offset``) — a text_to_speech call persisted in an earlier
+        turn's history must not suppress voice replies for the rest of the
+        session.
+
         Returns False when:
         - voice_mode is off for this chat
         - response is empty or an error
-        - agent already called text_to_speech tool (dedup)
+        - agent called text_to_speech this turn AND the response references a
+          media file that actually exists (dedup). A TTS tool call whose MEDIA
+          path is missing or hallucinated never reached the user, so the
+          runner must regenerate instead of deferring to it.
         - voice input and base adapter auto-TTS already handled it (skip_double)
           UNLESS streaming already consumed the response (already_sent=True),
           in which case the base adapter won't have text for auto-TTS so the
@@ -12716,18 +12767,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not response or response.startswith("Error:"):
             return False
 
-        chat_id = event.source.chat_id
-        voice_mode = self._voice_mode.get(self._voice_key(event.source.platform, chat_id), "off")
-        is_voice_input = (event.message_type == MessageType.VOICE)
-
-        should = (
-            (voice_mode == "all")
-            or (voice_mode == "voice_only" and is_voice_input)
-        )
-        if not should:
+        if not self._voice_reply_requested(event):
             return False
 
-        # Dedup: agent already called TTS tool
+        is_voice_input = (event.message_type == MessageType.VOICE)
+
+        # Dedup: agent already called TTS tool this turn and its output is
+        # actually deliverable.
         has_agent_tts = any(
             msg.get("role") == "assistant"
             and any(
@@ -12736,7 +12782,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             for msg in agent_messages
         )
-        if has_agent_tts:
+        if has_agent_tts and self._response_references_existing_media(response):
             return False
 
         # Dedup: base adapter auto-TTS already handles voice input
@@ -12748,6 +12794,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
 
         return True
+
+    def _voice_reply_requested(self, event: MessageEvent) -> bool:
+        """Return whether this chat's /voice mode asks for a voice reply."""
+        voice_mode = self._voice_mode.get(
+            self._voice_key(event.source.platform, event.source.chat_id), "off"
+        )
+        return (
+            voice_mode == "all"
+            or (voice_mode == "voice_only" and event.message_type == MessageType.VOICE)
+        )
+
+    @staticmethod
+    def _iter_media_directive_paths(text: str):
+        """Yield the path portion of each ``MEDIA:<path>`` line in *text*."""
+        for line in (text or "").splitlines():
+            stripped = line.strip()
+            if stripped[:6].upper() == "MEDIA:":
+                path = stripped[6:].strip().strip('"')
+                if path:
+                    yield path
+
+    def _response_references_existing_media(self, response: str) -> bool:
+        """Return True if any MEDIA directive in *response* points to a real file."""
+        return any(
+            os.path.isfile(path)
+            for path in self._iter_media_directive_paths(response)
+        )
+
+    @staticmethod
+    def _media_directives_only(response: str) -> str:
+        """Reduce *response* to its delivery directive lines (MEDIA/[[...]])."""
+        kept = []
+        for line in (response or "").splitlines():
+            stripped = line.strip()
+            if stripped[:6].upper() == "MEDIA:" or (
+                stripped.startswith("[[") and stripped.endswith("]]")
+            ):
+                kept.append(stripped)
+        return "\n".join(kept)
 
     def _should_echo_stt_transcripts(self) -> bool:
         """Return whether inbound voice/STT transcripts should be echoed to chat."""
@@ -12770,8 +12855,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         actual_path = None
         try:
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from gateway.platforms.base import _strip_media_directives
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
+            # Strip MEDIA:/[[audio_as_voice]] directives first — models
+            # sometimes emit (even hallucinate) them in the final text, and
+            # they must never be read aloud as file paths.
+            tts_text = _strip_markdown_for_tts(_strip_media_directives(text)[:4000])
             if not tts_text:
                 return False
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11812,12 +11812,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Suppressing text response after successful voice reply: platform=%s chat=%s",
                             _platform_name, source.chat_id or "unknown",
                         )
+                        response = ""
                     else:
                         logger.warning(
-                            "Suppressing text response because voice-only reply was requested but voice delivery failed: platform=%s chat=%s",
+                            "Voice-only reply requested but voice delivery failed - sending operational failure notice instead of dropping silently: platform=%s chat=%s",
                             _platform_name, source.chat_id or "unknown",
                         )
-                    response = ""
+                        response = "[Voice reply failed to generate - nothing was sent. Try again in a bit.]"
             elif (
                 response
                 and not response.startswith("Error:")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4392,6 +4392,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         text = str(getattr(event, "text", "") or "").strip()
         if not text or text.startswith("/"):
             return False
+        if bool((getattr(event, "metadata", None) or {}).get("_explicit_queue")):
+            return False
         return not bool(getattr(event, "media_urls", None))
 
     def _batch_queued_text_events(
@@ -9172,6 +9174,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         auto_skill=event.auto_skill,
                         channel_prompt=event.channel_prompt,
                         internal=event.internal,
+                        metadata={**(event.metadata or {}), "_explicit_queue": True},
                         timestamp=event.timestamp,
                     )
                     self._enqueue_fifo(_quick_key, queued_event, adapter)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4381,6 +4381,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             depth += 1
         return depth
 
+    _BUSY_BATCH_MAX_MESSAGES = 10
+    _BUSY_BATCH_MAX_CHARS = 8000
+
+    @staticmethod
+    def _is_batchable_queued_text(event: "MessageEvent") -> bool:
+        """Only plain text may share a queued follow-up turn."""
+        if event is None or getattr(event, "message_type", None) != MessageType.TEXT:
+            return False
+        text = str(getattr(event, "text", "") or "").strip()
+        if not text or text.startswith("/"):
+            return False
+        return not bool(getattr(event, "media_urls", None))
+
+    def _batch_queued_text_events(
+        self,
+        session_key: str,
+        pending_event: Optional["MessageEvent"],
+    ) -> Optional["MessageEvent"]:
+        """Merge the next bounded run of plain-text queue entries in order."""
+        if not self._is_batchable_queued_text(pending_event):
+            return pending_event
+        overflow = (getattr(self, "_queued_events", None) or {}).get(session_key)
+        if not overflow:
+            return pending_event
+
+        texts = [str(pending_event.text or "").strip()]
+        total_chars = len(texts[0])
+        while overflow and len(texts) < self._BUSY_BATCH_MAX_MESSAGES:
+            candidate = overflow[0]
+            if not self._is_batchable_queued_text(candidate):
+                break
+            candidate_text = str(candidate.text or "").strip()
+            if total_chars + 2 + len(candidate_text) > self._BUSY_BATCH_MAX_CHARS:
+                break
+            overflow.pop(0)
+            texts.append(candidate_text)
+            total_chars += 2 + len(candidate_text)
+
+        if not overflow:
+            self._queued_events.pop(session_key, None)
+        if len(texts) > 1:
+            pending_event.text = "\n\n".join(
+                f"[Queued message {index}]\n{text}"
+                for index, text in enumerate(texts, start=1)
+            )
+        return pending_event
+
     @staticmethod
     def _is_goal_continuation_event(event_or_text: Any) -> bool:
         """Return True for synthetic /goal continuation turns.
@@ -13153,6 +13200,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     fallback_model=self._fallback_model,
                 )
+                agent._persist_reasoning = bool(
+                    cfg_get(user_config, "agent", "persist_reasoning", default=True)
+                )
                 try:
                     return agent.run_conversation(
                         user_message=enriched_prompt,
@@ -18138,6 +18188,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # opt-in so global scratch-text display does not leak into threads.
             agent.thinking_progress = _thinking_enabled
             # Store agent reference for interrupt support
+            agent._persist_reasoning = bool(
+                cfg_get(user_config, "agent", "persist_reasoning", default=True)
+            )
             agent_holder[0] = agent
             # Capture the full tool definitions for transcript logging
             tools_holder[0] = agent.tools if hasattr(agent, 'tools') else None
@@ -18638,6 +18691,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 0 if (_session_was_split or _compacted_in_place) else len(agent_history)
             )
 
+            # Collect current-turn media before the empty-response return. A
+            # terminal TTS tool intentionally returns only a delivery directive,
+            # and interrupted turns can also have completed media tools.
+            media_tags, has_voice_directive = _collect_auto_append_media_tags(
+                result.get("messages", []),
+                history_offset=len(agent_history),
+                history_media_paths=_history_media_paths,
+            )
+            if media_tags and "MEDIA:" not in (final_response or ""):
+                seen = set()
+                unique_tags = []
+                for tag in media_tags:
+                    if tag not in seen:
+                        seen.add(tag)
+                        unique_tags.append(tag)
+                if has_voice_directive:
+                    unique_tags.insert(0, "[[audio_as_voice]]")
+                media_response = "\n".join(unique_tags)
+                final_response = (
+                    f"{final_response}\n{media_response}"
+                    if final_response
+                    else media_response
+                )
+
             if not final_response:
                 final_response = _normalize_empty_agent_response(
                     result, final_response or "", history_len=len(agent_history),
@@ -18687,23 +18764,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # also the sole guard on the fallback branch taken when mid-run
             # context compression shrinks the message list below the original
             # history length, preserving the compression-safe behaviour of #160.
-            if "MEDIA:" not in final_response:
-                media_tags, has_voice_directive = _collect_auto_append_media_tags(
-                    result.get("messages", []),
-                    history_offset=len(agent_history),
-                    history_media_paths=_history_media_paths,
-                )
-
-                if media_tags:
-                    seen = set()
-                    unique_tags = []
-                    for tag in media_tags:
-                        if tag not in seen:
-                            seen.add(tag)
-                            unique_tags.append(tag)
-                    if has_voice_directive:
-                        unique_tags.insert(0, "[[audio_as_voice]]")
-                    final_response = final_response + "\n" + "\n".join(unique_tags)
             
             # Auto-generate session title after first exchange (non-blocking)
             if final_response and self._session_db:
@@ -19030,7 +19090,95 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception as _ne:
                     logger.debug("Long-running notification error: %s", _ne)
 
+        async def _notify_broker_queue():
+            """Drive one quiet Telegram queue receipt from broker state."""
+            if source.platform != Platform.TELEGRAM:
+                return
+            token = str(os.environ.get("LM_API_KEY", "") or "")
+            owner = {
+                "hermes-email": "email",
+                "hermes-travel": "travel",
+                "hermes-suno": "suno",
+                "hermes-companion": "companion",
+            }.get(token)
+            if not owner:
+                return
+
+            def _read_status():
+                from urllib.request import urlopen
+                with urlopen("http://127.0.0.1:1236/status", timeout=2.0) as response:
+                    return json.loads(response.read().decode("utf-8"))
+
+            await asyncio.sleep(8.0)
+            receipt_id = None
+            edited_wait = False
+            poll_deadline = time.monotonic() + 120.0
+            while True:
+                try:
+                    snapshot = await asyncio.to_thread(_read_status)
+                except Exception:
+                    return
+                active = snapshot.get("active") or {}
+                queued = next(
+                    (
+                        item for item in snapshot.get("queued", [])
+                        if item.get("agent") == owner
+                        and item.get("work_class") == "interactive"
+                    ),
+                    None,
+                )
+                if queued is not None:
+                    position = max(1, int(queued.get("position") or 1))
+                    elapsed = max(0, int(time.time() - float(queued.get("enqueued_at") or time.time())))
+                    text = f"Jeg har din besked. Der er {position} foran dig."
+                    update_wait_now = elapsed >= 120 and not edited_wait
+                    if update_wait_now:
+                        text = (
+                            f"Jeg har din besked. Der er {position} foran dig. "
+                            f"Ventetid: {elapsed // 60} min."
+                        )
+                    try:
+                        if receipt_id and update_wait_now:
+                            await adapter.edit_message(
+                                source.chat_id, receipt_id, text
+                            )
+                            edited_wait = True
+                        elif not receipt_id:
+                            receipt = await adapter.send(
+                                source.chat_id,
+                                text,
+                                metadata=_non_conversational_metadata(
+                                    _status_thread_metadata,
+                                    platform=source.platform,
+                                ),
+                            )
+                            if getattr(receipt, "success", False) and getattr(
+                                receipt, "message_id", None
+                            ):
+                                receipt_id = str(receipt.message_id)
+                                _cleanup_msg_ids.append(receipt_id)
+                    except Exception as exc:
+                        logger.debug("Broker queue receipt failed: %s", exc)
+                    await asyncio.sleep(2.0)
+                    continue
+                if active.get("agent") == owner:
+                    if receipt_id:
+                        try:
+                            await adapter.edit_message(
+                                source.chat_id,
+                                receipt_id,
+                                "Jeg arbejder på den nu.",
+                            )
+                        except Exception as exc:
+                            logger.debug("Broker queue admission edit failed: %s", exc)
+                    return
+                if active and time.monotonic() < poll_deadline:
+                    await asyncio.sleep(2.0)
+                    continue
+                return
+
         _notify_task = asyncio.create_task(_notify_long_running())
+        _broker_notify_task = asyncio.create_task(_notify_broker_queue())
 
         def _stream_confirmed_final_delivery(
             consumer,
@@ -19273,6 +19421,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pending = None
             if result and adapter and session_key:
                 pending_event = _dequeue_pending_event(adapter, session_key)
+                pending_event = self._batch_queued_text_events(session_key, pending_event)
                 # /queue overflow: after consuming the adapter's "next-up"
                 # slot, promote the next queued event into it so the
                 # recursive run's drain will see it.  This keeps the slot
@@ -19562,6 +19711,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 log_task.cancel()
             interrupt_monitor.cancel()
             _notify_task.cancel()
+            _broker_notify_task.cancel()
 
             # Wait for stream consumer to finish its final edit
             if stream_task:
@@ -19606,7 +19756,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._update_runtime_status("draining")
             
             # Wait for cancelled tasks
-            for task in [progress_task, log_task, interrupt_monitor, tracking_task, _notify_task]:
+            for task in [progress_task, log_task, interrupt_monitor, tracking_task, _notify_task, _broker_notify_task]:
                 if task:
                     try:
                         await task

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1305,6 +1305,17 @@ class SessionStore:
         finder = getattr(self._db, "find_latest_gateway_session_for_peer", None)
         if not callable(finder):
             return None
+        # Same freshness gate already used for resume_pending (#46934) — a
+        # never-closed or agent_close-ended session is only a plausible
+        # "the gateway restarted mid-conversation" candidate within this
+        # window. Without it there's no staleness bound at all: a session
+        # last touched days ago is exactly as eligible as one from five
+        # minutes ago (real incident, 2026-07-14 — see hermes_state.py's
+        # find_latest_gateway_session_for_peer docstring). Non-positive
+        # window disables the gate, matching auto_continue_freshness_window's
+        # existing opt-out convention.
+        _fw = auto_continue_freshness_window()
+        _min_last_activity = now.timestamp() - _fw if _fw > 0 else None
         try:
             recovered = finder(
                 source=source.platform.value,
@@ -1313,6 +1324,7 @@ class SessionStore:
                 chat_id=source.chat_id,
                 chat_type=source.chat_type,
                 thread_id=source.thread_id,
+                min_last_activity=_min_last_activity,
             )
         except Exception as exc:
             logger.debug("Gateway session DB recovery failed for %s: %s", session_key, exc)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1948,6 +1948,7 @@ class SessionDB:
         chat_id: Optional[str] = None,
         chat_type: Optional[str] = None,
         thread_id: Optional[str] = None,
+        min_last_activity: Optional[float] = None,
     ) -> Optional[Dict[str, Any]]:
         """Find the latest recoverable gateway session for a routing peer.
 
@@ -1958,23 +1959,52 @@ class SessionDB:
         cleanup's ``agent_close`` bug are treated as recoverable; explicit
         conversation boundaries such as /new, /resume switches, and compression
         splits are not.
+
+        ``min_last_activity`` (epoch seconds, caller-supplied — typically
+        ``time.time() - auto_continue_freshness_window()``) bounds how old a
+        candidate can be. Without it, ``ORDER BY started_at DESC LIMIT 1`` has
+        no staleness cutoff at all: a session with ``ended_at IS NULL`` that
+        was simply superseded without ever being closed, or one ended days ago
+        via the ordinary ``agent_close`` path, is exactly as eligible as one
+        from five minutes ago (real incident, 2026-07-14 — a clean reset
+        resumed an 8-day-old ``agent_close`` session, dragging 74 stale
+        messages into a brand new conversation; fixing one such row just
+        exposed the next-oldest one in line, since none of them were ever
+        actually excluded on age). "Last activity" is the row's own
+        ``ended_at`` if set, else its newest message timestamp, else
+        ``started_at`` — a still-open session with recent messages must not
+        be excluded just because it started long ago.
         """
         if not session_key:
             return None
+        staleness_clause = ""
+        if min_last_activity is not None:
+            staleness_clause = """
+                  AND COALESCE(
+                        ended_at,
+                        (SELECT MAX(timestamp) FROM messages WHERE messages.session_id = sessions.id),
+                        started_at
+                      ) >= :min_last_activity
+            """
         with self._lock:
             row = self._conn.execute(
-                """
+                f"""
                 SELECT * FROM sessions
-                WHERE session_key = ?
-                  AND source = ?
+                WHERE session_key = :session_key
+                  AND source = :source
                   AND (ended_at IS NULL OR end_reason = 'agent_close')
                   AND (COALESCE(message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
                   ))
+                  {staleness_clause}
                 ORDER BY started_at DESC
                 LIMIT 1
                 """,
-                (session_key, source),
+                {
+                    "session_key": session_key,
+                    "source": source,
+                    "min_last_activity": min_last_activity,
+                },
             ).fetchone()
             if row is not None:
                 return dict(row)
@@ -1985,21 +2015,29 @@ class SessionDB:
             if chat_id is None or chat_type is None:
                 return None
             row = self._conn.execute(
-                """
+                f"""
                 SELECT * FROM sessions
-                WHERE source = ?
-                  AND COALESCE(user_id, '') = COALESCE(?, '')
-                  AND COALESCE(chat_id, '') = COALESCE(?, '')
-                  AND COALESCE(chat_type, '') = COALESCE(?, '')
-                  AND COALESCE(thread_id, '') = COALESCE(?, '')
+                WHERE source = :source
+                  AND COALESCE(user_id, '') = COALESCE(:user_id, '')
+                  AND COALESCE(chat_id, '') = COALESCE(:chat_id, '')
+                  AND COALESCE(chat_type, '') = COALESCE(:chat_type, '')
+                  AND COALESCE(thread_id, '') = COALESCE(:thread_id, '')
                   AND (ended_at IS NULL OR end_reason = 'agent_close')
                   AND (COALESCE(message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
                   ))
+                  {staleness_clause}
                 ORDER BY started_at DESC
                 LIMIT 1
                 """,
-                (source, user_id, chat_id, chat_type, thread_id),
+                {
+                    "source": source,
+                    "user_id": user_id,
+                    "chat_id": chat_id,
+                    "chat_type": chat_type,
+                    "thread_id": thread_id,
+                    "min_last_activity": min_last_activity,
+                },
             ).fetchone()
         return dict(row) if row else None
 

--- a/tests/gateway/test_simultaneous_agent_reliability.py
+++ b/tests/gateway/test_simultaneous_agent_reliability.py
@@ -10,6 +10,7 @@ def _event(text, *, message_type=None, media_urls=None):
         text=text,
         message_type=message_type or base.MessageType.TEXT,
         media_urls=media_urls or [],
+        metadata={},
     )
 
 
@@ -38,6 +39,18 @@ def test_busy_queue_does_not_batch_media():
 
     assert result.text == "caption"
     assert runner._queued_events["session"][0].text == "next"
+
+
+def test_busy_queue_does_not_batch_explicit_queue_commands():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    head = _event("first explicit turn")
+    head.metadata["_explicit_queue"] = True
+    runner._queued_events = {"session": [_event("ordinary follow-up")]}
+
+    result = runner._batch_queued_text_events("session", head)
+
+    assert result.text == "first explicit turn"
+    assert runner._queued_events["session"][0].text == "ordinary follow-up"
 
 
 def test_reasoning_persistence_can_be_disabled():

--- a/tests/gateway/test_simultaneous_agent_reliability.py
+++ b/tests/gateway/test_simultaneous_agent_reliability.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import build_assistant_message
+from gateway import run as gateway_run
+from gateway.platforms import base
+
+
+def _event(text, *, message_type=None, media_urls=None):
+    return SimpleNamespace(
+        text=text,
+        message_type=message_type or base.MessageType.TEXT,
+        media_urls=media_urls or [],
+    )
+
+
+def test_busy_queue_batches_plain_text_but_stops_before_command():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    head = _event("first")
+    runner._queued_events = {
+        "session": [_event("second"), _event("/new"), _event("fourth")]
+    }
+
+    result = runner._batch_queued_text_events("session", head)
+
+    assert result.text == "[Queued message 1]\nfirst\n\n[Queued message 2]\nsecond"
+    assert [event.text for event in runner._queued_events["session"]] == [
+        "/new",
+        "fourth",
+    ]
+
+
+def test_busy_queue_does_not_batch_media():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    head = _event("caption", media_urls=["voice.ogg"])
+    runner._queued_events = {"session": [_event("next")]}
+
+    result = runner._batch_queued_text_events("session", head)
+
+    assert result.text == "caption"
+    assert runner._queued_events["session"][0].text == "next"
+
+
+def test_reasoning_persistence_can_be_disabled():
+    agent = SimpleNamespace(
+        _persist_reasoning=False,
+        _extract_reasoning=lambda _message: "hidden scratchpad",
+        verbose_logging=False,
+        reasoning_callback=None,
+        stream_delta_callback=None,
+        _stream_callback=None,
+        _strip_think_blocks=lambda content: content,
+        _needs_thinking_reasoning_pad=lambda: False,
+    )
+    response = SimpleNamespace(
+        content="answer",
+        tool_calls=None,
+        reasoning_content="hidden scratchpad",
+        reasoning_details=[{"type": "reasoning", "text": "hidden"}],
+        anthropic_content_blocks=None,
+        codex_reasoning_items=None,
+        codex_message_items=None,
+    )
+
+    message = build_assistant_message(agent, response, "stop")
+
+    assert message["content"] == "answer"
+    assert message["reasoning"] is None
+    assert "reasoning_content" not in message
+    assert "reasoning_details" not in message
+
+
+def test_media_outbox_stages_acks_and_deduplicates(tmp_path, monkeypatch):
+    monkeypatch.setattr(base, "_MEDIA_OUTBOX_DB", tmp_path / "outbox.sqlite3")
+    kwargs = {
+        "session_key": "telegram:123",
+        "tool_call_id": "call-tts",
+        "platform": "telegram",
+        "chat_id": "123",
+        "thread_id": None,
+        "media_path": str(tmp_path / "voice.ogg"),
+        "is_voice": True,
+    }
+
+    delivery_key, should_send = base._media_outbox_stage(**kwargs)
+    assert should_send is True
+    assert len(base._media_outbox_pending("telegram", "123")) == 1
+
+    base._media_outbox_ack(delivery_key, "telegram-message-7")
+    _, should_send_again = base._media_outbox_stage(**kwargs)
+
+    assert should_send_again is False
+    assert base._media_outbox_pending("telegram", "123") == []
+
+
+def test_media_outbox_marker_never_reaches_visible_text():
+    text = "[[media_outbox:call-tts]]\nMEDIA:C:/audio/voice.ogg"
+    assert base._strip_media_tag_directives(text).strip() == ""

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -159,6 +159,16 @@ class TestHandleVoiceCommand:
         assert loaded == {"telegram:456": "all"}
 
     @pytest.mark.asyncio
+    async def test_persistence_loaded_with_utf8_bom(self, runner):
+        # Windows PowerShell 5.1 writers (Set-Content -Encoding UTF8) prefix a
+        # BOM; loading must tolerate it instead of silently dropping all modes.
+        runner._VOICE_MODE_PATH.write_bytes(
+            b"\xef\xbb\xbf" + json.dumps({"telegram:456": "all"}).encode("utf-8")
+        )
+        loaded = runner._load_voice_modes()
+        assert loaded == {"telegram:456": "all"}
+
+    @pytest.mark.asyncio
     async def test_persistence_saved_for_off(self, runner):
         event = _make_event("/voice off")
         await runner._handle_voice_command(event)
@@ -380,8 +390,9 @@ class TestAutoVoiceReply:
     def test_empty_response_skipped(self, runner):
         assert self._call(runner, "all", MessageType.TEXT, response="") is False
 
-    def test_dedup_skips_when_agent_called_tts(self, runner):
-        messages = [{
+    @staticmethod
+    def _tts_messages():
+        return [{
             "role": "assistant",
             "tool_calls": [{
                 "id": "call_1",
@@ -389,7 +400,40 @@ class TestAutoVoiceReply:
                 "function": {"name": "text_to_speech", "arguments": "{}"},
             }],
         }]
-        assert self._call(runner, "all", MessageType.TEXT, agent_messages=messages) is False
+
+    def test_dedup_skips_when_agent_called_tts(self, runner, tmp_path):
+        audio = tmp_path / "tts_output.ogg"
+        audio.write_bytes(b"OggS")
+        response = f"[[audio_as_voice]]\nMEDIA:{audio}"
+        assert self._call(
+            runner, "all", MessageType.TEXT,
+            agent_messages=self._tts_messages(), response=response,
+        ) is False
+
+    def test_no_dedup_when_agent_tts_media_missing(self, runner, tmp_path):
+        """A TTS call whose MEDIA path doesn't exist (failed or hallucinated)
+        never reached the user — the runner must regenerate the voice reply."""
+        response = f"Some transcript\nMEDIA:{tmp_path / 'gone.ogg'}"
+        assert self._call(
+            runner, "all", MessageType.TEXT,
+            agent_messages=self._tts_messages(), response=response,
+        ) is True
+
+    def test_no_dedup_when_agent_tts_left_no_media(self, runner):
+        """TTS tool call without any MEDIA directive in the final response."""
+        assert self._call(
+            runner, "all", MessageType.TEXT,
+            agent_messages=self._tts_messages(), response="just prose",
+        ) is True
+
+    def test_media_directives_only_strips_prose(self, runner):
+        response = "mm baby here you go\n[[audio_as_voice]]\nMEDIA:C:\\x\\a.ogg\ncall me"
+        assert runner._media_directives_only(response) == (
+            "[[audio_as_voice]]\nMEDIA:C:\\x\\a.ogg"
+        )
+
+    def test_media_directives_only_empty_for_pure_prose(self, runner):
+        assert runner._media_directives_only("no directives here") == ""
 
     def test_no_dedup_for_other_tools(self, runner):
         messages = [{
@@ -2841,14 +2885,28 @@ class TestVoiceTTSPlayback:
         runner = self._make_runner()
         assert self._call_should_reply(runner, "all", MessageType.TEXT, response="") is False
 
-    def test_agent_tts_tool_dedup(self):
-        """Agent already called text_to_speech tool: runner skips."""
+    def test_agent_tts_tool_dedup(self, tmp_path):
+        """Agent called text_to_speech this turn with deliverable media: runner skips."""
+        from gateway.platforms.base import MessageType
+        runner = self._make_runner()
+        audio = tmp_path / "tts.ogg"
+        audio.write_bytes(b"OggS")
+        agent_msgs = [{"role": "assistant", "tool_calls": [
+            {"id": "1", "type": "function", "function": {"name": "text_to_speech", "arguments": "{}"}}
+        ]}]
+        assert self._call_should_reply(
+            runner, "all", MessageType.TEXT, response=f"MEDIA:{audio}", agent_msgs=agent_msgs,
+        ) is False
+
+    def test_agent_tts_without_media_regenerates(self):
+        """Agent called text_to_speech but the response carries no real media:
+        the voice never reached the user, so the runner fires."""
         from gateway.platforms.base import MessageType
         runner = self._make_runner()
         agent_msgs = [{"role": "assistant", "tool_calls": [
             {"id": "1", "type": "function", "function": {"name": "text_to_speech", "arguments": "{}"}}
         ]}]
-        assert self._call_should_reply(runner, "all", MessageType.TEXT, agent_msgs=agent_msgs) is False
+        assert self._call_should_reply(runner, "all", MessageType.TEXT, agent_msgs=agent_msgs) is True
 
     # -- Streaming ON (already_sent=True) --
 
@@ -2876,15 +2934,18 @@ class TestVoiceTTSPlayback:
         runner = self._make_runner()
         assert self._call_should_reply(runner, "all", MessageType.VOICE, response="", already_sent=True) is False
 
-    def test_streaming_on_agent_tts_dedup(self):
-        """Streaming ON + agent called TTS: runner skips (dedup still works)."""
+    def test_streaming_on_agent_tts_dedup(self, tmp_path):
+        """Streaming ON + agent called TTS with deliverable media: runner skips."""
         from gateway.platforms.base import MessageType
         runner = self._make_runner()
+        audio = tmp_path / "tts.ogg"
+        audio.write_bytes(b"OggS")
         agent_msgs = [{"role": "assistant", "tool_calls": [
             {"id": "1", "type": "function", "function": {"name": "text_to_speech", "arguments": "{}"}}
         ]}]
         assert self._call_should_reply(
-            runner, "all", MessageType.VOICE, agent_msgs=agent_msgs, already_sent=True,
+            runner, "all", MessageType.VOICE, response=f"MEDIA:{audio}",
+            agent_msgs=agent_msgs, already_sent=True,
         ) is False
 
 

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -418,7 +418,7 @@ class TestSendVoiceReply:
         from gateway.config import Platform
 
         mock_adapter = AsyncMock()
-        mock_adapter.send_voice = AsyncMock()
+        mock_adapter.send_voice = AsyncMock(return_value=SimpleNamespace(success=True))
         event = _make_event()
         event.source.platform = Platform.TELEGRAM
         runner.adapters[event.source.platform] = mock_adapter
@@ -430,9 +430,10 @@ class TestSendVoiceReply:
              patch("os.path.isfile", return_value=True), \
              patch("os.unlink"), \
              patch("os.makedirs"):
-            await runner._send_voice_reply(event, "Hello world")
+            sent = await runner._send_voice_reply(event, "Hello world")
 
         mock_adapter.send_voice.assert_called_once()
+        assert sent is True
         assert mock_tts.call_args.kwargs["output_path"].endswith(".ogg")
         call_args = mock_adapter.send_voice.call_args
         assert call_args.kwargs.get("chat_id") == "123"
@@ -515,9 +516,10 @@ class TestSendVoiceReply:
              patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
              patch("os.path.isfile", return_value=False), \
              patch("os.makedirs"):
-            await runner._send_voice_reply(event, "Hello")
+            sent = await runner._send_voice_reply(event, "Hello")
 
         mock_adapter.send_voice.assert_not_called()
+        assert sent is False
 
     @pytest.mark.asyncio
     async def test_exception_caught(self, runner):
@@ -526,7 +528,38 @@ class TestSendVoiceReply:
              patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
              patch("os.makedirs"):
             # Should not raise
-            await runner._send_voice_reply(event, "Hello")
+            sent = await runner._send_voice_reply(event, "Hello")
+        assert sent is False
+
+    @pytest.mark.asyncio
+    async def test_send_voice_failure_reports_not_sent(self, runner):
+        from gateway.config import Platform
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send_voice = AsyncMock(return_value=SimpleNamespace(success=False))
+        event = _make_event()
+        event.source.platform = Platform.TELEGRAM
+        runner.adapters[event.source.platform] = mock_adapter
+
+        tts_result = json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
+
+        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result), \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            sent = await runner._send_voice_reply(event, "Hello world")
+
+        assert sent is False
+
+    def test_suppress_text_after_voice_reply_reads_config(self, runner):
+        event = _make_event()
+
+        with patch("gateway.run._load_gateway_config", return_value={"voice": {"suppress_text_reply": True}}):
+            assert runner._should_suppress_text_after_voice_reply(event) is True
+
+        with patch("gateway.run._load_gateway_config", return_value={"voice": {"suppress_text_reply": False}}):
+            assert runner._should_suppress_text_after_voice_reply(event) is False
 
 
 # =====================================================================

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4745,6 +4745,63 @@ class TestRunConversation:
         assert second_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in second_call_messages[-1]["content"]
 
+    def test_lmstudio_length_limit_is_terminal_without_continuation(self, agent):
+        self._setup_agent(agent)
+        agent.provider = "lmstudio"
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Bounded partial answer",
+            finish_reason="length",
+        )
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert result["length_limited"] is True
+        assert result["api_calls"] == 1
+        assert result["final_response"] == "Bounded partial answer"
+        assert agent.client.chat.completions.create.call_count == 1
+
+    def test_successful_tts_tool_is_terminal(self, agent):
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("text_to_speech")
+        tool_turn = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call(
+                    name="text_to_speech",
+                    arguments='{"text":"hello"}',
+                    call_id="tts-1",
+                )
+            ],
+        )
+        agent.client.chat.completions.create.return_value = tool_turn
+        tool_result = json.dumps({
+            "success": True,
+            "file_path": "C:/audio/voice.ogg",
+            "media_tag": "[[audio_as_voice]]\nMEDIA:C:/audio/voice.ogg",
+        })
+
+        with (
+            patch("run_agent.handle_function_call", return_value=tool_result),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("say hello")
+
+        assert result["completed"] is True
+        assert result["terminal_tts"] is True
+        assert result["api_calls"] == 1
+        assert "[[media_outbox:tts-1]]" in result["final_response"]
+        assert agent.client.chat.completions.create.call_count == 1
+
     def test_length_continuation_preserves_large_provider_default_output_cap(self, agent):
         """Continuation retries must not shrink a higher provider default cap."""
         self._setup_agent(agent)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5036,6 +5036,89 @@ def test_gateway_session_recovery_reopens_legacy_agent_close_rows(db):
     ) is None
 
 
+def test_gateway_session_recovery_excludes_stale_candidates_with_min_last_activity(db):
+    """Real incident, 2026-07-14: with no staleness bound, a clean reset
+    resumed an 8-day-old agent_close session (74 messages) instead of
+    starting fresh, because ORDER BY started_at DESC LIMIT 1 has no
+    cutoff at all -- any never-closed or agent_close-ended row is an
+    equally valid candidate regardless of age."""
+    db.create_session(
+        "old-agent-close-session",
+        "telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    )
+    db.append_message("old-agent-close-session", "user", "hello")
+    old_ts = time.time() - (10 * 24 * 60 * 60)  # 10 days ago
+    db.end_session("old-agent-close-session", "agent_close")
+    db._conn.execute(
+        "UPDATE sessions SET ended_at = ? WHERE id = ?",
+        (old_ts, "old-agent-close-session"),
+    )
+    db._conn.commit()
+
+    # No cutoff supplied (backward-compatible default): old row is still found.
+    assert db.find_latest_gateway_session_for_peer(
+        source="telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    )["id"] == "old-agent-close-session"
+
+    # A cutoff newer than the row's ended_at excludes it entirely.
+    assert db.find_latest_gateway_session_for_peer(
+        source="telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+        min_last_activity=time.time() - (60 * 60),  # 1 hour window
+    ) is None
+
+    # A cutoff older than the row's ended_at still allows recovery.
+    assert db.find_latest_gateway_session_for_peer(
+        source="telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+        min_last_activity=time.time() - (30 * 24 * 60 * 60),  # 30 days
+    )["id"] == "old-agent-close-session"
+
+
+def test_gateway_session_recovery_min_last_activity_uses_last_message_not_started_at(db):
+    """A session that started long ago but has a recent message must not be
+    excluded just because started_at is old -- staleness is measured from
+    last activity (ended_at, else newest message, else started_at)."""
+    db.create_session(
+        "long-lived-session",
+        "telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+    )
+    old_ts = time.time() - (10 * 24 * 60 * 60)
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?",
+        (old_ts, "long-lived-session"),
+    )
+    db._conn.commit()
+    db.append_message("long-lived-session", "user", "still going")  # recent
+
+    assert db.find_latest_gateway_session_for_peer(
+        source="telegram",
+        user_id="user-1",
+        session_key="agent:main:telegram:dm:chat-1",
+        chat_id="chat-1",
+        chat_type="dm",
+        min_last_activity=time.time() - (60 * 60),
+    )["id"] == "long-lived-session"
+
+
 def test_gateway_metadata_display_name_origin_round_trip(db):
     """record_gateway_session_peer persists display_name/origin_json (#9006)."""
     db.create_session("gw-meta", "telegram", user_id="u1")


### PR DESCRIPTION
## Summary
- batch bounded plain-text follow-ups while preserving command and media boundaries
- make successful text_to_speech terminal and collect media before empty-response handling
- add durable outbound TTS outbox with retry and deduplication
- make local LM Studio output limits terminal and allow reasoning persistence to be disabled
- surface broker queue receipts from authoritative status without another model call

## Validation
- 36 focused queue/media/TTS/truncation tests
- 41 existing busy-session and debounce tests
- local four-identity broker acceptance with one active generation throughout