### PR TITLE
fix(delegation): preserve pending results during cleanup

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -341,35 +341,71 @@ def test_submit_failure_removes_durable_running_record(tmp_path, monkeypatch):
         assert conn.execute("SELECT COUNT(*) FROM async_delegations").fetchone()[0] == 0
 
 
-def test_pending_retention_prunes_delivered_before_undelivered(tmp_path, monkeypatch):
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setattr(ad, "_MAX_RETAINED_COMPLETED", 2)
-    for index, delivery_state in enumerate(("pending", "delivered", "pending")):
-        delegation_id = f"deleg_{index}"
-        record = {
-            "delegation_id": delegation_id,
-            "session_key": "owner",
-            "origin_ui_session_id": "",
-            "parent_session_id": None,
-            "dispatched_at": float(index + 1),
-        }
-        ad._persist_dispatch(record)
-        ad._persist_completion(
-            {
-                "delegation_id": delegation_id,
-                "status": "completed",
-                "completed_at": float(index + 1),
-            },
-            {"status": "completed", "summary": delegation_id},
+def _seed_terminal_delegations(count, delivery_state):
+    base = time.time()
+    rows = [
+        (
+            f"deleg_{index:04d}",
+            "owner",
+            "completed",
+            base - count + index,
+            base - count + index,
+            base - count + index,
+            delivery_state,
         )
-        if delivery_state == "delivered":
-            ad.mark_completion_delivered(delegation_id)
+        for index in range(count)
+    ]
+    with ad._DB_LOCK, ad._connect() as conn:
+        conn.executemany(
+            """INSERT INTO async_delegations
+               (delegation_id, origin_session, state, dispatched_at,
+                completed_at, updated_at, delivery_state)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+
+
+def _durable_ids():
+    with ad._DB_LOCK, ad._connect() as conn:
+        return [
+            row[0]
+            for row in conn.execute(
+                "SELECT delegation_id FROM async_delegations ORDER BY updated_at"
+            )
+        ]
+
+
+def test_completed_history_cap_does_not_prune_60_pending(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _seed_terminal_delegations(60, "pending")
 
     ad._prune_durable_records()
 
-    assert ad.get_durable_delegation("deleg_0") is not None
-    assert ad.get_durable_delegation("deleg_1") is None
-    assert ad.get_durable_delegation("deleg_2") is not None
+    assert _durable_ids() == [f"deleg_{index:04d}" for index in range(60)]
+
+
+def test_completed_history_cap_keeps_newest_50_of_60_delivered(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _seed_terminal_delegations(60, "delivered")
+
+    ad._prune_durable_records()
+
+    assert _durable_ids() == [f"deleg_{index:04d}" for index in range(10, 60)]
+
+
+def test_pending_cap_prunes_oldest_of_1001_pending(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _seed_terminal_delegations(1001, "pending")
+
+    ad._prune_durable_records()
+
+    ids = _durable_ids()
+    assert len(ids) == ad._MAX_DURABLE_PENDING
+    assert ids[0] == "deleg_0001"
+    assert ids[-1] == "deleg_1000"
+    assert "deleg_0000" not in ids
 
 
 def test_recover_marks_abandoned_running_record_unknown(tmp_path, monkeypatch):
@@ -871,5 +907,3 @@ def test_gateway_cli_origin_event_left_unrouted():
     evt = _make_async_evt(session_key="")
     runner._enrich_async_delegation_routing(evt)
     assert "platform" not in evt
-
-

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -73,7 +73,7 @@ _records_lock = threading.Lock()
 _records: Dict[str, Dict[str, Any]] = {}
 
 _DEFAULT_MAX_ASYNC_CHILDREN = 3
-# How many completed records to retain for status queries before pruning.
+# How many delivered terminal records to retain for status queries before pruning.
 _MAX_RETAINED_COMPLETED = 50
 _DURABLE_RETENTION_SECONDS = 7 * 24 * 60 * 60
 _MAX_DURABLE_PENDING = 1000
@@ -158,7 +158,7 @@ def _delete_durable_delegation(delegation_id: str) -> None:
 
 
 def _prune_durable_records() -> None:
-    """Bound terminal history, preferring delivered records for deletion."""
+    """Bound delivered history and the pending-delivery backlog independently."""
     now = time.time()
     cutoff = now - _DURABLE_RETENTION_SECONDS
     with _DB_LOCK, _connect() as conn:
@@ -166,17 +166,19 @@ def _prune_durable_records() -> None:
             "DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ?",
             (cutoff,),
         )
-        terminal_count = conn.execute(
-            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing')"
+        delivered_count = conn.execute(
+            """SELECT COUNT(*) FROM async_delegations
+               WHERE state NOT IN ('running','finalizing')
+                 AND delivery_state='delivered'"""
         ).fetchone()[0]
-        excess = max(0, terminal_count - _MAX_RETAINED_COMPLETED)
+        excess = max(0, delivered_count - _MAX_RETAINED_COMPLETED)
         if excess:
             conn.execute(
                 """DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
                      WHERE state NOT IN ('running','finalizing')
-                     ORDER BY CASE delivery_state WHEN 'delivered' THEN 0 ELSE 1 END,
-                              updated_at ASC LIMIT ?
+                       AND delivery_state='delivered'
+                     ORDER BY updated_at ASC LIMIT ?
                    )""",
                 (excess,),
             )


### PR DESCRIPTION
## What does this PR do?

It keeps completed delegation results until the parent agent receives them.

Cleanup still keeps only the newest 50 delivered results. Undelivered results now use their separate 1,000-record limit.

## Related Issue

Fixes #65853

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- count delivered and undelivered results separately during cleanup;
- keep only the newest 50 delivered results;
- keep up to 1,000 results that are still waiting for delivery;
- add tests for both limits.

## How to Test

1. Run `uv run --frozen pytest tests/tools/test_async_delegation.py -q`.
2. Confirm all 28 tests pass.
3. Run `uv run --frozen ruff check tools/async_delegation.py tests/tools/test_async_delegation.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 with Python 3.13.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable.
