### PR TITLE
feat(cli): let ESC interrupt running responses

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12101,6 +12101,51 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             pass
 
+    def _escape_interrupt_blocked_by_modal(self) -> bool:
+        return bool(
+            self._secret_state
+            or self._sudo_state
+            or self._approval_state
+            or self._clarify_state
+            or self._slash_confirm_state
+            or self._model_picker_state
+        )
+
+    def _escape_interrupt_available(self) -> bool:
+        return bool(self._agent_running and self.agent and not self._escape_interrupt_blocked_by_modal())
+
+    def _interrupt_agent_from_prompt(
+        self,
+        event,
+        *,
+        force_exit_on_second_ctrl_c: bool = False,
+        now: float | None = None,
+    ) -> bool:
+        if not (self._agent_running and self.agent):
+            return False
+
+        if force_exit_on_second_ctrl_c:
+            now = time.time() if now is None else now
+            if now - self._last_ctrl_c_time < 2.0:
+                print("\n⚡ Force exiting...")
+                self._should_exit = True
+                event.app.exit()
+                return True
+
+            self._last_ctrl_c_time = now
+            print("\n⚡ Interrupting agent... (press Ctrl+C again to force exit)")
+        else:
+            print("\n⚡ Interrupting agent...")
+
+        self.agent.interrupt()
+        event.app.invalidate()
+        return True
+
+    def _handle_escape_interrupt(self, event) -> bool:
+        if not self._escape_interrupt_available():
+            return False
+        return self._interrupt_agent_from_prompt(event)
+
     def _clear_active_overlays_for_interrupt(self) -> None:
         """Drain and clear every input-blocking overlay left by an interrupted agent.
 
@@ -14046,19 +14091,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if _overlay_cleared and not (self._agent_running and self.agent):
                 return
 
-            if self._agent_running and self.agent:
-                if now - self._last_ctrl_c_time < 2.0:
-                    print("\n⚡ Force exiting...")
-                    self._should_exit = True
-                    event.app.exit()
-                    return
-                
-                self._last_ctrl_c_time = now
-                print("\n⚡ Interrupting agent... (press Ctrl+C again to force exit)")
-                self.agent.interrupt()
+            if self._interrupt_agent_from_prompt(
+                event,
+                force_exit_on_second_ctrl_c=True,
+                now=now,
+            ):
+                return
+
             # If there's text or images, clear them (like bash).
             # If everything is already empty, exit.
-            elif event.app.current_buffer.text or self._attached_images:
+            if event.app.current_buffer.text or self._attached_images:
                 event.app.current_buffer.reset()
                 self._attached_images.clear()
                 event.app.invalidate()
@@ -14131,10 +14173,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if _overlay_cleared and not (self._agent_running and self.agent):
                 return
 
-            if self._agent_running and self.agent:
-                print("\n⚡ Interrupting agent...")
-                self.agent.interrupt()
-            elif event.app.current_buffer.text or self._attached_images:
+            if self._interrupt_agent_from_prompt(event):
+                return
+
+            if event.app.current_buffer.text or self._attached_images:
                 event.app.current_buffer.reset()
                 self._attached_images.clear()
                 event.app.invalidate()
@@ -14181,6 +14223,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
+
+        _escape_interrupt_active = Condition(lambda: self._escape_interrupt_available())
+
+        @kb.add('escape', filter=_escape_interrupt_active)
+        def handle_escape_interrupt(event):
+            """ESC interrupts a running response when no modal owns it."""
+            self._handle_escape_interrupt(event)
 
         @kb.add('c-z')
         def handle_ctrl_z(event):

--- a/tests/cli/test_cli_escape_interrupt.py
+++ b/tests/cli/test_cli_escape_interrupt.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from cli import HermesCLI
+
+
+class _Buffer:
+    def __init__(self):
+        self.reset = MagicMock()
+
+
+class _App:
+    def __init__(self):
+        self.current_buffer = _Buffer()
+        self.invalidate = MagicMock()
+        self.exit = MagicMock()
+
+
+def _event():
+    return SimpleNamespace(app=_App())
+
+
+def _cli(**overrides):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.agent = MagicMock()
+    cli._agent_running = False
+    cli._secret_state = None
+    cli._sudo_state = None
+    cli._approval_state = None
+    cli._clarify_state = None
+    cli._slash_confirm_state = None
+    cli._model_picker_state = None
+    cli._last_ctrl_c_time = 0
+    cli._should_exit = False
+    for key, value in overrides.items():
+        setattr(cli, key, value)
+    return cli
+
+
+def test_escape_interrupts_running_agent_through_shared_prompt_path():
+    cli = _cli(_agent_running=True)
+    event = _event()
+
+    handled = cli._handle_escape_interrupt(event)
+
+    assert handled is True
+    cli.agent.interrupt.assert_called_once_with()
+    event.app.invalidate.assert_called_once_with()
+    event.app.exit.assert_not_called()
+
+
+def test_escape_does_not_interrupt_when_modal_prompt_has_priority():
+    cli = _cli(_agent_running=True, _secret_state={"response_queue": MagicMock()})
+    event = _event()
+
+    handled = cli._handle_escape_interrupt(event)
+
+    assert handled is False
+    cli.agent.interrupt.assert_not_called()
+    event.app.invalidate.assert_not_called()
+
+
+def test_escape_is_noop_when_idle():
+    cli = _cli(_agent_running=False)
+    event = _event()
+
+    handled = cli._handle_escape_interrupt(event)
+
+    assert handled is False
+    cli.agent.interrupt.assert_not_called()
+    event.app.exit.assert_not_called()
+    event.app.current_buffer.reset.assert_not_called()

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -5,6 +5,7 @@ import {
   applyVoiceRecordResponse,
   dismissSensitivePrompt,
   handleIdleHotkeyExit,
+  shouldAllowEscapeInterrupt,
   shouldAllowIdleHotkeyExit,
   shouldFallThroughForScroll
 } from '../app/useInputHandlers.js'
@@ -46,6 +47,27 @@ describe('shouldFallThroughForScroll — keep transcript scrolling alive during 
 
   it('does NOT fall through for unrelated state (no scroll keys held)', () => {
     expect(shouldFallThroughForScroll(baseKey)).toBe(false)
+  })
+})
+
+describe('shouldAllowEscapeInterrupt', () => {
+  const escapeKey = { escape: true }
+
+  it('allows plain Esc to interrupt a busy turn with an active session', () => {
+    expect(shouldAllowEscapeInterrupt(escapeKey, { busy: true, sid: 'session-1' }, false)).toBe(true)
+  })
+
+  it('does not interrupt while an overlay owns Esc', () => {
+    expect(shouldAllowEscapeInterrupt(escapeKey, { busy: true, sid: 'session-1' }, true)).toBe(false)
+  })
+
+  it('is a no-op when idle', () => {
+    expect(shouldAllowEscapeInterrupt(escapeKey, { busy: false, sid: 'session-1' }, false)).toBe(false)
+    expect(shouldAllowEscapeInterrupt(escapeKey, { busy: true, sid: null }, false)).toBe(false)
+  })
+
+  it('ignores non-Esc keys', () => {
+    expect(shouldAllowEscapeInterrupt({ escape: false }, { busy: true, sid: 'session-1' }, false)).toBe(false)
   })
 })
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -83,6 +83,14 @@ export function shouldFallThroughForScroll(key: {
   return false
 }
 
+export function shouldAllowEscapeInterrupt(
+  key: { escape?: boolean },
+  live: { busy?: boolean; sid?: null | string },
+  isBlocked: boolean
+): boolean {
+  return Boolean(key.escape && live.busy && live.sid && !isBlocked)
+}
+
 export function applyVoiceRecordResponse(
   response: null | VoiceRecordResponse,
   starting: boolean,
@@ -167,6 +175,14 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
   const clearSelection = () => {
     terminal.selection.clearSelection()
   }
+
+  const interruptRunningTurn = (sid: string) =>
+    turnController.interruptTurn({
+      appendMessage: actions.appendMessage,
+      gw: gateway.gw,
+      sid,
+      sys: actions.sys
+    })
 
   const cancelOverlayFromCtrlC = () => {
     if (overlay.clarify) {
@@ -472,6 +488,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return voiceRecordToggle()
     }
 
+    if (shouldAllowEscapeInterrupt(key, live, isBlocked)) {
+      return interruptRunningTurn(live.sid!)
+    }
+
     // Queue-edit cancel beats selection-clear for plain Esc: the queue header
     // explicitly promises "Esc cancel", so honoring it takes priority over the
     // implicit selection-dismissal convention. Without an active edit, fall through.
@@ -541,12 +561,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
     if (key.ctrl && ch.toLowerCase() === 'c') {
       if (live.busy && live.sid) {
-        return turnController.interruptTurn({
-          appendMessage: actions.appendMessage,
-          gw: gateway.gw,
-          sid: live.sid,
-          sys: actions.sys
-        })
+        return interruptRunningTurn(live.sid)
       }
 
       if (cState.input || cState.inputBuf.length) {


### PR DESCRIPTION
## Summary
- route classic CLI Esc through the same prompt interrupt helper used by Ctrl+C/Ctrl+Q when no modal prompt owns Esc
- let the Ink TUI use Esc to call the existing turnController.interruptTurn path while busy
- keep modal/overlay Esc priority and add regression coverage for idle/no-modal behavior

Fixes #65303

## Tests
- scripts/run_tests.sh tests/cli/test_cli_escape_interrupt.py tests/cli/test_cli_init.py -q
- cd ui-tui && npm run build:ink >/tmp/hermes-ink-build-final.log 2>&1 && npx vitest run src/__tests__/useInputHandlers.test.ts && npm run typecheck

## Platform tested
- macOS local worktree