### PR TITLE
fix(msgraph_webhook): guard the listener bind so a port conflict can't loop forever

### DIFF
--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import hmac
 import ipaddress
 import json
@@ -164,7 +165,36 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         self._runner = web.AppRunner(app)
         await self._runner.setup()
         site = web.TCPSite(self._runner, self._host, self._port)
-        await site.start()
+        try:
+            await site.start()
+        except OSError as exc:
+            # site.start() was previously unguarded, so any bind failure
+            # propagated out of connect() as an exception. The reconnect
+            # watcher in gateway.run treats that (like a bare False) as a
+            # transient failure and retries forever at the backoff cap.
+            await self._runner.cleanup()
+            self._runner = None
+            if getattr(exc, "errno", None) == errno.EADDRINUSE:
+                # A port conflict is a configuration error, not a transient
+                # blip — another process holds the port for its lifetime.
+                # Mark it non-retryable so the platform drops from the
+                # reconnect queue; recover with `/platform resume
+                # msgraph_webhook` after changing the port (mirrors the
+                # api_server / webhook direct-bind hardening).
+                self._set_fatal_error(
+                    "msgraph_webhook_port_in_use",
+                    f"Port {self._port} already in use. Set a different "
+                    f"host/port for the msgraph_webhook platform in "
+                    f"config.yaml, then `/platform resume msgraph_webhook`.",
+                    retryable=False,
+                )
+            logger.error(
+                "[msgraph_webhook] Could not bind %s:%d: %s",
+                self._host,
+                self._port,
+                exc,
+            )
+            return False
         self._mark_connected()
         logger.info(
             "[msgraph_webhook] Listening on %s:%d%s",

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -1,7 +1,9 @@
 """Tests for the Microsoft Graph webhook adapter."""
 
 import asyncio
+import errno
 import json
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -116,6 +118,55 @@ class TestMSGraphValidationHandshake:
             assert adapter.is_connected is True
         finally:
             await adapter.disconnect()
+
+    @pytest.mark.anyio
+    async def test_port_conflict_sets_non_retryable_fatal_error(self):
+        """A port conflict (EADDRINUSE) must set a non-retryable fatal error so
+        the reconnect watcher drops the platform from the retry queue instead
+        of looping indefinitely.
+
+        Previously ``site.start()`` was unguarded, so the bind OSError
+        propagated out of connect(); gateway.run's reconnect watcher treats an
+        exception (like a bare ``False``) as transient and retries forever at
+        the backoff cap. The failure is injected so the branch is exercised
+        deterministically regardless of the OS's rebinding semantics.
+        """
+        if not AIOHTTP_AVAILABLE:
+            pytest.skip("aiohttp not installed")
+        adapter = _make_adapter(host="127.0.0.1", port=8646, allowed_source_cidrs=[])
+        eaddrinuse = OSError(errno.EADDRINUSE, "address already in use")
+        with patch(
+            "gateway.platforms.msgraph_webhook.web.TCPSite"
+        ) as mock_site_cls:
+            mock_site_cls.return_value.start = AsyncMock(side_effect=eaddrinuse)
+            connected = await adapter.connect()
+        assert connected is False
+        assert adapter.is_connected is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "msgraph_webhook_port_in_use"
+        assert "8646" in (adapter.fatal_error_message or "")
+        # The runner must be cleaned up on the failure path, not leaked.
+        assert adapter._runner is None
+
+    @pytest.mark.anyio
+    async def test_transient_bind_error_stays_retryable(self):
+        """A non-EADDRINUSE bind failure (e.g. a transient OSError) must NOT be
+        marked fatal — connect() returns a bare ``False`` so the watcher keeps
+        retrying. Only a genuine port conflict is a configuration error.
+        """
+        if not AIOHTTP_AVAILABLE:
+            pytest.skip("aiohttp not installed")
+        adapter = _make_adapter(host="127.0.0.1", port=8646, allowed_source_cidrs=[])
+        transient = OSError(errno.EADDRNOTAVAIL, "cannot assign requested address")
+        with patch(
+            "gateway.platforms.msgraph_webhook.web.TCPSite"
+        ) as mock_site_cls:
+            mock_site_cls.return_value.start = AsyncMock(side_effect=transient)
+            connected = await adapter.connect()
+        assert connected is False
+        assert adapter.has_fatal_error is False
+        assert adapter._runner is None
 
     @pytest.mark.anyio
     async def test_validation_token_echo_on_get(self):


### PR DESCRIPTION
## What does this PR do?

`MSGraphWebhookAdapter.connect()` called `await site.start()` with **no error
handling**, so any bind failure propagated out of `connect()` as an exception.
The reconnect watcher in `gateway.run` treats an exception during connect (like
a bare `False` with no fatal-error info) as a transient failure:

> "No fatal error info means likely a transient issue — queue for retry"

…so it retries **forever** at the backoff cap, filling `errors.log`.

On `EADDRINUSE` that's the wrong signal: a port conflict is a configuration
error — another process owns the port for its lifetime — not a transient blip.
This is the same failure the `api_server` and `webhook` direct-bind paths were
hardened against. This PR wraps `site.start()` in the same `OSError` handling:
clean up the `AppRunner`, and on `EADDRINUSE` set a non-retryable fatal error
(`msgraph_webhook_port_in_use`) so the platform drops from the reconnect queue.
Other (transient) `OSError`s return a bare `False`, so they stay retryable. The
operator recovers with `/platform resume msgraph_webhook` after changing the
port.

## Related Issue

No separate issue. Parity fix for the Microsoft Graph webhook adapter, mirroring
the merged `api_server` port-conflict hardening.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/msgraph_webhook.py` — wrap the `site.start()` bind in a
  `try/except OSError`: clean up the runner, and on `errno.EADDRINUSE` call
  `self._set_fatal_error("msgraph_webhook_port_in_use", …, retryable=False)`
  before returning `False`; non-`EADDRINUSE` errors return a bare `False` (still
  retryable). Adds `import errno`.
- `tests/gateway/test_msgraph_webhook.py` — two regression tests (below).

## How to Test

1. `pytest tests/gateway/test_msgraph_webhook.py -q` → all pass (33), including
   the two new tests.
2. Proof the fix works — revert only the `msgraph_webhook.py` change and re-run:
   both new tests fail, because the injected bind `OSError` propagates out of
   `connect()` (the infinite-retry bug) instead of being caught. With the fix,
   `test_port_conflict_sets_non_retryable_fatal_error` gets
   `fatal_error_code == "msgraph_webhook_port_in_use"`,
   `fatal_error_retryable is False`, and a cleaned-up runner; a non-`EADDRINUSE`
   `OSError` leaves no fatal error (stays retryable).
3. The bind failure is injected (`OSError(errno.EADDRINUSE)`) so the branch is
   exercised deterministically, independent of the OS's rebinding semantics.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suite (`pytest tests/gateway/test_msgraph_webhook.py -q`) and all 33 tests pass
- [x] I've added tests for my changes
- [x] I've tested locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation — inline rationale added; no external docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the fix keys on `errno.EADDRINUSE` (symbolic, resolves per-OS) and the tests inject the error, so both are platform-independent