### PR TITLE
fix(bedrock): don't execute tool calls whose streamed JSON args are unparseable

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -34,6 +34,8 @@ import re
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
+from agent.message_sanitization import _repair_tool_call_arguments
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -819,6 +821,7 @@ def stream_converse_with_callbacks(
     current_tool: Optional[Dict] = None
     current_text_buffer: List[str] = []
     has_tool_use = False
+    has_truncated_tool_args = False
     stop_reason = "end_turn"
     usage_data: Dict[str, int] = {}
 
@@ -867,16 +870,32 @@ def stream_converse_with_callbacks(
 
         elif "contentBlockStop" in event:
             if current_tool is not None:
-                try:
-                    input_dict = json.loads(current_tool["input_json"]) if current_tool["input_json"] else {}
-                except (json.JSONDecodeError, TypeError):
-                    input_dict = {}
+                raw_input = current_tool["input_json"]
+                arguments = "{}"
+                if raw_input and raw_input.strip():
+                    try:
+                        json.loads(raw_input)
+                        arguments = raw_input
+                    except (json.JSONDecodeError, TypeError):
+                        # Same policy as the chat-completions streaming path:
+                        # attempt repair; if unrepairable, keep the raw args
+                        # and flag truncation so the loop's truncation handler
+                        # deals with it instead of executing the tool with
+                        # fabricated empty arguments.
+                        repaired = _repair_tool_call_arguments(
+                            raw_input, current_tool["name"] or "?"
+                        )
+                        if repaired != "{}":
+                            arguments = repaired
+                        else:
+                            arguments = raw_input
+                            has_truncated_tool_args = True
                 tool_calls.append(SimpleNamespace(
                     id=current_tool["toolUseId"],
                     type="function",
                     function=SimpleNamespace(
                         name=current_tool["name"],
-                        arguments=json.dumps(input_dict),
+                        arguments=arguments,
                     ),
                 ))
                 current_tool = None
@@ -916,6 +935,12 @@ def stream_converse_with_callbacks(
     finish_reason = _converse_stop_reason_to_openai(stop_reason)
     if tool_calls and finish_reason == "stop":
         finish_reason = "tool_calls"
+    if has_truncated_tool_args:
+        # Unrepairable tool-call JSON means the arguments were truncated or
+        # corrupted mid-stream.  Report "length" so the agent loop's
+        # truncation handling engages (same policy as the chat-completions
+        # streaming path) instead of executing the tool with empty arguments.
+        finish_reason = "length"
 
     choice = SimpleNamespace(
         index=0,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1073,6 +1073,64 @@ class TestStreamConverseWithCallbacks:
         assert reasoning == ["Let me think..."]
         assert result.choices[0].message.reasoning_content == "Let me think..."
 
+    def _tool_call_events(self, input_json):
+        """Synthetic Converse stream emitting one tool call with the given input JSON."""
+        return {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"contentBlockIndex": 0, "start": {
+                "toolUse": {"toolUseId": "c1", "name": "write_file"},
+            }}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {
+                "toolUse": {"input": input_json},
+            }}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"messageStop": {"stopReason": "tool_use"}},
+            {"metadata": {"usage": {"inputTokens": 0, "outputTokens": 0}}},
+        ]}
+
+    def test_valid_tool_args_pass_through(self):
+        """Well-formed streamed tool args are emitted unchanged as a normal tool call."""
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        result = stream_converse_with_callbacks(
+            self._tool_call_events('{"path": "/tmp/f", "content": "hi"}'),
+        )
+        choice = result.choices[0]
+        assert choice.finish_reason == "tool_calls"
+        tool_call = choice.message.tool_calls[0]
+        assert json.loads(tool_call.function.arguments) == {
+            "path": "/tmp/f", "content": "hi",
+        }
+
+    def test_repairable_tool_args_are_repaired(self):
+        """Malformed-but-repairable args (trailing comma) are repaired and executed."""
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        result = stream_converse_with_callbacks(
+            self._tool_call_events('{"path": "/tmp/f",}'),
+        )
+        choice = result.choices[0]
+        assert choice.finish_reason == "tool_calls"
+        tool_call = choice.message.tool_calls[0]
+        assert json.loads(tool_call.function.arguments) == {"path": "/tmp/f"}
+
+    def test_unrepairable_tool_args_flag_truncation(self):
+        """Unrepairable (truncated) args must NOT be executed as {}.
+
+        Regression: contentBlockStop used to swallow the JSONDecodeError and
+        emit the tool call as valid with empty arguments, so a stream that
+        dropped mid tool-call executed write_file/terminal/etc. with
+        fabricated empty args.  Now the raw arguments are preserved and
+        finish_reason is forced to "length" so the agent loop's truncation
+        handling engages (same policy as the chat-completions path).
+        """
+        from agent.bedrock_adapter import stream_converse_with_callbacks
+        truncated = '{"path": "/tmp/f", "content": "unterminated'
+        result = stream_converse_with_callbacks(self._tool_call_events(truncated))
+        choice = result.choices[0]
+        assert choice.finish_reason == "length"
+        tool_call = choice.message.tool_calls[0]
+        assert tool_call.function.arguments == truncated
+        assert tool_call.function.arguments != "{}"
+
 
 # ---------------------------------------------------------------------------
 # Guardrail config in build_converse_kwargs


