### PR TITLE
fix(uninstall): avoid deleting shared Python packages

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
@@ -28,6 +29,107 @@ def log_warn(msg: str):
 def get_project_root() -> Path:
     """Get the project installation directory."""
     return Path(__file__).parent.parent.resolve()
+
+
+def _is_hermes_distribution_metadata(path: Path) -> bool:
+    """Return whether a ``*.dist-info``/``*.egg-info`` entry belongs to Hermes."""
+    name = path.name.lower()
+    for suffix in (".dist-info", ".egg-info"):
+        if not name.endswith(suffix):
+            continue
+        stem = name[: -len(suffix)]
+        return stem == "hermes_agent" or stem.startswith(
+            ("hermes_agent-", "hermes-agent-")
+        )
+    return False
+
+
+def _pyproject_is_hermes(pyproject_path: Path) -> bool:
+    """Return whether a pyproject identifies the Hermes Agent distribution."""
+    try:
+        with pyproject_path.open("rb") as f:
+            project = tomllib.load(f).get("project", {})
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+    name = str(project.get("name", "")).strip().lower().replace("_", "-")
+    return name == "hermes-agent"
+
+
+def _project_root_removal_safety(
+    project_root: Path,
+    hermes_home: Path,
+) -> tuple[bool, str]:
+    """Validate that ``project_root`` is a dedicated Hermes source checkout.
+
+    A wheel puts ``hermes_cli/uninstall.py`` directly under the interpreter's
+    shared ``site-packages`` directory, so deriving the project root from
+    ``__file__`` must never be enough to authorize a recursive delete.  This
+    guard is deliberately fail-closed and lives at the final ``rmtree``
+    boundary so every caller, including ``--yes`` and the desktop module
+    entrypoint, gets the same protection.
+    """
+    try:
+        root = project_root.resolve(strict=False)
+    except (OSError, RuntimeError) as exc:
+        return False, f"the installation path could not be resolved safely ({exc})"
+
+    if root == Path(root.anchor):
+        return False, "the installation path is a filesystem root"
+
+    if any(part.lower() in {"site-packages", "dist-packages"} for part in root.parts):
+        return False, "the installation path is inside a shared Python package directory"
+
+    protected_paths = [
+        ("your home directory", Path.home()),
+        ("the Hermes data directory", hermes_home),
+        ("the active interpreter prefix", Path(sys.prefix)),
+        ("the base interpreter prefix", Path(sys.base_prefix)),
+        ("the active interpreter exec prefix", Path(sys.exec_prefix)),
+        ("the base interpreter exec prefix", Path(sys.base_exec_prefix)),
+    ]
+    checked: set[Path] = set()
+    for label, protected_path in protected_paths:
+        try:
+            protected = protected_path.resolve(strict=False)
+        except (OSError, RuntimeError) as exc:
+            return False, f"a protected path could not be resolved safely ({label}: {exc})"
+        if protected in checked:
+            continue
+        checked.add(protected)
+        # Refuse both the protected directory itself and any ancestor whose
+        # recursive removal would also remove that protected directory.
+        if root == protected or root in protected.parents:
+            return False, f"the installation path is {label} or one of its parents"
+
+    try:
+        metadata_entries = [
+            child
+            for child in root.iterdir()
+            if child.name.lower().endswith((".dist-info", ".egg-info"))
+        ]
+    except OSError as exc:
+        return False, f"the installation directory could not be inspected safely ({exc})"
+
+    unrelated = [
+        child.name
+        for child in metadata_entries
+        if not _is_hermes_distribution_metadata(child)
+    ]
+    if unrelated:
+        sample = ", ".join(sorted(unrelated)[:3])
+        return False, f"the directory contains unrelated Python distributions ({sample})"
+
+    hermes_module = root / "hermes_cli" / "uninstall.py"
+    # A generic .git directory is not proof that the whole repository belongs
+    # to Hermes.  Require package metadata that identifies this exact project;
+    # otherwise a copied hermes_cli module inside an unrelated monorepo could
+    # authorize deleting that monorepo.
+    if not hermes_module.is_file() or not _pyproject_is_hermes(
+        root / "pyproject.toml"
+    ):
+        return False, "the directory is not a verifiable Hermes source checkout"
+
+    return True, "verified Hermes source checkout"
 
 
 def find_shell_configs() -> list:
