### PR TITLE
fix(model_metadata): drop duplicate 'stepfun' entry in _PROVIDER_PREFIXES

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -60,7 +60,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "glm", "z-ai", "z.ai", "zhipu", "github", "github-copilot",
     "github-models", "kimi", "moonshot", "kimi-cn", "moonshot-cn", "claude", "deep-seek", "deep-infra",
     "ollama",
-    "stepfun", "opencode", "zen", "go", "kilo", "dashscope", "aliyun", "qwen",
+    "opencode", "zen", "go", "kilo", "dashscope", "aliyun", "qwen",
     "mimo", "xiaomi-mimo",
     "tencent", "tokenhub", "tencent-cloud", "tencentmaas",
     "arcee-ai", "arceeai",


### PR DESCRIPTION
### Problem

`"stepfun"` is listed **twice inside the same `frozenset` literal** in `agent/model_metadata.py`:

- **Line 50** — the canonical provider block, alongside `gemini`, `zai`, `minimax`, `anthropic`, `deepseek`.
- **Line 63** — the `# Common aliases` block, alongside `opencode`, `zen`, `go`, `kilo`, `dashscope`.

`stepfun` is a canonical provider name, not an alias, so the second copy is both redundant and filed under the wrong heading. `frozenset` dedupes on construction, so the alias-block entry has never had any effect — it is dead weight that misleads the next reader into thinking `stepfun` is an alias of something.

### Fix

Removes the duplicate from the alias block. One line, one file.

```diff
     "ollama",
-    "stepfun", "opencode", "zen", "go", "kilo", "dashscope", "aliyun", "qwen",
+    "opencode", "zen", "go", "kilo", "dashscope", "aliyun", "qwen",
     "mimo", "xiaomi-mimo",
```

### Why this is behavior-preserving

`_PROVIDER_PREFIXES` is only ever consumed as a membership test, so a duplicate element is a strict no-op and removing it cannot change any outcome:

- `"stepfun" in _PROVIDER_PREFIXES` is still `True` — line 50 still provides it.
- The set's contents, size, and every lookup against it are unchanged.

No logic, no control flow, and no public surface is touched. The unrelated `api.stepfun.ai` / `api.stepfun.com` → `stepfun` endpoint-host map further down the file is deliberately left alone.

### Verification

Provable by reading the literal — the same string appears twice in one `frozenset({...})`. Confirmed mechanically with an AST scan of the file (`ast.Set` element counting), which reports the frozenset going from 2 `stepfun` entries to 1 while the file's other two occurrences (the endpoint map) stay untouched.
