### PR TITLE
fix(gateway): store asyncio.create_task refs for process watchers and session expiry

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7547,7 +7547,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Process in batches of 100 with event-loop yield points to avoid
             # O(n^2) event-loop blocking when recovering thousands of watchers.
             for i, watcher in enumerate(watchers):
-                asyncio.create_task(self._run_process_watcher(watcher))
+                task = asyncio.create_task(self._run_process_watcher(watcher))
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
                 logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
                 if i % 100 == 99:
                     await asyncio.sleep(0)
@@ -7555,7 +7557,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.error("Recovered watcher setup error: %s", e)
 
         # Start background session expiry watcher to finalize expired sessions
-        asyncio.create_task(self._session_expiry_watcher())
+        task = asyncio.create_task(self._session_expiry_watcher())
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
         # Start background kanban notifier — delivers `completed`, `blocked`,
         # `spawn_auto_blocked`, and `crashed` events to gateway subscribers
@@ -12255,7 +12259,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 watchers = process_registry.pending_watchers
                 process_registry.pending_watchers = []
                 for i, watcher in enumerate(watchers):
-                    asyncio.create_task(self._run_process_watcher(watcher))
+                    task = asyncio.create_task(self._run_process_watcher(watcher))
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
                     if i % 100 == 99:
                         await asyncio.sleep(0)
             except Exception as e:


### PR DESCRIPTION
## Summary

Store task references for 3 fire-and-forget `asyncio.create_task()` calls in `gateway/run.py` that were not tracked in `self._background_tasks`, preventing Python 3.12+ GC warnings and potential silent task loss.

## Problem

On Python 3.12+, `asyncio.create_task()` without a stored reference produces a runtime warning when the task is garbage-collected before completion, and unhandled exceptions in those tasks are silently lost.

Three call sites in `gateway/run.py` were missed by prior task-ref hardening (PRs #64833, #64887 covered LSP and browser_supervisor, but not the gateway boot path):

1. **Line 7550**: `_run_process_watcher(watcher)` in the crash-recovery drain loop — each recovered process watcher task is fire-and-forget.
2. **Line 7558**: `_session_expiry_watcher()` at gateway startup — the periodic session expiry checker is fire-and-forget.
3. **Line 12258**: `_run_process_watcher(watcher)` in the post-turn process check — each post-turn watcher task is fire-and-forget.

## Fix

At each site, store the task in `self._background_tasks` and add a `done_callback(self._background_tasks.discard)` for self-cleanup — matching the established pattern used elsewhere in the gateway (e.g. lines 6841-6845 and 5474-5494).

## Testing
- Syntax check passed (py_compile)
- Minimal diff: +9/-3 lines across 3 sites, same pattern as existing tracked task creation