### PR TITLE
fix(cli): degrade _cprint to plain output when stdout has no console (fixes #65558)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2590,6 +2590,75 @@ def _replay_output_history() -> None:
         _OUTPUT_HISTORY_REPLAYING = False
 
 
+# Matches CSI escape sequences (SGR colors like \x1b[2;3m, cursor moves,
+# erases). Used to strip ANSI before plain output when there's no console.
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+
+def _stdout_is_console() -> bool:
+    """True when stdout is a real interactive console/terminal.
+
+    Mirrors the ``isatty()`` gate prompt_toolkit itself uses on POSIX (and
+    that ``_b``/``_d`` already use here). When stdout is piped/redirected/
+    captured — e.g. any non-interactive ``hermes chat -q`` spawned with
+    ``stdio: pipe`` — prompt_toolkit's output backend can't initialize: on
+    Windows ``Win32Output`` calls ``GetConsoleScreenBufferInfo`` on a pipe
+    handle and raises ``NoConsoleScreenBufferError``. Callers must avoid the
+    pt renderer in that case (#65558).
+    """
+    try:
+        return bool(sys.stdout.isatty())
+    except Exception:
+        return False
+
+
+def _plain_output(text: str) -> None:
+    """Emit text without prompt_toolkit: ANSI stripped, encoding-safe.
+
+    Used when stdout isn't a real console. Two failure modes the pt path
+    causes there and this avoids: literal ANSI escapes leaking into captured
+    output (stripped here), and ``UnicodeEncodeError`` when box-drawing /
+    braille characters hit a legacy Windows code page (cp1252). The latter is
+    handled by re-encoding through stdout's encoding with replacement, so such
+    characters degrade to ``?`` instead of raising (#65558).
+    """
+    plain = _ANSI_ESCAPE_RE.sub("", text)
+    try:
+        print(plain)
+        return
+    except UnicodeEncodeError:
+        pass
+    except Exception:
+        return
+    enc = getattr(sys.stdout, "encoding", None) or "utf-8"
+    safe = plain.encode(enc, "replace").decode(enc, "replace")
+    try:
+        print(safe)
+    except Exception:
+        pass
+
+
+def _emit_without_running_app(text: str) -> None:
+    """Emit ``text`` when no prompt_toolkit Application is running.
+
+    With no running app there is no live pt output backend, so ``_pt_print``
+    would construct a fresh one — which on a non-console stdout raises
+    ``NoConsoleScreenBufferError`` on Windows (#65558). Use the pt renderer
+    only when stdout is a real console; otherwise emit plain, ANSI-stripped,
+    encoding-safe text (parity with prompt_toolkit's own POSIX isatty
+    fallback). A running app's backend already exists and is not routed here.
+    """
+    if not _stdout_is_console():
+        _plain_output(text)
+        return
+    try:
+        _pt_print(_PT_ANSI(text))
+    except Exception:
+        # Console vanished / backend failed unexpectedly despite the isatty
+        # check — degrade cleanly rather than crash.
+        _plain_output(text)
+
+
 def _cprint(text: str):
     """Print ANSI-colored text through prompt_toolkit's native renderer.
 
@@ -2611,7 +2680,8 @@ def _cprint(text: str):
     try:
         from prompt_toolkit.application import get_app_or_none, run_in_terminal
     except Exception:
-        _pt_print(_PT_ANSI(text))
+        # prompt_toolkit.application unavailable — no app can be running.
+        _emit_without_running_app(text)
         return
 
     app = None
@@ -2620,20 +2690,12 @@ def _cprint(text: str):
     except Exception:
         app = None
 
-    # No active app, or we're already on the app's main thread: the
-    # direct prompt_toolkit print is safe and matches existing behavior
-    # (spinner frames, streamed tokens, tool activity prefixes, …).
+    # No active app, or app tearing down: emit via the console-aware path so a
+    # piped/redirected stdout (non-interactive `hermes chat -q`) degrades to
+    # plain text instead of crashing the pt Win32 backend (#65558). A running
+    # app's output backend already exists, so the branches below are unchanged.
     if app is None or not getattr(app, "_is_running", False):
-        try:
-            _pt_print(_PT_ANSI(text))
-        except Exception:
-            # Fallback when stdout is not a real console (e.g. subprocess
-            # worker logging to a file). prompt_toolkit raises
-            # NoConsoleScreenBufferError (Windows) or OSError (other).
-            try:
-                print(text)
-            except Exception:
-                pass
+        _emit_without_running_app(text)
         return
 
     try:

--- a/tests/cli/test_cli_cprint_no_console.py
+++ b/tests/cli/test_cli_cprint_no_console.py
@@ -1,0 +1,110 @@
+"""Regression tests for `_cprint` on a non-console stdout (issue #65558).
+
+On Windows, `hermes chat -q` with piped/redirected stdout crashed with
+`prompt_toolkit.output.win32.NoConsoleScreenBufferError`, because the pt
+output backend can't build a Win32 console from a pipe handle. `_cprint` now
+detects the non-console case up front and emits plain, ANSI-stripped,
+encoding-safe text instead — parity with prompt_toolkit's own POSIX fallback.
+
+Under pytest, `capsys` replaces stdout with a non-tty capture, so
+`_stdout_is_console()` naturally returns False — the exact broken path — with
+no monkeypatching needed.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import cli
+
+
+class TestStdoutIsConsole:
+    def test_false_when_not_a_tty(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdout", _FakeStream(isatty=False))
+        assert cli._stdout_is_console() is False
+
+    def test_true_when_a_tty(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdout", _FakeStream(isatty=True))
+        assert cli._stdout_is_console() is True
+
+    def test_false_when_isatty_raises(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdout", _FakeStream(isatty_raises=True))
+        assert cli._stdout_is_console() is False
+
+
+class TestPlainOutput:
+    def test_strips_ansi_escapes(self, capsys):
+        cli._plain_output("\x1b[2;3mInitializing agent...\x1b[0m")
+        out = capsys.readouterr().out
+        assert out == "Initializing agent...\n"
+        assert "\x1b" not in out
+
+    def test_strips_cursor_and_erase_sequences(self, capsys):
+        cli._plain_output("\x1b[2K\x1b[1Gline\x1b[0m")
+        assert capsys.readouterr().out == "line\n"
+
+    def test_encoding_safe_on_legacy_codepage(self, monkeypatch):
+        # A cp1252 stream raises UnicodeEncodeError on box/braille chars; the
+        # fallback must re-encode with replacement rather than crash (or drop).
+        stream = _Cp1252Stream()
+        monkeypatch.setattr(sys, "stdout", stream)
+        cli._plain_output("box █ braille ⠰")  # █ ⠰
+        written = "".join(stream.written)
+        assert "box " in written and "?" in written
+        assert "█" not in written  # the un-encodable char was replaced
+
+
+class TestCprintNoConsole:
+    def test_does_not_raise_and_strips_ansi(self, capsys):
+        # capsys stdout is non-tty → this is the piped `hermes chat -q` path
+        # that used to raise NoConsoleScreenBufferError on Windows.
+        cli._cprint("\x1b[2;3mInitializing agent...\x1b[0m")
+        out = capsys.readouterr().out
+        assert "Initializing agent..." in out
+        assert "\x1b" not in out
+
+    def test_console_path_still_uses_prompt_toolkit(self, monkeypatch):
+        # When stdout IS a console and no app is running, `_cprint` must still
+        # route through the prompt_toolkit renderer (unchanged behavior).
+        monkeypatch.setattr(cli, "_stdout_is_console", lambda: True)
+        calls = []
+        monkeypatch.setattr(cli, "_pt_print", lambda payload: calls.append(payload))
+        cli._cprint("hello")
+        assert len(calls) == 1
+
+
+class _FakeStream:
+    encoding = "utf-8"
+
+    def __init__(self, *, isatty: bool = False, isatty_raises: bool = False):
+        self._isatty = isatty
+        self._isatty_raises = isatty_raises
+
+    def isatty(self) -> bool:
+        if self._isatty_raises:
+            raise OSError("no fileno")
+        return self._isatty
+
+    def write(self, s):  # pragma: no cover - not exercised
+        return len(s)
+
+    def flush(self):  # pragma: no cover
+        pass
+
+
+class _Cp1252Stream:
+    encoding = "cp1252"
+
+    def __init__(self):
+        self.written = []
+
+    def isatty(self) -> bool:
+        return False
+
+    def write(self, s):
+        s.encode("cp1252")  # raises UnicodeEncodeError on un-encodable chars
+        self.written.append(s)
+        return len(s)
+
+    def flush(self):
+        pass

--- a/tests/cli/test_cprint_bg_thread.py
+++ b/tests/cli/test_cprint_bg_thread.py
@@ -33,6 +33,9 @@ def test_cprint_no_app_direct_print(monkeypatch):
     calls = []
     monkeypatch.setattr(cli, "_pt_print", lambda x: calls.append(("pt_print", x)))
     monkeypatch.setattr(cli, "_PT_ANSI", lambda t: ("ANSI", t))
+    # A real console is present → the pt renderer is used (the non-console
+    # fallback is covered in test_cli_cprint_no_console.py).
+    monkeypatch.setattr(cli, "_stdout_is_console", lambda: True)
 
     # Patch the prompt_toolkit import the function performs internally.
     fake_pt_app = types.ModuleType("prompt_toolkit.application")
@@ -50,6 +53,7 @@ def test_cprint_app_not_running_direct_print(monkeypatch):
     calls = []
     monkeypatch.setattr(cli, "_pt_print", lambda x: calls.append(("pt_print", x)))
     monkeypatch.setattr(cli, "_PT_ANSI", lambda t: t)
+    monkeypatch.setattr(cli, "_stdout_is_console", lambda: True)
 
     fake_app = SimpleNamespace(_is_running=False, loop=None)
     fake_pt_app = types.ModuleType("prompt_toolkit.application")
@@ -184,6 +188,7 @@ def test_cprint_swallows_prompt_toolkit_import_error(monkeypatch):
     direct_prints = []
     monkeypatch.setattr(cli, "_pt_print", lambda x: direct_prints.append(x))
     monkeypatch.setattr(cli, "_PT_ANSI", lambda t: t)
+    monkeypatch.setattr(cli, "_stdout_is_console", lambda: True)
 
     # Drop cached prompt_toolkit.application AND install a meta-path finder
     # that raises ImportError on re-import.


### PR DESCRIPTION
## What & why

On Windows, `hermes chat -q "<prompt>"` with piped/redirected stdout — the documented non-interactive path, and exactly what any orchestrator does to capture the response (`stdio: pipe`) — crashed with `prompt_toolkit.output.win32.NoConsoleScreenBufferError`. This made the `-q` flag unusable from any Windows automation/CI context.

Fixes #65558.

**Root cause (confirmed on Windows):** when no prompt_toolkit `Application` is running, `_cprint` calls `_pt_print`, which builds a *fresh* pt output backend via `create_output()`. On Windows that's `Win32Output`, which calls `GetConsoleScreenBufferInfo` on the process's stdout handle — a **pipe**, not a console — and raises. I reproduced it directly: `_pt_print(ANSI(...))` with a non-tty stdout → `NoConsoleScreenBufferError`. (The POSIX branch of `create_output()` has an `isatty()` fallback to `PlainTextOutput`; the win32 branch has none.)

## Fix

Suggested option 1 from the issue (in-tree, no upstream dependency): detect a non-console stdout up front and emit plain text instead of the pt renderer — but **only in the no-app path**, where a fresh backend would otherwise be constructed. This mirrors the `isatty()` gate prompt_toolkit uses on POSIX (and that this file's own `_b`/`_d` helpers already use). When an `Application` *is* running, its output backend already exists and works, so those paths (bg-thread `run_in_terminal` scheduling, etc.) are left completely unchanged.

The plain path also resolves the two related symptoms the reporter flagged, same "assume a real console" root cause:
- **ANSI escapes leaking** into captured output → stripped via a CSI regex.
- **`UnicodeEncodeError`** on box-drawing / braille characters under a legacy Windows code page (cp1252) → re-encode through stdout's encoding with replacement, so they degrade to `?` instead of raising (previously silently dropped by a bare `except`).

New helpers: `_stdout_is_console()`, `_plain_output()`, and `_emit_without_running_app()` (shared by the no-app and the pt-import-failure branches). The old inline `try: _pt_print except: print(text)` fallback — which leaked raw ANSI and could drop unicode — is replaced by this.

## Scope / compatibility

- Only the **no-app** and **pt-import-failure** branches of `_cprint` change. The app-running branches are byte-for-byte unchanged.
- When stdout **is** a console, behavior is identical to before (pt renderer, colors intact).

## Testing

`tests/cli/test_cli_cprint_no_console.py` (8 new): console detection (incl. `isatty()` raising), ANSI + cursor/erase stripping, the cp1252 encoding-safe fallback (via a fake cp1252 stream), the end-to-end no-console `_cprint` **regression** (pytest's `capsys` stdout is already non-tty — the exact broken path — so it asserts no crash + ANSI stripped), and that a real console still routes through prompt_toolkit.

Updated 3 existing tests in `test_cprint_bg_thread.py` that assert the pt-routing path, pinning `_stdout_is_console -> True` (the console presence they implicitly assumed); the no-console behavior is covered by the new file.

- `python -m pytest tests/cli/test_cli_cprint_no_console.py tests/cli/test_cprint_bg_thread.py -q` → **21 passed**.
- `python -m pytest tests/cli -k "cprint or output or print or terminal or replay or history" -q` → **161 passed**.
- Authored and reproduced on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
