### PR TITLE
fix(desktop): preserve zoom across display moves

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6951,8 +6951,9 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
 
   if (zoom) {
     installZoomShortcuts(win)
-    // Re-apply persisted zoom on show/restore (Windows drops webContents zoom on
-    // minimize/restore) and on first load (reloads / crash recovery).
+    // Re-apply persisted zoom on show/restore/cross-display move (Windows can
+    // drop webContents zoom after minimize or a monitor-scale change) and on
+    // first load (reloads / crash recovery).
     installZoomReassertOnWindowEvents(win, () => restorePersistedZoomLevel(win))
     win.webContents.once('did-finish-load', () => restorePersistedZoomLevel(win))
   }

--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -64,7 +64,7 @@ test('extreme percentages clamp to the level bounds', () => {
   assert.equal(percentToZoomLevel(1_000_000), 9)
 })
 
-test('installZoomReassertOnWindowEvents wires show and restore', () => {
+test('installZoomReassertOnWindowEvents wires show, restore, and cross-display moves', () => {
   const handlers = new Map()
 
   const win = {
@@ -82,7 +82,8 @@ test('installZoomReassertOnWindowEvents wires show and restore', () => {
   assert.deepEqual([...handlers.keys()], [...ZOOM_REASSERT_WINDOW_EVENTS])
   handlers.get('show')()
   handlers.get('restore')()
-  assert.equal(calls, 2)
+  handlers.get('moved')()
+  assert.equal(calls, 3)
 })
 
 test('installZoomReassertOnWindowEvents skips destroyed windows', () => {

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -49,8 +49,9 @@ export function applyZoomLevel(webContents, level) {
 }
 
 // Chromium on Windows can drop webContents zoom when a BrowserWindow is minimized
-// and restored. Re-apply the persisted level on these lifecycle transitions.
-export const ZOOM_REASSERT_WINDOW_EVENTS = ['show', 'restore']
+// and restored or crosses onto a monitor with different display scaling. Re-apply
+// the persisted level after each completed lifecycle transition.
+export const ZOOM_REASSERT_WINDOW_EVENTS = ['show', 'restore', 'moved']
 
 export function installZoomReassertOnWindowEvents(win, reassert) {
   if (!win?.on) {


### PR DESCRIPTION
## Summary

Reassert the persisted `webContents` zoom after a `BrowserWindow` finishes moving. On Windows, moving Hermes between monitors with different display scaling can cause Chromium to recalculate and drop the user-selected zoom.

This is the zoom-only follow-up requested after #65825 was closed. The session-routing part is intentionally omitted because #65283 now covers it on `main`.

## Changes

- Add `moved` to the zoom reassertion window events.
- Keep the same persisted-level restore path used by `show` and `restore`.
- Extend the focused regression to verify all three lifecycle events.

## Validation

- `npx vitest run --project electron electron/zoom.test.ts` — 14/14 passed
- ESLint on the three changed Electron files — passed
- `npm run typecheck` — passed
- `npm run build` — passed

Tested on Windows 11 with cross-display scaling.