### PR TITLE
feat(providers): add LLMRouter as a model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,15 @@
 # LLM_MODEL=anthropic/claude-opus-4.6
 
 # =============================================================================
+# LLM PROVIDER (LLMRouter)
+# =============================================================================
+# LLMRouter — OpenAI-compatible smart router; model="auto" picks the cheapest
+# model that meets the query's needs, or pin a vendor-slugged model directly.
+# Get your key at: https://llmrouter.sh/signup
+# LLMROUTER_API_KEY=
+# LLMROUTER_BASE_URL=https://llmrouter.sh/v1  # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (NovitaAI)
 # =============================================================================
 # NovitaAI — 90+ models, pay-per-use

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -54,6 +54,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="OPENROUTER_BASE_URL",
     ),
+    "llmrouter": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        extra_env_vars=("LLMROUTER_API_KEY",),
+        base_url_override="https://llmrouter.sh/v1",
+        base_url_env_var="LLMROUTER_BASE_URL",
+    ),
     "nous": HermesOverlay(
         transport="openai_chat",
         auth_type="oauth_device_code",
@@ -252,6 +259,11 @@ ALIASES: Dict[str, str] = {
     # openrouter
     "openai": "openrouter",     # bare "openai" → route through aggregator
 
+    # llmrouter
+    "llm-router": "llmrouter",
+    "llm_router": "llmrouter",
+    "llmr": "llmrouter",
+
     # zai
     "glm": "zai",
     "z-ai": "zai",
@@ -379,6 +391,7 @@ ALIASES: Dict[str, str] = {
 
 _LABEL_OVERRIDES: Dict[str, str] = {
     "moa": "Mixture of Agents",
+    "llmrouter": "LLMRouter",
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",

--- a/plugins/model-providers/llmrouter/__init__.py
+++ b/plugins/model-providers/llmrouter/__init__.py
@@ -1,0 +1,32 @@
+"""LLMRouter provider profile.
+
+LLMRouter (https://llmrouter.sh) is a hosted, OpenAI-compatible LLM gateway.
+Sending ``model="auto"`` routes each request to the cheapest model that meets
+the query's needs; sending a vendor-slugged model id (e.g.
+``anthropic/claude-sonnet-4.6``) pins to that model directly. Auth is a
+developer API key (``llmr_sk_...``) via ``Authorization: Bearer``.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+llmrouter = ProviderProfile(
+    name="llmrouter",
+    aliases=("llm-router", "llmr"),
+    display_name="LLMRouter",
+    description='LLMRouter — model="auto" routes to the cheapest model that fits',
+    signup_url="https://llmrouter.sh/signup",
+    env_vars=("LLMROUTER_API_KEY", "LLMROUTER_BASE_URL"),
+    base_url="https://llmrouter.sh/v1",
+    auth_type="api_key",
+    default_aux_model="auto",
+    fallback_models=(
+        "auto",
+        "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.4",
+        "deepseek/deepseek-chat",
+        "google/gemini-3-flash-preview",
+    ),
+)
+
+register_provider(llmrouter)

--- a/plugins/model-providers/llmrouter/plugin.yaml
+++ b/plugins/model-providers/llmrouter/plugin.yaml
@@ -1,0 +1,5 @@
+name: llmrouter-provider
+kind: model-provider
+version: 1.0.0
+description: LLMRouter — OpenAI-compatible smart router (model="auto")
+author: Nous Research


### PR DESCRIPTION
## Summary

Adds LLMRouter as a supported model provider. It's an OpenAI-compatible gateway that:
-- Routes each request to a cost-effective model that meets the query's requirements (`model="auto"`), or serves a specific pinned model directly
-- Exposes one API across many underlying models/vendors
-- Supports flexible SLAs for lower pricing on non-latency-sensitive workloads
-- Charges a 1% platform fee

- Registers LLMRouter (https://llmrouter.sh) as an OpenAI-compatible model provider, following the same wiring pattern as OpenRouter.
- Adds `plugins/model-providers/llmrouter/` (`ProviderProfile` + `plugin.yaml`) so auth, config, model listing, doctor, and the chat-completions transport auto-wire from the registry.
- Adds the `hermes_cli/providers.py` overlay/alias/label entries (LLMRouter isn't in the models.dev catalog, so it needs the same "Hermes-only provider" entry as OpenRouter/Nous).
- Documents `LLMROUTER_API_KEY` / `LLMROUTER_BASE_URL` in `.env.example`.
- `model="auto"` picks the cheapest model that meets the query's needs; a vendor-slugged model id (e.g. `anthropic/claude-sonnet-4.6`) pins directly.

## Test plan
- [x] `get_provider_profile("llmrouter")` and alias lookups (`llmr`, `llm-router`) resolve correctly
- [x] `hermes_cli.providers.get_provider("llmrouter")` resolves with `is_aggregator=True`
- [x] `tests/providers/`, `test_list_picker_providers.py`, `test_provider_precedence.py`, `test_api_key_providers.py` — 323 passed
- [x] `tests/hermes_cli/` + `test_provider_parity.py` + `test_chat_completion_helpers_provider_sort.py` — no provider/llmrouter-related failures (258 pre-existing, unrelated failures in git/webhook/web-ui-build tests due to missing `gh`/npm in sandbox)
- [x] Manual `hermes setup` / `hermes model set llmrouter/auto` smoke test with a live `LLMROUTER_API_KEY`
