### PR TITLE
refactor(tools): extract single-provider TTS dispatch into _synthesize_with_provider

### DIFF
--- a/contributors/emails/diegoberan@gmail.com
+++ b/contributors/emails/diegoberan@gmail.com
@@ -1,0 +1,2 @@
+diegoberan
+# PR #65768 (tools: single-provider TTS dispatch extraction)

--- a/tests/tools/test_tts_single_provider_dispatch.py
+++ b/tests/tools/test_tts_single_provider_dispatch.py
@@ -1,0 +1,164 @@
+"""Behavior contracts for single-provider TTS dispatch.
+
+``text_to_speech_tool()`` delegates one provider's synthesis to
+``_synthesize_with_provider()``. These tests pin the observable tool
+behavior across that seam: the effective-provider contract (the Edge
+default falls back to NeuTTS and the response must say so), actionable
+missing-SDK errors, exception messages labeled with the provider that
+actually ran, empty-output detection, and the success response shape.
+All assertions go through the public tool — no internals are inspected.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _default_config(monkeypatch):
+    """Pin an empty tts config so the host machine's config.yaml is inert."""
+    import tools.tts_tool as tts_tool
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {})
+    yield
+
+
+def _run_tool(tmp_path, filename="out.mp3"):
+    from tools.tts_tool import text_to_speech_tool
+
+    out = tmp_path / filename
+    return json.loads(text_to_speech_tool("hello world", output_path=str(out)))
+
+
+def _write_audio(path: str) -> str:
+    with open(path, "wb") as fh:
+        fh.write(b"fake-audio-bytes")
+    return path
+
+
+def test_edge_default_falls_back_to_neutts_and_reports_it(monkeypatch, tmp_path):
+    """Edge unavailable + NeuTTS available ⇒ success, provider says 'neutts'.
+
+    Downstream format/delivery decisions key off the provider that actually
+    ran, so the response must reflect the fallback, not the configured name.
+    """
+    import tools.tts_tool as tts_tool
+
+    monkeypatch.setattr(
+        tts_tool, "_import_edge_tts",
+        lambda: (_ for _ in ()).throw(ImportError("no edge-tts")),
+    )
+    monkeypatch.setattr(tts_tool, "_check_neutts_available", lambda: True)
+    monkeypatch.setattr(
+        tts_tool, "_generate_neutts",
+        lambda text, file_str, cfg: _write_audio(file_str),
+    )
+
+    data = _run_tool(tmp_path)
+
+    assert data["success"] is True
+    assert data["provider"] == "neutts"
+
+
+def test_missing_sdk_returns_actionable_error(monkeypatch, tmp_path):
+    """Configured provider whose SDK isn't importable ⇒ install hint, no crash."""
+    import tools.tts_tool as tts_tool
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "elevenlabs"})
+    monkeypatch.setattr(
+        tts_tool, "_import_elevenlabs",
+        lambda: (_ for _ in ()).throw(ImportError("not installed")),
+    )
+
+    data = _run_tool(tmp_path)
+
+    assert data["success"] is False
+    assert "pip install elevenlabs" in data["error"]
+
+
+def test_generator_exception_is_labeled_with_provider(monkeypatch, tmp_path):
+    """Unexpected generator failure ⇒ error names the provider that ran."""
+    import tools.tts_tool as tts_tool
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "minimax"})
+    monkeypatch.setattr(
+        tts_tool, "_generate_minimax_tts",
+        lambda text, file_str, cfg: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    data = _run_tool(tmp_path)
+
+    assert data["success"] is False
+    assert "TTS generation failed (minimax)" in data["error"]
+    assert "boom" in data["error"]
+
+
+def test_config_error_is_labeled_as_configuration(monkeypatch, tmp_path):
+    """ValueError from a provider ⇒ configuration-error message, not generic."""
+    import tools.tts_tool as tts_tool
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "minimax"})
+    monkeypatch.setattr(
+        tts_tool, "_generate_minimax_tts",
+        lambda text, file_str, cfg: (_ for _ in ()).throw(ValueError("MINIMAX_API_KEY missing")),
+    )
+
+    data = _run_tool(tmp_path)
+
+    assert data["success"] is False
+    assert "TTS configuration error (minimax)" in data["error"]
+
+
+def test_empty_output_is_a_failure(monkeypatch, tmp_path):
+    """Generator that produces no file ⇒ explicit no-output failure."""
+    import tools.tts_tool as tts_tool
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "minimax"})
+    monkeypatch.setattr(
+        tts_tool, "_generate_minimax_tts",
+        lambda text, file_str, cfg: None,
+    )
+
+    data = _run_tool(tmp_path)
+
+    assert data["success"] is False
+    assert "produced no output" in data["error"]
+    assert "minimax" in data["error"]
+
+
+def test_success_response_contract(monkeypatch, tmp_path):
+    """Happy path ⇒ file on disk, MEDIA tag, provider echoed, no voice flag off-platform."""
+    import tools.tts_tool as tts_tool
+
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "minimax"})
+    monkeypatch.setattr(
+        tts_tool, "_generate_minimax_tts",
+        lambda text, file_str, cfg: _write_audio(file_str),
+    )
+
+    data = _run_tool(tmp_path)
+
+    assert data["success"] is True
+    assert data["provider"] == "minimax"
+    assert os.path.getsize(data["file_path"]) > 0
+    assert data["media_tag"].startswith("MEDIA:")
+    assert data["voice_compatible"] is False
+
+
+def test_nothing_available_reports_setup_guidance(monkeypatch, tmp_path):
+    """Edge and NeuTTS both unavailable ⇒ actionable setup error."""
+    import tools.tts_tool as tts_tool
+
+    monkeypatch.setattr(
+        tts_tool, "_import_edge_tts",
+        lambda: (_ for _ in ()).throw(ImportError("no edge-tts")),
+    )
+    monkeypatch.setattr(tts_tool, "_check_neutts_available", lambda: False)
+
+    data = _run_tool(tmp_path)
+
+    assert data["success"] is False
+    assert "No TTS provider available" in data["error"]

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -49,7 +49,7 @@ import tempfile
 import threading
 import uuid
 from pathlib import Path
