### PR TITLE
PLA-1938: Expose plugin migration extension points

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1852,6 +1852,32 @@ class MessageEvent:
 
 
 @dataclass
+class MessageSendContext:
+    """Mutable context passed to ``pre_message_send`` plugin hooks."""
+
+    platform: str
+    chat_id: str
+    content: str
+    thread_id: Optional[str] = None
+    is_dm: bool = False
+    cancel: bool = False
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+def apply_pre_message_send(ctx: MessageSendContext) -> MessageSendContext:
+    """Run outbound message hooks and return their mutable context."""
+    try:
+        from hermes_cli.plugins import invoke_hook
+
+        invoke_hook("pre_message_send", ctx=ctx)
+    except ImportError:
+        # Platform adapters remain usable in minimal installs without the
+        # optional plugin loader.
+        pass
+    return ctx
+
+
+@dataclass
 class TextDebounceState:
     event: MessageEvent
     task: asyncio.Task | None

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -159,6 +159,10 @@ VALID_HOOKS: Set[str] = {
     "api_request_error",
     "on_session_start",
     "on_session_end",
+    # Gateway platform hook fired immediately before a completed outbound
+    # message is delivered. Callbacks may rewrite ``ctx.content`` or set
+    # ``ctx.cancel``. Kwargs: ctx: gateway.platforms.base.MessageSendContext.
+    "pre_message_send",
     "on_session_finalize",
     "on_session_reset",
     "subagent_start",
@@ -400,6 +404,7 @@ class PluginContext:
         description: str = "",
         emoji: str = "",
         override: bool = False,
+        max_result_size_chars: int | float | None = None,
     ) -> None:
         """Register a tool in the global registry **and** track it as plugin-provided.
 
@@ -438,11 +443,29 @@ class PluginContext:
             description=description,
             emoji=emoji,
             override=override,
+            max_result_size_chars=max_result_size_chars,
         )
         self._manager._plugin_tool_names.add(name)
         logger.debug(
             "Plugin %s registered tool: %s%s",
             self.manifest.name, name, " (override)" if override else "",
+        )
+
+    def register_memory_provider(self, provider) -> None:
+        """Register a memory provider exposed by a multi-capability plugin.
+
+        Directory-only memory plugins continue to use the exclusive
+        ``plugins/memory`` loader. This bridge lets pip entry-point and
+        standalone plugins expose a provider without duplicating themselves
+        into ``$HERMES_HOME/plugins``.
+        """
+        from plugins.memory import register_memory_provider
+
+        register_memory_provider(provider)
+        logger.info(
+            "Plugin '%s' registered memory provider: %s",
+            self.manifest.name,
+            provider.name,
         )
 
     # -- override trust gate ------------------------------------------------
@@ -1285,6 +1308,12 @@ class PluginManager:
         """
         if self._discovered and not force:
             return
+        # Memory providers registered by standalone/entry-point plugins are
+        # rebuilt by this discovery sweep. Clear stale registrations first so
+        # disabling a plugin or entering safe mode also removes its provider.
+        from plugins.memory import clear_registered_memory_providers
+
+        clear_registered_memory_providers()
         if env_var_enabled("HERMES_SAFE_MODE"):
             logger.info("HERMES_SAFE_MODE=1 — plugin discovery skipped")
             self._discovered = True

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -27,7 +27,7 @@ import importlib.util
 import logging
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Type
 from hermes_cli.config import cfg_get
 
 logger = logging.getLogger(__name__)
@@ -37,6 +37,36 @@ _MEMORY_PLUGINS_DIR = Path(__file__).parent
 # Synthetic parent package for user-installed providers, so they don't
 # collide with bundled providers in sys.modules.
 _USER_NAMESPACE = "_hermes_user_memory"
