### PR TITLE
fix(desktop): avoid WSL clipboard AV quarantine

### DIFF
--- a/apps/desktop/electron/wsl-clipboard-image.test.ts
+++ b/apps/desktop/electron/wsl-clipboard-image.test.ts
@@ -8,6 +8,7 @@ import {
   powershellCandidates,
   readWslWindowsClipboardImage
 } from './wsl-clipboard-image'
+import { WSL_CLIPBOARD_IMAGE_SCRIPT } from './wsl-clipboard-script'
 
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
 
@@ -15,10 +16,10 @@ function fakePngBuffer(extraBytes = 16) {
   return Buffer.concat([PNG_SIGNATURE, Buffer.alloc(extraBytes, 0x42)])
 }
 
-test('encodePowerShellCommand produces UTF-16LE base64 PowerShell can decode', () => {
-  const encoded = encodePowerShellCommand('Write-Output "hi"')
+test('encodePowerShellCommand preserves the clipboard script through UTF-16LE base64', () => {
+  const encoded = encodePowerShellCommand(WSL_CLIPBOARD_IMAGE_SCRIPT)
   const roundTripped = Buffer.from(encoded, 'base64').toString('utf16le')
-  assert.equal(roundTripped, 'Write-Output "hi"')
+  assert.equal(roundTripped, WSL_CLIPBOARD_IMAGE_SCRIPT)
 })
 
 test('decodeClipboardImageBase64 returns a Buffer for valid PNG base64', () => {
@@ -62,8 +63,18 @@ test('readWslWindowsClipboardImage decodes the first candidate that returns a PN
   assert.equal(calls.length, 1)
   assert.equal(calls[0].cmd, 'powershell.exe')
   // -STA is mandatory for System.Windows.Forms.Clipboard.
-  assert.ok(calls[0].args.includes('-STA'))
-  assert.ok(calls[0].args.includes('-EncodedCommand'))
+  assert.deepEqual(calls[0].args.slice(0, -1), [
+    '-NoProfile',
+    '-NonInteractive',
+    '-STA',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-EncodedCommand'
+  ])
+  assert.equal(
+    Buffer.from(calls[0].args.at(-1), 'base64').toString('utf16le'),
+    WSL_CLIPBOARD_IMAGE_SCRIPT
+  )
 })
 
 test('readWslWindowsClipboardImage returns null and stops when stdout is empty (no image)', () => {

--- a/apps/desktop/electron/wsl-clipboard-image.ts
+++ b/apps/desktop/electron/wsl-clipboard-image.ts
@@ -3,20 +3,9 @@
 
 import { execFileSync } from 'node:child_process'
 
-// STA is mandatory: System.Windows.Forms.Clipboard throws ThreadStateException
-// off a single-threaded apartment. We emit base64 (not raw bytes) so the PNG
-// survives stdout's text decoding intact, and write with [Console]::Out.Write
-// to avoid a trailing newline.
-const PS_SCRIPT = [
-  'Add-Type -AssemblyName System.Windows.Forms,System.Drawing',
-  '$img = [System.Windows.Forms.Clipboard]::GetImage()',
-  'if ($null -eq $img) { exit 0 }',
-  '$ms = New-Object System.IO.MemoryStream',
-  '$img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)',
-  '[Console]::Out.Write([System.Convert]::ToBase64String($ms.ToArray()))'
-].join('\n')
+import { WSL_CLIPBOARD_IMAGE_SCRIPT } from './wsl-clipboard-script'
 
-// PowerShell's -EncodedCommand takes UTF-16LE base64. Encoding the whole script
+// PowerShell's encoded-command mode takes UTF-16LE base64. Encoding the whole script
 // this way sidesteps every layer of WSL→Windows quoting (spaces, quotes,
 // brackets, newlines) that plain -Command arguments would mangle.
 function encodePowerShellCommand(script) {
@@ -63,13 +52,15 @@ function readWslWindowsClipboardImage({
   exec = execFileSync,
   candidates = powershellCandidates()
 }: { exec?: typeof execFileSync; candidates?: string[] } = {}) {
-  const encoded = encodePowerShellCommand(PS_SCRIPT)
+  const encoded = encodePowerShellCommand(WSL_CLIPBOARD_IMAGE_SCRIPT)
+  // Keep the encoded-command marker out of the enterprise AV source signature fixed in #65439.
+  const encodedCommandFlag = '\u002dEncodedCommand'
 
   for (const ps of candidates) {
     try {
       const stdout = exec(
         ps,
-        ['-NoProfile', '-NonInteractive', '-STA', '-ExecutionPolicy', 'Bypass', '-EncodedCommand', encoded],
+        ['-NoProfile', '-NonInteractive', '-STA', '-ExecutionPolicy', 'Bypass', encodedCommandFlag, encoded],
         {
           encoding: 'utf8',
           windowsHide: true,

--- a/apps/desktop/electron/wsl-clipboard-script.ts
+++ b/apps/desktop/electron/wsl-clipboard-script.ts
@@ -1,0 +1,14 @@
+// STA is mandatory: System.Windows.Forms.Clipboard throws ThreadStateException
+// off a single-threaded apartment. We emit base64 (not raw bytes) so the PNG
+// survives stdout's text decoding intact, and write with [Console]::Out.Write
+// to avoid a trailing newline.
+const WSL_CLIPBOARD_IMAGE_SCRIPT = [
+  'Add-Type -AssemblyName System.Windows.Forms,System.Drawing',
+  '$img = [System.Windows.Forms.Clipboard]::GetImage()',
+  'if ($null -eq $img) { exit 0 }',
+  '$ms = New-Object System.IO.MemoryStream',
+  '$img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)',
+  '[Console]::Out.Write([System.Convert]::ToBase64String($ms.ToArray()))'
+].join('\n')
+
+export { WSL_CLIPBOARD_IMAGE_SCRIPT }


### PR DESCRIPTION
## What does this PR do?

Prevents enterprise Bitdefender from quarantining the WSL clipboard bridge source by separating the raw PowerShell clipboard payload from the encoded-command invocation signature.

The runtime behavior is unchanged: Hermes still launches PowerShell with the exact `-EncodedCommand` argument and the same UTF-16LE Base64 payload.

## Related Issue

Fixes #65439

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Moved the raw Windows clipboard PowerShell payload to `apps/desktop/electron/wsl-clipboard-script.ts`.
- Kept encoded-command invocation in `wsl-clipboard-image.ts` without recreating the source signature reported by Bitdefender.
- Preserved the exact runtime PowerShell argument sequence and encoded payload.
- Extended behavior tests to round-trip the real clipboard script and inspect the actual injected exec arguments.

## How to Test

1. Run `npm exec vitest -- run --config vitest.config.ts electron/wsl-clipboard-image.test.ts` from `apps/desktop`.
2. Run `npm run typecheck` and targeted ESLint from `apps/desktop`.
3. Run `npm exec vitest -- run --config vitest.config.ts --project electron` and `npm run build`.
4. On a Windows 10/11 WSL2 machine managed by Bitdefender Endpoint Security Tools, restore or update both source files and confirm neither is quarantined; then copy an image in Windows and paste it through Hermes Desktop in WSL.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched open and closed PRs for the issue number, Bitdefender, WSL clipboard, PowerShell, and encoded-command variants
- [x] This PR contains only changes related to this fix
- [x] Python `pytest tests/ -q` is N/A for this Desktop-only TypeScript change; the Electron suite passed
- [x] I added regression tests for the runtime command and payload
- [x] Tested automated checks on macOS 26.2 arm64

### Documentation & Housekeeping

- [x] Documentation update is N/A; no user-facing interface changed
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the WSL behavior is covered by injected-exec tests, with enterprise Windows AV verification called out below
- [x] Tool descriptions/schemas update is N/A

## Screenshots / Logs

- Focused WSL clipboard tests: 10 passed
- Electron test project: 418 passed, 1 skipped
- Desktop typecheck: passed
- Targeted ESLint and `git diff --check`: passed
- Desktop production build: passed

Enterprise Bitdefender is not available on this machine, so the final quarantine check requires the Windows environment described in #65439. The code uses the source split proposed and reported as verified in that issue.