### PR TITLE
fix(photon): make packaged voice transcoding deterministic

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -39,9 +39,10 @@ jobs:
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     with:
       # Scan explicit lockfiles rather than recursing, so we only look at
-      # the three sources of truth and skip vendored / test / worktree dirs.
+      # the four sources of truth and skip vendored / test / worktree dirs.
       scan-args: |-
         --lockfile=uv.lock
         --lockfile=package-lock.json
         --lockfile=website/package-lock.json
+        --lockfile=plugins/platforms/photon/sidecar/package-lock.json
       fail-on-vuln: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -174,6 +174,11 @@ jobs:
           rm -rf "$RG_TARBALL" "ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl"
           rg --version
 
+      - name: Set up Node.js 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
         with:
@@ -204,7 +209,7 @@ jobs:
         # re-download, keeping the persisted cache small and fast to restore.
         run: uv cache prune --ci
 
-      - name: Packaged-wheel i18n smoke test
+      - name: Packaged-wheel runtime smoke test
         run: |
           source .venv/bin/activate
           python -m pytest -m integration tests/test_wheel_locales_e2e.py -v

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,10 @@ graft locales
 # built from the sdist (e.g. Homebrew, downstream packagers). package-data
 # below covers the wheel; this covers the sdist. See #34034 / #28149.
 recursive-include plugins plugin.yaml plugin.yml
