### PR TITLE
feat(gateway): support toolsets in API model routes

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -638,6 +638,7 @@ group_sessions_per_user: true
 #             # api_key: "sk-..."             # optional — per-route UPSTREAM provider
 #             #                                 key (NOT caller auth; never logged)
 #             # base_url: "https://..."       # optional — per-route base URL
+#             # toolsets: [web, no_mcp]        # optional — only for this route's agent
 #           # GPT clients keep their own alias
 #           gpt-5:
 #             model: "openai/gpt-5"

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -960,6 +960,7 @@ class APIServerAdapter(BasePlatformAdapter):
         #       api_key: "sk-…"          # optional — per-route UPSTREAM provider
         #                                # key override (NOT caller auth; never logged)
         #       base_url: "https://…"    # optional — per-route base URL override
+        #       toolsets: [web, no_mcp]   # optional — per-route platform toolsets
         self._model_routes: Dict[str, Dict[str, Any]] = self._parse_model_routes(
             extra.get("model_routes"),
         )
@@ -1629,7 +1630,8 @@ class APIServerAdapter(BasePlatformAdapter):
     def _parse_model_routes(raw: Any) -> Dict[str, Dict[str, Any]]:
         """Validate and normalize the ``model_routes`` config block.
 
-        Accepts a mapping of ``alias -> {model, provider?, api_key?, base_url?}``.
+        Accepts a mapping of
+        ``alias -> {model, provider?, api_key?, base_url?, toolsets?}``.
         Invalid shapes are dropped (never raised) so a config typo can't take
         the whole API server down.  Route values are coerced to strings.
 
@@ -1657,11 +1659,22 @@ class APIServerAdapter(BasePlatformAdapter):
                     "api_server model_routes: dropping invalid route entry %r", alias_str or alias
                 )
                 continue
-            route = {
+            route: Dict[str, Any] = {
                 key: str(cfg[key]).strip()
                 for key in allowed_keys
                 if cfg.get(key) is not None and str(cfg[key]).strip()
             }
+            if "toolsets" in cfg:
+                toolsets = cfg["toolsets"]
+                if not isinstance(toolsets, list) or not all(
+                    isinstance(name, str) and name.strip() for name in toolsets
+                ):
+                    logger.warning(
+                        "api_server model_routes: route %r has invalid 'toolsets'; dropping",
+                        alias_str,
+                    )
+                    continue
+                route["toolsets"] = [name.strip() for name in toolsets]
             if not route.get("model"):
                 logger.warning(
                     "api_server model_routes: route %r has no 'model'; dropping", alias_str
@@ -1725,7 +1738,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         ``route`` is an optional ``model_routes`` entry (per-client model
         routing).  When set — and no session ``/model`` override exists for
-        this session — its model/provider/api_key/base_url override the
+        this session — its model/provider/api_key/base_url/toolsets override the
         global defaults for this agent instance only.
         """
         from run_agent import AIAgent
@@ -1800,6 +1813,11 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         user_config = _load_gateway_config()
+        if route and not session_override and "toolsets" in route:
+            user_config = dict(user_config)
+            platform_toolsets = dict(user_config.get("platform_toolsets") or {})
+            platform_toolsets["api_server"] = route["toolsets"]
+            user_config["platform_toolsets"] = platform_toolsets
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 
         max_iterations = _current_max_iterations()

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -4035,6 +4035,18 @@ class TestModelRoutesParsing:
         )
         assert adapter._model_routes["a"] == {"model": "m", "provider": "p"}
 
+    def test_route_toolsets_are_parsed(self):
+        adapter = _make_routing_adapter(
+            {"a": {"model": "m", "toolsets": [" web ", "no_mcp"]}}
+        )
+        assert adapter._model_routes["a"]["toolsets"] == ["web", "no_mcp"]
+
+    def test_route_with_invalid_toolsets_is_dropped(self):
+        adapter = _make_routing_adapter(
+            {"bad": {"model": "m", "toolsets": "no_mcp"}}
+        )
+        assert adapter._model_routes == {}
+
     def test_resolve_route_lookup(self):
         adapter = _make_routing_adapter({"minimax-m2": {"model": "minimax/minimax-m1"}})
         assert adapter._resolve_route("minimax-m2") == {"model": "minimax/minimax-m1"}
@@ -4141,6 +4153,32 @@ class TestModelRoutesHandlers:
 
 
 class TestModelRoutesAgentCreation:
