### PR TITLE
fix(mattermost): report missing attachments as failed

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -571,10 +571,14 @@ class MattermostAdapter(BasePlatformAdapter):
 
         p = Path(file_path)
         if not p.exists():
+            safe_name = p.name or "attachment"
             logger.warning(
-                "Mattermost: local file not found, skipping: %s", file_path
+                "Mattermost: local file not found, skipping: %s", safe_name
             )
-            return SendResult(success=True, message_id=None)
+            return SendResult(
+                success=False,
+                error=f"Local file not found: {safe_name}",
+            )
 
         fname = file_name or p.name
         ct = mimetypes.guess_type(fname)[0] or "application/octet-stream"

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -817,6 +817,40 @@ class TestMattermostFileUpload:
         assert result.success is True
         assert result.message_id == "post_with_file"
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "file_name"),
+        [
+            ("send_image_file", "missing-image.png"),
+            ("send_document", "missing-document.pdf"),
+            ("send_voice", "missing-voice.ogg"),
+            ("send_video", "missing-video.mp4"),
+        ],
+    )
+    async def test_missing_local_file_fails_without_upload_or_post(
+        self,
+        tmp_path,
+        method_name,
+        file_name,
+    ):
+        missing_path = tmp_path / "private" / "attachments" / file_name
+        self.adapter._upload_file = AsyncMock()
+        self.adapter._thread_root_for_send = AsyncMock()
+        self.adapter._post_preserving_thread = AsyncMock()
+
+        result = await getattr(self.adapter, method_name)(
+            "channel_1",
+            str(missing_path),
+        )
+
+        assert result.success is False
+        assert result.message_id is None
+        assert result.error == f"Local file not found: {file_name}"
+        assert str(missing_path.parent) not in result.error
+        self.adapter._upload_file.assert_not_awaited()
+        self.adapter._thread_root_for_send.assert_not_awaited()
+        self.adapter._post_preserving_thread.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # Dedup cache


### PR DESCRIPTION
## What does this PR do?

It reports a failed Mattermost send when a local attachment does not exist.

This lets callers handle the failure instead of treating a missing image, document, audio file, or video as delivered.

## Related Issue

Fixes #65858

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- return `SendResult(success=False)` for a missing local file;
- include only the safe file name in the error and warning;
- add coverage for direct files and the image, document, audio, and video helpers.

## How to Test

1. Run `uv run --frozen pytest tests/gateway/test_mattermost.py -q`.
2. Confirm all 66 tests pass.
3. Run `uv run --frozen ruff check plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 with Python 3.13.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable.

