### PR TITLE
fix(desktop): preserve copy image for large media

### DIFF
--- a/apps/desktop/electron/image-context-menu.test.ts
+++ b/apps/desktop/electron/image-context-menu.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import { type ImageContextMenuActions, imageContextMenuItems } from './image-context-menu'
+
+type TestActions = Omit<ImageContextMenuActions, 'copyImageAt' | 'saveImageFromUrl' | 'writeText'> & {
+  copyImageAt: ReturnType<typeof vi.fn<(x: number, y: number) => void>>
+  saveImageFromUrl: ReturnType<typeof vi.fn<(url: string) => Promise<unknown>>>
+  writeText: ReturnType<typeof vi.fn<(text: string) => void>>
+}
+
+function actions(): TestActions {
+  return {
+    copyImageAt: vi.fn(),
+    openExternalUrl: vi.fn(),
+    reportError: vi.fn(),
+    saveImageFromUrl: vi.fn(async () => undefined),
+    writeText: vi.fn()
+  }
+}
+
+test('builds the existing image actions when Chromium provides a source URL', () => {
+  const items = imageContextMenuItems(
+    { hasImageContents: true, mediaType: 'image', srcURL: 'https://example.com/image.png', x: 12, y: 34 },
+    actions()
+  )
+
+  assert.deepEqual(
+    items.map(item => item.label),
+    ['Open Image', 'Copy Image', 'Copy Image Address', 'Save Image As...']
+  )
+})
+
+test('copies an above-limit image by coordinates when Chromium drops its source URL', () => {
+  const imageActions = actions()
+
+  const items = imageContextMenuItems(
+    { hasImageContents: true, mediaType: 'image', srcURL: '', x: 100, y: 200 },
+    imageActions
+  )
+
+  assert.deepEqual(
+    items.map(item => item.label),
+    ['Copy Image']
+  )
+
+  items[0]?.click?.({} as never, {} as never, {} as never)
+
+  assert.equal(imageActions.copyImageAt.mock.calls.length, 1)
+  assert.deepEqual(imageActions.copyImageAt.mock.calls[0], [100, 200])
+  assert.equal(imageActions.saveImageFromUrl.mock.calls.length, 0)
+  assert.equal(imageActions.writeText.mock.calls.length, 0)
+})
+
+test('does not add image actions for a non-image target', () => {
+  assert.deepEqual(
+    imageContextMenuItems(
+      { hasImageContents: false, mediaType: 'none', srcURL: '', x: 0, y: 0 },
+      actions()
+    ),
+    []
+  )
+})
+
+test('does not offer Copy Image when the image has no decoded contents', () => {
+  assert.deepEqual(
+    imageContextMenuItems(
+      { hasImageContents: false, mediaType: 'image', srcURL: '', x: 0, y: 0 },
+      actions()
+    ),
+    []
+  )
+})

--- a/apps/desktop/electron/image-context-menu.ts
+++ b/apps/desktop/electron/image-context-menu.ts
@@ -1,0 +1,55 @@
+import type { ContextMenuParams, MenuItemConstructorOptions } from 'electron'
+
+interface ImageContextMenuActions {
+  copyImageAt: (x: number, y: number) => void
+  openExternalUrl: (url: string) => void
+  reportError: (message: string) => void
+  saveImageFromUrl: (url: string) => Promise<unknown>
+  writeText: (text: string) => void
+}
+
+function imageContextMenuItems(
+  params: Pick<ContextMenuParams, 'hasImageContents' | 'mediaType' | 'srcURL' | 'x' | 'y'>,
+  actions: ImageContextMenuActions
+): MenuItemConstructorOptions[] {
+  if (params.mediaType !== 'image' || !params.hasImageContents) {
+    return []
+  }
+
+  const copyImage: MenuItemConstructorOptions = {
+    label: 'Copy Image',
+    click: () => actions.copyImageAt(params.x, params.y)
+  }
+
+  if (!params.srcURL) {
+    return [copyImage]
+  }
+
+  return [
+    {
+      label: 'Open Image',
+      click: () => {
+        if (!params.srcURL.startsWith('data:')) {
+          actions.openExternalUrl(params.srcURL)
+        }
+      },
+      enabled: !params.srcURL.startsWith('data:')
+    },
+    copyImage,
+    {
+      label: 'Copy Image Address',
+      click: () => actions.writeText(params.srcURL)
+    },
+    {
+      label: 'Save Image As...',
+      click: () => {
+        void actions
+          .saveImageFromUrl(params.srcURL)
+          .catch(error => actions.reportError(`Save image failed: ${error.message}`))
+      }
+    }
+  ]
+}
+
+export { imageContextMenuItems }
+export type { ImageContextMenuActions }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -15,7 +15,6 @@ import {
   net as electronNet,
   ipcMain,
   Menu,
-  nativeImage,
   nativeTheme,
   Notification,
   powerMonitor,
@@ -99,6 +98,7 @@ import {
   resolveTimeoutMs,
   TEXT_PREVIEW_SOURCE_MAX_BYTES
 } from './hardening'
+import { imageContextMenuItems } from './image-context-menu'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
@@ -4200,17 +4200,6 @@ async function resourceBufferFromUrl(rawUrl) {
   })
 }
 
