### PR TITLE
fix(cron): only install the profile secret scope when multiplexing is on (#65773)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3663,22 +3663,40 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # becomes running only immediately before the actual run.
         mark_execution_running(execution_id)
 
-        # Run the job under the profile's secret scope. get_secret() fails
-        # closed outside a scope once profile isolation is in play (multiple
-        # gateway profiles / room→profile multiplexing), and cron fires from
-        # the ticker thread where no per-turn scope is installed — so
-        # resolve_runtime_provider() raised UnscopedSecretError before model
-        # selection, breaking every cron job. Mirrors the per-turn pattern in
-        # gateway/run.py (_profile_runtime_scope).
+        # Run the job under the profile's secret scope, but ONLY when
+        # multiplexing is on. get_secret() fails closed outside a scope once
+        # profile isolation is in play (multiple gateway profiles →
+        # room→profile multiplexing), and cron fires from the ticker thread
+        # where no per-turn scope is installed — so resolve_runtime_provider()
+        # raised UnscopedSecretError before model selection, breaking every
+        # cron job (#60726).
+        #
+        # The multiplex guard mirrors the per-turn pattern in gateway/run.py
+        # (_profile_runtime_scope), which installs a scope only when
+        # multiplex_profiles is on. Installing it unconditionally is not merely
+        # redundant on a single-profile deployment — it is harmful:
+        # build_profile_secret_scope() returns ONLY <home>/.env, and an
+        # installed scope is authoritative (get_secret does NOT fall through to
+        # os.environ). Credentials injected via the process environment
+        # (container env vars, systemd Environment=) therefore became invisible
+        # to cron while interactive turns on the same deployment resolved them
+        # fine, and the provider call went out with a placeholder key → HTTP
+        # 401 (#65773). Outside multiplex, skipping the scope restores the
+        # os.environ read that every interactive path already does; <home>/.env
+        # is loaded into os.environ by load_hermes_dotenv() above, so .env-based
+        # credentials keep resolving with the same precedence.
         from agent.secret_scope import (
             build_profile_secret_scope,
+            is_multiplex_active,
             reset_secret_scope,
             set_secret_scope,
         )
 
-        _scope_token = set_secret_scope(
-            build_profile_secret_scope(_get_hermes_home())
-        )
+        _scope_token = None
+        if is_multiplex_active():
+            _scope_token = set_secret_scope(
+                build_profile_secret_scope(_get_hermes_home())
+            )
         # Defer the cron agent's async-resource teardown until AFTER delivery.
         # run_job normally closes the agent (and reaps stale async clients) in
         # its finally block; doing that before _deliver_result runs means the
@@ -3701,7 +3719,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                 _teardown_cron_agent(_deferred_agent, job["id"])
             raise
         finally:
-            reset_secret_scope(_scope_token)
+            if _scope_token is not None:
+                reset_secret_scope(_scope_token)
 
         # Everything from here through delivery runs with the agent still live
         # (deferred teardown). Wrap it ALL in a try/finally so that if any step

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -312,8 +312,15 @@ def test_run_one_job_skips_secret_scope_without_multiplex(monkeypatch, tmp_path)
     monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
     monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
 
+    # set_multiplex_active writes a module-level global (deployment mode, not a
+    # per-task value), so restore whatever was there rather than assuming the
+    # default — a leak here would silently change every test that runs after.
+    _prev_multiplex = ss.is_multiplex_active()
     ss.set_multiplex_active(False)
-    ok = s.run_one_job({"id": "j8", "name": "t"})
+    try:
+        ok = s.run_one_job({"id": "j8", "name": "t"})
+    finally:
+        ss.set_multiplex_active(_prev_multiplex)
 
     assert ok is True
     # The user-facing symptom first: under the unconditional scope this was
@@ -340,6 +347,7 @@ def test_run_one_job_env_scope_restored_after_run_without_multiplex(monkeypatch,
     monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
     monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
 
+    _prev_multiplex = ss.is_multiplex_active()
     ss.set_multiplex_active(False)
     sentinel = {"AMBIENT": "outer"}
     token = ss.set_secret_scope(sentinel)
@@ -350,3 +358,4 @@ def test_run_one_job_env_scope_restored_after_run_without_multiplex(monkeypatch,
         assert ss.current_secret_scope() is sentinel
     finally:
         ss.reset_secret_scope(token)
+        ss.set_multiplex_active(_prev_multiplex)

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -274,3 +274,79 @@ def test_run_one_job_tears_down_deferred_agent_when_save_raises(monkeypatch):
     assert ok is False
     assert "deliver" not in order
     assert order == ["save-raise", "agent.close", "cleanup_stale"], order
+
+
+def test_run_one_job_skips_secret_scope_without_multiplex(monkeypatch, tmp_path):
+    """Regression (#65773): on a single-profile deployment (multiplex OFF),
+    run_one_job must NOT install a profile secret scope.
+
+    build_profile_secret_scope() returns ONLY <home>/.env, and an installed
+    scope is authoritative — get_secret() does not fall through to os.environ.
+    So installing it unconditionally hid credentials injected via the process
+    environment (container env vars / systemd Environment=), and the provider
+    call went out with a placeholder key -> HTTP 401, while interactive turns
+    on the same deployment resolved the key fine.
+
+    Contract: multiplex OFF -> no scope during run_job, and an env-injected
+    secret resolves through os.environ.
+    """
+    from agent import secret_scope as ss
+
+    # Profile .env exists but does NOT carry the provider key — it is injected
+    # into the process environment instead, exactly like the reported
+    # deployment (Kubernetes secretKeyRef).
+    (tmp_path / ".env").write_text("SOME_OTHER_KEY=unrelated\n")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("DEEPINFRA_API_KEY", "env-injected-key")
+
+    observed = {}
+
+    def fake_run_job(job, *, defer_agent_teardown=None):
+        # Where resolve_runtime_provider() reads the provider credential.
+        observed["scope"] = ss.current_secret_scope()
+        observed["key"] = ss.get_secret("DEEPINFRA_API_KEY")
+        return (True, "out", "final", None)
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+
+    ss.set_multiplex_active(False)
+    ok = s.run_one_job({"id": "j8", "name": "t"})
+
+    assert ok is True
+    # The user-facing symptom first: under the unconditional scope this was
+    # None (the key is absent from .env), which resolved to the
+    # "no-key-required" placeholder and the provider returned HTTP 401.
+    assert observed["key"] == "env-injected-key"
+    # The mechanism: no scope installed -> get_secret reads os.environ.
+    assert observed["scope"] is None
+
+
+def test_run_one_job_env_scope_restored_after_run_without_multiplex(monkeypatch, tmp_path):
+    """The no-scope path must leave the ambient scope untouched on the way out.
+
+    Guards the `if _scope_token is not None` teardown: passing a None token to
+    reset_secret_scope() would raise, and an unbalanced reset would clobber a
+    scope this call never installed.
+    """
+    from agent import secret_scope as ss
+
+    (tmp_path / ".env").write_text("")
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(s, "run_job", lambda job, **kw: (True, "out", "final", None))
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+
+    ss.set_multiplex_active(False)
+    sentinel = {"AMBIENT": "outer"}
+    token = ss.set_secret_scope(sentinel)
+    try:
+        ok = s.run_one_job({"id": "j9", "name": "t"})
+        assert ok is True
+        # The ambient scope survived — run_one_job neither installed nor reset one.
+        assert ss.current_secret_scope() is sentinel
+    finally:
+        ss.reset_secret_scope(token)


### PR DESCRIPTION
## What does this PR do?

`run_one_job` wraps `run_job` in `set_secret_scope(build_profile_secret_scope(<home>))` **unconditionally**. Every interactive path in `gateway/run.py` installs that scope **only when `multiplex_profiles` is on** (`if not ...multiplex_profiles: return await self._run_agent_inner(...)`, e.g. L17228, L10830, L12467). The cron path had no such guard.

On a single-profile deployment whose credentials arrive via the **process environment** (container env vars, systemd `Environment=`) rather than `<home>/.env`, that asymmetry breaks cron:

- `build_profile_secret_scope()` returns **only** the parsed `.env`.
- An installed scope is **authoritative** — `get_secret()` deliberately does *not* fall through to `os.environ` (it can't, in a multiplexer: `os.environ` may hold another profile's value).
- So a scoped read of a provider key that lives only in the environment returns the default → the resolver ships `Authorization: Bearer no-key-required` → provider returns **HTTP 401**.

Interactive turns on the very same deployment resolve the key fine, because they skip the scope entirely. This fixes the asymmetry by mirroring the interactive guard.

### Why this is safe for `.env`-based deployments

This was the part worth checking, since dropping a scope could plausibly hide `.env` credentials. It can't:

`run_one_job` already calls `load_hermes_dotenv(hermes_home=_get_hermes_home())` (`cron/scheduler.py` ~L2917), which loads `<home>/.env` into `os.environ` with `override=True`. So with no scope installed, `get_secret()` reads an `os.environ` that contains env-injected values **plus** `.env` layered over them — at the same precedence the scope applied (`.env` wins). Case by case:

| credential source | with scope (before) | no scope (after) |
|---|---|---|
| in `.env` | `.env` value | `.env` value (override=True) — same |
| env-injected only | **default → 401** | env value — **fixed** |
| neither | default | default — same |

Dropping the scope is a strict superset of what it resolved: it can only make previously-invisible credentials visible, never the reverse.

### Why multiplex-ON is unaffected

`is_multiplex_active()` is a process-global set at gateway startup (`gateway/run.py` L2841), and cron runs on a thread pool **inside** that process — so the flag is visible to the scheduler. With multiplex on, the scope is still installed, so `get_secret()` neither fails closed with `UnscopedSecretError` (#60726) nor leaks a cross-profile value. The existing regression test for that case (`test_run_one_job_installs_secret_scope_under_multiplex`) passes untouched.

For the non-gateway entrypoints (standalone `__main__`, `hermes cron` tick, desktop scheduler) the flag is never set, so this takes the no-scope path — correct there, since only one home's `.env` is loaded into that process and there is no second profile to leak.

## Related Issue

Fixes #65773

Regression from #60726 (closed), which correctly added the cron scope wrapper for the multiplex-ON case but without the guard the interactive paths carry.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` — guard the scope install with `is_multiplex_active()`; make the teardown conditional (`if _scope_token is not None`). Comment explains why the unconditional install is harmful rather than merely redundant.
- `tests/cron/test_run_one_job.py` — two tests: multiplex-OFF installs no scope and an env-injected secret resolves; and the no-scope path leaves an ambient scope untouched (guards the conditional teardown).

## How to Test

```bash
pytest tests/cron/ -q                                     # 695 passed
pytest tests/agent/test_secret_scope.py \
       tests/gateway/test_multiplex_credential_isolation.py -q   # 23 passed
ruff check cron/scheduler.py tests/cron/test_run_one_job.py      # clean
```

The new tests are genuine regressions — reverting to the unconditional scope fails with the reported symptom, the credential invisible:

```
>       assert observed["key"] == "env-injected-key"
E       AssertionError: assert None == 'env-injected-key'
```

That `None` is what became `Bearer no-key-required` → HTTP 401.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no open PR references #65773 or touches this scope install
- [x] My PR contains **only** changes related to this fix
- [x] I've run the suite and all tests pass
- [x] I've added tests for my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)