### PR TITLE
fix(agent): guard int() against float infinity in wait-status heartbeat

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -40,6 +41,24 @@ from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 logger = logging.getLogger(__name__)
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
+
+
+def _safe_int_seconds(value: float) -> int:
+    """Convert a timeout/deadline to int for display without crashing on infinity.
+
+    Local providers (Ollama, MoA virtual endpoints) set the stale timeout to
+    ``float("inf")`` to disable the stale detector.  ``int(float("inf"))``
+    raises ``OverflowError: cannot convert float infinity to integer``, which
+    crashes the wait-status heartbeat and propagates through the retry layer
+    as a spurious API failure.  See issue #65746.
+
+    Returns a large sentinel (999999) for non-finite values so the display
+    reads "auto-reconnect at 999999s" — clearly indicating no timeout —
+    instead of crashing.
+    """
+    if math.isinf(value) or math.isnan(value):
+        return 999999
+    return int(value)
 
 # When the fallback chain is fully exhausted on a non-rate-limit failure
 # (e.g. every provider returns a non-retryable client error like HTTP 400),
@@ -620,7 +639,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
             agent._emit_wait_notice(
                 f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
                 f"{int(_elapsed)}s with no response yet (provider may be slow "
-                f"or overloaded; auto-reconnect at {int(_deadline)}s)"
+                f"or overloaded; auto-reconnect at {_safe_int_seconds(_deadline)}s)"
             )
 
         _elapsed = time.time() - _call_start
@@ -775,13 +794,13 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 if _silent_hint:
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s). "
+                        f"with no response (threshold: {_safe_int_seconds(_stale_timeout)}s). "
                         f"{_silent_hint}"
                     )
                 else:
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s)"
+                        f"with no response (threshold: {_safe_int_seconds(_stale_timeout)}s)"
                     )
             break
 

--- a/tests/agent/test_moa_infinity_crash.py
+++ b/tests/agent/test_moa_infinity_crash.py
@@ -1,0 +1,117 @@
+"""Tests for issue #65746 — MoA/local calls crash after 30s with
+``OverflowError: cannot convert float infinity to integer``.
+
+Local providers (Ollama, MoA virtual endpoints) set the stale timeout to
+``float("inf")`` to disable the stale detector. When the 30-second
+wait-status heartbeat fires and formats the deadline with ``int(_deadline)``,
+this raises ``OverflowError`` which propagates through the retry layer as
+a spurious API failure.
+
+The fix: ``_safe_int_seconds()`` guards against non-finite values before
+calling ``int()``, returning a large sentinel (999999) instead of crashing.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from agent.chat_completion_helpers import _safe_int_seconds
+
+
+# --------------------------------------------------------------------------- #
+# _safe_int_seconds
+# --------------------------------------------------------------------------- #
+
+
+def test_safe_int_with_finite_value():
+    """Normal finite values pass through int() unchanged."""
+    assert _safe_int_seconds(30.0) == 30
+    assert _safe_int_seconds(0.0) == 0
+    assert _safe_int_seconds(180.5) == 180
+    assert _safe_int_seconds(999.99) == 999
+
+
+def test_safe_int_with_infinity():
+    """float('inf') must not raise OverflowError — returns sentinel."""
+    # This is the exact crash from the bug report:
+    #   int(float('inf')) → OverflowError: cannot convert float infinity to integer
+    result = _safe_int_seconds(float("inf"))
+    assert result == 999999
+    # Must not raise
+    assert isinstance(result, int)
+
+
+def test_safe_int_with_negative_infinity():
+    """float('-inf') must also be handled without crashing."""
+    result = _safe_int_seconds(float("-inf"))
+    assert result == 999999
+
+
+def test_safe_int_with_nan():
+    """NaN must also be handled without crashing."""
+    result = _safe_int_seconds(float("nan"))
+    assert result == 999999
+
+
+def test_safe_int_does_not_raise_on_any_input():
+    """The helper must never raise — it's used in display formatting."""
+    # Test a range of edge cases
+    for val in [0, 0.0, -0.0, 1, 1e10, 1e-10, float("inf"), float("-inf"),
+                float("nan"), -100.5, 3.14159]:
+        result = _safe_int_seconds(val)
+        assert isinstance(result, int)
+
+
+def test_old_int_crashes_on_infinity():
+    """Verify the original bug: int(float('inf')) raises OverflowError.
+
+    This test documents the crash that _safe_int_seconds prevents.
+    """
+    with pytest.raises(OverflowError):
+        int(float("inf"))
+
+
+# --------------------------------------------------------------------------- #
+# Integration: the wait-status heartbeat format string
+# --------------------------------------------------------------------------- #
+
+
+def test_wait_notice_format_with_infinite_deadline():
+    """The format string that crashed must now work with infinite deadline.
+
+    Before the fix:
+        f"...auto-reconnect at {int(_deadline)}s)"  → OverflowError
+
+    After the fix:
+        f"...auto-reconnect at {_safe_int_seconds(_deadline)}s)"  → OK
+    """
+    _deadline = float("inf")  # The value that caused the crash
+    _elapsed = 30.0
+
+    # This is the exact format string from the heartbeat (line ~622)
+    msg = (
+        f"⏳ waiting on the provider — "
+        f"{int(_elapsed)}s with no response yet (provider may be slow "
+        f"or overloaded; auto-reconnect at {_safe_int_seconds(_deadline)}s)"
+    )
+
+    assert "999999s" in msg
+    assert "30s" in msg
+    assert "auto-reconnect" in msg
+
+
+def test_timeout_error_message_with_infinite_stale_timeout():
+    """The TimeoutError format strings must also handle infinite stale timeout."""
+    _stale_timeout = float("inf")
+    _elapsed = 45.0
+
+    # This is the format from the non-streaming timeout path (line ~778)
+    msg = (
+        f"Non-streaming API call timed out after {int(_elapsed)}s "
+        f"with no response (threshold: {_safe_int_seconds(_stale_timeout)}s)"
+    )
+
+    assert "999999s" in msg
+    assert "45s" in msg


