### PR TITLE
fix(desktop): guard second-instance handler against destroyed mainWindow

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9066,7 +9066,7 @@ if (!_gotSingleInstanceLock) {
 
     if (url) {
       handleDeepLink(url)
-    } else if (mainWindow) {
+    } else if (mainWindow && !mainWindow.isDestroyed()) {
       if (mainWindow.isMinimized()) {
         mainWindow.restore()
       }


### PR DESCRIPTION
## Summary
The Electron main-process `second-instance` handler dereferences `mainWindow` after the window has been torn down, throwing `Object has been destroyed` and aborting the app.

`app.on('second-instance', ...)` guards only on `if (mainWindow)` (non-null). `mainWindow` is never reset to `null` on window close, so after the main `BrowserWindow` is destroyed it still points at a dead object. When a second instance launches (double-clicking the app, or a `hermes://` deeplink) while the window is already gone, `mainWindow.isMinimized()` / `.restore()` / `.focus()` throw an uncaught exception:

```
A JavaScript error occurred in the main process
Uncaught Exception:
TypeError: Object has been destroyed
    at EventEmitter.<anonymous> (.../app.asar/dist/electron-main.mjs:15444:22)
```

## Fix
Guard with `!mainWindow.isDestroyed()`, matching the convention already used at the other four `mainWindow` null-gates in `electron/main.ts` (lines 4659, 4668, 7170, 7263). This covers the whole bug class — every site that dereferences `mainWindow` behind a null check now also checks `isDestroyed()`.

## Verification
- `tsc -p tsconfig.electron.json --noEmit` → clean
- `eslint electron/main.ts` → clean
- Rebuilt `app.asar` contains the corrected handler (confirmed by extracting the bundle)
- The patched desktop app launches and survives a second-instance focus attempt on a closed window

This is the **main-process** crash. It is distinct from the renderer SIGTRAP crash-loop (Rust→V8 bridge) — different root cause, not addressed here.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)