### PR TITLE
fix(copilot-acp): collect late assistant updates

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -32,6 +32,7 @@ from tools.environments.local import hermes_subprocess_env
 
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
+_EMPTY_PROMPT_LATE_UPDATE_GRACE_SECONDS = 0.5
 
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
@@ -104,6 +105,11 @@ def _build_subprocess_env() -> dict[str, str]:
     # provider credentials. Route through the central helper so Tier-1 secrets
     # (gateway bot tokens, GitHub auth, infra) are still stripped (#29157).
     env = hermes_subprocess_env(inherit_credentials=True)
+    # ACP is a request transport, not an interactive CLI lifecycle. Allowing the
+    # child to replace its own executable while a prompt is in flight can end a
+    # valid session without emitting assistant chunks. Users can explicitly opt
+    # back in, but stable subprocesses are the safe default.
+    env.setdefault("COPILOT_AUTO_UPDATE", "false")
     home = _resolve_home_dir()
     env["HOME"] = home
     from hermes_constants import apply_subprocess_home_env
@@ -474,6 +480,12 @@ class CopilotACPClient:
             prompt_text,
             timeout_seconds=_effective_timeout,
         )
+        if not response_text.strip() and not reasoning_text.strip():
+            raise RuntimeError(
+                "Copilot ACP session/prompt completed without assistant content or reasoning. "
+                "The ACP transport returned success but emitted no usable agent_message_chunk "
+                "or agent_thought_chunk events."
+            )
 
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
 
@@ -612,6 +624,33 @@ class CopilotACPClient:
                 raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
             raise TimeoutError(f"Timed out waiting for Copilot ACP response to {method}.")
 
+        def _drain_late_server_messages(
+            *,
+            deadline: float,
+            text_parts: list[str],
+            reasoning_parts: list[str],
+        ) -> None:
+            while time.monotonic() < deadline:
+                remaining = deadline - time.monotonic()
+                try:
+                    msg = inbox.get(timeout=min(0.05, max(0.0, remaining)))
+                except queue.Empty:
+                    if proc.poll() is not None:
+                        break
+                    continue
+                # The prompt result is terminal for request/response traffic.
+                # Only collect asynchronous output here; handling a late server
+                # request could write to stdin and exceed the bounded deadline.
+                if msg.get("method") != "session/update":
+                    continue
+                self._handle_server_message(
+                    msg,
+                    process=proc,
+                    cwd=self._acp_cwd,
+                    text_parts=text_parts,
+                    reasoning_parts=reasoning_parts,
+                )
+
         try:
             _request(
                 "initialize",
@@ -643,6 +682,7 @@ class CopilotACPClient:
 
             text_parts: list[str] = []
             reasoning_parts: list[str] = []
+            prompt_deadline = time.monotonic() + timeout_seconds
             _request(
                 "session/prompt",
                 {
@@ -654,6 +694,18 @@ class CopilotACPClient:
                         }
                     ],
                 },
+                text_parts=text_parts,
+                reasoning_parts=reasoning_parts,
+            )
+            # ACP normally sends all updates before the prompt result. Tolerate a
+            # bounded late-notification race before closing the session, including
+            # partial responses whose final chunks arrive late. The grace period
+            # never extends the caller's prompt timeout.
+            _drain_late_server_messages(
+                deadline=min(
+                    prompt_deadline,
+                    time.monotonic() + _EMPTY_PROMPT_LATE_UPDATE_GRACE_SECONDS,
+                ),
                 text_parts=text_parts,
                 reasoning_parts=reasoning_parts,
             )

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import io
 import json
 import os
+import sys
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from agent.copilot_acp_client import CopilotACPClient
+from agent.copilot_acp_client import CopilotACPClient, _build_subprocess_env
 
 
 class _FakeProcess:
@@ -55,6 +57,17 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertEqual(dict(tool_call)["id"], "call_read")
         self.assertEqual(dict(tool_call.function)["name"], "read_file")
         self.assertEqual(choice.message.content, "I'll inspect that.")
