### PR TITLE
fix(uninstall): verify project root before rmtree to protect shared folders

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -30,6 +30,51 @@ def get_project_root() -> Path:
     return Path(__file__).parent.parent.resolve()
 
 
+def _is_hermes_project_root(path: Path) -> bool:
+    """Verify a directory is actually a Hermes Agent project root.
+
+    Prevents ``shutil.rmtree(project_root)`` from deleting a shared Python
+    folder when Hermes is installed inside one (e.g. site-packages).
+    Checks for Hermes-specific markers: a ``pyproject.toml`` containing
+    ``hermes-agent`` as the package name, or the presence of both
+    ``hermes_cli/`` and ``run_agent.py`` (the core entry points).
+    A copied ``uninstall.py`` inside an unrelated repo passes this check
+    only if those sibling markers also exist. See issue #65854.
+    """
+    try:
+        # Fast check: pyproject.toml with hermes-agent package name
+        pyproject = path / "pyproject.toml"
+        if pyproject.exists():
+            try:
+                content = pyproject.read_text(encoding="utf-8", errors="ignore")
+                if "hermes-agent" in content or "hermes_agent" in content:
+                    return True
+            except Exception:
+                pass
+
+        # Sibling marker check: hermes_cli/ + run_agent.py must both exist
+        # These are core Hermes files that won't be in a random shared folder
+        has_hermes_cli = (path / "hermes_cli" / "__init__.py").exists()
+        has_run_agent = (path / "run_agent.py").exists()
+        if has_hermes_cli and has_run_agent:
+            return True
+
+        # Fallback: check for setup.py or setup.cfg with hermes-agent
+        for setup_file in ("setup.py", "setup.cfg"):
+            sf = path / setup_file
+            if sf.exists():
+                try:
+                    content = sf.read_text(encoding="utf-8", errors="ignore")
+                    if "hermes-agent" in content or "hermes_agent" in content:
+                        return True
+                except Exception:
+                    pass
+
+        return False
+    except Exception:
+        return False
+
+
 def find_shell_configs() -> list:
     """Find shell configuration files that might have PATH entries."""
     home = Path.home()