+# Photon launches this Node sidecar at runtime. Ship its source and npm lock in
+# sdists without recursively including a developer's node_modules directory.
+include plugins/platforms/photon/sidecar/*.mjs
+include plugins/platforms/photon/sidecar/*.json
 # Gateway assets include images plus YAML catalogs such as status_phrases.yaml.
 recursive-include gateway/assets *
 global-exclude __pycache__

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.0",
       "hasInstallScript": true,
       "dependencies": {
+        "ffmpeg-static": "5.2.0",
         "spectrum-ts": "8.0.0"
       },
       "engines": {
@@ -20,6 +21,21 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
       "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.4",
@@ -677,11 +693,29 @@
         "typescript": "^5 || ^6.0.0"
       }
     },
+    "node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "license": "MIT"
+    },
     "node_modules/abort-controller-x": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.5.0.tgz",
       "integrity": "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==",
       "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -796,6 +830,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -804,6 +844,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
     },
     "node_modules/chardet": {
       "version": "2.2.0",
@@ -892,6 +938,21 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -918,6 +979,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -1064,6 +1142,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1081,6 +1168,22 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/ffmpeg-static": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.2.0.tgz",
+      "integrity": "sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==",
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -1150,6 +1253,28 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -1191,8 +1316,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -1298,6 +1422,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -1374,6 +1504,11 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -1452,6 +1587,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.1.tgz",
@@ -1496,7 +1640,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1533,8 +1676,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1621,7 +1763,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -1711,6 +1852,12 @@
         "node": "*"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -1738,8 +1885,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/vcf": {
       "version": "2.1.2",

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.4.0",
       "hasInstallScript": true,
       "dependencies": {
-        "ffmpeg-static": "5.2.0",
         "spectrum-ts": "8.0.0"
       },
       "engines": {
         "node": ">=18.17"
+      },
+      "optionalDependencies": {
+        "ffmpeg-static": "5.2.0"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -27,6 +29,7 @@
       "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
       "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "caseless": "^0.12.0",
         "concat-stream": "^2.0.0",
@@ -697,7 +700,8 @@
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/abort-controller-x": {
       "version": "0.5.0",
@@ -710,6 +714,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "4"
       },
@@ -834,7 +839,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
@@ -849,7 +855,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/chardet": {
       "version": "2.2.0",
@@ -946,6 +953,7 @@
         "node >= 6.0"
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -986,6 +994,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1147,6 +1156,7 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -1176,6 +1186,7 @@
       "integrity": "sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
+      "optional": true,
       "dependencies": {
         "@derhuerst/http-basic": "^8.2.0",
         "env-paths": "^2.2.0",
@@ -1258,6 +1269,7 @@
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/node": "^10.0.3"
       }
@@ -1267,6 +1279,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -1316,7 +1329,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -1426,7 +1440,8 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
@@ -1508,7 +1523,8 @@
     "node_modules/parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "optional": true
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -1592,6 +1608,7 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1640,6 +1657,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1676,7 +1694,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1763,6 +1782,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -1856,7 +1876,8 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -1885,7 +1906,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/vcf": {
       "version": "2.1.2",

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -13,6 +13,7 @@
     "node": ">=18.17"
   },
   "dependencies": {
+    "ffmpeg-static": "5.2.0",
     "spectrum-ts": "8.0.0"
   },
   "overrides": {

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -13,8 +13,10 @@
     "node": ">=18.17"
   },
   "dependencies": {
-    "ffmpeg-static": "5.2.0",
     "spectrum-ts": "8.0.0"
+  },
+  "optionalDependencies": {
+    "ffmpeg-static": "5.2.0"
   },
   "overrides": {
     "protobufjs": "8.6.1",

--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -19,6 +19,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const MARKER = "Hermes patch: Preserve mixed text + attachment iMessage payloads";
+const VOICE_MARKER = "Hermes patch: Upload transcoded voice with an M4A filename";
 
 function scriptDir() {
   return path.dirname(fileURLToPath(import.meta.url));
@@ -115,6 +116,15 @@ function patchChildIndices(source) {
   );
 }
 
+function patchVoiceUploadName(source) {
+  return replaceOnce(
+    source,
+    `\tconst name = content.name ?? "voice.m4a";`,
+    `\t// ponytail: Spectrum transcodes bytes; keep the iMessage filename aligned.\n\tconst name = (content.name?.replace(/\\.[^./]+$/, "") || "voice") + ".m4a";`,
+    "voice upload filename"
+  );
+}
+
 export function patchSpectrumTs(root = scriptDir()) {
   const dist = path.join(
     root,
@@ -132,7 +142,7 @@ export function patchSpectrumTs(root = scriptDir()) {
 
   for (const file of files) {
     const raw = fs.readFileSync(file, "utf8");
-    if (raw.includes(MARKER)) {
+    if (raw.includes(MARKER) && raw.includes(VOICE_MARKER)) {
       return { patched: false, file, reason: "already patched" };
     }
     // Normalize to LF for matching so the patch works regardless of the
@@ -149,10 +159,16 @@ export function patchSpectrumTs(root = scriptDir()) {
       continue;
     }
     let patched = original;
-    patched = patchRebuild(patched);
-    patched = patchInbound(patched);
-    patched = patchChildIndices(patched);
-    patched = `// ${MARKER}\n${patched}`;
+    if (!patched.includes(MARKER)) {
+      patched = patchRebuild(patched);
+      patched = patchInbound(patched);
+      patched = patchChildIndices(patched);
+      patched = `// ${MARKER}\n${patched}`;
+    }
+    if (!patched.includes(VOICE_MARKER)) {
+      patched = patchVoiceUploadName(patched);
+      patched = `// ${VOICE_MARKER}\n${patched}`;
+    }
     if (usedCRLF) {
       patched = patched.split("\n").join(CRLF);
     }

--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -120,7 +120,7 @@ function patchVoiceUploadName(source) {
   return replaceOnce(
     source,
     `\tconst name = content.name ?? "voice.m4a";`,
-    `\t// ponytail: Spectrum transcodes bytes; keep the iMessage filename aligned.\n\tconst name = (content.name?.replace(/\\.[^./]+$/, "") || "voice") + ".m4a";`,
+    `\t// Spectrum transcodes the bytes; keep the iMessage filename aligned.\n\tconst name = (content.name?.replace(/\\.[^./]+$/, "") || "voice") + ".m4a";`,
     "voice upload filename"
   );
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,6 +351,10 @@ plugins = [
   "**/plugin.yaml",
   "**/plugin.yml",
   "**/README.md",
