### PR TITLE
fix(safety): block active Hermes home deletion

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -78,6 +78,16 @@ _HARDLINE_BLOCK = [
     "rm -rf ${HOME}",
     'rm -rf "${HOME}"',
     "rm -fr ${HOME}",
+    # The active Hermes profile is not disposable scratch space. This exact
+    # chained command deleted the live profile in the 2026-07-16 incident:
+    # the prefix assignment applied only to `hermes`, while the later `rm`
+    # expanded the shell's inherited HERMES_HOME.
+    'HERMES_HOME=$(mktemp -d) ~/.local/bin/hermes fallback add --help; rm -rf "$HERMES_HOME"',
+    'rm -rf "$HERMES_HOME"',
+    "rm -rf ${HERMES_HOME}",
+    "rm -rf ~/.hermes",
+    "rm -rf ~/.hermes/",
+    "rm -rf ~/.hermes/*",
     # Filesystem format
     "mkfs.ext4 /dev/sda1",
     "mkfs /dev/sdb",
@@ -148,6 +158,10 @@ _HARDLINE_ALLOW = [
     "rm -rf /home/user/scratch",  # subpath of /home, not /home itself
     "rm -rf ~/Downloads/old",
     "rm -rf $HOME/tmp",
+    # Deleting a child under the profile is still dangerous and approval-gated,
+    # but it is not equivalent to deleting the whole active profile.
+    "rm -rf ~/.hermes/cache",
+    "rm -rf $HERMES_HOME/cache",
     "rm foo.txt",
     "rm -rf some/path",
     # Literal root-level directories that only LOOK like root-collapse
@@ -237,6 +251,30 @@ def test_quoted_and_brace_paths_are_hardline_blocked(command):
     is_hl, desc = detect_hardline_command(command)
     assert is_hl, f"quoting/brace bypass leaked through hardline floor: {command!r}"
     assert desc
+
+
+def test_resolved_active_hermes_home_is_hardline_blocked(monkeypatch, tmp_path):
+    active_home = tmp_path / "custom-hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(active_home))
+
+    for command in (
+        f"rm -rf {active_home}",
+        f'rm -rf "{active_home}"',
+        f"rm -rf {active_home}/",
+        f"rm -rf {active_home}/*",
+    ):
+        is_hl, desc = detect_hardline_command(command)
+        assert is_hl, command
+        assert desc == "recursive delete of active Hermes home"
+
+
+def test_resolved_active_hermes_child_is_not_hardline(monkeypatch, tmp_path):
+    active_home = tmp_path / "custom-hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(active_home))
+
+    is_hl, desc = detect_hardline_command(f"rm -rf {active_home}/cache")
+    assert not is_hl
+    assert desc is None
 
 
 # Commands that carry the literal string "rm -rf /" (or a sibling) as DATA in
@@ -374,8 +412,16 @@ def test_yolo_env_var_cannot_bypass_hardline(clean_session, monkeypatch):
     """HERMES_YOLO_MODE=1 must not bypass the hardline floor."""
     monkeypatch.setenv("HERMES_YOLO_MODE", "1")
 
-    for cmd in ['rm -rf /', 'rm -rf "/"', 'rm -rf "$HOME"', "rm -rf ${HOME}",
-                "shutdown -h now", "mkfs.ext4 /dev/sda", "reboot"]:
+    for cmd in [
+        "rm -rf /",
+        'rm -rf "/"',
+        'rm -rf "$HOME"',
+        "rm -rf ${HOME}",
+        'HERMES_HOME=$(mktemp -d) hermes fallback add --help; rm -rf "$HERMES_HOME"',
+        "shutdown -h now",
+        "mkfs.ext4 /dev/sda",
+        "reboot",
+    ]:
         r1 = check_dangerous_command(cmd, "local")
         assert r1["approved"] is False, f"yolo leaked hardline on {cmd!r} (check_dangerous_command)"
         assert r1.get("hardline") is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -431,6 +431,13 @@ HARDLINE_PATTERNS = [
     (_RM_FLAG_PREFIX + _hardline_rm_path(r'/(?:(?:\.\.?)?/)*(?:\.\.?)?\**|/ \*'), "recursive delete of root filesystem"),
     (_RM_FLAG_PREFIX + _hardline_rm_path(_HARDLINE_SYSTEM_DIRS), "recursive delete of system directory"),
     (_RM_FLAG_PREFIX + _hardline_rm_path(r'(?:~|\$\{?HOME\}?)(?:/?|/\*)?'), "recursive delete of home directory"),
+    (
+        _RM_FLAG_PREFIX
+        + _hardline_rm_path(
+            r'(?:~/\.hermes|\$\{?HERMES_HOME\}?)(?:/?|/\*)?'
+        ),
+        "recursive delete of active Hermes home",
+    ),
     # Filesystem format
     (r'\bmkfs(\.[a-z0-9]+)?\b', "format filesystem (mkfs)"),
     # Raw block device overwrites (dd + redirection)
@@ -962,6 +969,35 @@ def _fold_home_prefixes(command: str, paths, replacement: str) -> str:
     return command
 
 
+def _fold_exact_home_paths(command: str, paths, replacement: str) -> str:
+    """Fold exact resolved home path tokens, without folding child paths.
+
+    ``_fold_home_prefixes`` intentionally requires a path tail, which is right
+    for sensitive files below a home but leaves the bare active Hermes home
+    unchanged. A recursive delete of that bare directory is catastrophic, so
+    fold only exact shell tokens here. Child paths remain handled by the prefix
+    fold and are not promoted to the hardline root-delete rule.
+    """
+    boundary = r"""(?=$|[\s'"`;|&<>()])"""
+    seen: set[str] = set()
+    for path in sorted((p for p in paths if p), key=len, reverse=True):
+        variants = {
+            path,
+            path.replace("\\", "/"),
+            path.replace("/", "\\"),
+        }
+        for variant in variants:
+            if not variant or variant in seen:
+                continue
+            seen.add(variant)
+            command = re.sub(
+                re.escape(variant) + boundary,
+                replacement,
+                command,
+            )
+    return command
+
+
 def _rewrite_resolved_user_home(command: str) -> str:
     """Rewrite the current user's absolute home prefix to ``~/``.
 
@@ -1006,7 +1042,8 @@ def _rewrite_resolved_hermes_home(command: str) -> str:
         ]
     except Exception:
         return command
-    return _fold_home_prefixes(command, candidates, "~/.hermes")
+    command = _fold_home_prefixes(command, candidates, "~/.hermes")
+    return _fold_exact_home_paths(command, candidates, "~/.hermes")
 
 
 _PARAM_REPLACEMENT_RE = re.compile(r"\$\{[^}/\s]+/[^}/]*/(?P<replacement>[^}]*)\}")


### PR DESCRIPTION
## What changed

- Hardline-block recursive deletion of the active Hermes home through
  `$HERMES_HOME`, `${HERMES_HOME}`, `~/.hermes`, and the resolved absolute
  profile path.
- Fold exact active-home path tokens for detection without promoting child
  paths such as `~/.hermes/cache` to the unconditional blocklist.
- Add regression coverage for quoted forms, trailing slash/glob forms, resolved
  paths, child-path behavior, and yolo bypass attempts.

## Why

A shell prefix assignment applies only to the command it prefixes. This command
therefore expanded the second `$HERMES_HOME` from the inherited shell and
deleted the live profile:

```bash
HERMES_HOME=$(mktemp -d) hermes fallback add --help; rm -rf "$HERMES_HOME"
```

The active Hermes profile contains configuration, session state, cron jobs,
memories, plugins, and the runtime environment. Its recursive deletion should
be below the approval/yolo floor.

## Validation

- `pytest -q tests/tools/test_hardline_blocklist.py tests/tools/test_approval.py`
  — 507 passed
- `ruff check tools/approval.py tests/tools/test_hardline_blocklist.py`
- Fable Max review: no blockers; PR-ready
