### PR TITLE
fix(cron): clear inherited thread_id for in_channel delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1572,6 +1572,31 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             )
             in_channel_surface = False
 
+        if in_channel_surface and mirror_this_target and runtime_adapter is not None:
+            # Force flat delivery (D2): the continuable-channel target must
+            # ignore any inherited origin/target thread_id, or the flat
+            # continuable session seeded below (thread_id=None, via
+            # _seed_cron_channel_session) never matches where the brief is
+            # actually delivered — route_thread_id further down in this loop
+            # reads `thread_id` and would otherwise route into the origin
+            # thread instead of flat into the channel.
+            #
+            # Scoped to EXACTLY the target that gets flat-seeded: the origin-
+            # continuable target (`mirror_this_target`) on a live, in_channel-
+            # capable adapter. The `runtime_adapter is not None` guard keeps
+            # this in lockstep with the D6 capability fail-safe (which only runs
+            # with a live adapter) and with the seed itself
+            # (`in_channel_surface and mirror_this_target`, inside the
+            # live-adapter block below): fan-out / broadcast / explicit-thread
+            # targets keep their thread_id (they are not continuable and are
+            # never seeded), and the standalone no-adapter path falls back to
+            # thread delivery — it can never seed the flat session, so
+            # flattening there would drop the brief out of any continuable lane
+            # while also bypassing the D6 capability check. Placed AFTER
+            # mirror_this_target / origin_user_id are computed above — those
+            # need the ORIGINAL thread_id to match the origin conversation.
+            thread_id = None
+
         # For an in_channel delivery the flat continuation session is created
         # explicitly below (the shipped mirror only APPENDS to an existing
         # session, and the flat channel row is otherwise absent for a

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1539,6 +1539,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
         runtime_adapter = (adapters or {}).get(platform)
+        # The live-send path (which SEEDS the flat in_channel continuation
+        # session via _seed_cron_channel_session) needs not just a live adapter
+        # but a running event loop to schedule the async send onto. Compute that
+        # gate ONCE so the in_channel thread_id clear below stays in lockstep
+        # with the live-send/seed block further down (they used to drift): an
+        # adapter can be present while the loop is absent/not-running, in which
+        # case the live-send block is skipped and delivery falls through to the
+        # standalone path — which cannot seed the flat session (r3609147550).
+        live_adapter_ready = (
+            runtime_adapter is not None
+            and loop is not None
+            and getattr(loop, "is_running", lambda: False)()
+        )
         delivered = False
         target_errors = []
 
@@ -1572,7 +1585,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             )
             in_channel_surface = False
 
-        if in_channel_surface and mirror_this_target and runtime_adapter is not None:
+        if in_channel_surface and mirror_this_target and live_adapter_ready:
             # Force flat delivery (D2): the continuable-channel target must
             # ignore any inherited origin/target thread_id, or the flat
             # continuable session seeded below (thread_id=None, via
@@ -1581,18 +1594,20 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             # reads `thread_id` and would otherwise route into the origin
             # thread instead of flat into the channel.
             #
-            # Scoped to EXACTLY the target that gets flat-seeded: the origin-
-            # continuable target (`mirror_this_target`) on a live, in_channel-
-            # capable adapter. The `runtime_adapter is not None` guard keeps
-            # this in lockstep with the D6 capability fail-safe (which only runs
-            # with a live adapter) and with the seed itself
-            # (`in_channel_surface and mirror_this_target`, inside the
-            # live-adapter block below): fan-out / broadcast / explicit-thread
-            # targets keep their thread_id (they are not continuable and are
-            # never seeded), and the standalone no-adapter path falls back to
-            # thread delivery — it can never seed the flat session, so
-            # flattening there would drop the brief out of any continuable lane
-            # while also bypassing the D6 capability check. Placed AFTER
+            # Gated on `live_adapter_ready` (adapter present AND a running loop)
+            # so the clear fires ONLY on the live-send path that actually seeds
+            # the flat session — the SAME condition as the live-send block
+            # below. `runtime_adapter is not None` alone is broader than that
+            # path: an adapter can be present while the event loop is absent or
+            # not running, in which case the live-send/seed block is skipped and
+            # delivery falls through to the standalone path. Clearing thread_id
+            # there would flatten a brief into a channel with NO seeded
+            # continuable session behind it (and bypass the D6 capability
+            # check), so the standalone fallback must keep the origin thread
+            # (review r3609147550).
+            #
+            # Fan-out / broadcast / explicit-thread targets keep their thread_id
+            # (they are not continuable and are never seeded). Placed AFTER
             # mirror_this_target / origin_user_id are computed above — those
             # need the ORIGINAL thread_id to match the origin conversation.
             thread_id = None
@@ -1649,7 +1664,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 thread_id = new_thread_id
                 opened_thread_id = new_thread_id
 
