### PR TITLE
fix(desktop): preserve explicit markdown link labels

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MarkdownTextContent } from './markdown-text'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+
+function installDesktopBridge(partial: Partial<Window['hermesDesktop']> = {}) {
+  desktopWindow.hermesDesktop = {
+    fetchLinkTitle: vi.fn().mockResolvedValue(''),
+    openExternal: vi.fn().mockResolvedValue(undefined),
+    ...partial
+  } as unknown as Window['hermesDesktop']
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  cleanup()
+
+  if (initialHermesDesktop) {
+    desktopWindow.hermesDesktop = initialHermesDesktop
+  } else {
+    delete desktopWindow.hermesDesktop
+  }
+})
+
+describe('MarkdownTextContent', () => {
+  it.each([
+    ['inline', '[Bug 8797](https://dev.azure.com/electronicdevice/Apps/_workitems/edit/8797)'],
+    [
+      'table cell',
+      '| Task |\n|---|\n| [Bug 8797](https://dev.azure.com/electronicdevice/Apps/_workitems/edit/8797): Site search |'
+    ]
+  ])('keeps explicit markdown link labels in %s instead of replacing them with fetched titles', async (_case, text) => {
+    const fetchLinkTitle = vi.fn().mockResolvedValue('Azure DevOps Services | Sign In')
+    installDesktopBridge({ fetchLinkTitle: fetchLinkTitle as unknown as Window['hermesDesktop']['fetchLinkTitle'] })
+
+    render(<MarkdownTextContent isRunning={false} text={text} />)
+
+    const link = await screen.findByRole('link', { name: 'Bug 8797' })
+    expect(link.getAttribute('href')).toBe('https://dev.azure.com/electronicdevice/Apps/_workitems/edit/8797')
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(fetchLinkTitle).not.toHaveBeenCalled()
+    expect(link.textContent).toBe('Bug 8797')
+  })
+})

--- a/apps/desktop/src/lib/external-link.tsx
+++ b/apps/desktop/src/lib/external-link.tsx
@@ -253,8 +253,9 @@ interface PrettyLinkProps extends Omit<ComponentProps<'a'>, 'href' | 'target'> {
 
 export function PrettyLink({ className, fallbackLabel, href, label, ...rest }: PrettyLinkProps) {
   const target = useMemo(() => normalizeExternalUrl(href), [href])
-  const fetched = useLinkTitle(label ? null : target)
-  const display = fetched || label?.trim() || fallbackLabel?.trim() || urlSlugTitleLabel(target)
+  const explicitLabel = label?.trim() || fallbackLabel?.trim()
+  const fetched = useLinkTitle(explicitLabel ? null : target)
+  const display = explicitLabel || fetched || urlSlugTitleLabel(target)
 
   return (
     <ExternalLink className={cn('wrap-break-word', className)} href={target} title={target} {...rest}>


### PR DESCRIPTION
## Summary
- Preserve explicit Markdown link labels before fetched URL titles in Desktop chat rendering.
- Avoid fetching link titles when a Markdown link already provides label text.
- Add coverage for inline and table-cell Markdown links so ADO links like `[Bug 8797](...)` stay readable.

## Test plan
- `npm run test -- --project ui src/components/assistant-ui/markdown-text.test.tsx`
- `npm run test -- --project ui src/lib/external-link.test.tsx src/components/assistant-ui/markdown-text.test.tsx`
- `npm run typecheck`
- `git diff --cached --check` before commit
- static scan of added lines for obvious secret/shell-injection/eval patterns
