### PR TITLE
fix(bedrock): skip profile-only foundation models in discovery (#58185)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1161,6 +1161,16 @@ def discover_bedrock_models(
             output_mods = summary.get("outputModalities", [])
             if "TEXT" not in output_mods:
                 continue
+            # Skip models that cannot be invoked by their bare foundation ID.
+            # ``inferenceTypesSupported == ["INFERENCE_PROFILE"]`` means AWS
+            # only accepts this model through an inference-profile ID
+            # (us.* / global.* / ...), which step 2 below discovers separately;
+            # offering the bare ID yields HTTP 400 "on-demand throughput isn't
+            # supported" at invoke time (#58185). Default permissive: an absent
+            # field (older API shapes) keeps the model.
+            inference_types = summary.get("inferenceTypesSupported")
+            if inference_types and "ON_DEMAND" not in inference_types:
+                continue
 
             models.append({
                 "id": model_id,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -920,6 +920,80 @@ class TestDiscoverBedrockModels:
 
         assert models == []
 
+    def test_skips_profile_only_foundation_models(self):
+        """Models with inferenceTypesSupported=["INFERENCE_PROFILE"] can't be
+        invoked by their bare ID and must not appear in discovery (#58185)."""
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [
+                {
+                    "modelId": "anthropic.claude-sonnet-5",
+                    "modelName": "Claude Sonnet 5",
+                    "providerName": "Anthropic",
+                    "inputModalities": ["TEXT", "IMAGE"],
+                    "outputModalities": ["TEXT"],
+                    "responseStreamingSupported": True,
+                    "modelLifecycle": {"status": "ACTIVE"},
+                    "inferenceTypesSupported": ["INFERENCE_PROFILE"],
+                },
+                {
+                    "modelId": "amazon.titan-text-express-v1",
+                    "modelName": "Titan Text Express",
+                    "providerName": "Amazon",
+                    "inputModalities": ["TEXT"],
+                    "outputModalities": ["TEXT"],
+                    "responseStreamingSupported": True,
+                    "modelLifecycle": {"status": "ACTIVE"},
+                    "inferenceTypesSupported": ["ON_DEMAND"],
+                },
+            ],
+        }
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{
+                "inferenceProfileId": "us.anthropic.claude-sonnet-5",
+                "inferenceProfileName": "US Claude Sonnet 5",
+                "status": "ACTIVE",
+                "models": [],
+            }],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        ids = [m["id"] for m in models]
+        assert "anthropic.claude-sonnet-5" not in ids
+        assert "us.anthropic.claude-sonnet-5" in ids
+        assert "amazon.titan-text-express-v1" in ids
+
+    def test_keeps_models_without_inference_types_field(self):
+        """Older API shapes may omit inferenceTypesSupported — default permissive."""
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [{
+                "modelId": "anthropic.claude-v2",
+                "modelName": "Claude V2",
+                "providerName": "Anthropic",
+                "inputModalities": ["TEXT"],
+                "outputModalities": ["TEXT"],
+                "responseStreamingSupported": True,
+                "modelLifecycle": {"status": "ACTIVE"},
+            }],
+        }
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        assert [m["id"] for m in models] == ["anthropic.claude-v2"]
+
 
 class TestExtractProviderFromArn:
     def test_extracts_anthropic(self):


### PR DESCRIPTION
## What does this PR do?

Bedrock model discovery (`discover_bedrock_models()` in `agent/bedrock_adapter.py`) includes foundation models that AWS marks as **not invokable by their bare ID**. `list_foundation_models` carries the signal explicitly:

```python
>>> [(s['modelId'], s.get('inferenceTypesSupported'))
...  for s in bedrock.list_foundation_models(byProvider='anthropic')['modelSummaries']
...  if 'sonnet-5' in s['modelId']]
[('anthropic.claude-sonnet-5', ['INFERENCE_PROFILE'])]
```

`inferenceTypesSupported == ["INFERENCE_PROFILE"]` means the model only works through an inference-profile ID (`us.*`/`global.*`/…). Discovery ignored the field, so the `/model` picker offered bare IDs that fail at invoke time with `ValidationException: ... on-demand throughput isn't supported` — and selecting one persists the un-invokable ID to `config.yaml` **and** per-session `model_override` pins (which survive config corrections).

Reproduced live on an on-demand account (2026-07-16): a Telegram session pinned `anthropic.claude-sonnet-5` and crash-looped the gateway until the pin was hand-edited to `us.anthropic.claude-sonnet-5`.

**Fix:** in the `list_foundation_models` loop, skip models whose `inferenceTypesSupported` is present but lacks `ON_DEMAND`. Absent field (older API shapes) stays permissive. The profile counterparts are discovered separately by the `list_inference_profiles` step, so nothing invokable is lost.

## Relationship to PR #58201

Complements it, doesn't compete. #58201 dedups bare IDs *when their profile sibling appears in the discovery output* — which requires `bedrock:ListInferenceProfiles` to succeed (its failure path is a silent `logger.debug` skip, and on-demand accounts commonly lack that IAM permission; the bare IDs then all survive dedup). This filter uses the authoritative per-model signal from `list_foundation_models` itself, so discovery is correct even when profile listing is denied. Both together give defense in depth at the source and at the picker.

## Related Issue

Fixes #58185

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/bedrock_adapter.py`: skip foundation models without `ON_DEMAND` in `inferenceTypesSupported` (default permissive when the field is absent)
- `tests/agent/test_bedrock_adapter.py`: two new tests — profile-only model excluded while its `us.*` profile and an `ON_DEMAND` sibling survive; absent field keeps the model

## Testing

- `pytest tests/agent/test_bedrock_adapter.py` → **138 passed** (136 existing + 2 new)
- Live verification against a real on-demand account in us-east-1: bare `anthropic.claude-sonnet-5` reports `['INFERENCE_PROFILE']` and 400s via Converse; `us.anthropic.claude-sonnet-5` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)