### PR TITLE
fix(auth): register OpenRouter in PROVIDER_REGISTRY so the desktop picker shows it

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -183,6 +183,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         client_id=DEFAULT_NOUS_CLIENT_ID,
         scope=DEFAULT_NOUS_SCOPE,
     ),
+    "openrouter": ProviderConfig(
+        id="openrouter",
+        name="OpenRouter",
+        auth_type="api_key",
+        inference_base_url=OPENROUTER_BASE_URL,
+        api_key_env_vars=("OPENROUTER_API_KEY",),
+        base_url_env_var="OPENROUTER_BASE_URL",
+    ),
     "openai-codex": ProviderConfig(
         id="openai-codex",
         name="OpenAI Codex",


### PR DESCRIPTION
## Summary
OpenRouter was never added to `PROVIDER_REGISTRY` in `hermes_cli/auth.py`. That dict is what `is_provider_explicitly_configured()` consults to gate the desktop chat picker's `explicit_only` view. `PROVIDER_REGISTRY.get("openrouter")` returned `None`, so the env-var check was skipped and the function returned `False` — dropping OpenRouter from the GUI model picker even when `OPENROUTER_API_KEY` was set.

CLI paths (`list_available_providers`) were unaffected because they read `CANONICAL_PROVIDERS` directly, which is why `hermes model` listed OpenRouter but the desktop app did not.

Fixes #65793

## Changes
Add the missing `openrouter` entry to `PROVIDER_REGISTRY`, mirroring sibling `api_key` providers (`deepseek`, `anthropic`):

```python
"openrouter": ProviderConfig(
    id="openrouter",
    name="OpenRouter",
    auth_type="api_key",
    inference_base_url=OPENROUTER_BASE_URL,
    api_key_env_vars=("OPENROUTER_API_KEY",),
    base_url_env_var="OPENROUTER_BASE_URL",
),
```

`OPENROUTER_BASE_URL` is already imported in `auth.py`.

## Verification
- `is_provider_explicitly_configured("openrouter")` returns `True` after the fix (was `False`); `nous` still `True`.
- `build_models_payload(explicit_only=True)` now includes both `nous` and `openrouter` (was just `nous`).
- `bash scripts/run_tests.sh tests/hermes_cli/test_inventory.py tests/hermes_cli/test_auth_provider_gate.py tests/hermes_cli/test_list_picker_providers.py tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_configured_builtin_models.py` -> **249 passed, 0 failed**.
- Bug confirmed present on `origin/main` (no `openrouter` key in `PROVIDER_REGISTRY` there either).
