### PR TITLE
fix(webhook): let channel_overrides match webhook routes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2507,6 +2507,17 @@ def _channel_override_lookup_keys(
             continue
         seen.add(sk)
         keys.append(sk)
+    # Webhook sessions use per-delivery chat ids ("webhook:<route>:<delivery>");
+    # also try the route-level "webhook:<route>" key so a static
+    # channel_overrides entry can target every delivery on a route.
+    for key in list(keys):
+        if key.startswith("webhook:"):
+            parts = key.split(":")
+            if len(parts) >= 3:
+                route_key = ":".join(parts[:2])
+                if route_key not in seen:
+                    seen.add(route_key)
+                    keys.append(route_key)
     return keys
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2489,6 +2489,7 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
 def _channel_override_lookup_keys(
     chat_id: str,
     *,
+    platform: Platform,
     thread_id: Optional[str] = None,
     parent_id: Optional[str] = None,
 ) -> list[str]:
@@ -2510,8 +2511,10 @@ def _channel_override_lookup_keys(
     # Webhook sessions use per-delivery chat ids ("webhook:<route>:<delivery>");
     # also try the route-level "webhook:<route>" key so a static
     # channel_overrides entry can target every delivery on a route.
-    for key in list(keys):
-        if key.startswith("webhook:"):
+    if platform == Platform.WEBHOOK:
+        for key in list(keys):
+            if not key.startswith("webhook:"):
+                continue
             parts = key.split(":")
             if len(parts) >= 3:
                 route_key = ":".join(parts[:2])
@@ -2542,7 +2545,7 @@ def _get_channel_override(
         return None
     overrides = platform_config.channel_overrides
     for key in _channel_override_lookup_keys(
-        chat_id, thread_id=thread_id, parent_id=parent_id
+        chat_id, platform=platform, thread_id=thread_id, parent_id=parent_id
     ):
         ov = overrides.get(key)
         if ov is not None:

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -156,6 +156,55 @@ class TestResolveModelForChannel:
         assert model == "global-model/default"
 
 
+class TestWebhookRouteLevelOverride:
+    """Webhook chat ids are per-delivery (webhook:<route>:<delivery_id>); a
+    static channel_overrides entry for the route must match every delivery."""
+
+    def test_route_level_key_matches_delivery_chat_id(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.WEBHOOK: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "webhook:mission-complete": ChannelOverride(model="route/model"),
+                    },
+                ),
+            },
+        )
+        ov = _get_channel_override(
+            config, Platform.WEBHOOK, "webhook:mission-complete:1784209310746"
+        )
+        assert ov is not None
+        assert ov.model == "route/model"
+
+    def test_exact_delivery_key_still_wins_over_route_key(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.WEBHOOK: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "webhook:mission-complete": ChannelOverride(model="route/model"),
+                        "webhook:mission-complete:42": ChannelOverride(model="delivery/model"),
+                    },
+                ),
+            },
+        )
+        ov = _get_channel_override(config, Platform.WEBHOOK, "webhook:mission-complete:42")
+        assert ov is not None
+        assert ov.model == "delivery/model"
+
+    def test_non_webhook_ids_gain_no_extra_keys(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={"chan": ChannelOverride(model="m")},
+                ),
+            },
+        )
+        assert _get_channel_override(config, Platform.DISCORD, "chan:sub:42") is None
+
+
 class TestGetSystemPromptForChannel:
     def test_uses_channel_override_when_present(self):
         config = GatewayConfig(

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -193,16 +193,25 @@ class TestWebhookRouteLevelOverride:
         assert ov is not None
         assert ov.model == "delivery/model"
 
-    def test_non_webhook_ids_gain_no_extra_keys(self):
+    def test_webhook_shaped_non_webhook_id_gains_no_route_key(self):
         config = GatewayConfig(
             platforms={
                 Platform.DISCORD: PlatformConfig(
                     enabled=True,
-                    channel_overrides={"chan": ChannelOverride(model="m")},
+                    channel_overrides={
+                        "webhook:mission-complete": ChannelOverride(model="m")
+                    },
                 ),
             },
         )
-        assert _get_channel_override(config, Platform.DISCORD, "chan:sub:42") is None
+        assert (
+            _get_channel_override(
+                config,
+                Platform.DISCORD,
+                "webhook:mission-complete:delivery-42",
+            )
+            is None
+        )
 
 
 class TestGetSystemPromptForChannel:


### PR DESCRIPTION
## Problem

Webhook sessions use per-delivery chat ids (`webhook:<route>:<delivery_id>`), so a static `platforms.webhook.channel_overrides` entry can never match them — there is currently no way to pin a model (or system prompt) for a webhook route, and every delivery runs on the gateway default model.

## Fix

`_channel_override_lookup_keys` now also derives the route-level key `webhook:<route>` from webhook chat ids, after the exact keys. Operators can then do:

```yaml
platforms:
  webhook:
    channel_overrides:
      "webhook:mission-complete":
        model: gpt-5.6-luna
```

Exact per-delivery keys still win over the route key (order preserved), and non-webhook ids gain no extra lookup keys.

## Tests

Three new tests in `tests/gateway/test_channel_overrides.py` (route key matches delivery ids; exact key beats route key; non-webhook ids unaffected). Full file: 18 passed.

Running in production on our gateway since 2026-07-16.