-async function copyImageFromUrl(rawUrl) {
-  const { buffer } = (await resourceBufferFromUrl(rawUrl)) as any
-  const image = nativeImage.createFromBuffer(buffer)
-
-  if (image.isEmpty()) {
-    throw new Error('Could not read image')
-  }
-
-  clipboard.writeImage(image)
-}
-
 async function saveImageFromUrl(rawUrl) {
   const { buffer, mimeType } = (await resourceBufferFromUrl(rawUrl)) as any
   const fallbackName = filenameFromUrl(rawUrl, `image${extensionForMimeType(mimeType) || '.png'}`)
@@ -4820,39 +4809,18 @@ function installContextMenu(window) {
   window.webContents.on('context-menu', (_event, params) => {
     const template = []
     const hasSelection = Boolean(params.selectionText?.trim())
-    const hasImage = params.mediaType === 'image' && Boolean(params.srcURL)
     const hasLink = Boolean(params.linkURL)
     const isEditable = Boolean(params.isEditable)
 
-    if (hasImage) {
-      template.push(
-        {
-          label: 'Open Image',
-          click: () => {
-            if (params.srcURL && !params.srcURL.startsWith('data:')) {
-              openExternalUrl(params.srcURL)
-            }
-          },
-          enabled: !params.srcURL.startsWith('data:')
-        },
-        {
-          label: 'Copy Image',
-          click: () => {
-            void copyImageFromUrl(params.srcURL).catch(error => rememberLog(`Copy image failed: ${error.message}`))
-          }
-        },
-        {
-          label: 'Copy Image Address',
-          click: () => clipboard.writeText(params.srcURL)
-        },
-        {
-          label: 'Save Image As...',
-          click: () => {
-            void saveImageFromUrl(params.srcURL).catch(error => rememberLog(`Save image failed: ${error.message}`))
-          }
-        }
-      )
-    }
+    template.push(
+      ...imageContextMenuItems(params, {
+        copyImageAt: (x, y) => window.webContents.copyImageAt(x, y),
+        openExternalUrl,
+        reportError: message => rememberLog(message),
+        saveImageFromUrl,
+        writeText: text => clipboard.writeText(text)
+      })
+    )
 
     if (hasLink) {
       if (template.length) {


### PR DESCRIPTION
## Summary

- preserve Copy Image when Chromium drops an oversized image data URL from context-menu params
- copy rendered images through Electron copyImageAt coordinates instead of fetching and decoding the Base64 URL again
- keep Open Image, Copy Image Address, and Save Image As gated on an available source URL
- add focused coverage for above-limit, URL-backed, non-image, and empty-image-content paths

Fixes #65767

## Verification

- npx vitest run --project electron electron/image-context-menu.test.ts: 4 passed
- npm run test:desktop:platforms: 422 passed, 1 skipped
- npm run typecheck: passed
- npm run lint: 0 errors, 15 pre-existing warnings outside changed files
- npm run build: passed

## Notes

PR #65817 opened during implementation and addresses the same issue. This patch was developed independently and retains typed Electron ContextMenuParams/MenuItemConstructorOptions boundaries.

RISK: GUI behavior was not manually verified because no display was available; coordinate-based copying is covered by unit tests, Electron type-checking, and the production build.
