### PR TITLE
docs(faq): use the correct default model command

### DIFF
--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -268,8 +268,8 @@ Make sure the key matches the provider. An OpenAI key won't work with OpenRouter
 # List available models for your provider
 hermes model
 
-# Set a valid model
-hermes config set HERMES_MODEL anthropic/claude-opus-4.7
+# Set a valid model (writes to model.default in ~/.hermes/config.yaml)
+hermes config set model.default anthropic/claude-opus-4.7
 
 # Or specify per-session
 hermes chat --model openrouter/meta-llama/llama-3.1-70b-instruct

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/faq.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/faq.md
@@ -287,8 +287,8 @@ hermes config set OPENROUTER_API_KEY sk-or-v1-xxxxxxxxxxxx
 # 列出您的提供商可用的模型
 hermes model
 
-# 设置有效的模型
-hermes config set HERMES_MODEL anthropic/claude-opus-4.7
+# 设置有效的模型（写入 ~/.hermes/config.yaml 中的 model.default）
+hermes config set model.default anthropic/claude-opus-4.7
 
 # 或按会话指定
 hermes chat --model openrouter/meta-llama/llama-3.1-70b-instruct


### PR DESCRIPTION
## What does this PR do?

It fixes the FAQ command for changing the default model.

The command now saves the model under `model.default`, which Hermes reads. It also updates the Chinese example and preserves `@xxxigm` as the author of both commits.

This salvages the focused documentation fix from #34585, which was closed without review or merge.

## Related Issue

Fixes #65855

Related: #34585 and #15148

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- use `hermes config set model.default ...` in the English FAQ;
- make the same correction in the Chinese FAQ;
- preserve the original contributor's authorship.

## How to Test

1. Save a model with `hermes config set model.default ...` and read it with `hermes config get model.default`.
2. Run the focused CLI and configuration tests; all 110 tests pass.
3. Build the English and Chinese documentation with Docusaurus.

Both locale builds finish successfully. They still show unrelated broken-link warnings that are already present on `main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes — N/A for a documentation-only change
- [x] I've tested on my platform: macOS 26.5.2 with Python 3.13.13 and Node 26.5.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable.