+  # Photon starts a Node sidecar from the installed plugins package. Keep its
+  # runtime and deterministic lockfile in wheels; README-only is not runnable.
+  "platforms/photon/sidecar/*.mjs",
+  "platforms/photon/sidecar/*.json",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -84,6 +84,15 @@ const buildAttachmentMessage = async (client, base, info, id, partIndex, parentI
   return msg;
 };
 const cacheMessage = (cache, message) => { cache.set(message.id, message); };
+const ensureM4a = async (buffer, mimeType) => ({ buffer });
+const uploadVoice = async (remote, content) => {
+  const { buffer } = await ensureM4a(await content.read(), content.mimeType);
+  const name = content.name ?? "voice.m4a";
+  return {
+    guid: (await remote.attachments.upload({ data: buffer, fileName: name })).attachment.guid,
+    name
+  };
+};
 const rebuildFromAppleMessage = async (client, message, phone, chatGuidHint) => {
   const messageGuidStr = message.guid;
   const base = buildMessageBase(message, chatGuidHint, message.dateCreated ?? /* @__PURE__ */ new Date(), phone);
@@ -148,7 +157,7 @@ const toInboundMessages = async (client, cache, event, phone) => {
   cacheMessage(cache, msg);
   return [msg];
 };
-export { rebuildFromAppleMessage, toInboundMessages };
+export { rebuildFromAppleMessage, toInboundMessages, uploadVoice };
 """
 
 
@@ -185,6 +194,7 @@ def test_spectrum_patch_rewrites_the_imessage_mapper(tmp_path: Path) -> None:
     # The text is captured in both mappers before the attachment branches run.
     assert "const text2 = message.content.text;" in patched
     assert "const text2 = event.message.content.text;" in patched
+    assert 'content.name?.replace(/\\.[^./]+$/, "") || "voice"' in patched
 
     # Re-running is a no-op (idempotent self-heal on every sidecar start).
     again = subprocess.run(
@@ -214,7 +224,7 @@ def test_spectrum_patch_preserves_text_at_runtime(tmp_path: Path) -> None:
 
     harness = textwrap.dedent(
         f"""
-        import {{ rebuildFromAppleMessage, toInboundMessages }} from {str(chunk)!r};
+        import {{ rebuildFromAppleMessage, toInboundMessages, uploadVoice }} from {str(chunk)!r};
         const assert = (c, m) => {{ if (!c) {{ console.error("FAIL: " + m); process.exit(1); }} }};
 
         // Mixed text + single attachment -> group [text@0, attachment@1].
@@ -243,6 +253,14 @@ def test_spectrum_patch_preserves_text_at_runtime(tmp_path: Path) -> None:
         // Text only, no attachments -> plain text (unchanged).
         r = await rebuildFromAppleMessage(null, {{ guid: "G4", content: {{ text: "just text", attachments: [] }} }}, "+1");
         assert(r.content.type === "text" && r.content.text === "just text" && r.id === "G4", "text-only unchanged");
+
+        // Spectrum transcodes the bytes to M4A; the uploaded filename must match.
+        const uploaded = [];
+        const voice = await uploadVoice(
+          {{ attachments: {{ upload: async (payload) => {{ uploaded.push(payload); return {{ attachment: {{ guid: "V" }} }}; }} }} }},
+          {{ name: "reply.mp3", mimeType: "audio/mpeg", read: async () => Buffer.from("mp3") }}
+        );
+        assert(voice.name === "reply.m4a" && uploaded[0].fileName === "reply.m4a", "voice upload uses m4a filename");
         """
     )
     run = subprocess.run(

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,4 +1,5 @@
 import ast
+import json
 import re
 import tomllib
 from pathlib import Path
@@ -154,6 +155,25 @@ def test_bundled_plugin_manifests_ship_in_both_wheel_and_sdist():
     assert "recursive-include plugins" in manifest and "plugin.yaml" in manifest, (
         "MANIFEST.in must recursive-include plugins plugin.yaml/plugin.yml (sdist)"
     )
+
+
+def test_photon_sidecar_runtime_ships_and_ffmpeg_is_optional():
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    plugin_data = data["tool"]["setuptools"]["package-data"]["plugins"]
+    assert "platforms/photon/sidecar/*.mjs" in plugin_data
+    assert "platforms/photon/sidecar/*.json" in plugin_data
+
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    assert "include plugins/platforms/photon/sidecar/*.mjs" in manifest
+    assert "include plugins/platforms/photon/sidecar/*.json" in manifest
+
+    package = json.loads(
+        (REPO_ROOT / "plugins/platforms/photon/sidecar/package.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert package["optionalDependencies"]["ffmpeg-static"] == "5.2.0"
+    assert "ffmpeg-static" not in package["dependencies"]
 
 
 # Minimum non-vulnerable Starlette: CVE-2026-48710 ("BadHost") was fixed in

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -175,6 +175,11 @@ def test_photon_sidecar_runtime_ships_and_ffmpeg_is_optional():
     assert package["optionalDependencies"]["ffmpeg-static"] == "5.2.0"
     assert "ffmpeg-static" not in package["dependencies"]
 
+    osv_workflow = (REPO_ROOT / ".github/workflows/osv-scanner.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "--lockfile=plugins/platforms/photon/sidecar/package-lock.json" in osv_workflow
+
 
 # Minimum non-vulnerable Starlette: CVE-2026-48710 ("BadHost") was fixed in
 # 1.0.1. Anything below that lets a malformed Host header desync

--- a/tests/test_wheel_locales_e2e.py
+++ b/tests/test_wheel_locales_e2e.py
@@ -26,11 +26,18 @@ import subprocess
 import sys
 import tarfile
 import venv
+import zipfile
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+PHOTON_SIDECAR_RUNTIME = {
+    "index.mjs",
+    "package-lock.json",
+    "package.json",
+    "patch-spectrum-mixed-attachments.mjs",
+}
 
 
 @pytest.mark.integration
@@ -49,6 +56,16 @@ def test_installed_wheel_renders_i18n_strings(tmp_path):
     wheels = glob.glob(str(wheel_dir / "*.whl"))
     assert wheels, "no wheel produced"
     wheel = wheels[0]
+
+    with zipfile.ZipFile(wheel) as archive:
+        names = set(archive.namelist())
+    expected_sidecar = {
+        f"plugins/platforms/photon/sidecar/{name}"
+        for name in PHOTON_SIDECAR_RUNTIME
+    }
+    assert expected_sidecar <= names, (
+        f"wheel missing Photon sidecar runtime files: {sorted(expected_sidecar - names)}"
+    )
 
     # 2. Fresh venv, install the wheel WITHOUT deps (we only exercise i18n,
     #    which needs pyyaml). --force-reinstall guards against pip's
@@ -117,9 +134,19 @@ def test_built_sdist_ships_locale_catalogs(tmp_path):
     assert tarballs, "no sdist produced"
 
     with tarfile.open(tarballs[0]) as tf:
+        names = tf.getnames()
         # Members are prefixed with the sdist root dir, e.g.
         # hermes_agent-0.15.1/locales/en.yaml — match on the suffix.
-        catalogs = [m for m in tf.getnames() if "/locales/" in m and m.endswith(".yaml")]
+        catalogs = [m for m in names if "/locales/" in m and m.endswith(".yaml")]
+
+    missing_sidecar = {
+        name
+        for name in PHOTON_SIDECAR_RUNTIME
+        if not any(m.endswith(f"/plugins/platforms/photon/sidecar/{name}") for m in names)
+    }
+    assert not missing_sidecar, (
+        f"sdist missing Photon sidecar runtime files: {sorted(missing_sidecar)}"
+    )
 
     # Compare against the canonical language list rather than a hardcoded floor
     # so adding/removing a catalog updates the guard automatically and a dropped

--- a/tests/test_wheel_locales_e2e.py
+++ b/tests/test_wheel_locales_e2e.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import glob
 import os
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -41,7 +42,7 @@ PHOTON_SIDECAR_RUNTIME = {
 
 
 @pytest.mark.integration
-@pytest.mark.timeout(300)  # overrides the global --timeout=30; cold-CI wheel build + venv + pip can exceed it
+@pytest.mark.timeout(600)  # cold-CI wheel build + npm binary download + venv/pip can exceed five minutes
 def test_installed_wheel_renders_i18n_strings(tmp_path):
     # 1. Build the wheel from the current tree.
     wheel_dir = tmp_path / "wheel"
@@ -57,14 +58,62 @@ def test_installed_wheel_renders_i18n_strings(tmp_path):
     assert wheels, "no wheel produced"
     wheel = wheels[0]
 
+    wheel_extract = tmp_path / "wheel-extract"
     with zipfile.ZipFile(wheel) as archive:
         names = set(archive.namelist())
+        for member in names:
+            if member.startswith("plugins/platforms/photon/sidecar/"):
+                archive.extract(member, wheel_extract)
     expected_sidecar = {
         f"plugins/platforms/photon/sidecar/{name}"
         for name in PHOTON_SIDECAR_RUNTIME
     }
     assert expected_sidecar <= names, (
         f"wheel missing Photon sidecar runtime files: {sorted(expected_sidecar - names)}"
+    )
+
+    # Exercise the exact packaged sidecar, not the source checkout. The static
+    # binary is optional on unsupported hosts, but must install and transcode on
+    # this supported Linux CI runner without falling back to a system ffmpeg.
+    sidecar = wheel_extract / "plugins/platforms/photon/sidecar"
+    npm = shutil.which("npm")
+    node = shutil.which("node")
+    assert npm and node, "packaged Photon smoke requires Node.js and npm"
+    install = subprocess.run(
+        [npm, "ci"],
+        cwd=sidecar,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert install.returncode == 0, f"packaged Photon npm ci failed:\n{install.stderr}"
+
+    probe = r"""
+import { execFileSync } from "node:child_process";
+import { readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import ffmpegPath from "ffmpeg-static";
+import { ensureM4a } from "@spectrum-ts/core/authoring";
+const input = join(tmpdir(), `hermes-wheel-photon-${process.pid}.mp3`);
+execFileSync(ffmpegPath, ["-hide_banner", "-loglevel", "error", "-f", "lavfi", "-i", "sine=frequency=440:duration=0.08", "-codec:a", "libmp3lame", "-y", input]);
+const { buffer } = await ensureM4a(readFileSync(input), "audio/mpeg");
+rmSync(input, { force: true });
+if (buffer.subarray(4, 8).toString("ascii") !== "ftyp") process.exit(2);
+"""
+    no_system_bin = tmp_path / "no-system-bin"
+    no_system_bin.mkdir()
+    transcode = subprocess.run(
+        [node, "--input-type=module", "-e", probe],
+        cwd=sidecar,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": str(no_system_bin)},
+        timeout=120,
+    )
+    assert transcode.returncode == 0, (
+        "packaged Photon static-ffmpeg transcode failed without system ffmpeg:\n"
+        f"stdout: {transcode.stdout}\nstderr: {transcode.stderr}"
     )
 
     # 2. Fresh venv, install the wheel WITHOUT deps (we only exercise i18n,


### PR DESCRIPTION
## What does this PR do?

Makes Photon/iMessage voice replies deterministic on clean installs.

`spectrum-ts` already transcodes non-M4A voice bytes before upload, but its `ffmpeg-static` peer is optional and the Photon sidecar did not install it. That leaves first-hop installs dependent on a system `ffmpeg`. After a successful transcode, Spectrum also preserves the source filename (for example, `reply.mp3`) while uploading M4A bytes, which iMessage can render as a broken or zero-duration audio attachment.

This PR exact-pins Spectrum's supported static ffmpeg peer as optional and extends the sidecar's existing fail-loud Spectrum patch so transcoded voice uploads always use an `.m4a` filename. Supported hosts get deterministic conversion; unsupported architectures retain Spectrum's system-ffmpeg fallback instead of failing the whole Photon install. The patch migrates existing installs that already have the older mixed-attachment marker and remains idempotent on subsequent starts.

This is complementary to draft PR #65322: that PR improves adapter-level voice normalization and fallback behavior; this change makes Spectrum's final upload hop deterministic on current `main` and when the host has no system ffmpeg.

## Related Issue

Related: #65322 (companion fix; does not close it)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Pin `ffmpeg-static@5.2.0` as an optional sidecar dependency and lock its transitive tree as optional.
- Extend `patch-spectrum-mixed-attachments.mjs` to rewrite Spectrum's post-transcode upload filename to `.m4a`.
- Preserve migration/idempotency for already-patched sidecar installs.
- Ship the complete Photon sidecar runtime and lockfile in wheels and sdists; current release artifacts contain only its README.
- Add an executable regression fixture proving `reply.mp3` becomes `reply.m4a` at the upload boundary.
- Extend the existing packaged-artifact CI smoke to inspect the real wheel and sdist for all four sidecar runtime files.
- Add the nested Photon lockfile to the repository's recurring OSV scan.

## How to Test

1. `cd plugins/platforms/photon/sidecar && npm ci`
2. Verify the postinstall patch applies and `node --input-type=module -e 'import p from "ffmpeg-static"; console.log(p)'` resolves an installed binary.
3. `scripts/run_tests.sh tests/plugins/platforms/photon/ -q`
4. `scripts/run_tests.sh tests/test_packaging_metadata.py -q`
5. `scripts/run_tests.sh -m integration tests/test_wheel_locales_e2e.py -q`
6. `scripts/run_tests.sh -q`

Verified locally:

- Clean `npm ci` applied the patch to the real `@spectrum-ts/imessage@8.0.0` install.
- Real MP3 -> M4A conversion through `@spectrum-ts/core/authoring.ensureM4a` and the installed static ffmpeg succeeded.
- Simulated unsupported Windows ARM64 `npm ci` succeeded, installed Spectrum, and cleanly omitted the optional static binary.
- Photon + packaging metadata: `123 passed`.
- Real wheel/sdist artifact smoke: `2 passed`.
- Full suite on final stable HEAD: `41,950 passed, 27 failed`; those 27 failures exactly match `origin/main` across the same six unrelated files in this configured profile, and no Photon tests failed.
- `npm audit` findings are unchanged from `origin/main`: 17 moderate, 0 high, 0 critical.

## Supply-chain note

`ffmpeg-static@5.2.0` is Spectrum's declared optional peer. Its npm install hook downloads a GPL-3.0-or-later platform binary from the package's GitHub release; the npm lockfile verifies the package tarball, not that downloaded binary. This PR does not redistribute that binary, adds no npm audit findings, adds the sidecar lock to recurring OSV scans, and keeps the dependency optional so unsupported or failed downloads preserve Spectrum's system-ffmpeg fallback. Maintainers should explicitly confirm that trade-off before merge.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and documented the relationship to #65322
- [x] My PR contains only changes related to this fix
- [ ] I've run the full test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Linux (clean sidecar install plus real static-ffmpeg transcode)

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration changes
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow change
- [x] Cross-platform impact considered: unsupported Windows ARM64 install was exercised and degrades to Spectrum's existing system-ffmpeg fallback
- [x] Tool descriptions/schemas: N/A
- [ ] Maintainer: review the CI-sensitive workflow changes and apply `ci-reviewed`

## Screenshots / Logs

```text
photon-sidecar: spectrum mixed attachment patch patched: .../node_modules/@spectrum-ts/imessage/dist/index.js
supported static-ffmpeg transcode ok: 2020 bytes
unsupported win32/arm64 install degrades cleanly: optional ffmpeg omitted
123 passed
2 passed (real wheel/sdist artifact smoke)
```
