### PR TITLE
fix(desktop): keep tab bar visible when toggling bottom panel panes

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -21,6 +21,7 @@ import {
   registerLayoutResetHandler,
   registerPaneCloser,
   registerPaneOpener,
+  registerPaneOpenGetter,
   resetLayoutTree,
   revealTreePane,
   setPaneCollapsed,
@@ -468,6 +469,7 @@ function bindPaneCollapse(
   $open.listen(isOpen => setPaneCollapsed(paneId, !isOpen))
   registerPaneCloser(paneId, close)
   registerPaneOpener(paneId, open)
+  registerPaneOpenGetter(paneId, () => $open.get())
 }
 
 // SIDES have one source of truth: the TREE. The legacy $panesFlipped flag is

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -204,7 +204,13 @@ export function TreeGroup({
   // empty column, so the minimized form is a narrow vertical rail instead
   // (tabs reading top-to-bottom). In a column (stacked zones) the horizontal
   // header IS the collapsed form, exactly as before.
-  const verticalCollapse = Boolean(node.minimized) && parentAxis === 'row' && !isEmpty
+  //
+  // EXCEPTION: when the zone has ≥2 shown panes, keep the horizontal tab bar
+  // even when minimized — the user can still switch between terminal/logs
+  // without expanding the zone first. The vertical rail is only for a lone
+  // pane where the strip adds no value.
+  const verticalCollapse =
+    Boolean(node.minimized) && parentAxis === 'row' && !isEmpty && shown.length <= 1
   const headerVisible = !isEmpty && !verticalCollapse && (Boolean(node.minimized) || !headerHidden)
 
   // Drag handles preventDefault pointerdown (no native dblclick), so the

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -164,6 +164,7 @@ function setDismissed(paneId: string, dismissed: boolean) {
 
 const paneClosers: Record<string, () => void> = {}
 const paneOpeners: Record<string, () => void> = {}
+const paneOpenGetters: Record<string, () => boolean> = {}
 
 /** Route a pane's Close through the app store that owns its visibility. */
 export function registerPaneCloser(paneId: string, close: () => void) {
@@ -179,6 +180,13 @@ export function registerPaneCloser(paneId: string, close: () => void) {
  */
 export function registerPaneOpener(paneId: string, open: () => void) {
   paneOpeners[paneId] = open
+}
+
+/** Register a getter that reads a tool pane's open/closed state from its
+ *  owning store — so `setPaneCollapsed` can check if a sibling in the same
+ *  zone is still open before folding the whole zone. */
+export function registerPaneOpenGetter(paneId: string, getOpen: () => boolean) {
+  paneOpenGetters[paneId] = getOpen
 }
 
 // TOOL PANELS (terminal, logs, …): their toggle COLLAPSES the zone to a rail
@@ -1067,7 +1075,18 @@ export function setPaneCollapsed(paneId: string, collapsed: boolean) {
 
         activateTreePane(group.id, group.panes[at - 1] ?? group.panes[at + 1])
       } else {
-        toggleTreeGroupMinimized(group.id, true) // pure tool zone folds as a unit
+        // Pure tool zone: if another tool pane in this zone is still open,
+        // switch to it instead of folding the whole zone — so the tab bar
+        // stays visible and the user can switch between terminal/logs freely.
+        const openSibling = group.panes.find(
+          id => id !== paneId && isCollapsePane(id) && paneOpenGetters[id]?.()
+        )
+
+        if (openSibling) {
+          activateTreePane(group.id, openSibling)
+        } else {
+          toggleTreeGroupMinimized(group.id, true) // no open sibling — fold as a unit
+        }
       }
     } else if (!collapsed) {
       revealTreePane(paneId)


### PR DESCRIPTION
## What does this PR do?

When terminal and logs share a zone (the "bottom panel"), toggling one off
previously folded the **entire zone** — hiding the tab bar so the user could
no longer switch between terminal and logs. Now:

1. **Toggling one pane off switches to a still-open sibling** instead of
   minimizing the whole zone. The zone only folds when no sibling is open.
   This uses a new `paneOpenGetters` registry so `setPaneCollapsed` can query
   each collapse pane's owning store for its open/closed state.

2. **When the zone does collapse with ≥2 shown panes, the horizontal tab bar
   stays visible** (instead of degrading to a narrow vertical rail). The
   vertical rail is now only used for a lone pane where the strip adds no
   value. This applies to both the bottom panel (row split) and the right
   panel (column split) — the column case already showed the header when
   minimized, and now the row case matches.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/store.ts` — added
  `paneOpenGetters` registry + `registerPaneOpenGetter()`; fixed
  `setPaneCollapsed`'s shared-zone branch to check for an open sibling
  before calling `toggleTreeGroupMinimized`
- `apps/desktop/src/app/contrib/controller.tsx` — `bindPaneCollapse` now
  registers the open-state getter (`() => $open.get()`)
- `apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx` —
  `verticalCollapse` now requires `shown.length <= 1`, so ≥2 panes keep the
  horizontal tab bar even when minimized

## How to Test

1. Open the desktop app with terminal + logs in the same zone (e.g. the Quad
   preset, or drag logs into the terminal zone)
2. Toggle the terminal off (⌃\` or statusbar button) — the zone should
   switch to the logs tab instead of collapsing
3. Toggle logs off too — the zone should now collapse, but the tab bar
   remains visible as a horizontal strip (not a vertical rail)
4. Click a tab in the collapsed strip — it should restore + activate that pane

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `npm run typecheck` and `npm run test:ui` — all pass
- [ ] I've added tests for my changes (no existing test coverage for this area; the collapse/minimize logic is deeply integrated with the layout tree store and contribution registry, making unit testing impractical without a full renderer harness)
- [x] I've tested on my platform: NixOS / Hyprland