+
+# Providers registered by general standalone/pip plugins through
+# PluginContext.register_memory_provider(). Store classes, not instances:
+# MemoryProvider objects carry per-session state and must be fresh per agent.
+_REGISTERED_PROVIDER_CLASSES: Dict[str, Type["MemoryProvider"]] = {}
+_REGISTERED_PROVIDER_DESCRIPTIONS: Dict[str, str] = {}
+
+
+def register_memory_provider(provider: "MemoryProvider") -> None:
+    """Register a provider instance as a fresh-instance factory."""
+    from agent.memory_provider import MemoryProvider
+
+    if not isinstance(provider, MemoryProvider):
+        raise TypeError("provider must inherit from MemoryProvider")
+    name = str(provider.name or "").strip()
+    if not name:
+        raise ValueError("memory provider name cannot be empty")
+    provider_class = type(provider)
+    _REGISTERED_PROVIDER_CLASSES[name] = provider_class
+    description = str(getattr(provider, "description", "") or "").strip()
+    if not description:
+        doc = (provider_class.__doc__ or "").strip()
+        description = doc.splitlines()[0] if doc else ""
+    _REGISTERED_PROVIDER_DESCRIPTIONS[name] = description
+
+
+def clear_registered_memory_providers() -> None:
+    """Clear providers contributed by the general plugin discovery sweep."""
+    _REGISTERED_PROVIDER_CLASSES.clear()
+    _REGISTERED_PROVIDER_DESCRIPTIONS.clear()
 
 
 def _register_synthetic_package(name: str, search_locations: List[str]) -> None:
@@ -151,7 +181,9 @@ def list_memory_provider_names() -> List[str]:
     call at module-import time (e.g. when building the dashboard config
     schema).
     """
-    return sorted({name for name, _ in _iter_provider_dirs()})
+    return sorted(
+        {name for name, _ in _iter_provider_dirs()} | set(_REGISTERED_PROVIDER_CLASSES)
+    )
 
 
 def discover_memory_providers() -> List[Tuple[str, str, bool]]:
@@ -161,8 +193,10 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
     Bundled providers take precedence on name collisions.
     """
     results = []
+    directory_names = set()
 
     for name, child in _iter_provider_dirs():
+        directory_names.add(name)
         # Read description from plugin.yaml if available
         desc = ""
         yaml_file = child / "plugin.yaml"
@@ -188,6 +222,17 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
 
         results.append((name, desc, available))
 
+    for name, provider_class in sorted(_REGISTERED_PROVIDER_CLASSES.items()):
+        if name in directory_names:
+            continue
+        try:
+            available = bool(provider_class().is_available())
+        except Exception:
+            available = False
+        results.append(
+            (name, _REGISTERED_PROVIDER_DESCRIPTIONS.get(name, ""), available)
+        )
+
     return results
 
 