-from typing import Callable, Dict, Any, Optional
+from typing import Callable, Dict, Any, NamedTuple, Optional
 from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -2281,6 +2281,208 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 # ===========================================================================
 # Main tool function
 # ===========================================================================
+class _ProviderSynthesis(NamedTuple):
+    """Outcome of one provider synthesis attempt.
+
+    ``provider`` is the *effective* provider — the Edge default falls back
+    to NeuTTS when edge-tts isn't importable, and downstream format/delivery
+    decisions must follow the provider that actually ran. ``error`` is a
+    ready-to-return tool JSON string when the attempt failed, else None.
+    """
+
+    file_str: str
+    provider: str
+    error: Optional[str]
+
+
+def _synthesize_with_provider(
+    text: str,
+    file_str: str,
+    provider: str,
+    command_provider_config: Optional[Dict[str, Any]],
+    tts_config: Dict[str, Any],
+) -> _ProviderSynthesis:
+    """Run one provider's synthesis and verify it produced output.
+
+    Extracted verbatim from ``text_to_speech_tool()`` so the dispatch can be
+    invoked once per provider. Dispatch precedence is unchanged: command
+    provider → plugin provider → built-in chain → Edge default. Exceptions
+    are converted to the same error JSON the tool returned before the
+    extraction; they do not escape.
+    """
+    try:
+        # Generate audio with the configured provider
+        if command_provider_config is not None:
+            logger.info(
+                "Generating speech with command TTS provider '%s'...", provider,
+            )
+            file_str = _generate_command_tts(
+                text, file_str, provider, command_provider_config, tts_config,
+            )
+
+        # Plugin-registered TTS backend (issue #30398). Fires when the
+        # configured provider is neither a built-in nor a command-type
+        # entry, AND a plugin is registered under that name. The walrus
+        # binds `_plugin_path` only when the dispatcher returns a path
+        # (i.e. a plugin was actually found); a None return falls
+        # through to the built-in elif chain so unknown names hit the
+        # Edge TTS default at the bottom. The dispatcher itself enforces
+        # built-ins-always-win + command-wins-over-plugin defensively.
+        elif provider not in BUILTIN_TTS_PROVIDERS and (
+            _plugin_path := _dispatch_to_plugin_provider(
+                text, file_str, provider, tts_config,
+            )
+        ) is not None:
+            file_str = _plugin_path
+
+        elif provider == "elevenlabs":
+            try:
+                _import_elevenlabs()
+            except ImportError:
+                return _ProviderSynthesis(file_str, provider, json.dumps({
+                    "success": False,
+                    "error": "ElevenLabs provider selected but 'elevenlabs' package not installed. Run: pip install elevenlabs"
+                }, ensure_ascii=False))
+            logger.info("Generating speech with ElevenLabs...")
+            _generate_elevenlabs(text, file_str, tts_config)
+
+        elif provider == "openai":
+            try:
+                _import_openai_client()
+            except ImportError:
+                return _ProviderSynthesis(file_str, provider, json.dumps({
+                    "success": False,
+                    "error": "OpenAI provider selected but 'openai' package not installed."
+                }, ensure_ascii=False))
+            logger.info("Generating speech with OpenAI TTS...")
+            _generate_openai_tts(text, file_str, tts_config)
+
+        elif provider == "deepinfra":
+            try:
+                _import_openai_client()
+            except ImportError:
+                return _ProviderSynthesis(file_str, provider, json.dumps({
+                    "success": False,
+                    "error": "DeepInfra TTS uses the 'openai' SDK but it isn't installed."
+                }, ensure_ascii=False))
+            logger.info("Generating speech with DeepInfra TTS...")
+            _generate_deepinfra_tts(text, file_str, tts_config)
+
+        elif provider == "minimax":
+            logger.info("Generating speech with MiniMax TTS...")
+            _generate_minimax_tts(text, file_str, tts_config)
+
+        elif provider == "xai":
+            logger.info("Generating speech with xAI TTS...")
+            _generate_xai_tts(text, file_str, tts_config)
+
+        elif provider == "mistral":
+            try:
+                _import_mistral_client()
+            except ImportError:
+                return _ProviderSynthesis(file_str, provider, json.dumps({
+                    "success": False,
+                    "error": "Mistral provider selected but 'mistralai' package not installed. "
+                             "Run: pip install 'hermes-agent[mistral]'"
+                }, ensure_ascii=False))
+            logger.info("Generating speech with Mistral Voxtral TTS...")
+            _generate_mistral_tts(text, file_str, tts_config)
+
+        elif provider == "gemini":
+            logger.info("Generating speech with Google Gemini TTS...")
+            _generate_gemini_tts(text, file_str, tts_config)
+
+        elif provider == "neutts":
+            if not _check_neutts_available():
+                return _ProviderSynthesis(file_str, provider, json.dumps({
+                    "success": False,
+                    "error": "NeuTTS provider selected but neutts is not installed. "
+                             "Run hermes setup and choose NeuTTS, or install espeak-ng and run python -m pip install -U neutts[all]."
+                }, ensure_ascii=False))
+            logger.info("Generating speech with NeuTTS (local)...")
+            _generate_neutts(text, file_str, tts_config)
+
+        elif provider == "kittentts":
+            try:
+                _import_kittentts()
+            except ImportError:
+                return _ProviderSynthesis(file_str, provider, json.dumps({
+                    "success": False,
+                    "error": "KittenTTS provider selected but 'kittentts' package not installed. "
+                             "Run 'hermes setup tts' and choose KittenTTS, or install manually: "
+                             "pip install https://github.com/KittenML/KittenTTS/releases/download/0.8.1/kittentts-0.8.1-py3-none-any.whl"
+                }, ensure_ascii=False))
+            logger.info("Generating speech with KittenTTS (local, ~25MB)...")
+            _generate_kittentts(text, file_str, tts_config)
+
+        elif provider == "piper":
+            try:
+                _import_piper()
+            except ImportError:
+                return _ProviderSynthesis(file_str, provider, json.dumps({
+                    "success": False,
+                    "error": "Piper provider selected but 'piper-tts' package not installed. "
+                             "Run 'hermes tools' and select Piper under TTS, or install manually: "
+                             "pip install piper-tts",
+                }, ensure_ascii=False))
+            logger.info("Generating speech with Piper (local)...")
+            _generate_piper_tts(text, file_str, tts_config)
+
+        else:
+            # Default: Edge TTS (free), with NeuTTS as local fallback
+            edge_available = True
+            try:
+                _import_edge_tts()
+            except ImportError:
+                edge_available = False
+
+            if edge_available:
+                logger.info("Generating speech with Edge TTS...")
+                try:
+                    import concurrent.futures
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                        pool.submit(
+                            lambda: asyncio.run(_generate_edge_tts(text, file_str, tts_config))
+                        ).result(timeout=60)
+                except RuntimeError:
+                    asyncio.run(_generate_edge_tts(text, file_str, tts_config))
+            elif _check_neutts_available():
+                logger.info("Edge TTS not available, falling back to NeuTTS (local)...")
+                provider = "neutts"
+                _generate_neutts(text, file_str, tts_config)
+            else:
+                return _ProviderSynthesis(file_str, provider, json.dumps({
+                    "success": False,
+                    "error": "No TTS provider available. Install edge-tts (pip install edge-tts) "
+                             "or set up NeuTTS for local synthesis."
+                }, ensure_ascii=False))
+
+        # Check the file was actually created
+        if not os.path.exists(file_str) or os.path.getsize(file_str) == 0:
+            return _ProviderSynthesis(file_str, provider, json.dumps({
+                "success": False,
+                "error": f"TTS generation produced no output (provider: {provider})"
+            }, ensure_ascii=False))
+
+        return _ProviderSynthesis(file_str, provider, None)
+
+    except ValueError as e:
+        # Configuration errors (missing API keys, etc.)
+        error_msg = f"TTS configuration error ({provider}): {e}"
+        logger.error("%s", error_msg)
+        return _ProviderSynthesis(file_str, provider, tool_error(error_msg, success=False))
+    except FileNotFoundError as e:
+        # Missing dependencies or files
+        error_msg = f"TTS dependency missing ({provider}): {e}"
+        logger.error("%s", error_msg, exc_info=True)
+        return _ProviderSynthesis(file_str, provider, tool_error(error_msg, success=False))
+    except Exception as e:
+        # Unexpected errors
+        error_msg = f"TTS generation failed ({provider}): {e}"
+        logger.error("%s", error_msg, exc_info=True)
+        return _ProviderSynthesis(file_str, provider, tool_error(error_msg, success=False))
+
+
 def text_to_speech_tool(
     text: str,
     output_path: Optional[str] = None,
@@ -2378,160 +2580,17 @@ def text_to_speech_tool(
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_str = str(file_path)
 
+    result = _synthesize_with_provider(
+        text, file_str, provider, command_provider_config, tts_config,
+    )
+    if result.error is not None:
+        return result.error
+    # The Edge default may have fallen back to NeuTTS; format and delivery
+    # decisions below must follow the provider that actually ran.
+    file_str = result.file_str
+    provider = result.provider
+
     try:
-        # Generate audio with the configured provider
-        if command_provider_config is not None:
-            logger.info(
-                "Generating speech with command TTS provider '%s'...", provider,
-            )
-            file_str = _generate_command_tts(
-                text, file_str, provider, command_provider_config, tts_config,
-            )
-
-        # Plugin-registered TTS backend (issue #30398). Fires when the
-        # configured provider is neither a built-in nor a command-type
-        # entry, AND a plugin is registered under that name. The walrus
-        # binds `_plugin_path` only when the dispatcher returns a path
-        # (i.e. a plugin was actually found); a None return falls
-        # through to the built-in elif chain so unknown names hit the
-        # Edge TTS default at the bottom. The dispatcher itself enforces
-        # built-ins-always-win + command-wins-over-plugin defensively.
-        elif provider not in BUILTIN_TTS_PROVIDERS and (
-            _plugin_path := _dispatch_to_plugin_provider(
-                text, file_str, provider, tts_config,
-            )
-        ) is not None:
-            file_str = _plugin_path
-
-        elif provider == "elevenlabs":
-            try:
-                _import_elevenlabs()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "ElevenLabs provider selected but 'elevenlabs' package not installed. Run: pip install elevenlabs"
-                }, ensure_ascii=False)
-            logger.info("Generating speech with ElevenLabs...")
-            _generate_elevenlabs(text, file_str, tts_config)
-
-        elif provider == "openai":
-            try:
-                _import_openai_client()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "OpenAI provider selected but 'openai' package not installed."
-                }, ensure_ascii=False)
-            logger.info("Generating speech with OpenAI TTS...")
-            _generate_openai_tts(text, file_str, tts_config)
-
-        elif provider == "deepinfra":
-            try:
-                _import_openai_client()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "DeepInfra TTS uses the 'openai' SDK but it isn't installed."
-                }, ensure_ascii=False)
-            logger.info("Generating speech with DeepInfra TTS...")
-            _generate_deepinfra_tts(text, file_str, tts_config)
-
-        elif provider == "minimax":
-            logger.info("Generating speech with MiniMax TTS...")
-            _generate_minimax_tts(text, file_str, tts_config)
-
-        elif provider == "xai":
-            logger.info("Generating speech with xAI TTS...")
-            _generate_xai_tts(text, file_str, tts_config)
-
-        elif provider == "mistral":
-            try:
-                _import_mistral_client()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "Mistral provider selected but 'mistralai' package not installed. "
-                             "Run: pip install 'hermes-agent[mistral]'"
-                }, ensure_ascii=False)
-            logger.info("Generating speech with Mistral Voxtral TTS...")
-            _generate_mistral_tts(text, file_str, tts_config)
-
-        elif provider == "gemini":
-            logger.info("Generating speech with Google Gemini TTS...")
-            _generate_gemini_tts(text, file_str, tts_config)
-
-        elif provider == "neutts":
-            if not _check_neutts_available():
-                return json.dumps({
-                    "success": False,
-                    "error": "NeuTTS provider selected but neutts is not installed. "
-                             "Run hermes setup and choose NeuTTS, or install espeak-ng and run python -m pip install -U neutts[all]."
-                }, ensure_ascii=False)
-            logger.info("Generating speech with NeuTTS (local)...")
-            _generate_neutts(text, file_str, tts_config)
-
-        elif provider == "kittentts":
-            try:
-                _import_kittentts()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "KittenTTS provider selected but 'kittentts' package not installed. "
-                             "Run 'hermes setup tts' and choose KittenTTS, or install manually: "
-                             "pip install https://github.com/KittenML/KittenTTS/releases/download/0.8.1/kittentts-0.8.1-py3-none-any.whl"
-                }, ensure_ascii=False)
-            logger.info("Generating speech with KittenTTS (local, ~25MB)...")
-            _generate_kittentts(text, file_str, tts_config)
-
-        elif provider == "piper":
-            try:
-                _import_piper()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "Piper provider selected but 'piper-tts' package not installed. "
-                             "Run 'hermes tools' and select Piper under TTS, or install manually: "
-                             "pip install piper-tts",
-                }, ensure_ascii=False)
-            logger.info("Generating speech with Piper (local)...")
-            _generate_piper_tts(text, file_str, tts_config)
-
-        else:
-            # Default: Edge TTS (free), with NeuTTS as local fallback
-            edge_available = True
-            try:
-                _import_edge_tts()
-            except ImportError:
-                edge_available = False
-
-            if edge_available:
-                logger.info("Generating speech with Edge TTS...")
-                try:
-                    import concurrent.futures
-                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                        pool.submit(
-                            lambda: asyncio.run(_generate_edge_tts(text, file_str, tts_config))
-                        ).result(timeout=60)
-                except RuntimeError:
-                    asyncio.run(_generate_edge_tts(text, file_str, tts_config))
-            elif _check_neutts_available():
-                logger.info("Edge TTS not available, falling back to NeuTTS (local)...")
-                provider = "neutts"
-                _generate_neutts(text, file_str, tts_config)
-            else:
-                return json.dumps({
-                    "success": False,
-                    "error": "No TTS provider available. Install edge-tts (pip install edge-tts) "
-                             "or set up NeuTTS for local synthesis."
-                }, ensure_ascii=False)
-
-        # Check the file was actually created
-        if not os.path.exists(file_str) or os.path.getsize(file_str) == 0:
-            return json.dumps({
-                "success": False,
-                "error": f"TTS generation produced no output (provider: {provider})"
-            }, ensure_ascii=False)
-
         # Try Opus conversion for Telegram compatibility.
         # Edge TTS outputs MP3, NeuTTS/KittenTTS output WAV. Keep those native
         # formats for local/CLI playback and only convert when the current