+    def test_route_overrides_toolsets_without_mutating_global_config(self, monkeypatch):
+        from hermes_cli.tools_config import _get_platform_tools
+
+        captured = {}
+        user_config = {"platform_toolsets": {"api_server": ["web"]}}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        _patch_create_agent_runtime(monkeypatch, captured, FakeAgent)
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: user_config)
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools", _get_platform_tools
+        )
+        adapter = _make_routing_adapter(
+            {"alias": {"model": "other/model", "toolsets": ["no_mcp"]}}
+        )
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        monkeypatch.setattr(adapter, "_session_model_override_for", lambda *_: None)
+
+        adapter._create_agent(session_id="s1", route=adapter._resolve_route("alias"))
+
+        assert captured["enabled_toolsets"] == []
+        assert user_config == {"platform_toolsets": {"api_server": ["web"]}}
+
     def test_route_overrides_model_and_credentials(self, monkeypatch):
         captured = {}
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -196,7 +196,10 @@ Delete a stored response.
 
 ### GET /v1/models
 
-Lists the agent as an available model. The advertised model name defaults to the [profile](/user-guide/profiles) name (or `hermes-agent` for the default profile). Required by most frontends for model discovery.
+Lists the agent and configured model-route aliases as available models. The
+advertised base model name defaults to the [profile](/user-guide/profiles) name
+(or `hermes-agent` for the default profile). Required by most frontends for
+model discovery.
 
 ### GET /v1/capabilities
 
@@ -426,10 +429,25 @@ The API server gives full access to hermes-agent's toolset, **including terminal
 
 ### config.yaml
 
+Environment variables configure the listener and client authentication.
+`config.yaml` can additionally map an OpenAI request's `model` field to a
+server-side model route:
+
 ```yaml
-# Not yet supported — use environment variables.
-# config.yaml support coming in a future release.
+platforms:
+  api_server:
+    extra:
+      model_routes:
+        coding:
+          model: "openai/gpt-4o-mini"
+          provider: "openai"
+          toolsets: [web, no_mcp]  # Optional: only for requests using "coding"
 ```
+
+Configured aliases are returned by `GET /v1/models`. A route can also set a
+provider API key or base URL. Its `toolsets` use the normal API-server toolset
+resolution and do not modify global configuration; `no_mcp` is supported. A
+session-level `/model` selection takes precedence over a route.
 
 ## Security Headers
 
@@ -511,7 +529,9 @@ In Open WebUI, add each as a separate connection. The model dropdown shows `alic
 
 - **Response storage** — stored responses (for `previous_response_id`) are persisted in SQLite and survive gateway restarts. Max 100 stored responses (LRU eviction).
 - **No file upload** — inline images are supported on both `/v1/chat/completions` and `/v1/responses`, but uploaded files (`file`, `input_file`, `file_id`) and non-image document inputs are not supported through the API.
-- **Model field is cosmetic** — the `model` field in requests is accepted but the actual LLM model used is configured server-side in config.yaml.
+- **Unmapped model names are cosmetic** — configure a `model_routes` alias
+  when a request's `model` field should select a server-side model; otherwise
+  the server uses its configured default.
 
 ## Proxy Mode
 


### PR DESCRIPTION
## What changed and why

Follow-up to #3155.

API-server `model_routes` can now optionally define `toolsets`. A route alias
therefore selects its model/provider and the toolsets supplied to the
request-local agent.

This is deliberately route-scoped: it reuses API-server toolset resolution,
does not change global configuration, and supports `no_mcp`.

## How to test

1. Configure an API-server route:

   ```yaml
   platforms:
     api_server:
       extra:
         model_routes:
           coding:
             model: "openai/gpt-4o-mini"
             provider: "openai"
             toolsets: [web, no_mcp]
   ```

2. Start Hermes with the API server enabled and send a request using
   `"model": "coding"`.
3. Confirm that the route selects the configured model and supplies only the
   configured toolsets to the request-local agent.
4. Run `scripts/run_tests.sh`.

## Platforms tested

- Windows 11, Python 3.13.14: `tests/gateway/test_api_server.py` — 204
  passed, 1 skipped.
- Ruff, whitespace, and the Windows-footgun check pass.
- A direct API-server adapter route-resolution smoke test passed.

## Related issue

Implements part of #66949.

#3155 added per-client model/provider routing; this PR extends that route
configuration with request-local execution policy.


