### PR TITLE
fix(desktop): slow session switch

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -31,7 +31,16 @@ if (new URLSearchParams(window.location.search).get('win') === 'overlay') {
           <I18nProvider>
             <ThemeProvider>
               <HapticsProvider>
-                <HashRouter>
+                {/* useTransitions={false}: react-router v7's HashRouter wraps every
+                    route state update in React.startTransition() by default. In
+                    React 19's concurrent renderer, transitions are non-urgent — React
+                    can yield mid-render and resume later. When the app is under load
+                    (streaming token deltas, gateway events, store updates), those
+                    higher-priority updates keep interrupting the transition, starving
+                    the route change commit. The session sidebar highlight + main pane
+                    both freeze for seconds despite the main thread being free.
+                    Disabling transitions makes navigate() commit at default priority. */}
+                <HashRouter useTransitions={false}>
                   <App />
                 </HashRouter>
               </HapticsProvider>


### PR DESCRIPTION
## Problem

Switching sessions in the desktop sidebar can take several seconds — neither the sidebar highlight nor the main pane updates, despite the main thread being free (animations still run, clicks still work). Worse under load (many active sessions, streaming turns).

## Root Cause

react-router v7's `HashRouter` wraps every route state update in `React.startTransition()` by default ([source](https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/dom-export.tsx)):

```js
let setState = React.useCallback((newState) => {
  if (useTransitions === false) {
    setStateImpl(newState)                    // synchronous — paints immediately
  } else {
    React.startTransition(() => setStateImpl(newState))  // DEFERRED
  }
}, [useTransitions])
```

In React 19's concurrent renderer, `startTransition` marks the update as non-urgent — React can yield mid-render and resume later. When the app is under load (streaming token deltas via rAF-batched flushes, gateway event handlers, nanostore updates from active sessions), those higher-priority updates keep interrupting the transition. React keeps yielding and the route change commit gets **starved** — it does not paint until React finds a gap in the work to finish the transition.

This explains every symptom:
- **Main thread is free** → `startTransition` defers, it does not block
- **navigate() does not take effect for seconds** → the transition keeps getting interrupted
- **Worse under load** → more concurrent re-renders = more interruptions = longer starvation
- **The whole UI (sidebar + main pane) does not update** → the entire route change is one transition

## Fix

Pass `useTransitions={false}` to `<HashRouter>` in `apps/desktop/src/main.tsx`:

```tsx
<HashRouter useTransitions={false}>
```

Route state updates are now synchronous at default React priority. `navigate()` commits and paints immediately.

## Verification

- `npx tsc -p . --noEmit` — clean (0 errors)
- `npx vitest run --environment jsdom` — 205/205 files, 1721 passed + 1 skipped, 0 failures