### PR TITLE
fix(delegation): cleanup must not delete undelivered results before parent receives them

### DIFF
--- a/tests/test_delegation_cleanup.py
+++ b/tests/test_delegation_cleanup.py
@@ -1,0 +1,167 @@
+"""Tests for issue #65853 — delegation cleanup can delete results before
+delivery.
+
+The 50-record history limit was counting ALL terminal records (both
+delivered and pending/undelivered), so cleanup could delete completed
+task results before the parent agent received them. The fix limits the
+50-record cap to delivered records only, leaving undelivered results
+under their separate 1,000-record limit.
+"""
+
+from __future__ import annotations
+
+import time
+import sqlite3
+from unittest.mock import patch
+from pathlib import Path
+
+import pytest
+
+from tools.async_delegation import (
+    _MAX_RETAINED_COMPLETED,
+    _MAX_DURABLE_PENDING,
+    _prune_durable_records,
+    _connect,
+)
+
+
+# --------------------------------------------------------------------------- #
+# _prune_durable_records only deletes delivered records for the 50-limit
+# --------------------------------------------------------------------------- #
+
+
+def test_prune_does_not_delete_pending_records_under_50_delivered():
+    """Cleanup must not delete pending (undelivered) records when there are
+    fewer than 50 delivered records. See issue #65853.
+    """
+    # Use a temporary in-memory DB
+    with patch("tools.async_delegation._connect") as mock_connect:
+        conn = sqlite3.connect(":memory:")
+        conn.execute("""
+            CREATE TABLE async_delegations (
+                delegation_id TEXT PRIMARY KEY,
+                state TEXT,
+                delivery_state TEXT,
+                updated_at REAL,
+                completed_at REAL,
+                event_json TEXT,
+                result_json TEXT,
+                delivery_attempts INTEGER DEFAULT 0
+            )
+        """)
+        mock_connect.return_value.__enter__ = lambda self: conn
+        mock_connect.return_value.__exit__ = lambda *a: None
+
+        # Insert 10 delivered + 10 pending = 20 total terminal
+        for i in range(10):
+            conn.execute(
+                "INSERT INTO async_delegations (delegation_id, state, delivery_state, updated_at) VALUES (?, ?, ?, ?)",
+                (f"del-{i}", "completed", "delivered", time.time() - i),
+            )
+        for i in range(10):
+            conn.execute(
+                "INSERT INTO async_delegations (delegation_id, state, delivery_state, updated_at) VALUES (?, ?, ?, ?)",
+                (f"pend-{i}", "completed", "pending", time.time() - i),
+            )
+        conn.commit()
+
+        _prune_durable_records()
+
+        # All 10 pending should survive
+        pending_after = conn.execute(
+            "SELECT COUNT(*) FROM async_delegations WHERE delivery_state='pending'"
+        ).fetchone()[0]
+        assert pending_after == 10, (
+            f"Expected 10 pending records after prune, got {pending_after} — "
+            f"cleanup must not delete undelivered results (issue #65853)"
+        )
+
+        # All 10 delivered should also survive (under the 50 limit)
+        delivered_after = conn.execute(
+            "SELECT COUNT(*) FROM async_delegations WHERE delivery_state='delivered'"
+        ).fetchone()[0]
+        assert delivered_after == 10
+
+
+def test_prune_deletes_excess_delivered_records():
+    """When there are >50 delivered records, excess (oldest) should be deleted."""
+    with patch("tools.async_delegation._connect") as mock_connect:
+        conn = sqlite3.connect(":memory:")
+        conn.execute("""
+            CREATE TABLE async_delegations (
+                delegation_id TEXT PRIMARY KEY,
+                state TEXT,
+                delivery_state TEXT,
+                updated_at REAL,
+                completed_at REAL,
+                event_json TEXT,
+                result_json TEXT,
+                delivery_attempts INTEGER DEFAULT 0
+            )
+        """)
+        mock_connect.return_value.__enter__ = lambda self: conn
+        mock_connect.return_value.__exit__ = lambda *a: None
+
+        # Insert 55 delivered (5 over limit)
+        for i in range(55):
+            conn.execute(
+                "INSERT INTO async_delegations (delegation_id, state, delivery_state, updated_at) VALUES (?, ?, ?, ?)",
+                (f"del-{i}", "completed", "delivered", time.time() - 100 + i),
+            )
+        conn.commit()
+
+        _prune_durable_records()
+
+        delivered_after = conn.execute(
+            "SELECT COUNT(*) FROM async_delegations WHERE delivery_state='delivered'"
+        ).fetchone()[0]
+        assert delivered_after == _MAX_RETAINED_COMPLETED, (
+            f"Expected {_MAX_RETAINED_COMPLETED} delivered after prune, got {delivered_after}"
+        )
+
+
+def test_prune_preserves_pending_even_with_many_delivered():
+    """Even with >50 delivered records, pending records must not be touched."""
+    with patch("tools.async_delegation._connect") as mock_connect:
+        conn = sqlite3.connect(":memory:")
+        conn.execute("""
+            CREATE TABLE async_delegations (
+                delegation_id TEXT PRIMARY KEY,
+                state TEXT,
+                delivery_state TEXT,
+                updated_at REAL,
+                completed_at REAL,
+                event_json TEXT,
+                result_json TEXT,
+                delivery_attempts INTEGER DEFAULT 0
+            )
+        """)
+        mock_connect.return_value.__enter__ = lambda self: conn
+        mock_connect.return_value.__exit__ = lambda *a: None
+
+        # Insert 60 delivered (excess) + 5 pending
+        for i in range(60):
+            conn.execute(
+                "INSERT INTO async_delegations (delegation_id, state, delivery_state, updated_at) VALUES (?, ?, ?, ?)",
+                (f"del-{i}", "completed", "delivered", time.time() - 100 + i),
+            )
+        for i in range(5):
+            conn.execute(
+                "INSERT INTO async_delegations (delegation_id, state, delivery_state, updated_at) VALUES (?, ?, ?, ?)",
+                (f"pend-{i}", "completed", "pending", time.time() - i),
+            )
+        conn.commit()
+
+        _prune_durable_records()
+
+        pending_after = conn.execute(
+            "SELECT COUNT(*) FROM async_delegations WHERE delivery_state='pending'"
+        ).fetchone()[0]
+        assert pending_after == 5, (
+            f"Expected 5 pending records preserved, got {pending_after}"
+        )
+
+        delivered_after = conn.execute(
+            "SELECT COUNT(*) FROM async_delegations WHERE delivery_state='delivered'"
+        ).fetchone()[0]
+        assert delivered_after == _MAX_RETAINED_COMPLETED

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -158,7 +158,14 @@ def _delete_durable_delegation(delegation_id: str) -> None:
 
 
 def _prune_durable_records() -> None:
-    """Bound terminal history, preferring delivered records for deletion."""
+    """Bound terminal history, preferring delivered records for deletion.
+
+    The 50-record history limit (_MAX_RETAINED_COMPLETED) applies only to
+    delivered results. Undelivered results (delivery_state='pending') are
+    protected by the separate 1,000-record limit (_MAX_DURABLE_PENDING)
+    so cleanup can't delete a completed task's result before the parent
+    agent receives it. See issue #65853.
+    """
     now = time.time()
     cutoff = now - _DURABLE_RETENTION_SECONDS
     with _DB_LOCK, _connect() as conn:
@@ -166,17 +173,18 @@ def _prune_durable_records() -> None:
             "DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ?",
             (cutoff,),
         )
-        terminal_count = conn.execute(
-            "SELECT COUNT(*) FROM async_delegations WHERE state NOT IN ('running','finalizing')"
+        # Count only delivered records toward the 50-record history limit.
+        # Pending (undelivered) records have their own 1,000-record limit below.
+        delivered_count = conn.execute(
+            "SELECT COUNT(*) FROM async_delegations WHERE delivery_state='delivered'"
         ).fetchone()[0]
-        excess = max(0, terminal_count - _MAX_RETAINED_COMPLETED)
+        excess = max(0, delivered_count - _MAX_RETAINED_COMPLETED)
         if excess:
             conn.execute(
                 """DELETE FROM async_delegations WHERE delegation_id IN (
                      SELECT delegation_id FROM async_delegations
-                     WHERE state NOT IN ('running','finalizing')
-                     ORDER BY CASE delivery_state WHEN 'delivered' THEN 0 ELSE 1 END,
-                              updated_at ASC LIMIT ?
+                     WHERE delivery_state='delivered'
+                     ORDER BY updated_at ASC LIMIT ?
                    )""",
                 (excess,),
             )


### PR DESCRIPTION
## Summary

Delegation cleanup keeps only 50 completed records, but it currently counts results that are still waiting for delivery in that limit. If many delegated tasks finish together, cleanup can delete some results before the parent agent receives them. The work finishes successfully, but the parent agent can never collect the answer.

## Root cause

`_prune_durable_records()` in `tools/async_delegation.py` counted ALL terminal records (both delivered and pending/undelivered) against the 50-record limit (`_MAX_RETAINED_COMPLETED`). The DELETE query prioritized delivered records but could still delete pending records if there weren't enough delivered ones to fill the excess.

## Fix

Count only delivered records toward the 50-record limit. The DELETE query now targets only `delivery_state='delivered'` records. Pending (undelivered) results remain protected by their separate 1,000-record limit (`_MAX_DURABLE_PENDING`).

## Test plan

- [x] `pytest tests/test_delegation_cleanup.py` — 3 passed
- [x] 10 delivered + 10 pending: all 10 pending survive prune (under 50 limit)
- [x] 55 delivered: excess 5 deleted, 50 remain
- [x] 60 delivered + 5 pending: 10 delivered pruned to 50, all 5 pending preserved

Closes #65853

Platforms tested: Windows 10, Python 3.11.15