@@ -201,9 +246,17 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
     Returns None if the provider is not found or fails to load.
     """
     provider_dir = find_provider_dir(name)
-    if not provider_dir:
+    provider_class = _REGISTERED_PROVIDER_CLASSES.get(name)
+    if not provider_dir and provider_class is None:
         logger.debug("Memory provider '%s' not found in bundled or user plugins", name)
         return None
+
+    if not provider_dir:
+        try:
+            return provider_class()
+        except Exception as e:
+            logger.warning("Failed to load memory provider '%s': %s", name, e)
+            return None
 
     try:
         provider = _load_provider_from_dir(provider_dir)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -41,6 +41,7 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    MessageSendContext,
     MessageEvent,
     MessageType,
     ProcessingOutcome,
@@ -53,6 +54,7 @@ from gateway.platforms.base import (
     safe_url_for_log,
     cache_document_from_bytes,
     cache_video_from_bytes,
+    apply_pre_message_send,
 )
 
 try:  # sibling module; support both package and flat plugin-dir import
@@ -1423,11 +1425,29 @@ class SlackAdapter(BasePlatformAdapter):
 
             # Convert standard markdown → Slack mrkdwn
             formatted = self.format_message(content)
+            block_content = content
+
+            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            hook_ctx = apply_pre_message_send(
+                MessageSendContext(
+                    platform="slack",
+                    chat_id=chat_id,
+                    content=formatted,
+                    thread_id=thread_ts,
+                    is_dm=bool(chat_id and chat_id.startswith("D")),
+                    metadata=dict(metadata or {}),
+                )
+            )
+            if hook_ctx.cancel or not str(hook_ctx.content or "").strip():
+                if thread_ts:
+                    await self.stop_typing(chat_id, metadata=metadata)
+                return SendResult(success=True)
+            if hook_ctx.content != formatted:
+                block_content = hook_ctx.content
+            formatted = hook_ctx.content
 
             # Split long messages, preserving code block boundaries
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
-
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
             last_result = None
 
             # reply_broadcast: also post thread replies to the main channel.
@@ -1439,7 +1459,7 @@ class SlackAdapter(BasePlatformAdapter):
             # that had to be split is pathological for Block Kit's 50-block /
             # 3000-char limits, so those fall back to plain text. The ``text``
             # field is always kept as the notification/accessibility fallback.
-            blocks = self._maybe_blocks(content) if len(chunks) == 1 else None
+            blocks = self._maybe_blocks(block_content) if len(chunks) == 1 else None
 
             for i, chunk in enumerate(chunks):
                 kwargs = {
@@ -1540,6 +1560,24 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         try:
             formatted = self.format_message(content)
+            block_content = content
+            if finalize:
+                hook_ctx = apply_pre_message_send(
+                    MessageSendContext(
+                        platform="slack",
+                        chat_id=chat_id,
+                        content=formatted,
+                        thread_id=self._resolve_thread_ts(None, metadata),
+                        is_dm=bool(chat_id and chat_id.startswith("D")),
+                        metadata=dict(metadata or {}),
+                    )
+                )
+                if hook_ctx.cancel or not str(hook_ctx.content or "").strip():
+                    await self.stop_typing(chat_id, metadata=metadata)
+                    return SendResult(success=True, message_id=message_id)
+                if hook_ctx.content != formatted:
+                    block_content = hook_ctx.content
+                formatted = hook_ctx.content
             update_kwargs: Dict[str, Any] = {
                 "channel": chat_id,
                 "ts": message_id,
@@ -1550,7 +1588,7 @@ class SlackAdapter(BasePlatformAdapter):
             # progressive flush would be wasteful and jittery. ``text`` is kept
             # as the fallback either way.
             if finalize:
-                blocks = self._maybe_blocks(content)
+                blocks = self._maybe_blocks(block_content)
                 if blocks:
                     update_kwargs["blocks"] = blocks
             await self._get_client(

--- a/tests/gateway/test_slack_adapter_pre_message_send.py
+++ b/tests/gateway/test_slack_adapter_pre_message_send.py
@@ -1,0 +1,105 @@
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageSendContext
+from hermes_cli.plugins import VALID_HOOKS
+
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules and hasattr(sys.modules["slack_bolt"], "__file__"):
+        return
+    slack = MagicMock()
+    slack.async_app.AsyncApp = MagicMock
+    slack.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+    slack.web.async_client.AsyncWebClient = MagicMock
+    for name in (
+        "slack_bolt",
+        "slack_bolt.async_app",
+        "slack_bolt.adapter",
+        "slack_bolt.adapter.socket_mode",
+        "slack_bolt.adapter.socket_mode.async_handler",
+        "slack_sdk",
+        "slack_sdk.web",
+        "slack_sdk.web.async_client",
+        "slack_sdk.errors",
+    ):
+        sys.modules.setdefault(name, slack)
+
+
+_ensure_slack_mock()
+
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def adapter():
+    value = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+    value._app = MagicMock()
+    value._pop_slash_context = MagicMock(return_value=None)
+    value._resolve_thread_ts = MagicMock(return_value=None)
+    value.stop_typing = AsyncMock()
+    client = MagicMock()
+    client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "111.222"})
+    client.chat_update = AsyncMock(return_value={"ok": True})
+    value._get_client = MagicMock(return_value=client)
+    return value
+
+
+def test_hook_contract_is_public():
+    assert "pre_message_send" in VALID_HOOKS
+    ctx = MessageSendContext(platform="slack", chat_id="C1", content="hello")
+    assert ctx.metadata == {}
+    assert ctx.cancel is False
+
+
+def test_hook_rewrite_reaches_send(adapter):
+    def rewrite(_name, *, ctx, **_kwargs):
+        ctx.content = ctx.content.replace("Recovered", "Recovery unverified")
+
+    with patch("hermes_cli.plugins.invoke_hook", side_effect=rewrite):
+        result = _run(adapter.send("C1", "**Status:** Recovered"))
+
+    assert result.success
+    posted = adapter._get_client().chat_postMessage.await_args.kwargs["text"]
+    assert "Recovery unverified" in posted
+    assert "Recovered" not in posted
+
+
+def test_hook_cancel_suppresses_send(adapter):
+    def cancel(_name, *, ctx, **_kwargs):
+        ctx.cancel = True
+
+    with patch("hermes_cli.plugins.invoke_hook", side_effect=cancel):
+        result = _run(adapter.send("C1", "progress only"))
+
+    assert result.success
+    assert result.message_id is None
+    adapter._get_client().chat_postMessage.assert_not_awaited()
+
+
+def test_only_final_edit_runs_hook(adapter):
+    seen = []
+
+    def rewrite(_name, *, ctx, **_kwargs):
+        seen.append(ctx.content)
+        ctx.content = "guarded final"
+
+    with patch("hermes_cli.plugins.invoke_hook", side_effect=rewrite):
+        preview = _run(adapter.edit_message("C1", "111.222", "preview"))
+        final = _run(
+            adapter.edit_message("C1", "111.222", "unverified", finalize=True)
+        )
+
+    assert preview.success and final.success
+    assert seen == ["unverified"]
+    calls = adapter._get_client().chat_update.await_args_list
+    assert calls[0].kwargs["text"] == "preview"
+    assert calls[1].kwargs["text"] == "guarded final"

--- a/tests/hermes_cli/test_plugin_migration_surfaces.py
+++ b/tests/hermes_cli/test_plugin_migration_surfaces.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+
+from agent.memory_provider import MemoryProvider
+from hermes_cli.plugins import PluginContext, PluginManifest
+from plugins.memory import (
+    clear_registered_memory_providers,
+    discover_memory_providers,
+    list_memory_provider_names,
+    load_memory_provider,
+)
+from tools.registry import registry
+
+
+class _MemoryProvider(MemoryProvider):
+    """Test memory provider."""
+
+    @property
+    def name(self):
+        return "entrypoint-test-memory"
+
+    def is_available(self):
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        self.session_id = session_id
+
+    def get_tool_schemas(self):
+        return []
+
+
+def _context():
+    manager = SimpleNamespace(_plugin_tool_names=set())
+    manifest = PluginManifest(name="migration-test", source="entrypoint")
+    return PluginContext(manifest, manager)
+
+
+def test_plugin_tool_preserves_result_bound():
+    name = "plugin_result_bound_migration_test"
+    ctx = _context()
+    try:
+        ctx.register_tool(
+            name=name,
+            toolset="migration-test",
+            schema={"name": name, "description": "test", "parameters": {}},
+            handler=lambda _args: "ok",
+            max_result_size_chars=1234,
+        )
+        assert registry.get_entry(name).max_result_size_chars == 1234
+    finally:
+        registry.deregister(name)
+
+
+def test_entrypoint_memory_provider_is_discoverable_and_fresh():
+    clear_registered_memory_providers()
+    try:
+        _context().register_memory_provider(_MemoryProvider())
+
+        assert "entrypoint-test-memory" in list_memory_provider_names()
+        discovered = {
+            name: available
+            for name, _desc, available in discover_memory_providers()
+        }
+        assert discovered["entrypoint-test-memory"] is True
+        first = load_memory_provider("entrypoint-test-memory")
+        second = load_memory_provider("entrypoint-test-memory")
+        assert isinstance(first, _MemoryProvider)
+        assert isinstance(second, _MemoryProvider)
+        assert first is not second
+    finally:
+        clear_registered_memory_providers()

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -139,6 +139,11 @@ def register(ctx) -> None:
     ctx.register_memory_provider(MyMemoryProvider())
 ```
 
+The same registration works from a standalone or pip entry-point plugin that
+also provides tools or hooks. Hermes stores the provider class and creates a
+fresh instance for every agent session; provider classes therefore need a
+zero-argument constructor.
+
 ## plugin.yaml
 
 ```yaml

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -371,7 +371,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. [`pre_message_send`](#pre_message_send) mutates its context instead. All other hooks are fire-and-forget observers.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
@@ -390,6 +390,7 @@ def register(ctx):
 | [`subagent_start`](#subagent_start) | A `delegate_task` child has been constructed and is about to run | ignored |
 | [`subagent_stop`](#subagent_stop) | A `delegate_task` child has exited | ignored |
 | [`pre_gateway_dispatch`](#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch | `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow |
+| [`pre_message_send`](#pre_message_send) | Slack is about to deliver a completed message | Mutate `ctx.content` or set `ctx.cancel = True` |
 | [`pre_approval_request`](#pre_approval_request) | An approval decision is requested, including smart-mode auto decisions | ignored |
 | [`post_approval_response`](#post_approval_response) | An approval decision is made (or a prompt times out) | ignored |
 | [`transform_tool_result`](#transform_tool_result) | After any tool returns, before the result is handed back to the model | `str` to replace the result, `None` to leave unchanged |
@@ -993,6 +994,29 @@ def register(ctx):
 :::info
 With heavy delegation (e.g. orchestrator roles × 5 leaves × nested depth), `subagent_stop` fires many times per turn. Keep your callback fast; push expensive work to a background queue.
 :::
+
+---
+
+### `pre_message_send`
+
+Fires immediately before Slack posts a completed message or finalizes a
+streamed message edit. Intermediate streaming previews do not fire it. The
+callback receives one mutable `MessageSendContext` as `ctx`:
+
+```python
+def guard_outbound(*, ctx, **kwargs):
+    if "internal only" in ctx.content.lower():
+        ctx.cancel = True
+        return
+    ctx.content = ctx.content.replace("Recovered", "Recovery unverified")
+
+def register(ctx):
+    ctx.register_hook("pre_message_send", guard_outbound)
+```
+
+The context exposes `platform`, `chat_id`, `content`, `thread_id`, `is_dm`,
+`metadata`, and `cancel`. Returning a value has no effect. Cancelling is treated
+as a successful no-op so gateway retry logic does not resend the blocked text.
 
 ---
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -201,6 +201,7 @@ Plugins can register callbacks for these lifecycle events. See the **[Event Hook
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`, `/clear`, idle rotation) |
 | [`subagent_stop`](/user-guide/features/hooks#subagent_stop) | Once per child after `delegate_task` finishes |
 | [`pre_gateway_dispatch`](/user-guide/features/hooks#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch. Return `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow. |
+| [`pre_message_send`](/user-guide/features/hooks#pre_message_send) | Slack is about to deliver a completed message. Mutate `ctx.content` or set `ctx.cancel = True`. |
 
 ## Plugin types
 


### PR DESCRIPTION
## Summary

- add a mutable `pre_message_send` hook to Slack final delivery
- allow standalone/pip plugins to register fresh per-session memory providers
- preserve plugin tool `max_result_size_chars` bounds
- document and regression-test all three public surfaces

## Why

These are generic gaps that currently force multi-capability plugins to patch Hermes core or duplicate themselves into `$HERMES_HOME/plugins`. The new surfaces keep user-specific policy and providers outside the core while preserving bounded tool output and final-message enforcement.

Linear: https://linear.app/morpho-labs/issue/PLA-1938/fully-migrate-morpho-hermes-fork-custom-code-to-carapulse

## Verification

- canonical per-file runner: 476 passed
- exact Carapulse wheel smoke against this branch: passed (75 tools, 45 skills, 4 hooks, Obsidian provider, 3 result bounds)
- `git diff --check`
