### PR TITLE
fix(cron): preserve env credentials outside multiplex mode

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3599,13 +3599,16 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # gateway/run.py (_profile_runtime_scope).
         from agent.secret_scope import (
             build_profile_secret_scope,
+            is_multiplex_active,
             reset_secret_scope,
             set_secret_scope,
         )
 
-        _scope_token = set_secret_scope(
-            build_profile_secret_scope(_get_hermes_home())
-        )
+        _scope_token = None
+        if is_multiplex_active():
+            _scope_token = set_secret_scope(
+                build_profile_secret_scope(_get_hermes_home())
+            )
         # Defer the cron agent's async-resource teardown until AFTER delivery.
         # run_job normally closes the agent (and reaps stale async clients) in
         # its finally block; doing that before _deliver_result runs means the
@@ -3628,7 +3631,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                 _teardown_cron_agent(_deferred_agent, job["id"])
             raise
         finally:
-            reset_secret_scope(_scope_token)
+            if _scope_token is not None:
+                reset_secret_scope(_scope_token)
 
         # Everything from here through delivery runs with the agent still live
         # (deferred teardown). Wrap it ALL in a try/finally so that if any step

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -162,6 +162,37 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     assert ss.current_secret_scope() is None
 
 
+def test_run_one_job_preserves_env_credentials_without_multiplex(monkeypatch, tmp_path):
+    """Single-profile cron must retain process-environment credentials."""
+    from agent import secret_scope as ss
+
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("DEEPINFRA_API_KEY", "test-env-credential")
+    observed = {}
+
+    def fake_run_job(job, *, defer_agent_teardown=None):
+        observed["scope"] = ss.current_secret_scope()
+        observed["credential"] = ss.get_secret("DEEPINFRA_API_KEY")
+        return (True, "out", "final", None)
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+
+    prior_multiplex = ss.is_multiplex_active()
+    ss.set_multiplex_active(False)
+    try:
+        ok = s.run_one_job({"id": "j-env", "name": "t"})
+    finally:
+        ss.set_multiplex_active(prior_multiplex)
+
+    assert ok is True
+    assert observed["scope"] is None
+    assert observed["credential"] == "test-env-credential"
+    assert ss.current_secret_scope() is None
+
+
 def test_run_one_job_delivers_before_agent_teardown(monkeypatch):
     """Regression for #58720: the cron agent's async-resource teardown
     (agent.close + cleanup_stale_async_clients) MUST run AFTER delivery, not


### PR DESCRIPTION
## Summary

- install the cron profile secret scope only when profile multiplexing is active
- preserve process-environment provider credentials for single-profile cron jobs
- add regression coverage for both multiplex and non-multiplex behavior

## Root cause

`run_one_job()` unconditionally installed a profile-local secret mapping built from `<home>/.env`. In single-profile deployments, that authoritative mapping shadowed credentials injected through the process environment, unlike interactive gateway paths that skip profile scoping when multiplexing is disabled.

## Testing

- `scripts/run_tests.sh tests/cron -q` (695 passed)
- `.venv/bin/ruff check .`
- `git diff --check`

Tested on macOS arm64 with Python 3.11.

Fixes #65773