@@ -837,12 +882,22 @@ def _perform_uninstall(
     # We need to be careful here
     try:
         if project_root.exists():
-            # If the install is inside ~/.hermes/, just remove the hermes-agent subdir
-            if hermes_home in project_root.parents or project_root.parent == hermes_home:
+            # Safety check: verify this is actually a Hermes project before
+            # removing it. If Hermes is installed inside a shared Python folder
+            # (e.g. site-packages), project_root could resolve to that shared
+            # folder and rmtree would delete other packages' files too.
+            # See issue #65854.
+            if not _is_hermes_project_root(project_root):
+                log_warn(
+                    f"Refusing to remove {project_root} — it does not appear to "
+                    f"be a Hermes Agent project directory (no pyproject.toml or "
+                    f"setup markers found). This may be a shared Python folder. "
+                    f"Please remove Hermes files manually."
+                )
+            elif hermes_home in project_root.parents or project_root.parent == hermes_home:
                 shutil.rmtree(project_root)
                 log_success(f"Removed {project_root}")
             else:
-                # Installation is somewhere else entirely
                 shutil.rmtree(project_root)
                 log_success(f"Removed {project_root}")
     except Exception as e:

--- a/tests/test_uninstall_safety.py
+++ b/tests/test_uninstall_safety.py
@@ -1,0 +1,106 @@
+"""Tests for issue #65854 — uninstall can delete other packages from a
+shared Python folder.
+
+The fix adds _is_hermes_project_root() which verifies a directory is
+actually a Hermes Agent project before allowing shutil.rmtree.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.uninstall import _is_hermes_project_root
+
+
+# --------------------------------------------------------------------------- #
+# _is_hermes_project_root
+# --------------------------------------------------------------------------- #
+
+
+def test_real_hermes_project_detected():
+    """The actual hermes-agent repo should be detected as a Hermes project."""
+    # The repo root is the parent of the hermes_cli directory
+    from hermes_cli.uninstall import get_project_root
+    repo_root = get_project_root()
+    assert _is_hermes_project_root(repo_root) is True
+
+
+def test_shared_python_folder_not_detected(tmp_path):
+    """A random folder with other packages should NOT be detected as Hermes."""
+    # Create a folder that looks like a shared Python folder
+    (tmp_path / "some_package").mkdir()
+    (tmp_path / "some_package" / "__init__.py").write_text("")
+    (tmp_path / "other_package").mkdir()
+    (tmp_path / "other_package" / "__init__.py").write_text("")
+
+    assert _is_hermes_project_root(tmp_path) is False, (
+        "A shared Python folder must not be detected as a Hermes project — see issue #65854"
+    )
+
+
+def test_empty_folder_not_detected(tmp_path):
+    """An empty folder should not be detected as a Hermes project."""
+    assert _is_hermes_project_root(tmp_path) is False
+
+
+def test_folder_with_copied_uninstall_but_no_markers(tmp_path):
+    """A folder with just a copied uninstall.py should not be detected.
+
+    The issue mentions 'a copied uninstall module inside an unrelated Git
+    repository can also pass the current safety check.' Our fix requires
+    sibling markers (hermes_cli/ + run_agent.py) or pyproject.toml.
+    """
+    (tmp_path / "uninstall.py").write_text("# copied from hermes")
+    (tmp_path / "README.md").write_text("# unrelated project")
+
+    assert _is_hermes_project_root(tmp_path) is False
+
+
+def test_folder_with_pyproject_containing_hermes_detected(tmp_path):
+    """A folder with pyproject.toml containing 'hermes-agent' is detected."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "hermes-agent"\nversion = "0.1.0"\n'
+    )
+
+    assert _is_hermes_project_root(tmp_path) is True
+
+
+def test_folder_with_sibling_markers_detected(tmp_path):
+    """A folder with hermes_cli/__init__.py + run_agent.py is detected."""
+    (tmp_path / "hermes_cli").mkdir()
+    (tmp_path / "hermes_cli" / "__init__.py").write_text("")
+    (tmp_path / "run_agent.py").write_text("# Hermes entry point")
+
+    assert _is_hermes_project_root(tmp_path) is True
+
+
+def test_folder_with_only_hermes_cli_not_detected(tmp_path):
+    """Only hermes_cli/ without run_agent.py should not be enough."""
+    (tmp_path / "hermes_cli").mkdir()
+    (tmp_path / "hermes_cli" / "__init__.py").write_text("")
+
+    assert _is_hermes_project_root(tmp_path) is False
+
+
+def test_folder_with_only_run_agent_not_detected(tmp_path):
+    """Only run_agent.py without hermes_cli/ should not be enough."""
+    (tmp_path / "run_agent.py").write_text("# something")
+
+    assert _is_hermes_project_root(tmp_path) is False
+
+
+def test_pyproject_without_hermes_not_detected(tmp_path):
+    """A pyproject.toml for a different project should not be detected."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "some-other-project"\nversion = "1.0.0"\n'
+    )
+
+    assert _is_hermes_project_root(tmp_path) is False
+
+
+def test_nonexistent_path_returns_false():
+    """A nonexistent path should return False, not crash."""
+    assert _is_hermes_project_root(Path("/nonexistent/path/that/does/not/exist")) is False


### PR DESCRIPTION
## Summary

Hermes can be installed inside a Python folder that also contains other packages. The uninstall command treated any folder with a copied uninstall module as Hermes-owned and could `shutil.rmtree` the whole shared folder, deleting packages that do not belong to Hermes. A copied uninstall module inside an unrelated Git repository could also pass the current safety check.

## Fix

Add `_is_hermes_project_root()` which verifies a directory is actually a Hermes Agent project before allowing `rmtree`. Checks in order:

1. `pyproject.toml` containing `hermes-agent` or `hermes_agent` as the package name
2. Sibling markers: both `hermes_cli/__init__.py` and `run_agent.py` exist
3. `setup.py` or `setup.cfg` containing `hermes-agent` or `hermes_agent`

If none match, the uninstall refuses to remove the directory and prints a warning telling the user to remove Hermes files manually.

## Test plan

- [x] `pytest tests/test_uninstall_safety.py` — 10 passed
- [x] Real hermes-agent repo detected as Hermes project
- [x] Shared Python folder with other packages NOT detected
- [x] Empty folder NOT detected
- [x] Folder with copied uninstall.py but no markers NOT detected
- [x] pyproject.toml with hermes-agent detected
- [x] Sibling markers (hermes_cli + run_agent.py) detected
- [x] Only hermes_cli without run_agent.py NOT detected
- [x] pyproject.toml for different project NOT detected
- [x] Nonexistent path returns False

Closes #65854

Platforms tested: Windows 10, Python 3.11.15
