### PR TITLE
fix(streaming): add jittered exponential backoff between stream retries

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2799,7 +2799,28 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     def _call():
         import httpx as _httpx
 
+        from agent.retry_utils import jittered_backoff as _jittered_backoff
+
         _max_stream_retries = env_int("HERMES_STREAM_RETRIES", 2)
+
+        def _backoff_before_retry(_attempt: int) -> None:
+            """Sleep with jittered exponential backoff between stream retries.
+
+            Back-to-back reconnects hammer a provider that is mid-outage and
+            compound rate-limit exposure.  Sleep in short slices so /stop
+            (interrupt) stays responsive during the backoff window.
+            """
+            _delay = _jittered_backoff(
+                _attempt + 1, base_delay=1.0, max_delay=15.0
+            )
+            _deadline = time.monotonic() + _delay
+            while True:
+                _remaining = _deadline - time.monotonic()
+                if _remaining <= 0:
+                    return
+                if agent._interrupt_requested or _request_cancelled["value"]:
+                    return
+                time.sleep(min(0.2, _remaining))
 
         try:
             for _stream_attempt in range(_max_stream_retries + 1):
@@ -2952,6 +2973,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                 )
                             except Exception:
                                 pass
+                        _backoff_before_retry(_stream_attempt)
                         continue
 
                     # SSE error events from proxies (e.g. OpenRouter sends
@@ -3018,6 +3040,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                                     )
                                 except Exception:
                                     pass
+                            _backoff_before_retry(_stream_attempt)
                             continue
                         # Retries exhausted. Log the final failure with
                         # full diagnostic detail (chain, headers,


### PR DESCRIPTION

## Bug

The streaming retry loop in `interruptible_streaming_api_call` (`agent/chat_completion_helpers.py`, loop starting at line 2805 on current `main`) retries transient stream failures with **zero delay**. Both retry points — the mid-tool-call silent retry (`continue` at line 2955) and the plain transient-error retry (`continue` at line 3021) — reconnect back-to-back immediately.

## Failure scenario

During a provider outage or throttling window, every reconnect lands while the provider is still down: with `HERMES_STREAM_RETRIES=2` the agent burns all retries within milliseconds and surfaces a hard failure to the user, when waiting 1–3 seconds would have succeeded. Against a rate-limiting provider, instant reconnects compound the 429 pressure (each doomed retry is another counted request), making the throttling worse and — with credential pools — accelerating pool exhaustion.

## Fix

Add a `_backoff_before_retry(attempt)` helper inside `_call()` and invoke it immediately before each of the two existing `continue` statements. It:

- computes the delay via the existing `agent.retry_utils.jittered_backoff(attempt + 1, base_delay=1.0, max_delay=15.0)` — no new backoff policy, the same one the conversation loop uses;
- sleeps in 0.2s slices, bailing out immediately if `agent._interrupt_requested` or the request has been cancelled, so `/stop` stays exactly as responsive as before.

Additions only (+23, no lines removed or moved), so it composes trivially with the other churn in this file and cannot change behavior on the success path or the retries-exhausted path.

## Testing

Verified against the repo's own streaming test suites (all pass with the patch applied):

- `tests/run_agent/test_streaming.py`
- `tests/run_agent/test_stream_interrupt_retry.py`
- `tests/run_agent/test_stream_stale_breaker_reset.py`
- `tests/run_agent/test_partial_stream_finish_reason.py`
- `tests/agent/test_bedrock_interrupt_post_worker.py`
- `tests/run_agent/test_28161_anthropic_stream_pool_cleanup.py`

75 passed, 0 failed. The interrupt-retry suite in particular confirms `/stop` responsiveness is unaffected.

Honest note: no new regression test is included. A good one would stub the stream to fail twice, patch `time.sleep`/`time.monotonic`, and assert a nonzero, increasing delay is requested between attempts — and that setting the interrupt flag mid-backoff returns immediately. Say so in the PR and offer to add it.

## Scope

- `agent/chat_completion_helpers.py` — 1 file, +23 / -0 (one helper, two one-line call sites).

## Related

Fixes #60029. I'm aware of the existing PRs #60299 and #60031 for the same issue — offering this as a narrower alternative: it reuses the repo's existing `agent.retry_utils.jittered_backoff` (the same policy the conversation loop already uses) rather than introducing new backoff code, and keeps `/stop` responsive by sleeping in 0.2s slices with interrupt/cancel checks. Happy to close in favor of either if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
