### PR TITLE
fix(cli): surface local STT model preparation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11311,13 +11311,36 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         threading.Thread(target=_refresh_level, daemon=True).start()
 
     def _voice_stt_model(self) -> Optional[str]:
-        """STT model override from config, or None for the provider default."""
+        """STT model override from config, or None for the provider default.
+
+        For the local provider, prefer stt.local.model (default ``base``) so the
+        CLI passes a real model name into the local STT backend.
+        """
         try:
             from hermes_cli.config import load_config
             stt_config = load_config().get("stt", {})
-            return stt_config.get("model") if isinstance(stt_config, dict) else None
+            if not isinstance(stt_config, dict):
+                return None
+            provider = str(stt_config.get("provider") or "").strip().lower()
+            if provider == "local":
+                local_config = stt_config.get("local") or {}
+                if not isinstance(local_config, dict):
+                    local_config = {}
+                return local_config.get("model") or "base"
+            return stt_config.get("model")
         except Exception:
             return None
+
+    def _voice_stt_provider(self) -> str:
+        """Configured STT provider name (lowercased), or empty string."""
+        try:
+            from hermes_cli.config import load_config
+            stt_config = load_config().get("stt", {})
+            if not isinstance(stt_config, dict):
+                return ""
+            return str(stt_config.get("provider") or "").strip().lower()
+        except Exception:
+            return ""
 
     def _voice_restart_recording_async(self) -> None:
         """Restart continuous-mode recording off-thread (start() can block)."""
@@ -11365,10 +11388,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # _voice_processing is already True (set atomically above)
             if hasattr(self, '_app') and self._app:
                 self._app.invalidate()
-            _cprint(f"{_DIM}Transcribing...{_RST}")
+
+            stt_model = self._voice_stt_model()
+            if self._voice_stt_provider() == "local":
+                _cprint(
+                    f"{_DIM}Preparing local STT model '{stt_model}' "
+                    f"(first use may download it from Hugging Face)...{_RST}"
+                )
+            else:
+                _cprint(f"{_DIM}Transcribing...{_RST}")
 
             from tools.voice_mode import transcribe_recording
-            result = transcribe_recording(wav_path, model=self._voice_stt_model())
+            result = transcribe_recording(wav_path, model=stt_model)
 
             if result.get("success") and result.get("transcript", "").strip():
                 transcript = result["transcript"].strip()

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -1203,6 +1203,56 @@ class TestVoiceStopAndTranscribeReal:
         cli._voice_stop_and_transcribe()
         cli._voice_start_recording.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("stt_config", "expected_model"),
+        [
+            ({"provider": "local", "model": "whisper-1", "local": {"model": "small"}}, "small"),
+            ({"provider": "local", "local": {"model": "tiny"}}, "tiny"),
+            ({"provider": "local", "model": "whisper-1"}, "base"),
+        ],
+    )
+    def test_local_stt_shows_model_download_status(self, stt_config, expected_model):
+        recorder = MagicMock()
+        recorder.stop.return_value = "/tmp/test.wav"
+        cli = _make_voice_cli(_voice_recording=True, _voice_recorder=recorder)
+
+        with patch("cli._cprint") as mock_print, \
+             patch("cli.os.path.isfile", return_value=False), \
+             patch("hermes_cli.config.load_config", return_value={"stt": stt_config}), \
+             patch("tools.voice_mode.transcribe_recording",
+                   return_value={"success": True, "transcript": "hello"}) as mock_transcribe, \
+             patch("tools.voice_mode.play_beep"):
+            cli._voice_stop_and_transcribe()
+
+        messages = [call.args[0] for call in mock_print.call_args_list]
+        assert any(
+            f"local STT model '{expected_model}'" in message
+            and "first use may download it from Hugging Face" in message
+            for message in messages
+        )
+        mock_transcribe.assert_called_once_with("/tmp/test.wav", model=expected_model)
+
+    def test_non_local_stt_keeps_generic_transcribing_status(self):
+        recorder = MagicMock()
+        recorder.stop.return_value = "/tmp/test.wav"
+        cli = _make_voice_cli(_voice_recording=True, _voice_recorder=recorder)
+
+        with patch("cli._cprint") as mock_print, \
+             patch("cli.os.path.isfile", return_value=False), \
+             patch(
+                 "hermes_cli.config.load_config",
+                 return_value={"stt": {"provider": "openai", "model": "whisper-1"}},
+             ), \
+             patch("tools.voice_mode.transcribe_recording",
+                   return_value={"success": True, "transcript": "hello"}) as mock_transcribe, \
+             patch("tools.voice_mode.play_beep"):
+            cli._voice_stop_and_transcribe()
+
+        messages = [call.args[0] for call in mock_print.call_args_list]
+        assert any("Transcribing..." in message for message in messages)
+        assert all("Hugging Face" not in message for message in messages)
+        mock_transcribe.assert_called_once_with("/tmp/test.wav", model="whisper-1")
+
     @patch("cli._cprint")
     @patch("cli.os.unlink")
     @patch("cli.os.path.isfile", return_value=True)


### PR DESCRIPTION
## What does this PR do?

Makes local voice transcription visibly explain the potentially slow first-run faster-whisper preparation step instead of showing only the generic `Transcribing...` status.

For an explicitly configured local STT provider, the CLI now displays the effective configured model and notes that first use may download it from Hugging Face before entering the blocking transcription call. Other providers keep the existing generic status.

## Related Issue

Fixes #8098

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a local-provider-specific preparation message before the blocking voice transcription call.
- Resolved the local model from `stt.local.model`, defaulting to `base`, without allowing the legacy flat `stt.model` key to override provider-specific configuration.
- Passed the same resolved local model to `transcribe_recording` so the preparation status and actual faster-whisper selection stay consistent; non-local providers keep the existing generic status.
- Added real-method behavior coverage for model resolution and provider-specific output.

## How to Test

1. Configure `stt.provider: local` and `stt.local.model: base`.
2. Start CLI voice mode, record a prompt, and stop recording.
3. Confirm the CLI prints `Preparing local STT model base` plus the first-use Hugging Face download note before transcription.
4. Run `HERMES_PYTHON=/path/to/python bash scripts/run_tests.sh tests/tools/test_voice_cli_integration.py`.
5. Run `ruff check cli.py tests/tools/test_voice_cli_integration.py`.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched open and closed PRs for the issue number, faster-whisper progress, first-use model fetch, and Transcribing status variants
- [x] This PR contains only changes related to this fix
- [x] The relevant test file passed through the project test runner: 88 tests
- [x] I added behavior tests for this bug
- [x] Tested automated checks on macOS 26.2 arm64 with Python 3.12

### Documentation & Housekeeping

- [x] Documentation update is N/A; this clarifies an existing runtime state
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the change only resolves provider-specific configuration within the existing transcription path
- [x] Tool descriptions/schemas update is N/A

## Screenshots / Logs

- `scripts/run_tests.sh tests/tools/test_voice_cli_integration.py`: 88 passed, 0 failed
- `ruff check cli.py tests/tools/test_voice_cli_integration.py`: passed
- Python 3.12 `py_compile`: passed
- `git diff --check`: passed