### PR DESCRIPTION
## What does this PR do?

Extracts the single-provider synthesis block of `text_to_speech_tool()` — the dispatch (command → plugin → built-in chain → Edge default) plus the produced-output check — into `_synthesize_with_provider()`, so one provider attempt is callable as a unit. This is step 1 of the plan in #65752 (opt-in TTS fallback chain on the existing extension surfaces); step 2 loops this unit over a validated chain.

Pure move, no behavior change:

- Dispatch precedence and every error string are moved verbatim.
- The Edge→NeuTTS fallback reassigns the provider mid-dispatch; the helper returns the **effective** provider and the caller now uses it for the same format/delivery/logging decisions it made before (same values, same order).
- Synthesis-phase exceptions convert to the same tool JSON as before, still labeled with the provider that actually ran (including after the Edge→NeuTTS fallback). Post-synthesis code (Opus conversion, response build) keeps its original exception handling.

## Related Issue

Part of #65752 (design note). Series context: #56585 (closed), #56599 (draft, will be reworked on top of this seam).

## Type of Change

- [x] ♻️ Refactor (no behavior change)

## Changes Made

- `tools/tts_tool.py`: new `_ProviderSynthesis` NamedTuple + `_synthesize_with_provider()`; `text_to_speech_tool()` now calls it and consumes `(file_str, effective_provider, error)`.
- `tests/tools/test_tts_single_provider_dispatch.py`: 7 behavior contracts through the public tool — effective-provider fallback reporting, actionable missing-SDK errors, provider-labeled exception/config errors, empty-output failure, success response shape, nothing-available guidance.
- `scripts/release.py`: AUTHOR_MAP entry for `diegoberan@gmail.com` (first-time contributor email; per `contributor-check` guidance).

## How to Test

1. `scripts/run_tests.sh tests/tools/test_tts_single_provider_dispatch.py -q` — the new contracts.
2. Parity proof: the new tests pass **unchanged on the pre-refactor code** (revert `tools/tts_tool.py`, keep the test file, run again — verified both ways locally).
3. `scripts/run_tests.sh tests/tools/ -q` and the five `tests/gateway/test_*voice*/topic*` files that exercise `text_to_speech_tool` — all green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the TTS + gateway-voice test subsets and all pass (full-suite judge: CI; my dev box is native Windows where a set of pre-existing POSIX-ism failures unrelated to this change exists)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation — N/A (private helper, no user-facing change)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform impact considered (`scripts/check-windows-footguns.py` clean on both touched files)
- [x] Tool descriptions/schemas — N/A (no tool behavior change)

## Screenshots / Logs

N/A (no user-facing change).
