### PR TITLE
fix(acp): drain late assistant chunks after Copilot prompt result

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -32,6 +32,7 @@ from tools.environments.local import hermes_subprocess_env
 
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
+_PROMPT_RESULT_DRAIN_SECONDS = 0.5
 
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
@@ -104,6 +105,7 @@ def _build_subprocess_env() -> dict[str, str]:
     # provider credentials. Route through the central helper so Tier-1 secrets
     # (gateway bot tokens, GitHub auth, infra) are still stripped (#29157).
     env = hermes_subprocess_env(inherit_credentials=True)
+    env.setdefault("COPILOT_AUTO_UPDATE", "false")
     home = _resolve_home_dir()
     env["HOME"] = home
     from hermes_constants import apply_subprocess_home_env
@@ -552,6 +554,33 @@ class CopilotACPClient:
 
         next_id = 0
 
+        def _drain_prompt_notifications(
+            *,
+            deadline: float,
+            text_parts: list[str],
+            reasoning_parts: list[str],
+        ) -> None:
+            # ACP has no separate end-of-turn notification for Copilot's final
+            # assistant chunks.  After the prompt result, drain only already
+            # arriving async messages for a bounded 0.5s window, capped by the
+            # caller's original timeout so this never extends a timed-out call.
+            drain_deadline = min(deadline, time.monotonic() + _PROMPT_RESULT_DRAIN_SECONDS)
+            while time.monotonic() < drain_deadline:
+                timeout = max(0.0, min(0.1, drain_deadline - time.monotonic()))
+                try:
+                    msg = inbox.get(timeout=timeout)
+                except queue.Empty:
+                    if proc.poll() is not None:
+                        break
+                    continue
+                self._handle_server_message(
+                    msg,
+                    process=proc,
+                    cwd=self._acp_cwd,
+                    text_parts=text_parts,
+                    reasoning_parts=reasoning_parts,
+                )
+
         def _request(method: str, params: dict[str, Any], *, text_parts: list[str] | None = None, reasoning_parts: list[str] | None = None) -> Any:
             nonlocal next_id
             next_id += 1
@@ -590,7 +619,14 @@ class CopilotACPClient:
                     raise RuntimeError(
                         f"Copilot ACP {method} failed: {err.get('message') or err}"
                     )
-                return msg.get("result")
+                result = msg.get("result")
+                if method == "session/prompt" and text_parts is not None and reasoning_parts is not None:
+                    _drain_prompt_notifications(
+                        deadline=deadline,
+                        text_parts=text_parts,
+                        reasoning_parts=reasoning_parts,
+                    )
+                return result
 
             stderr_text = "\n".join(stderr_tail).strip()
             if proc.poll() is not None and stderr_text:
@@ -657,7 +693,14 @@ class CopilotACPClient:
                 text_parts=text_parts,
                 reasoning_parts=reasoning_parts,
             )
-            return "".join(text_parts), "".join(reasoning_parts)
+            response_text = "".join(text_parts)
+            reasoning_text = "".join(reasoning_parts)
+            if not response_text and not reasoning_text:
+                raise RuntimeError(
+                    "Copilot ACP returned an empty response after the prompt result; "
+                    "no assistant chunks arrived during the bounded drain window."
+                )
+            return response_text, reasoning_text
         finally:
             self.close()
 

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import io
 import json
 import os
