### PR TITLE
fix(agent): steer background review to permitted tools

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -830,7 +830,10 @@ def _run_review_in_thread(
                 review_whitelist,
                 deny_msg_fmt=(
                     "Background review denied non-whitelisted tool: "
-                    "{tool_name}. Only memory/skill tools are allowed."
+                    "{tool_name}. Use skills_list to find skills, "
+                    "skill_view(name) to read SKILL.md before editing, and "
+                    "skill_manage(action='patch', ...) to change it. Use "
+                    "memory for notes only when it is allowed."
                 ),
             )
             try:

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -134,6 +134,20 @@ def test_background_review_installs_thread_local_whitelist():
     assert "web_search" not in whitelist
     assert "execute_code" not in whitelist
 
+    _plugins.set_thread_tool_whitelist(
+        whitelist,
+        deny_msg_fmt=captured["deny_msg_fmt"],
+    )
+    try:
+        deny_msg = _plugins.get_pre_tool_call_block_message("read_file", {})
+    finally:
+        _plugins.clear_thread_tool_whitelist()
+
+    assert "read_file" in deny_msg
+    assert "skill_view" in deny_msg
+    assert "skill_manage(action='patch'" in deny_msg
+    assert "memory" in deny_msg
+
 
 def test_background_review_agent_tools_are_limited():
     """Verify the resolved memory+skills toolsets only contain memory and skill tools.


### PR DESCRIPTION
## Summary

- preserve the background review fork's parent tool schemas for prompt-cache byte parity
- make denied file-tool results name the permitted `skills_list`, `skill_view`, and `skill_manage` path
- cover the model-visible `read_file` denial through the real thread-local dispatch gate

## Root cause

The review fork intentionally advertises the parent agent's full tool schema, but runtime dispatch only permits memory and skill tools. The denial result previously said only that memory/skill tools were allowed, so it did not redirect models from `read_file` or `patch` to the APIs that satisfy the skill manager's read-before-write guard.

## Testing

- `uv run --extra dev pytest tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cost_controls.py tests/run_agent/test_background_review_cache_parity.py tests/run_agent/test_background_review_summary.py tests/run_agent/test_background_review_toolset_restriction.py tests/test_background_review_session_isolation.py tests/test_background_review_list_shapes.py tests/hermes_cli/test_plugins.py::TestThreadToolWhitelist -q`
- `uv run --extra dev ruff check agent/background_review.py tests/run_agent/test_background_review_toolset_restriction.py`
- `uv run --extra dev python -m py_compile agent/background_review.py tests/run_agent/test_background_review_toolset_restriction.py`

Tested on macOS.

## Alternative considered

Narrowing the fork's advertised schemas would eliminate invalid calls earlier, but it would break the intentional byte parity with the parent request and lose prompt-cache reuse. This change keeps parity and improves self-correction at the dispatch boundary.

Fixes #61521