### PR TITLE
feat(security): homelab infrastructure pack for DANGEROUS_PATTERNS (closes #65122)

### DIFF
--- a/tests/tools/test_dangerous_patterns_infra.py
+++ b/tests/tools/test_dangerous_patterns_infra.py
@@ -1,0 +1,229 @@
+"""Tests for the homelab/infrastructure DANGEROUS_PATTERNS pack (#65122).
+
+kubectl / talosctl / zfs / zpool / firewall / wireguard / ansible mutations
+should route through the native approval prompt, while their read-only forms
+stay unprompted.
+
+The kubectl `--dry-run=client|server` and ansible-playbook
+`--check`/`--syntax-check` exemptions are ARGV-scoped and SEGMENT-scoped, not
+substring-scoped: a flag exempts only when it parses as an option token of that
+command in that shell segment. The mere spelling of the flag inside a filepath,
+an option operand, or a quoted value must never suppress the prompt, and a flag
+in one segment must never whitelist a live command after `&&`/`||`/`;`/`|`. The
+exemption runs on the non-lowercased command so ansible's `-C` (--check) stays
+distinct from `-c` (--connection).
+
+Host-power verbs are deliberately left to the (stronger) hardline floor.
+"""
+
+import pytest
+
+from tools.approval import detect_dangerous_command, detect_hardline_command
+
+
+# Mutations that MUST be flagged dangerous (→ approval prompt).
+_DANGEROUS = [
+    "kubectl delete pod nginx",
+    "kubectl apply -f manifest.yaml",
+    "kubectl --namespace prod scale deploy web --replicas=0",
+    "kubectl drain node-1",
+    "kubectl cordon node-2",
+    "kubectl taint nodes n1 key=val:NoSchedule",
+    "kubectl patch deploy web -p '{}'",
+    "kubectl exec my-pod -- rm -rf /data",
+    "kubectl cp local pod:/remote",
+    "kubectl replace -f m.yaml",
+    "kubectl create -f m.yaml",
+    "sudo kubectl edit configmap app",
+    "talosctl reset --nodes 10.0.0.1",
+    "talosctl reboot --nodes 10.0.0.1",
+    "talosctl apply-config -f controlplane.yaml",
+    "talosctl upgrade --image ghcr.io/x",
+    "zfs destroy tank/dataset",
+    "zfs rollback tank/ds@snap",
+    "zfs rename tank/a tank/b",
+    "zfs set compression=on tank",
+    "zfs unmount tank/ds",
+    "zpool destroy tank",
+    "zpool labelclear /dev/sda",
+    "zpool detach tank /dev/sdb",
+    "zpool remove tank /dev/sdc",
+    "zpool offline tank /dev/sdd",
+    "zpool replace tank old new",
+    "zpool clear tank",
+    "ufw allow 22",
+    "ufw deny 80",
+    "ufw delete allow 22",
+    "ufw enable",
+    "ufw disable",
+    "ufw reset",
+    "iptables -A INPUT -j DROP",
+    "iptables -D INPUT 1",
+    "iptables -F",
+    "iptables -X",
+    "iptables -P INPUT DROP",
+    "ip6tables -A INPUT -j DROP",
+    "sudo iptables -t nat -I PREROUTING 1 -j REDIRECT",
+    "nft add rule inet filter input drop",
+    "nft delete table inet filter",
+    "nft flush ruleset",
+    "firewall-cmd --add-port=8080/tcp",
+    "firewall-cmd --remove-service=ssh",
+    "firewall-cmd --set-default-zone=public",
+    "firewall-cmd --new-zone=custom",
+    "wg set wg0 peer ABC allowed-ips 0.0.0.0/0",
+    "wg setconf wg0 /etc/wireguard/wg0.conf",
+    "wg addconf wg0 /etc/wireguard/wg0.conf",
+    "ansible-playbook site.yml",
+    "ansible-playbook -i inventory prod.yml --become",
+]
+
+# Read-only / dry-run forms that MUST stay unprompted.
+_SAFE = [
+    "kubectl get pods",
+    "kubectl get pods -o yaml",
+    "kubectl describe pod nginx",
+    "kubectl logs my-pod",
+    "kubectl diff -f manifest.yaml",
+    "kubectl apply -f manifest.yaml --dry-run=client",
+    "kubectl delete pod nginx --dry-run=server",
+    "talosctl get members",
+    "talosctl dmesg",
+    "zfs list",
+    "zfs get all tank",
+    "zpool status",
+    "zpool list",
+    "ufw status",
+    "ufw status verbose",
+    "iptables -L",
+    "iptables -nvL",
+    "iptables -S",
+    "ip6tables -L",
+    "nft list ruleset",
+    "nft list tables",
+    "firewall-cmd --list-all",
+    "firewall-cmd --state",
+    "firewall-cmd --get-default-zone",
+    "wg show",
+    "wg showconf wg0",
+    "ansible-playbook --check site.yml",
+    "ansible-playbook site.yml --check",
+    "ansible-playbook --syntax-check site.yml",
+]
+
+
+@pytest.mark.parametrize("command", _DANGEROUS)
+def test_infra_mutations_are_flagged(command):
+    is_dangerous, _key, _desc = detect_dangerous_command(command)
+    assert is_dangerous is True, f"expected dangerous: {command!r}"
+
+
+@pytest.mark.parametrize("command", _SAFE)
+def test_readonly_and_dryrun_forms_are_not_flagged(command):
+    is_dangerous, _key, _desc = detect_dangerous_command(command)
+    assert is_dangerous is False, f"expected safe: {command!r}"
+
+
+def test_dry_run_none_is_a_live_apply():
+    # `--dry-run=none` is a real mutation; only client/server are exempt.
+    assert detect_dangerous_command("kubectl delete pod x --dry-run=none")[0] is True
+
+
+class TestSegmentScopedExemptions:
+    """A dry-run/check flag in one shell segment must not whitelist a live
+    command in another segment (the key correctness nuance from the issue)."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "kubectl apply -f m.yaml --dry-run=client && kubectl delete pod live",
+            "kubectl delete pod a --dry-run=server; kubectl delete pod b",
+            "echo ok --dry-run=client | kubectl delete pod b",
+            "ansible-playbook staging.yml --check && ansible-playbook prod.yml",
+        ],
+    )
+    def test_live_segment_still_prompts(self, command):
+        assert detect_dangerous_command(command)[0] is True, command
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "kubectl apply -f a.yaml --dry-run=client && kubectl diff -f b.yaml",
+            "ansible-playbook a.yml --check && ansible-playbook b.yml --syntax-check",
+        ],
+    )
+    def test_all_dry_run_segments_stay_safe(self, command):
+        assert detect_dangerous_command(command)[0] is False, command
+
+
+class TestExemptionsAreOptionTokensNotSubstrings:
+    """The exempt SPELLING appearing anywhere in the command must not exempt.
+
+    A negative-lookahead exemption over the raw character run matched the flag
+    text wherever it occurred: in a filepath, in an `--option=<value>` operand,
+    in a quoted string, after `--`, or as the operand of an option that takes a
+    separate argument. Every command here performs a real mutation.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # The flag text is part of a path operand, not an option token.
+            "kubectl apply -f /tmp/--dry-run=client",
+            "kubectl delete pod prod-db -f /tmp/--dry-run=server",
+            "kubectl apply -f ./--dry-run=client/manifest.yaml",
+            "ansible-playbook /tmp/--check",
+            "ansible-playbook /tmp/--syntax-check",
+            # The flag text is the value of a different option.
+            "kubectl delete ns prod --context=--dry-run=client",
+            "kubectl create secret generic s --from-literal=note=--dry-run=client",
+            "kubectl apply -f m.yaml -o jsonpath='--dry-run=client'",
+            "ansible-playbook prod.yml -e 'mode=--check'",
+            "ansible-playbook prod.yml --extra-vars notes=--syntax-check",
+            # The flag text is the separate argument of a preceding option.
+            "kubectl delete pod x -n --dry-run=client",
+            "ansible-playbook -i inv prod.yml --tags --check",
+            "ansible-playbook prod.yml -t --check",
+            # Everything after `--` belongs to an inner command.
+            "kubectl exec pod -- echo --dry-run=client",
+            # A longer option that merely starts with the exempt spelling.
+            "ansible-playbook prod.yml --check-mode",
+            # kubectl's --dry-run has a NoOptDefVal: a following bare word is a
+            # positional, so the detached spelling supplies no value.
+            "kubectl apply -f m.yaml --dry-run client",
+            # Case matters: `-c` is --connection, not --check.
+            "ansible-playbook prod.yml -c ssh",
+        ],
+    )
+    def test_substring_lookalikes_still_prompt(self, command):
+        assert detect_dangerous_command(command)[0] is True, command
+
+
+class TestArgvParsedExemptionsStayExempt:
+    """Genuine dry runs must keep their exemption after the argv rewrite."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "kubectl apply -f manifest.yaml --dry-run=client",
+            "kubectl delete pod nginx --dry-run=server",
+            "sudo kubectl apply -f m.yaml --dry-run=server",
+            "kubectl apply -f m.yaml --wait --dry-run=client",
+            "kubectl delete pod x --namespace prod --dry-run=server",
+            "ansible-playbook -C prod.yml",
+            "ansible-playbook -Cv prod.yml",
+            "ansible-playbook -i inv prod.yml --check",
+        ],
+    )
+    def test_real_dry_runs_are_not_flagged(self, command):
+        assert detect_dangerous_command(command)[0] is False, command
+
+
+def test_host_power_delegated_to_hardline_not_dangerous():
+    # Host-power verbs are intentionally omitted from DANGEROUS_PATTERNS: the
+    # hardline floor blocks them unconditionally, which is stronger than a
+    # prompt. Assert the division of responsibility so a future edit can't
+    # silently downgrade them to a bypassable prompt.
+    for cmd in ("reboot", "poweroff", "shutdown -h now", "init 0"):
+        assert detect_dangerous_command(cmd)[0] is False, f"{cmd!r} should not be a DANGEROUS prompt"
+        assert detect_hardline_command(cmd)[0] is True, f"{cmd!r} should be hardline-blocked"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -813,6 +813,48 @@ DANGEROUS_PATTERNS = [
     # into a single -X token. Catches the same threat class.
     (r'\bsudo\b[^;|&\n]*?\s+-[a-z]*[sa][a-z]*\b',
      "sudo with combined-flag privilege escalation"),
+    # ---- Homelab / infrastructure mutation pack (#65122) ----
+    # Route destructive cluster / storage / firewall / VPN ops through the
+    # native approval prompt (same shape as the #63236 Bitwarden pack).
+    # Matching runs on command.lower() (see _command_detection_variants), so
+    # every token here is lowercase — e.g. `iptables -A` is matched as `-a`.
+    # Read-only forms (kubectl get/diff, zfs list, zpool status, ufw status,
+    # nft list, firewall-cmd --list-all, wg show, ansible-playbook --check) are
+    # deliberately NOT in the verb lists, so they stay unprompted. Host-power
+    # verbs (shutdown/reboot/halt/poweroff/init 0|6) are intentionally omitted:
+    # HARDLINE_PATTERNS already blocks them unconditionally, which is stronger
+    # than a prompt.
+    #
+    # kubectl's `--dry-run=client|server` and ansible-playbook's
+    # `--check`/`--syntax-check` exemptions are NOT expressed here. A regex
+    # lookahead over the raw character run would exempt the mere SPELLING of
+    # the flag anywhere in the command (a filepath, a `-o jsonpath=` value, a
+    # `--tags` operand), silently suppressing the prompt. Both are instead
+    # applied as argv-scoped, per-segment checks keyed on the description via
+    # `_SEGMENT_EXEMPTABLE_KEYS` in `detect_dangerous_command`.
+    (r'\bkubectl\b[^;|&\n]*'
+     r'\b(?:delete|apply|patch|edit|scale|drain|cordon|uncordon|taint|replace|create|exec|cp)\b',
+     "kubectl cluster mutation"),
+    (r'\btalosctl\b[^;|&\n]*\b(?:reset|reboot|shutdown|apply-config|upgrade|patch|edit)\b',
+     "talosctl node mutation"),
+    (r'\bzfs\s+(?:destroy|rollback|rename|set|unmount)\b',
+     "zfs dataset mutation"),
+    (r'\bzpool\s+(?:destroy|labelclear|detach|remove|offline|replace|clear)\b',
+     "zpool mutation"),
+    (r'\bufw\s+(?:-[^\s]+\s+)*(?:allow|deny|delete|enable|disable|reset)\b',
+     "ufw firewall mutation"),
+    (r'\bip6?tables\b[^;|&\n]*\s-(?:a|d|i|f|x|p)\b',
+     "iptables ruleset mutation"),
+    (r'\bnft\s+(?:-[^\s]+\s+)*(?:add|delete|flush|insert|replace)\b',
+     "nftables ruleset mutation"),
+    (r'\bfirewall-cmd\b[^;|&\n]*\s--(?:add|remove|set|new|delete)',
+     "firewall-cmd mutation"),
+    (r'\bwg\s+(?:set|setconf|addconf)\b',
+     "wireguard config mutation"),
+    # ansible-playbook runs a play unless it's a check/syntax-check; see the
+    # kubectl note above for where that exemption actually lives.
+    (r'\bansible-playbook\b',
+     "ansible-playbook run without --check"),
 ]
 
 
@@ -1539,6 +1581,156 @@ def _execution_flag_findings(command: str):
                     yield (f"arbitrary program execution via {tool} {option}", payload)
 
 
+_KUBECTL_DRY_RUN_VALUES = {"client", "server"}
+# Options whose value is a SEPARATE token. Omitting one only risks reading its
+# operand as a flag; including one that takes no argument only skips a real
+# flag. Both failure modes over-prompt, matching the explicit-allowlist
+# tradeoff already made by `_READ_TOOL_LONG_OPTIONS_WITH_ARG` / `_SUDO_OPTIONS_WITH_ARG`.
+_KUBECTL_OPTIONS_WITH_ARG = {
+    "-c", "--container",
+    "-f", "--filename",
+    "-l", "--selector",
+    "-n", "--namespace",
+    "-o", "--output",
+    "-p", "--patch",
+    "--as", "--as-group",
+    "--cluster", "--context", "--kubeconfig", "--user",
+    "--field-selector", "--from-file", "--from-literal",
+    "--grace-period", "--image", "--server", "--timeout", "--token", "--type",
+}
+_ANSIBLE_CHECK_LONG_OPTIONS = {"--check", "--syntax-check"}
+_ANSIBLE_OPTIONS_WITH_ARG = {
+    "--become-method", "--become-user", "--connection", "--extra-vars",
+    "--forks", "--inventory", "--inventory-file", "--key-file", "--limit",
+    "--module-path", "--private-key", "--scp-extra-args", "--sftp-extra-args",
+    "--skip-tags", "--ssh-common-args", "--ssh-extra-args", "--start-at-task",
+    "--tags", "--task-timeout", "--timeout", "--user", "--vault-id",
+    "--vault-password-file",
+}
+_ANSIBLE_SHORT_OPTIONS_WITH_ARG = {
+    "-c", "-e", "-f", "-i", "-l", "-M", "-t", "-T", "-u",
+}
+
+
+def _kubectl_dry_run_exempt(args: list[str]) -> bool:
+    """Return whether *args* carries an explicit client/server dry run.
+
+    ``--dry-run`` has a NoOptDefVal in kubectl, so only the ATTACHED
+    ``--dry-run=<value>`` spelling supplies a value; a following bare word is
+    a positional, not the flag's operand. Everything after ``--`` belongs to
+    an inner command (``kubectl exec pod -- echo --dry-run=client``) and is
+    therefore not kubectl's own flag.
+    """
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--":
+            break
+        option, value = _split_option(token)
+        if option == "--dry-run":
+            if value in _KUBECTL_DRY_RUN_VALUES:
+                return True
+            index += 1
+            continue
+        if value is None and option in _KUBECTL_OPTIONS_WITH_ARG:
+            index += 2
+            continue
+        index += 1
+    return False
+
+
+def _ansible_check_exempt(args: list[str]) -> bool:
+    """Return whether *args* requests a check / syntax-check run.
+
+    Case matters: ``-C`` is ``--check`` while ``-c`` is ``--connection``, so
+    this must run on the non-lowercased command. In a short bundle the first
+    argument-taking letter owns the rest of the token (``-tC`` is ``--tags C``,
+    not a check run).
+    """
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--":
+            break
+        option, value = _split_option(token)
+        if value is None and option in _ANSIBLE_CHECK_LONG_OPTIONS:
+            return True
+        if value is None and option in _ANSIBLE_OPTIONS_WITH_ARG:
+            index += 2
+            continue
+        if (
+            value is None
+            and token.startswith("-")
+            and not token.startswith("--")
+            and len(token) > 1
+        ):
+            consumed = 1
+            for short_index, char in enumerate(token[1:], start=1):
+                short = f"-{char}"
+                if short in _ANSIBLE_SHORT_OPTIONS_WITH_ARG:
+                    consumed = 2 if short_index == len(token) - 1 else 1
+                    break
+                if short == "-C":
+                    return True
+            index += consumed
+            continue
+        index += 1
+    return False
+
+
+_INFRA_DRY_RUN_CHECKS = {
+    "kubectl": _kubectl_dry_run_exempt,
+    "ansible-playbook": _ansible_check_exempt,
+}
+
+
+def _infra_dry_run_exempt_segment(segment: str) -> bool:
+    """Return whether every infra command in *segment* is an explicit dry run.
+
+    Fails closed: an unparseable segment, or one whose pattern match does not
+    come from a real kubectl / ansible-playbook command word, is never exempt.
+    """
+    exempted_any = False
+    for start, _end, word in _iter_shell_command_word_spans(segment):
+        executable = _deobfuscate_shell_word_for_detection(word)
+        checker = _INFRA_DRY_RUN_CHECKS.get(os.path.basename(executable).lower())
+        if checker is None:
+            continue
+        tokens = _shell_segment_tokens(segment, start)
+        if not tokens:
+            # Malformed quoting (None) or an empty argv: fail closed.
+            return False
+        if not checker(tokens[1:]):
+            return False
+        exempted_any = True
+    return exempted_any
+
+
+_SEGMENT_EXEMPTABLE_KEYS = {
+    "kubectl cluster mutation",
+    "ansible-playbook run without --check",
+}
+
+
+def _all_matching_segments_exempt(command_variant: str, pattern_re) -> bool:
+    """Return whether every segment reproducing *pattern_re* is a dry run.
+
+    Segment scope preserves the guarantee a lookahead was reaching for:
+    ``kubectl apply --dry-run=client && kubectl delete pod live`` still prompts
+    on the live segment. Returns False when NO segment reproduces the
+    whole-string match, so an exemption is never granted for a match this
+    walk cannot account for.
+    """
+    matched_any = False
+    for segment in _iter_top_level_shell_segments(command_variant):
+        if not pattern_re.search(segment.lower()):
+            continue
+        matched_any = True
+        if not _infra_dry_run_exempt_segment(segment):
+            return False
+    return matched_any
+
+
 def _skip_shell_whitespace(command: str, pos: int) -> int:
     while pos < len(command) and command[pos].isspace():
         pos += 1
@@ -2000,6 +2192,14 @@ def detect_dangerous_command(command: str) -> tuple:
         command_lower = command_variant.lower()
         for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
             if pattern_re.search(command_lower):
+                # Dry-run exemptions are argv-scoped, not substring-scoped, and
+                # run per segment on the NON-lowercased variant so ansible's
+                # `-C` (--check) stays distinct from `-c` (--connection).
+                if (
+                    description in _SEGMENT_EXEMPTABLE_KEYS
+                    and _all_matching_segments_exempt(command_variant, pattern_re)
+                ):
+                    continue
                 pattern_key = description
                 return (True, pattern_key, description)
     normalized = _normalize_command_for_detection(command)


### PR DESCRIPTION
## What does this PR do?

Adds a homelab/infrastructure pack to `DANGEROUS_PATTERNS` so destructive cluster/storage/firewall/VPN mutation commands route through the **native approval prompt** (platform approve buttons, permanent allowlist, yolo/`approvals.deny` interplay) instead of being invisible to the guard. Same shape as the merged #63236 Bitwarden pack.

**Revised after review.** The first revision expressed the kubectl `--dry-run` and ansible `--check` exemptions as regex negative lookaheads over a raw character run (`(?![^;|&\n]*--dry-run=(?:client|server))`). That was wrong, and it is the part of this PR that needed the most scrutiny — details in "How the exemptions work" below. The exemptions are now argv-scoped and per-segment, reusing the shell/argv layer that landed after this PR was first authored.

## Related Issue

Fixes #65122

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py:816-857` — ten new `DANGEROUS_PATTERNS` entries appended (kubectl, talosctl, zfs, zpool, ufw, iptables, nft, firewall-cmd, wg, ansible-playbook). No pattern carries an inline exemption.
- `tools/approval.py:1584-1612` — `_KUBECTL_DRY_RUN_VALUES`, `_KUBECTL_OPTIONS_WITH_ARG`, `_ANSIBLE_CHECK_LONG_OPTIONS`, `_ANSIBLE_OPTIONS_WITH_ARG`, `_ANSIBLE_SHORT_OPTIONS_WITH_ARG`.
- `tools/approval.py:1615` `_kubectl_dry_run_exempt()`, `:1642` `_ansible_check_exempt()`, `:1687` `_infra_dry_run_exempt_segment()`, `:1715` `_all_matching_segments_exempt()` — the argv walk, placed beside `_execution_flag_findings` whose idiom it copies.
- `tools/approval.py:2195-2204` — `detect_dangerous_command` consults the exemption only for descriptions in `_SEGMENT_EXEMPTABLE_KEYS` (`:1709`), mirroring the existing function-based `_is_verification_artifact_cleanup` exemption.
- `tests/tools/test_dangerous_patterns_infra.py` — 115 cases.

## Coverage

Every mutation is flagged; every read-only / dry-run form stays unprompted (both directions are covered by tests):

| Family | Flagged | Stays unprompted |
|--------|---------|------------------|
| kubectl | delete/apply/patch/edit/scale/drain/cordon/uncordon/taint/replace/create/exec/cp | `get`, `diff`, `describe`, `logs`, `--dry-run=client\|server` |
| talosctl | reset/reboot/shutdown/apply-config/upgrade/patch/edit | `get`, `dmesg` |
| ZFS | `zfs destroy/rollback/rename/set/unmount`, `zpool destroy/labelclear/detach/remove/offline/replace/clear` | `zfs list/get`, `zpool status/list` |
| Firewall | `ufw allow/deny/delete/enable/disable/reset`, `iptables -A/-D/-I/-F/-X/-P`, `nft add/delete/flush/insert/replace`, `firewall-cmd --add/--remove/--set/--new/--delete` | `ufw status`, `iptables -L/-S/-nvL`, `nft list`, `firewall-cmd --list-all/--state/--get-*` |
| WireGuard | `wg set/setconf/addconf` | `wg show/showconf` |
| Ansible | `ansible-playbook` … | `--check`, `--syntax-check` |

## How the exemptions work

**The lookahead was a bypass, not a safety mechanism.** `detect_dangerous_command` applies each regex to the whole lowercased command variant, so a negative lookahead over `[^;|&\n]*` exempts the mere *spelling* of the flag anywhere in the string. It never had to parse as an option. Measured against the previous revision, 15 mutating commands were silently exempted with no prompt, in four classes:

| Class | Example (all real mutations) |
|---|---|
| Flag text inside a path operand | `kubectl apply -f /tmp/--dry-run=client` · `ansible-playbook /tmp/--check` |
| Flag text as another option's value | `kubectl delete ns prod --context=--dry-run=client` · `kubectl apply -f m.yaml -o jsonpath='--dry-run=client'` |
| Flag text as the separate argument of an option that takes one | `kubectl delete pod x -n --dry-run=client` · `ansible-playbook -i inv prod.yml --tags --check` |
| Flag text after `--`, i.e. belonging to an inner command | `kubectl exec pod -- echo --dry-run=client` |

**The replacement.** Both patterns now carry no exemption at all. `detect_dangerous_command` instead calls `_all_matching_segments_exempt(command_variant, pattern_re)` for the two exemptable descriptions. That function splits the variant with `_iter_top_level_shell_segments`, and for each segment that reproduces the match it requires `_infra_dry_run_exempt_segment` to find a real `kubectl` / `ansible-playbook` **command word** (via `_iter_shell_command_word_spans`, which already strips `sudo`/`env` wrappers), tokenize its argv (`_shell_segment_tokens`), and see the flag as an actual option token (`_split_option`). It fails closed in three places: `_shell_segment_tokens` returning falsy (malformed quoting), a segment whose match comes from something that is not one of these commands (`echo kubectl delete pod --dry-run=client` still prompts), and a whole-string match that no segment reproduces.

Three parsing details worth calling out:

- **`--` is a boundary.** kubectl's `--dry-run` cannot appear after it; the rest is the inner command's argv.
- **kubectl's `--dry-run` has a NoOptDefVal**, so only the attached `--dry-run=<value>` spelling supplies a value. `kubectl apply -f m.yaml --dry-run client` prompts, because `client` is a positional there — which matches what kubectl itself does.
- **The exemption deliberately runs on the NON-lowercased variant**, so ansible's `-C` (`--check`) stays distinct from `-c` (`--connection`). `ansible-playbook prod.yml -c ssh` prompts; `ansible-playbook -Cv prod.yml` does not. Short bundles follow the house rule from `_read_tool_exec_flag`: the first argument-taking letter owns the rest of the token, so `-tC` is `--tags C`, not a check run.

Per-segment scope preserves the guarantee the lookahead was reaching for, without the lookahead:

- `kubectl apply -f m.yaml --dry-run=client && kubectl delete pod live` → **prompts** (second segment is live).
- `kubectl delete pod --dry-run=none` → **prompts** (`none` is a real apply; only `client`/`server` are exempt).

## Residual limitations (disclosed, not hidden)

- **Verb matching is still regex.** `kubectl get pods -n delete-me` over-prompts because `delete` appears in a value. That is friction, not a hole — the argv layer scopes the *exemption*, not the *match*.
- **A quoted separator before the verb is not matched.** `kubectl -f "a;b" delete pod x` does not match, because `[^;|&\n]*` stops at the `;` even though it is quoted. This is pre-existing to the whole `DANGEROUS_PATTERNS` style and is shared by the existing `git branch` and `sudo` patterns; fixing it belongs to a separate change to the pattern engine, not to this pack.
- **The options-with-argument sets are explicit allowlists** and will drift as kubectl and ansible add flags. Both drift directions over-prompt rather than under-prompt: an unlisted option makes its operand look like a flag (no exemption granted), and a wrongly listed one skips a token that might have been a real `--dry-run` (again, no exemption). This is the same tradeoff already made by `_READ_TOOL_LONG_OPTIONS_WITH_ARG` and `_SUDO_OPTIONS_WITH_ARG`.
- **A dry run wrapped in `bash -c '…'` prompts.** The quoted payload has no command-position word of its own in the outer segment, so no exemption is granted. Safe direction; the previous revision exempted it via substring.

## Deliberate omission: host-power

`shutdown`/`reboot`/`halt`/`poweroff`/`init 0|6` are **not** added here — `HARDLINE_PATTERNS` already blocks them unconditionally, which is stronger than a prompt (adding them to `DANGEROUS_PATTERNS` would be a bypassable downgrade). A test pins this division: they are not a `DANGEROUS` prompt, and `detect_hardline_command` flags them.

## How to Test

1. `python -m pytest tests/tools/test_dangerous_patterns_infra.py -q` → **115 passed**.
2. `python -m pytest tests/tools/ -k approval -q` → **534 passed, 1 skipped, 1 failed**. The one failure is `test_approval.py::TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`, which fails identically on pristine `main` on this macOS host (`/tmp` → `/private/tmp` realpath in `_is_verification_artifact_cleanup`) and is unrelated to this change.
3. `python -m pytest tests/tools/test_approval.py tests/tools/test_approval_deny_rules.py tests/tools/test_hardline_blocklist.py tests/tools/test_command_guards.py tests/tools/test_force_dangerous_override.py tests/tools/test_dangerous_patterns_infra.py tests/tools/test_smart_approval_injection.py -q` → **691 passed, 1 failed** (same pre-existing failure).
4. `python -m ruff check tools/approval.py tests/tools/test_dangerous_patterns_infra.py` → clean.
5. To see the bypass this fixes, run any row of the table above against the previous revision: all were `(False, None, None)`, i.e. executed with no prompt.

The test file's two new classes pin the fix directly: `TestExemptionsAreOptionTokensNotSubstrings` (17 mutations that must prompt) and `TestArgvParsedExemptionsStayExempt` (8 genuine dry runs that must not), alongside the original `TestSegmentScopedExemptions` and the host-power/hardline division test.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the approval/dangerous/hardline test set and all tests pass (one pre-existing macOS temp-dir failure, reproduced on pristine `main` — see "How to Test")
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helpers carry docstrings stating why the exemption is argv-scoped and case-sensitive; no user-facing docs change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string/argv parsing, no filesystem or platform dependency
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