+import sys
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -317,3 +319,135 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+def _write_fake_acp_server(tmp_path, *, prompt_body: str) -> Path:
+    server = tmp_path / "fake_acp_server.py"
+    server.write_text(
+        textwrap.dedent(
+            """
+            import json
+            import sys
+            import time
+
+            session_id = "fake-session"
+            for line in sys.stdin:
+                request = json.loads(line)
+                method = request.get("method")
+                request_id = request.get("id")
+                if method == "initialize":
+                    print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": {}}), flush=True)
+                elif method == "session/new":
+                    print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": {"sessionId": session_id}}), flush=True)
+                elif method == "session/prompt":
+            """
+        ).lstrip()
+        + textwrap.indent(prompt_body.rstrip(), "        ")
+        + textwrap.dedent(
+            """
+                else:
+                    print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": None}), flush=True)
+            """
+        )
+    )
+    return server
+
+
+def _session_update(text: str) -> str:
+    return "print(json.dumps({payload}), flush=True)".format(
+        payload=json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": "fake-session",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": text},
+                    },
+                },
+            }
+        )
+    )
+
+
+def test_run_prompt_drains_late_assistant_chunk_after_prompt_result(tmp_path):
+    server = _write_fake_acp_server(
+        tmp_path,
+        prompt_body="\n".join(
+            [
+                'print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": {}}), flush=True)',
+                "time.sleep(0.25)",
+                _session_update("late assistant text"),
+            ]
+        ),
+    )
+    client = CopilotACPClient(
+        acp_command=sys.executable,
+        acp_args=[str(server)],
+        acp_cwd=str(tmp_path),
+    )
+
+    assert client._run_prompt("hello", timeout_seconds=2) == ("late assistant text", "")
+
+
+def test_run_prompt_drains_final_chunk_after_partial_response(tmp_path):
+    server = _write_fake_acp_server(
+        tmp_path,
+        prompt_body="\n".join(
+            [
+                _session_update("partial "),
+                'print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": {}}), flush=True)',
+                "time.sleep(0.25)",
+                _session_update("final"),
+            ]
+        ),
+    )
+    client = CopilotACPClient(
+        acp_command=sys.executable,
+        acp_args=[str(server)],
+        acp_cwd=str(tmp_path),
+    )
+
+    assert client._run_prompt("hello", timeout_seconds=2) == ("partial final", "")
+
+
+def test_run_prompt_raises_transport_error_when_prompt_result_stays_empty(tmp_path):
+    server = _write_fake_acp_server(
+        tmp_path,
+        prompt_body='print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": {}}), flush=True)',
+    )
+    client = CopilotACPClient(
+        acp_command=sys.executable,
+        acp_args=[str(server)],
+        acp_cwd=str(tmp_path),
+    )
+
+    with pytest.raises(RuntimeError, match="empty response"):
+        client._run_prompt("hello", timeout_seconds=2)
+
+
+def test_build_subprocess_env_disables_copilot_auto_update_by_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("COPILOT_AUTO_UPDATE", raising=False)
+
+    captured = {}
+    client = _make_home_client(tmp_path)
+
+    with _patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_fake_popen_capture(captured)):
+        with pytest.raises(RuntimeError, match="Could not start Copilot ACP command"):
+            client._run_prompt("hello", timeout_seconds=1)
+
+    assert captured["kwargs"]["env"]["COPILOT_AUTO_UPDATE"] == "false"
+
+
+def test_build_subprocess_env_preserves_explicit_copilot_auto_update(monkeypatch, tmp_path):
+    monkeypatch.setenv("COPILOT_AUTO_UPDATE", "true")
+
+    captured = {}
+    client = _make_home_client(tmp_path)
+
+    with _patch("agent.copilot_acp_client.subprocess.Popen", side_effect=_fake_popen_capture(captured)):
+        with pytest.raises(RuntimeError, match="Could not start Copilot ACP command"):
+            client._run_prompt("hello", timeout_seconds=1)
+
+    assert captured["kwargs"]["env"]["COPILOT_AUTO_UPDATE"] == "true"


### PR DESCRIPTION
## Summary

- drain already-arriving async ACP notifications for a bounded window after the `session/prompt` result, so Copilot assistant chunks emitted just after the result are no longer lost
- raise an explicit transport error when the prompt result yields no text and no reasoning, instead of silently returning an empty response that triggers retries and model fallback
- pin `COPILOT_AUTO_UPDATE=false` for the short-lived ACP subprocess so it cannot self-update mid-turn

## Root cause

`CopilotACPClient._request()` returned immediately on the matching `session/prompt` JSON-RPC result and `_run_prompt()` then closed the ACP process. Result-before-final-chunk ordering is legal in ACP, so chunks emitted just after the result were dropped.

## Bounded drain rationale

ACP offers no end-of-turn notification for Copilot's final assistant chunks, so a fully deterministic drain signal does not exist. The fallback drains for at most 0.5s, capped by the caller's original deadline (never extends a timed-out call), and exits early when the process ends.

## Tests

- `scripts/run_tests.sh tests/agent/test_copilot_acp_client.py -q` — 16 passed, 0 failed
- new regression tests: late-chunk-after-result drain, partial-response final-chunk drain, empty-result error
- `.venv/bin/ruff check` clean

Fixes #65788