### PR TITLE
fix(mcp_catalog): add timeout and stdin=DEVNULL to _run_bootstrap subprocess.run

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -380,7 +380,10 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        proc = subprocess.run(
+            cmd, cwd=str(cwd), shell=True, timeout=300,
+            stdin=subprocess.DEVNULL,
+        )
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -380,10 +380,15 @@ def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(
-            cmd, cwd=str(cwd), shell=True, timeout=300,
-            stdin=subprocess.DEVNULL,
-        )
+        try:
+            proc = subprocess.run(
+                cmd, cwd=str(cwd), shell=True, timeout=300,
+                stdin=subprocess.DEVNULL,
+            )
+        except subprocess.TimeoutExpired:
+            raise CatalogError(
+                f"bootstrap step timed out after 300s: {cmd}"
+            )
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -421,9 +421,16 @@ def _do_git_install(entry: CatalogEntry) -> Path:
     is_sha_ref = bool(re.fullmatch(r"[0-9a-f]{7,40}", install.ref))
 
     if not is_sha_ref:
-        proc = subprocess.run(
-            [git, "clone", "--depth", "1", "--branch", install.ref, install.url, str(dest)],
-        )
+        try:
+            proc = subprocess.run(
+                [git, "clone", "--depth", "1", "--branch", install.ref, install.url, str(dest)],
+                timeout=300,
+                stdin=subprocess.DEVNULL,
+            )
+        except subprocess.TimeoutExpired:
+            raise CatalogError(
+                f"git clone timed out after 300s for {install.url} ({install.ref})"
+            )
         if proc.returncode == 0:
             pass
         else:
@@ -434,10 +441,28 @@ def _do_git_install(entry: CatalogEntry) -> Path:
             is_sha_ref = True  # treat the same as a SHA ref from here
 
     if is_sha_ref:
-        proc = subprocess.run([git, "clone", install.url, str(dest)])
+        try:
+            proc = subprocess.run(
+                [git, "clone", install.url, str(dest)],
+                timeout=300,
+                stdin=subprocess.DEVNULL,
+            )
+        except subprocess.TimeoutExpired:
+            raise CatalogError(
+                f"git clone timed out after 300s for {install.url}"
+            )
         if proc.returncode != 0:
             raise CatalogError(f"git clone failed for {install.url}")
-        proc = subprocess.run([git, "-C", str(dest), "checkout", install.ref])
+        try:
+            proc = subprocess.run(
+                [git, "-C", str(dest), "checkout", install.ref],
+                timeout=300,
+                stdin=subprocess.DEVNULL,
+            )
+        except subprocess.TimeoutExpired:
+            raise CatalogError(
+                f"git checkout timed out after 300s for {install.ref}"
+            )
         if proc.returncode != 0:
             raise CatalogError(f"git checkout {install.ref} failed")
 

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -8,6 +8,7 @@ launch an MCP is mocked.
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -351,6 +352,63 @@ class TestInstall:
 
         with pytest.raises(CatalogError):
             install_entry(_entry("demo"), enable=True)
