### PR TITLE
fix: make curator, skill, and plugin updates transactional

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1518,12 +1518,11 @@ def run_curator_review(
     skipped entirely (no aux-model cost).
 
     If *dry_run* is True, the automatic stale/archive transitions are SKIPPED
-    and the LLM review pass is instructed to produce a report only — no
-    skill_manage mutations, no terminal archive moves. The REPORT.md still
-    gets written and ``state.last_report_path`` still records it so users
-    can read what the curator WOULD have done. A dry-run also honors
-    *consolidate*: when consolidation is off, the preview only reports the
-    deterministic prune candidates.
+    and the LLM review pass is instructed to preview only — no skill_manage
+    mutations, terminal archive moves, report files, or curator-state writes.
+    The preview is returned through the normal summary callback/stdout surface.
+    A dry-run also honors *consolidate*: when consolidation is off, the preview
+    only reports the deterministic prune candidates.
     """
     if consolidate is None:
         consolidate = get_consolidate()
@@ -1567,18 +1566,15 @@ def run_curator_review(
         auto_summary_parts.append(f"{counts['reactivated']} reactivated")
     auto_summary = ", ".join(auto_summary_parts) if auto_summary_parts else "no changes"
 
-    # Persist state before the LLM pass so a crash mid-review still records
-    # the run and doesn't immediately re-trigger. In dry-run we do NOT bump
-    # last_run_at or run_count — a preview shouldn't push the next scheduled
-    # real pass out. We still record a summary so `hermes curator status`
-    # shows that a preview ran.
-    state = load_state()
+    # Persist only real runs. A preview is observational: no report, state,
+    # timestamp, counter, or summary write is allowed.
+    prefix = "dry-run auto: " if dry_run else "auto: "
     if not dry_run:
+        state = load_state()
         state["last_run_at"] = start.isoformat()
         state["run_count"] = int(state.get("run_count", 0)) + 1
-    prefix = "dry-run auto: " if dry_run else "auto: "
-    state["last_run_summary"] = f"{prefix}{auto_summary}"
-    save_state(state)
+        state["last_run_summary"] = f"{prefix}{auto_summary}"
+        save_state(state)
 
     def _llm_pass():
         nonlocal auto_summary
@@ -1606,29 +1602,30 @@ def run_curator_review(
                 "error": None,
             }
             elapsed = (datetime.now(timezone.utc) - start).total_seconds()
-            state2 = load_state()
-            state2["last_run_duration_seconds"] = elapsed
-            state2["last_run_summary"] = final_summary
-            try:
-                after_report = skill_usage.agent_created_report()
-            except Exception:
-                after_report = []
-            try:
-                report_path = _write_run_report(
-                    started_at=start,
-                    elapsed_seconds=elapsed,
-                    auto_counts=counts,
-                    auto_summary=auto_summary,
-                    before_report=before_report,
-                    before_names=before_names,
-                    after_report=after_report,
-                    llm_meta=llm_meta,
-                )
-                if report_path is not None:
-                    state2["last_report_path"] = str(report_path)
-            except Exception as e:
-                logger.debug("Curator report write failed: %s", e, exc_info=True)
-            save_state(state2)
+            if not dry_run:
+                state2 = load_state()
+                state2["last_run_duration_seconds"] = elapsed
+                state2["last_run_summary"] = final_summary
+                try:
+                    after_report = skill_usage.agent_created_report()
+                except Exception:
+                    after_report = []
+                try:
+                    report_path = _write_run_report(
+                        started_at=start,
+                        elapsed_seconds=elapsed,
+                        auto_counts=counts,
+                        auto_summary=auto_summary,
+                        before_report=before_report,
+                        before_names=before_names,
+                        after_report=after_report,
+                        llm_meta=llm_meta,
+                    )
+                    if report_path is not None:
+                        state2["last_report_path"] = str(report_path)
+                except Exception as e:
+                    logger.debug("Curator report write failed: %s", e, exc_info=True)
+                save_state(state2)
             if on_summary:
                 try:
                     on_summary(f"curator: {final_summary}")
@@ -1707,34 +1704,34 @@ def run_curator_review(
             logger.debug("Curator rename summary build failed: %s", e, exc_info=True)
 
         elapsed = (datetime.now(timezone.utc) - start).total_seconds()
-        state2 = load_state()
-        state2["last_run_duration_seconds"] = elapsed
-        state2["last_run_summary"] = final_summary
+        if not dry_run:
+            state2 = load_state()
+            state2["last_run_duration_seconds"] = elapsed
+            state2["last_run_summary"] = final_summary
 
-        # Write the per-run report. Runs in a best-effort try so a
-        # reporting bug never breaks the curator itself. Report path is
-        # recorded in state so `hermes curator status` can point at it.
-        try:
-            after_report = skill_usage.agent_created_report()
-        except Exception:
-            after_report = []
-        try:
-            report_path = _write_run_report(
-                started_at=start,
-                elapsed_seconds=elapsed,
-                auto_counts=counts,
-                auto_summary=auto_summary,
-                before_report=before_report,
-                before_names=before_names,
-                after_report=after_report,
-                llm_meta=llm_meta,
-            )
-            if report_path is not None:
-                state2["last_report_path"] = str(report_path)
-        except Exception as e:
-            logger.debug("Curator report write failed: %s", e, exc_info=True)
+            # Write the per-run report only for a real run. Preview mode must
+            # leave both report storage and curator state byte-for-byte intact.
+            try:
+                after_report = skill_usage.agent_created_report()
+            except Exception:
+                after_report = []
+            try:
+                report_path = _write_run_report(
+                    started_at=start,
+                    elapsed_seconds=elapsed,
+                    auto_counts=counts,
+                    auto_summary=auto_summary,
+                    before_report=before_report,
+                    before_names=before_names,
+                    after_report=after_report,
+                    llm_meta=llm_meta,
+                )
+                if report_path is not None:
+                    state2["last_report_path"] = str(report_path)
+            except Exception as e:
+                logger.debug("Curator report write failed: %s", e, exc_info=True)
 
-        save_state(state2)
+            save_state(state2)
 
         if on_summary:
             try:

--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -183,7 +183,7 @@ def _cmd_run(args) -> int:
     # so run_curator_review reads curator.consolidate from config.
     consolidate = True if bool(getattr(args, "consolidate", False)) else None
     if dry:
-        print("curator: running DRY-RUN (report only, no mutations)...")
+        print("curator: running DRY-RUN (preview only, no filesystem or state mutations)...")
     else:
         print("curator: running review pass...")
     if consolidate is None and not curator.get_consolidate():
@@ -221,8 +221,8 @@ def _cmd_run(args) -> int:
     if dry:
         if synchronous:
             print(
-                "dry-run: no changes applied. Read the report with "
-                "`hermes curator status` and run `hermes curator run` (no flag) to apply."
+                "dry-run: no changes applied and no report/state files written. "
+                "Run `hermes curator run` (no flag) to apply."
             )
         else:
             print(
@@ -594,8 +594,8 @@ def register_cli(parent: argparse.ArgumentParser) -> None:
     )
     p_run.add_argument(
         "--dry-run", dest="dry_run", action="store_true",
-        help="Report only — no state changes, no archives, no consolidation "
-             "(use this to preview what curator would do)",
+        help="Preview only — no filesystem/state changes, archives, or consolidation "
+             "(prints what curator would do)",
     )
     p_run.add_argument(
         "--consolidate", dest="consolidate", action="store_true",

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -633,6 +633,28 @@ def cmd_install(
     console.print()
 
 
+def _validate_updated_plugin(target: Path, expected_name: str) -> None:
+    """Fail closed when a pulled revision no longer satisfies the plugin contract."""
+    manifest = _read_manifest(target)
+    if not manifest and not (target / "__init__.py").exists():
+        raise PluginOperationError("updated revision has no plugin manifest or __init__.py")
+    declared_name = str(manifest.get("name") or expected_name)
+    if declared_name != expected_name:
+        raise PluginOperationError(
+            f"updated revision changed plugin name from {expected_name!r} to {declared_name!r}"
+        )
+    mv = manifest.get("manifest_version")
+    if mv is not None:
+        try:
+            mv_int = int(mv)
+        except (TypeError, ValueError) as exc:
+            raise PluginOperationError(f"invalid manifest_version {mv!r}") from exc
+        if mv_int > _SUPPORTED_MANIFEST_VERSION:
+            raise PluginOperationError(
+                f"plugin requires manifest_version {mv_int}; supported maximum is {_SUPPORTED_MANIFEST_VERSION}"
+            )
+
+
 def cmd_update(name: str) -> None:
     """Update an installed plugin by pulling latest from its git remote."""
     from rich.console import Console
@@ -653,11 +675,44 @@ def cmd_update(name: str) -> None:
         )
         sys.exit(1)
 
-    console.print(f"[dim]Updating {name}...[/dim]")
+    status = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=target, text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    if status.returncode != 0 or status.stdout.strip():
+        console.print("[red]Error:[/red] Plugin working tree must be clean before update.")
+        sys.exit(1)
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=target, text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    if head.returncode != 0:
+        console.print(f"[red]Error:[/red] {(head.stderr or head.stdout).strip()}")
+        sys.exit(1)
+    previous_head = head.stdout.strip()
 
+    console.print(f"[dim]Updating {name}...[/dim]")
     ok, output = _git_pull_plugin_dir(target)
+    if ok:
+        try:
+            _validate_updated_plugin(target, name)
+        except PluginOperationError as exc:
+            rollback = subprocess.run(
+                ["git", "reset", "--hard", previous_head], cwd=target, text=True,
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            )
+            detail = "rollback complete" if rollback.returncode == 0 else f"ROLLBACK FAILED: {rollback.stdout.strip()}"
+            console.print(f"[red]Error:[/red] update rejected: {exc}; {detail}")
+            sys.exit(1)
     if not ok:
-        console.print(f"[red]Error:[/red] {output}")
+        # Pull may have partially advanced refs/files before failing. Restore the
+        # exact verified revision and report rollback failure explicitly.
+        rollback = subprocess.run(
+            ["git", "reset", "--hard", previous_head], cwd=target, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        )
+        detail = "rollback complete" if rollback.returncode == 0 else f"ROLLBACK FAILED: {rollback.stdout.strip()}"
+        console.print(f"[red]Error:[/red] {output}; {detail}")
         sys.exit(1)
 
     # Copy any new .example files

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -576,11 +576,8 @@ def test_run_review_records_state(curator_env):
     assert state["last_run_summary"] is not None
 
 
-def test_dry_run_does_not_advance_state(curator_env, monkeypatch):
-    """Dry-run previews must not bump last_run_at or run_count. A preview
-    shouldn't defer the next scheduled real pass or look like a real run in
-    `hermes curator status`. Fixes #18373.
-    """
+def test_dry_run_does_not_mutate_state_or_reports(curator_env, monkeypatch):
+    """A preview must leave curator state and report storage unchanged."""
     c = curator_env["curator"]
     u = curator_env["usage"]
     skills_dir = curator_env["home"] / "skills"
@@ -596,13 +593,22 @@ def test_dry_run_does_not_advance_state(curator_env, monkeypatch):
         },
     )
 
-    c.run_curator_review(synchronous=True, dry_run=True)
-    state = c.load_state()
-    assert state.get("last_run_at") is None, "dry-run must not seed last_run_at"
-    assert state.get("run_count", 0) == 0, "dry-run must not bump run_count"
-    assert "dry-run" in (state.get("last_run_summary") or ""), (
-        "dry-run summary should be labeled so status output is unambiguous"
+    before_state = c.load_state()
+    reports_root = c._reports_root()
+    before_reports = sorted(str(path.relative_to(reports_root)) for path in reports_root.rglob("*")) if reports_root.exists() else []
+    summaries = []
+
+    c.run_curator_review(
+        synchronous=True,
+        dry_run=True,
+        consolidate=True,
+        on_summary=summaries.append,
     )
+
+    assert c.load_state() == before_state
+    after_reports = sorted(str(path.relative_to(reports_root)) for path in reports_root.rglob("*")) if reports_root.exists() else []
+    assert after_reports == before_reports
+    assert any("dry-run" in summary for summary in summaries)
 
 
 def test_dry_run_injects_report_only_banner(curator_env, monkeypatch):

--- a/tests/hermes_cli/test_curator_run.py
+++ b/tests/hermes_cli/test_curator_run.py
@@ -84,4 +84,4 @@ def test_dry_run_default_reports_synchronous_wording(monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert "When the report lands" not in out
-    assert "Read the report with `hermes curator status`" in out
+    assert "no report/state files written" in out

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -467,11 +467,15 @@ class TestCmdUpdate:
         )
         mock_sanitize.return_value = mock_target
 
-        mock_run.return_value = MagicMock(returncode=0, stdout="Updated", stderr="")
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="abc123\n", stderr=""),
+            MagicMock(returncode=0, stdout="Updated", stderr=""),
+        ]
 
         cmd_update("test-plugin")
 
-        mock_run.assert_called_once()
+        assert mock_run.call_count == 3
 
     @patch("hermes_cli.plugins_cmd._sanitize_plugin_name")
     @patch("hermes_cli.plugins_cmd._plugins_dir")

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -2395,6 +2395,42 @@ class TestInstallPathSafety:
         assert not (skills_dir / "bad-skill" / "leak.txt").exists()
         assert secret.read_text() == "data exfiltration payload\n"
 
+    def test_install_rolls_back_existing_skill_and_lock_on_failure(self, tmp_path, monkeypatch):
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir(parents=True)
+        (q_dir / "SKILL.md").write_text("---\nname: demo\n---\nnew\n")
+        installed = skills_dir / "demo"
+        installed.mkdir()
+        (installed / "SKILL.md").write_text("---\nname: demo\n---\nold\n")
+        lock_path = skills_dir / ".hub" / "lock.json"
+        lock_path.parent.mkdir(exist_ok=True)
+        lock_path.write_text('{"installed":{"demo":{"content_hash":"old"}}}')
+        before_lock = lock_path.read_bytes()
+        bundle = hub.SkillBundle(
+            name="demo", files={"SKILL.md": "new"}, source="community",
+            identifier="x", trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="demo", source="community", trust_level="community",
+            verdict="safe",
+        )
+
+        monkeypatch.setattr(hub.HubLockFile, "record_install", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("lock failed")))
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root), \
+             patch.object(hub, "LOCK_FILE", lock_path):
+            with pytest.raises(RuntimeError, match="lock failed"):
+                hub.install_from_quarantine(q_dir, "demo", "", bundle, scan_result)
+
+        assert (installed / "SKILL.md").read_text().endswith("old\n")
+        assert lock_path.read_bytes() == before_lock
+        assert not list(skills_dir.glob(".demo.rollback-*"))
+
 
 # ---------------------------------------------------------------------------
 # parallel_search_sources — overall_timeout must be honoured even when a

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3595,8 +3595,7 @@ def install_from_quarantine(
     # path can never refer to a redirected target.
     install_dir = _resolve_lock_install_path(install_rel_path, safe_skill_name)
 
-    if install_dir.exists():
-        shutil.rmtree(install_dir)
+    backup_dir: Optional[Path] = None
 
     # Warn (but don't block) if SKILL.md is very large
     skill_md = quarantine_path / "SKILL.md"
@@ -3630,28 +3629,51 @@ def install_from_quarantine(
         )
 
     install_dir.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(str(quarantine_path), str(install_dir))
+    lock_path = _lock_file()
+    prior_lock = lock_path.read_bytes() if lock_path.exists() else None
+    if install_dir.exists():
+        backup_dir = install_dir.with_name(
+            f".{safe_skill_name}.rollback-{os.getpid()}-{time.time_ns()}"
+        )
+        install_dir.rename(backup_dir)
 
-    # Record in lock file
-    lock = HubLockFile()
-    lock.record_install(
-        name=safe_skill_name,
-        source=bundle.source,
-        identifier=bundle.identifier,
-        trust_level=bundle.trust_level,
-        scan_verdict=scan_result.verdict,
-        skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(_skills_dir())),
-        files=list(bundle.files.keys()),
-        metadata=bundle.metadata,
-        scan_provenance=scan_provenance or getattr(scan_result, "scan_provenance", None),
-    )
+    try:
+        shutil.move(str(quarantine_path), str(install_dir))
 
-    append_audit_log(
-        "INSTALL", safe_skill_name, bundle.source,
-        bundle.trust_level, scan_result.verdict,
-        content_hash(install_dir),
-    )
+        # Record in lock file only after the promoted tree is in place.
+        lock = HubLockFile()
+        lock.record_install(
+            name=safe_skill_name,
+            source=bundle.source,
+            identifier=bundle.identifier,
+            trust_level=bundle.trust_level,
+            scan_verdict=scan_result.verdict,
+            skill_hash=content_hash(install_dir),
+            install_path=str(install_dir.relative_to(_skills_dir())),
+            files=list(bundle.files.keys()),
+            metadata=bundle.metadata,
+            scan_provenance=scan_provenance or getattr(scan_result, "scan_provenance", None),
+        )
+
+        append_audit_log(
+            "INSTALL", safe_skill_name, bundle.source,
+            bundle.trust_level, scan_result.verdict,
+            content_hash(install_dir),
+        )
+    except Exception:
+        if install_dir.exists():
+            shutil.rmtree(install_dir)
+        if backup_dir is not None and backup_dir.exists():
+            backup_dir.rename(install_dir)
+        if prior_lock is None:
+            lock_path.unlink(missing_ok=True)
+        else:
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            lock_path.write_bytes(prior_lock)
+        raise
+    else:
+        if backup_dir is not None and backup_dir.exists():
+            shutil.rmtree(backup_dir)
 
     return install_dir
 


### PR DESCRIPTION
## Summary
- make curator dry-run leave state and report storage byte-for-byte unchanged
- transactionally replace hub skills and restore both the prior tree and lock on failure
- require clean plugin trees, validate pulled manifests, and reset to the verified commit on rejection/failure
- align CLI help/output with the strict no-write dry-run contract

## Verification
- 491 focused tests passed from a clean upstream worktree
- live curator dry-run returned rc=0 with identical before/after state+report hash
