### PR TITLE
fix(desktop): sidebar status indicators lag for background sessions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -313,10 +313,11 @@ const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
     role: 'status'
   },
   // Pulsing gray — a terminal(background=true) process is alive while the LLM
-  // is idle. Gray (not accent) reads as "something chugging along".
+  // is idle. Gray (not accent) reads as "something chugging along". Brighter
+  // than muted-foreground so it's visible against the sidebar surface.
   background: {
     ariaLabel: r => r.backgroundRunning,
-    className: `${DOT_BASE} bg-muted-foreground/50 ${PING} before:bg-muted-foreground/50 before:opacity-50`,
+    className: `${DOT_BASE} bg-muted-foreground/80 ${PING} before:bg-muted-foreground/80 before:opacity-60`,
     role: 'status',
     title: r => r.backgroundRunning
   },

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -218,17 +218,30 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         }
 
         if (sessionId && hasStatePatch) {
-          updateSessionState(sessionId, state => ({
-            ...state,
-            ...statePatch,
-            branch: statePatch.branch ?? state.branch,
-            cwd: statePatch.cwd ?? state.cwd
-          }))
+          updateSessionState(
+            sessionId,
+            state => ({
+              ...state,
+              ...statePatch,
+              branch: statePatch.branch ?? state.branch,
+              cwd: statePatch.cwd ?? state.cwd
+            }),
+            payload?.stored_session_id || undefined
+          )
         }
 
-        if (apply) {
-          if (runningChanged && sessionId) {
-            updateSessionState(sessionId, state => {
+        // The running→busy transition must reach EVERY session, not just the
+        // active one. The `apply` gate above correctly scopes view-only side
+        // effects (setCurrentModel, setCurrentCwd, etc.) to the focused chat,
+        // but the per-session busy state is what drives the sidebar working
+        // indicator — a background session's turn start/finish must update
+        // its dot without the user opening it. updateSessionState only
+        // mutates the per-runtime cache entry, and syncSessionStateToView
+        // guards the view publish to the active session, so this is safe.
+        if (runningChanged && sessionId) {
+          updateSessionState(
+            sessionId,
+            state => {
               const busy = Boolean(payload!.running)
 
               if (state.busy === busy && (busy || !state.awaitingResponse)) {
@@ -255,8 +268,9 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
                 streamId: null,
                 turnStartedAt: null
               }
-            })
-          }
+            },
+            payload?.stored_session_id || undefined
+          )
         }
 
         if (payload?.usage && (!explicitSid || isActiveEvent)) {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -79,6 +79,10 @@ export type GatewayEventPayload = {
   // session.title (live auto-title push) — stored session id + generated title
   session_id?: string
   title?: string
+  // session.info — the stored (durable) session id for this runtime session.
+  // Lets the desktop app map runtime→stored for background sessions it hasn't
+  // opened, so the sidebar working indicator updates without opening the chat.
+  stored_session_id?: string
   // moa.reference / moa.aggregating (Mixture of Agents per-model relay)
   label?: string
   index?: number

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3429,6 +3429,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "personality": str(personality or ""),
         "running": bool((session or {}).get("running")),
         "title": _session_live_title(session or {}, session_key) if session_key else "",
+        "stored_session_id": session_key or "",
         "desktop_contract": DESKTOP_BACKEND_CONTRACT,
         "version": "",
         "release_date": "",


### PR DESCRIPTION
## What does this PR do?

Fixes the sidebar status indicators (working dot) not updating for background sessions until the user opens them.

## The Problem

The desktop sidebar's working indicator (`$workingSessionIds`) is keyed by **stored session id** — the durable id in the SessionDB that survives process restarts and is what the sidebar session list is built from at boot.

But gateway events arrive keyed by **runtime session id** — the ephemeral id the gateway assigns to each live agent process. The event envelope carries `event.session_id` (runtime id), but until now `session.info` had no stored id in its payload.

For a session the user has **opened**, this is fine: the frontend learned the runtime→stored mapping when it created/resumed the session via `prompt.submit`, so the per-runtime cache entry already has `storedSessionId` populated. `setSessionWorking(storedId, busy)` gets a real id and the dot lights up.

For a **background session the user has never opened**, the first `session.info` event arrives with just the runtime id in the envelope and no way to connect it to any stored id in the sidebar list. The old code called `updateSessionState(runtimeId, updater)` with no stored id. This flows into `ensureSessionState(runtimeId, undefined)` → `createClientSessionState(null)` → `storedSessionId: null` → `setSessionWorking(null, true)` — which is a **no-op** because `setSessionWorking` returns early when `sessionId` is null/falsy (`session.ts:557`). The sidebar dot stays dead until the user opens the chat.

The sidebar already had the stored id (from the boot `/api/sessions` fetch), and the event already had the runtime id (in the envelope) — there was just no bridge connecting the two id spaces for sessions the user hadn't opened themselves.

## Root Cause: Two Coupled Issues

1. **Backend:** The gateway's `session.info` event payload omitted `stored_session_id`. The desktop app needs this to map a background session's runtime id → stored id, because `$workingSessionIds` (the atom driving the sidebar dot) is keyed by stored id. Without it, `setSessionWorking(null, ...)` was a no-op — the atom never updated for sessions the user hadn't opened.

2. **Frontend:** The `running` → `busy` transition in the `session.info` handler was gated on `apply` (active session only). The `apply` gate correctly scopes view-only side effects (`setCurrentModel`, `setCurrentCwd`, etc.) to the focused chat, but the per-session `busy` state drives the sidebar working indicator and must reach every session. `updateSessionState` only mutates the per-runtime cache entry, and `syncSessionStateToView` already guards the view publish to the active session, so ungating is safe.

## Changes Made

- `tui_gateway/server.py:3432` — added `"stored_session_id": session_key or ""` to `_session_info()` payload
- `apps/desktop/src/lib/chat-messages.ts:82-86` — added `stored_session_id?: string` to `GatewayEventPayload`
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts:221-272` — pass `payload?.stored_session_id` to both `updateSessionState` calls in the `session.info` handler; removed the `apply` gate around the `runningChanged` block so the busy transition reaches all sessions
- `apps/desktop/src/app/chat/sidebar/session-row.tsx` — brighten the `background` dot variant (muted-foreground/50 → /80) so it's visible against the sidebar surface

## How to Test

1. Start a turn in session A (active in the sidebar)
2. Switch to session B without waiting for A to finish
3. The sidebar dot for A should show "working" (accent pulse) while the turn runs, then clear when it finishes — without opening A again

Before the fix, A's dot stayed idle until you opened it, then suddenly showed active.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS Linux

### Documentation & Housekeeping

- [x] N/A — I've updated relevant documentation
- [x] N/A — I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] N/A — I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows
- [x] N/A — I've considered cross-platform impact (Windows, macOS)
- [x] N/A — I've updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

N/A