-        if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
+        if live_adapter_ready:
             # Telegram topic routing (#22773, regression fixed #52060): a
             # ``telegram:<positive_chat_id>:<numeric_thread_id>`` cron target is
             # ambiguous — a forum-style topic in a private chat and a genuine

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -4754,6 +4754,78 @@ class TestCronContinuableSurfaceInChannel:
         mirror_mock.assert_called_once()
         assert mirror_mock.call_args.kwargs.get("thread_id") is None
 
+    def test_in_channel_from_origin_thread_delivers_flat_not_to_thread(self):
+        """Regression: a job scheduled from INSIDE a Slack thread (origin carries
+        a thread_id) must still deliver FLAT when cron_continuable_surface is
+        in_channel — not into the origin thread. Without clearing the inherited
+        thread_id, the live-adapter route (DeliveryRouter._deliver_to_platform)
+        folds target.thread_id into send_metadata['thread_id'], so the brief
+        would land in the origin thread while the seeded continuable session
+        (thread_id=None, asserted above) never matches where it actually went."""
+        adapter = self._slack_adapter(supports_inchannel=True)
+        _, mirror_mock = self._run_inchannel_delivery(
+            {"cron_continuable_surface": "in_channel"}, adapter,
+            origin={
+                "platform": "slack", "chat_id": "C123", "user_id": "U_HUMAN",
+                "thread_id": "999.888",
+            },
+        )
+        # The thread-open branch must still be skipped (in_channel behavior).
+        adapter.send.assert_awaited_once()
+        _, send_kwargs = adapter.send.await_args
+        send_metadata = send_kwargs.get("metadata") or {}
+        assert "thread_id" not in send_metadata, (
+            "in_channel delivery must be flat — the origin's thread_id must "
+            "not be forwarded to the adapter, even though the job was "
+            "scheduled from inside that thread"
+        )
+        # The seeded continuable session must match where the brief actually
+        # landed: flat (thread_id=None), not the origin thread.
+        adapter._session_store.get_or_create_session.assert_called_once()
+        seeded = adapter._session_store.get_or_create_session.call_args[0][0]
+        assert seeded.thread_id is None
+        mirror_mock.assert_called_once()
+        assert mirror_mock.call_args.kwargs.get("thread_id") is None
+
+    def test_in_channel_standalone_no_adapter_preserves_origin_thread(self):
+        """Fail-safe (D6 bypass guard): with NO live adapter, an
+        in_channel-configured job must NOT be flattened. The flat continuable
+        session can only be seeded on the live-adapter path, and the D6
+        capability check can't run without an adapter — so the standalone send
+        must fall back to the origin thread rather than silently flattening
+        (which would bypass D6 and drop the brief out of any continuable lane).
+        Scoping the thread_id clear to `runtime_adapter is not None` keeps the
+        clear in lockstep with the seed and the D6 fail-safe."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {"cron_continuable_surface": "in_channel"}
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SLACK: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform",
+                   new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "brief-job",
+                "name": "Daily Brief",
+                "deliver": "origin",
+                "origin": {
+                    "platform": "slack", "chat_id": "C123",
+                    "user_id": "U_HUMAN", "thread_id": "999.888",
+                },
+            }
+            # No adapters/loop → standalone (no-live-adapter) delivery path.
+            _deliver_result(job, "Here is today's brief.")
+
+        send_mock.assert_called_once()
+        assert send_mock.call_args.kwargs.get("thread_id") == "999.888", (
+            "standalone in_channel delivery must fall back to the origin thread "
+            "(no live adapter can seed a flat continuable session), not flatten"
+        )
+
     def test_thread_mode_default_still_opens_thread(self):
         """G1 regression: the default (thread) mode is byte-identical — the
         thread-open branch still fires when no surface key is set."""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -4826,6 +4826,67 @@ class TestCronContinuableSurfaceInChannel:
             "(no live adapter can seed a flat continuable session), not flatten"
         )
 
+    def test_in_channel_adapter_present_but_loop_not_running_preserves_origin_thread(self):
+        """Regression (review r3609147550): the thread_id clear must be scoped to
+        the FULL live-send condition (adapter present AND a running loop), not
+        just ``runtime_adapter is not None``. An adapter can be present while the
+        event loop is absent/not-running — then the live-send block that seeds
+        the flat continuable session (``_seed_cron_channel_session``) is SKIPPED
+        and delivery falls through to the standalone path. Clearing thread_id in
+        that case would flatten an UNSEEDED brief (no continuable session behind
+        it) and bypass the D6 capability check, so the standalone fallback must
+        keep the origin thread. Bites an unscoped clear AND a partial fix that
+        adds ``loop is not None`` but omits ``loop.is_running()``."""
+        from gateway.config import Platform
+
+        adapter = self._slack_adapter(supports_inchannel=True)
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.extra = {"cron_continuable_surface": "in_channel"}
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SLACK: pconfig}
+
+        # Live adapter present, but the event loop is NOT running — the middle
+        # state between the live-send path and the no-adapter standalone path.
+        # ``runtime_adapter is not None`` is true here (so an unscoped clear
+        # would wrongly flatten); ``live_adapter_ready`` is false.
+        loop = MagicMock()
+        loop.is_running.return_value = False
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform",
+                   new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "brief-job",
+                "name": "Daily Brief",
+                "deliver": "origin",
+                # attach_to_session=True → mirror_this_target is True, so the
+                # (buggy) clear guard would actually fire without the loop gate.
+                "attach_to_session": True,
+                "origin": {
+                    "platform": "slack", "chat_id": "C123",
+                    "user_id": "U_HUMAN", "thread_id": "999.888",
+                },
+            }
+            _deliver_result(
+                job, "Here is today's brief.",
+                adapters={Platform.SLACK: adapter}, loop=loop,
+            )
+
+        # The live-send block never ran (loop not running): the flat session was
+        # never seeded and the adapter was never used to send.
+        adapter.send.assert_not_awaited()
+        adapter._session_store.get_or_create_session.assert_not_called()
+        # Standalone fallback must preserve the origin thread, not flatten.
+        send_mock.assert_called_once()
+        assert send_mock.call_args.kwargs.get("thread_id") == "999.888", (
+            "in_channel delivery with an adapter but no running loop must fall "
+            "back to the origin thread — the live-send block that seeds the flat "
+            "continuable session never ran, so flattening would leave an "
+            "unseeded brief"
+        )
+
     def test_thread_mode_default_still_opens_thread(self):
         """G1 regression: the default (thread) mode is byte-identical — the
         thread-open branch still fires when no surface key is set."""


### PR DESCRIPTION
## Summary

`cron_continuable_surface=in_channel` is meant to deliver a cron brief **flat** into a channel (`thread_id=None`) so a plain channel reply continues the job via the shared-channel session that `_seed_cron_channel_session` seeds. The scheduler already seeds that flat session, but it never cleared an inherited origin/target `thread_id` before routing the actual delivery — so a job scheduled from inside a Slack thread still delivered into that origin thread, and the seeded continuable session never matched where the brief actually landed.

Fix: clear `thread_id` once `in_channel_surface` is finalized (after the D6 capability fail-safe), before it's re-read for `route_thread_id` / the standalone fallback.

## Scope of the clear

The clear is gated to **exactly the target that gets flat-seeded** — the origin-continuable target on a live, in-channel-capable adapter:

```python
if in_channel_surface and mirror_this_target and runtime_adapter is not None:
    thread_id = None
```

This keeps the clear in lockstep with the seed condition (`in_channel_surface and mirror_this_target`, inside the live-adapter block) and the D6 capability fail-safe (which can only run with a live adapter):

- Fan-out / broadcast / explicit-thread targets keep their `thread_id` — they're not continuable and are never seeded.
- The standalone (no-live-adapter) path keeps the origin thread — it can never seed the flat session, and without an adapter the D6 capability check can't run, so flattening there would both drop the brief out of any continuable lane and bypass D6.

`mirror_this_target` / `origin_user_id` are computed earlier in the loop using the original `thread_id` to match the origin conversation.

## Testing

`tests/cron/test_scheduler.py::TestCronContinuableSurfaceInChannel`:
- `test_in_channel_from_origin_thread_delivers_flat_not_to_thread` — a job whose origin carries a `thread_id` must not forward it to the live adapter (`DeliveryRouter` folds `target.thread_id` into send metadata), and the seeded continuable session stays flat. Verified this FAILS without the source change (`thread_id='999.888'` leaks into send metadata).
- `test_in_channel_standalone_no_adapter_preserves_origin_thread` — with no live adapter, the standalone send falls back to the origin thread rather than flattening. Verified this FAILS against an un-scoped clear.

`scripts/run_tests.sh tests/cron/test_scheduler.py` — 219 passed.

## Considerations for reviewers (known narrow edges, intentionally not in scope here)

Flagging a few adjacent edges surfaced during review, for maintainer input on whether they warrant follow-ups:

1. **Failed live delivery → standalone fallback.** When a live send fails and the loop falls back to the standalone path, the origin thread is preserved (this PR) — but the flat continuable session also isn't seeded (seeding is live-success-only, pre-existing). So that fallback is non-continuable either way.
2. **Explicit target matching the origin thread.** An explicit `deliver` target whose resolved `(platform, chat_id, thread_id)` equals the origin's is treated as the origin-continuable target and flattened. This is consistent with opting into `in_channel`, but relies on value-equality rather than routing provenance.
3. **`deliver=origin,slack:C123` with a threaded origin.** `_resolve_delivery_targets` dedups on `(platform, chat_id, thread_id)` before delivery, so `(C123, thread)` and an explicit `(C123, None)` survive as distinct targets; flattening the origin then collapses them into two identical flat sends. A robust fix would dedup effective routes after normalization, preferring the origin-continuable representative so seeding still runs regardless of token order.

## Provenance

The underlying bug was surfaced by an AI review bot while reviewing a mirror of #56512; it originally rode along in that PR and has been split out here per reviewer feedback. Cross-ref: #56512.

---
*Drafted with AI assistance, reviewed by @vb3.*
