### PR TITLE
fix(desktop): preserve Copy Image for large remote media

### DIFF
--- a/apps/desktop/electron/image-context-menu.test.ts
+++ b/apps/desktop/electron/image-context-menu.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { imageContextMenuItems } from './image-context-menu'
+
+function createActions() {
+  const calls = {
+    copyImageAt: [],
+    openImage: [],
+    copyImageAddress: [],
+    saveImage: []
+  }
+
+  return {
+    calls,
+    actions: {
+      copyImageAt: (x, y) => calls.copyImageAt.push([x, y]),
+      openImage: url => calls.openImage.push(url),
+      copyImageAddress: url => calls.copyImageAddress.push(url),
+      saveImage: url => calls.saveImage.push(url)
+    }
+  }
+}
+
+test('keeps Copy Image available when Chromium omits a large image srcURL', () => {
+  const { actions, calls } = createActions()
+  const items = imageContextMenuItems({ mediaType: 'image', srcURL: '', x: 100, y: 120 }, actions)
+
+  assert.deepEqual(
+    items.map(item => item.label),
+    ['Copy Image']
+  )
+
+  items[0].click()
+  assert.deepEqual(calls.copyImageAt, [[100, 120]])
+})
+
+test('keeps URL-dependent image actions when srcURL is available', () => {
+  const { actions, calls } = createActions()
+  const url = 'https://example.com/image.png'
+  const items = imageContextMenuItems({ mediaType: 'image', srcURL: url, x: 5, y: 8 }, actions)
+
+  assert.deepEqual(
+    items.map(item => item.label),
+    ['Open Image', 'Copy Image', 'Copy Image Address', 'Save Image As...']
+  )
+
+  items[0].click()
+  items[1].click()
+  items[2].click()
+  items[3].click()
+
+  assert.deepEqual(calls.openImage, [url])
+  assert.deepEqual(calls.copyImageAt, [[5, 8]])
+  assert.deepEqual(calls.copyImageAddress, [url])
+  assert.deepEqual(calls.saveImage, [url])
+})
+
+test('does not add image actions for a non-image target', () => {
+  const { actions } = createActions()
+
+  assert.deepEqual(imageContextMenuItems({ mediaType: 'none', srcURL: '', x: 0, y: 0 }, actions), [])
+})