### PR DESCRIPTION
## Summary

A healthy non-streaming provider call can be aborted by Hermes' 30-second wait-status heartbeat when the effective stale timeout is non-finite. The concrete production path is Mixture of Agents (MoA) with a local provider, where the stale timeout is `float("inf")` to disable the stale detector.

When the heartbeat fires and formats the deadline with `int(_deadline)`, this raises:

```
OverflowError: cannot convert float infinity to integer
```

The generic retry layer then mislabels the local polling/display exception as an API failure, retries the otherwise healthy request five times, and ultimately makes the agent unavailable.

## Root cause

`int(float("inf"))` raises `OverflowError`. Three call sites in `agent/chat_completion_helpers.py` pass timeout/deadline values directly to `int()` for display formatting:

1. **Line 623** (the crash site): `int(_deadline)` in the wait-status heartbeat
2. **Line 778**: `int(_stale_timeout)` in the non-streaming timeout error message
3. **Line 784**: `int(_stale_timeout)` in the non-streaming timeout error message (no-hint variant)

Regression introduced by `569b912d7d0931c7256e9f5fb326609e9deda377`.

## Fix

Add `_safe_int_seconds()` helper that guards against non-finite values (`inf`, `-inf`, `nan`) before `int()` conversion, returning a large sentinel (999999) instead of crashing. Applied to all three affected call sites.

The sentinel reads as "auto-reconnect at 999999s" in the UI — clearly indicating no timeout is set, rather than crashing the session.

## What changed

| File | Change |
|------|--------|
| `agent/chat_completion_helpers.py` | +18 lines: `_safe_int_seconds()` helper + `import math` + 3 call site fixes |
| `tests/agent/test_moa_infinity_crash.py` | +85 lines: 8 new tests |

## Test plan

- [x] `pytest tests/agent/test_moa_infinity_crash.py` — 8 passed
- [x] `pytest tests/agent/test_streaming_context_scrubber.py tests/agent/test_local_stream_timeout.py tests/agent/test_non_stream_stale_timeout.py tests/agent/test_stream_read_timeout_floor.py` — 105 passed (no regressions)
- [ ] Manual: configure MoA with a local provider, verify the 30s heartbeat displays instead of crashing

Closes #65746

## Platforms tested

- Windows 10 (native, git-bash/MSYS)
- Python 3.11.15