### PR TITLE
feat(cli): let ESC interrupt a running agent, alongside Ctrl+C (closes #65303)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12101,6 +12101,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             pass
 
+    def _esc_interrupt_active(self) -> bool:
+        """Whether a bare ESC should interrupt the running agent (#65303).
+
+        True only when the agent is actively responding AND nothing else owns
+        the screen: no /model picker, no secret/sudo/slash-confirm modal, and
+        no approval/clarify overlay. The picker and modal ESC bindings own ESC
+        while their state is set, so excluding those keeps this mutually
+        exclusive with them (two eager ``escape`` bindings must never both
+        qualify). Approval/clarify overlays are intentionally left to Ctrl+C
+        so ESC there stays a no-op rather than aborting the whole turn.
+        """
+        return bool(
+            self._agent_running
+            and self.agent
+            and not self._model_picker_state
+            and not self._secret_state
+            and not self._sudo_state
+            and not self._slash_confirm_state
+            and not self._approval_state
+            and not self._clarify_state
+        )
+
     def _clear_active_overlays_for_interrupt(self) -> None:
         """Drain and clear every input-blocking overlay left by an interrupted agent.
 
@@ -14181,6 +14203,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
+
+        @kb.add('escape', filter=Condition(lambda: self._esc_interrupt_active()), eager=True)
+        def handle_escape_interrupt(event):
+            """ESC interrupts a running agent — an ergonomic alternative to
+            Ctrl+C (#65303).
+
+            Gated by ``_esc_interrupt_active`` so it only fires while the agent
+            is responding with no modal/picker/overlay on screen, keeping it
+            mutually exclusive with the modal and /model-picker ESC bindings
+            above. Reuses the exact Ctrl+Q interrupt path (``agent.interrupt()``)
+            with no double-press force-exit.
+            """
+            if self._agent_running and self.agent:
+                print("\n⚡ Interrupting agent...")
+                self.agent.interrupt()
 
         @kb.add('c-z')
         def handle_ctrl_z(event):

--- a/tests/cli/test_cli_esc_interrupt.py
+++ b/tests/cli/test_cli_esc_interrupt.py
@@ -1,0 +1,77 @@
+"""Tests for ESC-to-interrupt gating (issue #65303).
+
+The ESC key binding that interrupts a running agent is a closure inside
+``HermesCLI.run()`` and can't be imported, but its whole risk lives in the
+filter predicate ``HermesCLI._esc_interrupt_active`` — a pure reader of
+instance state. We bind that unbound method to a lightweight namespace so we
+can assert the gating without constructing a full CLI or a prompt_toolkit
+Application.
+
+The predicate must be mutually exclusive with the other eager ``escape``
+bindings (modal + /model picker) and must leave approval/clarify overlays to
+Ctrl+C, so ESC there stays a no-op rather than aborting the turn.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import cli
+
+# Every state attribute the predicate reads. Defaults describe the one case
+# where ESC SHOULD interrupt: agent responding, nothing else on screen.
+_BASE_STATE = dict(
+    _agent_running=True,
+    agent=object(),
+    _model_picker_state=None,
+    _secret_state=None,
+    _sudo_state=None,
+    _slash_confirm_state=None,
+    _approval_state=None,
+    _clarify_state=None,
+)
+
+# Attributes whose truthiness must veto the ESC interrupt (a modal/picker owns
+# ESC, or an overlay is intentionally reserved for Ctrl+C).
+_BLOCKING_STATES = [
+    "_model_picker_state",
+    "_secret_state",
+    "_sudo_state",
+    "_slash_confirm_state",
+    "_approval_state",
+    "_clarify_state",
+]
+
+
+def _predicate(**overrides) -> bool:
+    state = {**_BASE_STATE, **overrides}
+    return cli.HermesCLI._esc_interrupt_active(SimpleNamespace(**state))
+
+
+def test_interrupts_when_agent_running_and_screen_clear():
+    assert _predicate() is True
+
+
+def test_no_interrupt_when_agent_not_running():
+    assert _predicate(_agent_running=False) is False
+
+
+def test_no_interrupt_when_agent_is_none():
+    # Mirrors the `and self.agent` guard the Ctrl+C/Ctrl+Q paths use.
+    assert _predicate(agent=None) is False
+
+
+@pytest.mark.parametrize("blocking", _BLOCKING_STATES)
+def test_no_interrupt_while_any_overlay_or_modal_active(blocking):
+    # A truthy modal/picker/overlay state must veto ESC-interrupt so it never
+    # competes with the modal/picker ESC bindings (mutual exclusivity) and so
+    # approval/clarify keep their Ctrl+C-only behavior.
+    assert _predicate(**{blocking: {"response_queue": object()}}) is False
+
+
+def test_returns_a_plain_bool_not_truthy_object():
+    # The prompt_toolkit Condition wraps this; keep it a real bool.
+    result = _predicate()
+    assert result is True and isinstance(result, bool)


### PR DESCRIPTION
## What & why

ESC previously only cancelled modal prompts and did nothing while the agent was responding — the only interrupt was Ctrl+C / Ctrl+Q. This adds ESC as an ergonomic alternative, per the request: useful on terminals that intercept Ctrl+C (some SSH clients, custom tmux bindings) and for users who expect ESC to abort.

Closes #65303.

## Behavior — follows the issue's stated priority order

1. **Modal prompt active** (secret / sudo / slash-confirm) or **/model picker open** → the existing eager `escape` bindings keep ESC (unchanged).
2. **Agent running, nothing else on screen** → **new** eager `escape` binding reuses the *exact* Ctrl+Q interrupt path — `self.agent.interrupt()` — with no double-press force-exit.
3. **Otherwise** → no-op. We never bind bare unconditional `escape`, so the escape-as-meta/arrow prefix byte stays intact and no input latency is introduced.

## Implementation

- New predicate `HermesCLI._esc_interrupt_active()`: `self._agent_running and self.agent and not (any of _model_picker_state / _secret_state / _sudo_state / _slash_confirm_state / _approval_state / _clarify_state)`.
- New binding `@kb.add('escape', filter=Condition(lambda: self._esc_interrupt_active()), eager=True)` calling `self.agent.interrupt()`.

Two design points worth calling out:

- **Mutual exclusivity.** prompt_toolkit picks among multiple `escape` bindings by their filters; two *eager* escapes must never both qualify. Excluding the picker and the three modal states from the predicate makes the new binding disjoint from the existing modal (`filter=_modal_prompt_active`) and /model-picker escape bindings.
- **Approval/clarify left to Ctrl+C.** Those overlays are agent-blocking but not "modal prompts". Rather than have ESC abort the whole turn while an approval overlay is waiting, the predicate excludes them, so ESC stays a no-op there and their current Ctrl+C behavior is untouched. This keeps the change strictly additive.
- **Escape-prefix safety.** The binding is `filter`-gated + `eager=True`, matching exactly how the existing modal and /model-picker escapes disambiguate ESC-as-meta/arrow-prefix; the two-key Alt combos (`escape,enter` / `escape,g` / `escape,v`) are unaffected.

## Testing

`tests/cli/test_cli_esc_interrupt.py` (10): the binding is a closure inside `run()` and can't be imported, but its entire risk is the filter predicate — a pure state reader. The tests bind the unbound method to a lightweight namespace and assert it:
- fires only when the agent is running with a clear screen,
- is vetoed by `_agent_running=False`, `agent=None`, and **each** of the six blocking states (parametrized),
- returns a real `bool`.

- `python -m pytest tests/cli/test_cli_esc_interrupt.py -q` → **10 passed**.
- `python -m pytest tests/cli -k "interrupt or shortcut or keybind or steer" -q` → **66 passed**, no regressions.
- Platform: authored on Windows.

Note: the interrupt call itself is a one-line reuse of the existing, well-tested `self.agent.interrupt()` path (same as Ctrl+Q), so the added logic under test is the gating predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
