### PR TITLE
feat(hindsight): browser "Connect" for the desktop memory provider

### DIFF
--- a/apps/desktop/src/app/settings/credential-key-ui.test.tsx
+++ b/apps/desktop/src/app/settings/credential-key-ui.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { EnvVarInfo } from '@/types/hermes'
+
+import { CredentialKeyCard } from './credential-key-ui'
+
+// MemoryConnect (rendered for connect-capable credentials) probes the backend
+// on mount via these bridge calls; stub them so the button surfaces.
+const getMemoryProviderOAuthStatus = vi.fn()
+const startMemoryProviderOAuth = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getMemoryProviderOAuthStatus: (provider: string) => getMemoryProviderOAuthStatus(provider),
+  startMemoryProviderOAuth: (provider: string) => startMemoryProviderOAuth(provider)
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+const rowProps = {
+  edits: {},
+  revealed: {},
+  saving: null,
+  setEdits: vi.fn(),
+  onSave: vi.fn(),
+  onClear: vi.fn(),
+  onReveal: vi.fn()
+}
+
+function makeInfo(overrides: Partial<EnvVarInfo> = {}): EnvVarInfo {
+  return {
+    advanced: false,
+    category: 'tool',
+    description: 'Hindsight API key for graph-aware persistent memory',
+    is_password: true,
+    is_set: false,
+    redacted_value: null,
+    tools: [],
+    url: 'https://hindsight.vectorize.io',
+    ...overrides
+  }
+}
+
+function renderCard(info: EnvVarInfo, varKey: string) {
+  return render(
+    <CredentialKeyCard
+      expanded
+      info={info}
+      label="Hindsight API Key"
+      onExpand={vi.fn()}
+      onToggle={vi.fn()}
+      placeholder="Enter key"
+      rowProps={rowProps}
+      varKey={varKey}
+    />
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('CredentialKeyCard — connect_provider', () => {
+  it('renders the browser Connect button (not the external "Get a key" link) when connect_provider is set', async () => {
+    getMemoryProviderOAuthStatus.mockResolvedValue({ state: 'idle', detail: '', connected: false, auth: null })
+
+    renderCard(makeInfo({ connect_provider: 'hindsight' }), 'HINDSIGHT_API_KEY')
+
+    // MemoryConnect probes on mount, then surfaces a Connect button.
+    await screen.findByText('Connect')
+    expect(getMemoryProviderOAuthStatus).toHaveBeenCalledWith('hindsight')
+    // The plain external "Get a key" anchor is replaced by the connect flow.
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+
+  it('renders the external "Get a key" link when connect_provider is absent', () => {
+    renderCard(makeInfo(), 'SOME_API_KEY')
+
+    expect(getMemoryProviderOAuthStatus).not.toHaveBeenCalled()
+    const link = screen.getByRole('link')
+    expect(link.getAttribute('href')).toBe('https://hindsight.vectorize.io')
+  })
+})

--- a/apps/desktop/src/app/settings/credential-key-ui.tsx
+++ b/apps/desktop/src/app/settings/credential-key-ui.tsx
@@ -9,6 +9,7 @@ import type { EnvVarInfo } from '@/types/hermes'
 
 import { CONTROL_TEXT } from './constants'
 import { prettyName, withoutKey } from './helpers'
+import { MemoryConnect } from './memory/connect'
 import { ListRow } from './primitives'
 import type { EnvRowProps } from './types'
 
@@ -170,7 +171,10 @@ export function CredentialKeyCard({
 }: CredentialKeyCardProps) {
   const docsUrl = info.url?.trim()
   const description = info.description?.trim()
-  const expandable = Boolean(description || docsUrl)
+  // A memory provider whose browser "Connect" flow can provision this key.
+  // When present we surface that button instead of the plain "Get a key" link.
+  const connectProvider = info.connect_provider?.trim()
+  const expandable = Boolean(description || docsUrl || connectProvider)
 
   return (
     <div
@@ -244,7 +248,11 @@ export function CredentialKeyCard({
               </p>
             )}
 
-            {docsUrl && <CredentialDocsLink href={docsUrl} />}
+            {connectProvider ? (
+              <MemoryConnect provider={connectProvider} />
+            ) : (
+              docsUrl && <CredentialDocsLink href={docsUrl} />
+            )}
           </div>
         )}
       </div>

--- a/apps/desktop/src/app/settings/memory/connect.tsx
+++ b/apps/desktop/src/app/settings/memory/connect.tsx
@@ -7,7 +7,11 @@ import { notifyError } from '@/store/notifications'
 import type { MemoryProviderOAuthStatus } from '@/types/hermes'
 
 const POLL_MS = 1500
-const POLL_TIMEOUT_MS = 120_000
+// Must outlast the backend loopback wait (oauth_flow.py `_DEFAULT_TIMEOUT`, 300s)
+// plus a couple of poll intervals, otherwise a slow sign-in (login + MFA + org
+// pick) makes the UI report "Timed out" while the backend still completes and
+// stores the key.
+const POLL_TIMEOUT_MS = 315_000
 
 // Small connect affordance rendered under the provider dropdown. Capability is
 // backend-driven: the status route 404s for providers without an oauth_flow
@@ -124,7 +128,7 @@ export function MemoryConnect({ provider }: { provider: string }) {
     return null
   }
 
-  const connectLabel = connected ? (auth === 'apikey' ? 'Connect via OAuth' : 'Reconnect') : 'Connect'
+  const connectLabel = connected ? 'Reconnect' : 'Connect'
 
   return (
     <span className="inline-flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -106,6 +106,10 @@ export interface EnvVarInfo {
   // the dedicated Messaging page. The Keys page hides these to avoid
   // duplicating the richer channel-configuration UI.
   channel_managed?: boolean
+  // Memory provider whose browser "Connect" flow can provision this credential
+  // (loopback sign-in). When set, the credential card renders a Connect button
+  // in place of the plain "Get a key" link. Empty for ordinary credentials.
+  connect_provider?: string
   description: string
   is_password: boolean
   is_set: boolean

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3973,6 +3973,10 @@ OPTIONAL_ENV_VARS = {
         "description": "Hindsight API key for graph-aware persistent memory",
         "prompt": "Hindsight API key",
         "url": "https://hindsight.vectorize.io",
+        # Memory provider whose browser "Connect" flow can provision this key
+        # (loopback sign-in via the Hindsight UI). Surfaces a Connect button on
+        # the credential card in place of the plain "Get a key" link.
+        "connect_provider": "hindsight",
         "tools": ["hindsight_recall"],
         "password": True,
         "category": "tool",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6067,6 +6067,10 @@ async def get_env_vars(profile: Optional[str] = None):
             "url": info.get("url") if info.get("url") is not None else cat_meta.get("url"),
             "category": info.get("category") or cat_meta.get("category", ""),
             "is_password": info.get("password", cat_meta.get("is_password", False)),
+            # Memory provider whose browser "Connect" flow can provision this
+            # credential. When set, the desktop credential card offers a
+            # loopback sign-in button instead of only a "Get a key" link.
+            "connect_provider": info.get("connect_provider", ""),
             "tools": info.get("tools", []),
             "advanced": info.get("advanced", cat_meta.get("advanced", False)),
             # True when this var is a messaging-platform credential owned by a

--- a/plugins/memory/hindsight/oauth_flow.py
+++ b/plugins/memory/hindsight/oauth_flow.py
@@ -1,0 +1,262 @@
+"""Browser "Connect" flow for the Hindsight memory provider — no CLI step.
+
+This is the counter-proposal to a JWT key-minting endpoint. Hermes never touches
+OAuth or JWTs. It opens the browser to the Hindsight UI — where the user is
+already signed in — and the UI creates an API key through its existing
+key-creation path and hands it back to the desktop over a ``127.0.0.1`` loopback
+redirect (the ``gh`` / ``gcloud auth login`` pattern). A Hindsight API key
+authenticates exactly like a pasted key, so it is stored as the provider's
+``apiKey``.
+
+Plugs into the generic memory-provider connect framework in
+``hermes_cli.memory_oauth`` via the ``start_loopback_flow_background`` /
+``get_flow_status`` convention — same wiring Honcho uses.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import socket
+import threading
+import time
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Callable
+from urllib.parse import urlencode, urlparse, parse_qs
+
+logger = logging.getLogger(__name__)
+
+LOOPBACK_HOST = "127.0.0.1"
+
+# The Hindsight UI route that mints a key for the desktop and redirects it back
+# to the loopback. Env-overridable for dev / self-hosted / tests.
+_CLOUD_CONNECT_URL = "https://ui.hindsight.vectorize.io/connect/desktop"
+
+# Pending connects live only until their callback returns; the loopback is
+# single-use with a bounded wait, so there's no long-lived pending registry.
+_DEFAULT_TIMEOUT = 300.0
+
+
+def resolve_connect_url() -> str:
+    """The UI /connect/desktop route (env-overridable)."""
+    return os.environ.get("HINDSIGHT_CONNECT_URL", _CLOUD_CONNECT_URL).rstrip("/")
+
+
+def resolve_config_path() -> Path:
+    """The Hindsight provider's config file (where it reads ``apiKey``)."""
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "hindsight" / "config.json"
+
+
+def build_connect_url(
+    port: int,
+    state: str,
+    *,
+    source: str = "hermes-desktop",
+    hostname: str | None = None,
+) -> str:
+    """The URL the desktop opens: UI mints a key and redirects it to the loopback."""
+    params = {"port": str(port), "state": state, "source": source}
+    if hostname:
+        params["host"] = hostname
+    return f"{resolve_connect_url()}?{urlencode(params)}"
+
+
+def _store_api_key(config_path: Path, api_key: str) -> None:
+    """Persist the minted key as the provider's ``apiKey`` (0600)."""
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    data: dict = {}
+    if config_path.is_file():
+        try:
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+        except Exception:
+            data = {}
+    if not isinstance(data, dict):
+        data = {}
+    data["apiKey"] = api_key
+    data.setdefault("mode", "cloud")
+    try:
+        from utils import atomic_json_write
+
+        atomic_json_write(config_path, data, mode=0o600)
+    except Exception:
+        config_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        try:
+            os.chmod(config_path, 0o600)
+        except OSError:
+            pass
+
+
+_CALLBACK_HTML = (
+    b"<!doctype html><meta charset=utf-8><title>Hindsight connected</title>"
+    b"<body style='font:14px ui-monospace,monospace;background:#0b0e14;color:#c9d1d9;"
+    b"display:flex;align-items:center;justify-content:center;height:100vh;margin:0'>"
+    b"<div>Connected to Hindsight. You can close this tab and return to Hermes.</div>"
+)
+
+
+def _bind_loopback_server() -> tuple[HTTPServer, dict[str, str]]:
+    """Bind a one-shot ``127.0.0.1`` callback server on a random port."""
+    captured: dict[str, str] = {}
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - stdlib API name
+            parsed = urlparse(self.path)
+            if parsed.path != "/callback":
+                self.send_response(404)
+                self.end_headers()
+                return
+            params = parse_qs(parsed.query)
+            captured["key"] = (params.get("key") or [""])[0]
+            captured["state"] = (params.get("state") or [""])[0]
+            captured["error"] = (params.get("error") or [""])[0]
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(_CALLBACK_HTML)
+
+        def log_message(self, *args):  # silence stdlib request logging
+            return
+
+    server = HTTPServer((LOOPBACK_HOST, 0), _Handler)
+    return server, captured
+
+
+def capture_loopback_key(
+    server: HTTPServer, captured: dict[str, str], *, timeout: float = _DEFAULT_TIMEOUT
+) -> tuple[str, str]:
+    """Serve a single ``/callback`` GET and return ``(key, state)``."""
+    server.timeout = timeout
+    try:
+        deadline = time.monotonic() + timeout
+        while "key" not in captured and time.monotonic() < deadline:
+            server.handle_request()
+    finally:
+        server.server_close()
+    if captured.get("error"):
+        raise ValueError(f"connect denied: {captured['error']}")
+    if not captured.get("key"):
+        raise TimeoutError("no connect callback received before timeout")
+    return captured["key"], captured.get("state", "")
+
+
+def connect_via_loopback(
+    *,
+    config_path: Path | None = None,
+    open_url: Callable[[str], None] | None = None,
+    source: str = "hermes-desktop",
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> str:
+    """Drive the full connect flow: open browser → capture minted key → store it.
+
+    ``open_url`` defaults to the system browser; tests inject a driver that
+    follows the UI redirect into the loopback callback.
+    """
+    server, captured = _bind_loopback_server()
+    port = server.server_address[1]
+    state = secrets.token_urlsafe(32)
+    url = build_connect_url(port, state, source=source, hostname=socket.gethostname())
+
+    if open_url is None:
+        import webbrowser
+
+        open_url = webbrowser.open
+
+    # Browser opens from a short-lived thread; the socket is already bound, so a
+    # fast redirect can't beat it.
+    threading.Thread(target=lambda: open_url(url), daemon=True).start()
+
+    key, returned_state = capture_loopback_key(server, captured, timeout=timeout)
+    if returned_state != state:
+        raise ValueError("connect state mismatch — possible CSRF, aborting")
+    if not key.startswith("hsk_"):
+        raise ValueError(
+            "connect returned an unexpected credential (not a Hindsight API key)"
+        )
+
+    _store_api_key(config_path or resolve_config_path(), key)
+    logger.info("Hindsight connect: stored a browser-provisioned API key")
+    return key
+
+
+# — Background launcher + status, for the desktop "Connect" button —
+# The flow blocks on a browser round-trip, so the connect endpoint kicks it off
+# in a thread and the UI polls status rather than holding the request open.
+
+
+@dataclass
+class FlowStatus:
+    state: str = "idle"  # idle | pending | connected | error
+    detail: str = ""
+
+
+_status = FlowStatus()
+_status_lock = threading.Lock()
+_flow_thread: threading.Thread | None = None
+
+
+def _detect_connection() -> tuple[bool, str | None]:
+    """Whether a Hindsight credential is already stored."""
+    try:
+        path = resolve_config_path()
+        if path.is_file():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and (data.get("apiKey") or data.get("api_key")):
+                return True, "apikey"
+    except Exception:
+        pass
+    if os.environ.get("HINDSIGHT_API_KEY"):
+        return True, "apikey"
+    return False, None
+
+
+def _set_status(state: str, detail: str = "") -> None:
+    with _status_lock:
+        _status.state, _status.detail = state, detail
+
+
+def get_flow_status() -> dict[str, object]:
+    with _status_lock:
+        state, detail = _status.state, _status.detail
+    connected, auth = _detect_connection()
+    return {"state": state, "detail": detail, "connected": connected, "auth": auth}
+
+
+def start_loopback_flow_background(
+    *,
+    config_path: Path | None = None,
+    source: str = "hermes-desktop",
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> dict[str, object]:
+    """Launch the connect flow in a daemon thread; returns the initial status.
+
+    Idempotent while a flow is pending — a second call is a no-op so a
+    double-clicked button can't open two browser tabs.
+    """
+    global _flow_thread
+    config_path = config_path or resolve_config_path()
+    with _status_lock:
+        if _status.state == "pending" and _flow_thread and _flow_thread.is_alive():
+            return get_flow_status()
+        _status.state, _status.detail = "pending", "waiting for browser consent"
+
+    def _run() -> None:
+        try:
+            connect_via_loopback(
+                config_path=config_path, source=source, timeout=timeout
+            )
+            _set_status("connected", "Hindsight connected")
+        except Exception as exc:
+            logger.warning("Hindsight connect loopback flow failed: %s", exc)
+            _set_status("error", str(exc))
+
+    _flow_thread = threading.Thread(
+        target=_run, name="hindsight-connect-loopback", daemon=True
+    )
+    _flow_thread.start()
+    return get_flow_status()

--- a/plugins/memory/hindsight/oauth_flow.py
+++ b/plugins/memory/hindsight/oauth_flow.py
@@ -46,6 +46,29 @@ def resolve_connect_url() -> str:
     return os.environ.get("HINDSIGHT_CONNECT_URL", _CLOUD_CONNECT_URL).rstrip("/")
 
 
+def resolve_api_url() -> str | None:
+    """Best-effort API base URL for the environment the key is minted in.
+
+    A key minted against one environment (e.g. dev) paired with a different
+    ``api_url`` (e.g. prod) 401s on the first memory call, so we align the two.
+
+    Precedence: an explicit ``HINDSIGHT_API_URL`` override wins; otherwise map
+    the connect (UI) host to its API host by swapping the leading ``ui.`` label
+    (``ui.dev.hindsight… → api.dev.hindsight…``; ``ui.hindsight… → api.hindsight…``).
+    Returns ``None`` for hosts that don't follow that convention (e.g. a custom
+    self-hosted UI, or the ``127.0.0.1`` used in tests) so any existing/default
+    ``api_url`` is left untouched.
+    """
+    override = os.environ.get("HINDSIGHT_API_URL")
+    if override:
+        return override.rstrip("/")
+    parsed = urlparse(resolve_connect_url())
+    host = parsed.hostname or ""
+    if parsed.scheme and host.startswith("ui."):
+        return f"{parsed.scheme}://api.{host[len('ui.') :]}"
+    return None
+
+
 def resolve_config_path() -> Path:
     """The Hindsight provider's config file (where it reads ``apiKey``)."""
     from hermes_constants import get_hermes_home
@@ -67,8 +90,14 @@ def build_connect_url(
     return f"{resolve_connect_url()}?{urlencode(params)}"
 
 
-def _store_api_key(config_path: Path, api_key: str) -> None:
-    """Persist the minted key as the provider's ``apiKey`` (0600)."""
+def _store_api_key(
+    config_path: Path, api_key: str, *, api_url: str | None = None
+) -> None:
+    """Persist the minted key as the provider's ``apiKey`` (0600).
+
+    When ``api_url`` is given it is stored too, so the key targets the same
+    environment it was minted in (see :func:`resolve_api_url`).
+    """
     config_path.parent.mkdir(parents=True, exist_ok=True)
     data: dict = {}
     if config_path.is_file():
@@ -80,6 +109,8 @@ def _store_api_key(config_path: Path, api_key: str) -> None:
         data = {}
     data["apiKey"] = api_key
     data.setdefault("mode", "cloud")
+    if api_url:
+        data["api_url"] = api_url
     try:
         from utils import atomic_json_write
 
@@ -179,7 +210,9 @@ def connect_via_loopback(
             "connect returned an unexpected credential (not a Hindsight API key)"
         )
 
-    _store_api_key(config_path or resolve_config_path(), key)
+    _store_api_key(
+        config_path or resolve_config_path(), key, api_url=resolve_api_url()
+    )
     logger.info("Hindsight connect: stored a browser-provisioned API key")
     return key
 

--- a/plugins/memory/hindsight/oauth_flow.py
+++ b/plugins/memory/hindsight/oauth_flow.py
@@ -274,9 +274,16 @@ def start_loopback_flow_background(
     global _flow_thread
     config_path = config_path or resolve_config_path()
     with _status_lock:
-        if _status.state == "pending" and _flow_thread and _flow_thread.is_alive():
-            return get_flow_status()
-        _status.state, _status.detail = "pending", "waiting for browser consent"
+        # Idempotent while pending — but compute the decision under the lock and
+        # report status *after* releasing it: get_flow_status() re-acquires the
+        # (non-reentrant) _status_lock, so calling it here would deadlock.
+        already_pending = (
+            _status.state == "pending" and _flow_thread and _flow_thread.is_alive()
+        )
+        if not already_pending:
+            _status.state, _status.detail = "pending", "waiting for browser consent"
+    if already_pending:
+        return get_flow_status()
 
     def _run() -> None:
         try:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -508,6 +508,19 @@ class TestWebServerEndpoints:
 
         assert failures == []
 
+    def test_env_hindsight_exposes_connect_provider(self):
+        """The HINDSIGHT_API_KEY credential advertises its browser-connect
+        provider so the desktop card can offer a loopback sign-in button in
+        place of the plain "Get a key" link. Ordinary credentials leave it
+        empty."""
+        resp = self.client.get("/api/env")
+        assert resp.status_code == 200
+        rows = resp.json()
+
+        assert rows["HINDSIGHT_API_KEY"]["connect_provider"] == "hindsight"
+        # A credential without a connect flow reports an empty provider.
+        assert rows["HINDSIGHT_API_URL"].get("connect_provider", "") == ""
+
     def test_memory_provider_payloads_include_manifest_setup_hints(self):
         resp = self.client.get("/api/memory")
 

--- a/tests/hindsight_plugin/test_oauth_flow.py
+++ b/tests/hindsight_plugin/test_oauth_flow.py
@@ -1,0 +1,155 @@
+"""Confirm the DESKTOP side of the Hindsight browser-connect flow, end to end,
+against a fake UI — no real Hindsight Cloud, no Zitadel, no browser, no Cloud
+changes.
+
+A local server stands in for the Hindsight UI's ``/connect/desktop`` route: it
+"mints" an API key and 302-redirects it to the desktop's loopback callback,
+exactly as the counter-proposal describes. We drive the whole desktop path:
+bind loopback → open (fake) browser → UI 302 with ?key= → capture → validate the
+CSRF state → store the key as the provider's ``apiKey``.
+"""
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+
+from plugins.memory.hindsight import oauth_flow
+
+MINTED_KEY = "hsk_testconnect_0123456789abcdef"
+
+
+def _make_ui(*, state_override: str | None = None):
+    """A fake Hindsight UI: /connect/desktop 302s a minted key to the loopback."""
+
+    class _FakeUI(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != "/connect/desktop":
+                self.send_response(404)
+                self.end_headers()
+                return
+            q = parse_qs(parsed.query)
+            port = q["port"][0]
+            state = state_override if state_override is not None else q["state"][0]
+            # The desktop identifies its surface so the consent side can attribute it.
+            assert q["source"][0] == "hermes-desktop"
+            # The UI (user already signed in) creates a key via its existing
+            # key-creation path, then hands it back over the loopback redirect.
+            location = (
+                f"http://127.0.0.1:{port}/callback?state={state}&key={MINTED_KEY}"
+            )
+            self.send_response(302)
+            self.send_header("Location", location)
+            self.end_headers()
+
+        def log_message(self, *args):
+            return
+
+    return _FakeUI
+
+
+def _serve(handler_cls, monkeypatch):
+    server = HTTPServer(("127.0.0.1", 0), handler_cls)
+    port = server.server_address[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    monkeypatch.setenv(
+        "HINDSIGHT_CONNECT_URL", f"http://127.0.0.1:{port}/connect/desktop"
+    )
+    return server
+
+
+def _browser_driver(url: str) -> None:
+    """Stand in for the user's browser: follow the UI's 302 into the loopback."""
+    resp = httpx.get(url, follow_redirects=False, timeout=5.0)
+    location = resp.headers["Location"]
+    for _ in range(100):
+        try:
+            httpx.get(location, timeout=1.0)
+            return
+        except Exception:
+            time.sleep(0.02)
+
+
+@pytest.fixture(autouse=True)
+def _reset_status():
+    oauth_flow._set_status("idle", "")
+    yield
+    oauth_flow._set_status("idle", "")
+
+
+def test_connect_stores_minted_key(monkeypatch, tmp_path):
+    server = _serve(_make_ui(), monkeypatch)
+    try:
+        cfg = tmp_path / "hindsight" / "config.json"
+        key = oauth_flow.connect_via_loopback(
+            config_path=cfg, open_url=_browser_driver, timeout=10.0
+        )
+        assert key == MINTED_KEY
+        # Stored where the Hindsight provider actually reads it.
+        data = json.loads(cfg.read_text())
+        assert data["apiKey"] == MINTED_KEY
+        assert (cfg.stat().st_mode & 0o777) == 0o600
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_connect_rejects_state_mismatch(monkeypatch, tmp_path):
+    # UI returns the WRONG state → CSRF guard fires, nothing is stored.
+    server = _serve(_make_ui(state_override="not-the-real-state"), monkeypatch)
+    try:
+        cfg = tmp_path / "hindsight" / "config.json"
+        with pytest.raises(ValueError, match="state mismatch"):
+            oauth_flow.connect_via_loopback(
+                config_path=cfg, open_url=_browser_driver, timeout=10.0
+            )
+        assert not cfg.exists()
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_memory_oauth_router_dispatches_to_hindsight():
+    """The generic connect framework resolves the hindsight flow by convention,
+    so /api/memory/providers/hindsight/oauth/{start,status} work with no new
+    route code — the same wiring Honcho uses."""
+    from hermes_cli.memory_oauth import _resolve_flow
+
+    flow = _resolve_flow("hindsight")
+    assert callable(getattr(flow, "start_loopback_flow_background", None))
+    assert callable(getattr(flow, "get_flow_status", None))
+
+
+def test_background_flow_reports_connected(monkeypatch, tmp_path):
+    server = _serve(_make_ui(), monkeypatch)
+    try:
+        cfg = tmp_path / "hindsight" / "config.json"
+        # Point BOTH the flow and the connection detector at the temp config.
+        monkeypatch.setattr(oauth_flow, "resolve_config_path", lambda: cfg)
+        # The background flow uses the real webbrowser.open — swap in our driver.
+        import webbrowser
+
+        monkeypatch.setattr(webbrowser, "open", _browser_driver)
+
+        initial = oauth_flow.start_loopback_flow_background(timeout=10.0)
+        assert initial["state"] in ("pending", "connected")
+
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            if oauth_flow.get_flow_status()["state"] == "connected":
+                break
+            time.sleep(0.05)
+
+        status = oauth_flow.get_flow_status()
+        assert status["state"] == "connected"
+        assert status["connected"] is True
+        assert status["auth"] == "apikey"
+        assert json.loads(cfg.read_text())["apiKey"] == MINTED_KEY
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/hindsight_plugin/test_oauth_flow.py
+++ b/tests/hindsight_plugin/test_oauth_flow.py
@@ -10,6 +10,7 @@ CSRF state → store the key as the provider's ``apiKey``.
 """
 
 import json
+import os
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -93,7 +94,10 @@ def test_connect_stores_minted_key(monkeypatch, tmp_path):
         # Stored where the Hindsight provider actually reads it.
         data = json.loads(cfg.read_text())
         assert data["apiKey"] == MINTED_KEY
-        assert (cfg.stat().st_mode & 0o777) == 0o600
+        # POSIX mode bits aren't enforced on Windows; keep the connect-path
+        # assertions cross-platform and guard only the permission check.
+        if os.name != "nt":
+            assert (cfg.stat().st_mode & 0o777) == 0o600
     finally:
         server.shutdown()
         server.server_close()
@@ -202,3 +206,33 @@ def test_background_flow_reports_connected(monkeypatch, tmp_path):
     finally:
         server.shutdown()
         server.server_close()
+
+
+def test_second_start_while_pending_returns_status_without_deadlock(
+    monkeypatch, tmp_path
+):
+    """A repeated start while the first flow is still pending must return the
+    idempotent status, not deadlock. Regression: ``start_loopback_flow_background``
+    used to call ``get_flow_status()`` while holding the non-reentrant
+    ``_status_lock``, so a second start re-acquired the same lock and hung."""
+    monkeypatch.setattr(oauth_flow, "resolve_config_path", lambda: tmp_path / "c.json")
+    # No-op browser → the first flow blocks in the loopback wait and stays
+    # pending/alive, so the second start hits the idempotent branch.
+    import webbrowser
+
+    monkeypatch.setattr(webbrowser, "open", lambda *a, **k: None)
+
+    first = oauth_flow.start_loopback_flow_background(timeout=2.0)
+    assert first["state"] == "pending"
+
+    result: dict[str, object] = {}
+
+    def _second():
+        result["status"] = oauth_flow.start_loopback_flow_background(timeout=2.0)
+
+    t = threading.Thread(target=_second, daemon=True)
+    t.start()
+    t.join(timeout=5.0)
+
+    assert not t.is_alive(), "second start() deadlocked while a flow was pending"
+    assert result["status"]["state"] == "pending"

--- a/tests/hindsight_plugin/test_oauth_flow.py
+++ b/tests/hindsight_plugin/test_oauth_flow.py
@@ -99,6 +99,55 @@ def test_connect_stores_minted_key(monkeypatch, tmp_path):
         server.server_close()
 
 
+@pytest.mark.parametrize(
+    "connect_url, expected",
+    [
+        # Prod and dev UI hosts map to their sibling API hosts.
+        ("https://ui.hindsight.vectorize.io/connect/desktop",
+         "https://api.hindsight.vectorize.io"),
+        ("https://ui.dev.hindsight.vectorize.io/connect/desktop",
+         "https://api.dev.hindsight.vectorize.io"),
+        # A host that doesn't follow the ui.* convention → leave api_url alone.
+        ("http://127.0.0.1:5173/connect/desktop", None),
+        ("https://memory.acme.example/connect/desktop", None),
+    ],
+)
+def test_resolve_api_url_maps_ui_host_to_api(monkeypatch, connect_url, expected):
+    monkeypatch.delenv("HINDSIGHT_API_URL", raising=False)
+    monkeypatch.setenv("HINDSIGHT_CONNECT_URL", connect_url)
+    assert oauth_flow.resolve_api_url() == expected
+
+
+def test_resolve_api_url_explicit_override_wins(monkeypatch):
+    monkeypatch.setenv("HINDSIGHT_CONNECT_URL", "https://ui.dev.hindsight.vectorize.io/connect/desktop")
+    monkeypatch.setenv("HINDSIGHT_API_URL", "https://api.self-hosted.example/")
+    # Explicit override beats the derived host, trailing slash trimmed.
+    assert oauth_flow.resolve_api_url() == "https://api.self-hosted.example"
+
+
+def test_connect_stores_api_url_aligned_to_connect_env(monkeypatch, tmp_path):
+    # Drive the real flow against a fake UI, but claim a prod-shaped connect URL
+    # so the stored api_url is derived from it (not the loopback host).
+    server = _serve(_make_ui(), monkeypatch)
+    try:
+        monkeypatch.delenv("HINDSIGHT_API_URL", raising=False)
+        monkeypatch.setattr(
+            oauth_flow,
+            "resolve_api_url",
+            lambda: "https://api.dev.hindsight.vectorize.io",
+        )
+        cfg = tmp_path / "hindsight" / "config.json"
+        oauth_flow.connect_via_loopback(
+            config_path=cfg, open_url=_browser_driver, timeout=10.0
+        )
+        data = json.loads(cfg.read_text())
+        assert data["apiKey"] == MINTED_KEY
+        assert data["api_url"] == "https://api.dev.hindsight.vectorize.io"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
 def test_connect_rejects_state_mismatch(monkeypatch, tmp_path):
     # UI returns the WRONG state → CSRF guard fires, nothing is stored.
     server = _serve(_make_ui(state_override="not-the-real-state"), monkeypatch)


### PR DESCRIPTION
## What

Adds a browser **Connect** flow for the Hindsight memory provider so a user can provision a Hindsight API key from the browser instead of pasting one — the `gh` / `gcloud auth login` pattern.

The desktop binds a one-shot `127.0.0.1` loopback, opens the browser to Hindsight's `/connect/desktop` page (where the user is already, or gets, signed in), and the page hands a freshly-minted API key back over the loopback redirect. A Hindsight API key authenticates exactly like a pasted one, so it is stored as the provider's `apiKey`.

## How it works

- **Loopback flow** (`plugins/memory/hindsight/oauth_flow.py`): bind random loopback port + CSRF `state` nonce → open browser → capture the redirect → validate `state` and the `hsk_` prefix → store the key `0600`. Runs in a background thread with a `start`/`status` polling contract (the same convention other providers use), so the request never blocks on the browser round-trip.
- **Reachable surface** (`credential-key-ui.tsx` + `MemoryConnect`): the API-key credential is tagged with a `connect_provider` and exposed via `/api/env`, so the credential card renders a **Connect** button. (The provider-dropdown config panel isn't mounted, so the button previously had nowhere to live.)
- **Environment-aligned `api_url`** (`resolve_api_url`): the stored `api_url` is derived from the connect environment (or an explicit override), so a minted key targets the same backend it was minted against instead of defaulting to a mismatched host.
- **Poll-timeout alignment**: the desktop status poll outlasts the backend loopback wait, so a slow sign-in doesn't surface a false "timed out" while the key is in fact stored.

## Tests

- `tests/hindsight_plugin/test_oauth_flow.py`: full desktop path against a fake UI (mint → loopback → store), CSRF `state` mismatch rejection, `resolve_api_url` host mapping / override precedence / aligned-store, background start→status→connected.
- `tests/hermes_cli/test_web_server.py`: `/api/env` exposes `connect_provider` for the credential.
- `apps/desktop/.../credential-key-ui.test.tsx`: Connect button renders when `connect_provider` is set; external link otherwise.

Validated end-to-end against a live deployment through the in-app button: key minted, rotated on reconnect (idempotent), stored `0600`, authenticates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)