### PR TITLE
fix(agent): survive context-files kwarg skew instead of crashing the backend (#65868)

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -509,7 +509,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             # Retry without the new kwarg so context files still load (the stale
             # callee just keeps its old fallback behavior), and say so once —
             # silent version skew is how these bugs go unnoticed (#64333).
-            if "allow_install_tree_fallback" not in str(exc):
+            # Match CPython's exact unexpected-keyword diagnostic rather than a
+            # bare substring: a callee that *accepts* the parameter but raises an
+            # internal TypeError merely mentioning it must still propagate, not
+            # be retried and have its real failure masked.
+            if ("unexpected keyword argument 'allow_install_tree_fallback'"
+                    not in str(exc)):
                 raise
             global _WARNED_CONTEXT_FILES_KWARG_SKEW
             if not _WARNED_CONTEXT_FILES_KWARG_SKEW:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -54,6 +54,9 @@ from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
+# Warn-once latch for the context-files version-skew path below (#65868).
+_WARNED_CONTEXT_FILES_KWARG_SKEW = False
+
 
 def _ra():
     """Lazy reference to the ``run_agent`` module.
@@ -490,10 +493,37 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # (developing Hermes). Every other surface (desktop chat panel,
         # gateway daemons) self-spawns into the install tree, where the
         # fallback would inject this repo's contributor AGENTS.md (#64590).
-        context_files_prompt = _r.build_context_files_prompt(
-            cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
-            context_length=_ctx_len,
-            allow_install_tree_fallback=agent.platform in ("cli", "tui"))
+        try:
+            context_files_prompt = _r.build_context_files_prompt(
+                cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
+                context_length=_ctx_len,
+                allow_install_tree_fallback=agent.platform in ("cli", "tui"))
+        except TypeError as exc:
+            # Version-skewed install (#65868): a long-running backend that
+            # imported an older prompt_builder whose build_context_files_prompt
+            # predates allow_install_tree_fallback (added in 244f70aa), while
+            # this freshly-reloaded caller passes it. Seen when a Desktop
+            # auto-update lands mid-session and the system prompt is rebuilt at
+            # context compaction — before this guard the TypeError propagated
+            # out of the rebuild and took the whole backend down (SIGTERM).
+            # Retry without the new kwarg so context files still load (the stale
+            # callee just keeps its old fallback behavior), and say so once —
+            # silent version skew is how these bugs go unnoticed (#64333).
+            if "allow_install_tree_fallback" not in str(exc):
+                raise
+            global _WARNED_CONTEXT_FILES_KWARG_SKEW
+            if not _WARNED_CONTEXT_FILES_KWARG_SKEW:
+                _WARNED_CONTEXT_FILES_KWARG_SKEW = True
+                logger.warning(
+                    "build_context_files_prompt() rejected "
+                    "allow_install_tree_fallback — mixed/stale install detected "
+                    "(#65868). Falling back to the pre-244f70aa call. Run "
+                    "`hermes update` (or reinstall the Desktop app) to resync "
+                    "the runtime."
+                )
+            context_files_prompt = _r.build_context_files_prompt(
+                cwd=resolve_context_cwd(), skip_soul=_soul_loaded,
+                context_length=_ctx_len)
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -30,6 +30,8 @@ from hermes_constants import get_default_hermes_root, get_hermes_home
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
+# Warn once per process on a version-skewed build_context_files_prompt (#65868).
+_WARNED_CONTEXT_FILES_KWARG_SKEW = False
 _PLUGIN_SECTION_FRAME_RE = re.compile(
     r"^## Plugin Context: (?P<id>[a-z0-9][a-z0-9._-]{0,127})\n<!-- hermes-plugin-section-chars:(?P<chars>[0-9]{1,4}) -->\n\n",
     re.MULTILINE,
@@ -592,9 +594,44 @@ def _context_files_part(agent: Any, ctx_len: Optional[int], soul_loaded: bool) -
     if agent.skip_context_files:
         return []
     launch_artifact = getattr(agent, "_context_cwd_is_launch_artifact", False)
-    return [_pb.build_context_files_prompt(
-        cwd=None if launch_artifact else resolve_context_cwd(), skip_soul=soul_loaded, context_length=ctx_len,
-        allow_install_tree_fallback=agent.platform in ("cli", "tui"), home_override=_agent_home(agent))]
+    _cwd = None if launch_artifact else resolve_context_cwd()
+    try:
+        prompt = _pb.build_context_files_prompt(
+            cwd=_cwd, skip_soul=soul_loaded, context_length=ctx_len,
+            allow_install_tree_fallback=agent.platform in ("cli", "tui"), home_override=_agent_home(agent))
+    except TypeError as exc:
+        # Version-skewed install (#65868): a long-running backend that imported
+        # an older prompt_builder whose build_context_files_prompt predates
+        # allow_install_tree_fallback (added in 244f70aa) or the later
+        # home_override kwarg, while this freshly-reloaded caller passes them.
+        # Seen when a Desktop auto-update lands mid-session and the system
+        # prompt is rebuilt at context compaction — before this guard the
+        # TypeError propagated out of the rebuild and took the whole backend
+        # down (SIGTERM). Retry without the new kwargs so context files still
+        # load (the stale callee keeps its old fallback behavior), and say so
+        # once — silent version skew is how these bugs go unnoticed (#64333).
+        # Match CPython's exact unexpected-keyword diagnostic rather than a bare
+        # substring: a callee that *accepts* the parameter but raises an internal
+        # TypeError merely mentioning it must still propagate, not be retried and
+        # have its real failure masked.
+        if (
+            "unexpected keyword argument 'allow_install_tree_fallback'" not in str(exc)
+            and "unexpected keyword argument 'home_override'" not in str(exc)
+        ):
+            raise
+        global _WARNED_CONTEXT_FILES_KWARG_SKEW
+        if not _WARNED_CONTEXT_FILES_KWARG_SKEW:
+            _WARNED_CONTEXT_FILES_KWARG_SKEW = True
+            logger.warning(
+                "build_context_files_prompt() rejected a runtime kwarg "
+                "(allow_install_tree_fallback/home_override) — mixed/stale "
+                "install detected (#65868). Falling back to the pre-244f70aa "
+                "call. Run `hermes update` (or reinstall the Desktop app) to "
+                "resync the runtime."
+            )
+        prompt = _pb.build_context_files_prompt(
+            cwd=_cwd, skip_soul=soul_loaded, context_length=ctx_len)
+    return [prompt]
 
 
 def _join_tier(parts: List[Optional[str]]) -> str:

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -125,6 +125,28 @@ class TestContextFilesKwargSkew:
         with pytest.raises(TypeError, match="something else entirely"):
             _run_with_context_files(_make_agent(platform="cli"), boom)
 
+    def test_accepting_callee_internal_typeerror_naming_kwarg_propagates(
+        self, monkeypatch
+    ):
+        """A callee that *accepts* allow_install_tree_fallback but raises its own
+        internal TypeError mentioning the parameter must propagate — not be
+        mistaken for signature skew, retried, and have its real failure masked."""
+        import agent.system_prompt as sp
+
+        monkeypatch.setattr(sp, "_WARNED_CONTEXT_FILES_KWARG_SKEW", False)
+        calls = []
+
+        def build(cwd=None, skip_soul=False, context_length=None,
+                  allow_install_tree_fallback=False):
+            calls.append(True)
+            raise TypeError(
+                "allow_install_tree_fallback must be bool, not str")
+
+        with pytest.raises(TypeError, match="must be bool"):
+            _run_with_context_files(_make_agent(platform="cli"), build)
+        # Never retried: the accepting callee was invoked exactly once.
+        assert len(calls) == 1
+
 
 def _stable_prompt(agent):
     with (

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from agent.system_prompt import build_system_prompt, build_system_prompt_parts
 
 
@@ -60,6 +62,68 @@ class TestContextFileCwd:
     def test_configured_dir_when_terminal_cwd_set(self, monkeypatch, tmp_path):
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
         assert _captured_context_cwd(_make_agent()) == tmp_path
+
+
+def _run_with_context_files(agent, context_files):
+    """Run build_system_prompt_parts with a stubbed build_context_files_prompt."""
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", side_effect=context_files),
+    ):
+        return build_system_prompt_parts(agent)
+
+
+class TestContextFilesKwargSkew:
+    """#65868 — a version-skewed prompt_builder whose build_context_files_prompt
+    predates allow_install_tree_fallback must not crash the rebuild. Before the
+    guard the TypeError propagated and took the whole backend down (SIGTERM)."""
+
+    @staticmethod
+    def _stale_callee():
+        """Mimic the pre-244f70aa signature: no allow_install_tree_fallback."""
+        calls = []
+
+        def build(cwd=None, skip_soul=False, context_length=None):
+            calls.append({"cwd": cwd})
+            return "STALE-CONTEXT-FILES"
+
+        return build, calls
+
+    def test_kwarg_skew_retries_without_new_kwarg_and_warns_once(
+        self, monkeypatch, caplog
+    ):
+        import agent.system_prompt as sp
+
+        monkeypatch.setattr(sp, "_WARNED_CONTEXT_FILES_KWARG_SKEW", False)
+        build, calls = self._stale_callee()
+
+        with caplog.at_level("WARNING", logger="agent.system_prompt"):
+            parts = _run_with_context_files(_make_agent(platform="cli"), build)
+            # A second rebuild must not re-warn.
+            _run_with_context_files(_make_agent(platform="cli"), build)
+
+        # Retried the stale callee successfully → context files still load.
+        assert "STALE-CONTEXT-FILES" in parts["context"]
+        # Both rebuilds reached the stale callee (2 sessions × 1 retry each).
+        assert len(calls) == 2
+        skew_warnings = [
+            r for r in caplog.records if "#65868" in r.getMessage()
+        ]
+        assert len(skew_warnings) == 1  # warned once, not per rebuild
+
+    def test_unrelated_typeerror_still_propagates(self, monkeypatch):
+        import agent.system_prompt as sp
+
+        monkeypatch.setattr(sp, "_WARNED_CONTEXT_FILES_KWARG_SKEW", False)
+
+        def boom(cwd=None, skip_soul=False, context_length=None,
+                 allow_install_tree_fallback=False):
+            raise TypeError("something else entirely")
+
+        with pytest.raises(TypeError, match="something else entirely"):
+            _run_with_context_files(_make_agent(platform="cli"), boom)
 
 
 def _stable_prompt(agent):

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -135,6 +135,83 @@ class TestContextFileCwd:
         assert "chosen workspace instructions" in context
 
 
+def _run_with_context_files(agent, context_files):
+    """Run build_system_prompt_parts with a stubbed build_context_files_prompt."""
+    with (
+        patch("agent.prompt_builder.load_soul_md", return_value=""),
+        patch("agent.prompt_builder.build_environment_hints", return_value=""),
+        patch("agent.prompt_builder.build_context_files_prompt", side_effect=context_files),
+    ):
+        return build_system_prompt_parts(agent)
+
+
+class TestContextFilesKwargSkew:
+    """#65868 — a version-skewed prompt_builder whose build_context_files_prompt
+    predates allow_install_tree_fallback must not crash the rebuild. Before the
+    guard the TypeError propagated and took the whole backend down (SIGTERM)."""
+
+    def test_kwarg_skew_retries_without_new_kwarg_and_warns_once(
+        self, monkeypatch, caplog
+    ):
+        import agent.system_prompt as sp
+
+        monkeypatch.setattr(sp, "_WARNED_CONTEXT_FILES_KWARG_SKEW", False)
+        calls = []
+
+        def stale(cwd=None, skip_soul=False, context_length=None):
+            """Mimic the pre-244f70aa signature: no allow_install_tree_fallback."""
+            calls.append({"cwd": cwd})
+            return "STALE-CONTEXT-FILES"
+
+        with caplog.at_level("WARNING", logger="agent.system_prompt"):
+            parts = _run_with_context_files(_make_agent(platform="cli"), stale)
+            # A second rebuild must not re-warn.
+            _run_with_context_files(_make_agent(platform="cli"), stale)
+
+        # Retried the stale callee successfully → context files still load.
+        assert "STALE-CONTEXT-FILES" in parts["context"]
+        # Both rebuilds reached the stale callee (2 sessions × 1 retry each).
+        assert len(calls) == 2
+        skew_warnings = [
+            r for r in caplog.records if "#65868" in r.getMessage()
+        ]
+        assert len(skew_warnings) == 1  # warned once, not per rebuild
+
+    def test_unrelated_typeerror_still_propagates(self, monkeypatch):
+        import agent.system_prompt as sp
+
+        monkeypatch.setattr(sp, "_WARNED_CONTEXT_FILES_KWARG_SKEW", False)
+
+        def boom(cwd=None, skip_soul=False, context_length=None,
+                 allow_install_tree_fallback=False, home_override=None):
+            raise TypeError("something else entirely")
+
+        with pytest.raises(TypeError, match="something else entirely"):
+            _run_with_context_files(_make_agent(platform="cli"), boom)
+
+    def test_accepting_callee_internal_typeerror_naming_kwarg_propagates(
+        self, monkeypatch
+    ):
+        """A callee that *accepts* allow_install_tree_fallback but raises its own
+        internal TypeError mentioning the parameter must propagate — not be
+        mistaken for signature skew, retried, and have its real failure masked."""
+        import agent.system_prompt as sp
+
+        monkeypatch.setattr(sp, "_WARNED_CONTEXT_FILES_KWARG_SKEW", False)
+        calls = []
+
+        def build(cwd=None, skip_soul=False, context_length=None,
+                  allow_install_tree_fallback=False, home_override=None):
+            calls.append(True)
+            raise TypeError(
+                "allow_install_tree_fallback must be bool, not str")
+
+        with pytest.raises(TypeError, match="must be bool"):
+            _run_with_context_files(_make_agent(platform="cli"), build)
+        # Never retried: the accepting callee was invoked exactly once.
+        assert len(calls) == 1
+
+
 def _stable_prompt(agent):
     with (
         patch("agent.prompt_builder.load_soul_md", return_value=""),


### PR DESCRIPTION
## What does this PR do?

Hardens the agent against the **version-skew crash** in #65868 (crash 2, the main-process abort).

When a Desktop auto-update lands **mid-session**, the updater rewrites `agent/prompt_builder.py` and `agent/system_prompt.py` on disk while the already-running backend still holds the **old** `prompt_builder` module imported. As soon as a long conversation crosses the context-compaction threshold and rebuilds the system prompt, the freshly-resolved caller passes the new `allow_install_tree_fallback` kwarg (added in `244f70aa`) to the stale `build_context_files_prompt`, which raises:

```
TypeError: build_context_files_prompt() got an unexpected keyword argument 'allow_install_tree_fallback'
```

That `TypeError` propagated out of the rebuild → the backend exited (`SIGTERM`) → the Electron shell crashed during handle teardown.

This applies the **same remedy the maintainers already blessed for the sibling bootstrap-skew bug** (`07be37d99`, #64333): catch the skew at the call boundary, **degrade gracefully**, and **warn once** with a resync hint instead of letting silent skew fester. On a `TypeError` that names the new kwarg, we retry `build_context_files_prompt` **without** it — context files still load (the stale callee just keeps its old fallback behavior). Any *other* `TypeError` still propagates, so we don't mask unrelated bugs.

**Scope note:** #65868 also reports a renderer crash-loop inside Electron/Chromium's own Rust→V8 IPC bridge (`serde_json_lenient$cxxbridge1$decode_json` → `v8::Isolate::Free` → `ud2`). That is framework-internal (not hermes-agent code) and out of scope here. The deeper "updater should fully restart the embedded backend" request is orthogonal to this agent-side hardening; this PR makes the agent survive the skew window rather than crash inside it.

## Related Issue

Fixes #65868

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/system_prompt.py`: wrap the `build_context_files_prompt(...)` call in `build_system_prompt_parts`; on a `TypeError` naming `allow_install_tree_fallback`, retry without the kwarg and log a one-time warning (module-level `_WARNED_CONTEXT_FILES_KWARG_SKEW` latch + module `logger`). Other `TypeError`s re-raise.
- `tests/agent/test_system_prompt.py`: `TestContextFilesKwargSkew` — the skewed path retries the stale callee, context files still load, and the warning fires once across two rebuilds; an unrelated `TypeError` still propagates.

## How to Test

```
scripts/run_tests.sh tests/agent/test_system_prompt.py
```

Result: `10 tests passed, 0 failed`. Preflight (`check-windows-footguns`, `ruff`, affected tests) all green vs `upstream/main`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass (`scripts/run_tests.sh tests/agent/test_system_prompt.py`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Credits

Applies the version-skew remedy established by @teknium1 in `07be37d99` (#64333) — warn-once + graceful degradation at the call boundary. The new kwarg guarded here was introduced by @teknium1 in `244f70aa`.
