### PR TITLE
fix(memory): snapshot message list before handing it to mem-sync thread

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3492,7 +3492,12 @@ class AIAgent:
         try:
             sync_kwargs = {"session_id": self.session_id or ""}
             if messages is not None:
-                sync_kwargs["messages"] = messages
+                # Snapshot: sync_all hands this list to a background worker
+                # thread while the conversation loop keeps appending to the
+                # live list — iterating the shared list there races with the
+                # next turn ("list changed size during iteration"). Same
+                # idiom as _spawn_background_review's messages_snapshot.
+                sync_kwargs["messages"] = list(messages)
             self._memory_manager.sync_all(
                 user_text,
                 response_text,


### PR DESCRIPTION

## Bug

`AIAgent._sync_external_memory_for_turn` (`run_agent.py:3447`, assignment at `run_agent.py:3495` on current `main`) passes the **live** conversation message list into `MemoryManager.sync_all`:

```python
sync_kwargs["messages"] = messages
```

`sync_all` hands that list to a background worker thread, where memory providers iterate it in `sync_turn`. Meanwhile the conversation loop keeps appending to the same list object on the next turn. This is a classic shared-mutable-state race: the background thread iterates a list that another thread is mutating.

The adjacent code path already knows about this hazard — `_spawn_background_review` snapshots with `list(messages)` before spawning its thread. The mem-sync path is the one caller that forgot.

## Failure scenario

A user with an external memory provider enabled sends a message while the previous turn's memory sync is still running. The provider thread either:

- crashes with `RuntimeError: list changed size during iteration` (sync for that turn is silently lost), or
- observes a half-updated transcript — e.g. a user message from turn N+1 with no assistant reply — and persists a corrupted turn into external memory.

It is timing-dependent, so it shows up as rare, unreproducible memory-sync failures under fast consecutive turns.

## Fix

Snapshot with `list(messages)` at the single choke point (`_sync_external_memory_for_turn`) that both callers — `turn_finalizer` and `codex_runtime` — go through. One shallow copy per turn; same idiom the codebase already uses for `_spawn_background_review`'s `messages_snapshot`. No behavior change other than removing the race.

## Testing

Verified against the repo's own test suites (all pass with the patch applied):

- `tests/agent/test_memory_async_sync.py`
- `tests/agent/test_memory_boundary_commit.py`
- `tests/agent/test_memory_provider.py`
- `tests/agent/test_memory_session_switch.py`
- `tests/run_agent/test_memory_sync_interrupted.py`

143 passed, 0 failed.

Honest note: this commit does **not** add a new regression test. A deterministic test would monkeypatch `MemoryManager.sync_all`, capture the `messages` kwarg, append to the original list, and assert the captured list is unaffected (i.e. it is a copy). Happy to add that if the maintainers want it in this PR.

## Scope

- `run_agent.py` — 1 file, +6 / -1 (one line of code, five lines of comment).
🤖 Generated with [Claude Code](https://claude.com/claude-code)
