### PR TITLE
fix(gateway): preserve delegation completion across compression

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11114,6 +11114,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
         return source
 
+    async def _resolve_async_completion_session(
+        self, pinned_session_id: str,
+    ) -> Optional[str]:
+        """Resolve a delegation's owner without reviving an ended conversation.
+
+        Explicitly ended sessions remain dead. Compression is different: it
+        preserves the same conversation in a continuation child, so a
+        delegation dispatched before rotation still belongs to the live tip.
+        """
+        if self._session_db is None:
+            return None
+        try:
+            pinned_row = await self._session_db.get_session(pinned_session_id)
+        except Exception:
+            return None
+        if not isinstance(pinned_row, dict):
+            return None
+        if not pinned_row.get("ended_at"):
+            return pinned_session_id
+        if pinned_row.get("end_reason") != "compression":
+            return None
+        try:
+            continuation_id = str(
+                await self._session_db.get_compression_tip(pinned_session_id) or ""
+            )
+            if not continuation_id or continuation_id == pinned_session_id:
+                return None
+            continuation_row = await self._session_db.get_session(continuation_id)
+        except Exception:
+            return None
+        if not isinstance(continuation_row, dict) or continuation_row.get("ended_at"):
+            return None
+        return continuation_id
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -11149,42 +11183,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
         ).strip()
         if pinned_session_id and pinned_session_id != session_entry.session_id:
-            # Fail closed (#55578): the spawning session may have ENDED since
-            # dispatch (user /new-reset, compression rotation whose parent was
-            # closed). switch_session() re-opens ended sessions, so pinning
-            # blindly would RESURRECT a conversation the user explicitly
-            # ended and inject into it — the same illicit-revival class as
-            # the ws_orphan_reap loop (#60609). A completion whose spawning
-            # session is dead is dropped from injection; the subagent's
-            # output remains in the delegation records.
-            pinned_row = None
-            try:
-                if self._session_db is not None:
-                    # AsyncSessionDB already offloads to a thread.
-                    pinned_row = await self._session_db.get_session(pinned_session_id)
-            except Exception:
-                pinned_row = None
-            if pinned_row is None or pinned_row.get("ended_at"):
+            # Fail closed for explicit session boundaries (#55578), but preserve
+            # ownership across context compression: compression continues the
+            # same conversation under a child session rather than ending it.
+            original_pinned_session_id = pinned_session_id
+            pinned_session_id = (
+                await self._resolve_async_completion_session(pinned_session_id) or ""
+            )
+            if not pinned_session_id:
                 logger.warning(
-                    "Async-delegation completion pinned to session %s, which is "
-                    "%s — dropping injection instead of resurrecting it "
-                    "(#55578 fail-closed; result remains in the delegation "
-                    "records).",
-                    pinned_session_id,
-                    "unknown" if pinned_row is None else "ended",
+                    "Async-delegation completion pinned to session %s, which has "
+                    "no live continuation — dropping injection instead of "
+                    "resurrecting it (#55578 fail-closed; result remains in the "
+                    "delegation records).",
+                    original_pinned_session_id,
                 )
                 return
-            prior_session_id = session_entry.session_id
-            switched = await self.async_session_store.switch_session(session_key, pinned_session_id)
-            if switched is not None:
-                session_entry = switched
+            if pinned_session_id != original_pinned_session_id:
                 logger.info(
-                    "Pinned async-delegation completion to spawning session %s "
-                    "(was %s) for routing key %s (#57498)",
+                    "Resolved async-delegation owner across compression: %s -> %s",
+                    original_pinned_session_id,
                     pinned_session_id,
-                    prior_session_id,
-                    session_key,
                 )
+            if pinned_session_id != session_entry.session_id:
+                prior_session_id = session_entry.session_id
+                switched = await self.async_session_store.switch_session(
+                    session_key, pinned_session_id
+                )
+                if switched is not None:
+                    session_entry = switched
+                    logger.info(
+                        "Pinned async-delegation completion to spawning session %s "
+                        "(was %s) for routing key %s (#57498)",
+                        pinned_session_id,
+                        prior_session_id,
+                        session_key,
+                    )
         self._cache_session_source(session_key, source)
         if await asyncio.to_thread(self._is_telegram_topic_lane, source):
             try:

--- a/tests/gateway/test_async_delegation_session_binding.py
+++ b/tests/gateway/test_async_delegation_session_binding.py
@@ -133,6 +133,34 @@ class TestGatewayPinningFailsClosed:
         assert resolved == "sess_child"
         db.get_compression_tip.assert_awaited_once_with("sess_parent")
 
+    def test_compression_grandparent_resolves_to_final_live_tip(self, tmp_path):
+        """A completion survives every compression hop before the worker exits."""
+        from gateway.run import GatewayRunner
+        from hermes_state import AsyncSessionDB, SessionDB
+
+        state = SessionDB(tmp_path / "state.db")
+        state.create_session("parent", "telegram")
+        state.end_session("parent", "compression")
+        state.create_session(
+            "child", "telegram", parent_session_id="parent",
+        )
+        state.end_session("child", "compression")
+        state.create_session(
+            "live_tip", "telegram", parent_session_id="child",
+        )
+
+        runner, _ = self._make_runner(None)
+        runner._session_db = AsyncSessionDB(state)
+
+        try:
+            resolved = asyncio.run(
+                GatewayRunner._resolve_async_completion_session(runner, "parent")
+            )
+        finally:
+            state.close()
+
+        assert resolved == "live_tip"
+
 
 class TestResetHandlerInterruptsDelegations:
     def test_reset_command_calls_interrupt_for_session(self):

