### PR TITLE
fix(plugins): secure standalone model-provider lifecycle

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -27,6 +27,7 @@ import sys
 import tempfile
 import threading
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple, Set
@@ -6911,6 +6912,44 @@ def read_raw_config() -> Dict[str, Any]:
             data = {}
         _RAW_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], copy.deepcopy(data))
         return data
+
+
+def read_raw_config_strict() -> Dict[str, Any]:
+    """Read the raw config without defaults or fail-open recovery.
+
+    An absent config is the one valid empty-config case. Existing files must
+    be readable, valid YAML mappings; I/O, parse, and shape errors propagate
+    to callers that need to fail closed before loading or publishing code.
+    """
+    config_path = get_config_path()
+    with _CONFIG_LOCK:
+        try:
+            config_path.lstat()
+        except FileNotFoundError:
+            return {}
+
+        with open(config_path, encoding="utf-8") as f:
+            data = fast_safe_load(f)
+
+    if not isinstance(data, Mapping):
+        raise ValueError(f"Config at {config_path} must contain a YAML mapping")
+    return dict(data)
+
+
+def read_plugin_activation_config_strict() -> tuple[Dict[str, Any], dict, set[str], set[str]]:
+    """Return validated raw plugin activation state without fail-open defaults."""
+    config = read_raw_config_strict()
+    plugins = config.setdefault("plugins", {})
+    if not isinstance(plugins, dict):
+        raise ValueError("config plugins section must be a mapping")
+
+    values: list[set[str]] = []
+    for field in ("enabled", "disabled"):
+        raw = plugins.get(field, [])
+        if not isinstance(raw, list) or any(not isinstance(item, str) for item in raw):
+            raise ValueError(f"config plugins.{field} must be a list of strings")
+        values.append(set(raw))
+    return config, plugins, values[0], values[1]
 
 
 def require_readable_config_before_write(config_path: Optional[Path] = None) -> None:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -136,6 +136,23 @@ def _sanitize_plugin_name(
     return target
 
 
+def _reject_symlink_components(root: Path, path: Path) -> None:
+    """Reject symlinks below *root* before mutating an inventory path."""
+    root = Path(os.path.abspath(root))
+    path = Path(os.path.abspath(path))
+    try:
+        relative = path.relative_to(root)
+    except ValueError as exc:
+        raise PluginOperationError("Plugin path escapes the plugins directory.") from exc
+    current = root
+    for component in relative.parts:
+        current /= component
+        if current.is_symlink():
+            raise PluginOperationError(
+                f"Refusing to mutate plugin path with symlink component: {current}"
+            )
+
+
 _GITHUB_BROWSER_SEGMENTS = {
     "actions",
     "blob",
@@ -428,25 +445,12 @@ def _display_removed(name: str, plugins_dir: Path) -> None:
     console.print()
 
 
-def _require_installed_plugin(name: str, plugins_dir: Path, console) -> Path:
-    """Return the plugin path if it exists, or exit with an error listing installed plugins."""
-    target = _sanitize_plugin_name(name, plugins_dir, allow_subdir=True)
-    if not target.exists():
-        installed = ", ".join(d.name for d in plugins_dir.iterdir() if d.is_dir()) or "(none)"
-        console.print(
-            f"[red]Error:[/red] Plugin '{name}' not found in {plugins_dir}.\n"
-            f"Installed plugins: {installed}"
-        )
-        sys.exit(1)
-    return target
-
-
-# ---------------------------------------------------------------------------
-# Commands
-# ---------------------------------------------------------------------------
-
-
-def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, str]:
+def _install_plugin_core(
+    identifier: str,
+    *,
+    force: bool,
+    enabled: bool = False,
+) -> tuple[Path, dict, str]:
     """Clone Git plugin into ``~/.hermes/plugins``.
 
     Returns ``(target_dir, installed_manifest, canonical_name)``.
@@ -461,7 +465,9 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
 
     plugins_dir = _plugins_dir()
 
-    with tempfile.TemporaryDirectory() as tmp:
+    # Hidden staging below the plugins root remains outside passive discovery
+    # and guarantees that publication stays on one filesystem.
+    with tempfile.TemporaryDirectory(prefix=".install-", dir=plugins_dir) as tmp:
         tmp_clone = Path(tmp) / "plugin"
 
         git_exe = _resolve_git_executable()
@@ -499,8 +505,19 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
             subdir.rstrip("/").rsplit("/", 1)[-1] if subdir else _repo_name_from_url(git_url)
         )
 
+        kind = manifest.get("kind")
+        canonical_name = (
+            f"model-providers/{plugin_name}"
+            if kind == "model-provider"
+            else plugin_name
+        )
+        _reject_symlink_components(plugins_dir, plugins_dir / canonical_name)
         try:
-            target = _sanitize_plugin_name(plugin_name, plugins_dir)
+            target = _sanitize_plugin_name(
+                canonical_name,
+                plugins_dir,
+                allow_subdir=kind == "model-provider",
+            )
         except ValueError as e:
             raise PluginOperationError(str(e)) from e
 
@@ -522,15 +539,31 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
                     f"Run {recommended_update_command()} to update Hermes.",
                 ) from None
 
-        if target.exists():
-            if not force:
-                raise PluginOperationError(
-                    f"Plugin '{plugin_name}' already exists. Use force reinstall "
-                    f"or run `hermes plugins update {plugin_name}`.",
-                )
-            shutil.rmtree(target)
+        if target.exists() and not force:
+            raise PluginOperationError(
+                f"Plugin '{plugin_name}' already exists. Use force reinstall "
+                f"or run `hermes plugins update {canonical_name}`.",
+            )
 
-        shutil.move(str(tmp_target), str(target))
+        staged = tmp_target
+        identities = {plugin_name, target.name, canonical_name}
+        if kind == "model-provider":
+            _write_plugin_activation(canonical_name, identities, False)
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        backup: Path | None = None
+        if target.exists():
+            backup = Path(tmp) / "previous"
+            target.rename(backup)
+        try:
+            os.replace(staged, target)
+        except Exception:
+            if backup is not None and not target.exists():
+                backup.rename(target)
+            raise
+
+        if kind == "model-provider" and enabled:
+            _write_plugin_activation(canonical_name, identities, True)
 
     has_yaml = (target / "plugin.yaml").exists() or (target / "plugin.yml").exists()
     if not has_yaml and not (target / "__init__.py").exists():
@@ -544,7 +577,12 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
     _copy_example_files(target, Console())
     installed_manifest = _read_manifest(target)
     installed_name = installed_manifest.get("name") or target.name
-    return target, installed_manifest, installed_name
+    installed_key = (
+        f"model-providers/{target.name}"
+        if installed_manifest.get("kind") == "model-provider"
+        else installed_name
+    )
+    return target, installed_manifest, installed_key
 
 
 def cmd_install(
@@ -578,10 +616,22 @@ def cmd_install(
     else:
         console.print(f"[dim]Cloning {git_url}...[/dim]")
 
+    should_enable = enable
+    if should_enable is None:
+        if sys.stdin.isatty() and sys.stdout.isatty():
+            try:
+                answer = input(f"  Enable '{identifier}' now? [y/N]: ").strip().lower()
+                should_enable = answer in {"y", "yes"}
+            except (EOFError, KeyboardInterrupt):
+                should_enable = False
+        else:
+            should_enable = False
+
     try:
         target, installed_manifest, installed_name = _install_plugin_core(
             identifier,
             force=force,
+            enabled=bool(should_enable),
         )
     except PluginOperationError as e:
         console.print(f"[red]Error:[/red] {e}")
@@ -599,26 +649,14 @@ def cmd_install(
 
     _display_after_install(target, identifier)
 
-    should_enable = enable
-    if should_enable is None:
-        if sys.stdin.isatty() and sys.stdout.isatty():
-            try:
-                answer = input(
-                    f"  Enable '{installed_name}' now? [y/N]: ",
-                ).strip().lower()
-                should_enable = answer in {"y", "yes"}
-            except (EOFError, KeyboardInterrupt):
-                should_enable = False
-        else:
-            should_enable = False
+    if installed_manifest.get("kind") != "model-provider" and should_enable:
+        _write_legacy_plugin_activation(
+            installed_name,
+            {installed_name, target.name},
+            True,
+        )
 
     if should_enable:
-        enabled = _get_enabled_set()
-        disabled = _get_disabled_set()
-        enabled.add(installed_name)
-        disabled.discard(installed_name)
-        _save_enabled_set(enabled)
-        _save_disabled_set(disabled)
         console.print(
             f"[green]✓[/green] Plugin [bold]{installed_name}[/bold] enabled.",
         )
@@ -634,61 +672,38 @@ def cmd_install(
 
 
 def cmd_update(name: str) -> None:
-    """Update an installed plugin by pulling latest from its git remote."""
+    """Update an installed Git plugin through the shared lifecycle."""
     from rich.console import Console
 
     console = Console()
-    plugins_dir = _plugins_dir()
-
-    try:
-        target = _require_installed_plugin(name, plugins_dir, console)
-    except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
-        sys.exit(1)
-
-    if not (target / ".git").exists():
-        console.print(
-            f"[red]Error:[/red] Plugin '{name}' was not installed from git "
-            f"(no .git directory). Cannot update."
-        )
-        sys.exit(1)
-
     console.print(f"[dim]Updating {name}...[/dim]")
-
-    ok, output = _git_pull_plugin_dir(target)
-    if not ok:
-        console.print(f"[red]Error:[/red] {output}")
+    result = dashboard_update_user_plugin(name)
+    if not result["ok"]:
+        console.print(f"[red]Error:[/red] {result['error']}")
         sys.exit(1)
 
-    # Copy any new .example files
-    _copy_example_files(target, console)
-
-    out = output.strip()
-    if "Already up to date" in out:
+    out = result.get("output", "").strip()
+    if result.get("unchanged"):
         console.print(
             f"[green]✓[/green] Plugin [bold]{name}[/bold] is already up to date."
         )
     else:
         console.print(f"[green]✓[/green] Plugin [bold]{name}[/bold] updated.")
-        console.print(f"[dim]{out}[/dim]")
+        if out:
+            console.print(f"[dim]{out}[/dim]")
 
 
 def cmd_remove(name: str) -> None:
-    """Remove an installed plugin by name."""
+    """Remove an installed plugin through the shared lifecycle."""
     from rich.console import Console
 
     console = Console()
     plugins_dir = _plugins_dir()
-
-    try:
-        target = _require_installed_plugin(name, plugins_dir, console)
-    except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+    result = dashboard_remove_user_plugin(name)
+    if not result["ok"]:
+        console.print(f"[red]Error:[/red] {result['error']}")
         sys.exit(1)
-
-    shutil.rmtree(target)
-    _display_removed(name, plugins_dir)
-
+    _display_removed(result["name"], plugins_dir)
 
 def _get_disabled_set() -> set:
     """Read the disabled plugins set from config.yaml.
@@ -711,7 +726,10 @@ def _save_disabled_set(disabled: set) -> None:
     config = load_config()
     if "plugins" not in config:
         config["plugins"] = {}
-    config["plugins"]["disabled"] = sorted(disabled)
+    plugins = config["plugins"]
+    if not isinstance(plugins, dict):
+        return
+    plugins["disabled"] = sorted(disabled)
     save_config(config)
 
 
@@ -739,56 +757,156 @@ def _save_enabled_set(enabled: set) -> None:
     config = load_config()
     if "plugins" not in config:
         config["plugins"] = {}
-    config["plugins"]["enabled"] = sorted(enabled)
+    plugins = config["plugins"]
+    if not isinstance(plugins, dict):
+        return
+    plugins["enabled"] = sorted(enabled)
     save_config(config)
 
 
-def _resolve_plugin_key(name: str) -> Optional[str]:
-    """Resolve a user-supplied plugin identifier to its canonical registry key.
+def _write_legacy_plugin_activation(
+    key: str, aliases: set[str], enabled: Optional[bool]
+) -> None:
+    """Preserve the pre-existing two-write lifecycle for non-provider plugins."""
+    aliases = set(aliases) | {key}
+    allow = _get_enabled_set() - aliases
+    deny = _get_disabled_set() - aliases
+    if enabled is not None:
+        (allow if enabled else deny).add(key)
+    _save_enabled_set(allow)
+    _save_disabled_set(deny)
 
-    Accepts either the bare manifest name (``nemo_relay``), the directory
-    name, or the full path-derived key (``observability/nemo_relay``) and
-    returns the canonical key the loader gates on (``manifest.key`` or, for a
-    flat plugin, the bare name). Returns ``None`` when no plugin matches.
 
-    This is the single normalization point so ``hermes plugins enable`` /
-    ``disable`` write the same key that ``PluginManager`` matches against —
-    nested category plugins (e.g. ``observability/nemo_relay``) included.
-    """
+def _plugin_aliases(entry: tuple) -> set[str]:
+    """Return every supported activation spelling for an inventory entry."""
+    name, _version, _description, _source, _path, key = entry
+    return {name, key, key.split("/")[-1]}
+
+
+def _resolve_plugin_entry(name: str) -> Optional[tuple]:
+    """Resolve a canonical key, manifest name, leaf name, source, or path."""
     entries = _discover_all_plugins()
-    # 1. Exact match on canonical key or manifest name — always unambiguous.
-    for entry in entries:
-        # entry = (name, version, description, source, dir_path, key)
-        if name == entry[5] or name == entry[0]:
-            return entry[5]
-    # 2. Fall back to a bare leaf-name match (e.g. "nemo_relay" ->
-    #    "observability/nemo_relay"), but only when it resolves to exactly one
-    #    plugin so we never silently pick the wrong same-named nested plugin.
-    leaf_matches = [entry[5] for entry in entries if name == entry[5].split("/")[-1]]
-    if len(leaf_matches) == 1:
-        return leaf_matches[0]
-    return None
-
-
-def _resolve_plugin_key_and_source(name: str) -> Optional[tuple]:
-    """Resolve *name* to ``(canonical_key, source)`` or ``None`` if no match.
-
-    Mirrors :func:`_resolve_plugin_key`'s normalization but also returns the
-    plugin's source (``"bundled"``, ``"user"``, ``"project"``, ...) so the
-    enable path can tell whether a built-in-override consent prompt is needed.
-    """
-    entries = _discover_all_plugins()
-    for entry in entries:
-        # entry = (name, version, description, source, dir_path, key)
-        if name == entry[5] or name == entry[0]:
-            return (entry[5], entry[3])
-    leaf_matches = [
-        (entry[5], entry[3]) for entry in entries
-        if name == entry[5].split("/")[-1]
+    exact = [
+        entry
+        for entry in entries
+        if name in {entry[0], str(entry[4]), entry[5]}
     ]
-    if len(leaf_matches) == 1:
-        return leaf_matches[0]
-    return None
+    if len(exact) == 1:
+        return exact[0]
+    leaf = [entry for entry in entries if name == entry[5].split("/")[-1]]
+    return leaf[0] if len(leaf) == 1 else None
+
+
+def _resolve_plugin_key(name: str) -> Optional[str]:
+    """Resolve any supported plugin identifier to its canonical key."""
+    entry = _resolve_plugin_entry(name)
+    return entry[5] if entry is not None else None
+
+
+def _strict_activation_state() -> tuple[dict, dict, set[str], set[str]]:
+    """Load validated raw activation state without fail-open recovery."""
+    try:
+        from hermes_cli.config import read_plugin_activation_config_strict
+
+        return read_plugin_activation_config_strict()
+    except Exception as exc:
+        raise PluginOperationError(f"Could not parse plugin activation config: {exc}") from exc
+
+
+def _persist_plugin_activation(
+    config: dict,
+    plugins: dict,
+    allow: set[str],
+    deny: set[str],
+    *,
+    action: str,
+) -> None:
+    """Save both activation sets once and verify the exact persisted state."""
+    plugins["enabled"] = sorted(allow)
+    plugins["disabled"] = sorted(deny)
+    try:
+        from hermes_cli.config import save_config
+
+        save_config(config)
+        _verified, _plugins, actual_allow, actual_deny = _strict_activation_state()
+    except PluginOperationError:
+        raise
+    except Exception as exc:
+        raise PluginOperationError(
+            f"Could not persist plugin {action}: {exc}"
+        ) from exc
+    if actual_allow != allow or actual_deny != deny:
+        raise PluginOperationError(
+            f"Plugin {action} could not be persisted or verified "
+            "(managed config may be read-only)."
+        )
+
+
+def _write_plugin_activation(key: str, aliases: set[str], enabled: bool) -> None:
+    """Atomically persist one canonical activation decision and verify it."""
+    config, plugins, allow, deny = _strict_activation_state()
+    aliases = set(aliases) | {key}
+    allow.difference_update(aliases)
+    deny.difference_update(aliases)
+    (allow if enabled else deny).add(key)
+    _persist_plugin_activation(
+        config, plugins, allow, deny, action="activation"
+    )
+
+
+def _write_plugin_selection(keys: list[str], selected: set[str]) -> None:
+    """Persist model-provider choices strictly and generic choices compatibly."""
+    model_keys = [key for key in keys if key.startswith("model-providers/")]
+    if model_keys:
+        config, plugins, allow, deny = _strict_activation_state()
+        for key in model_keys:
+            entry = _resolve_plugin_entry(key)
+            aliases = (
+                _plugin_aliases(entry)
+                if entry is not None
+                else {key, key.split("/")[-1]}
+            )
+            allow.difference_update(aliases)
+            deny.difference_update(aliases)
+            (allow if key in selected else deny).add(key)
+        _persist_plugin_activation(config, plugins, allow, deny, action="selection")
+
+    for key in set(keys) - set(model_keys):
+        entry = _resolve_plugin_entry(key)
+        aliases = _plugin_aliases(entry) if entry is not None else {key}
+        _write_legacy_plugin_activation(key, aliases, key in selected)
+
+
+def _clear_plugin_activation(key: str, aliases: set[str]) -> None:
+    """Remove activation aliases after a plugin tree was deleted successfully."""
+    config, plugins, allow, deny = _strict_activation_state()
+    aliases = set(aliases) | {key}
+    allow.difference_update(aliases)
+    deny.difference_update(aliases)
+    _persist_plugin_activation(config, plugins, allow, deny, action="cleanup")
+
+def _set_plugin_activation(name: str, enabled: bool) -> tuple[str, bool]:
+    """Shared CLI/dashboard activation transition."""
+    entry = _resolve_plugin_entry(name)
+    if entry is None:
+        raise PluginOperationError(f"Plugin '{name}' is not installed or bundled.")
+    key = entry[5]
+    aliases = _plugin_aliases(entry)
+    allow = _get_enabled_set()
+    deny = _get_disabled_set()
+    stale_aliases = aliases - {key}
+    configured = (
+        key in allow and not (aliases & deny) and not (stale_aliases & allow)
+        if enabled
+        else key in deny and not (aliases & allow) and not (stale_aliases & deny)
+    )
+    if configured:
+        return key, False
+    if key.startswith("model-providers/"):
+        _write_plugin_activation(key, aliases, enabled)
+    else:
+        _write_legacy_plugin_activation(key, aliases, enabled)
+    return key, True
 
 
 def _set_plugin_entry_flag(plugin_id: str, key: str, value: bool) -> None:
@@ -824,39 +942,18 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
     from rich.console import Console
 
     console = Console()
-    # Discover the plugin — check installed (user) AND bundled, including
-    # nested category plugins — and normalize to its canonical registry key.
-    resolved = _resolve_plugin_key_and_source(name)
-    if resolved is None:
+    entry = _resolve_plugin_entry(name)
+    if entry is None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
-    key, source = resolved
+    source = entry[3]
+    try:
+        key, changed = _set_plugin_activation(name, True)
+    except PluginOperationError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        sys.exit(1)
 
-    enabled = _get_enabled_set()
-    disabled = _get_disabled_set()
-
-    already_enabled = key in enabled and key not in disabled
-
-    if not already_enabled:
-        enabled.add(key)
-        disabled.discard(key)
-        # Drop every alias of this plugin from the disabled list so an
-        # explicit disable under a different form can't keep it off. The
-        # loader's disable check matches on BOTH the canonical key
-        # (``web/firecrawl``) AND the manifest name (``web-firecrawl``);
-        # a stale entry under either form makes "explicit disable wins"
-        # (plugins.py) silently veto this enable. Discard the key, its
-        # bare leaf, and the manifest name. (#40190 follow-up.)
-        bare = key.split("/")[-1]
-        if bare != key:
-            disabled.discard(bare)
-        for entry in _discover_all_plugins():
-            # entry = (name, version, description, source, dir_path, key)
-            if entry[5] == key:
-                disabled.discard(entry[0])
-                break
-        _save_enabled_set(enabled)
-        _save_disabled_set(disabled)
+    if changed:
         console.print(
             f"[green]✓[/green] Plugin [bold]{key}[/bold] enabled. "
             "Takes effect on next session."
@@ -866,7 +963,7 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
 
     # Built-in tool override is a privileged grant. Bundled plugins ship with
     # Hermes core and are trusted; every other source needs operator opt-in.
-    if source == "bundled":
+    if source == "bundled" or key.startswith("model-providers/"):
         return
 
     _resolve_tool_override_grant(console, key, allow_tool_override)
@@ -917,36 +1014,19 @@ def cmd_disable(name: str) -> None:
     from rich.console import Console
 
     console = Console()
-    key = _resolve_plugin_key(name)
-    if key is None:
-        console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
+    try:
+        key, changed = _set_plugin_activation(name, False)
+    except PluginOperationError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
         sys.exit(1)
 
-    enabled = _get_enabled_set()
-    disabled = _get_disabled_set()
-
-    if key not in enabled and key in disabled:
+    if not changed:
         console.print(f"[dim]Plugin '{key}' is already disabled.[/dim]")
         return
-
-    enabled.discard(key)
-    # Drop any legacy bare-name entry from the allow-list too, so a stale
-    # bare name can't keep a nested plugin loading after an explicit disable.
-    bare = key.split("/")[-1]
-    if bare != key:
-        enabled.discard(bare)
-    disabled.add(key)
-    _save_enabled_set(enabled)
-    _save_disabled_set(disabled)
     console.print(
-        f"[yellow]\u2298[/yellow] Plugin [bold]{key}[/bold] disabled. "
+        f"[yellow]⊘[/yellow] Plugin [bold]{key}[/bold] disabled. "
         "Takes effect on next session."
     )
-
-
-def _plugin_exists(name: str) -> bool:
-    """Return True if a plugin with *name* (bare name or key) exists."""
-    return _resolve_plugin_key(name) is not None
 
 
 def _read_manifest_info(d: Path, prefix: str):
@@ -994,7 +1074,7 @@ def _scan_level(
     if not base.is_dir():
         return
     for d in sorted(base.iterdir()):
-        if not d.is_dir():
+        if d.name.startswith(".") or not d.is_dir():
             continue
         if depth == 0 and skip_names and d.name in skip_names:
             continue
@@ -1033,51 +1113,78 @@ def _discover_all_plugins() -> list:
     ):
         _scan_level(base, source, skip, "", 0, seen)
 
-    # Entry-point plugins (installed as Python packages; no plugin directory).
+    # General entry-point plugins retain their historical bare keys.
     for name, version, description, path in _discover_entrypoint_plugins():
         seen[name] = (name, version, description, "entrypoint", path, name)
+
+    # Dedicated model-provider distributions use the same canonical namespace
+    # as directory providers.  A package may replace a bundled row, but never
+    # hide a mutable user/git checkout with the same provider key.
+    for name, version, description, path in _discover_model_provider_entrypoints():
+        key = f"model-providers/{name}"
+        existing = seen.get(key)
+        if existing is not None and existing[3] in {"user", "git", "project"}:
+            continue
+        seen[key] = (name, version, description, "entrypoint", path, key)
     return list(seen.values())
 
 
-def _discover_entrypoint_plugins() -> list[tuple[str, str, str, str]]:
-    """Return plugin entries advertised through ``hermes_agent.plugins``.
+def _discover_entrypoint_plugins(
+    group: str | None = None,
+) -> list[tuple[str, str, str, str]]:
+    """Return package metadata for one Hermes plugin entry-point group."""
+    if group is None:
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
 
-    Entry-point plugins are installed as Python packages, so they do not have a
-    plugin directory under ``~/.hermes/plugins``. Include package metadata here
-    so ``hermes plugins list`` can show and enable them.
-    """
-    from hermes_cli.plugins import ENTRY_POINTS_GROUP
-
+        group = ENTRY_POINTS_GROUP
     try:
-        eps = importlib.metadata.entry_points()
+        eps: Any = importlib.metadata.entry_points()
         if hasattr(eps, "select"):
-            group_eps = eps.select(group=ENTRY_POINTS_GROUP)
+            group_eps = eps.select(group=group)
         elif isinstance(eps, dict):
-            group_eps = eps.get(ENTRY_POINTS_GROUP, [])
+            group_eps = eps.get(group, [])
         else:
-            group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
+            group_eps = [ep for ep in eps if ep.group == group]
     except Exception as exc:
-        logger.debug("Entry-point plugin discovery failed: %s", exc)
+        logger.debug("Entry-point discovery failed for %s: %s", group, exc)
         return []
 
     entries: list[tuple[str, str, str, str]] = []
     for ep in group_eps:
-        version = ""
-        description = ""
         dist = getattr(ep, "dist", None)
         metadata = getattr(dist, "metadata", None)
-        if metadata is not None:
-            version = str(getattr(dist, "version", "") or "")
-            description = str(metadata.get("Summary", "") or "")
+        version = str(getattr(dist, "version", "") or "")
+        description = str(metadata.get("Summary", "") or "") if metadata else ""
         entries.append((ep.name, version, description, ep.value))
     return entries
 
 
-def _plugin_status(name: str, enabled: set, disabled: set, key: str = "") -> str:
-    """Return the user-facing activation state for a plugin name or key."""
-    if name in disabled or key in disabled:
+def _discover_model_provider_entrypoints() -> list[tuple[str, str, str, str]]:
+    entries = _discover_entrypoint_plugins("hermes_agent.model_providers")
+    counts: dict[str, int] = {}
+    for name, *_rest in entries:
+        counts[name] = counts.get(name, 0) + 1
+    return [entry for entry in entries if counts[entry[0]] == 1]
+
+
+def _plugin_status(
+    name: str,
+    enabled: set,
+    disabled: set,
+    key: str = "",
+    source: str = "",
+) -> str:
+    """Return activation state without broadening defaults for other kinds."""
+    identities = (
+        {key}
+        if source == "entrypoint" and key.startswith("model-providers/")
+        else {name, key, key.split("/")[-1]}
+    )
+    if identities & disabled:
         return "disabled"
-    if name in enabled or key in enabled:
+    if identities & enabled:
+        return "enabled"
+    if key.startswith("model-providers/") and source in {"user", "git"}:
         return "enabled"
     return "not enabled"
 
@@ -1090,7 +1197,10 @@ def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set
     if getattr(args, "enabled", False):
         filtered = [
             entry for entry in filtered
-            if _plugin_status(entry[0], enabled, disabled, key=entry[5]) == "enabled"
+            if _plugin_status(
+                entry[0], enabled, disabled, key=entry[5], source=entry[3]
+            )
+            == "enabled"
         ]
     return filtered
 
@@ -1115,7 +1225,9 @@ def cmd_list(args: Any | None = None) -> None:
         payload = [
             {
                 "name": name,
-                "status": _plugin_status(name, enabled, disabled, key=key),
+                "status": _plugin_status(
+                    name, enabled, disabled, key=key, source=source
+                ),
                 "version": str(version),
                 "description": description,
                 "source": source,
@@ -1127,7 +1239,9 @@ def cmd_list(args: Any | None = None) -> None:
 
     if getattr(args, "plain", False):
         for name, version, _description, source, _dir, key in entries:
-            status = _plugin_status(name, enabled, disabled, key=key)
+            status = _plugin_status(
+                name, enabled, disabled, key=key, source=source
+            )
             print(f"{status:12} {source:8} {str(version):8} {name}")
         return
 
@@ -1143,7 +1257,9 @@ def cmd_list(args: Any | None = None) -> None:
     table.add_column("Source", style="dim")
 
     for name, version, description, source, _dir, key in entries:
-        status_name = _plugin_status(name, enabled, disabled, key=key)
+        status_name = _plugin_status(
+            name, enabled, disabled, key=key, source=source
+        )
         if status_name == "disabled":
             status = "[red]disabled[/red]"
         elif status_name == "enabled":
@@ -1361,9 +1477,14 @@ def cmd_toggle() -> None:
         # Accept the legacy bare name on either side for back-compat with
         # existing configs written before this normalization.
         is_on = (
-            (key in enabled_set or name in enabled_set)
-            and key not in disabled_set
-            and name not in disabled_set
+            _plugin_status(
+                name,
+                enabled_set,
+                disabled_set,
+                key=key,
+                source=source,
+            )
+            == "enabled"
         )
         if is_on:
             plugin_selected.add(i)
@@ -1644,8 +1765,8 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
     disabled_changed = new_disabled != disabled
 
     if enabled_changed or disabled_changed:
-        _save_enabled_set(new_enabled)
-        _save_disabled_set(new_disabled)
+        selected_keys = {key for i, key in enumerate(plugin_keys) if i in chosen}
+        _write_plugin_selection(plugin_keys, selected_keys)
         console.print(
             f"\n[green]\u2713[/green] General plugins: {len(new_enabled)} enabled, "
             f"{len(plugin_keys) - len(new_enabled)} disabled."
@@ -1711,8 +1832,8 @@ def _run_composite_fallback(plugin_keys, plugin_labels, plugin_selected,
                 new_disabled.add(key)
         prev_enabled = _get_enabled_set()
         if new_enabled != prev_enabled or new_disabled != disabled:
-            _save_enabled_set(new_enabled)
-            _save_disabled_set(new_disabled)
+            selected_keys = {key for i, key in enumerate(plugin_keys) if i in chosen}
+            _write_plugin_selection(plugin_keys, selected_keys)
 
     # Provider categories
     if categories:
@@ -1753,18 +1874,19 @@ def dashboard_install_plugin(
         target, installed_manifest, installed_name = _install_plugin_core(
             identifier,
             force=force,
+            enabled=enable,
         )
     except PluginOperationError as exc:
         return {"ok": False, "error": str(exc)}
 
     missing_env = _missing_requires_env_names(installed_manifest)
-    if enable:
-        en = _get_enabled_set()
-        dis = _get_disabled_set()
-        en.add(installed_name)
-        dis.discard(installed_name)
-        _save_enabled_set(en)
-        _save_disabled_set(dis)
+
+    if installed_manifest.get("kind") != "model-provider" and enable:
+        _write_legacy_plugin_activation(
+            installed_name,
+            {installed_name, target.name},
+            True,
+        )
 
     hint: str | None = None
     ap = target / "after-install.md"
@@ -1871,51 +1993,44 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     For plugins that provide tools (toolsets), also toggles the toolset in
     ``platform_toolsets`` so the agent actually sees the tools in sessions.
     """
-    if not _plugin_exists(name):
-        return {"ok": False, "error": f"Plugin '{name}' is not installed or bundled."}
-
-    en = _get_enabled_set()
-    dis = _get_disabled_set()
-
-    if enabled:
-        if name in en and name not in dis:
-            return {"ok": True, "name": name, "unchanged": True}
-        en.add(name)
-        dis.discard(name)
-        _save_enabled_set(en)
-        _save_disabled_set(dis)
-        _toggle_plugin_toolset(name, enable=True)
-        return {"ok": True, "name": name, "unchanged": False}
-
-    if name not in en and name in dis:
-        return {"ok": True, "name": name, "unchanged": True}
-
-    en.discard(name)
-    dis.add(name)
-    _save_enabled_set(en)
-    _save_disabled_set(dis)
-    _toggle_plugin_toolset(name, enable=False)
-    return {"ok": True, "name": name, "unchanged": False}
-
-
-def _user_installed_plugin_dir(name: str) -> Optional[Path]:
-    """Resolved path under ``~/.hermes/plugins/<name>`` if it exists."""
-    plugins_dir = _plugins_dir()
     try:
-        target = _sanitize_plugin_name(name, plugins_dir, allow_subdir=True)
-    except ValueError:
-        return None
-    return target if target.is_dir() else None
+        key, changed = _set_plugin_activation(name, enabled)
+    except PluginOperationError as exc:
+        return {"ok": False, "error": str(exc)}
+    if changed and not key.startswith("model-providers/"):
+        _toggle_plugin_toolset(key, enable=enabled)
+    return {"ok": True, "name": key, "unchanged": not changed}
+
+
+def _resolve_user_plugin_path(name: str) -> Path:
+    """Resolve a mutable inventory entry and reject symlinked path components."""
+    entry = _resolve_plugin_entry(name)
+    if entry is None:
+        raise PluginOperationError(f"Plugin '{name}' was not found under {_plugins_dir()}.")
+    source = entry[3]
+    if source == "entrypoint":
+        raise PluginOperationError(
+            f"Plugin '{entry[5]}' is pip-managed; update or remove its Python package with pip."
+        )
+    if source not in {"user", "git"}:
+        raise PluginOperationError(f"Plugin '{entry[5]}' is not a mutable user plugin.")
+
+    root = Path(os.path.abspath(_plugins_dir()))
+    path = Path(entry[4])
+    lexical = path if path.is_absolute() else root / path
+    lexical = Path(os.path.abspath(lexical))
+    _reject_symlink_components(root, lexical)
+    if not lexical.is_dir():
+        raise PluginOperationError(f"Plugin '{name}' was not found under {root}.")
+    return lexical
 
 
 def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
     """``git pull`` inside ``~/.hermes/plugins/<name>``."""
-    target = _user_installed_plugin_dir(name)
-    if target is None:
-        return {
-            "ok": False,
-            "error": f"Plugin '{name}' was not found under {_plugins_dir()}.",
-        }
+    try:
+        target = _resolve_user_plugin_path(name)
+    except PluginOperationError as exc:
+        return {"ok": False, "error": str(exc)}
 
     if not (target / ".git").exists():
         return {
@@ -1958,21 +2073,39 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
 
 
 def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
-    """Delete a plugin tree under ``~/.hermes/plugins/`` only."""
-    plugins_dir = _plugins_dir()
-    for n, _ver, _d, src, _path, _key in _discover_all_plugins():
-        if n == name and src == "bundled":
-            return {"ok": False, "error": "Bundled plugins cannot be removed from the dashboard."}
+    """Deny, delete, then clear activation state for a mutable plugin."""
+    entry = _resolve_plugin_entry(name)
+    if entry is None:
+        return {"ok": False, "error": f"Plugin '{name}' was not found under {_plugins_dir()}."}
+    try:
+        target = _resolve_user_plugin_path(name)
+    except PluginOperationError as exc:
+        return {"ok": False, "error": str(exc)}
 
-    target = _user_installed_plugin_dir(name)
-    if target is None:
-        return {
-            "ok": False,
-            "error": f"Plugin '{name}' was not found under {plugins_dir}.",
-        }
+    key = entry[5]
+    if not key.startswith("model-providers/"):
+        try:
+            shutil.rmtree(target)
+        except OSError as exc:
+            return {"ok": False, "error": str(exc)}
+        return {"ok": True, "name": key}
 
-    shutil.rmtree(target)
-    return {"ok": True, "name": name}
+    aliases = _plugin_aliases(entry)
+    try:
+        _write_plugin_activation(key, aliases, False)
+    except PluginOperationError as exc:
+        return {"ok": False, "error": str(exc)}
+
+    try:
+        shutil.rmtree(target)
+    except OSError as exc:
+        return {"ok": False, "error": str(exc)}
+
+    try:
+        _clear_plugin_activation(key, aliases)
+    except PluginOperationError as exc:
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True, "name": key}
 
 
 def plugins_command(args) -> None:

--- a/plugins/model-providers/README.md
+++ b/plugins/model-providers/README.md
@@ -16,14 +16,19 @@ plugins/model-providers/
 
 ## How discovery works
 
-`providers/__init__.py._discover_providers()` scans this directory (and
-`$HERMES_HOME/plugins/model-providers/`) the first time anything calls
-`get_provider_profile()` or `list_providers()`. Each `__init__.py` is
-imported and expected to call `providers.register_provider(profile)`.
+`providers/__init__.py._discover_providers()` loads bundled profiles, enabled
+Python-package entry points from `hermes_agent.model_providers`, and then
+`$HERMES_HOME/plugins/model-providers/` the first time anything calls
+`get_provider_profile()` or `list_providers()`. Each directory `__init__.py`
+is imported and expected to call `providers.register_provider(profile)`.
 
-User plugins at `$HERMES_HOME/plugins/model-providers/<name>/` override
-bundled plugins of the same name — last-writer-wins in
-`register_provider()`. Drop a file there to replace a built-in.
+A user-directory leaf reserves its canonical `model-providers/<leaf>` key, so a
+same-named package entry point is skipped without invoking its registrar. User
+directories can still override bundled registrations through last-writer-wins
+registration. Legacy `<repo>/providers/<name>.py` modules load last and can
+replace earlier registrations by the same rule. Package providers must be
+explicitly enabled. Manually dropped directories remain active by default, but
+an explicit `plugins.disabled` entry always wins.
 
 ## Adding a new provider
 
@@ -60,6 +65,30 @@ bundled plugins of the same name — last-writer-wins in
 Nothing else needs to change. `auth.py`, `config.py`, `models.py`,
 `doctor.py`, `model_metadata.py`, `runtime_provider.py`, and the
 chat_completions transport all auto-wire from the registry.
+
+## Distribution and lifecycle
+
+Python packages publish a zero-argument registration callable in the dedicated
+entry-point group, then require explicit activation:
+
+```toml
+[project.entry-points."hermes_agent.model_providers"]
+your-provider = "your_provider_package:register"
+```
+
+```bash
+pip install <distribution>
+hermes plugins enable model-providers/your-provider
+```
+
+Git repositories with `kind: model-provider` install under
+`$HERMES_HOME/plugins/model-providers/<name>/`. See the
+[model-provider plugin guide](../../website/docs/developer-guide/model-provider-plugin.md)
+for package, Git, activation, ownership, and restart details.
+
+A repository supporting both pip and Git/manual installation also needs a root
+`__init__.py` shim that imports and calls the same registrar exposed by the
+package entry point.
 
 ## Non-trivial profiles
 

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,19 +1,19 @@
 """Provider module registry.
 
-Provider profiles can live in two places:
+Provider profiles can live in three places:
 
 1. Bundled plugins: ``plugins/model-providers/<name>/`` (shipped with hermes-agent)
-2. User plugins: ``$HERMES_HOME/plugins/model-providers/<name>/``
+2. Enabled Python packages exposing ``hermes_agent.model_providers`` entry points
+3. User plugins: ``$HERMES_HOME/plugins/model-providers/<name>/``
 
 Each plugin directory contains:
   - ``__init__.py`` — calls ``register_provider(profile)`` at import
   - ``plugin.yaml`` — manifest (name, kind: model-provider, version, description)
 
 Discovery is lazy: the first call to ``get_provider_profile()`` or
-``list_providers()`` scans both locations and imports every plugin. User
-plugins override bundled plugins on name collision (last-writer-wins), so
-third parties can monkey-patch or replace any built-in profile without
-editing the repo.
+``list_providers()`` scans all sources. User paths suppress same-key package
+entry points before invocation, then user registrations can override bundled
+profiles without editing the repo.
 
 For backward compatibility, ``providers/*.py`` files (other than ``base.py``
 and ``__init__.py``) are still discovered via ``pkgutil.iter_modules``.
@@ -31,14 +31,19 @@ Usage::
 from __future__ import annotations
 
 import importlib
+import importlib.metadata
 import importlib.util
 import logging
 import sys
 from pathlib import Path
 
+import yaml
+
 from providers.base import OMIT_TEMPERATURE, ProviderProfile  # noqa: F401
 
 logger = logging.getLogger(__name__)
+
+MODEL_PROVIDER_ENTRY_POINTS_GROUP = "hermes_agent.model_providers"
 
 _REGISTRY: dict[str, ProviderProfile] = {}
 _ALIASES: dict[str, str] = {}
@@ -137,16 +142,91 @@ def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
         sys.modules.pop(module_name, None)
 
 
+def _provider_is_active(
+    identities: set[str],
+    *,
+    enabled: set[str],
+    disabled: set[str],
+    opt_in: bool,
+) -> bool:
+    """Return whether a provider is active under its known identities."""
+    if identities & disabled:
+        return False
+    return bool(identities & enabled) if opt_in else True
+
+
+def _load_package_providers(
+    enabled: set[str], disabled: set[str], blocked: set[str]
+) -> None:
+    """Load explicitly enabled dedicated model-provider entry points."""
+    try:
+        entry_points = list(
+            importlib.metadata.entry_points().select(
+                group=MODEL_PROVIDER_ENTRY_POINTS_GROUP
+            )
+        )
+    except Exception as exc:
+        logger.warning("Skipping package provider discovery: %s", exc)
+        return
+
+    counts: dict[str, int] = {}
+    for entry_point in entry_points:
+        counts[entry_point.name] = counts.get(entry_point.name, 0) + 1
+
+    for entry_point in entry_points:
+        canonical = f"model-providers/{entry_point.name}"
+        if canonical in blocked:
+            continue
+        if counts[entry_point.name] > 1:
+            logger.warning(
+                "Skipping ambiguous package provider entry point %s",
+                entry_point.name,
+            )
+            continue
+        if not _provider_is_active(
+            {canonical}, enabled=enabled, disabled=disabled, opt_in=True
+        ):
+            continue
+        try:
+            register = entry_point.load()
+            if callable(register):
+                register()
+        except Exception as exc:
+            logger.warning(
+                "Failed to load package provider entry point %s: %s",
+                entry_point.name,
+                exc,
+            )
+
+
+def _user_provider_identities(plugin_dir: Path) -> set[str]:
+    """Return canonical, directory-leaf, and manifest identities."""
+    identities = {
+        plugin_dir.name,
+        f"model-providers/{plugin_dir.name}",
+    }
+    manifest_path = plugin_dir / "plugin.yaml"
+    try:
+        manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+        if isinstance(manifest, dict) and isinstance(manifest.get("name"), str):
+            identities.add(manifest["name"])
+    except (OSError, yaml.YAMLError):
+        pass
+    return identities
+
+
 def _discover_providers() -> None:
     """Populate the registry by importing every provider plugin.
 
     Order:
       1. Bundled plugins at ``<repo>/plugins/model-providers/<name>/``
-      2. User plugins at ``$HERMES_HOME/plugins/model-providers/<name>/``
-      3. Legacy per-file modules at ``providers/<name>.py`` (back-compat)
+      2. Enabled ``hermes_agent.model_providers`` package entry points
+      3. User plugins at ``$HERMES_HOME/plugins/model-providers/<name>/``
+      4. Legacy per-file modules at ``providers/<name>.py`` (back-compat)
 
-    Each step imports its plugins, which call ``register_provider()`` at
-    module-level. Later steps win on name collision.
+    Directory plugins call ``register_provider()`` at module-level. User paths
+    suppress same-key package entry points; later user registrations can still
+    override bundled profiles.
     """
     global _discovered
     if _discovered:
@@ -160,17 +240,53 @@ def _discover_providers() -> None:
                 continue
             _import_plugin_dir(child, "bundled")
 
-    # 2. User plugins — under $HERMES_HOME/plugins/model-providers/<name>/.
+    # Read activation without defaults or fail-open parsing. A malformed or
+    # unreadable existing config must not authorize untrusted package/user code.
+    try:
+        from hermes_cli.config import read_plugin_activation_config_strict
+
+        _config, _plugins, enabled, disabled = read_plugin_activation_config_strict()
+        activation_readable = True
+    except Exception as exc:
+        logger.warning("Skipping external provider plugins: %s", exc)
+        enabled = set()
+        disabled = set()
+        activation_readable = False
+
+    # 2. User plugin paths reserve their canonical package keys even when
+    # disabled, so one activation token can never execute hidden package code.
+    user_dir = _user_plugins_dir() if activation_readable else None
+    blocked_package_keys = (
+        {
+            f"model-providers/{child.name}"
+            for child in user_dir.iterdir()
+            if child.is_dir() and not child.name.startswith(("_", "."))
+        }
+        if user_dir is not None
+        else set()
+    )
+
+    # 3. Dedicated package providers are opt-in.
+    if activation_readable:
+        _load_package_providers(enabled, disabled, blocked_package_keys)
+
+    # 4. User plugins — under $HERMES_HOME/plugins/model-providers/<name>/.
     #    These can override any bundled profile of the same name (last-writer-wins
     #    in register_provider()).
-    user_dir = _user_plugins_dir()
     if user_dir is not None:
         for child in sorted(user_dir.iterdir()):
             if not child.is_dir() or child.name.startswith(("_", ".")):
                 continue
+            if not _provider_is_active(
+                _user_provider_identities(child),
+                enabled=enabled,
+                disabled=disabled,
+                opt_in=False,
+            ):
+                continue
             _import_plugin_dir(child, "user")
 
-    # 3. Legacy single-file profiles at providers/<name>.py. Kept for
+    # 5. Legacy single-file profiles at providers/<name>.py. Kept for
     #    back-compat — if someone drops a ``providers/foo.py`` into an
     #    editable install, it still works without the plugin layout.
     try:

--- a/tests/hermes_cli/test_model_provider_distribution.py
+++ b/tests/hermes_cli/test_model_provider_distribution.py
@@ -1,0 +1,198 @@
+"""Behavior contracts for model-provider package inventory and lifecycle state."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from hermes_cli import plugins_cmd as pc
+
+KEY = "model-providers/acme-provider"
+
+
+def _entry(
+    *,
+    name="acme-provider",
+    source="entrypoint",
+    path: str | Path = "acme_provider:register",
+    key=KEY,
+):
+    return (name, "1.2.3", "Acme provider", source, path, key)
+
+
+def _args(**overrides):
+    values = {
+        "json": True,
+        "plain": False,
+        "enabled": False,
+        "no_bundled": False,
+        "user": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_dedicated_package_inventory_uses_canonical_namespace(monkeypatch, tmp_path):
+    user = tmp_path / "user"
+    bundled = tmp_path / "bundled"
+    user.mkdir()
+    bundled.mkdir()
+    eps = importlib.metadata.EntryPoints([
+        importlib.metadata.EntryPoint(
+            name="generic", value="generic:register", group="hermes_agent.plugins"
+        ),
+        importlib.metadata.EntryPoint(
+            name="acme-provider",
+            value="acme_provider:register",
+            group="hermes_agent.model_providers",
+        ),
+    ])
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: user)
+    monkeypatch.setattr("hermes_cli.plugins.get_bundled_plugins_dir", lambda: bundled)
+    monkeypatch.setattr(pc.importlib.metadata, "entry_points", lambda: eps)
+
+    entries = {entry[5]: entry for entry in pc._discover_all_plugins()}
+
+    assert entries["generic"][3] == "entrypoint"
+    assert entries[KEY][0] == "acme-provider"
+    assert entries[KEY][4] == "acme_provider:register"
+
+
+def test_generic_entrypoint_inventory_accepts_list_api(monkeypatch):
+    entry = SimpleNamespace(
+        name="generic",
+        value="generic:register",
+        group="hermes_agent.plugins",
+        dist=None,
+    )
+    monkeypatch.setattr(pc.importlib.metadata, "entry_points", lambda: [entry])
+
+    assert pc._discover_entrypoint_plugins() == [
+        ("generic", "", "", "generic:register")
+    ]
+
+
+def test_list_shows_package_opt_in_and_directory_default_on(monkeypatch, capsys):
+    entries = [
+        _entry(),
+        _entry(
+            name="local-provider",
+            source="user",
+            path=Path("/plugins/model-providers/local-provider"),
+            key="model-providers/local-provider",
+        ),
+    ]
+    monkeypatch.setattr(pc, "_discover_all_plugins", lambda: entries)
+    monkeypatch.setattr(pc, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(pc, "_get_disabled_set", lambda: set())
+
+    pc.cmd_list(_args())
+
+    rows = {row["name"]: row for row in json.loads(capsys.readouterr().out)}
+    assert rows["acme-provider"]["status"] == "not enabled"
+    assert rows["local-provider"]["status"] == "enabled"
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_activation_write_canonicalizes_aliases(monkeypatch, tmp_path, enabled):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    aliases = {KEY, "acme-provider", "acme"}
+    config = home / "config.yaml"
+    config.write_text(
+        yaml.safe_dump({
+            "plugins": {
+                "enabled": ["unrelated", "acme", "acme-provider"],
+                "disabled": ["old-deny", "acme", "acme-provider"],
+            }
+        })
+    )
+
+    pc._write_plugin_activation(KEY, aliases, enabled)
+
+    plugins = yaml.safe_load(config.read_text())["plugins"]
+    allow, deny = set(plugins["enabled"]), set(plugins["disabled"])
+    assert not (allow | deny) & (aliases - {KEY})
+    assert allow == ({"unrelated", KEY} if enabled else {"unrelated"})
+    assert deny == ({"old-deny"} if enabled else {"old-deny", KEY})
+
+
+def test_bulk_selection_is_canonical_and_preserves_unrelated(monkeypatch, tmp_path):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    config = home / "config.yaml"
+    config.write_text(
+        yaml.safe_dump({
+            "plugins": {
+                "enabled": ["unrelated", "acme-provider"],
+                "disabled": ["old-deny", "local-provider"],
+            }
+        })
+    )
+    local_key = "model-providers/local-provider"
+    entries = {
+        KEY: _entry(),
+        local_key: _entry(name="Local Provider", source="user", key=local_key),
+    }
+    monkeypatch.setattr(pc, "_resolve_plugin_entry", entries.get)
+
+    pc._write_plugin_selection(list(entries), {local_key})
+
+    plugins = yaml.safe_load(config.read_text())["plugins"]
+    assert set(plugins["enabled"]) == {"unrelated", local_key}
+    assert set(plugins["disabled"]) == {"old-deny", KEY}
+
+
+@pytest.mark.parametrize(
+    "operation", [pc.dashboard_update_user_plugin, pc.dashboard_remove_user_plugin]
+)
+def test_pip_provider_update_and_remove_are_pip_owned(monkeypatch, operation):
+    monkeypatch.setattr(pc, "_resolve_plugin_entry", lambda _name: _entry())
+
+    result = operation("acme-provider")
+
+    assert result["ok"] is False
+    assert "pip" in result["error"].lower()
+
+
+@pytest.mark.parametrize(
+    ("name", "source", "enabled", "disabled", "expected"),
+    [
+        ("Manifest Name", "user", set(), {"leaf"}, "disabled"),
+        ("cloudflare", "entrypoint", {"cloudflare"}, set(), "not enabled"),
+        ("cloudflare", "entrypoint", {"model-providers/leaf"}, set(), "enabled"),
+    ],
+)
+def test_status_matches_runtime_identities(name, source, enabled, disabled, expected):
+    assert (
+        pc._plugin_status(
+            name,
+            enabled,
+            disabled,
+            key="model-providers/leaf",
+            source=source,
+        )
+        == expected
+    )
+
+
+def test_toggle_selects_default_active_user_model_provider(monkeypatch):
+    entry = _entry(name="Manifest Name", source="user", key="model-providers/leaf")
+    run_ui = MagicMock()
+    monkeypatch.setattr(pc, "_discover_all_plugins", lambda: [entry])
+    monkeypatch.setattr(pc, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(pc, "_get_disabled_set", lambda: set())
+    monkeypatch.setattr(pc.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(pc, "_run_composite_ui", run_ui)
+
+    pc.cmd_toggle()
+
+    assert run_ui.call_args.args[3] == {0}

--- a/tests/hermes_cli/test_model_provider_distribution_security.py
+++ b/tests/hermes_cli/test_model_provider_distribution_security.py
@@ -1,0 +1,307 @@
+"""Security contracts for model-provider distribution lifecycle operations."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import os
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import yaml
+
+from hermes_cli import plugins_cmd as pc
+import providers
+
+KEY = "model-providers/acme"
+ALIASES = {KEY, "acme", "Acme Provider"}
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    path = tmp_path / "hermes"
+    (path / "plugins").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(path))
+    return path
+
+
+def _config(home, *, enabled=(), disabled=()):
+    path = home / "config.yaml"
+    path.write_text(
+        yaml.safe_dump({
+            "plugins": {"enabled": list(enabled), "disabled": list(disabled)}
+        })
+    )
+    return path
+
+
+def _activation(path):
+    plugins = yaml.safe_load(path.read_text())["plugins"]
+    return set(plugins["enabled"]), set(plugins["disabled"])
+
+
+def _clone(manifest):
+    def run(argv, **_kwargs):
+        target = Path(argv[-1])
+        target.mkdir(parents=True)
+        (target / "plugin.yaml").write_text(manifest)
+        (target / "__init__.py").write_text("# provider\n")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    return run
+
+
+def _entry(path, *, name="Acme Provider", key=KEY):
+    return (name, "1.0.0", "test provider", "user", path, key)
+
+
+def _provider(home, monkeypatch, *, enabled=ALIASES):
+    root = home / "plugins"
+    target = root / "model-providers" / "acme"
+    target.mkdir(parents=True)
+    config = _config(home, enabled=enabled)
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: root)
+    monkeypatch.setattr(pc, "_discover_all_plugins", lambda: [_entry(target)])
+    return target, config
+
+
+def _install_env(home, monkeypatch, manifest):
+    root = home / "plugins"
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: root)
+    monkeypatch.setattr(pc, "_resolve_git_executable", lambda: "/usr/bin/git")
+    monkeypatch.setattr(pc.subprocess, "run", _clone(manifest))
+    return root
+
+
+def test_activation_write_rejects_save_noop(home):
+    config = _config(home)
+    original = config.read_bytes()
+    with patch("hermes_cli.config.save_config", return_value=None):
+        with pytest.raises(pc.PluginOperationError, match="persist|verif|managed"):
+            pc._write_plugin_activation(KEY, ALIASES, True)
+    assert config.read_bytes() == original
+
+
+def test_activation_write_preserves_malformed_yaml(home):
+    config = home / "config.yaml"
+    malformed = b"plugins: [unterminated\n"
+    config.write_bytes(malformed)
+    save = Mock()
+    with patch("hermes_cli.config.save_config", save):
+        with pytest.raises(pc.PluginOperationError, match="config|YAML|parse"):
+            pc._write_plugin_activation(KEY, ALIASES, True)
+    save.assert_not_called()
+    assert config.read_bytes() == malformed
+
+
+def test_install_does_not_publish_when_activation_fails(home, monkeypatch):
+    root = _install_env(
+        home, monkeypatch, "name: acme\nmanifest_version: 1\nkind: model-provider\n"
+    )
+    monkeypatch.setattr(
+        pc,
+        "_write_plugin_activation",
+        Mock(side_effect=pc.PluginOperationError("cannot persist")),
+    )
+    with pytest.raises(pc.PluginOperationError, match="cannot persist"):
+        pc._install_plugin_core("owner/acme", force=False, enabled=False)
+    assert not (root / "model-providers" / "acme").exists()
+    assert not list(root.glob(".install-*"))
+
+
+def test_install_stages_hidden_and_publishes_with_one_rename(home, monkeypatch):
+    root = home / "plugins"
+    events = []
+
+    def clone(argv, **_kwargs):
+        stage = Path(argv[-1])
+        assert stage.parent.parent == root and stage.parent.name.startswith(".install-")
+        stage.mkdir()
+        (stage / "plugin.yaml").write_text("name: acme\nkind: model-provider\n")
+        events.append("clone")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: root)
+    monkeypatch.setattr(pc, "_resolve_git_executable", lambda: "/usr/bin/git")
+    monkeypatch.setattr(pc.subprocess, "run", clone)
+    monkeypatch.setattr(
+        pc,
+        "_write_plugin_activation",
+        lambda _key, _aliases, enabled: events.append(("activation", enabled)),
+    )
+    real_replace = os.replace
+
+    def publish(source, target):
+        assert events == ["clone", ("activation", False)]
+        events.append("publish")
+        real_replace(source, target)
+
+    monkeypatch.setattr(pc.os, "replace", publish)
+    target, _manifest, key = pc._install_plugin_core(
+        "owner/acme", force=False, enabled=True
+    )
+    assert events == [
+        "clone",
+        ("activation", False),
+        "publish",
+        ("activation", True),
+    ]
+    assert target == root / "model-providers" / "acme"
+    assert key == KEY
+
+
+def test_failed_enabled_publish_retains_deny_and_blocks_package(home, monkeypatch):
+    root = _install_env(home, monkeypatch, "name: acme\nkind: model-provider\n")
+    real_replace = os.replace
+
+    def fail_publication(source, target):
+        if ".install-" in str(source):
+            raise OSError("publish failed")
+        return real_replace(source, target)
+
+    monkeypatch.setattr(pc.os, "replace", fail_publication)
+
+    with pytest.raises(OSError, match="publish failed"):
+        pc._install_plugin_core("owner/acme", force=False, enabled=True)
+
+    enabled, disabled = _activation(home / "config.yaml")
+    assert KEY not in enabled and KEY in disabled
+    assert not (root / "model-providers" / "acme").exists()
+
+    called = Mock()
+    entry = SimpleNamespace(name="acme", load=lambda: called)
+    monkeypatch.setattr(
+        importlib.metadata,
+        "entry_points",
+        lambda: SimpleNamespace(select=lambda **_kwargs: [entry]),
+    )
+    providers._load_package_providers(enabled, disabled, set())
+    called.assert_not_called()
+
+
+def test_remove_rejects_symlink_before_mutation(home, monkeypatch):
+    root = home / "plugins"
+    actual = root / "holding" / "acme"
+    actual.mkdir(parents=True)
+    link = root / "model-providers"
+    link.symlink_to(root / "holding", target_is_directory=True)
+    write = Mock()
+    remove = Mock()
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: root)
+    monkeypatch.setattr(pc, "_discover_all_plugins", lambda: [_entry(link / "acme")])
+    monkeypatch.setattr(pc, "_write_plugin_activation", write)
+    monkeypatch.setattr(pc.shutil, "rmtree", remove)
+    assert pc.dashboard_remove_user_plugin(KEY)["ok"] is False
+    write.assert_not_called()
+    remove.assert_not_called()
+    assert actual.is_dir()
+
+
+def test_install_rejects_symlinked_category_before_activation(home, monkeypatch):
+    root = home / "plugins"
+    holding = root / "holding"
+    holding.mkdir()
+    (root / "model-providers").symlink_to(holding, target_is_directory=True)
+    _install_env(home, monkeypatch, "name: acme\nkind: model-provider\n")
+    write = Mock()
+    monkeypatch.setattr(pc, "_write_plugin_activation", write)
+    with pytest.raises(pc.PluginOperationError, match="symlink"):
+        pc._install_plugin_core("owner/acme", force=False, enabled=False)
+    write.assert_not_called()
+    assert not (holding / "acme").exists()
+
+
+def test_remove_aborts_when_deny_cannot_persist(home, monkeypatch):
+    target, config = _provider(home, monkeypatch)
+    original = config.read_bytes()
+    remove = Mock()
+    monkeypatch.setattr(pc.shutil, "rmtree", remove)
+    with patch("hermes_cli.config.save_config", return_value=None):
+        assert pc.dashboard_remove_user_plugin(KEY)["ok"] is False
+    remove.assert_not_called()
+    assert target.is_dir() and config.read_bytes() == original
+
+
+def test_remove_retains_canonical_deny_when_delete_fails(home, monkeypatch):
+    target, config = _provider(home, monkeypatch)
+
+    def fail_delete(path):
+        enabled, disabled = _activation(config)
+        assert not enabled & ALIASES and KEY in disabled
+        raise OSError("delete failed")
+
+    monkeypatch.setattr(pc.shutil, "rmtree", fail_delete)
+    assert pc.dashboard_remove_user_plugin(KEY)["ok"] is False
+    enabled, disabled = _activation(config)
+    assert target.is_dir() and not enabled & ALIASES and KEY in disabled
+
+
+def test_remove_cleans_aliases_only_after_successful_delete(home, monkeypatch):
+    target, config = _provider(home, monkeypatch)
+    real_rmtree = shutil.rmtree
+
+    def delete_after_deny(path):
+        enabled, disabled = _activation(config)
+        assert not enabled & ALIASES and KEY in disabled
+        real_rmtree(path)
+
+    monkeypatch.setattr(pc.shutil, "rmtree", delete_after_deny)
+    assert pc.dashboard_remove_user_plugin(KEY) == {"ok": True, "name": KEY}
+    enabled, disabled = _activation(config)
+    assert not target.exists() and not enabled & ALIASES and not disabled & ALIASES
+
+
+def test_generic_disabled_install_preserves_activation_boundary(home, monkeypatch):
+    root = _install_env(home, monkeypatch, "name: generic\nkind: tool\n")
+    config = home / "config.yaml"
+    original = b"plugins:\n  enabled: [existing]\n  disabled: []\n"
+    config.write_bytes(original)
+    save_enabled = Mock(side_effect=RuntimeError("must not write"))
+    save_disabled = Mock(side_effect=RuntimeError("must not write"))
+    monkeypatch.setattr(pc, "_save_enabled_set", save_enabled)
+    monkeypatch.setattr(pc, "_save_disabled_set", save_disabled)
+    target, _manifest, key = pc._install_plugin_core(
+        "owner/generic", force=False, enabled=False
+    )
+    assert key == "generic" and target == root / "generic"
+    assert config.read_bytes() == original
+    save_enabled.assert_not_called()
+    save_disabled.assert_not_called()
+
+
+def test_dashboard_generic_enabled_install_persists_activation(home, monkeypatch):
+    _install_env(home, monkeypatch, "name: generic\nkind: tool\n")
+
+    result = pc.dashboard_install_plugin("owner/generic", force=False, enable=True)
+
+    assert result["ok"] is True and result["enabled"] is True
+    plugins = yaml.safe_load((home / "config.yaml").read_text())["plugins"]
+    assert "generic" in plugins["enabled"]
+    assert "generic" not in plugins["disabled"]
+
+
+def test_generic_remove_preserves_activation_boundary(home, monkeypatch):
+    root = home / "plugins"
+    target = root / "generic"
+    target.mkdir()
+    (target / "plugin.yaml").write_text("name: generic\nkind: tool\n")
+    config = home / "config.yaml"
+    original = b"plugins:\n  enabled: [generic]\n  disabled: []\n"
+    config.write_bytes(original)
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: root)
+    monkeypatch.setattr(
+        pc,
+        "_discover_all_plugins",
+        lambda: [_entry(target, name="generic", key="generic")],
+    )
+    save_enabled = Mock(side_effect=RuntimeError("must not write"))
+    save_disabled = Mock(side_effect=RuntimeError("must not write"))
+    monkeypatch.setattr(pc, "_save_enabled_set", save_enabled)
+    monkeypatch.setattr(pc, "_save_disabled_set", save_disabled)
+    assert pc.dashboard_remove_user_plugin("generic")["ok"] is True
+    assert not target.exists()
+    assert config.read_bytes() == original
+    save_enabled.assert_not_called()
+    save_disabled.assert_not_called()

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -450,41 +450,28 @@ class TestCmdInstall:
 
 
 class TestCmdUpdate:
-    """Test the update command."""
+    """Test the update command adapter."""
 
-    @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
-    @patch("hermes_cli.plugins_cmd._plugins_dir")
-    @patch("hermes_cli.plugins_cmd.subprocess.run")
-    def test_update_git_pull_success(self, mock_run, mock_plugins_dir, mock_sanitize):
+    @patch("hermes_cli.plugins_cmd.dashboard_update_user_plugin")
+    def test_update_git_pull_success(self, mock_update):
         from hermes_cli.plugins_cmd import cmd_update
 
-        mock_plugins_dir_val = MagicMock()
-        mock_plugins_dir.return_value = mock_plugins_dir_val
-        mock_target = MagicMock()
-        mock_target.exists.return_value = True
-        mock_target.__truediv__ = lambda self, x: MagicMock(
-            exists=MagicMock(return_value=True)
-        )
-        mock_sanitize.return_value = mock_target
-
-        mock_run.return_value = MagicMock(returncode=0, stdout="Updated", stderr="")
+        mock_update.return_value = {
+            "ok": True,
+            "name": "test-plugin",
+            "output": "Updated",
+            "unchanged": False,
+        }
 
         cmd_update("test-plugin")
 
-        mock_run.assert_called_once()
+        mock_update.assert_called_once_with("test-plugin")
 
-    @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
-    @patch("hermes_cli.plugins_cmd._plugins_dir")
-    def test_update_plugin_not_found(self, mock_plugins_dir, mock_sanitize):
+    @patch("hermes_cli.plugins_cmd.dashboard_update_user_plugin")
+    def test_update_plugin_not_found(self, mock_update):
         from hermes_cli.plugins_cmd import cmd_update
 
-        mock_plugins_dir_val = MagicMock()
-        mock_plugins_dir_val.iterdir.return_value = []
-        mock_plugins_dir.return_value = mock_plugins_dir_val
-        mock_target = MagicMock()
-        mock_target.exists.return_value = False
-        mock_sanitize.return_value = mock_target
-
+        mock_update.return_value = {"ok": False, "error": "not found"}
         with pytest.raises(SystemExit) as exc_info:
             cmd_update("nonexistent-plugin")
 
@@ -495,35 +482,28 @@ class TestCmdUpdate:
 
 
 class TestCmdRemove:
-    """Test the remove command."""
+    """Test the remove command adapter."""
 
-    @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
+    @patch("hermes_cli.plugins_cmd._display_removed")
     @patch("hermes_cli.plugins_cmd._plugins_dir")
-    @patch("hermes_cli.plugins_cmd.shutil.rmtree")
-    def test_remove_deletes_plugin(self, mock_rmtree, mock_plugins_dir, mock_sanitize):
+    @patch("hermes_cli.plugins_cmd.dashboard_remove_user_plugin")
+    def test_remove_deletes_plugin(self, mock_remove, mock_plugins_dir, mock_display):
         from hermes_cli.plugins_cmd import cmd_remove
 
-        mock_plugins_dir.return_value = MagicMock()
-        mock_target = MagicMock()
-        mock_target.exists.return_value = True
-        mock_sanitize.return_value = mock_target
+        mock_remove.return_value = {"ok": True, "name": "test-plugin"}
+        plugins_dir = MagicMock()
+        mock_plugins_dir.return_value = plugins_dir
 
         cmd_remove("test-plugin")
 
-        mock_rmtree.assert_called_once_with(mock_target)
+        mock_remove.assert_called_once_with("test-plugin")
+        mock_display.assert_called_once_with("test-plugin", plugins_dir)
 
-    @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
-    @patch("hermes_cli.plugins_cmd._plugins_dir")
-    def test_remove_plugin_not_found(self, mock_plugins_dir, mock_sanitize):
+    @patch("hermes_cli.plugins_cmd.dashboard_remove_user_plugin")
+    def test_remove_plugin_not_found(self, mock_remove):
         from hermes_cli.plugins_cmd import cmd_remove
 
-        mock_plugins_dir_val = MagicMock()
-        mock_plugins_dir_val.iterdir.return_value = []
-        mock_plugins_dir.return_value = mock_plugins_dir_val
-        mock_target = MagicMock()
-        mock_target.exists.return_value = False
-        mock_sanitize.return_value = mock_target
-
+        mock_remove.return_value = {"ok": False, "error": "not found"}
         with pytest.raises(SystemExit) as exc_info:
             cmd_remove("nonexistent-plugin")
 

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py
@@ -379,60 +379,40 @@ class TestEnableToolOverrideConsent:
 
 
 class TestCompositeMenuWritesCanonicalKey:
-    """#40190 follow-up: the interactive `hermes plugins` menu must persist
-    the CANONICAL KEY (``web/firecrawl``), never the bare manifest name
-    (``web-firecrawl``), so its disabled-list entries stay aligned with what
-    ``cmd_enable`` clears and what PluginManager gates on. Writing the bare
-    name is what silently vetoed a bundled backend forever (pi314).
-    """
+    """The fallback UI delegates canonical selections to the shared writer."""
 
-    @patch("hermes_cli.plugins_cmd._save_disabled_set")
-    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._write_plugin_selection")
     @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
     def test_fallback_unchecked_plugin_disables_by_key_not_name(
-        self, mock_en, mock_save_en, mock_save_dis,
+        self, mock_en, mock_write_selection,
     ):
         from hermes_cli.plugins_cmd import _run_composite_fallback
         from rich.console import Console
 
-        # key differs from the manifest name, mirroring web/firecrawl.
         plugin_keys = ["web/firecrawl"]
         plugin_labels = ["web-firecrawl — firecrawl [bundled]"]
-        plugin_selected = set()  # unchecked → should be disabled
-
-        # First input() toggles nothing (blank Enter confirms immediately),
-        # second (category prompt) is skipped with blank Enter.
         with patch("builtins.input", return_value=""):
             _run_composite_fallback(
-                plugin_keys, plugin_labels, plugin_selected,
-                set(), [], Console(),
+                plugin_keys, plugin_labels, set(), set(), [], Console(),
             )
 
-        saved_dis = mock_save_dis.call_args[0][0]
-        assert "web/firecrawl" in saved_dis      # canonical key persisted
-        assert "web-firecrawl" not in saved_dis   # never the bare name
+        mock_write_selection.assert_called_once_with(plugin_keys, set())
 
-    @patch("hermes_cli.plugins_cmd._save_disabled_set")
-    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._write_plugin_selection")
     @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
     def test_fallback_checked_plugin_enables_by_key_and_clears_aliases(
-        self, mock_en, mock_save_en, mock_save_dis,
+        self, mock_en, mock_write_selection,
     ):
         from hermes_cli.plugins_cmd import _run_composite_fallback
         from rich.console import Console
 
         plugin_keys = ["web/firecrawl"]
         plugin_labels = ["web-firecrawl — firecrawl [bundled]"]
-        plugin_selected = {0}  # checked → enabled
-
-        # Pre-existing stale bare-leaf disable should be cleared on enable.
         with patch("builtins.input", return_value=""):
             _run_composite_fallback(
-                plugin_keys, plugin_labels, plugin_selected,
-                {"firecrawl"}, [], Console(),
+                plugin_keys, plugin_labels, {0}, {"firecrawl"}, [], Console(),
             )
 
-        saved_en = mock_save_en.call_args[0][0]
-        saved_dis = mock_save_dis.call_args[0][0]
-        assert "web/firecrawl" in saved_en
-        assert "firecrawl" not in saved_dis  # stale bare-leaf alias cleared
+        mock_write_selection.assert_called_once_with(
+            plugin_keys, {"web/firecrawl"}
+        )

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -8,9 +8,12 @@ Verifies that:
 
 from __future__ import annotations
 
+import importlib.metadata
+import pkgutil
 import sys
 from pathlib import Path
 
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -27,8 +30,82 @@ def _clear_provider_caches():
         if (
             mod.startswith("plugins.model_providers")
             or mod.startswith("_hermes_user_provider")
+            or mod.startswith("_test_provider_ep_")
         ):
             del sys.modules[mod]
+
+
+@pytest.fixture(autouse=True)
+def _reset_provider_state_after_test(monkeypatch):
+    yield
+    _clear_provider_caches()
+
+
+def _write_provider_module(path: Path, name: str, base_url: str) -> None:
+    path.write_text(
+        "from providers import register_provider\n"
+        "from providers.base import ProviderProfile\n"
+        "register_provider(ProviderProfile(\n"
+        f"    name={name!r},\n"
+        f"    base_url={base_url!r},\n"
+        "    auth_type='none',\n"
+        "))\n"
+    )
+
+
+def _entry_point(
+    name: str, module: str, attribute: str | None = None
+) -> importlib.metadata.EntryPoint:
+    return importlib.metadata.EntryPoint(
+        name=name,
+        value=f"{module}:{attribute}" if attribute else module,
+        group="hermes_agent.model_providers",
+    )
+
+
+def _isolate_discovery(tmp_path, monkeypatch, entry_points=()) -> Path:
+    import providers
+    from hermes_cli import config
+
+    home = tmp_path / ".hermes"
+    home.mkdir(exist_ok=True)
+    empty_bundled = tmp_path / "bundled"
+    empty_bundled.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(providers, "_BUNDLED_PLUGINS_DIR", empty_bundled)
+    monkeypatch.setattr(pkgutil, "iter_modules", lambda _paths: [])
+    selected = importlib.metadata.EntryPoints(entry_points)
+
+    def fake_entry_points(**params):
+        return selected.select(**params) if params else selected
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+    config._LOAD_CONFIG_CACHE.clear()
+    config._RAW_CONFIG_CACHE.clear()
+    _clear_provider_caches()
+    return home
+
+
+def _write_activation_config(home: Path, *, enabled=(), disabled=()) -> None:
+    lines = ["plugins:", "  enabled:"]
+    lines.extend(f"    - {name}" for name in enabled)
+    if not enabled:
+        lines.append("    []")
+    lines.append("  disabled:")
+    lines.extend(f"    - {name}" for name in disabled)
+    if not disabled:
+        lines.append("    []")
+    (home / "config.yaml").write_text("\n".join(lines) + "\n")
+
+
+def _write_user_provider(home: Path, directory: str, name: str, base_url: str) -> Path:
+    plugin_dir = home / "plugins" / "model-providers" / directory
+    plugin_dir.mkdir(parents=True)
+    _write_provider_module(plugin_dir / "__init__.py", name, base_url)
+    (plugin_dir / "plugin.yaml").write_text(
+        f"name: {directory}\nkind: model-provider\nversion: 0.0.1\n"
+    )
+    return plugin_dir
 
 
 def test_bundled_plugins_discovered():
@@ -153,3 +230,180 @@ def test_general_plugin_manager_skips_model_provider_kind(tmp_path, monkeypatch)
     # No import means the module must NOT be in the plugins list as a loaded one.
     # We check that the general loader didn't crash and didn't raise from the
     # broken __init__.py.
+
+
+def _write_marker_module(path: Path, marker: Path) -> None:
+    path.write_text(f"from pathlib import Path\nPath({str(marker)!r}).touch()\n")
+
+
+def test_enabled_model_provider_entry_point_invokes_registrar(tmp_path, monkeypatch):
+    module = "_test_provider_ep_enabled"
+    (tmp_path / f"{module}.py").write_text(
+        "def register():\n"
+        "    from providers import register_provider\n"
+        "    from providers.base import ProviderProfile\n"
+        "    register_provider(ProviderProfile(name='package-enabled', "
+        "base_url='https://package.example/v1', auth_type='none'))\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    home = _isolate_discovery(
+        tmp_path, monkeypatch, [_entry_point("package-enabled", module, "register")]
+    )
+    _write_activation_config(home, enabled=["model-providers/package-enabled"])
+
+    from providers import get_provider_profile
+
+    assert get_provider_profile("package-enabled").base_url == "https://package.example/v1"
+
+
+@pytest.mark.parametrize(
+    ("enabled", "disabled"),
+    [([], []), (["model-providers/package-gated"], ["model-providers/package-gated"])],
+)
+def test_package_provider_requires_unopposed_canonical_enable(
+    tmp_path, monkeypatch, enabled, disabled
+):
+    marker = tmp_path / "package-executed"
+    module = "_test_provider_ep_gated"
+    _write_marker_module(tmp_path / f"{module}.py", marker)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    home = _isolate_discovery(
+        tmp_path, monkeypatch, [_entry_point("package-gated", module)]
+    )
+    _write_activation_config(home, enabled=enabled, disabled=disabled)
+
+    from providers import list_providers
+
+    list_providers()
+    assert not marker.exists()
+
+
+def test_failing_package_entry_point_does_not_block_another(tmp_path, monkeypatch):
+    failing = "_test_provider_ep_failing"
+    working = "_test_provider_ep_working"
+    (tmp_path / f"{failing}.py").write_text("raise RuntimeError('broken')\n")
+    _write_provider_module(
+        tmp_path / f"{working}.py", "package-working", "https://working.example/v1"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    home = _isolate_discovery(
+        tmp_path,
+        monkeypatch,
+        [_entry_point("failing", failing), _entry_point("working", working)],
+    )
+    _write_activation_config(
+        home, enabled=["model-providers/failing", "model-providers/working"]
+    )
+
+    from providers import get_provider_profile
+
+    assert get_provider_profile("package-working").base_url == "https://working.example/v1"
+
+
+def test_user_directory_claim_suppresses_package_registration(tmp_path, monkeypatch):
+    module = "_test_provider_ep_overridden"
+    marker = tmp_path / "package-executed"
+    _write_marker_module(tmp_path / f"{module}.py", marker)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    home = _isolate_discovery(
+        tmp_path, monkeypatch, [_entry_point("shared-provider", module)]
+    )
+    _write_activation_config(home, enabled=["model-providers/shared-provider"])
+    _write_user_provider(
+        home, "shared-provider", "shared-provider", "https://user.example/v1"
+    )
+
+    from providers import get_provider_profile
+
+    assert get_provider_profile("shared-provider").base_url == "https://user.example/v1"
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
+    ("config_text", "executes"),
+    [
+        (None, True),
+        ("plugins:\n  enabled: []\n  disabled: []\n", True),
+        ("plugins:\n  enabled: []\n  disabled: [model-providers/directory]\n", False),
+    ],
+)
+def test_user_directory_activation_matrix(tmp_path, monkeypatch, config_text, executes):
+    home = _isolate_discovery(tmp_path, monkeypatch)
+    if config_text is not None:
+        (home / "config.yaml").write_text(config_text)
+    marker = tmp_path / "directory-executed"
+    plugin_dir = home / "plugins" / "model-providers" / "directory"
+    plugin_dir.mkdir(parents=True)
+    _write_marker_module(plugin_dir / "__init__.py", marker)
+
+    from providers import list_providers
+
+    list_providers()
+    assert marker.exists() is executes
+
+
+@pytest.mark.parametrize(
+    "config_text",
+    [
+        "plugins: [not valid\n",
+        "plugins: []\n",
+        "plugins:\n  enabled:\n    model-providers/shape-evil: true\n",
+        "plugins:\n  enabled: model-providers/shape-evil\n",
+        "plugins:\n  enabled: []\n  disabled:\n    shape-evil: true\n",
+    ],
+)
+def test_external_providers_fail_closed_for_invalid_activation_config(
+    tmp_path, monkeypatch, config_text
+):
+    package_marker = tmp_path / "package-executed"
+    module = "_test_provider_ep_shape_evil"
+    _write_marker_module(tmp_path / f"{module}.py", package_marker)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    home = _isolate_discovery(
+        tmp_path, monkeypatch, [_entry_point("shape-evil", module)]
+    )
+    (home / "config.yaml").write_text(config_text)
+    user_marker = tmp_path / "user-executed"
+    plugin_dir = home / "plugins" / "model-providers" / "shape-evil"
+    plugin_dir.mkdir(parents=True)
+    _write_marker_module(plugin_dir / "__init__.py", user_marker)
+
+    from providers import list_providers
+
+    list_providers()
+    assert not package_marker.exists()
+    assert not user_marker.exists()
+
+
+def test_duplicate_package_names_execute_neither_and_are_absent_from_inventory(
+    tmp_path, monkeypatch
+):
+    markers = [tmp_path / "duplicate-a", tmp_path / "duplicate-b"]
+    modules = ["_test_provider_ep_duplicate_a", "_test_provider_ep_duplicate_b"]
+    for module, marker in zip(modules, markers):
+        _write_marker_module(tmp_path / f"{module}.py", marker)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    home = _isolate_discovery(
+        tmp_path, monkeypatch, [_entry_point("duplicate", module) for module in modules]
+    )
+    _write_activation_config(home, enabled=["model-providers/duplicate"])
+
+    from hermes_cli.plugins_cmd import _discover_model_provider_entrypoints
+    from providers import list_providers
+
+    assert _discover_model_provider_entrypoints() == []
+    list_providers()
+    assert not any(marker.exists() for marker in markers)
+
+
+def test_package_metadata_enumeration_failure_is_isolated(tmp_path, monkeypatch):
+    _isolate_discovery(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        importlib.metadata,
+        "entry_points",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("metadata unavailable")),
+    )
+
+    from providers import list_providers
+
+    assert list_providers() == []

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -14,13 +14,16 @@ Model provider plugins are the third kind of **provider plugin**. The others are
 
 ## How discovery works
 
-`providers/__init__.py._discover_providers()` runs lazily the first time any code calls `get_provider_profile()` or `list_providers()`. Discovery order:
+`providers/__init__.py._discover_providers()` runs lazily the first time any code calls `get_provider_profile()` or `list_providers()`. Provider sources are considered in this order:
 
 1. **Bundled plugins** — `<repo>/plugins/model-providers/<name>/` — ship with Hermes
-2. **User plugins** — `$HERMES_HOME/plugins/model-providers/<name>/` — drop in any directory; no restart required for subsequent sessions
-3. **Legacy single-file** — `<repo>/providers/<name>.py` — back-compat for out-of-tree editable installs
+2. **Enabled package plugins** — installed Python distributions that publish the dedicated `hermes_agent.model_providers` entry-point group
+3. **User plugins** — `$HERMES_HOME/plugins/model-providers/<name>/` — manually dropped or Git-installed directories
+4. **Legacy modules** — `<repo>/providers/<name>.py` — compatibility profiles loaded last
 
-**User plugins override bundled plugins of the same name** because `register_provider()` is last-writer-wins. Drop a `$HERMES_HOME/plugins/model-providers/gmi/` directory to replace the built-in GMI profile without touching the repo.
+A user-directory leaf reserves its canonical `model-providers/<leaf>` key before package loading, so a same-named package entry point is skipped without invoking its registrar. User directories load after bundled plugins and can replace bundled registrations through `register_provider()`'s last-writer-wins behavior. Legacy modules load after every plugin source and can replace earlier registrations by the same rule. Drop a `$HERMES_HOME/plugins/model-providers/gmi/` directory to replace the built-in GMI profile without touching the repo.
+
+Package providers are opt-in. Manually dropped user directories remain active by default for backward compatibility, but an explicit entry in `plugins.disabled` wins over every enabled/default-active state.
 
 ## Directory structure
 
@@ -31,7 +34,7 @@ plugins/model-providers/my-provider/
 └── README.md         # Setup instructions (optional)
 ```
 
-The only required file is `__init__.py`. `plugin.yaml` is used by `hermes plugins` for introspection and by the general PluginManager to route the plugin to the right loader; without it, the general loader falls back to a source-text heuristic.
+The only required file for a manual directory drop is `__init__.py`. `plugin.yaml` is used by `hermes plugins` for introspection and is required for kind-aware Git installation into the model-provider directory.
 
 ## Minimal example — a simple API-key provider
 
@@ -175,7 +178,7 @@ register_provider(ProviderProfile(
 ))
 ```
 
-Next session, `get_provider_profile("gmi").base_url` returns the staging URL. No repo patch, no rebuild. Because user plugins are discovered after bundled ones, the user `register_provider()` call wins.
+After restarting Hermes, `get_provider_profile("gmi").base_url` returns the staging URL. No repo patch or rebuild is needed. Because user plugins are discovered after package and bundled plugins, the user `register_provider()` call wins.
 
 ## api_mode selection
 
@@ -204,7 +207,7 @@ Set `profile.api_mode` to match the default your provider ships — it acts as a
 
 ## Discovery timing
 
-Provider discovery is **lazy** — triggered by the first `get_provider_profile()` or `list_providers()` call in the process. In practice this happens early at startup (`auth.py` module load extends `PROVIDER_REGISTRY` eagerly). If you need to verify your plugin loaded, run:
+Provider discovery is **lazy** — triggered by the first `get_provider_profile()` or `list_providers()` call in the process — and cached for that process. Restart the CLI, desktop app, or gateway after installing, enabling, disabling, updating, or removing a provider. If you need to verify your plugin loaded in a fresh process, run:
 
 ```bash
 hermes doctor
@@ -242,22 +245,51 @@ export MY_API_KEY=your-test-key
 hermes -z "hello" --provider my-provider -m some-model
 ```
 
-## General PluginManager integration
+## Installation and lifecycle
 
-The general `PluginManager` (the thing `hermes plugins` operates on) **sees** model-provider plugins but does not import them — `providers/__init__.py` owns their lifecycle. The manager records the manifest for introspection and categorizes by `kind: model-provider`. When you drop an unlabeled user plugin into `$HERMES_HOME/plugins/` that happens to call `register_provider` with a `ProviderProfile`, the manager auto-coerces it to `kind: model-provider` via a source-text heuristic — so the plugin still routes correctly even without `plugin.yaml`.
+The general `PluginManager` (the thing `hermes plugins` operates on) may inventory model-provider manifests, but it does **not** import or register provider profiles. `providers/__init__.py` exclusively owns provider loading.
 
-## Distribute via pip
+### Distribute via pip
 
-Like any Hermes plugin, model providers can ship as a pip package. Add an entry point to your `pyproject.toml`:
+Model providers can ship as a Python package. Add a dedicated entry point to `pyproject.toml`:
 
 ```toml
-[project.entry-points."hermes_agent.plugins"]
+[project.entry-points."hermes_agent.model_providers"]
 acme-inference = "acme_hermes_plugin:register"
 ```
 
-…where `acme_hermes_plugin:register` is a function that calls `register_provider(profile)`. The general PluginManager picks up entry-point plugins during `discover_and_load()`. For `kind: model-provider` pip plugins, you still need to declare the kind in your manifest (or rely on the source-text heuristic).
+`acme_hermes_plugin:register` must be a zero-argument callable that invokes `register_provider(profile)`. Install and enable the provider separately:
 
-See [Building a Hermes Plugin](/developer-guide/plugins#distribute-via-pip) for the full entry-points setup.
+```bash
+pip install <distribution>
+hermes plugins enable model-providers/acme-inference
+```
+
+Package providers are updated and removed with pip, not `hermes plugins update` or `hermes plugins remove`.
+
+If one repository supports both package and Git/manual distribution, add a root
+`__init__.py` shim because directory discovery executes that file rather than
+the package entry point:
+
+```python
+from .acme_hermes_plugin import register
+
+register()
+```
+
+### Install from Git
+
+A repository with `kind: model-provider` in `plugin.yaml` is routed to `$HERMES_HOME/plugins/model-providers/<name>/`:
+
+```bash
+hermes plugins install owner/repo --enable
+# or install inactive:
+hermes plugins install owner/repo --no-enable
+```
+
+`hermes plugins update <name>` requires a Git checkout. `hermes plugins remove <name>` deletes either a Git-installed or manually dropped user-directory provider; package providers remain owned by pip.
+
+Activation changes apply only after restarting the running Hermes process. `plugins.disabled` always takes precedence over `plugins.enabled`, and manually dropped directories are default-active only when they are not explicitly disabled.
 
 ## Related pages
 


### PR DESCRIPTION
## What does this PR do?

Makes standalone model providers a complete, secure distribution lifecycle rather than only a discovery path.

It supports both documented distribution modes:

- Git plugins installed under `$HERMES_HOME/plugins/model-providers/<name>/`
- Python packages exposing `hermes_agent.model_providers` entry points

It also gives both modes one canonical activation and ownership contract across CLI and dashboard install/list/enable/disable/update/remove flows.

This addresses the same core distribution gap identified by @theQuert in #64277. Thank you for establishing the nested Git placement and dedicated package entry-point direction there. This implementation was developed independently around a Cloudflare Workers AI provider and expands that work to cover activation authority, package opt-in, lifecycle ownership, publication/deletion ordering, collision handling, symlink safety, and compatibility with existing generic plugins. If maintainers prefer #64277 plus a smaller hardening follow-up, I am happy to collaborate on that shape.

## Related Issue

Related to #21685 and #33752.

Alternative/hardening implementation for #64277.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Route `kind: model-provider` Git installs to the provider discovery namespace with validated canonical keys.
- Add dedicated `hermes_agent.model_providers` package discovery and inventory.
- Require explicit canonical opt-in before package entry points execute; manually installed provider directories remain backward-compatible and default active.
- Make explicit disable authoritative and suppress colliding package providers when a user-directory provider owns the same key.
- Persist and verify deny state before publishing or deleting executable provider code.
- Reject symlinked lifecycle mutation paths and ambiguous plugin identities.
- Keep pip-installed providers pip-owned while Git-installed providers retain Hermes update/remove support.
- Preserve existing generic plugin install/remove and list/dict-style metadata entry-point compatibility.
- Document discovery order, precedence, activation defaults, ownership, Git/pip installation, and dual-distribution shims.

## How to Test

1. Run the expanded plugin/provider compatibility matrix:
   ```bash
   scripts/run_tests.sh \
     tests/hermes_cli/test_plugin*.py \
     tests/providers \
     tests/hermes_cli/test_model_provider_distribution.py \
     tests/hermes_cli/test_model_provider_distribution_security.py \
     tests/hermes_cli/test_provider_auth_catalog.py \
     tests/hermes_cli/test_provider_config_projection.py \
     tests/hermes_cli/test_auth_api_keys.py \
     tests/hermes_cli/test_auth_model_provider_aliases.py
   ```
   Result after rebasing onto current `origin/main`: **476 passed, 0 failed**.
2. Run the standalone Cloudflare provider suite against this checkout: **32 passed**, Ruff clean.
3. Install the standalone Cloudflare provider through the canonical Git lifecycle, discover its native catalog, and run a real Workers AI request through the candidate core.
4. Verified live response using `@cf/openai/gpt-oss-20b`: `CLOUDFLARE_REBASE_OK`.
5. The transactional live test restored the user's real `config.yaml` byte-for-byte.

Independent exact-patch reviews passed for AppSec, correctness/minimality, and documentation contracts. The pre- and post-rebase stable patch IDs are identical.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and credited the directly overlapping #64277
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the focused 476-test compatibility matrix is green; the repository-wide macOS baseline has unrelated failures documented during development
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on macOS 27.0 with Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] `cli-config.yaml.example` update is N/A; no new config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A
- [x] I've considered cross-platform impact; implementation uses `pathlib`, stdlib metadata APIs, and existing filesystem abstractions
- [x] Tool descriptions/schemas update is N/A

## Screenshots / Logs

CLI/integration change; no visual surface changed.

Live provider proof:

```text
core=.../hermes-agent-model-provider-v4
model=@cf/openai/gpt-oss-20b
session_id: 20260716_114804_494d8d
CLOUDFLARE_REBASE_OK
live_inference=PASS
config_restore=PASS
```
