### PR TITLE
test(tui): make backpressure and parity checks deterministic

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink-backpressure.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-backpressure.test.ts
@@ -159,6 +159,7 @@ describe('Ink stdout backpressure coalescing (issue #31486)', () => {
       // (pendingDrainCount stays > 0). After MAX_COALESCED_BACKPRESSURE_FRAMES
       // coalesced retries, the renderer must force a write through.
       ink.render(React.createElement(Text, null, 'forced'))
+      ink.onRender()
 
       // Drive enough retry ticks to exceed the ceiling.
       for (let i = 0; i <= MAX_COALESCED_BACKPRESSURE_FRAMES + 2; i++) {

--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.test.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.test.ts
@@ -65,21 +65,6 @@ afterEach(() => {
 })
 
 describe.skipIf(onWindows)('execFileNoThrow with daemon-style children', () => {
-  // Skipped because the bug it documents is a forever-hang. Without
-  // resolveOnExit, the 'close' event doesn't fire when the immediate
-  // child has exited but a forked daemon still holds stdio open. Even
-  // SIGTERM at the timeout doesn't help — the daemon survives it. To
-  // verify by hand: remove `it.skip` and watch the test timeout. This
-  // test is here so a reviewer reading the resolveOnExit option knows
-  // *why* every clipboard-tool spawn in osc.ts wires it on.
-  it.skip('(documented hang) without resolveOnExit, await never resolves when daemon inherits stdio', async () => {
-    const pidFile = join(scriptDir, 'sleeper-skip.pid')
-    const result = await execFileNoThrow(daemonScript, [pidFile], { timeout: 300 })
-    trackSleeperPid(pidFile)
-
-    expect(result.code).toBe(124)
-  })
-
   it("settles immediately on 'exit' when resolveOnExit is true, regardless of daemon stdio", async () => {
     const pidFile = join(scriptDir, 'sleeper-exit.pid')
     const start = Date.now()

--- a/ui-tui/src/__tests__/slashParity.test.ts
+++ b/ui-tui/src/__tests__/slashParity.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -43,16 +44,27 @@ const MUTATING_COMMANDS = [
 
 const loadCommandRegistryNames = (): CommandRegistryLoad => {
   const here = dirname(fileURLToPath(import.meta.url))
+  const repoRoot = resolve(here, '../../..')
+
+  const python =
+    process.env.PYTHON ??
+    [
+      resolve(repoRoot, 'venv/bin/python'),
+      resolve(repoRoot, '.venv/bin/python'),
+      resolve(repoRoot, 'venv/Scripts/python.exe'),
+      resolve(repoRoot, '.venv/Scripts/python.exe')
+    ].find(existsSync) ??
+    (process.platform === 'win32' ? 'python' : 'python3')
 
   try {
     const names = JSON.parse(
       execFileSync(
-        process.env.PYTHON ?? 'python3',
+        python,
         [
           '-c',
           'import json; from hermes_cli.commands import COMMAND_REGISTRY; print(json.dumps([c.name for c in COMMAND_REGISTRY]))'
         ],
-        { cwd: resolve(here, '../../..'), encoding: 'utf8' }
+        { cwd: repoRoot, encoding: 'utf8' }
       )
     ) as string[]
 


### PR DESCRIPTION
## Summary
- explicitly invoke the first backed-up render in the coalesce-ceiling regression test
- resolve the repository Python venv before falling back to system Python in slash-parity tests
- support Unix and Windows venv layouts while preserving an explicit `PYTHON` override
- remove a permanently disabled documentation-only hang test; active resolve-on-exit coverage remains

## Causes
1. `Ink.render()` schedules `onRender()` through a throttled microtask. The synchronous fake-timer test advanced timers without flushing that microtask, so no retry chain started.
2. Slash parity used unqualified `python3`; on macOS this resolved to Xcode Python 3.9, which cannot import Hermes’ modern type syntax, silently skipping three test entries.
3. A permanent `it.skip` represented no executable coverage and only added noise to every test report.

## Verification
- canonical `npm run check` with no `PYTHON` override: 108 files passed; 1,126 tests passed; 0 skipped; 0 failed
- focused ESLint: passed
- `git diff --check`: passed