+
+    def test_run_bootstrap_timeout_raises_catalog_error(self, monkeypatch):
+        """subprocess.TimeoutExpired in _run_bootstrap is converted to CatalogError."""
+        from hermes_cli import mcp_catalog
+        from hermes_cli.mcp_catalog import CatalogError, _run_bootstrap
+        from pathlib import Path
+
+        def _timeout_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="test-command", timeout=300)
+
+        monkeypatch.setattr(mcp_catalog.subprocess, "run", _timeout_run)
+
+        with pytest.raises(CatalogError, match="timed out"):
+            _run_bootstrap(Path("/tmp"), ["pip install -r requirements.txt"])
+
+    def test_run_bootstrap_nonzero_exit_raises_catalog_error(self, monkeypatch):
+        """Non-zero exit code from _run_bootstrap raises CatalogError."""
+        from hermes_cli import mcp_catalog
+        from hermes_cli.mcp_catalog import CatalogError, _run_bootstrap
+        from pathlib import Path
+
+        class _FakeProc:
+            def __init__(self):
+                self.returncode = 1
+
+        monkeypatch.setattr(
+            mcp_catalog.subprocess, "run",
+            lambda *a, **kw: _FakeProc(),
+        )
+
+        with pytest.raises(CatalogError, match="failed"):
+            _run_bootstrap(Path("/tmp"), ["pip install -r requirements.txt"])
+
+    def test_run_bootstrap_with_timeout_kwarg(self, monkeypatch):
+        """Verify subprocess.run is called with timeout=300 and stdin=DEVNULL."""
+        from hermes_cli import mcp_catalog
+        from hermes_cli.mcp_catalog import _run_bootstrap
+        from pathlib import Path
+
+        calls = []
+
+        class _FakeProc:
+            def __init__(self):
+                self.returncode = 0
+
+        def fake_run(*args, **kwargs):
+            calls.append(kwargs)
+            return _FakeProc()
+
+        monkeypatch.setattr(mcp_catalog.subprocess, "run", fake_run)
+
+        _run_bootstrap(Path("/tmp"), ["echo done"])
+
+        assert len(calls) == 1
+        assert calls[0].get("timeout") == 300
+        assert calls[0].get("stdin") == subprocess.DEVNULL
+        assert calls[0].get("shell") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -823,6 +823,132 @@ class TestGitInstallShaRef:
 
 
 # ---------------------------------------------------------------------------