+
+    def test_empty_successful_prompt_raises_transport_error(self) -> None:
+        with patch.object(self.client, "_run_prompt", return_value=("", "")):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "completed without assistant content or reasoning",
+            ):
+                self.client._create_chat_completion(
+                    model="gpt-5.6-terra",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
 
     def test_stream_true_returns_iterable_text_chunks(self) -> None:
         with patch.object(self.client, "_run_prompt", return_value=("Hello from ACP", "")):
@@ -282,6 +295,96 @@ def _fake_popen_capture(captured):
         captured["kwargs"] = kwargs
         raise FileNotFoundError("copilot not found")
     return _fake
+
+
+def _write_late_update_fake_acp(tmp_path):
+    server_script = tmp_path / "fake_acp.py"
+    server_script.write_text(
+        textwrap.dedent(
+            """
+            import json
+            import sys
+            import time
+
+            def emit_chunk(text):
+                print(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "session/update",
+                            "params": {
+                                "sessionId": "late-update-session",
+                                "update": {
+                                    "sessionUpdate": "agent_message_chunk",
+                                    "content": {"type": "text", "text": text},
+                                },
+                            },
+                        }
+                    ),
+                    flush=True,
+                )
+
+            for line in sys.stdin:
+                request = json.loads(line)
+                method = request.get("method")
+                request_id = request.get("id")
+                if method == "initialize":
+                    result = {"protocolVersion": 1}
+                elif method == "session/new":
+                    result = {"sessionId": "late-update-session"}
+                elif method == "session/prompt":
+                    prompt = request["params"]["prompt"][0]["text"]
+                    if prompt == "early-and-late":
+                        emit_chunk("early ")
+                    print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": {}}), flush=True)
+                    time.sleep(0.25)
+                    emit_chunk("late" if prompt == "early-and-late" else "late assistant text")
+                    continue
+                else:
+                    result = {}
+                print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}), flush=True)
+            """
+        )
+    )
+    return server_script
+
+
+def _late_update_client(tmp_path):
+    return CopilotACPClient(
+        acp_command=sys.executable,
+        acp_args=[str(_write_late_update_fake_acp(tmp_path))],
+        acp_cwd=str(tmp_path),
+    )
+
+
+def test_run_prompt_collects_late_update_after_successful_prompt_result(tmp_path):
+    assert _late_update_client(tmp_path)._run_prompt("hello", timeout_seconds=2) == (
+        "late assistant text",
+        "",
+    )
+
+
+def test_run_prompt_collects_final_late_update_after_early_chunk(tmp_path):
+    assert _late_update_client(tmp_path)._run_prompt(
+        "early-and-late",
+        timeout_seconds=2,
+    ) == ("early late", "")
+
+
+def test_run_prompt_disables_copilot_auto_update_by_default(monkeypatch):
+    monkeypatch.delenv("COPILOT_AUTO_UPDATE", raising=False)
+
+    env = _build_subprocess_env()
+
+    assert env["COPILOT_AUTO_UPDATE"] == "false"
+
+
+def test_run_prompt_preserves_explicit_copilot_auto_update_setting(monkeypatch):
+    monkeypatch.setenv("COPILOT_AUTO_UPDATE", "true")
+
+    env = _build_subprocess_env()
+
+    assert env["COPILOT_AUTO_UPDATE"] == "true"
 
 
 def test_run_prompt_preserves_real_home_when_profile_home_available(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- prevent Copilot CLI self-updates inside short-lived ACP request processes by default
- tolerate a bounded `session/prompt` result-before-`session/update` race for empty and partially collected responses
- report a transport-specific failure if no assistant content or reasoning arrives after the grace period
- add deterministic regression coverage for late assistant chunks and child auto-update behavior

## Root cause

`CopilotACPClient._request()` returns as soon as the matching `session/prompt` result arrives. `_run_prompt()` then returns its current buffers and closes the subprocess. If Copilot emits an asynchronous assistant `session/update` just after the result, that text is dropped and Hermes receives a synthetic empty completion.

The regression fixture reproduces this deterministically by sending the result, waiting 250 ms, and then emitting `agent_message_chunk`. The pre-fix client returns `("", "")`.

A Copilot CLI self-update during an active production request was a credible trigger for the unusual ordering, so ACP children now default to `COPILOT_AUTO_UPDATE=false`. Explicit operator overrides remain respected.

## Implementation

The grace period is intentionally narrow:

- it collects only asynchronous `session/update` notifications after the prompt result;
- it is bounded to 0.5 seconds;
- it never extends the caller's prompt timeout;
- it covers both all-late output and final chunks arriving after an early chunk;
- the existing retry/fallback policy remains unchanged;
- a session still empty after the drain raises a clear transport error.

## Validation

- deterministic all-late and early-plus-late regressions: red before fix, green after fix
- focused Copilot ACP and fallback suites: 91 passed
- independent re-review of revised patch: PASS, no blocking or nonblocking findings
- live `gpt-5.6-terra` Copilot ACP probes: 5/5 passed
- Ruff: passed
- Python compilation: passed
- `git diff --check`: passed
- static security scan: no findings

Fixes #65788