--- a/apps/desktop/electron/image-context-menu.test.ts
+++ b/apps/desktop/electron/image-context-menu.test.ts
@@ -25,7 +25,11 @@ function createActions() {
 
 test('keeps Copy Image available when Chromium omits a large image srcURL', () => {
   const { actions, calls } = createActions()
-  const items = imageContextMenuItems({ mediaType: 'image', srcURL: '', x: 100, y: 120 }, actions)
+
+  const items = imageContextMenuItems(
+    { mediaType: 'image', hasImageContents: true, srcURL: '', x: 100, y: 120 },
+    actions
+  )
 
   assert.deepEqual(
     items.map(item => item.label),
@@ -39,7 +43,11 @@ test('keeps Copy Image available when Chromium omits a large image srcURL', () =
 test('keeps URL-dependent image actions when srcURL is available', () => {
   const { actions, calls } = createActions()
   const url = 'https://example.com/image.png'
-  const items = imageContextMenuItems({ mediaType: 'image', srcURL: url, x: 5, y: 8 }, actions)
+
+  const items = imageContextMenuItems(
+    { mediaType: 'image', hasImageContents: true, srcURL: url, x: 5, y: 8 },
+    actions
+  )
 
   assert.deepEqual(
     items.map(item => item.label),
@@ -60,5 +68,17 @@ test('keeps URL-dependent image actions when srcURL is available', () => {
 test('does not add image actions for a non-image target', () => {
   const { actions } = createActions()
 
-  assert.deepEqual(imageContextMenuItems({ mediaType: 'none', srcURL: '', x: 0, y: 0 }, actions), [])
+  assert.deepEqual(
+    imageContextMenuItems({ mediaType: 'none', hasImageContents: false, srcURL: '', x: 0, y: 0 }, actions),
+    []
+  )
+})
+
+test('does not offer Copy Image when the target has no decoded image contents', () => {
+  const { actions } = createActions()
+
+  assert.deepEqual(
+    imageContextMenuItems({ mediaType: 'image', hasImageContents: false, srcURL: '', x: 0, y: 0 }, actions),
+    []
+  )
 })

--- a/apps/desktop/electron/image-context-menu.ts
+++ b/apps/desktop/electron/image-context-menu.ts
@@ -1,0 +1,40 @@
+export function imageContextMenuItems(params, actions) {
+  if (params.mediaType !== 'image') {
+    return []
+  }
+
+  const items = []
+  const srcURL = params.srcURL || ''
+
+  if (srcURL) {
+    items.push({
+      label: 'Open Image',
+      click: () => {
+        if (!srcURL.startsWith('data:')) {
+          actions.openImage(srcURL)
+        }
+      },
+      enabled: !srcURL.startsWith('data:')
+    })
+  }
+
+  items.push({
+    label: 'Copy Image',
+    click: () => actions.copyImageAt(params.x, params.y)
+  })
+
+  if (srcURL) {
+    items.push(
+      {
+        label: 'Copy Image Address',
+        click: () => actions.copyImageAddress(srcURL)
+      },
+      {
+        label: 'Save Image As...',
+        click: () => actions.saveImage(srcURL)
+      }
+    )
+  }
+
+  return items
+}

--- a/apps/desktop/electron/image-context-menu.ts
+++ b/apps/desktop/electron/image-context-menu.ts
@@ -1,5 +1,5 @@
 export function imageContextMenuItems(params, actions) {
-  if (params.mediaType !== 'image') {
+  if (params.mediaType !== 'image' || !params.hasImageContents) {
     return []
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -15,7 +15,6 @@ import {
   net as electronNet,
   ipcMain,
   Menu,
-  nativeImage,
   nativeTheme,
   Notification,
   powerMonitor,
@@ -99,6 +98,7 @@ import {
   resolveTimeoutMs,
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
+import { imageContextMenuItems } from './image-context-menu'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
@@ -4200,17 +4200,6 @@ async function resourceBufferFromUrl(rawUrl) {
   })
 }
 
-async function copyImageFromUrl(rawUrl) {
-  const { buffer } = (await resourceBufferFromUrl(rawUrl)) as any
-  const image = nativeImage.createFromBuffer(buffer)
-
-  if (image.isEmpty()) {
-    throw new Error('Could not read image')
-  }
-
-  clipboard.writeImage(image)
-}
-
 async function saveImageFromUrl(rawUrl) {
   const { buffer, mimeType } = (await resourceBufferFromUrl(rawUrl)) as any
   const fallbackName = filenameFromUrl(rawUrl, `image${extensionForMimeType(mimeType) || '.png'}`)
@@ -4820,39 +4809,19 @@ function installContextMenu(window) {
   window.webContents.on('context-menu', (_event, params) => {
     const template = []
     const hasSelection = Boolean(params.selectionText?.trim())
-    const hasImage = params.mediaType === 'image' && Boolean(params.srcURL)
     const hasLink = Boolean(params.linkURL)
     const isEditable = Boolean(params.isEditable)
 
-    if (hasImage) {
-      template.push(
-        {
-          label: 'Open Image',
-          click: () => {
-            if (params.srcURL && !params.srcURL.startsWith('data:')) {
-              openExternalUrl(params.srcURL)
-            }
-          },
-          enabled: !params.srcURL.startsWith('data:')
-        },
-        {
-          label: 'Copy Image',
-          click: () => {
-            void copyImageFromUrl(params.srcURL).catch(error => rememberLog(`Copy image failed: ${error.message}`))
-          }
-        },
-        {
-          label: 'Copy Image Address',
-          click: () => clipboard.writeText(params.srcURL)
-        },
-        {
-          label: 'Save Image As...',
-          click: () => {
-            void saveImageFromUrl(params.srcURL).catch(error => rememberLog(`Save image failed: ${error.message}`))
-          }
+    template.push(
+      ...imageContextMenuItems(params, {
+        copyImageAt: (x, y) => window.webContents.copyImageAt(x, y),
+        openImage: openExternalUrl,
+        copyImageAddress: url => clipboard.writeText(url),
+        saveImage: url => {
+          void saveImageFromUrl(url).catch(error => rememberLog(`Save image failed: ${error.message}`))
         }
-      )
-    }
+      })
+    )
 
     if (hasLink) {
       if (template.length) {


### PR DESCRIPTION
## What does this PR do?

Keeps the Desktop **Copy Image** context-menu action available when Chromium omits `params.srcURL` for a large rendered `data:` image.

Image detection now uses `mediaType` plus Electron `hasImageContents`, and copying uses `webContents.copyImageAt(params.x, params.y)`. Actions that require a URL remain hidden when `srcURL` is unavailable, while broken or undecoded images do not receive a no-op copy action.

## Related Issue

Fixes #65767

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a small pure image context-menu builder in `apps/desktop/electron/image-context-menu.ts`.
- Kept **Copy Image** for decoded image targets even when `srcURL` is empty.
- Routed image copying through coordinate-based `webContents.copyImageAt(...)`.
- Kept Open Image, Copy Image Address, and Save Image As gated on a usable `srcURL`.
- Added regression coverage for empty `srcURL`, decoded-content gating, and existing URL-backed behavior.

## How to Test

1. Run `npm exec vitest -- run --config vitest.config.ts electron/image-context-menu.test.ts` from `apps/desktop`.
2. Run `npm run typecheck` and `npm run lint` from `apps/desktop`.
3. Run `npm exec vitest -- run --config vitest.config.ts --project electron` and `npm run build` from `apps/desktop`.
4. In Desktop, right-click a successfully rendered image whose context-menu params have `mediaType: image`, `hasImageContents: true`, and an empty `srcURL`; **Copy Image** remains available and copies the image at the clicked coordinates.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched open and closed PRs for issue number, `copyImageAt`, `srcURL`, and large data URL variants
- [x] This PR contains only changes related to this fix
- [x] Python `pytest tests/ -q` is N/A for this Desktop-only TypeScript change; the Desktop Electron suite passed
- [x] I added regression tests for the change
- [x] Tested on macOS 26.2 arm64

### Documentation & Housekeeping

- [x] Documentation update is N/A; this restores existing UI behavior
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; `WebContents.copyImageAt` and `hasImageContents` are Electron APIs on all Desktop targets
- [x] Tool descriptions/schemas update is N/A

## Screenshots / Logs

- Focused regression tests: 4 passed
- Electron test project: 422 passed, 1 skipped
- Desktop typecheck: passed
- Desktop lint: 0 errors (15 pre-existing warnings outside changed files)
- Desktop production build: passed