### PR TITLE
fix(desktop): model picker reverts in existing threads

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -227,7 +227,6 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   })
 
   const { refreshCurrentModel, selectModel, updateModelOptionsCache } = useModelControls({
-    activeSessionId,
     queryClient,
     requestGateway
   })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -32,16 +32,13 @@ vi.mock('@/store/notifications', () => ({
 type Controls = ReturnType<typeof useModelControls>
 
 function Harness({
-  activeSessionId,
   onReady,
   requestGateway
 }: {
-  activeSessionId: string | null
   onReady: (controls: Controls) => void
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }) {
   const controls = useModelControls({
-    activeSessionId,
     queryClient: new QueryClient(),
     requestGateway
   })
@@ -74,7 +71,6 @@ describe('useModelControls', () => {
 
     const { result } = renderHook(() =>
       useModelControls({
-        activeSessionId: null,
         queryClient: new QueryClient(),
         requestGateway: vi.fn()
       })
@@ -97,7 +93,6 @@ describe('useModelControls', () => {
 
     const { result } = renderHook(() =>
       useModelControls({
-        activeSessionId: 'runtime-1',
         queryClient: new QueryClient(),
         requestGateway: vi.fn()
       })
@@ -110,12 +105,11 @@ describe('useModelControls', () => {
   })
 
   it('routes active-session picker changes through config.set with an explicit session-scoped provider', async () => {
+    $activeSessionId.set('session-1')
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'claude-sonnet-4.6' }) as never)
     let controls!: Controls
 
-    render(
-      <Harness activeSessionId="session-1" onReady={value => (controls = value)} requestGateway={requestGateway} />
-    )
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
 
     await expect(
       controls.selectModel({
@@ -133,12 +127,11 @@ describe('useModelControls', () => {
   })
 
   it('session-scopes MoA preset selections so they cannot persist as the global gateway default', async () => {
+    $activeSessionId.set('session-1')
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'BeastMode' }) as never)
     let controls!: Controls
 
-    render(
-      <Harness activeSessionId="session-1" onReady={value => (controls = value)} requestGateway={requestGateway} />
-    )
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
 
     await expect(
       controls.selectModel({
@@ -158,7 +151,7 @@ describe('useModelControls', () => {
     const requestGateway = vi.fn()
     let controls!: Controls
 
-    render(<Harness activeSessionId={null} onReady={value => (controls = value)} requestGateway={requestGateway} />)
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
 
     await expect(
       controls.selectModel({
@@ -180,7 +173,6 @@ describe('useModelControls', () => {
 
     const { result } = renderHook(() =>
       useModelControls({
-        activeSessionId: null,
         queryClient: new QueryClient(),
         requestGateway: vi.fn()
       })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -13,26 +13,30 @@ interface ModelSelection {
 }
 
 interface ModelControlsOptions {
-  activeSessionId: string | null
   queryClient: QueryClient
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
 
-export function useModelControls({ activeSessionId, queryClient, requestGateway }: ModelControlsOptions) {
+export function useModelControls({ queryClient, requestGateway }: ModelControlsOptions) {
   const { t } = useI18n()
   const copy = t.desktop
 
+  // All callbacks here read reactive session state from the store (.get())
+  // rather than capturing it as a prop. The actions bag in wiring.tsx mutates
+  // in place to keep a stable identity, so memoized surfaces capture these
+  // callbacks once and never re-evaluate — a captured prop would be stale
+  // forever. The store read is always current.
   const updateModelOptionsCache = useCallback(
     (provider: string, model: string, includeGlobal: boolean) => {
       const patch = (prev: ModelOptionsResponse | undefined) => ({ ...(prev ?? {}), provider, model })
 
-      queryClient.setQueryData<ModelOptionsResponse>(['model-options', activeSessionId || 'global'], patch)
+      queryClient.setQueryData<ModelOptionsResponse>(['model-options', $activeSessionId.get() || 'global'], patch)
 
       if (includeGlobal) {
         queryClient.setQueryData<ModelOptionsResponse>(['model-options', 'global'], patch)
       }
     },
-    [activeSessionId, queryClient]
+    [queryClient]
   )
 
   // Seed the composer's model state from the profile default. `force` reseeds
@@ -82,36 +86,38 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
       const prevModel = $currentModel.get()
       const prevProvider = $currentProvider.get()
 
+      const liveSessionId = $activeSessionId.get()
+
       setCurrentModel(selection.model)
       setCurrentProvider(selection.provider)
-      updateModelOptionsCache(selection.provider, selection.model, !activeSessionId)
+      updateModelOptionsCache(selection.provider, selection.model, !liveSessionId)
 
       // No live session yet: the pick is pure UI state. session.create reads
       // $currentModel/$currentProvider and applies it as that session's override.
-      if (!activeSessionId) {
+      if (!liveSessionId) {
         return true
       }
 
       try {
         await requestGateway('config.set', {
-          session_id: activeSessionId,
+          session_id: liveSessionId,
           key: 'model',
           value: `${selection.model} --provider ${selection.provider} --session`
         })
 
-        void queryClient.invalidateQueries({ queryKey: ['model-options', activeSessionId] })
+        void queryClient.invalidateQueries({ queryKey: ['model-options', liveSessionId] })
 
         return true
       } catch (err) {
         setCurrentModel(prevModel)
         setCurrentProvider(prevProvider)
-        updateModelOptionsCache(prevProvider, prevModel, !activeSessionId)
+        updateModelOptionsCache(prevProvider, prevModel, !liveSessionId)
         notifyError(err, copy.modelSwitchFailed)
 
         return false
       }
     },
-    [activeSessionId, copy.modelSwitchFailed, queryClient, requestGateway, updateModelOptionsCache]
+    [copy.modelSwitchFailed, queryClient, requestGateway, updateModelOptionsCache]
   )
 
   return { refreshCurrentModel, selectModel, updateModelOptionsCache }


### PR DESCRIPTION
## What does this PR do?

Fixes a model-switching race in the desktop app where clicking a model in an
existing thread sometimes instantly reverts to the previous one.

`selectModel` in `use-model-controls.ts` captured `activeSessionId` as a
closure prop. But the actions bag in `wiring.tsx` deliberately mutates in
place (`Object.assign(actionsRef.current, nextActions)`) to keep a stable
identity, so memoized surfaces like `modelMenuContent = useMemo(..., [actions,
gateway, gatewayState])` capture `selectModel` once when the gateway first
opens — before any session is active — and never re-evaluate. That stale
closure has `activeSessionId = null` baked in, so clicking a model in an
existing thread treats the pick as UI-only, never sends `config.set` to the
gateway, and the next `session.info` event clobbers the optimistic update back
to the session's real model.

New threads worked because the pick is stored as UI state and shipped on the
next `session.create` — the gateway never clobbers it.

The fix drops the `activeSessionId` prop entirely. All three callbacks in
`useModelControls` now read `$activeSessionId.get()` live from the store,
matching the pattern `refreshCurrentModel` already followed. This is the
correct contract for the actions bag's in-place mutation: callbacks read live
state from the store, not from captured props.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-model-controls.ts` — removed
  `activeSessionId` from `ModelControlsOptions` and the `selectModel` /
  `updateModelOptionsCache` closures; both now read `$activeSessionId.get()`
  live from the store.
- `apps/desktop/src/app/contrib/wiring.tsx` — stop passing `activeSessionId`
  to `useModelControls`.
- `apps/desktop/src/app/session/hooks/use-model-controls.test.tsx` — set
  `$activeSessionId` in the store for session-scoped tests instead of passing
  it as a prop; removed the prop from the `Harness` and `renderHook` calls.

## How to Test

1. Open an existing thread in the desktop app.
2. Wait a few seconds for the session to become active.
3. Click the model picker and select a different model.
4. The model should switch and stay — no revert.

Automated:

```
cd apps/desktop
nix develop --command npx tsc -p . --noEmit
nix develop --command npx vitest run --environment jsdom src/app/session/hooks/use-model-controls.test.tsx
```

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS

### Documentation & Housekeeping

- [x] N/A — no config keys, tool schemas, or architecture docs changed
