### PR TITLE
fix(tui): launch production process from workspace cwd

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2290,11 +2290,17 @@ def _launch_tui(
     if resume_session_id:
         env["HERMES_TUI_RESUME"] = resume_session_id
 
-    argv, cwd = _make_tui_argv(tui_dir, tui_dev)
+    argv, tui_cwd = _make_tui_argv(tui_dir, tui_dev)
+    # Production entrypoints are absolute, so keep the foreground process
+    # group in the user's workspace. Launching Node from ui-tui leaks Hermes's
+    # implementation directory to terminal multiplexers that follow the
+    # foreground cwd when creating a split. Dev mode still needs the package
+    # cwd for relative npm/tsx commands.
+    launch_cwd = tui_cwd if tui_dev else Path(env["HERMES_CWD"])
     code: Optional[int] = None
     try:
         try:
-            code = subprocess.call(argv, cwd=str(cwd), env=env)
+            code = subprocess.call(argv, cwd=str(launch_cwd), env=env)
         except KeyboardInterrupt:
             code = 130
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1711,6 +1711,61 @@ def test_launch_tui_worktree_validates_relative_python_against_final_cwd(
     assert captured["env"]["HERMES_PYTHON"] == str(relative_python)
 
 
+def test_launch_tui_runs_production_entrypoint_from_user_cwd(
+    monkeypatch, main_mod, tmp_path
+):
+    captured = {}
+    tui_cwd = tmp_path / "hermes" / "ui-tui"
+    tui_cwd.mkdir(parents=True)
+    user_cwd = tmp_path / "workspace"
+    user_cwd.mkdir()
+    monkeypatch.chdir(user_cwd)
+    monkeypatch.delenv("HERMES_CWD", raising=False)
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["node", "/hermes/ui-tui/dist/entry.js"], tui_cwd),
+    )
+    monkeypatch.setattr(
+        main_mod.subprocess,
+        "call",
+        lambda argv, cwd=None, env=None: (
+            captured.update({"argv": argv, "cwd": cwd, "env": env}) or 1
+        ),
+    )
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui()
+
+    assert captured["cwd"] == str(user_cwd)
+    assert captured["env"]["HERMES_CWD"] == str(user_cwd)
+
+
+def test_launch_tui_keeps_package_cwd_in_dev_mode(monkeypatch, main_mod, tmp_path):
+    captured = {}
+    tui_cwd = tmp_path / "hermes" / "ui-tui"
+    tui_cwd.mkdir(parents=True)
+    user_cwd = tmp_path / "workspace"
+    user_cwd.mkdir()
+    monkeypatch.chdir(user_cwd)
+    monkeypatch.delenv("HERMES_CWD", raising=False)
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["npm", "start"], tui_cwd),
+    )
+    monkeypatch.setattr(
+        main_mod.subprocess,
+        "call",
+        lambda argv, cwd=None, env=None: captured.update({"cwd": cwd}) or 1,
+    )
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui(tui_dev=True)
+
+    assert captured["cwd"] == str(tui_cwd)
+
+
 def test_launch_tui_applies_terminal_backend_config(
     monkeypatch, main_mod, _isolate_hermes_home
 ):

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1701,12 +1701,14 @@ def test_launch_tui_worktree_validates_relative_python_against_final_cwd(
     monkeypatch.setattr(
         main_mod.subprocess,
         "call",
-        lambda argv, cwd=None, env=None: captured.update({"env": env}) or 1,
+        lambda argv, cwd=None, env=None: captured.update({"cwd": cwd, "env": env})
+        or 1,
     )
 
     with pytest.raises(SystemExit):
         main_mod._launch_tui(worktree=True)
 
+    assert captured["cwd"] == str(worktree)
     assert captured["env"]["HERMES_CWD"] == str(worktree)
     assert captured["env"]["HERMES_PYTHON"] == str(relative_python)
 


### PR DESCRIPTION
## Summary

- launch the production Node TUI from `HERMES_CWD` instead of the internal `ui-tui` package directory
- keep the package directory as the runtime CWD for dev-mode npm/tsx commands
- cover both production and dev launch behavior

## Problem

`_make_tui_argv` returns an absolute production entrypoint together with the TUI package directory. `_launch_tui` used that package directory as the Node process CWD even though `HERMES_CWD` correctly tracked the user's workspace.

Terminal multiplexers that follow the foreground process CWD could therefore create a split in `~/.hermes/hermes-agent/ui-tui` instead of the active workspace, particularly while foreground-process detection was settling.

## Verification

- `uv run pytest tests/hermes_cli/test_tui_resume_flow.py tests/hermes_cli/test_tui_bundled.py tests/hermes_cli/test_tui_npm_install.py tests/hermes_cli/test_tui_heap_sizing.py tests/cli/test_update_command.py -q -o 'addopts='` (122 passed)
- `uv run ruff check hermes_cli/main.py tests/hermes_cli/test_tui_resume_flow.py`
- `git diff --check`
- live Herdr check: launched the patched TUI from a project pane and confirmed an implicit split inherited the project CWD
