### PR TITLE
feat(desktop): archive all threads in a branch from sidebar lane menu

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -216,7 +216,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onLoadMoreMessaging?: (platform: string) => Promise<void> | void
   onResumeSession: (sessionId: string) => void
   onDeleteSession: (sessionId: string) => void
-  onArchiveSession: (sessionId: string) => void
+  onArchiveSession: (sessionId: string) => Promise<void> | void
   onBranchSession: (sessionId: string) => void
   onNewSessionInWorkspace: (path: null | string) => void
   /** Create a brand-new session and open it as a tile on `dir`. */

--- a/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/entered-content.tsx
@@ -39,6 +39,7 @@ import { WorkspaceAddButton, WorkspaceHeader } from './workspace-header'
 export function EnteredProjectContent({
   project,
   renderRows,
+  onArchiveSession,
   onNewSession,
   repoWorktrees,
   liveSessions,
@@ -46,6 +47,7 @@ export function EnteredProjectContent({
 }: {
   project: SidebarProjectTree
   renderRows: (sessions: SessionInfo[]) => React.ReactNode
+  onArchiveSession?: (sessionId: string) => Promise<void> | void
   onNewSession?: (path: null | string) => void
   repoWorktrees?: Record<string, HermesGitWorktree[]>
   liveSessions?: SessionInfo[]
@@ -64,6 +66,7 @@ export function EnteredProjectContent({
           discoveredWorktrees={repo.path ? repoWorktrees?.[repo.path] : undefined}
           key={repo.id}
           liveSessions={liveSessions}
+          onArchiveSession={onArchiveSession}
           onNewSession={onNewSession}
           removedSessionIds={removedSessionIds}
           renderRows={renderRows}
@@ -79,6 +82,7 @@ function RepoFlatSection({
   repo,
   showHeader,
   renderRows,
+  onArchiveSession,
   onNewSession,
   discoveredWorktrees,
   liveSessions,
@@ -87,6 +91,7 @@ function RepoFlatSection({
   repo: SidebarWorkspaceTree
   showHeader: boolean
   renderRows: (sessions: SessionInfo[]) => React.ReactNode
+  onArchiveSession?: (sessionId: string) => Promise<void> | void
   onNewSession?: (path: null | string) => void
   discoveredWorktrees?: HermesGitWorktree[]
   liveSessions?: SessionInfo[]
@@ -166,6 +171,7 @@ function RepoFlatSection({
         <SidebarWorkspaceGroup
           group={group}
           key={group.id}
+          onArchiveSession={onArchiveSession}
           // The kanban bucket is read-only: it aggregates many task worktrees, so
           // "new session here" and "remove worktree" have no single target.
           onNewSession={group.isKanban ? undefined : onNewSession}

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+
+import { SidebarWorkspaceGroup } from './workspace-group'
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('SidebarWorkspaceGroup branch actions', () => {
+  it('archives every session in the branch from its actions menu', async () => {
+    const onArchiveSession = vi.fn()
+    const sessions = [
+      { id: 'session-a', started_at: 2 },
+      { id: 'session-b', started_at: 1 }
+    ]
+
+    render(
+      <I18nProvider configClient={null}>
+        <SidebarWorkspaceGroup
+          group={{
+            id: '/repo/.worktrees/feature',
+            label: 'feature/archive-all',
+            mode: 'workspace',
+            path: '/repo/.worktrees/feature',
+            sessions: sessions as never
+          }}
+          onArchiveSession={onArchiveSession}
+          renderRows={() => null}
+        />
+      </I18nProvider>
+    )
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Project actions' }), { button: 0 })
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Archive all threads' }))
+
+    await waitFor(() => {
+      expect(onArchiveSession).toHaveBeenCalledTimes(2)
+    })
+    expect(onArchiveSession).toHaveBeenNthCalledWith(1, 'session-a')
+    expect(onArchiveSession).toHaveBeenNthCalledWith(2, 'session-b')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -18,13 +18,20 @@ import { WorkspaceAddButton, WorkspaceHeader, WorkspaceMenu, WorkspaceShowMoreBu
 interface SidebarWorkspaceGroupProps {
   group: SidebarSessionGroup
   renderRows: (sessions: SessionInfo[]) => React.ReactNode
+  onArchiveSession?: (sessionId: string) => Promise<void> | void
   onNewSession?: (path: null | string) => void
   // When set (linked worktree rows), shows a remove affordance that runs a real
   // `git worktree remove`.
   onRemove?: () => void
 }
 
-export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemove }: SidebarWorkspaceGroupProps) {
+export function SidebarWorkspaceGroup({
+  group,
+  renderRows,
+  onArchiveSession,
+  onNewSession,
+  onRemove
+}: SidebarWorkspaceGroupProps) {
   const { t } = useI18n()
   const s = t.sidebar
   const isProfileGroup = group.mode === 'profile'
@@ -94,11 +101,25 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
     onNewSession(group.path)
   }
 
+  // Archive every session in this lane. Each session action owns its optimistic
+  // state + rollback snapshot, so we go one at a time — overlapping parallel
+  // calls could restore stale sidebar/pin state if one request failed while
+  // another succeeded. Sequential keeps the rollback per-session.
+  const handleArchiveAll = async () => {
+    if (!onArchiveSession) {
+      return
+    }
+
+    for (const session of group.sessions) {
+      await onArchiveSession(session.id)
+    }
+  }
+
   return (
     <SidebarRowStack>
       <WorkspaceHeader
         action={
-          (onNewSession || isProfileGroup || onRemove) && (
+          (onNewSession || isProfileGroup || onRemove || (!isProfileGroup && group.sessions.length > 0)) && (
             <div className="flex items-center">
               {(onNewSession || isProfileGroup) && (
                 <WorkspaceAddButton
@@ -109,7 +130,15 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
                   onClick={() => void handleNewSession()}
                 />
               )}
-              {onRemove && <WorkspaceMenu onRemove={onRemove} path={group.path} />}
+              {!isProfileGroup && (onRemove || (onArchiveSession && group.sessions.length > 0)) && (
+                <WorkspaceMenu
+                  onArchiveAll={
+                    onArchiveSession && group.sessions.length > 0 ? handleArchiveAll : undefined
+                  }
+                  onRemove={onRemove}
+                  path={group.path}
+                />
+              )}
             </div>
           )
         }

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-header.tsx
@@ -106,7 +106,17 @@ export function WorkspaceShowMoreButton({
 // Per-worktree actions (linked worktree lanes only), mirroring the session row
 // and ProjectMenu kebab: reveal in the file manager, copy path, and remove the
 // worktree (runs a real `git worktree remove` via the caller's confirm dialog).
-export function WorkspaceMenu({ path, onRemove }: { path: null | string; onRemove: () => void }) {
+// ``onArchiveAll`` adds a bulk-archive entry that archives every session in the
+// lane — available on any lane with sessions, including the main/home checkout.
+export function WorkspaceMenu({
+  path,
+  onArchiveAll,
+  onRemove
+}: {
+  path: null | string
+  onArchiveAll?: () => Promise<void> | void
+  onRemove?: () => void
+}) {
   const { t } = useI18n()
   const p = t.sidebar.projects
 
@@ -123,19 +133,34 @@ export function WorkspaceMenu({ path, onRemove }: { path: null | string; onRemov
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-48" sideOffset={6}>
-        <DropdownMenuItem disabled={!path} onSelect={() => void revealPath(path)}>
-          <Codicon name="folder-opened" size="0.875rem" />
-          <span>{p.reveal}</span>
-        </DropdownMenuItem>
-        <DropdownMenuItem disabled={!path} onSelect={() => void copyPath(path)}>
-          <Codicon name="copy" size="0.875rem" />
-          <span>{p.copyPath}</span>
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={onRemove} variant="destructive">
-          <Codicon name="trash" size="0.875rem" />
-          <span>{`${p.removeWorktree}…`}</span>
-        </DropdownMenuItem>
+        {onArchiveAll && (
+          <DropdownMenuItem onSelect={() => void onArchiveAll()}>
+            <Codicon name="archive" size="0.875rem" />
+            <span>{p.archiveAllThreads}</span>
+          </DropdownMenuItem>
+        )}
+        {path && (onArchiveAll || onRemove) && <DropdownMenuSeparator />}
+        {path && (
+          <DropdownMenuItem onSelect={() => void revealPath(path)}>
+            <Codicon name="folder-opened" size="0.875rem" />
+            <span>{p.reveal}</span>
+          </DropdownMenuItem>
+        )}
+        {path && (
+          <DropdownMenuItem onSelect={() => void copyPath(path)}>
+            <Codicon name="copy" size="0.875rem" />
+            <span>{p.copyPath}</span>
+          </DropdownMenuItem>
+        )}
+        {onRemove && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={onRemove} variant="destructive">
+              <Codicon name="trash" size="0.875rem" />
+              <span>{`${p.removeWorktree}…`}</span>
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -88,7 +88,7 @@ interface SidebarSessionsSectionProps {
   workingSessionIdSet: Set<string>
   onResumeSession: (sessionId: string) => void
   onDeleteSession: (sessionId: string) => void
-  onArchiveSession: (sessionId: string) => void
+  onArchiveSession: (sessionId: string) => Promise<void> | void
   onBranchSession?: (sessionId: string, profile?: string) => void
   onTogglePin: (sessionId: string) => void
   onNewSessionInWorkspace?: (path: null | string) => void
@@ -245,6 +245,7 @@ export function SidebarSessionsSection({
         {hasProjectContent ? (
           <EnteredProjectContent
             liveSessions={liveSessions}
+            onArchiveSession={onArchiveSession}
             onNewSession={onNewSessionInWorkspace}
             project={projectContent}
             removedSessionIds={removedSessionIds}
@@ -295,6 +296,7 @@ export function SidebarSessionsSection({
       <SidebarWorkspaceGroup
         group={group}
         key={group.id}
+        onArchiveSession={group.mode === 'workspace' ? onArchiveSession : undefined}
         onNewSession={onNewSessionInWorkspace}
         renderRows={renderRows}
       />

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1597,6 +1597,7 @@ export const en: Translations = {
       menuDelete: 'Delete',
       reveal: 'Reveal in folder',
       copyPath: 'Copy path',
+      archiveAllThreads: 'Archive all threads',
       removeFromSidebar: 'Hide from sidebar',
       createFailed: 'Could not create project',
       staleBackend:

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1323,6 +1323,7 @@ export interface Translations {
       menuDelete: string
       reveal: string
       copyPath: string
+      archiveAllThreads: string
       removeFromSidebar: string
       createFailed: string
       staleBackend: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1775,6 +1775,7 @@ export const zh: Translations = {
       menuDelete: '删除',
       reveal: '在文件夹中显示',
       copyPath: '复制路径',
+      archiveAllThreads: '归档所有对话',
       removeFromSidebar: '从侧边栏移除',
       createFailed: '无法创建项目',
       staleBackend: '请更新 Hermes 后端以创建项目——当前后端比桌面应用旧（设置 → 更新 → 后端）。',


### PR DESCRIPTION
## What does this PR do?

Adds an "Archive all threads" action to the branch/worktree lane kebab menu (the `⋮` dropdown) in the desktop sidebar. Previously the kebab only appeared on removable linked worktree lanes and offered reveal/copy-path/remove. Now it appears on **any** non-profile lane that has sessions — including the main/home checkout — and offers a bulk archive that sweeps every session in that lane.

The action archives each session sequentially through the existing per-session `onArchiveSession` path (the same one right-click → Archive uses), so optimistic state, rollback, pin cleanup, and tile closing all work per-session. Sequential (not parallel) prevents overlapping rollbacks from restoring stale sidebar/pin state when one request fails mid-batch.

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `workspace-header.tsx` — `WorkspaceMenu` takes optional `onArchiveAll`; renders it as the first dropdown item with an `archive` codicon. Existing reveal/copy-path/remove items conditionally render with separators only between groups that exist.
- `workspace-group.tsx` — `SidebarWorkspaceGroup` takes `onArchiveSession`; `handleArchiveAll` loops sequentially; kebab now shows on any non-profile lane with sessions, not just lanes with `onRemove`.
- `entered-content.tsx` — threads `onArchiveSession` through `EnteredProjectContent` → `RepoFlatSection` → `SidebarWorkspaceGroup`.
- `sessions-section.tsx` — passes `onArchiveSession` to `EnteredProjectContent` and grouped `SidebarWorkspaceGroup` (workspace mode only).
- `index.tsx` — `ChatSidebarProps.onArchiveSession` widened to `Promise<void> | void`.
- `i18n/en.ts` + `i18n/types.ts` — new `archiveAllThreads` string.
- `i18n/zh.ts` — Chinese translation for the new string (ja/zh-hant fall back via `defineLocale`).
- `workspace-group.test.tsx` — TDD test: renders a lane with 2 sessions, opens the kebab, clicks "Archive all threads", asserts `onArchiveSession` called with each session id in order.

## How to Test

1. `cd apps/desktop && npm run typecheck` — passes clean
2. `cd apps/desktop && npm run test:ui -- src/app/chat/sidebar/` — 55 tests pass (4 test files)
3. Open the desktop app, enter a project, hover a branch lane header → kebab `⋮` appears → click it → "Archive all threads" is the first item → click it → all sessions in that lane archive and disappear from the sidebar

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