--- a/tests/gateway/test_async_delegation_session_binding.py
+++ b/tests/gateway/test_async_delegation_session_binding.py
@@ -78,45 +78,60 @@ class TestGatewayPinningFailsClosed:
         runner.session_store = MagicMock()
         runner.session_store.get_or_create_session.return_value = entry
         runner.session_store.switch_session.return_value = entry
-        return runner, entry
+        return runner, db
 
-    def _run_pinning_prefix(self, runner, pinned_session_id):
-        """Execute the pinning guard logic exactly as _handle_message does."""
+    def _resolve(self, runner, pinned_session_id):
+        from gateway.run import GatewayRunner
 
-        async def _go():
-            event = MagicMock()
-            event.metadata = {"gateway_session_id": pinned_session_id}
-            session_entry = runner.session_store.get_or_create_session(MagicMock())
-            pinned = str((getattr(event, "metadata", None) or {}).get("gateway_session_id") or "").strip()
-            if pinned and pinned != session_entry.session_id:
-                pinned_row = None
-                try:
-                    if runner._session_db is not None:
-                        pinned_row = await runner._session_db.get_session(pinned)
-                except Exception:
-                    pinned_row = None
-                if pinned_row is None or pinned_row.get("ended_at"):
-                    return "dropped"
-                switched = runner.session_store.switch_session(session_entry.session_key, pinned)
-                if switched is not None:
-                    return "pinned"
-            return "default"
-
-        return asyncio.run(_go())
+        return asyncio.run(
+            GatewayRunner._resolve_async_completion_session(
+                runner, pinned_session_id
+            )
+        )
 
     def test_live_spawning_session_pins(self):
         runner, _ = self._make_runner({"id": "sess_old", "ended_at": None})
-        assert self._run_pinning_prefix(runner, "sess_old") == "pinned"
+        assert self._resolve(runner, "sess_old") == "sess_old"
 
     def test_ended_spawning_session_drops(self):
-        runner, _ = self._make_runner({"id": "sess_old", "ended_at": "2026-07-08T00:00:00"})
-        assert self._run_pinning_prefix(runner, "sess_old") == "dropped"
-        runner.session_store.switch_session.assert_not_called()
+        runner, db = self._make_runner({
+            "id": "sess_old",
+            "ended_at": "2026-07-08T00:00:00",
+            "end_reason": "session_reset",
+        })
+        assert self._resolve(runner, "sess_old") is None
+        db.get_compression_tip.assert_not_called()
 
     def test_unknown_spawning_session_drops(self):
         runner, _ = self._make_runner(None)
-        assert self._run_pinning_prefix(runner, "sess_gone") == "dropped"
-        runner.session_store.switch_session.assert_not_called()
+        assert self._resolve(runner, "sess_gone") is None
+
+    def test_compression_parent_resolves_to_live_continuation(self):
+        from gateway.run import GatewayRunner
+
+        runner, _ = self._make_runner(None)
+        db = MagicMock()
+        db.get_session = AsyncMock(side_effect=[
+            {
+                "id": "sess_parent",
+                "ended_at": 100.0,
+                "end_reason": "compression",
+            },
+            {
+                "id": "sess_child",
+                "ended_at": None,
+                "parent_session_id": "sess_parent",
+            },
+        ])
+        db.get_compression_tip = AsyncMock(return_value="sess_child")
+        runner._session_db = db
+
+        resolved = asyncio.run(
+            GatewayRunner._resolve_async_completion_session(runner, "sess_parent")
+        )
+
+        assert resolved == "sess_child"
+        db.get_compression_tip.assert_awaited_once_with("sess_parent")
 
 
 class TestResetHandlerInterruptsDelegations:


### PR DESCRIPTION
## Summary

- resolve an async delegation owner from a compression-ended parent to its live continuation tip
- retain the #55578 fail-closed behavior for explicit reset, missing, or otherwise ended sessions
- replace the duplicated pinning-prefix test with direct tests of the production resolver

Closes #65779.

## Root cause

Async completion events remain pinned to the session that dispatched them. If context compression rotates that parent before the worker finishes, the #55578 dead-session guard drops the event without consulting the compression lineage. Adapter-level acceptance then marks the durable row delivered, so restart recovery cannot replay it.

Compression is not an explicit conversation boundary: `get_compression_tip()` already provides the lineage-safe continuation used by session resume/topic healing. This patch follows only that chain and only when the tip is live.

## Security boundary

The patch does **not** revive sessions ended by `/new`, reset, orphan reap, or any non-compression reason. If the compression tip is absent or ended, delivery still fails closed.

## Verification

- RED: new compression-parent regression test failed with missing resolver before implementation
- `scripts/run_tests.sh tests/gateway/test_async_delegation_session_binding.py tests/gateway/test_completion_delivery.py -q` — 22 passed
- `scripts/run_tests.sh tests/gateway/test_session_race_guard.py tests/gateway/test_telegram_topic_mode.py -q` — 64 passed
- `python -m py_compile gateway/run.py tests/gateway/test_async_delegation_session_binding.py`
- `git diff --check`