### PR TITLE
feat(desktop): add setting to keep reasoning expanded

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -15,6 +15,7 @@ import { cn } from '@/lib/utils'
 import { $backdrop, setBackdrop } from '@/store/backdrop'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
+import { $keepReasoningExpanded, setKeepReasoningExpanded } from '@/store/reasoning-view'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
@@ -245,6 +246,7 @@ export function AppearanceSettings() {
   const { t, isSavingLocale } = useI18n()
   const { themeName, mode, resolvedMode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
+  const keepReasoningExpanded = useStore($keepReasoningExpanded)
   const zoomPercent = useStore($zoomPercent)
   const embedMode = useStore($embedMode)
   const embedAllowed = useStore($embedAllowed)
@@ -484,6 +486,24 @@ export function AppearanceSettings() {
             }
             description={a.toolViewDesc}
             title={a.toolViewTitle}
+          />
+
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={id => {
+                  triggerHaptic('selection')
+                  setKeepReasoningExpanded(id === 'on')
+                }}
+                options={[
+                  { id: 'off', label: t.common.off },
+                  { id: 'on', label: t.common.on }
+                ]}
+                value={keepReasoningExpanded ? 'on' : 'off'}
+              />
+            }
+            description={a.keepReasoningExpandedDesc}
+            title={a.keepReasoningExpandedTitle}
           />
 
           <ListRow

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -4,6 +4,7 @@ import {
   useAuiState,
   useMessagePartReasoning
 } from '@assistant-ui/react'
+import { useStore } from '@nanostores/react'
 import { type ComponentProps, type FC, type ReactNode, useEffect, useRef, useState } from 'react'
 
 import { ClarifyTool } from '@/components/assistant-ui/clarify-tool'
@@ -16,6 +17,7 @@ import { GeneratedImage } from '@/components/chat/generated-image-result'
 import { useI18n } from '@/i18n'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
+import { $keepReasoningExpanded } from '@/store/reasoning-view'
 
 const ImageGenerateTool: FC<ToolCallMessagePartProps> = ({ args, result }) => {
   const aspectRatio = typeof args?.aspect_ratio === 'string' ? args.aspect_ratio : undefined
@@ -54,14 +56,17 @@ const ThinkingDisclosure: FC<{
   // `null` = no explicit user toggle yet, defer to the streaming default.
   // The default is "auto-open while streaming, auto-collapse when done" so
   // reasoning surfaces a live preview without manual interaction. The first
-  // explicit toggle wins from then on.
+  // explicit toggle wins from then on. When the "keep reasoning expanded"
+  // preference is on, the resting default flips to open so a finished turn
+  // stays expanded — the explicit toggle still wins.
   const [userOpen, setUserOpen] = useState<boolean | null>(null)
+  const keepExpanded = useStore($keepReasoningExpanded)
   const elapsed = useElapsedSeconds(pending, timerKey)
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
   const enterRef = useEnterAnimation(messageRunning, timerKey)
 
-  const open = userOpen ?? pending
+  const open = userOpen ?? (keepExpanded || pending)
   const isPreview = pending && userOpen === null
 
   // While the preview is live, pin the scroll container to the bottom on

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -3,6 +3,8 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import { useEffect, useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setKeepReasoningExpanded } from '@/store/reasoning-view'
+
 import { Thread } from '.'
 
 const createdAt = new Date('2026-05-01T00:00:00.000Z')
@@ -524,6 +526,30 @@ describe('assistant-ui streaming renderer', () => {
     expect(disclosures[1].querySelector('button')?.getAttribute('aria-expanded')).toBe('true')
     expect(container.textContent).not.toContain('Complete first thought.')
     expect(container.textContent).toContain('Interim answer.')
+  })
+
+  it('keeps a completed reasoning disclosure collapsed by default', () => {
+    const { container } = render(<ReasoningHarness />)
+
+    const toggle = within(container).getByRole('button', { name: /thinking/i })
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(container.querySelector('[data-slot="aui_reasoning-text"]')).toBeNull()
+  })
+
+  it('keeps a completed reasoning disclosure expanded when the preference is on', () => {
+    setKeepReasoningExpanded(true)
+
+    try {
+      const { container } = render(<ReasoningHarness />)
+
+      const toggle = within(container).getByRole('button', { name: /thinking/i })
+      expect(toggle.getAttribute('aria-expanded')).toBe('true')
+      expect(container.querySelector('[data-slot="aui_reasoning-text"]')?.textContent).toBe(
+        'The user is asking what this file is.'
+      )
+    } finally {
+      setKeepReasoningExpanded(false)
+    }
   })
 
   it('does not render an inline todo panel — todos live in the composer status stack', () => {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -406,6 +406,8 @@ export const en: Translations = {
       colorModeDesc: 'Pick a fixed mode or let Hermes follow your system setting.',
       toolViewTitle: 'Tool Call Display',
       toolViewDesc: 'Product hides raw tool payloads; Technical shows full input/output.',
+      keepReasoningExpandedTitle: 'Keep Reasoning Expanded',
+      keepReasoningExpandedDesc: 'The "Thinking" section stays open after a response instead of auto-collapsing.',
       uiScaleTitle: 'UI Scale',
       uiScaleDesc: (percent: number) =>
         `Scales text and controls across the whole app. Cmd/Ctrl with +, - and 0 also works. Current: ${percent}%.`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -293,6 +293,8 @@ export const ja = defineLocale({
       colorModeDesc: '固定モードを選ぶか、Hermes をシステム設定に合わせます。',
       toolViewTitle: 'ツール呼び出しの表示',
       toolViewDesc: 'プロダクト表示は生のツールペイロードを隠し、テクニカル表示は入出力をすべて表示します。',
+      keepReasoningExpandedTitle: '推論を展開したままにする',
+      keepReasoningExpandedDesc: '応答完了後も「考え中」セクションを自動的に折りたたまず、展開したままにします。',
       uiScaleTitle: 'UI スケール',
       uiScaleDesc: (percent: number) =>
         `アプリ全体の文字と UI を拡大縮小します。Cmd/Ctrl と +、-、0 でも変更できます。現在: ${percent}%`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -323,6 +323,8 @@ export interface Translations {
       colorModeDesc: string
       toolViewTitle: string
       toolViewDesc: string
+      keepReasoningExpandedTitle: string
+      keepReasoningExpandedDesc: string
       uiScaleTitle: string
       uiScaleDesc: (percent: number) => string
       translucencyTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -285,6 +285,8 @@ export const zhHant = defineLocale({
       colorModeDesc: '選擇固定模式，或讓 Hermes 跟隨系統設定。',
       toolViewTitle: '工具呼叫顯示',
       toolViewDesc: '產品模式會隱藏原始工具 payload；技術模式會顯示完整輸入/輸出。',
+      keepReasoningExpandedTitle: '保持推理展開',
+      keepReasoningExpandedDesc: '回覆完成後，「思考中」部分保持展開，而不是自動折疊。',
       uiScaleTitle: '介面縮放',
       uiScaleDesc: (percent: number) =>
         `縮放整個應用程式的文字與介面。也可使用 Cmd/Ctrl 加 +、- 或 0 調整。目前：${percent}%`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -395,6 +395,8 @@ export const zh: Translations = {
       colorModeDesc: '选择固定模式，或让 Hermes 跟随系统设置。',
       toolViewTitle: '工具调用显示',
       toolViewDesc: '产品模式隐藏原始工具数据；技术模式显示完整输入/输出。',
+      keepReasoningExpandedTitle: '保持推理展开',
+      keepReasoningExpandedDesc: '回复完成后，"思考中"部分保持展开，而不是自动折叠。',
       uiScaleTitle: '界面缩放',
       uiScaleDesc: (percent: number) =>
         `缩放整个应用的文字和界面。也可使用 Cmd/Ctrl 加 +、- 或 0 调整。当前：${percent}%`,

--- a/apps/desktop/src/store/reasoning-view.ts
+++ b/apps/desktop/src/store/reasoning-view.ts
@@ -1,0 +1,16 @@
+import { atom } from 'nanostores'
+
+import { persistBoolean, storedBoolean } from '@/lib/storage'
+
+const KEY = 'hermes.desktop.keepReasoningExpanded.v1'
+
+/** Whether the "Thinking" reasoning disclosure stays open after a turn finishes
+ *  instead of auto-collapsing. Off by default → the streaming preview still
+ *  auto-collapses on completion, as before. */
+export const $keepReasoningExpanded = atom(storedBoolean(KEY, false))
+
+$keepReasoningExpanded.subscribe(on => persistBoolean(KEY, on))
+
+export function setKeepReasoningExpanded(on: boolean) {
+  $keepReasoningExpanded.set(on)
+}


### PR DESCRIPTION
## Motivation

The desktop "Thinking" reasoning disclosure is hardcoded to auto-open while a
turn streams and auto-collapse once the turn finishes. Users who read the
reasoning as it lands lose it the moment the response completes and have to
re-expand the block to review it. This has been requested in #53617 (and is
adjacent to #55036 and #58931).

This PR makes the resting default configurable via a preference. The default
is unchanged, so nothing changes for users who do not enable it.

## Behavior

- New Appearance setting: **Keep Reasoning Expanded**, off by default.
- Default off reproduces today's behavior exactly: reasoning auto-opens while
  streaming and auto-collapses when the turn ends.
- When on, a finished turn's reasoning stays expanded instead of collapsing.
- An explicit per-message toggle always wins over the preference, in both
  directions. The live streaming preview (scroll pinning + mask) is untouched.
- The setting persists in `localStorage`, matching the other Appearance
  toggles.

## Implementation

- `store/reasoning-view.ts`: `$keepReasoningExpanded` boolean atom with
  `localStorage` persistence, mirroring `store/backdrop.ts`.
- `assistant-ui/thread/message-parts.tsx`: `ThinkingDisclosure` reads the atom
  and changes its resting default from `userOpen ?? pending` to
  `userOpen ?? (keepExpanded || pending)`. The first explicit user toggle still
  takes precedence.
- `app/settings/appearance-settings.tsx`: on/off `SegmentedControl` row under
  Appearance, following the existing "Chat Backdrop" toggle.
- `i18n/*`: `keepReasoningExpandedTitle` / `keepReasoningExpandedDesc` strings
  for en, ja, zh, zh-hant, plus the `types.ts` contract.

## Tests

`apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx`:

- New: a completed reasoning disclosure stays collapsed by default.
- New: a completed reasoning disclosure starts expanded when the preference is
  on.
- Existing reasoning/streaming tests are unchanged and remain green (the
  default-off path is identical to before).

Verified locally:

- `npx vitest run src/components/assistant-ui/thread/streaming.test.tsx` — 14/14 pass
- `tsc -p . --noEmit` — clean
- `eslint` on the touched files — clean
