### PR TITLE
feat(desktop): improve Quick Choice keyboard navigation and history

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -98,7 +98,8 @@ describe('readClarifyResult', () => {
     ).toEqual({
       question: 'Which target?',
       answer: 'staging',
-      error: undefined
+      error: undefined,
+      choices: ['staging', 'prod']
     })
   })
 
@@ -143,7 +144,9 @@ describe('ClarifyTool settled view', () => {
     )
 
     expect(screen.getByText('Which deployment target?')).toBeTruthy()
-    expect(screen.getByText('staging')).toBeTruthy()
+    expect(screen.getByTestId('clarify-answer').textContent).toBe('staging')
+    expect(screen.getByText('Quick Choice options')).toBeTruthy()
+    expect(screen.getByText('prod')).toBeTruthy()
     expect(document.querySelector('[data-clarify-settled]')).toBeTruthy()
     expect(document.querySelector('[data-clarify-answer]')?.textContent).toBe('staging')
   })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,14 +1,25 @@
 import type { ToolCallMessagePartProps } from '@assistant-ui/react'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
+import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
+import { $gateway } from '@/store/gateway'
+import { $activeSessionId } from '@/store/session'
 
 import { ClarifyTool, readClarifyResult } from './clarify-tool'
 
+vi.mock('@assistant-ui/react', () => ({
+  useAuiState: () => true
+}))
+
 afterEach(() => {
   cleanup()
+  clearClarifyRequest()
+  $activeSessionId.set(null)
+  $gateway.set(null)
+  vi.clearAllMocks()
 })
 
 function renderClarify(ui: ReactNode) {
@@ -37,6 +48,37 @@ function settledClarifyProps(
     toolName: 'clarify',
     type: 'tool-call'
   }
+}
+
+function liveClarifyProps(choices = ['staging', 'production']): ToolCallMessagePartProps {
+  return {
+    addResult: vi.fn(),
+    args: { choices, question: 'Which deployment target?' },
+    argsText: JSON.stringify({ choices, question: 'Which deployment target?' }),
+    isError: false,
+    result: undefined,
+    resume: vi.fn(),
+    status: { type: 'running' },
+    toolCallId: 'clarify-live',
+    toolName: 'clarify',
+    type: 'tool-call'
+  }
+}
+
+function renderLiveClarify() {
+  const request = vi.fn().mockResolvedValue({ ok: true })
+
+  $activeSessionId.set('session-1')
+  $gateway.set({ request } as never)
+  setClarifyRequest({
+    choices: ['staging', 'production'],
+    question: 'Which deployment target?',
+    requestId: 'request-1',
+    sessionId: 'session-1'
+  })
+  renderClarify(<ClarifyTool {...liveClarifyProps()} />)
+
+  return request
 }
 
 describe('readClarifyResult', () => {
@@ -113,5 +155,72 @@ describe('ClarifyTool settled view', () => {
 
     expect(screen.getByText('Anything else?')).toBeTruthy()
     expect(screen.getByText('Skipped')).toBeTruthy()
+  })
+})
+
+describe('ClarifyTool keyboard navigation', () => {
+  it('cycles through choices and Other with the arrow keys', () => {
+    renderLiveClarify()
+
+    const staging = screen.getByRole('button', { name: /staging/ })
+    const production = screen.getByRole('button', { name: /production/ })
+    const other = screen.getByPlaceholderText(/Other/)
+
+    expect(staging.getAttribute('data-highlighted')).toBe('true')
+    expect(staging.getAttribute('aria-current')).toBe('true')
+    expect(staging.getAttribute('aria-keyshortcuts')).toBe('A 1')
+
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    expect(production.getAttribute('data-highlighted')).toBe('true')
+
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    expect(other.closest('label')?.getAttribute('data-highlighted')).toBe('true')
+    expect(other.getAttribute('aria-current')).toBe('true')
+    expect(other.getAttribute('aria-keyshortcuts')).toBe('C 3')
+
+    fireEvent.keyDown(window, { key: 'ArrowDown' })
+    expect(staging.getAttribute('data-highlighted')).toBe('true')
+
+    fireEvent.keyDown(window, { key: 'ArrowUp' })
+    expect(other.closest('label')?.getAttribute('data-highlighted')).toBe('true')
+  })
+
+  it('selects by number and confirms the answer with Enter', async () => {
+    const request = renderLiveClarify()
+
+    fireEvent.keyDown(window, { key: '2' })
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'production',
+        request_id: 'request-1'
+      })
+    })
+  })
+
+  it('focuses Other when its number is pressed and leaves typing keys alone', () => {
+    renderLiveClarify()
+
+    const other = screen.getByPlaceholderText(/Other/)
+
+    fireEvent.keyDown(window, { key: '3' })
+    expect(document.activeElement).toBe(other)
+
+    fireEvent.change(other, { target: { value: 'canary' } })
+    fireEvent.keyDown(window, { key: 'ArrowUp' })
+    expect(document.activeElement).toBe(other)
+    expect((other as HTMLTextAreaElement).value).toBe('canary')
+  })
+
+  it('does not intercept keyboard events while an action button has focus', () => {
+    const request = renderLiveClarify()
+    const skip = screen.getByRole('button', { name: 'Skip' })
+
+    skip.focus()
+
+    expect(fireEvent.keyDown(window, { key: 'Enter' })).toBe(true)
+    expect(fireEvent.keyDown(window, { key: 'ArrowDown' })).toBe(true)
+    expect(request).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -56,6 +56,7 @@ function liveClarifyProps(choices = ['staging', 'production']): ToolCallMessageP
     args: { choices, question: 'Which deployment target?' },
     argsText: JSON.stringify({ choices, question: 'Which deployment target?' }),
     isError: false,
+    respondToApproval: vi.fn(),
     result: undefined,
     resume: vi.fn(),
     status: { type: 'running' },

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -81,6 +81,12 @@ function renderLiveClarify() {
   return request
 }
 
+function focusClarifySurface(index = 0) {
+  const surface = globalThis.document.querySelectorAll('[data-clarify-focus-scope]')[index]
+
+  ;(surface as HTMLElement).focus()
+}
+
 describe('readClarifyResult', () => {
   it('reads question + user_response from the tool JSON payload', () => {
     expect(
@@ -211,6 +217,19 @@ describe('ClarifyTool keyboard navigation', () => {
     fireEvent.keyDown(window, { key: 'ArrowUp' })
     expect(document.activeElement).toBe(other)
     expect((other as HTMLTextAreaElement).value).toBe('canary')
+  })
+
+  it('does not let Enter answer an unfocused clarify card', async () => {
+    const request = renderLiveClarify()
+
+    renderClarify(<ClarifyTool {...liveClarifyProps()} />)
+    focusClarifySurface(0)
+    fireEvent.keyDown(window, { key: '2' })
+    fireEvent.keyDown(window, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('does not intercept keyboard events while an action button has focus', () => {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -423,6 +423,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
       // typed content, the composer owns its cursor/navigation keys again.
       const isTextEntry =
         active?.isContentEditable || active?.matches('input, select, textarea')
+
       const isEmptyComposer =
         isTextEntry &&
         active &&

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -217,6 +217,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   const [draft, setDraft] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [selectedChoice, setSelectedChoice] = useState<string | null>(null)
+  const [activeIndex, setActiveIndex] = useState(0)
   const [otherFocused, setOtherFocused] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
@@ -265,11 +266,27 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   // confirms with Continue (or Enter from the field).
   const pendingAnswer = selectedChoice ?? (trimmedDraft || null)
 
-  const selectChoice = useCallback((choice: string) => {
+  const selectChoice = useCallback((choice: string, index: number) => {
     // Picking a choice and typing are mutually exclusive answers.
     setDraft('')
     setSelectedChoice(choice)
+    setActiveIndex(index)
   }, [])
+
+  useEffect(() => {
+    setActiveIndex(index => Math.min(index, choices.length))
+  }, [choices.length])
+
+  const moveActive = useCallback(
+    (delta: number) => {
+      const itemCount = choices.length + 1
+
+      setDraft('')
+      setSelectedChoice(null)
+      setActiveIndex(index => (index + delta + itemCount) % itemCount)
+    },
+    [choices.length]
+  )
 
   const submitAnswer = useCallback(() => {
     if (selectedChoice !== null) {
@@ -305,10 +322,28 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
     [submitAnswer]
   )
 
-  // Letter shortcuts: A/B/C… pick the matching option, the trailing letter jumps
-  // into "Other", and Enter confirms the current pick. Stands down whenever a
-  // field is focused (you're typing, not navigating) so it never eats keystrokes
-  // meant for the composer or the Other box.
+  const activateActive = useCallback(() => {
+    if (pendingAnswer) {
+      submitAnswer()
+
+      return
+    }
+
+    const choice = choices[activeIndex]
+
+    if (choice) {
+      void respond(choice)
+
+      return
+    }
+
+    textareaRef.current?.focus()
+  }, [activeIndex, choices, pendingAnswer, respond, submitAnswer])
+
+  // Arrow keys move a visual cursor, 1-9 and A/B/C… pick directly, and Enter
+  // confirms the current answer (or the highlighted row). Stands down whenever
+  // a field is focused so it never eats keystrokes meant for the composer or
+  // the Other box.
   useEffect(() => {
     if (!ready || !hasChoices || submitting) {
       return
@@ -321,7 +356,32 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
       const active = document.activeElement as HTMLElement | null
 
-      if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) {
+      if (
+        active &&
+        (active.isContentEditable || active.matches('a[href], button, input, select, textarea, [role="button"]'))
+      ) {
+        return
+      }
+
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault()
+        moveActive(event.key === 'ArrowDown' ? 1 : -1)
+
+        return
+      }
+
+      if (/^[1-9]$/.test(event.key)) {
+        const index = Number(event.key) - 1
+
+        if (index < choices.length) {
+          event.preventDefault()
+          selectChoice(choices[index], index)
+        } else if (index === choices.length) {
+          event.preventDefault()
+          setActiveIndex(index)
+          textareaRef.current?.focus()
+        }
+
         return
       }
 
@@ -332,25 +392,26 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
         if (index < choices.length) {
           event.preventDefault()
-          selectChoice(choices[index])
+          selectChoice(choices[index], index)
         } else if (index === choices.length) {
           event.preventDefault()
+          setActiveIndex(index)
           textareaRef.current?.focus()
         }
 
         return
       }
 
-      if (event.key === 'Enter' && pendingAnswer) {
+      if (event.key === 'Enter') {
         event.preventDefault()
-        submitAnswer()
+        activateActive()
       }
     }
 
     window.addEventListener('keydown', onKeyDown)
 
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [choices, hasChoices, pendingAnswer, ready, selectChoice, submitAnswer, submitting])
+  }, [activateActive, choices, hasChoices, moveActive, ready, selectChoice, submitting])
 
   if (loading) {
     return (
@@ -386,30 +447,52 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
           <div className="grid gap-px" role="group">
             {choices.map((choice, index) => (
               <button
+                aria-current={activeIndex === index || undefined}
+                aria-keyshortcuts={`${letterFor(index)} ${index + 1}`}
                 className={cn(
                   OPTION_ROW_CLASS,
                   'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-primary)',
+                  activeIndex === index && 'bg-(--chrome-action-hover) text-(--ui-text-primary)',
                   selectedChoice === choice && 'text-(--ui-text-primary)'
                 )}
                 data-choice
+                data-highlighted={activeIndex === index || undefined}
                 disabled={submitting}
                 key={`${index}-${choice}`}
-                onClick={() => selectChoice(choice)}
+                onClick={() => selectChoice(choice, index)}
                 type="button"
               >
-                <KeyBadge char={letterFor(index)} selected={selectedChoice === choice} />
+                <KeyBadge
+                  char={letterFor(index)}
+                  preview={activeIndex === index}
+                  selected={selectedChoice === choice}
+                />
                 <span className="flex-1 wrap-anywhere">{choice}</span>
               </button>
             ))}
-            <label className={cn(OPTION_ROW_CLASS, 'items-center')}>
-              <KeyBadge char={letterFor(choices.length)} preview={otherFocused} selected={Boolean(trimmedDraft)} />
+            <label
+              className={cn(
+                OPTION_ROW_CLASS,
+                'items-center',
+                activeIndex === choices.length && 'bg-(--chrome-action-hover)'
+              )}
+              data-highlighted={activeIndex === choices.length || undefined}
+            >
+              <KeyBadge
+                char={letterFor(choices.length)}
+                preview={otherFocused || activeIndex === choices.length}
+                selected={Boolean(trimmedDraft)}
+              />
               <Textarea
+                aria-current={activeIndex === choices.length || undefined}
+                aria-keyshortcuts={`${letterFor(choices.length)} ${choices.length + 1}`}
                 className={CLARIFY_TEXTAREA_CLASS}
                 disabled={submitting}
                 onBlur={() => setOtherFocused(false)}
                 onChange={event => onDraftChange(event.target.value)}
                 onFocus={() => {
                   setSelectedChoice(null)
+                  setActiveIndex(choices.length)
                   setOtherFocused(true)
                 }}
                 onKeyDown={handleTextareaKey}

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -77,6 +77,31 @@ export function readClarifyResult(result: unknown): ClarifyResult {
 
 const letterFor = (index: number): string => String.fromCharCode(65 + index)
 
+let clarifySurfaceSequence = 0
+const clarifySurfaceOrder: number[] = []
+let activeClarifySurface: number | null = null
+
+function registerClarifySurface(id: number): () => void {
+  clarifySurfaceOrder.push(id)
+  activeClarifySurface ??= id
+
+  return () => {
+    const index = clarifySurfaceOrder.indexOf(id)
+
+    if (index >= 0) {
+      clarifySurfaceOrder.splice(index, 1)
+    }
+
+    if (activeClarifySurface === id) {
+      activeClarifySurface = clarifySurfaceOrder[0] ?? null
+    }
+  }
+}
+
+const claimClarifySurface = (id: number): void => {
+  activeClarifySurface = id
+}
+
 const OPTION_ROW_CLASS =
   'flex w-full items-start gap-2 rounded-[0.25rem] px-1.5 py-1 text-left disabled:cursor-not-allowed disabled:opacity-50'
 
@@ -220,6 +245,22 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   const [activeIndex, setActiveIndex] = useState(0)
   const [otherFocused, setOtherFocused] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const surfaceRef = useRef<HTMLDivElement | null>(null)
+  const surfaceIdRef = useRef<number | null>(null)
+
+  if (surfaceIdRef.current === null) {
+    surfaceIdRef.current = clarifySurfaceSequence++
+  }
+
+  useEffect(() => {
+    const surfaceId = surfaceIdRef.current
+
+    if (surfaceId === null) {
+      return
+    }
+
+    return registerClarifySurface(surfaceId)
+  }, [])
 
   // Race: tool.start fires a tick before clarify.request, so request_id
   // arrives slightly after the tool block mounts. Hold the whole panel on a
@@ -355,6 +396,14 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
       }
 
       const active = document.activeElement as HTMLElement | null
+      const surfaceId = surfaceIdRef.current
+
+      // Only the active clarify surface may consume window-level navigation.
+      // The first mounted surface is the fallback owner when focus is in the
+      // chat body; pointer/focus interaction transfers ownership explicitly.
+      if (surfaceId === null || activeClarifySurface !== surfaceId) {
+        return
+      }
 
       if (
         active &&
@@ -436,7 +485,22 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
   }
 
   return (
-    <ClarifyShell className="grid gap-2 px-2.5 py-2">
+    <ClarifyShell
+      className="grid gap-2 px-2.5 py-2"
+      data-clarify-focus-scope=""
+      onFocusCapture={() => {
+        if (surfaceIdRef.current !== null) {
+          claimClarifySurface(surfaceIdRef.current)
+        }
+      }}
+      onPointerDown={() => {
+        if (surfaceIdRef.current !== null) {
+          claimClarifySurface(surfaceIdRef.current)
+        }
+      }}
+      ref={surfaceRef}
+      tabIndex={0}
+    >
       <div className="flex items-start gap-2">
         <span className="flex-1 whitespace-pre-wrap font-medium leading-(--conversation-line-height)">{question}</span>
         <MessageQuestion aria-hidden className="mt-px size-4 shrink-0 text-(--ui-text-tertiary)" />

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -442,6 +442,7 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
       if (
         active &&
+        !isEmptyComposer &&
         (active.isContentEditable || active.matches('a[href], button, input, select, textarea, [role="button"]'))
       ) {
         return

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -38,6 +38,7 @@ interface ClarifyResult {
   question?: string
   answer?: string
   error?: string
+  choices?: string[]
 }
 
 function stringField(row: Record<string, unknown>, ...keys: string[]): string | undefined {
@@ -68,10 +69,15 @@ export function readClarifyResult(result: unknown): ClarifyResult {
     return typeof result === 'string' && result.trim() ? { answer: result.trim() } : {}
   }
 
+  const choices = Array.isArray(row.choices_offered)
+    ? row.choices_offered.filter((choice): choice is string => typeof choice === 'string')
+    : undefined
+
   return {
     question: stringField(row, 'question'),
     answer: stringField(row, 'user_response', 'answer'),
-    error: stringField(row, 'error')
+    error: stringField(row, 'error'),
+    ...(choices && choices.length > 0 ? { choices } : {})
   }
 }
 
@@ -177,6 +183,7 @@ function ClarifyToolSettled({ args, result }: ToolCallMessagePartProps) {
   const fromResult = useMemo(() => readClarifyResult(result), [result])
 
   const question = fromResult.question || fromArgs.question || ''
+  const choices = fromArgs.choices ?? fromResult.choices ?? []
   const answer = fromResult.answer
   const error = fromResult.error
   const skipped = !error && answer !== undefined && !answer.trim()
@@ -198,10 +205,23 @@ function ClarifyToolSettled({ args, result }: ToolCallMessagePartProps) {
               skipped && 'italic text-(--ui-text-tertiary)'
             )}
             data-clarify-answer=""
+            data-testid="clarify-answer"
           >
             {answerText}
           </p>
         </ClarifyLine>
+      ) : null}
+      {choices.length > 0 ? (
+        <details className="rounded border border-primary/10 px-2 py-1 text-(--ui-text-tertiary)">
+          <summary className="cursor-pointer select-none text-xs">Quick Choice options</summary>
+          <ul className="mt-1 grid gap-0.5 pl-4 text-xs">
+            {choices.map(choice => (
+              <li className={choice === answer ? 'font-medium text-(--ui-text-primary)' : undefined} key={choice}>
+                {choice}
+              </li>
+            ))}
+          </ul>
+        </details>
       ) : null}
     </ClarifyShell>
   )
@@ -397,6 +417,21 @@ function ClarifyToolPending({ args }: ToolCallMessagePartProps) {
 
       const active = document.activeElement as HTMLElement | null
       const surfaceId = surfaceIdRef.current
+
+      // Keep normal text-entry behavior intact. If the chat composer is empty,
+      // arrow navigation may still activate Quick Choice; once the user has
+      // typed content, the composer owns its cursor/navigation keys again.
+      const isTextEntry =
+        active?.isContentEditable || active?.matches('input, select, textarea')
+      const isEmptyComposer =
+        isTextEntry &&
+        active &&
+        !surfaceRef.current?.contains(active) &&
+        (active.isContentEditable ? active.textContent?.trim() === '' : (active as HTMLInputElement).value.trim() === '')
+
+      if (isTextEntry && !isEmptyComposer) {
+        return
+      }
 
       // Only the active clarify surface may consume window-level navigation.
       // The first mounted surface is the fallback owner when focus is in the

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -8,7 +8,8 @@ const reactUi: TestProjectConfiguration = {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
-    globals: true
+    globals: true,
+    fileParallelism: false
   }
 }
 


### PR DESCRIPTION
## Summary

- add keyboard navigation and numeric shortcuts to Desktop `clarify` / Quick Choice cards
- scope global shortcuts to the active clarify card so multiple cards cannot answer at once
- allow arrow navigation while the empty chat composer is focused, while preserving normal text-entry behavior once text exists
- preserve offered choices in the settled chat history behind a `Quick Choice options` disclosure
- serialize UI test files to avoid shared-state races in the full check suite

The backend/tool name remains `clarify`; `Quick Choice` is presentation-only.

## Verification

- `npm run test`: 205 files passed, 1726 tests passed, 1 skipped
- `npm run typecheck`: passed
- `npm run test:desktop:all`: passed
- `npm run check`: passed in the separated verification run
- `npx eslint src/components/assistant-ui/clarify-tool.tsx src/components/assistant-ui/clarify-tool.test.tsx`: 0 errors (4 existing `document` warnings in tests)
- Desktop Linux unpacked artifact generated successfully

## Testing notes

The isolated build was manually exercised with Quick Choice. Arrow navigation works with an empty composer without first clicking the card, Enter confirms the active choice, and the settled history exposes the offered options in a disclosure menu.
