### PR TITLE
feat(providers): add cursor-acp (Hermes → Cursor Agent via ACP)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -521,8 +521,9 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
+        and agent.provider not in {"copilot-acp", "cursor-acp"}
         and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and not str(agent.base_url or "").lower().startswith("acp://cursor")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1740,7 +1740,21 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+    if agent.provider in {"copilot-acp", "cursor-acp"} or str(client_kwargs.get("base_url", "")).startswith(
+        ("acp://copilot", "acp://cursor")
+    ):
+        if agent.provider == "cursor-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://cursor"):
+            from agent.cursor_acp_client import CursorACPClient
+
+            client = CursorACPClient(**client_kwargs)
+            _ra().logger.info(
+                "Cursor ACP client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                agent._client_log_context(),
+            )
+            return client
+
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -292,6 +292,9 @@ _PROVIDER_ALIASES = {
     "github-models": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "cursor": "cursor-acp",
+    "cursor-agent": "cursor-acp",
+    "cursor-cli": "cursor-acp",
     "tencent": "tencent-tokenhub",
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
@@ -1631,6 +1634,12 @@ def _maybe_wrap_anthropic(
     try:
         from agent.copilot_acp_client import CopilotACPClient
         if _safe_isinstance(client_obj, CopilotACPClient):
+            return client_obj
+    except ImportError:
+        pass
+    try:
+        from agent.cursor_acp_client import CursorACPClient
+        if _safe_isinstance(client_obj, CursorACPClient):
             return client_obj
     except ImportError:
         pass
@@ -4523,6 +4532,12 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
             return sync_client, model
     except ImportError:
         pass
+    try:
+        from agent.cursor_acp_client import CursorACPClient
+        if isinstance(sync_client, CursorACPClient):
+            return sync_client, model
+    except ImportError:
+        pass
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -5178,31 +5193,43 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
-        if provider == "copilot-acp":
+        if provider in {"copilot-acp", "cursor-acp"}:
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None
             args = list(creds.get("args") or [])
             if not final_model:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
+                    "resolve_provider_client: %s requested but no model "
+                    "was provided or configured",
+                    provider,
                 )
                 return None, None
             if not api_key or not base_url:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
+                    "resolve_provider_client: %s requested but external "
+                    "process credentials are incomplete",
+                    provider,
                 )
                 return None, None
-            from agent.copilot_acp_client import CopilotACPClient
+            if provider == "cursor-acp":
+                from agent.cursor_acp_client import CursorACPClient
 
-            client = CopilotACPClient(
-                api_key=api_key,
-                base_url=base_url,
-                command=command,
-                args=args,
-            )
+                client = CursorACPClient(
+                    api_key=api_key,
+                    base_url=base_url,
+                    command=command,
+                    args=args,
+                )
+            else:
+                from agent.copilot_acp_client import CopilotACPClient
+
+                client = CopilotACPClient(
+                    api_key=api_key,
+                    base_url=base_url,
+                    command=command,
+                    args=args,
+                )
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
@@ -6162,6 +6189,7 @@ def _resolve_task_provider_model(
                 "anthropic",
                 "copilot",
                 "copilot-acp",
+                "cursor-acp",
                 "minimax-oauth",
                 "nous",
                 "openai-codex",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -617,10 +617,18 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 and getattr(agent, "_codex_stream_last_event_ts", None) is None
             ):
                 _deadline = min(_deadline, _ttfb_timeout)
