### PR TITLE
fix(desktop): preserve active session and zoom across transitions

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6951,8 +6951,9 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
 
   if (zoom) {
     installZoomShortcuts(win)
-    // Re-apply persisted zoom on show/restore (Windows drops webContents zoom on
-    // minimize/restore) and on first load (reloads / crash recovery).
+    // Re-apply persisted zoom on show/restore/cross-display move (Windows can
+    // drop webContents zoom after minimize or a monitor-scale change) and on
+    // first load (reloads / crash recovery).
     installZoomReassertOnWindowEvents(win, () => restorePersistedZoomLevel(win))
     win.webContents.once('did-finish-load', () => restorePersistedZoomLevel(win))
   }

--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -64,7 +64,7 @@ test('extreme percentages clamp to the level bounds', () => {
   assert.equal(percentToZoomLevel(1_000_000), 9)
 })
 
-test('installZoomReassertOnWindowEvents wires show and restore', () => {
+test('installZoomReassertOnWindowEvents wires show, restore, and cross-display moves', () => {
   const handlers = new Map()
 
   const win = {
@@ -82,7 +82,8 @@ test('installZoomReassertOnWindowEvents wires show and restore', () => {
   assert.deepEqual([...handlers.keys()], [...ZOOM_REASSERT_WINDOW_EVENTS])
   handlers.get('show')()
   handlers.get('restore')()
-  assert.equal(calls, 2)
+  handlers.get('moved')()
+  assert.equal(calls, 3)
 })
 
 test('installZoomReassertOnWindowEvents skips destroyed windows', () => {

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -49,8 +49,9 @@ export function applyZoomLevel(webContents, level) {
 }
 
 // Chromium on Windows can drop webContents zoom when a BrowserWindow is minimized
-// and restored. Re-apply the persisted level on these lifecycle transitions.
-export const ZOOM_REASSERT_WINDOW_EVENTS = ['show', 'restore']
+// and restored or crosses onto a monitor with different display scaling. Re-apply
+// the persisted level after each completed lifecycle transition.
+export const ZOOM_REASSERT_WINDOW_EVENTS = ['show', 'restore', 'moved']
 
 export function installZoomReassertOnWindowEvents(win, reassert) {
   if (!win?.on) {

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -130,7 +130,6 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
   // The REAL submit pipeline with tile seams: session always exists, and the
   // scope's writers replace the global view/attachment writes.
   const submitPromptText = useSubmitPrompt({
-    activeSessionId: runtimeId,
     activeSessionIdRef: runtimeIdRef,
     busyRef,
     copy,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1396,6 +1396,87 @@ describe('usePromptActions submit session-context isolation (#54527)', () => {
     vi.restoreAllMocks()
   })
 
+  it('targets the synchronously selected session when the render-captured active id is stale', async () => {
+    // Session navigation updates the refs synchronously, then React publishes
+    // the new activeSessionId prop. Enter can land between those two steps. The
+    // submit must use the ref snapshot for Session B, never the stale prop for A.
+    const requestGateway = vi.fn(async () => ({}) as never)
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_B }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: STORED_SESSION_B }
+    let handle: HarnessHandle | null = null
+
+    await actRender(
+      <Harness
+        activeSessionId="rt-session-a-stale"
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={STORED_SESSION_B}
+      />
+    )
+
+    expect(await handle!.submitText('message for session B')).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      { session_id: RUNTIME_SESSION_B, text: 'message for session B' },
+      1_800_000
+    )
+    expect(requestGateway).not.toHaveBeenCalledWith(
+      'prompt.submit',
+      expect.objectContaining({ session_id: 'rt-session-a-stale' }),
+      expect.anything()
+    )
+  })
+
+  it('creates a new session when fresh-draft refs have already cleared a stale active id', async () => {
+    // Opening New Chat clears the routing refs synchronously. If the user hits
+    // Enter before React refreshes the activeSessionId prop, the stale prop must
+    // not resurrect the previous chat as the submit target.
+    const requestGateway = vi.fn(async () => ({}) as never)
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: null }
+    let routeToken = '/new'
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = 'rt-fresh-chat'
+      selectedStoredSessionIdRef.current = 'stored-fresh-chat'
+      routeToken = '/session/stored-fresh-chat'
+
+      return 'rt-fresh-chat'
+    })
+
+    let handle: HarnessHandle | null = null
+
+    await actRender(
+      <Harness
+        activeSessionId="rt-previous-chat-stale"
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        getRouteToken={() => routeToken}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={null}
+      />
+    )
+
+    expect(await handle!.submitText('first message in the new chat')).toBe(true)
+    expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      { session_id: 'rt-fresh-chat', text: 'first message in the new chat' },
+      1_800_000
+    )
+    expect(requestGateway).not.toHaveBeenCalledWith(
+      'prompt.submit',
+      expect.objectContaining({ session_id: 'rt-previous-chat-stale' }),
+      expect.anything()
+    )
+  })
+
   it('aborts submit when the user switches sessions during session.resume (no misroute)', async () => {
     // Exact #54527 failure: user submits in Session A while its runtime binding
     // is gone; before resume returns they switch to Session B. Without a pinned

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -365,7 +365,6 @@ export function usePromptActions({
   }, [activeSessionId, composerAttachments, eagerlyUploadAttachment])
 
   const submitPromptText = useSubmitPrompt({
-    activeSessionId,
     activeSessionIdRef,
     busyRef,
     copy,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -31,7 +31,6 @@ import {
 } from './utils'
 
 interface SubmitPromptDeps {
-  activeSessionId: string | null
   activeSessionIdRef: MutableRefObject<string | null>
   busyRef: MutableRefObject<boolean>
   copy: Translations['desktop']
@@ -74,7 +73,6 @@ const MAIN_SUBMIT_SCOPE: NonNullable<SubmitPromptDeps['scope']> = {
 /** The prompt submit pipeline, extracted from usePromptActions. */
 export function useSubmitPrompt(deps: SubmitPromptDeps) {
   const {
-    activeSessionId,
     activeSessionIdRef,
     busyRef,
     copy,
@@ -249,7 +247,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       scope.setAwaitingResponse(true)
       clearNotifications()
 
-      let sessionId: null | string = activeSessionId
+      // Read the pinned live identity, not the render-captured prop. Session
+      // navigation updates activeSessionIdRef synchronously before React can
+      // publish a fresh callback; preferring the prop in that window sends the
+      // prompt to the previously active chat.
+      let sessionId: null | string = startingActiveSessionId
 
       if (sessionId) {
         seedOptimistic(sessionId)
@@ -450,7 +452,6 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       }
     },
     [
-      activeSessionId,
       activeSessionIdRef,
       busyRef,
       copy,


### PR DESCRIPTION
## What does this PR do?

This fixes two Hermes Desktop state-transition regressions:

- Prompt submissions could be routed to the previously active chat after switching sessions or opening New Chat. The submit path captured the current runtime-session ref, but initialized its target from a stale render-captured `activeSessionId` prop. It now uses the synchronously updated ref snapshot for the target and removes the stale prop from the shared submit API.
- A persisted UI scale could reset when moving the Electron window between monitors with different Windows display scaling. The existing zoom reassertion now also runs on BrowserWindow `moved`, alongside `show` and `restore`.

Regression tests cover switching existing chats, opening New Chat during the render-prop race, and moving a zoomed window between displays.

## Related Issue

No issue filed; both bugs were reproduced in Hermes Desktop on Windows 11.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Use `activeSessionIdRef.current` as the pinned submission target in `useSubmitPrompt`.
- Remove the stale `activeSessionId` dependency from both prompt-action call sites.
- Add regression tests for stale-prop routing and New Chat submission.
- Reassert persisted Electron zoom on `moved`.
- Extend zoom event tests to cover cross-display moves.

## How to Test

1. Open chat A, switch quickly to chat B, and submit before the renderer publishes the new active-session prop. The prompt must go to chat B.
2. Open New Chat and submit during the same transition. Hermes must create and submit to the new session rather than chat A.
3. Set UI Scale to a value other than 100%, then move the window between monitors with different display scaling. The configured zoom must remain applied.
4. Run:
   - `npx vitest run --project ui src/app/session/hooks/use-prompt-actions/index.test.tsx` — 47 passed
   - `npx vitest run --project electron electron/zoom.test.ts` — 14 passed
   - `npm run typecheck`
   - `npm run build`

The packaged Windows app was also launched and passed the desktop remote verifier.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to these desktop transition regressions
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: this changes the Electron/TypeScript desktop app; the focused Vitest suites, typecheck, and production build pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update — N/A
- [x] I've considered cross-platform impact; the routing change is platform-neutral and the zoom event is supported by Electron across platforms
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

Not applicable. The regressions are covered by focused unit tests and a packaged-app verification.