+# Git install — timeout / subprocess kwargs coverage
+# ---------------------------------------------------------------------------
+
+
+class TestGitInstallTimeout:
+    """subprocess.TimeoutExpired in _do_git_install is converted to CatalogError."""
+
+    def test_branch_clone_timeout_raises_catalog_error(self, catalog_dir, monkeypatch):
+        """git clone --branch timeout is converted to CatalogError."""
+        from hermes_cli import mcp_catalog
+        from hermes_cli.mcp_catalog import CatalogError, _do_git_install, get_entry
+        import subprocess
+
+        body = _basic_manifest(
+            install={
+                "type": "git",
+                "url": "https://example.com/x.git",
+                "ref": "v1.0.0",
+                "bootstrap": [],
+            },
+            transport={
+                "type": "stdio",
+                "command": "${INSTALL_DIR}/run.sh",
+                "args": [],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        def _timeout_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=300)
+
+        monkeypatch.setattr(mcp_catalog.subprocess, "run", _timeout_run)
+        monkeypatch.setattr(mcp_catalog.shutil, "which", lambda x: "/usr/bin/git")
+
+        entry = get_entry("demo")
+        assert entry is not None
+        with pytest.raises(CatalogError, match="timed out"):
+            _do_git_install(entry)
+
+    def test_checkout_timeout_raises_catalog_error(self, catalog_dir, monkeypatch):
+        """git checkout timeout is converted to CatalogError."""
+        from hermes_cli import mcp_catalog
+        from hermes_cli.mcp_catalog import CatalogError, _do_git_install, get_entry
+        import subprocess
+
+        body = _basic_manifest(
+            install={
+                "type": "git",
+                "url": "https://example.com/x.git",
+                "ref": "abc1234567890abcdef1234567890abcdef12345",
+                "bootstrap": [],
+            },
+            transport={
+                "type": "stdio",
+                "command": "${INSTALL_DIR}/run.sh",
+                "args": [],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        call_count = [0]
+
+        class _FakeProc:
+            def __init__(self):
+                self.returncode = 0
+
+        def _conditional_run(*args, **kwargs):
+            call_count[0] += 1
+            # clone succeeds, checkout times out
+            if call_count[0] == 1:
+                return _FakeProc()
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=300)
+
+        monkeypatch.setattr(mcp_catalog.subprocess, "run", _conditional_run)
+        monkeypatch.setattr(mcp_catalog.shutil, "which", lambda x: "/usr/bin/git")
+
+        entry = get_entry("demo")
+        assert entry is not None
+        with pytest.raises(CatalogError, match="git checkout timed out"):
+            _do_git_install(entry)
+
+    def test_git_subprocess_kwargs(self, catalog_dir, monkeypatch):
+        """Verify git clone/checkout subprocess.run calls receive timeout=300
+        and stdin=subprocess.DEVNULL."""
+        from hermes_cli import mcp_catalog
+        from hermes_cli.mcp_catalog import _do_git_install, get_entry
+        import subprocess
+
+        body = _basic_manifest(
+            install={
+                "type": "git",
+                "url": "https://example.com/x.git",
+                "ref": "abc1234567890abcdef1234567890abcdef12345",
+                "bootstrap": [],
+            },
+            transport={
+                "type": "stdio",
+                "command": "${INSTALL_DIR}/run.sh",
+                "args": [],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        calls = []
+
+        class _FakeProc:
+            def __init__(self):
+                self.returncode = 0
+
+        def fake_run(*args, **kwargs):
+            calls.append((list(args) if args else [], kwargs))
+            return _FakeProc()
+
+        monkeypatch.setattr(mcp_catalog.subprocess, "run", fake_run)
+        monkeypatch.setattr(mcp_catalog.shutil, "which", lambda x: "/usr/bin/git")
+
+        entry = get_entry("demo")
+        assert entry is not None
+        _do_git_install(entry)
+
+        for _, kwargs in calls:
+            assert kwargs.get("timeout") == 300, f"Missing timeout in call: {kwargs}"
+            assert kwargs.get("stdin") == subprocess.DEVNULL, f"Missing stdin=DEVNULL in call: {kwargs}"
+
+
+# ---------------------------------------------------------------------------
 # Existing tools_config converged to tools.include
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -862,6 +862,38 @@ class TestGitInstallTimeout:
         with pytest.raises(CatalogError, match="timed out"):
             _do_git_install(entry)
 
+    def test_sha_clone_timeout_raises_catalog_error(self, catalog_dir, monkeypatch):
+        """git clone (SHA ref) timeout is converted to CatalogError."""
+        from hermes_cli import mcp_catalog
+        from hermes_cli.mcp_catalog import CatalogError, _do_git_install, get_entry
+        import subprocess
+
+        body = _basic_manifest(
+            install={
+                "type": "git",
+                "url": "https://example.com/x.git",
+                "ref": "abc1234567890abcdef1234567890abcdef12345",
+                "bootstrap": [],
+            },
+            transport={
+                "type": "stdio",
+                "command": "${INSTALL_DIR}/run.sh",
+                "args": [],
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        def _timeout_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=300)
+
+        monkeypatch.setattr(mcp_catalog.subprocess, "run", _timeout_run)
+        monkeypatch.setattr(mcp_catalog.shutil, "which", lambda x: "/usr/bin/git")
+
+        entry = get_entry("demo")
+        assert entry is not None
+        with pytest.raises(CatalogError, match="git clone timed out"):
+            _do_git_install(entry)
+
     def test_checkout_timeout_raises_catalog_error(self, catalog_dir, monkeypatch):
         """git checkout timeout is converted to CatalogError."""
         from hermes_cli import mcp_catalog


### PR DESCRIPTION
## Summary

Add a 300-second timeout and stdin=DEVNULL to the subprocess.run call in _run_bootstrap() to prevent the MCP install CLI from hanging indefinitely when a bootstrap command stalls.

## Problem

`hermes_cli/mcp_catalog.py:383` calls `subprocess.run(cmd, cwd=str(cwd), shell=True)` without a timeout or stdin redirection. If a bootstrap command (e.g. npm install, pip install, or any network-dependent step) hangs, the entire `hermes mcp install` / `hermes setup` CLI session blocks forever — no error is logged and no fallback exists. Additionally, without stdin=DEVNULL, the child inherits the terminal stdin pipe, which can cause platform-specific issues (e.g. reading EOF, TTY hijacking).

## Fix

Added `timeout=300` (5 minutes, generous enough for real bootstrap commands like npm install) and `stdin=subprocess.DEVNULL` to the subprocess.run call in `_run_bootstrap`. A 300s timeout is consistent with other install-time subprocesses in the codebase (e.g. espeak-ng install in setup, node bootstrap, photon npm ci).