+            # Local / ACP endpoints disable stale detection with +inf; int(inf)
+            # raises OverflowError and aborts an otherwise healthy long call.
+            if _deadline != float("inf"):
+                _wait_suffix = (
+                    f"provider may be slow or overloaded; "
+                    f"auto-reconnect at {int(_deadline)}s"
+                )
+            else:
+                _wait_suffix = "provider may be slow or overloaded"
             agent._emit_wait_notice(
                 f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
-                f"{int(_elapsed)}s with no response yet (provider may be slow "
-                f"or overloaded; auto-reconnect at {int(_deadline)}s)"
+                f"{int(_elapsed)}s with no response yet ({_wait_suffix})"
             )
 
         _elapsed = time.time() - _call_start

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1324,8 +1324,9 @@ def run_conversation(
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider in {"copilot-acp"}
+                    agent.provider in {"copilot-acp", "cursor-acp"}
                     or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    or str(agent.base_url or "").lower().startswith("acp://cursor")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/cursor_acp_client.py
+++ b/agent/cursor_acp_client.py
@@ -1,0 +1,580 @@
+"""OpenAI-compatible shim that forwards Hermes requests to Cursor CLI (`agent acp`).
+
+Unlike Copilot ACP (which denies tool permissions and tries to extract Hermes
+``<tool_call>`` blocks), Cursor Agent is the full executor: Hermes is only the
+ACP client. Each turn spawns a short-lived ACP session, auto-allows tool
+permissions, and returns the agent's final text as a chat completion.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shlex
+import subprocess
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from agent.file_safety import get_read_block_error, get_write_denied_error
+from agent.redact import redact_sensitive_text
+from tools.environments.local import hermes_subprocess_env
+
+ACP_MARKER_BASE_URL = "acp://cursor"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+_AUTH_METHOD_ID = "cursor_login"
+
+
+def _resolve_command() -> str:
+    return os.getenv("HERMES_CURSOR_ACP_COMMAND", "").strip() or "agent"
+
+
+def _resolve_args() -> list[str]:
+    raw = os.getenv("HERMES_CURSOR_ACP_ARGS", "").strip()
+    if not raw:
+        return ["acp"]
+    return shlex.split(raw)
+
+
+def _resolve_home_dir() -> str:
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return home
+
+    expanded = os.path.expanduser("~")
+    if expanded and expanded != "~":
+        return expanded
+
+    try:
+        import pwd
+
+        resolved = pwd.getpwuid(os.getuid()).pw_dir.strip()
+        if resolved:
+            return resolved
+    except Exception:
+        pass
+
+    return "/tmp"
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    env = hermes_subprocess_env(inherit_credentials=True)
+    home = _resolve_home_dir()
+    env["HOME"] = home
+    from hermes_constants import apply_subprocess_home_env
+
+    apply_subprocess_home_env(env)
+    return env
+
+
+def _jsonrpc_error(message_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+
+
+def _permission_allow_once(message_id: Any) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "result": {
+            "outcome": {
+                "outcome": "selected",
+                "optionId": "allow-once",
+            }
+        },
+    }
+
+
+def _format_messages_as_prompt(
+    messages: list[dict[str, Any]],
+    model: str | None = None,
+) -> str:
+    sections: list[str] = [
+        "You are Cursor Agent, used as the coding backend for Hermes.",
+        "Complete the user's request using your own tools (files, terminal, etc.).",
+        "When finished, reply with a clear summary of what you did and any remaining caveats.",
+    ]
+    if model and model not in {"cursor-acp", "agent", "cursor"}:
+        sections.append(f"Hermes requested mode/model hint: {model}")
+
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        if role == "tool":
+            label = "Tool"
+        elif role in {"system", "user", "assistant"}:
+            label = role.title()
+        else:
+            label = "Context"
+
+        rendered = _render_message_content(message.get("content"))
+        if not rendered:
+            continue
+        transcript.append(f"{label}:\n{rendered}")
+
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+
+    sections.append("Continue from the latest user request.")
+    return "\n\n".join(section.strip() for section in sections if section and section.strip())
+
+
+def _render_message_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        if "text" in content:
+            return str(content.get("text") or "").strip()
+        if "content" in content and isinstance(content.get("content"), str):
+            return str(content.get("content") or "").strip()
+        return json.dumps(content, ensure_ascii=True)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+        return "\n".join(parts).strip()
+    return str(content).strip()
+
+
+def _completion_to_stream_chunks(completion: SimpleNamespace) -> list[SimpleNamespace]:
+    choice = completion.choices[0]
+    message = choice.message
+    delta = SimpleNamespace(
+        role="assistant",
+        content=message.content or None,
+        tool_calls=None,
+        reasoning_content=message.reasoning_content,
+        reasoning=message.reasoning,
+    )
+    data_chunk = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                index=0,
+                delta=delta,
+                finish_reason=choice.finish_reason,
+            )
+        ],
+        model=completion.model,
+        usage=None,
+    )
+    usage_chunk = SimpleNamespace(
+        choices=[],
+        model=completion.model,
+        usage=completion.usage,
+    )
+    return [data_chunk, usage_chunk]
+
+
+def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
+    candidate = Path(path_text)
+    if not candidate.is_absolute():
+        raise PermissionError("ACP file-system paths must be absolute.")
+    resolved = candidate.resolve()
+    root = Path(cwd).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise PermissionError(f"Path '{resolved}' is outside the session cwd '{root}'.") from exc
+    return resolved
+
+
+def _effective_timeout(timeout: Any) -> float:
+    if timeout is None:
+        return _DEFAULT_TIMEOUT_SECONDS
+    if isinstance(timeout, (int, float)):
+        return float(timeout)
+    candidates = [
+        getattr(timeout, attr, None)
+        for attr in ("read", "write", "connect", "pool", "timeout")
+    ]
+    numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+    return max(numeric) if numeric else _DEFAULT_TIMEOUT_SECONDS
+
+
+class _ACPChatCompletions:
+    def __init__(self, client: "CursorACPClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ACPChatNamespace:
+    def __init__(self, client: "CursorACPClient"):
+        self.completions = _ACPChatCompletions(client)
+
+
+class CursorACPClient:
+    """Minimal OpenAI-client-compatible facade for Cursor Agent ACP."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "cursor-acp"
+        self.base_url = base_url or ACP_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._acp_command = acp_command or command or _resolve_command()
+        self._acp_args = list(acp_args or args or _resolve_args())
+        self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self.chat = _ACPChatNamespace(self)
+        self.is_closed = False
+        self._active_process: subprocess.Popen[str] | None = None
+        self._active_process_lock = threading.Lock()
+
+    def close(self) -> None:
+        proc: subprocess.Popen[str] | None
+        with self._active_process_lock:
+            proc = self._active_process
+            self._active_process = None
+        self.is_closed = True
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        stream: bool = False,
+        **_: Any,
+    ) -> Any:
+        # Intentionally ignore Hermes `tools` / `tool_choice` — Cursor Agent
+        # executes with its own tool surface; Hermes is only the ACP host.
+        prompt_text = _format_messages_as_prompt(messages or [], model=model)
+        response_text, reasoning_text = self._run_prompt(
+            prompt_text,
+            timeout_seconds=_effective_timeout(timeout),
+        )
+
+        usage = SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        assistant_message = SimpleNamespace(
+            content=response_text or "",
+            tool_calls=None,
+            reasoning=reasoning_text or None,
+            reasoning_content=reasoning_text or None,
+            reasoning_details=None,
+        )
+        choice = SimpleNamespace(message=assistant_message, finish_reason="stop")
+        completion = SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or "cursor-acp",
+        )
+        if stream:
+            return _completion_to_stream_chunks(completion)
+        return completion
+
+    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        try:
+            proc = subprocess.Popen(
+                [self._acp_command] + self._acp_args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                cwd=self._acp_cwd,
+                env=_build_subprocess_env(),
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start Cursor ACP command '{self._acp_command}'. "
+                "Install Cursor CLI (`agent`) or set HERMES_CURSOR_ACP_COMMAND. "
+                "Then run `agent login` (or set CURSOR_API_KEY)."
+            ) from exc
+
+        if proc.stdin is None or proc.stdout is None:
+            proc.kill()
+            raise RuntimeError("Cursor ACP process did not expose stdin/stdout pipes.")
+
+        self.is_closed = False
+        with self._active_process_lock:
+            self._active_process = proc
+
+        inbox: queue.Queue[dict[str, Any]] = queue.Queue()
+        stderr_tail: deque[str] = deque(maxlen=40)
+
+        def _stdout_reader() -> None:
+            if proc.stdout is None:
+                return
+            for line in proc.stdout:
+                try:
+                    inbox.put(json.loads(line))
+                except Exception:
+                    inbox.put({"raw": line.rstrip("\n")})
+
+        def _stderr_reader() -> None:
+            if proc.stderr is None:
+                return
+            for line in proc.stderr:
+                stderr_tail.append(line.rstrip("\n"))
+
+        out_thread = threading.Thread(target=_stdout_reader, daemon=True)
+        err_thread = threading.Thread(target=_stderr_reader, daemon=True)
+        out_thread.start()
+        err_thread.start()
+
+        next_id = 0
+
+        def _request(
+            method: str,
+            params: dict[str, Any],
+            *,
+            text_parts: list[str] | None = None,
+            reasoning_parts: list[str] | None = None,
+        ) -> Any:
+            nonlocal next_id
+            next_id += 1
+            request_id = next_id
+            payload = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            }
+            proc.stdin.write(json.dumps(payload) + "\n")
+            proc.stdin.flush()
+
+            deadline = time.monotonic() + timeout_seconds
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    break
+                try:
+                    msg = inbox.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+
+                if self._handle_server_message(
+                    msg,
+                    process=proc,
+                    cwd=self._acp_cwd,
+                    text_parts=text_parts,
+                    reasoning_parts=reasoning_parts,
+                ):
+                    continue
+
+                if msg.get("id") != request_id:
+                    continue
+                if "error" in msg:
+                    err = msg.get("error") or {}
+                    raise RuntimeError(
+                        f"Cursor ACP {method} failed: {err.get('message') or err}"
+                    )
+                return msg.get("result")
+
+            stderr_text = "\n".join(stderr_tail).strip()
+            if proc.poll() is not None and stderr_text:
+                raise RuntimeError(f"Cursor ACP process exited early: {stderr_text}")
+            raise TimeoutError(f"Timed out waiting for Cursor ACP response to {method}.")
+
+        try:
+            _request(
+                "initialize",
+                {
+                    "protocolVersion": 1,
+                    "clientCapabilities": {
+                        "fs": {
+                            "readTextFile": True,
+                            "writeTextFile": True,
+                        },
+                        "terminal": False,
+                    },
+                    "clientInfo": {
+                        "name": "hermes-agent",
+                        "title": "Hermes Agent",
+                        "version": "0.0.0",
+                    },
+                },
+            )
+            _request("authenticate", {"methodId": _AUTH_METHOD_ID})
+            session = _request(
+                "session/new",
+                {
+                    "cwd": self._acp_cwd,
+                    "mcpServers": [],
+                },
+            ) or {}
+            session_id = str(session.get("sessionId") or "").strip()
+            if not session_id:
+                raise RuntimeError("Cursor ACP did not return a sessionId.")
+
+            text_parts: list[str] = []
+            reasoning_parts: list[str] = []
+            _request(
+                "session/prompt",
+                {
+                    "sessionId": session_id,
+                    "prompt": [
+                        {
+                            "type": "text",
+                            "text": prompt_text,
+                        }
+                    ],
+                },
+                text_parts=text_parts,
+                reasoning_parts=reasoning_parts,
+            )
+            return "".join(text_parts), "".join(reasoning_parts)
+        finally:
+            self.close()
+
+    def _handle_server_message(
+        self,
+        msg: dict[str, Any],
+        *,
+        process: subprocess.Popen[str],
+        cwd: str,
+        text_parts: list[str] | None,
+        reasoning_parts: list[str] | None,
+    ) -> bool:
+        method = msg.get("method")
+        if not isinstance(method, str):
+            return False
+
+        if method == "session/update":
+            params = msg.get("params") or {}
+            update = params.get("update") or {}
+            kind = str(update.get("sessionUpdate") or "").strip()
+            content = update.get("content") or {}
+            chunk_text = ""
+            if isinstance(content, dict):
+                chunk_text = str(content.get("text") or "")
+            if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
+                text_parts.append(chunk_text)
+            elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:
+                reasoning_parts.append(chunk_text)
+            return True
+
+        # Fire-and-forget Cursor extension notifications
+        if method in {
+            "cursor/update_todos",
+            "cursor/task",
+            "cursor/generate_image",
+        }:
+            return True
+
+        if process.stdin is None:
+            return True
+
+        message_id = msg.get("id")
+        params = msg.get("params") or {}
+
+        if method == "session/request_permission":
+            response = _permission_allow_once(message_id)
+        elif method == "cursor/ask_question":
+            response = {
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "result": {
+                    "outcome": {
+                        "outcome": "skipped",
+                        "reason": "Hermes auto-skipped interactive Cursor questions in ACP mode.",
+                    }
+                },
+            }
+        elif method == "cursor/create_plan":
+            response = {
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "result": {
+                    "outcome": {
+                        "outcome": "accepted",
+                    }
+                },
+            }
+        elif method == "fs/read_text_file":
+            try:
+                path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
+                block_error = get_read_block_error(str(path))
+                if block_error:
+                    raise PermissionError(block_error)
+                try:
+                    content = path.read_text()
+                except FileNotFoundError:
+                    content = ""
+                line = params.get("line")
+                limit = params.get("limit")
+                if isinstance(line, int) and line > 1:
+                    lines = content.splitlines(keepends=True)
+                    start = line - 1
+                    end = start + limit if isinstance(limit, int) and limit > 0 else None
+                    content = "".join(lines[start:end])
+                if content:
+                    content = redact_sensitive_text(content, force=True)
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": {
+                        "content": content,
+                    },
+                }
+            except Exception as exc:
+                response = _jsonrpc_error(message_id, -32602, str(exc))
+        elif method == "fs/write_text_file":
+            try:
+                path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
+                denied = get_write_denied_error(str(path))
+                if denied:
+                    raise PermissionError(denied)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(str(params.get("content") or ""))
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": None,
+                }
+            except Exception as exc:
+                response = _jsonrpc_error(message_id, -32602, str(exc))
+        else:
+            response = _jsonrpc_error(
+                message_id,
+                -32601,
+                f"ACP client method '{method}' is not supported by Hermes yet.",
+            )
+
+        process.stdin.write(json.dumps(response) + "\n")
+        process.stdin.flush()
+        return True

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -96,6 +96,35 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_CURSOR_ACP_BASE_URL = "acp://cursor"
+
+# Per-provider subprocess launch config for auth_type="external_process".
+_EXTERNAL_PROCESS_LAUNCH: Dict[str, Dict[str, Any]] = {
+    "copilot-acp": {
+        "command_envs": ("HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"),
+        "args_env": "HERMES_COPILOT_ACP_ARGS",
+        "default_command": "copilot",
+        "default_args": ["--acp", "--stdio"],
+        "api_key": "copilot-acp",
+        "missing_code": "missing_copilot_cli",
+        "missing_hint": (
+            "Install GitHub Copilot CLI or set "
+            "HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+        ),
+    },
+    "cursor-acp": {
+        "command_envs": ("HERMES_CURSOR_ACP_COMMAND",),
+        "args_env": "HERMES_CURSOR_ACP_ARGS",
+        "default_command": "agent",
+        "default_args": ["acp"],
+        "api_key": "cursor-acp",
+        "missing_code": "missing_cursor_cli",
+        "missing_hint": (
+            "Install Cursor CLI (`agent`) or set HERMES_CURSOR_ACP_COMMAND. "
+            "Then run `agent login` (or set CURSOR_API_KEY)."
+        ),
+    },
+}
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -231,6 +260,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "cursor-acp": ProviderConfig(
+        id="cursor-acp",
+        name="Cursor Agent ACP",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_CURSOR_ACP_BASE_URL,
+        base_url_env_var="CURSOR_ACP_BASE_URL",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -1766,6 +1802,7 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        "cursor": "cursor-acp", "cursor-agent": "cursor-acp", "cursor-cli": "cursor-acp",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
@@ -6370,19 +6407,48 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+def _resolve_external_process_launch(provider_id: str) -> Dict[str, Any]:
+    """Resolve command/args for an external-process provider."""
+    launch = _EXTERNAL_PROCESS_LAUNCH.get(provider_id)
+    if not launch:
+        raise AuthError(
+            f"Provider '{provider_id}' has no external-process launch config.",
+            provider=provider_id,
+            code="invalid_provider",
+        )
+
+    command = ""
+    for env_name in launch["command_envs"]:
+        command = os.getenv(env_name, "").strip()
+        if command:
+            break
+    if not command:
+        command = str(launch["default_command"])
+
+    raw_args = os.getenv(str(launch["args_env"]), "").strip()
+    args = shlex.split(raw_args) if raw_args else list(launch["default_args"])
+    return {
+        "command": command,
+        "args": args,
+        "api_key": str(launch["api_key"]),
+        "missing_code": str(launch["missing_code"]),
+        "missing_hint": str(launch["missing_hint"]),
+    }
+
+
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    try:
+        launch = _resolve_external_process_launch(provider_id)
+    except AuthError:
+        return {"configured": False, "provider": provider_id}
+
+    command = launch["command"]
+    args = list(launch["args"])
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
@@ -6417,7 +6483,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    if target in _EXTERNAL_PROCESS_LAUNCH:
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -6596,29 +6662,24 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
+    launch = _resolve_external_process_launch(provider_id)
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    command = launch["command"]
+    args = list(launch["args"])
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the CLI command '{command}'. {launch['missing_hint']}",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code=launch["missing_code"],
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": launch["api_key"],
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -629,6 +629,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_cursor_acp,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock_api_key,
@@ -3140,6 +3141,8 @@ def select_provider_and_model(args=None):
         _model_flow_minimax_oauth(config, current_model, args=args)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "cursor-acp":
+        _model_flow_cursor_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -12616,7 +12619,7 @@ def _build_provider_choices() -> list[str]:
     except Exception:
         # Fallback: static list guarantees the CLI always works
         return [
-            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "copilot",
+            "auto", "openrouter", "nous", "openai-codex", "xai-oauth", "copilot-acp", "cursor-acp", "copilot",
             "anthropic", "gemini", "vertex", "xai", "bedrock", "azure-foundry",
             "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn",
             "stepfun", "minimax", "minimax-cn", "kilocode", "novita", "xiaomi", "arcee",

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1925,6 +1925,83 @@ def _model_flow_copilot_acp(config, current_model=""):
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
 
+
+def _model_flow_cursor_acp(config, current_model=""):
+    """Cursor Agent ACP flow using the local Cursor CLI (`agent acp`)."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    del config
+
+    provider_id = "cursor-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = (
+        status.get("resolved_command") or status.get("command") or "agent"
+    )
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Cursor Agent ACP delegates Hermes turns to `agent acp`.")
+    print("  Cursor Agent runs its own tools (files/terminal); Hermes auto-allows permissions.")
+    print("  Prerequisite: install Cursor CLI and run `agent login` (or set CURSOR_API_KEY).")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print("  Set HERMES_CURSOR_ACP_COMMAND if the Cursor CLI binary is elsewhere.")
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+    model_list = list(_PROVIDER_MODELS.get("cursor-acp", ["agent", "cursor-acp"]))
+
+    if model_list:
+        selected = _prompt_model_selection(
+            model_list,
+            current_model=current_model or "agent",
+            confirm_provider=provider_id,
+            confirm_base_url=effective_base,
+            confirm_api_key="",
+        )
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -13,9 +13,10 @@ This module ties together the foundation layers:
 - ``hermes_cli.providers``        -- canonical provider identity + overlays
 - ``hermes_cli.model_normalize``  -- per-provider name formatting
 
-Provider switching uses the ``--provider`` flag exclusively.
-No colon-based ``provider:model`` syntax — colons are reserved for
-OpenRouter variant suffixes (``:free``, ``:extended``, ``:fast``).
+Provider switching uses the ``--provider`` flag, or a bare provider slug
+(``/model cursor-acp``). Colon-based ``provider:model`` is not used here —
+colons are reserved for OpenRouter variant suffixes (``:free``, ``:extended``,
+``:fast``).
 """
 
 from __future__ import annotations
@@ -854,6 +855,32 @@ def switch_model(
     target_provider = current_provider
     resolved_moa_preset = False
 
+    # Bare provider slug: `/model cursor-acp` (or `/model cursor`) means
+    # "switch to that provider with its default model", NOT "use a model
+    # named cursor-acp on the current custom endpoint". Without this,
+    # Telegram/gateway soft-accepts unknown model names on custom endpoints
+    # and leaves the provider unchanged.
+    if (
+        not explicit_provider
+        and new_model
+        and "/" not in new_model
+        and ":" not in new_model
+        and not new_model.startswith("-")
+    ):
+        bare_pdef = resolve_provider_full(
+            new_model,
+            user_providers,
+            custom_providers,
+        )
+        if bare_pdef is not None and bare_pdef.id not in {"custom", "auto"}:
+            from hermes_cli.providers import normalize_provider as _norm_prov
+
+            # Only hijack when the typed token IS the provider id/alias,
+            # not when resolve_provider_full coincidentally matched something else.
+            if _norm_prov(new_model) == bare_pdef.id:
+                explicit_provider = new_model
+                new_model = ""
+
     # =================================================================
     # PATH A: Explicit --provider given
     # =================================================================
@@ -940,11 +967,23 @@ def switch_model(
                     ),
                 )
 
-        # If no model specified, try auto-detect from endpoint
+        # If no model specified, try curated catalog then auto-detect from endpoint
         if not new_model:
-            if pdef.base_url:
+            try:
+                from hermes_cli.models import provider_model_ids
+
+                catalog = provider_model_ids(target_provider)
+                if catalog:
+                    new_model = str(catalog[0]).strip()
+            except Exception:
+                pass
+
+        if not new_model:
+            base = str(pdef.base_url or "").strip()
+            # ACP marker URLs are not HTTP model catalogs
+            if base and not base.lower().startswith("acp://") and not base.lower().startswith("acp+tcp://"):
                 from hermes_cli.runtime_provider import _auto_detect_local_model
-                detected = _auto_detect_local_model(pdef.base_url)
+                detected = _auto_detect_local_model(base)
                 if detected:
                     new_model = detected
                 else:
@@ -965,8 +1004,8 @@ def switch_model(
                     provider_label=pdef.name,
                     is_global=is_global,
                     error_message=(
-                        f"Provider '{pdef.name}' has no base URL configured. "
-                        f"Specify a model: /model <model-name> --provider {explicit_provider}"
+                        f"Provider '{pdef.name}' needs an explicit model. "
+                        f"Try: /model <model-name> --provider {explicit_provider}"
                     ),
                 )
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -273,6 +273,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "cursor-acp": [
+        "agent",
+        "cursor-acp",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -1067,6 +1071,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models via build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (Uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (Spawns copilot --acp --stdio)"),
+    ProviderEntry("cursor-acp",     "Cursor Agent ACP",         "Cursor Agent ACP (Spawns agent acp)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Native Gemini API)"),
     ProviderEntry("vertex",         "Google Vertex AI",         "Google Vertex AI (Gemini via GCP; OAuth2 service account or ADC, GCP billing/quotas)"),
@@ -1228,6 +1233,9 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "cursor": "cursor-acp",
+    "cursor-agent": "cursor-acp",
+    "cursor-cli": "cursor-acp",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -94,6 +94,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "cursor-acp": HermesOverlay(
+        transport="openai_chat",
+        auth_type="external_process",
+        base_url_override="acp://cursor",
+        base_url_env_var="CURSOR_ACP_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -295,6 +301,9 @@ ALIASES: Dict[str, str] = {
     "copilot": "github-copilot",
     "github": "github-copilot",
     "github-copilot-acp": "copilot-acp",
+    "cursor": "cursor-acp",
+    "cursor-agent": "cursor-acp",
+    "cursor-cli": "cursor-acp",
 
     # opencode (models.dev ID for OpenCode Zen)
     "opencode-zen": "opencode",
@@ -382,6 +391,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "cursor-acp": "Cursor Agent ACP",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -25,6 +25,7 @@ from hermes_cli.auth import (
     DEFAULT_QWEN_BASE_URL,
     DEFAULT_XAI_OAUTH_BASE_URL,
     PROVIDER_REGISTRY,
+    _EXTERNAL_PROCESS_LAUNCH,
     _agent_key_is_usable,
     _nous_inference_env_override,
     format_auth_error,
@@ -1851,10 +1852,10 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
 
-    if provider == "copilot-acp":
+    if provider in _EXTERNAL_PROCESS_LAUNCH:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8411,6 +8411,18 @@ def _copilot_acp_status() -> Dict[str, Any]:
     }
 
 
+def _cursor_acp_status() -> Dict[str, Any]:
+    """Status for cursor-acp — credentials are owned by the Cursor CLI."""
+    return {
+        "logged_in": False,
+        "source": "cursor_cli",
+        "source_label": "Managed by the Cursor CLI (agent login / CURSOR_API_KEY)",
+        "token_preview": None,
+        "expires_at": None,
+        "has_refresh_token": False,
+    }
+
+
 # Explicit, hand-tuned OAuth/account provider cards. These carry the bits that
 # can't be derived from the unified provider catalog: the OAuth ``flow`` shape,
 # the per-provider ``status_fn``, the ``cli_command`` fallback, and curated
@@ -8480,6 +8492,14 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "cli_command": "copilot /login",
         "docs_url": "https://docs.github.com/en/copilot",
         "status_fn": _copilot_acp_status,
+    },
+    {
+        "id": "cursor-acp",
+        "name": "Cursor Agent (ACP)",
+        "flow": "external",
+        "cli_command": "agent login",
+        "docs_url": "https://cursor.com/docs/cli/acp",
+        "status_fn": _cursor_acp_status,
     },
     # ── Anthropic / Claude entries sit at the bottom: the API-key path
     # first, then the subscription OAuth path (which only works with extra

--- a/plugins/model-providers/cursor-acp/__init__.py
+++ b/plugins/model-providers/cursor-acp/__init__.py
@@ -1,0 +1,34 @@
+"""Cursor Agent ACP provider profile.
+
+cursor-acp uses an external ACP subprocess (`agent acp`) — NOT a REST
+transport. api_mode="chat_completions" routes through CursorACPClient.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class CursorACPProfile(ProviderProfile):
+    """Cursor Agent ACP — external process, no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is handled by the ACP subprocess."""
+        return None
+
+
+cursor_acp = CursorACPProfile(
+    name="cursor-acp",
+    aliases=("cursor", "cursor-agent", "cursor-cli"),
+    api_mode="chat_completions",
+    env_vars=(),
+    base_url="acp://cursor",
+    auth_type="external_process",
+)
+
+register_provider(cursor_acp)

--- a/plugins/model-providers/cursor-acp/plugin.yaml
+++ b/plugins/model-providers/cursor-acp/plugin.yaml
@@ -1,0 +1,5 @@
+name: cursor-acp-provider
+kind: model-provider
+version: 1.0.0
+description: Cursor Agent via ACP subprocess (agent acp)
+author: Nous Research

--- a/tests/agent/test_cursor_acp_client.py
+++ b/tests/agent/test_cursor_acp_client.py
@@ -1,0 +1,155 @@
+"""Focused regressions for the Cursor ACP shim."""
+
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.cursor_acp_client import CursorACPClient, _format_messages_as_prompt
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.stdin = io.StringIO()
+
+
+class CursorACPClientTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = CursorACPClient(acp_cwd="/tmp")
+
+    def test_completion_ignores_hermes_tools_and_returns_stop(self) -> None:
+        with patch.object(self.client, "_run_prompt", return_value=("Done.", "thinking")):
+            response = self.client._create_chat_completion(
+                model="agent",
+                messages=[{"role": "user", "content": "fix the bug"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "read_file", "parameters": {}},
+                    }
+                ],
+            )
+
+        choice = response.choices[0]
+        self.assertEqual(choice.finish_reason, "stop")
+        self.assertIsNone(choice.message.tool_calls)
+        self.assertEqual(choice.message.content, "Done.")
+        self.assertEqual(choice.message.reasoning, "thinking")
+
+    def test_prompt_format_excludes_tool_schemas(self) -> None:
+        prompt = _format_messages_as_prompt(
+            [
+                {"role": "system", "content": "Be helpful"},
+                {"role": "user", "content": "Refactor auth"},
+            ],
+            model="agent",
+        )
+        self.assertIn("Refactor auth", prompt)
+        self.assertNotIn("Available tools", prompt)
+        self.assertNotIn("<tool_call>", prompt)
+
+    def test_permission_requests_are_allowed_once(self) -> None:
+        proc = _FakeProcess()
+        handled = self.client._handle_server_message(
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "session/request_permission",
+                "params": {},
+            },
+            process=proc,
+            cwd="/tmp",
+            text_parts=[],
+            reasoning_parts=[],
+        )
+        self.assertTrue(handled)
+        reply = json.loads(proc.stdin.getvalue().strip())
+        self.assertEqual(reply["id"], 7)
+        self.assertEqual(reply["result"]["outcome"]["outcome"], "selected")
+        self.assertEqual(reply["result"]["outcome"]["optionId"], "allow-once")
+
+    def test_cursor_ask_question_is_skipped(self) -> None:
+        proc = _FakeProcess()
+        handled = self.client._handle_server_message(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "cursor/ask_question",
+                "params": {"questions": []},
+            },
+            process=proc,
+            cwd="/tmp",
+            text_parts=[],
+            reasoning_parts=[],
+        )
+        self.assertTrue(handled)
+        reply = json.loads(proc.stdin.getvalue().strip())
+        self.assertEqual(reply["result"]["outcome"]["outcome"], "skipped")
+
+    def test_cursor_create_plan_is_accepted(self) -> None:
+        proc = _FakeProcess()
+        handled = self.client._handle_server_message(
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "cursor/create_plan",
+                "params": {"plan": "do stuff"},
+            },
+            process=proc,
+            cwd="/tmp",
+            text_parts=[],
+            reasoning_parts=[],
+        )
+        self.assertTrue(handled)
+        reply = json.loads(proc.stdin.getvalue().strip())
+        self.assertEqual(reply["result"]["outcome"]["outcome"], "accepted")
+
+    def test_agent_message_chunks_are_collected(self) -> None:
+        text_parts: list[str] = []
+        handled = self.client._handle_server_message(
+            {
+                "method": "session/update",
+                "params": {
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"text": "hello "},
+                    }
+                },
+            },
+            process=_FakeProcess(),
+            cwd="/tmp",
+            text_parts=text_parts,
+            reasoning_parts=[],
+        )
+        self.assertTrue(handled)
+        self.assertEqual(text_parts, ["hello "])
+
+    def test_fs_write_stays_within_cwd(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as cwd_str:
+            cwd = Path(cwd_str)
+            client = CursorACPClient(acp_cwd=str(cwd))
+            target = cwd / "out.txt"
+            proc = _FakeProcess()
+            handled = client._handle_server_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 9,
+                    "method": "fs/write_text_file",
+                    "params": {"path": str(target), "content": "ok"},
+                },
+                process=proc,
+                cwd=str(cwd),
+                text_parts=[],
+                reasoning_parts=[],
+            )
+            self.assertTrue(handled)
+            self.assertEqual(target.read_text(), "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -31,6 +31,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("cursor-acp", "Cursor Agent ACP", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
@@ -125,6 +126,7 @@ class TestProviderRegistry:
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
+        assert PROVIDER_REGISTRY["cursor-acp"].inference_base_url == "acp://cursor"
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["stepfun"].inference_base_url == STEPFUN_STEP_PLAN_INTL_BASE_URL
@@ -241,6 +243,11 @@ class TestResolveProvider:
     def test_alias_github_copilot_acp(self):
         assert resolve_provider("github-copilot-acp") == "copilot-acp"
         assert resolve_provider("copilot-acp-agent") == "copilot-acp"
+
+    def test_alias_cursor_acp(self):
+        assert resolve_provider("cursor") == "cursor-acp"
+        assert resolve_provider("cursor-agent") == "cursor-acp"
+        assert resolve_provider("cursor-cli") == "cursor-acp"
 
     def test_explicit_huggingface(self):
         assert resolve_provider("huggingface") == "huggingface"
@@ -511,6 +518,19 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["args"] == ["--acp", "--stdio"]
         assert creds["source"] == "process"
 
+    def test_resolve_cursor_acp_with_local_cli(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CURSOR_ACP_ARGS", "acp")
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+        creds = resolve_external_process_provider_credentials("cursor-acp")
+
+        assert creds["provider"] == "cursor-acp"
+        assert creds["api_key"] == "cursor-acp"
+        assert creds["base_url"] == "acp://cursor"
+        assert creds["command"] == "/usr/local/bin/agent"
+        assert creds["args"] == ["acp"]
+        assert creds["source"] == "process"
+
     def test_resolve_kimi_with_key(self, monkeypatch):
         monkeypatch.setenv("KIMI_API_KEY", "kimi-secret-key")
         creds = resolve_api_key_provider_credentials("kimi-coding")
@@ -715,6 +735,21 @@ class TestRuntimeProviderResolution:
         assert result["base_url"] == "acp://copilot"
         assert result["command"] == "/usr/local/bin/copilot"
         assert result["args"] == ["--acp", "--stdio", "--debug"]
+
+    def test_runtime_cursor_acp_uses_process_runtime(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+        monkeypatch.setenv("HERMES_CURSOR_ACP_ARGS", "acp --stdio")
+
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="cursor-acp")
+
+        assert result["provider"] == "cursor-acp"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "cursor-acp"
+        assert result["base_url"] == "acp://cursor"
+        assert result["command"] == "/usr/local/bin/agent"
+        assert result["args"] == ["acp", "--stdio"]
 
 
 # =============================================================================

--- a/tests/hermes_cli/test_model_switch_bare_provider.py
+++ b/tests/hermes_cli/test_model_switch_bare_provider.py
@@ -1,0 +1,120 @@
+"""Bare `/model <provider>` must switch provider, not treat the slug as a model name."""
+
+from __future__ import annotations
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def test_bare_cursor_acp_switches_provider(monkeypatch):
+    """`/model cursor-acp` from a custom Gemma endpoint must flip provider."""
+    monkeypatch.setattr(
+        "hermes_cli.auth.shutil.which",
+        lambda command: f"/usr/local/bin/{command}",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: dict(_MOCK_VALIDATION),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "cursor-acp",
+            "api_mode": "chat_completions",
+            "base_url": "acp://cursor",
+            "api_key": "cursor-acp",
+            "command": "/usr/local/bin/agent",
+            "args": ["acp"],
+            "source": "process",
+        },
+    )
+
+    result = switch_model(
+        raw_input="cursor-acp",
+        current_provider="custom",
+        current_model="gemma-4",
+        current_base_url="http://213.221.10.157:1234/v1",
+        current_api_key="lm-token",
+        is_global=True,
+    )
+
+    assert result.success is True
+    assert result.target_provider == "cursor-acp"
+    assert result.new_model in {"agent", "cursor-acp"}
+    assert str(result.base_url or "").startswith("acp://cursor")
+
+
+def test_bare_cursor_alias_switches_provider(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth.shutil.which",
+        lambda command: f"/usr/local/bin/{command}",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: dict(_MOCK_VALIDATION),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "cursor-acp",
+            "api_mode": "chat_completions",
+            "base_url": "acp://cursor",
+            "api_key": "cursor-acp",
+            "command": "/usr/local/bin/agent",
+            "args": ["acp"],
+            "source": "process",
+        },
+    )
+
+    result = switch_model(
+        raw_input="cursor",
+        current_provider="custom",
+        current_model="gemma-4",
+        current_base_url="http://127.0.0.1:1234/v1",
+        is_global=False,
+    )
+
+    assert result.success is True
+    assert result.target_provider == "cursor-acp"
+
+
+def test_provider_flag_without_model_uses_catalog_default(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth.shutil.which",
+        lambda command: f"/usr/local/bin/{command}",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: dict(_MOCK_VALIDATION),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "cursor-acp",
+            "api_mode": "chat_completions",
+            "base_url": "acp://cursor",
+            "api_key": "cursor-acp",
+            "command": "/usr/local/bin/agent",
+            "args": ["acp"],
+            "source": "process",
+        },
+    )
+
+    result = switch_model(
+        raw_input="",
+        current_provider="custom",
+        current_model="gemma-4",
+        current_base_url="http://127.0.0.1:1234/v1",
+        explicit_provider="cursor-acp",
+    )
+
+    assert result.success is True
+    assert result.target_provider == "cursor-acp"
+    assert result.new_model == "agent"

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -171,6 +171,7 @@ class TestProviderLabel:
         assert provider_label("stepfun") == "StepFun Step Plan"
         assert provider_label("copilot") == "GitHub Copilot"
         assert provider_label("copilot-acp") == "GitHub Copilot ACP"
+        assert provider_label("cursor-acp") == "Cursor Agent ACP"
         assert provider_label("auto") == "Auto"
 
     def test_unknown_provider_preserves_original_name(self):

--- a/tests/run_agent/test_wait_state_visibility.py
+++ b/tests/run_agent/test_wait_state_visibility.py
@@ -121,3 +121,67 @@ def test_nonstream_wait_loop_emits_explained_notice(tmp_path, monkeypatch):
     reconnect_notices = [s for s in seen if "reconnecting" in s]
     assert reconnect_notices, f"expected a reconnect wait-notice, saw: {seen}"
     assert "no response from provider" in reconnect_notices[0]
+
+
+def test_nonstream_wait_notice_survives_infinite_stale_timeout(tmp_path, monkeypatch):
+    """Local/ACP endpoints use stale_timeout=+inf; the 30s wait notice must not
+    crash with OverflowError from int(inf) (seen with cursor-acp / acp://cursor)."""
+    import threading
+
+    from agent import chat_completion_helpers as h
+
+    seen: list = []
+    agent = _make_agent(tmp_path, monkeypatch, thinking_callback=seen.append)
+    agent.api_mode = "chat_completions"
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda *a, **k: float("inf")
+    )
+
+    dummy_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=None))
+    )
+
+    # Drive the poll loop: hang long enough for ~100 × 0.3s cadence, but shrink
+    # join timeout so the test finishes quickly while still hitting % 100 == 0.
+    real_join = threading.Thread.join
+    poll_state = {"joins": 0}
+
+    def fast_join(self, timeout=None):
+        poll_state["joins"] += 1
+        if timeout is not None:
+            return real_join(self, timeout=0.001)
+        return real_join(self, timeout=timeout)
+
+    hang_until = {"n": 105}  # >100 polls so the notice fires once
+
+    def fake_create(**kwargs):
+        while poll_state["joins"] < hang_until["n"] and not agent._interrupt_requested:
+            time.sleep(0.001)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="ok", tool_calls=None),
+                    finish_reason="stop",
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=1,
+                completion_tokens=1,
+                total_tokens=2,
+                prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+            ),
+            model="agent",
+        )
+
+    dummy_client.chat.completions.create = fake_create
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(agent, "_abort_request_openai_client", lambda c, reason=None: None)
+    monkeypatch.setattr(agent, "_close_request_openai_client", lambda c, reason=None: None)
+    monkeypatch.setattr(threading.Thread, "join", fast_join)
+
+    result = h.interruptible_api_call(agent, {"model": "agent", "messages": []})
+    assert result is not None
+    wait_notices = [s for s in seen if "with no response yet" in s]
+    assert wait_notices, f"expected wait notice, saw: {seen}"
+    assert "auto-reconnect" not in wait_notices[0]
+    assert "slow or overloaded" in wait_notices[0]

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -30,6 +30,10 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `COPILOT_CLI_PATH` | Alias for `HERMES_COPILOT_ACP_COMMAND` |
 | `HERMES_COPILOT_ACP_ARGS` | Override Copilot ACP arguments (default: `--acp --stdio`) |
 | `COPILOT_ACP_BASE_URL` | Override Copilot ACP base URL |
