### PR TITLE
feat(desktop): add managed gateway tunnel commands

### DIFF
--- a/apps/desktop/electron/gateway-tunnel.test.ts
+++ b/apps/desktop/electron/gateway-tunnel.test.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createGatewayTunnelCleanup, createGatewayTunnelManager } from './gateway-tunnel'
+
+const tempDirs: string[] = []
+
+function testScript(dir: string): string {
+  const scriptPath = path.join(dir, 'hermes-tunnel.sh')
+  fs.writeFileSync(scriptPath, '#!/bin/sh\n')
+  fs.chmodSync(scriptPath, 0o700)
+
+  return scriptPath
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { force: true, recursive: true })
+  }
+})
+
+describe('managed gateway tunnel', () => {
+  it('starts the configured script and records ownership', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-gateway-tunnel-'))
+    tempDirs.push(dir)
+    const scriptPath = testScript(dir)
+    const markerPath = path.join(dir, 'managed.json')
+    const run = vi.fn(() => ({ status: 0, stdout: 'Tunnel Hermes actif.\n', stderr: '' }))
+    const manager = createGatewayTunnelManager({ markerPath, run, scriptPath })
+
+    expect(manager.activate()).toMatchObject({ active: true, url: 'http://127.0.0.1:9119' })
+    expect(run).toHaveBeenCalledWith(scriptPath, ['start'])
+    expect(JSON.parse(fs.readFileSync(markerPath, 'utf8'))).toMatchObject({ scriptPath })
+  })
+
+  it('stops only a tunnel owned by the desktop command', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-gateway-tunnel-'))
+    tempDirs.push(dir)
+    const scriptPath = testScript(dir)
+    const markerPath = path.join(dir, 'managed.json')
+    fs.writeFileSync(markerPath, JSON.stringify({ scriptPath }))
+    const run = vi.fn(() => ({ status: 0, stdout: 'Tunnel arrêté.\n', stderr: '' }))
+    const manager = createGatewayTunnelManager({ markerPath, run, scriptPath })
+
+    expect(manager.deactivate()).toMatchObject({ active: false })
+    expect(run).toHaveBeenCalledWith(scriptPath, ['stop'])
+    expect(fs.existsSync(markerPath)).toBe(false)
+  })
+
+  it('surfaces script failures without claiming ownership', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-gateway-tunnel-'))
+    tempDirs.push(dir)
+    const scriptPath = testScript(dir)
+    const markerPath = path.join(dir, 'managed.json')
+    const run = vi.fn(() => ({ status: 1, stdout: '', stderr: 'Azure indisponible' }))
+    const manager = createGatewayTunnelManager({ markerPath, run, scriptPath })
+
+    expect(() => manager.activate()).toThrow('Azure indisponible')
+    expect(fs.existsSync(markerPath)).toBe(false)
+  })
+
+  it('restores Local mode and stops an owned tunnel when the main window closes', () => {
+    const writeLocalConfig = vi.fn()
+    const deactivate = vi.fn()
+
+    const cleanup = createGatewayTunnelCleanup({
+      manager: { deactivate, isOwned: () => true },
+      onError: vi.fn(),
+      writeLocalConfig
+    })
+
+    cleanup()
+
+    expect(writeLocalConfig).toHaveBeenCalledOnce()
+    expect(deactivate).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/electron/gateway-tunnel.ts
+++ b/apps/desktop/electron/gateway-tunnel.ts
@@ -1,0 +1,100 @@
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+export const DEFAULT_GATEWAY_TUNNEL_URL = 'http://127.0.0.1:9119'
+
+export interface GatewayTunnelRunResult {
+  status: number | null
+  stderr?: string | Buffer
+  stdout?: string | Buffer
+}
+
+export interface GatewayTunnelManagerOptions {
+  markerPath: string
+  run?: (scriptPath: string, args: string[]) => GatewayTunnelRunResult
+  scriptPath: string
+  url?: string
+}
+
+export interface GatewayTunnelCleanupOptions {
+  manager: {
+    deactivate: () => unknown
+    isOwned: () => boolean
+  }
+  onError: (error: unknown) => void
+  writeLocalConfig: () => void
+}
+
+function outputText(value: string | Buffer | undefined): string {
+  return value ? String(value).trim() : ''
+}
+
+export function createGatewayTunnelManager(options: GatewayTunnelManagerOptions) {
+  const { markerPath, scriptPath } = options
+  const url = options.url ?? DEFAULT_GATEWAY_TUNNEL_URL
+
+  const run =
+    options.run ??
+    ((command: string, args: string[]) =>
+      spawnSync('/bin/bash', [command, ...args], {
+        encoding: 'utf8',
+        timeout: 45_000
+      }))
+
+  const invoke = (action: 'start' | 'stop') => {
+    if (!fs.existsSync(scriptPath)) {
+      throw new Error(`Gateway tunnel script not found: ${scriptPath}`)
+    }
+
+    const result = run(scriptPath, [action])
+    const stdout = outputText(result.stdout)
+    const stderr = outputText(result.stderr)
+
+    if (result.status !== 0) {
+      throw new Error(stderr || stdout || `Gateway tunnel script failed (${action}).`)
+    }
+
+    return stdout
+  }
+
+  return {
+    activate() {
+      const output = invoke('start')
+      fs.mkdirSync(path.dirname(markerPath), { recursive: true })
+      fs.writeFileSync(markerPath, JSON.stringify({ scriptPath, startedAt: new Date().toISOString(), url }, null, 2))
+
+      return { active: true, output, url }
+    },
+
+    deactivate() {
+      if (!fs.existsSync(markerPath)) {
+        return { active: false, output: '', url }
+      }
+
+      const output = invoke('stop')
+      fs.rmSync(markerPath, { force: true })
+
+      return { active: false, output, url }
+    },
+
+    isOwned() {
+      return fs.existsSync(markerPath)
+    }
+  }
+}
+
+export function createGatewayTunnelCleanup(options: GatewayTunnelCleanupOptions): () => void {
+  return () => {
+    if (!options.manager.isOwned()) {
+      return
+    }
+
+    try {
+      options.writeLocalConfig()
+      options.manager.deactivate()
+    } catch (error) {
+      options.onError(error)
+    }
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -52,7 +52,7 @@ import {
   resolveTestWsUrl,
   tokenPreview
 } from './connection-config'
-import { adoptServedDashboardToken } from './dashboard-token'
+import { adoptServedDashboardToken, resolveServedDashboardToken } from './dashboard-token'
 import {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -64,6 +64,7 @@ import {
 } from './desktop-uninstall'
 import { installEmbedReferer } from './embed-referer'
 import { readDirForIpc } from './fs-read-dir'
+import { createGatewayTunnelCleanup, createGatewayTunnelManager } from './gateway-tunnel'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { scanGitRepos } from './git-repo-scan'
 import {
@@ -378,6 +379,20 @@ const BOOTSTRAP_COMPLETE_MARKER = path.join(ACTIVE_HERMES_ROOT, '.hermes-bootstr
 const BOOTSTRAP_MARKER_SCHEMA_VERSION = 1
 
 const DESKTOP_CONNECTION_CONFIG_PATH = path.join(app.getPath('userData'), 'connection.json')
+const GATEWAY_TUNNEL_SCRIPT_PATH = path.join(HERMES_HOME, 'mcp-workspaces', 'gateway', 'hermes-tunnel.sh')
+const GATEWAY_TUNNEL_MARKER_PATH = path.join(app.getPath('userData'), 'managed-gateway-tunnel.json')
+
+const gatewayTunnel = createGatewayTunnelManager({
+  markerPath: GATEWAY_TUNNEL_MARKER_PATH,
+  scriptPath: GATEWAY_TUNNEL_SCRIPT_PATH
+})
+
+const cleanupManagedGatewayTunnel = createGatewayTunnelCleanup({
+  manager: gatewayTunnel,
+  onError: error => rememberLog(`[gateway-tunnel] cleanup failed: ${String(error)}`),
+  writeLocalConfig: () => writeDesktopConnectionConfig(coerceDesktopConnectionConfig({ mode: 'local' }))
+})
+
 const DESKTOP_UPDATE_CONFIG_PATH = path.join(app.getPath('userData'), 'updates.json')
 const DESKTOP_WINDOW_STATE_PATH = path.join(app.getPath('userData'), 'window-state.json')
 // active-profile.json records which Hermes profile the desktop launches its
@@ -7276,7 +7291,10 @@ function createWindow() {
   mainWindow.on('moved', schedulePersistWindowState)
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
-  mainWindow.on('close', () => schedulePersistWindowState.flush())
+  mainWindow.on('close', () => {
+    schedulePersistWindowState.flush()
+    cleanupManagedGatewayTunnel()
+  })
 
   // The overlay rides the main window — closing the app's primary window must
   // tear it down too (otherwise it strands as an orphan that blocks
@@ -7696,6 +7714,70 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
   }
 
   return sanitizeDesktopConnectionConfig(config, payload?.profile)
+})
+
+ipcMain.handle('hermes:gateway-tunnel:activate', async () => {
+  if (process.env.HERMES_DESKTOP_REMOTE_URL) {
+    throw new Error('HERMES_DESKTOP_REMOTE_URL overrides desktop gateway settings; unset it before using /activate-gateway.')
+  }
+
+  const result = gatewayTunnel.activate()
+  let payload
+
+  try {
+    const probe = await probeRemoteAuthMode(result.url)
+
+    if (probe.authMode === 'oauth') {
+      payload = {
+        mode: 'remote',
+        remoteAuthMode: 'oauth',
+        remoteUrl: result.url
+      }
+    } else {
+      const remoteToken = await resolveServedDashboardToken(result.url, null, { rememberLog })
+
+      if (!remoteToken) {
+        throw new Error('Le dashboard distant ne fournit aucun token de session.')
+      }
+
+      payload = {
+        mode: 'remote',
+        remoteAuthMode: 'token',
+        remoteToken,
+        remoteUrl: result.url
+      }
+    }
+
+    await testDesktopConnectionConfig(payload)
+    const config = coerceDesktopConnectionConfig(payload)
+    writeDesktopConnectionConfig(config)
+    await teardownPrimaryBackendAndWait({ soft: true })
+    sendConnectionApplied()
+
+    return result
+  } catch (error) {
+    try {
+      gatewayTunnel.deactivate()
+    } catch (cleanupError) {
+      rememberLog(`Gateway tunnel cleanup after failed activation: ${String(cleanupError)}`)
+    }
+
+    throw error
+  }
+})
+
+ipcMain.handle('hermes:gateway-tunnel:deactivate', async () => {
+  if (process.env.HERMES_DESKTOP_REMOTE_URL) {
+    throw new Error('HERMES_DESKTOP_REMOTE_URL overrides desktop gateway settings; unset it before using /deactivate-gateway.')
+  }
+
+  const config = coerceDesktopConnectionConfig({ mode: 'local' })
+  writeDesktopConnectionConfig(config)
+  await teardownPrimaryBackendAndWait({ soft: true })
+  const result = gatewayTunnel.deactivate()
+  sendConnectionApplied()
+
+  return result
 })
 
 ipcMain.handle('hermes:profile:get', async () => ({ profile: readActiveDesktopProfile() }))
@@ -9084,6 +9166,9 @@ app.on('open-url', (event, url) => {
 })
 
 app.whenReady().then(() => {
+  // Recover a managed tunnel left by a crash or force-quit.
+  cleanupManagedGatewayTunnel()
+
   if (IS_MAC) {
     Menu.setApplicationMenu(buildApplicationMenu())
   } else {
@@ -9142,6 +9227,9 @@ function configureSpellChecker() {
 }
 
 app.on('before-quit', () => {
+  // Electron does not await arbitrary async quit handlers; cleanup is synchronous.
+  cleanupManagedGatewayTunnel()
+
   // The always-on-top overlay isn't a "real" app window; close it so a stray
   // pet can't keep the process alive or float over a quit app.
   closePetOverlay()

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -43,6 +43,10 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   probeConnectionConfig: remoteUrl => ipcRenderer.invoke('hermes:connection-config:probe', remoteUrl),
   oauthLoginConnectionConfig: remoteUrl => ipcRenderer.invoke('hermes:connection-config:oauth-login', remoteUrl),
   oauthLogoutConnectionConfig: remoteUrl => ipcRenderer.invoke('hermes:connection-config:oauth-logout', remoteUrl),
+  gatewayTunnel: {
+    activate: () => ipcRenderer.invoke('hermes:gateway-tunnel:activate'),
+    deactivate: () => ipcRenderer.invoke('hermes:gateway-tunnel:deactivate')
+  },
   // Hermes Cloud: one portal login powers discovery + silent per-agent sign-in
   // (cloud-auto-discovery Phase 3).
   cloud: {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -234,6 +234,24 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         branch: async () => {
           await branchCurrentSession()
         },
+        'activate-gateway': async () => {
+          notify({ kind: 'success', message: 'Démarrage du tunnel Hermes Cloud…' })
+
+          try {
+            const result = await window.hermesDesktop.gatewayTunnel.activate()
+            notify({ kind: 'success', message: `Gateway distante activée via ${result.url}` })
+          } catch (err) {
+            notifyError(err, "Impossible d'activer la gateway distante")
+          }
+        },
+        'deactivate-gateway': async () => {
+          try {
+            await window.hermesDesktop.gatewayTunnel.deactivate()
+            notify({ kind: 'success', message: 'Gateway locale réactivée et tunnel arrêté.' })
+          } catch (err) {
+            notifyError(err, "Impossible d'arrêter le tunnel de gateway")
+          }
+        },
         // /yolo maps to the status-bar YOLO control — a per-session approval
         // bypass, same scope as the TUI's Shift+Tab. With no session yet we arm
         // it locally; the session-create path applies it on the first message.

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -55,6 +55,10 @@ declare global {
       probeConnectionConfig: (remoteUrl: string) => Promise<DesktopConnectionProbeResult>
       oauthLoginConnectionConfig: (remoteUrl: string) => Promise<DesktopOauthLoginResult>
       oauthLogoutConnectionConfig: (remoteUrl?: string) => Promise<DesktopOauthLogoutResult>
+      gatewayTunnel: {
+        activate: () => Promise<DesktopGatewayTunnelResult>
+        deactivate: () => Promise<DesktopGatewayTunnelResult>
+      }
       // Hermes Cloud: one portal login powers discovery + silent per-agent
       // sign-in (cloud-auto-discovery Phase 3).
       cloud: {
@@ -412,6 +416,12 @@ export interface DesktopActiveProfile {
   // The desktop's stored profile preference, or null when unset (legacy launch
   // that defers to the sticky active_profile / default).
   profile: string | null
+}
+
+export interface DesktopGatewayTunnelResult {
+  active: boolean
+  output: string
+  url: string
 }
 
 export interface DesktopConnectionConfig {

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -73,6 +73,16 @@ describe('desktop slash command curation', () => {
     expect(resolveDesktopCommand('/browser')?.args).toBe(true)
   })
 
+  it('routes the managed gateway tunnel commands through desktop actions', () => {
+    expect(resolveDesktopCommand('/activate-gateway')?.surface).toEqual({ kind: 'action', action: 'activate-gateway' })
+    expect(resolveDesktopCommand('/deactivate-gateway')?.surface).toEqual({
+      kind: 'action',
+      action: 'deactivate-gateway'
+    })
+    expect(isDesktopSlashSuggestion('/activate-gateway')).toBe(true)
+    expect(isDesktopSlashSuggestion('/deactivate-gateway')).toBe(true)
+  })
+
   it('routes /journey (and aliases) to the memory graph overlay action', () => {
     expect(resolveDesktopCommand('/journey')?.surface).toEqual({ kind: 'action', action: 'journey' })
     expect(resolveDesktopCommand('/memory-graph')?.surface).toEqual({ kind: 'action', action: 'journey' })

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -29,8 +29,10 @@ export interface DesktopThemeCommandOption {
  * keyed by the id.
  */
 export type DesktopActionId =
+  | 'activate-gateway'
   | 'branch'
   | 'browser'
+  | 'deactivate-gateway'
   | 'handoff'
   | 'hatch'
   | 'help'
@@ -107,6 +109,16 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     surface: action('branch')
   },
   { name: '/yolo', description: 'Toggle YOLO — auto-approve dangerous commands', surface: action('yolo') },
+  {
+    name: '/activate-gateway',
+    description: 'Start the Azure tunnel and connect this app to the remote gateway',
+    surface: action('activate-gateway')
+  },
+  {
+    name: '/deactivate-gateway',
+    description: 'Return to the local gateway and stop the managed Azure tunnel',
+    surface: action('deactivate-gateway')
+  },
   {
     name: '/handoff',
     description: 'Hand off this session to a messaging platform',


### PR DESCRIPTION
## Summary
- Add Desktop-managed `/activate-gateway` and `/deactivate-gateway` commands.
- Start/stop a local gateway tunnel script through Electron IPC and switch Desktop between Local and Remote connection modes.
- Clean up owned tunnels on close/quit/startup recovery and cover the manager/slash-command routing with tests.

## Test plan
- `npm run typecheck`
- `npm run test -- --project electron electron/gateway-tunnel.test.ts electron/dashboard-token.test.ts`
- `npm run test -- --project ui src/lib/desktop-slash-commands.test.ts`
- `git diff --cached --check` before commit
- static scan of added lines for obvious secret/shell-injection/eval patterns
