### PR TITLE
fix(gateway): preserve delegation completion across compression

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15919,7 +15919,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             metadata = {}
             parent_session_id = str(evt.get("parent_session_id") or "").strip()
             if parent_session_id:
-                metadata["gateway_session_id"] = parent_session_id
+                pinned_session_id = await self._resolve_completion_session_id(
+                    parent_session_id,
+                )
+                if not pinned_session_id:
+                    return False
+                metadata["gateway_session_id"] = pinned_session_id
             synth_event = MessageEvent(
                 text=synth_text,
                 message_type=MessageType.TEXT,
@@ -15939,6 +15944,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as e:
             logger.error("Watch notification injection error: %s", e)
             return False
+
+    async def _resolve_completion_session_id(
+        self, parent_session_id: str,
+    ) -> Optional[str]:
+        """Return a live delivery target without crossing user boundaries."""
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return None
+        try:
+            parent = await session_db.get_session(parent_session_id)
+            if parent is None:
+                return None
+            if not parent.get("ended_at"):
+                return parent_session_id
+            if parent.get("end_reason") != "compression":
+                return None
+            tip_session_id = await session_db.get_compression_tip(parent_session_id)
+            if not tip_session_id or tip_session_id == parent_session_id:
+                return None
+            tip = await session_db.get_session(tip_session_id)
+            if tip is None or tip.get("ended_at"):
+                return None
+            return tip_session_id
+        except Exception:
+            logger.debug(
+                "Could not resolve async completion session %s",
+                parent_session_id,
+                exc_info=True,
+            )
+            return None
 
     @staticmethod
     def _completion_delivery_identity(evt: dict) -> Optional[tuple[str, str, object]]:

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -186,6 +186,94 @@ def test_failed_async_injection_is_retried_and_only_success_is_acked(
     assert acknowledgements == ["deleg_duplicate"]
 
 
+def test_compression_parent_delivery_targets_live_tip_and_is_acked(
+    monkeypatch, isolated_registry,
+):
+    from tools import async_delegation
+
+    event = _async_event("deleg_compression")
+    event["parent_session_id"] = "sess_parent"
+    async_delegation._persist_dispatch({
+        "delegation_id": event["delegation_id"],
+        "session_key": event["session_key"],
+        "origin_ui_session_id": "",
+        "parent_session_id": event["parent_session_id"],
+        "dispatched_at": event["dispatched_at"],
+    })
+    async_delegation._persist_completion(event, {
+        "status": "completed",
+        "summary": event["summary"],
+    })
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._session_db = SimpleNamespace(
+        get_session=AsyncMock(side_effect=[
+            {
+                "id": "sess_parent",
+                "ended_at": "2026-07-16T12:00:00",
+                "end_reason": "compression",
+            },
+            {"id": "sess_tip", "ended_at": None, "end_reason": None},
+        ]),
+        get_compression_tip=AsyncMock(return_value="sess_tip"),
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is True
+
+    delivered = adapter.handle_message.await_args.args[0]
+    assert delivered.metadata["gateway_session_id"] == "sess_tip"
+    durable = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "delivered"
+
+
+def test_explicit_new_drop_stays_pending_for_restart_recovery(
+    monkeypatch, isolated_registry,
+):
+    from tools import async_delegation
+
+    event = _async_event("deleg_explicit_new")
+    event["parent_session_id"] = "sess_reset"
+    async_delegation._persist_dispatch({
+        "delegation_id": event["delegation_id"],
+        "session_key": event["session_key"],
+        "origin_ui_session_id": "",
+        "parent_session_id": event["parent_session_id"],
+        "dispatched_at": event["dispatched_at"],
+    })
+    async_delegation._persist_completion(event, {
+        "status": "completed",
+        "summary": event["summary"],
+    })
+
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner = _runner(adapter)
+    runner._session_db = SimpleNamespace(
+        get_session=AsyncMock(return_value={
+            "id": "sess_reset",
+            "ended_at": "2026-07-16T12:00:00",
+            "end_reason": "session_reset",
+        }),
+        get_compression_tip=AsyncMock(),
+    )
+
+    assert asyncio.run(
+        runner._deliver_completion_notification("completion", event)
+    ) is False
+
+    adapter.handle_message.assert_not_awaited()
+    durable = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert durable is not None
+    assert durable["delivery_state"] == "pending"
+    assert durable["delivery_attempts"] == 1
+    restored = queue.Queue()
+    assert async_delegation.restore_undelivered_completions(restored) == 1
+    assert restored.get_nowait()["delegation_id"] == event["delegation_id"]
+
+
 def test_distinct_process_incarnations_are_not_deduplicated():
     """Producer spawn time distinguishes a reused process session ID."""
     adapter = SimpleNamespace(handle_message=AsyncMock())


### PR DESCRIPTION
## Summary

- resolve a compression-ended delegation parent to its live continuation before adapter acceptance
- keep explicit `/new` / `session_reset` boundaries fail-closed
- leave rejected delivery claims pending so restart recovery can replay them instead of falsely marking them delivered

Fixes #65779

## Root cause

The completion was pinned to the pre-compression parent. The inner #55578 guard correctly rejected that ended row, but `BasePlatformAdapter.handle_message()` had already returned after scheduling background handling. The outer delivery path interpreted that adapter acceptance as success and marked the durable row `delivered`.

This patch preflights the pinned session at the durable delivery boundary. It follows only `end_reason=compression` lineage and accepts only a live tip. Missing sessions, explicit reset boundaries, and ended tips return retryable failure, which releases the durable claim. The existing #55578 inner guard is unchanged.

## Tests

Red before implementation: 2 new regressions failed because compression still targeted the parent and explicit reset was falsely acknowledged.

After implementation:

- `scripts/run_tests.sh tests/gateway/test_async_delegation_session_binding.py tests/gateway/test_completion_delivery.py tests/gateway/test_background_process_notifications.py tests/gateway/test_session_race_guard.py tests/gateway/test_telegram_topic_mode.py tests/tools/test_async_delegation.py -q` -> 144 passed
- `uv run ruff check gateway/run.py tests/gateway/test_completion_delivery.py` -> passed
- `uv run ty check tests/gateway/test_completion_delivery.py` -> passed
- `python -m py_compile gateway/run.py tests/gateway/test_completion_delivery.py` -> passed
- `python scripts/check-windows-footguns.py gateway/run.py tests/gateway/test_completion_delivery.py` -> passed
- `git diff --check` -> passed

## Platforms

Tested locally on macOS with hermetic gateway/unit tests. No live Telegram gateway was exercised.

## Residual risk

Adapter acceptance is still not a transactional acknowledgement that a synthetic turn was persisted. This patch closes the known fail-closed compression/reset path and its preflight race window, but a future unrelated early return after preflight would need an explicit inner-handler disposition or persisted completion-turn ID for end-to-end acknowledgment.