+| `HERMES_CURSOR_ACP_COMMAND` | Override Cursor Agent ACP CLI binary path (default: `agent`) |
+| `HERMES_CURSOR_ACP_ARGS` | Override Cursor Agent ACP arguments (default: `acp`) |
+| `CURSOR_ACP_BASE_URL` | Override Cursor ACP base URL (default: `acp://cursor`) |
+| `CURSOR_API_KEY` | Optional Cursor CLI API key (alternative to `agent login`) |
 | `COPILOT_API_BASE_URL` | Override the Copilot API base URL (`copilot` provider) |
 | `GLM_API_KEY` | z.ai / ZhipuAI GLM API key ([z.ai](https://z.ai)) |
 | `ZAI_API_KEY` | Alias for `GLM_API_KEY` |

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -52,6 +52,7 @@ Each entry requires both `provider` and `model`. Entries missing either field ar
 | OpenAI Codex | `openai-codex` | `hermes model` (ChatGPT OAuth) |
 | GitHub Copilot | `copilot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` |
 | GitHub Copilot ACP | `copilot-acp` | External process (editor integration) |
+| Cursor Agent ACP | `cursor-acp` | External process (`agent acp`; requires Cursor CLI + `agent login`) |
 | Anthropic | `anthropic` | `ANTHROPIC_API_KEY` or Claude Code credentials |
 | z.ai / GLM | `zai` | `GLM_API_KEY` |
 | Kimi / Moonshot | `kimi-coding` | `KIMI_API_KEY` |


### PR DESCRIPTION
## Summary
- Add `cursor-acp` external-process provider that spawns Cursor CLI (`agent acp`), authenticates with `cursor_login`, auto-allows tool permissions, and returns Cursor's final text (Cursor owns tools; Hermes is the ACP client).
- Generalize external-process credential resolution beyond Copilot-only so multiple ACP backends can share the same auth/runtime path.
- Fix `/model cursor-acp` (and `/model cursor`) so Telegram/gateway treat a bare provider slug as a provider switch instead of saving it as a model name on the current custom endpoint.

## Motivation
Users want Hermes (CLI/Telegram/gateway) as the front-end while Cursor Agent does the coding work with its own tools. This mirrors `copilot-acp`, but with the opposite permission policy (allow, not deny).

## Usage
```bash
# prerequisites
agent login   # or CURSOR_API_KEY
# then
hermes model  # pick Cursor Agent ACP
# Telegram / gateway:
/model cursor-acp
# or
/model agent --provider cursor-acp
```

Env overrides: `HERMES_CURSOR_ACP_COMMAND`, `HERMES_CURSOR_ACP_ARGS`, `CURSOR_ACP_BASE_URL`.

## Caveats (v1)
- Permissions default to auto-allow-once (needed for unattended Telegram/cron).
- Cursor extension methods: `ask_question` skipped, `create_plan` accepted; notifications ignored.
- No `session/load` between turns (transcript replay, like Copilot ACP).

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_cursor_acp_client.py`
- [x] `scripts/run_tests.sh tests/hermes_cli/test_model_switch_bare_provider.py`
- [x] Provider registry / credential / runtime resolution tests for `cursor-acp`
- [x] Manual smoke: `CursorACPClient` → `agent acp` returns expected text
- [ ] Reviewer: `/model cursor-acp` from a custom-endpoint session flips provider (not model name)
- [ ] Reviewer: Telegram turn with `provider: cursor-acp` exercises Cursor tools on gateway host cwd


Made with [Cursor](https://cursor.com)