@@ -722,7 +824,15 @@ def _print_uninstall_dry_run(*, project_root: Path, hermes_home: Path, full_unin
     print("  • Hermes PATH entries from shell configs / Windows User PATH")
     print("  • Hermes wrapper scripts and Hermes-managed node/npm/npx symlinks")
     print("  • Desktop Chat GUI artifacts")
-    print(f"  • Code checkout: {project_root}")
+    if project_root.exists():
+        safe_to_remove, reason = _project_root_removal_safety(project_root, hermes_home)
+    else:
+        safe_to_remove, reason = True, "installation directory is already absent"
+    if safe_to_remove:
+        print(f"  • Code checkout: {project_root}")
+    else:
+        print(f"  • Package-managed code will not be recursively removed: {project_root}")
+        print(f"    Reason: {reason}")
     if full_uninstall:
         print(f"  • Hermes config/data: {hermes_home}")
         if _is_default_hermes_home(hermes_home):
@@ -833,16 +943,24 @@ def _perform_uninstall(
     # 4. Remove installation directory (code)
     log_info("Removing installation directory...")
     
-    # Check if we're running from within the install dir
-    # We need to be careful here
+    # Never authorize recursive deletion from __file__ alone. In a wheel,
+    # project_root is the interpreter's shared site-packages directory.
     try:
         if project_root.exists():
-            # If the install is inside ~/.hermes/, just remove the hermes-agent subdir
-            if hermes_home in project_root.parents or project_root.parent == hermes_home:
-                shutil.rmtree(project_root)
-                log_success(f"Removed {project_root}")
+            safe_to_remove, reason = _project_root_removal_safety(
+                project_root,
+                hermes_home,
+            )
+            if not safe_to_remove:
+                log_warn(f"Refusing to recursively remove {project_root}: {reason}")
+                log_info(
+                    "Hermes code was left intact. Remove package-managed installs "
+                    "with the same tool that installed them (for example, "
+                    "'python -m pip uninstall hermes-agent', "
+                    "'uv tool uninstall hermes-agent', or "
+                    "'pipx uninstall hermes-agent')."
+                )
             else:
-                # Installation is somewhere else entirely
                 shutil.rmtree(project_root)
                 log_success(f"Removed {project_root}")
     except Exception as e:

--- a/tests/hermes_cli/test_gui_uninstall.py
+++ b/tests/hermes_cli/test_gui_uninstall.py
@@ -23,6 +23,17 @@ def _make_agent(hermes_home: Path) -> Path:
     return agent_root
 
 
+def _make_source_checkout(path: Path) -> Path:
+    """Create the minimum shape the uninstaller accepts as Hermes source."""
+    (path / "hermes_cli").mkdir(parents=True)
+    (path / "hermes_cli" / "uninstall.py").write_text("# test checkout\n")
+    (path / ".git").mkdir()
+    (path / "pyproject.toml").write_text(
+        '[project]\nname = "hermes-agent"\nversion = "1.0"\n'
+    )
+    return path
+
+
 def _make_gui_build(hermes_home: Path) -> None:
     """Create the source-built GUI artifacts a `hermes desktop` run produces."""
     desktop = hermes_home / "hermes-agent" / "apps" / "desktop"
@@ -234,8 +245,7 @@ def test_run_uninstall_yes_keep_data_is_non_interactive(tmp_path, monkeypatch):
     desktop = agent_root / "apps" / "desktop"
     (desktop / "release").mkdir(parents=True)
     (hermes_home / "desktop-build-stamp.json").write_text("{}")
-    fake_code = tmp_path / "checkout"
-    fake_code.mkdir()
+    fake_code = _make_source_checkout(tmp_path / "checkout")
 
     # Stub every destructive external so the test only exercises the control
     # flow + the real GUI sweep (which is safe inside tmp_path).
@@ -270,8 +280,7 @@ def test_run_uninstall_yes_full_wipes_home(tmp_path, monkeypatch):
     hermes_home = tmp_path / ".hermes"
     (hermes_home / "hermes-agent" / "hermes_cli").mkdir(parents=True)
     (hermes_home / "config.yaml").write_text("x: 1\n")
-    fake_code = tmp_path / "checkout"
-    fake_code.mkdir()
+    fake_code = _make_source_checkout(tmp_path / "checkout")
 
     monkeypatch.setattr(uninstall, "get_hermes_home", lambda: hermes_home)
     monkeypatch.setattr(uninstall, "get_project_root", lambda: fake_code)
@@ -345,4 +354,3 @@ def test_uninstall_args_namespace_mode_mapping():
 
     full = uninstall._UninstallArgs(mode="full")
     assert full.gui is False and full.full is True and full.yes is True
-

--- a/tests/hermes_cli/test_uninstall_dry_run.py
+++ b/tests/hermes_cli/test_uninstall_dry_run.py
@@ -7,7 +7,12 @@ from hermes_cli import uninstall
 def test_dry_run_prints_plan_without_mutating(monkeypatch, tmp_path, capsys):
     project_root = tmp_path / "hermes-agent"
     hermes_home = tmp_path / ".hermes"
-    project_root.mkdir()
+    (project_root / "hermes_cli").mkdir(parents=True)
+    (project_root / "hermes_cli" / "uninstall.py").write_text("# source checkout\n")
+    (project_root / ".git").mkdir()
+    (project_root / "pyproject.toml").write_text(
+        '[project]\nname = "hermes-agent"\nversion = "1.0"\n'
+    )
     hermes_home.mkdir()
     (hermes_home / "config.yaml").write_text("model: {}\n")
 

--- a/tests/hermes_cli/test_uninstall_project_root_safety.py
+++ b/tests/hermes_cli/test_uninstall_project_root_safety.py
@@ -1,0 +1,197 @@
+"""Behavioral coverage for recursive uninstall root safety."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import uninstall
+
+
+def _stub_external_cleanup(monkeypatch, tmp_path: Path) -> None:
+    """Keep run_uninstall real while isolating machine-level cleanup effects."""
+    monkeypatch.setattr(uninstall, "uninstall_gateway_service", lambda: False)
+    monkeypatch.setattr(uninstall, "remove_path_from_shell_configs", lambda: [])
+    monkeypatch.setattr(uninstall, "remove_wrapper_script", lambda: [])
+    monkeypatch.setattr(uninstall, "remove_node_symlinks", lambda _home: [])
+    monkeypatch.setattr(uninstall, "_discover_named_profiles", lambda: [])
+    monkeypatch.setattr(uninstall, "_is_windows", lambda: False)
+
+    from hermes_cli import gui_uninstall
+
+    monkeypatch.setattr(gui_uninstall, "uninstall_gui", lambda _home: [])
+    monkeypatch.setattr(gui_uninstall, "packaged_gui_app_paths", lambda: [])
+    monkeypatch.setattr(gui_uninstall, "desktop_userdata_dir", lambda: tmp_path / "none")
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda *_args, **_kwargs: pytest.fail("--yes uninstall prompted"),
+    )
+
+
+@pytest.mark.parametrize("package_dir_name", ["site-packages", "dist-packages"])
+def test_run_uninstall_refuses_shared_python_package_directory(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    package_dir_name,
+):
+    """A wheel-shaped install must preserve Hermes and every sibling package."""
+    package_root = tmp_path / "venv" / "lib" / "python3.13" / package_dir_name
+    (package_root / "hermes_cli").mkdir(parents=True)
+    (package_root / "hermes_cli" / "uninstall.py").write_text("# installed wheel\n")
+    (package_root / "hermes_agent-1.0.dist-info").mkdir()
+
+    sentinel_package = package_root / "sentinel_package"
+    sentinel_package.mkdir()
+    sentinel_file = sentinel_package / "__init__.py"
+    sentinel_file.write_text("SENTINEL = True\n")
+    (package_root / "sentinel_package-1.0.dist-info").mkdir()
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config = hermes_home / "config.yaml"
+    config.write_text("model: {}\n")
+
+    monkeypatch.setattr(uninstall, "get_project_root", lambda: package_root)
+    monkeypatch.setattr(uninstall, "get_hermes_home", lambda: hermes_home)
+    _stub_external_cleanup(monkeypatch, tmp_path)
+
+    uninstall.run_uninstall(SimpleNamespace(yes=True, full=False, dry_run=False))
+
+    assert sentinel_file.read_text() == "SENTINEL = True\n"
+    assert (package_root / "hermes_cli" / "uninstall.py").exists()
+    assert config.exists()
+    assert "Refusing to recursively remove" in capsys.readouterr().out
+
+
+def test_run_uninstall_refuses_nonstandard_root_with_unrelated_distribution(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    """Distribution metadata also protects shared roots with nonstandard names."""
+    shared_root = tmp_path / "python-libs"
+    (shared_root / "hermes_cli").mkdir(parents=True)
+    (shared_root / "hermes_cli" / "uninstall.py").write_text("# installed\n")
+    (shared_root / "pyproject.toml").write_text(
+        '[project]\nname = "hermes-agent"\nversion = "1.0"\n'
+    )
+    sentinel = shared_root / "other_project-2.0.dist-info"
+    sentinel.mkdir()
+    (sentinel / "METADATA").write_text("Name: other-project\n")
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(uninstall, "get_project_root", lambda: shared_root)
+    monkeypatch.setattr(uninstall, "get_hermes_home", lambda: hermes_home)
+    _stub_external_cleanup(monkeypatch, tmp_path)
+
+    uninstall.run_uninstall(SimpleNamespace(yes=True, full=False, dry_run=False))
+
+    assert (sentinel / "METADATA").exists()
+    assert (shared_root / "hermes_cli" / "uninstall.py").exists()
+    assert "unrelated Python distributions" in capsys.readouterr().out
+
+
+def test_run_uninstall_still_removes_verified_source_checkout(
+    tmp_path,
+    monkeypatch,
+):
+    checkout = tmp_path / "hermes-agent"
+    (checkout / "hermes_cli").mkdir(parents=True)
+    (checkout / "hermes_cli" / "uninstall.py").write_text("# source checkout\n")
+    (checkout / ".git").mkdir()
+    (checkout / "pyproject.toml").write_text(
+        '[project]\nname = "hermes-agent"\nversion = "1.0"\n'
+    )
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+
+    monkeypatch.setattr(uninstall, "get_project_root", lambda: checkout)
+    monkeypatch.setattr(uninstall, "get_hermes_home", lambda: hermes_home)
+    _stub_external_cleanup(monkeypatch, tmp_path)
+
+    uninstall.run_uninstall(SimpleNamespace(yes=True, full=False, dry_run=False))
+
+    assert not checkout.exists()
+    assert hermes_home.exists()
+
+
+def test_run_uninstall_refuses_unrelated_git_repository(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    """A copied Hermes module must not authorize deleting an unrelated repo."""
+    unrelated_repo = tmp_path / "unrelated-monorepo"
+    (unrelated_repo / "hermes_cli").mkdir(parents=True)
+    (unrelated_repo / "hermes_cli" / "uninstall.py").write_text("# copied file\n")
+    (unrelated_repo / ".git").mkdir()
+    sentinel = unrelated_repo / "important-project" / "data.txt"
+    sentinel.parent.mkdir()
+    sentinel.write_text("keep me\n")
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(uninstall, "get_project_root", lambda: unrelated_repo)
+    monkeypatch.setattr(uninstall, "get_hermes_home", lambda: hermes_home)
+    _stub_external_cleanup(monkeypatch, tmp_path)
+
+    uninstall.run_uninstall(SimpleNamespace(yes=True, full=False, dry_run=False))
+
+    assert sentinel.read_text() == "keep me\n"
+    assert "not a verifiable Hermes source checkout" in capsys.readouterr().out
+
+
+def test_run_uninstall_wheel_full_still_removes_hermes_home(
+    tmp_path,
+    monkeypatch,
+):
+    package_root = tmp_path / "venv" / "lib" / "python3.13" / "site-packages"
+    (package_root / "hermes_cli").mkdir(parents=True)
+    (package_root / "hermes_cli" / "uninstall.py").write_text("# installed wheel\n")
+    sentinel = package_root / "sentinel_package" / "__init__.py"
+    sentinel.parent.mkdir()
+    sentinel.write_text("SENTINEL = True\n")
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("model: {}\n")
+
+    monkeypatch.setattr(uninstall, "get_project_root", lambda: package_root)
+    monkeypatch.setattr(uninstall, "get_hermes_home", lambda: hermes_home)
+    _stub_external_cleanup(monkeypatch, tmp_path)
+
+    uninstall.run_uninstall(SimpleNamespace(yes=True, full=True, dry_run=False))
+
+    assert sentinel.read_text() == "SENTINEL = True\n"
+    assert (package_root / "hermes_cli" / "uninstall.py").exists()
+    assert not hermes_home.exists()
+
+
+def test_root_and_interpreter_prefixes_are_never_safe(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+
+    filesystem_root = Path(tmp_path.anchor)
+    safe, reason = uninstall._project_root_removal_safety(filesystem_root, hermes_home)
+    assert safe is False
+    assert "filesystem root" in reason
+
+    safe, reason = uninstall._project_root_removal_safety(Path.home(), hermes_home)
+    assert safe is False
+    assert "home directory" in reason
+
+    safe, reason = uninstall._project_root_removal_safety(hermes_home, hermes_home)
+    assert safe is False
+    assert "Hermes data directory" in reason
+
+    interpreter_prefix = tmp_path / "python"
+    interpreter_prefix.mkdir()
+    monkeypatch.setattr(uninstall.sys, "prefix", str(interpreter_prefix))
+    safe, reason = uninstall._project_root_removal_safety(
+        interpreter_prefix,
+        hermes_home,
+    )
+    assert safe is False
+    assert "interpreter prefix" in reason


### PR DESCRIPTION
## What does this PR do?

It prevents uninstall from deleting a shared Python package folder or an unrelated source repository.

The uninstall command now removes a whole code folder only when `pyproject.toml` identifies it as the `hermes-agent` project. Package-managed installs are left for pip, uv, or pipx to remove safely.

## Related Issue

Fixes #65854

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- fail closed before recursively deleting the detected project root;
- reject shared `site-packages` and `dist-packages` folders;
- reject unrelated repositories, interpreter folders, home folders, and folders with other Python distributions;
- show the same safety decision in dry-run mode;
- add tests for source checkouts, shared installs, unrelated repositories, and protected paths.

## How to Test

1. Run `uv run --frozen pytest tests/hermes_cli/test_uninstall_project_root_safety.py tests/hermes_cli/test_uninstall_dry_run.py tests/hermes_cli/test_gui_uninstall.py -q`.
2. Confirm all 27 tests pass.
3. Run `uv run --frozen ruff check hermes_cli/uninstall.py tests/hermes_cli/test_uninstall_project_root_safety.py tests/hermes_cli/test_uninstall_dry_run.py tests/hermes_cli/test_gui_uninstall.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 with Python 3.13.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; the command explains how to remove package-managed installs
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable.

