### PR TITLE
fix: defer gateway restart after update exits

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9608,6 +9608,53 @@ def _discard_lockfile_churn(git_cmd, repo_root):
         pass
 
 
+def _fork_deferred_gateway_restart_for_gateway_update(
+    *, gateway_mode: bool, delay: float = 3.0
+) -> bool:
+    """Defer gateway restarts until after ``hermes update --gateway`` exits.
+
+    ``/update`` runs ``hermes update --gateway`` as a child of the running
+    gateway.  Restarting the gateway inline from that updater is self-defeating:
+    the service manager can kill the updater's cgroup before the wrapper shell
+    records the final exit status, so the update looks failed even though the
+    update itself succeeded.  Fork a tiny detached continuation instead.  The
+    parent returns success; the child sleeps for a few seconds, then falls
+    through into the existing restart logic below.
+
+    Returns ``True`` in the parent when the restart continuation was scheduled.
+    Returns ``False`` in the child, or when no deferral was possible, so callers
+    continue through the normal inline restart path.
+    """
+    if not gateway_mode:
+        return False
+    if sys.platform == "win32" or not hasattr(os, "fork"):
+        return False
+
+    try:
+        pid = os.fork()  # windows-footgun: POSIX-only path, guarded above
+    except OSError as exc:
+        logger.debug("Could not fork delayed gateway restart helper: %s", exc)
+        return False
+
+    if pid:
+        print(f"→ Gateway restart scheduled in {int(delay)}s after updater exits.")
+        return True
+
+    # Child: detach from the updater's session and wait long enough for the
+    # parent process and its shell wrapper to exit cleanly before touching the
+    # gateway service.  Keep stdout/stderr as-is so any restart diagnostics still
+    # land in update.log / .update_output.txt when available.
+    try:
+        os.setsid()
+    except OSError:
+        pass
+    try:
+        _time.sleep(max(float(delay), 0.0))
+    except Exception:
+        pass
+    return False
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version.
 
@@ -10651,6 +10698,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _exit_code_path.write_text("0")
             except OSError:
                 pass
+
+        if _fork_deferred_gateway_restart_for_gateway_update(
+            gateway_mode=gateway_mode
+        ):
+            _resume_windows_gateways_after_update(_windows_gateway_resume)
+            return
 
         # Auto-restart ALL gateways after update.
         # The code update (git pull) is shared across all profiles, so every

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1029,6 +1029,65 @@ class TestCmdUpdateZipBranchRefusal:
         assert "Downloading latest version" not in out
 
 
+class TestGatewayUpdateDeferredRestart:
+    """``hermes update --gateway`` must exit before restarting its parent gateway."""
+
+    def test_non_gateway_mode_does_not_fork(self, monkeypatch):
+        from hermes_cli import main as hm
+
+        monkeypatch.setattr(hm.sys, "platform", "linux")
+
+        def fail_fork():  # pragma: no cover - should never be called
+            raise AssertionError("fork should not be called outside gateway mode")
+
+        monkeypatch.setattr(hm.os, "fork", fail_fork, raising=False)
+
+        assert hm._fork_deferred_gateway_restart_for_gateway_update(
+            gateway_mode=False
+        ) is False
+
+    def test_parent_returns_true_after_scheduling_child(self, monkeypatch, capsys):
+        from hermes_cli import main as hm
+
+        monkeypatch.setattr(hm.sys, "platform", "linux")
+        monkeypatch.setattr(hm.os, "fork", lambda: 12345, raising=False)
+
+        assert hm._fork_deferred_gateway_restart_for_gateway_update(
+            gateway_mode=True,
+            delay=3.0,
+        ) is True
+        assert "Gateway restart scheduled in 3s" in capsys.readouterr().out
+
+    def test_child_detaches_sleeps_and_continues_inline_path(self, monkeypatch):
+        from hermes_cli import main as hm
+
+        calls = []
+        monkeypatch.setattr(hm.sys, "platform", "linux")
+        monkeypatch.setattr(hm.os, "fork", lambda: 0, raising=False)
+        monkeypatch.setattr(hm.os, "setsid", lambda: calls.append("setsid"), raising=False)
+        monkeypatch.setattr(hm._time, "sleep", lambda seconds: calls.append(("sleep", seconds)))
+
+        assert hm._fork_deferred_gateway_restart_for_gateway_update(
+            gateway_mode=True,
+            delay=1.5,
+        ) is False
+        assert calls == ["setsid", ("sleep", 1.5)]
+
+    def test_windows_keeps_existing_inline_restart_path(self, monkeypatch):
+        from hermes_cli import main as hm
+
+        monkeypatch.setattr(hm.sys, "platform", "win32")
+
+        def fail_fork():  # pragma: no cover - should never be called
+            raise AssertionError("Windows must not use POSIX fork")
+
+        monkeypatch.setattr(hm.os, "fork", fail_fork, raising=False)
+
+        assert hm._fork_deferred_gateway_restart_for_gateway_update(
+            gateway_mode=True
+        ) is False
+
+
 def test_is_termux_env_true_for_termux_prefix():
     from hermes_cli import main as hm
 


### PR DESCRIPTION
## Summary
- Add a POSIX fork helper for `hermes update --gateway` so the updater exits successfully before triggering gateway restarts.
- Keep the existing inline restart path as a fallback when not in gateway mode, on Windows, or if fork fails.
- Add regression coverage for parent, child, non-gateway, and Windows paths.

## Verification
- `venv/bin/python -m py_compile hermes_cli/main.py tests/hermes_cli/test_cmd_update.py`
- `/home/ericwooley/.local/bin/uv run --with pytest --with pytest-asyncio python -m pytest tests/hermes_cli/test_cmd_update.py::TestGatewayUpdateDeferredRestart tests/gateway/test_update_streaming.py::TestUpdateCommandGatewayFlag::test_spawns_with_gateway_flag -q -o 'addopts='` → 5 passed\n\n## Note\n- A broader local run of `tests/hermes_cli/test_cmd_update.py tests/gateway/test_update_command.py tests/gateway/test_update_streaming.py` hit an existing unrelated failure in `test_update_refreshes_repo_and_tui_node_dependencies` where `_run_with_idle_timeout` was not called under this environment; the focused regression coverage above passed.