### PR TITLE
feat(gateway): support reasoning effort in API model routes

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -638,6 +638,7 @@ group_sessions_per_user: true
 #             # api_key: "sk-..."             # optional — per-route UPSTREAM provider
 #             #                                 key (NOT caller auth; never logged)
 #             # base_url: "https://..."       # optional — per-route base URL
+#             # reasoning_effort: "low"        # optional — overrides global effort for this route
 #           # GPT clients keep their own alias
 #           gpt-5:
 #             model: "openai/gpt-5"

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -960,6 +960,7 @@ class APIServerAdapter(BasePlatformAdapter):
         #       api_key: "sk-…"          # optional — per-route UPSTREAM provider
         #                                # key override (NOT caller auth; never logged)
         #       base_url: "https://…"    # optional — per-route base URL override
+        #       reasoning_effort: "low"  # optional — per-route reasoning override
         self._model_routes: Dict[str, Dict[str, Any]] = self._parse_model_routes(
             extra.get("model_routes"),
         )
@@ -1629,7 +1630,8 @@ class APIServerAdapter(BasePlatformAdapter):
     def _parse_model_routes(raw: Any) -> Dict[str, Dict[str, Any]]:
         """Validate and normalize the ``model_routes`` config block.
 
-        Accepts a mapping of ``alias -> {model, provider?, api_key?, base_url?}``.
+        Accepts a mapping of
+        ``alias -> {model, provider?, api_key?, base_url?, reasoning_effort?}``.
         Invalid shapes are dropped (never raised) so a config typo can't take
         the whole API server down.  Route values are coerced to strings.
 
@@ -1657,11 +1659,25 @@ class APIServerAdapter(BasePlatformAdapter):
                     "api_server model_routes: dropping invalid route entry %r", alias_str or alias
                 )
                 continue
-            route = {
+            route: Dict[str, Any] = {
                 key: str(cfg[key]).strip()
                 for key in allowed_keys
                 if cfg.get(key) is not None and str(cfg[key]).strip()
             }
+            if "reasoning_effort" in cfg and cfg["reasoning_effort"] is not None:
+                from hermes_constants import parse_reasoning_effort
+
+                effort = cfg["reasoning_effort"]
+                if parse_reasoning_effort(effort) is None:
+                    logger.warning(
+                        "api_server model_routes: route %r has invalid "
+                        "'reasoning_effort'; dropping",
+                        alias_str,
+                    )
+                    continue
+                route["reasoning_effort"] = (
+                    False if effort is False else str(effort).strip().lower()
+                )
             if not route.get("model"):
                 logger.warning(
                     "api_server model_routes: route %r has no 'model'; dropping", alias_str
@@ -1725,8 +1741,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
         ``route`` is an optional ``model_routes`` entry (per-client model
         routing).  When set — and no session ``/model`` override exists for
-        this session — its model/provider/api_key/base_url override the
-        global defaults for this agent instance only.
+        this session — its model/provider/api_key/base_url/reasoning effort
+        override the global defaults for this agent instance only.
         """
         from run_agent import AIAgent
         from gateway.run import (
@@ -1788,6 +1804,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 runtime_kwargs["api_key"] = route["api_key"]
             if route.get("base_url"):
                 runtime_kwargs["base_url"] = route["base_url"]
+            if "reasoning_effort" in route:
+                from hermes_constants import parse_reasoning_effort
+
+                reasoning_config = parse_reasoning_effort(route["reasoning_effort"])
             logger.debug(
                 "api_server model route applied: model=%s provider=%s",
                 model,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -4035,6 +4035,18 @@ class TestModelRoutesParsing:
         )
         assert adapter._model_routes["a"] == {"model": "m", "provider": "p"}
 
+    def test_route_reasoning_effort_is_parsed(self):
+        adapter = _make_routing_adapter(
+            {"a": {"model": "m", "reasoning_effort": " HIGH "}}
+        )
+        assert adapter._model_routes["a"]["reasoning_effort"] == "high"
+
+    def test_route_with_invalid_reasoning_effort_is_dropped(self):
+        adapter = _make_routing_adapter(
+            {"bad": {"model": "m", "reasoning_effort": "warp-nine"}}
+        )
+        assert adapter._model_routes == {}
+
     def test_resolve_route_lookup(self):
         adapter = _make_routing_adapter({"minimax-m2": {"model": "minimax/minimax-m1"}})
         assert adapter._resolve_route("minimax-m2") == {"model": "minimax/minimax-m1"}
@@ -4141,6 +4153,24 @@ class TestModelRoutesHandlers:
 
 
 class TestModelRoutesAgentCreation:
+    def test_route_overrides_reasoning_effort(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        _patch_create_agent_runtime(monkeypatch, captured, FakeAgent)
+        adapter = _make_routing_adapter(
+            {"alias": {"model": "other/model", "reasoning_effort": "low"}}
+        )
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        monkeypatch.setattr(adapter, "_session_model_override_for", lambda *_: None)
+
+        adapter._create_agent(session_id="s1", route=adapter._resolve_route("alias"))
+
+        assert captured["reasoning_config"] == {"enabled": True, "effort": "low"}
+
     def test_route_overrides_model_and_credentials(self, monkeypatch):
         captured = {}
 
@@ -4223,7 +4253,13 @@ class TestModelRoutesAgentCreation:
                 captured.update(kwargs)
 
         _patch_create_agent_runtime(monkeypatch, captured, FakeAgent)
-        adapter = _make_routing_adapter({"alias": {"model": "route/model", "api_key": "sk-route"}})
+        adapter = _make_routing_adapter(
+            {"alias": {
+                "model": "route/model",
+                "api_key": "sk-route",
+                "reasoning_effort": "low",
+            }}
+        )
         monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
         monkeypatch.setattr(
             adapter,
@@ -4237,6 +4273,7 @@ class TestModelRoutesAgentCreation:
         # runtime here, since the gateway applies /model separately) wins.
         assert captured["model"] == "global/model"
         assert captured["api_key"] == "sk-global"
+        assert captured["reasoning_config"] == {}
 
     def test_session_override_lookup_reads_gateway_runner(self, monkeypatch):
         """_session_model_override_for consults GatewayRunner._session_model_overrides."""

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -196,7 +196,10 @@ Delete a stored response.
 
 ### GET /v1/models
 
-Lists the agent as an available model. The advertised model name defaults to the [profile](/user-guide/profiles) name (or `hermes-agent` for the default profile). Required by most frontends for model discovery.
+Lists the agent and configured model-route aliases as available models. The
+advertised base model name defaults to the [profile](/user-guide/profiles) name
+(or `hermes-agent` for the default profile). Required by most frontends for
+model discovery.
 
 ### GET /v1/capabilities
 
@@ -426,10 +429,26 @@ The API server gives full access to hermes-agent's toolset, **including terminal
 
 ### config.yaml
 
+Environment variables configure the listener and client authentication.
+`config.yaml` can additionally map an OpenAI request's `model` field to a
+server-side model route:
+
 ```yaml
-# Not yet supported — use environment variables.
-# config.yaml support coming in a future release.
+platforms:
+  api_server:
+    extra:
+      model_routes:
+        coding:
+          model: "openai/gpt-4o-mini"
+          provider: "openai"
+          reasoning_effort: "low"  # Optional: only for requests using "coding"
 ```
+
+Configured aliases are returned by `GET /v1/models`. A route can also set a
+provider API key or base URL. Its `reasoning_effort` accepts the normal Hermes
+levels (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`)
+and does not modify global configuration. A session-level `/model` selection
+takes precedence over a route.
 
 ## Security Headers
 
@@ -511,7 +530,9 @@ In Open WebUI, add each as a separate connection. The model dropdown shows `alic
 
 - **Response storage** — stored responses (for `previous_response_id`) are persisted in SQLite and survive gateway restarts. Max 100 stored responses (LRU eviction).
 - **No file upload** — inline images are supported on both `/v1/chat/completions` and `/v1/responses`, but uploaded files (`file`, `input_file`, `file_id`) and non-image document inputs are not supported through the API.
-- **Model field is cosmetic** — the `model` field in requests is accepted but the actual LLM model used is configured server-side in config.yaml.
+- **Unmapped model names are cosmetic** — configure a `model_routes` alias
+  when a request's `model` field should select a server-side model; otherwise
+  the server uses its configured default.
 
 ## Proxy Mode
 


### PR DESCRIPTION
## What changed and why

Follow-up to #3155.

API-server `model_routes` can now optionally define `reasoning_effort`. A
route alias therefore selects its model/provider and the reasoning level used
for that request.

The setting is route-local, uses Hermes' existing reasoning-effort parsing,
and does not mutate global configuration. An explicit session-level `/model`
selection continues to take precedence.

## How to test

1. Configure an API-server route:

   ```yaml
   platforms:
     api_server:
       extra:
         model_routes:
           coding:
             model: "openai/gpt-4o-mini"
             provider: "openai"
             reasoning_effort: "low"
   ```

2. Start Hermes with the API server enabled and send a request using
   `"model": "coding"`.
3. Confirm that the route selects the configured model and enables reasoning
   with effort `low`.
4. Run `scripts/run_tests.sh`.

## Platforms tested

- Windows 11, Python 3.13.14: `tests/gateway/test_api_server.py` — 204
  passed, 1 skipped.
- Ruff, whitespace, and the Windows-footgun check pass.
- A direct API-server adapter route-resolution smoke test passed.

## Related issue

Implements part of #66949.

#3155 added per-client model/provider routing; this PR extends that route
configuration with request-local execution policy.


