### PR TITLE
fix(copilot-acp): keep GPT-5 fallbacks on chat completions

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1438,6 +1438,16 @@ class AIAgent:
             # relay GPT-5 models without full Responses semantics, so only
             # direct OpenAI/xAI URL detection should auto-upgrade them.
             return False
+        # The Copilot ACP facade deliberately exposes the OpenAI-compatible
+        # chat.completions shape regardless of model family. It has no
+        # ``responses`` attribute, so GPT-5 fallback routing must not upgrade
+        # it to codex_responses.
+        if normalized_provider in {
+            "copilot-acp",
+            "github-copilot-acp",
+            "copilot-acp-agent",
+        }:
+            return False
         if normalized_provider == "copilot":
             try:
                 from hermes_cli.models import _should_use_copilot_responses_api

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -5,7 +5,10 @@ the new list-based ``fallback_providers`` config format and chain
 advancement through multiple providers.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
@@ -210,6 +213,34 @@ class TestFallbackChainAdvancement:
         ):
             assert agent._try_activate_fallback() is True
             assert agent.api_mode == "anthropic_messages"
+
+    @pytest.mark.parametrize(
+        "provider",
+        ("copilot-acp", "github-copilot-acp", "copilot-acp-agent"),
+    )
+    def test_copilot_acp_gpt5_fallback_stays_on_chat_completions(self, provider):
+        """The ACP facade exposes ``chat.completions``, not ``responses``.
+
+        GPT-5 model-name routing must not upgrade a copilot-acp fallback to
+        codex_responses, or the next request crashes on ``client.responses``.
+        """
+        agent = _make_agent(
+            fallback_model={"provider": provider, "model": "gpt-5.6-luna"}
+        )
+        fallback_client = SimpleNamespace(
+            api_key="",
+            base_url="acp://copilot",
+            chat=SimpleNamespace(completions=object()),
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fallback_client, "gpt-5.6-luna"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "chat_completions"
+        assert not hasattr(agent.client, "responses")
 
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────


### PR DESCRIPTION
## Summary

Keep `copilot-acp` fallbacks on the OpenAI-compatible `chat.completions` facade, including GPT-5.x models.

When a primary Copilot ACP request failed and Hermes activated `copilot-acp / gpt-5.6-luna`, generic GPT-5 routing changed the fallback API mode to `codex_responses`. `CopilotACPClient` intentionally exposes `chat.completions`, not `responses`, so the next request failed with:

```text
'CopilotACPClient' object has no attribute 'responses'
```

## Root cause

`_provider_model_requires_responses_api()` had provider-specific handling for `copilot`, but not the separate `copilot-acp` transport. The fallback path therefore applied the generic GPT-5 rule and selected an interface that the ACP facade does not implement.

## Fix

- Treat `copilot-acp` and its supported aliases (`github-copilot-acp`, `copilot-acp-agent`) as a chat-completions-only facade in provider/model API-mode routing.
- Add parameterized regressions that activate a `gpt-5.6-luna` fallback through all three provider IDs and verify:
  - fallback activation succeeds;
  - `api_mode` remains `chat_completions`;
  - the client is not expected to expose `responses`.

## Validation

- Regression test demonstrated the defect before the fix:
  - expected `chat_completions`
  - actual `codex_responses`
- Focused provider fallback and Copilot ACP suites: **71 passed**
- Independent re-review of revised alias-complete patch: **PASS**, no blocking gaps found
- Ruff: passed
- Python compilation: passed
- `git diff --check`: passed
- Live forced fallbacks through the canonical provider and both supported aliases:
  - before: `copilot-acp/gpt-5.6-terra`, `chat_completions`
  - after activation: `gpt-5.6-luna`, `chat_completions`
  - assistant responses: `ALIAS_OK_copilot-acp`, `ALIAS_OK_github-copilot-acp`, and `ALIAS_OK_copilot-acp-agent`

## Scope

Two files:

- `run_agent.py`
- `tests/run_agent/test_provider_fallback.py`
