### PR TITLE
fix(tui): clean up and exit after fatal errors

### DIFF
--- a/ui-tui/src/__tests__/gracefulExit.test.ts
+++ b/ui-tui/src/__tests__/gracefulExit.test.ts
@@ -1,11 +1,180 @@
-import { describe, expect, it } from 'vitest'
+import { spawn } from 'node:child_process'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { shouldExitForSignal } from '../lib/gracefulExit.js'
+
+type FatalScope = 'uncaughtException' | 'unhandledRejection'
+type InstalledHandler = (...args: unknown[]) => void
+
+interface InstallOptions {
+  cleanups?: (() => Promise<void> | void)[]
+  failsafeMs?: number
+  ignoredSignals?: ('SIGHUP' | 'SIGINT' | 'SIGTERM')[]
+  onError?: (scope: FatalScope, err: unknown) => void
+  onSignal?: (signal: NodeJS.Signals) => void
+}
+
+interface ChildResult {
+  code: number | null
+  signal: NodeJS.Signals | null
+  stderr: string
+}
+
+function runNodeScript(script: string): Promise<ChildResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', script], {
+      stdio: ['ignore', 'ignore', 'pipe']
+    })
+
+    const stderr: Buffer[] = []
+
+    child.stderr.on('data', chunk => stderr.push(Buffer.from(chunk)))
+
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error('fatal-exit child did not stop within five seconds'))
+    }, 5000)
+
+    child.once('error', error => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout)
+      resolve({ code, signal, stderr: Buffer.concat(stderr).toString() })
+    })
+  })
+}
+
+async function installGracefulExit(options: InstallOptions = {}) {
+  const handlers = new Map<string | symbol, InstalledHandler>()
+  const onSpy = vi.spyOn(process, 'on')
+
+  onSpy.mockImplementation(((event: string | symbol, listener: InstalledHandler) => {
+    handlers.set(event, listener)
+
+    return process
+  }) as typeof process.on)
+
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation((_code?: string | number | null) => undefined as never)
+
+  const { setupGracefulExit } = await import('../lib/gracefulExit.js')
+
+  setupGracefulExit(options)
+
+  return {
+    exitSpy,
+    handler(event: string) {
+      const installed = handlers.get(event)
+
+      if (!installed) {
+        throw new Error(`missing process handler for ${event}`)
+      }
+
+      return installed
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
 
 describe('shouldExitForSignal', () => {
   it('ignores only the signals explicitly disabled for embedded dashboard chat', () => {
     expect(shouldExitForSignal('SIGINT', ['SIGINT'])).toBe(false)
     expect(shouldExitForSignal('SIGTERM', ['SIGINT'])).toBe(true)
     expect(shouldExitForSignal('SIGHUP', ['SIGINT'])).toBe(true)
+  })
+})
+
+describe('setupGracefulExit', () => {
+  it('keeps the failsafe alive when cleanup never finishes', async () => {
+    vi.useRealTimers()
+
+    const moduleUrl = new URL('../lib/gracefulExit.ts', import.meta.url).href
+
+    const script = `
+      import { setupGracefulExit } from ${JSON.stringify(moduleUrl)}
+      setupGracefulExit({
+        cleanups: [() => new Promise(() => {})],
+        failsafeMs: 50
+      })
+      queueMicrotask(() => { throw new Error('fatal child error') })
+    `
+
+    const result = await runNodeScript(script)
+
+    expect(result, result.stderr).toMatchObject({ code: 1, signal: null })
+  })
+
+  it.each([
+    ['uncaughtException', new Error('fatal exception')],
+    ['unhandledRejection', new Error('fatal rejection')]
+  ] as const)('cleans up and exits 1 after %s even when the error hook throws', async (scope, error) => {
+    const cleanup = vi.fn()
+
+    const onError = vi.fn(() => {
+      expect(vi.getTimerCount()).toBe(1)
+      throw new Error('diagnostic hook failed')
+    })
+
+    const { exitSpy, handler } = await installGracefulExit({ cleanups: [cleanup], onError })
+
+    handler(scope)(error)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(onError).toHaveBeenCalledWith(scope, error)
+    expect(cleanup).toHaveBeenCalledOnce()
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it.each([
+    ['SIGHUP', 129],
+    ['SIGINT', 130],
+    ['SIGTERM', 143]
+  ] as const)('preserves the %s exit code when the signal hook throws', async (signal, exitCode) => {
+    const cleanup = vi.fn()
+
+    const onSignal = vi.fn(() => {
+      expect(vi.getTimerCount()).toBe(1)
+      throw new Error('signal hook failed')
+    })
+
+    const { exitSpy, handler } = await installGracefulExit({ cleanups: [cleanup], onSignal })
+
+    handler(signal)()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(onSignal).toHaveBeenCalledWith(signal)
+    expect(cleanup).toHaveBeenCalledOnce()
+    expect(exitSpy).toHaveBeenCalledWith(exitCode)
+  })
+
+  it('does not run hooks, cleanup, or exit for an ignored signal', async () => {
+    const cleanup = vi.fn()
+    const onSignal = vi.fn()
+
+    const { exitSpy, handler } = await installGracefulExit({
+      cleanups: [cleanup],
+      ignoredSignals: ['SIGINT'],
+      onSignal
+    })
+
+    handler('SIGINT')()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(vi.getTimerCount()).toBe(0)
+    expect(onSignal).not.toHaveBeenCalled()
+    expect(cleanup).not.toHaveBeenCalled()
+    expect(exitSpy).not.toHaveBeenCalled()
   })
 })

--- a/ui-tui/src/lib/gracefulExit.ts
+++ b/ui-tui/src/lib/gracefulExit.ts
@@ -36,18 +36,27 @@ export function setupGracefulExit({
 
   let shuttingDown = false
 
-  const exit = (code: number, signal?: NodeJS.Signals) => {
+  const exit = (code: number, beforeCleanup?: () => void) => {
     if (shuttingDown) {
       return
     }
 
     shuttingDown = true
 
-    if (signal) {
-      onSignal?.(signal)
-    }
+    // Arm the hard-exit backstop before diagnostics or other user-provided
+    // hooks. A hook is allowed to fail, but it must never strand the process
+    // with an uncaught fatal error and a still-running gateway child.
+    // Keep this timer referenced. A pending Promise does not keep Node alive,
+    // so unref'ing the only backstop can make a fatal process exit naturally
+    // with status 0 while cleanup is still hung.
+    setTimeout(() => process.exit(code), failsafeMs)
 
-    setTimeout(() => process.exit(code), failsafeMs).unref?.()
+    try {
+      beforeCleanup?.()
+    } catch {
+      // Best-effort diagnostics only. Cleanup and the requested exit code are
+      // the lifecycle contract, even when a hook throws.
+    }
 
     void Promise.allSettled(cleanups.map(fn => Promise.resolve().then(fn))).finally(() => process.exit(code))
   }
@@ -58,10 +67,10 @@ export function setupGracefulExit({
         return
       }
 
-      exit(SIGNAL_EXIT_CODE[sig], sig)
+      exit(SIGNAL_EXIT_CODE[sig], () => onSignal?.(sig))
     })
   }
 
-  process.on('uncaughtException', err => onError?.('uncaughtException', err))
-  process.on('unhandledRejection', reason => onError?.('unhandledRejection', reason))
+  process.on('uncaughtException', err => exit(1, () => onError?.('uncaughtException', err)))
+  process.on('unhandledRejection', reason => exit(1, () => onError?.('unhandledRejection', reason)))
 }


### PR DESCRIPTION
## What does this PR do?

It makes the TUI exit with an error when fatal cleanup gets stuck.

Cleanup still has a short chance to finish. A referenced fail-safe timer then ends the process with exit code 1, even when no other Node handles remain.

## Related Issue

Fixes #65859

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- use one guarded handler for uncaught errors and unhandled rejections;
- prevent repeated fatal events from starting cleanup more than once;
- keep the fail-safe timer alive until it can force an error exit;
- add unit tests and a real child-process test for cleanup that never resolves.

## How to Test

1. Run the focused Vitest file for `src/__tests__/gracefulExit.test.ts`.
2. Confirm all 8 tests pass, including the child-process exit test.
3. Run the TUI TypeScript check, ESLint, and Prettier check.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this TypeScript-only change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 with Node 26.5.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable.