### PR DESCRIPTION
## Bug

In `stream_converse_with_callbacks` (`agent/bedrock_adapter.py`, function at line 786 on current `main`), the `contentBlockStop` handler silently swallows unparseable tool-call input JSON (lines 868–873):

```python
try:
    input_dict = json.loads(current_tool["input_json"]) if current_tool["input_json"] else {}
except (json.JSONDecodeError, TypeError):
    input_dict = {}
```

A stream that drops or truncates mid-tool-call yields partial JSON; this code replaces it with `{}` and emits the tool call as **valid with empty arguments**, and the finish-reason mapping (line 916) still reports a normal `tool_calls` finish. The chat-completions streaming path already repairs or flags exactly this case (`_repair_tool_call_arguments` in `agent/message_sanitization.py`); Bedrock had no equivalent.

## Failure scenario

A Bedrock stream is interrupted mid-way through emitting a `write_file` / `terminal` / similar tool call. Instead of the agent loop's truncation handling engaging, the agent **executes the tool with fabricated empty arguments**: `write_file` with no path/content errors confusingly at best; a mutating tool running with defaulted arguments is worse — the user sees the agent perform an action the model never actually specified, with no indication anything was truncated.

## Fix

Mirror the chat-completions policy at the same boundary:

1. If the buffered JSON parses, pass it through as-is (previous behavior, minus a redundant decode/re-encode round-trip).
2. If not, attempt `_repair_tool_call_arguments` (fixes trailing commas, unclosed brackets, etc.). If repair succeeds, use the repaired arguments.
3. If unrepairable, keep the raw arguments and force `finish_reason = "length"`, so the agent loop's existing truncation handling engages instead of executing a fabricated call.

Minimal because it introduces no new policy — it reuses the exact repair helper and the exact "report truncation as `length`" convention the OpenAI-compatible streaming path already established, confined to the one event handler with the bug.


## Testing

Adds three regression tests to `tests/agent/test_bedrock_adapter.py::TestStreamConverseWithCallbacks`: valid args pass through unchanged; repairable args (trailing comma) are repaired and executed; unrepairable truncated args are kept raw with `finish_reason` forced to `"length"`. The truncation tests fail on unpatched `main`. Full bedrock suites pass with the patch: 203 passed (test_bedrock_adapter.py, test_bedrock_interrupt_post_worker.py, test_bedrock_1m_context.py, test_bedrock_integration.py).

Related (different code paths, same bug family): #62937 (Gemini args dropped as `{}`), #13480 (generic tool-call JSON parse error).

## Scope

- `agent/bedrock_adapter.py` — +30 / -5 (one import, one flag, the `contentBlockStop` handler, one finish-reason clause), plus the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
