### PR TITLE
fix: label Codex quota windows by duration

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -449,6 +449,21 @@ def _resolve_codex_usage_url(base_url: str) -> str:
     return _codex_backend_urls(base_url)[0]
 
 
+def _codex_window_label(window: dict[str, Any], fallback: str) -> str:
+    """Name Codex quota windows by duration, not primary/secondary position."""
+    seconds = window.get("limit_window_seconds")
+    if not _is_finite_num(seconds) or seconds <= 0:
+        return fallback
+
+    for expected_seconds, label in (
+        (5 * 60 * 60, "Session"),
+        (7 * 24 * 60 * 60, "Weekly"),
+    ):
+        if expected_seconds * 0.95 <= seconds <= expected_seconds * 1.05:
+            return label
+    return fallback
+
+
 def _resolve_codex_usage_credentials(
     base_url: Optional[str],
     api_key: Optional[str],
@@ -525,14 +540,14 @@ def _fetch_codex_account_usage(
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
-    for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
+    for key, fallback_label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
         window = rate_limit.get(key) or {}
         used = window.get("used_percent")
         if used is None:
             continue
         windows.append(
             AccountUsageWindow(
-                label=label,
+                label=_codex_window_label(window, fallback_label),
                 used_percent=float(used),
                 reset_at=_parse_dt(window.get("reset_at")),
             )

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -95,6 +95,42 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert "Credits balance: $12.50" in snapshot.details
 
 
+def test_fetch_account_usage_codex_labels_weekly_only_primary_by_duration(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "access-token",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage._read_codex_tokens",
+        lambda: {"tokens": {"account_id": "acct_123"}},
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "plan_type": "pro",
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 1,
+                        "reset_at": 1_900_000_000,
+                        "limit_window_seconds": 604800,
+                    },
+                    "secondary_window": None,
+                },
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert [window.label for window in snapshot.windows] == ["Weekly"]
+
+
 def test_render_account_usage_lines_includes_reset_and_provider():
     snapshot = AccountUsageSnapshot(
         provider="openai-codex",


### PR DESCRIPTION
## Summary
- derive OpenAI Codex quota labels from `limit_window_seconds` instead of assuming primary=session and secondary=weekly
- preserve the legacy positional fallback when duration is missing or unknown
- fix weekly-only payloads so a seven-day primary window renders as `w:<n>% left`, not `s:<n>% left`

## Tests
- `scripts/run_tests.sh tests/test_account_usage.py tests/gateway/test_runtime_footer.py` (30 passed)
- `ruff check agent/account_usage.py tests/test_account_usage.py`
- `python -m compileall -q agent/account_usage.py tests/test_account_usage.py`
- live Pro account payload: one 604800-second primary window + null secondary now formats as `w:99% left`

The ±5% duration match follows Codex CLI's own approximate-window classification behavior.