### PR TITLE
feat(models): add moonshotai/kimi-k3 to Nous Portal + OpenRouter curated lists, retire kimi-k2.x

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -69,8 +69,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("qwen/qwen3.7-plus",                      ""),
     ("qwen/qwen3.6-35b-a3b",                   ""),
     # MoonshotAI
-    ("moonshotai/kimi-k2.6",                   "recommended"),
-    ("moonshotai/kimi-k2.7-code",              ""),
+    ("moonshotai/kimi-k3",                     "recommended"),
     # MiniMax
     ("minimax/minimax-m3",                     ""),
     # Z-AI
@@ -220,8 +219,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "qwen/qwen3.7-plus",
         "qwen/qwen3.6-35b-a3b",
         # MoonshotAI
-        "moonshotai/kimi-k2.6",
-        "moonshotai/kimi-k2.7-code",
+        "moonshotai/kimi-k3",
         # MiniMax
         "minimax/minimax-m3",
         # Z-AI

--- a/website/docs/reference/model-catalog.md
+++ b/website/docs/reference/model-catalog.md
@@ -30,7 +30,7 @@ Published on every merge to `main` via the existing `deploy-site.yml` GitHub Pag
       "metadata": {},
       "models": [
         {"id": "z-ai/glm-5.2",         "description": "default", "default": true},
-        {"id": "moonshotai/kimi-k2.6", "description": "recommended", "metadata": {}},
+        {"id": "moonshotai/kimi-k3",   "description": "recommended", "metadata": {}},
         {"id": "openai/gpt-5.4",       "description": ""}
       ]
     },
@@ -39,7 +39,7 @@ Published on every merge to `main` via the existing `deploy-site.yml` GitHub Pag
       "models": [
         {"id": "z-ai/glm-5.2", "default": true},
         {"id": "anthropic/claude-opus-4.7"},
-        {"id": "moonshotai/kimi-k2.6"}
+        {"id": "moonshotai/kimi-k3"}
       ]
     }
   }

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/model-catalog.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/model-catalog.md
@@ -29,7 +29,7 @@ https://hermes-agent.nousresearch.com/docs/api/model-catalog.json
     "openrouter": {
       "metadata": {},
       "models": [
-        {"id": "moonshotai/kimi-k2.6", "description": "recommended", "metadata": {}},
+        {"id": "moonshotai/kimi-k3",   "description": "recommended", "metadata": {}},
         {"id": "openai/gpt-5.4",       "description": ""}
       ]
     },
@@ -37,7 +37,7 @@ https://hermes-agent.nousresearch.com/docs/api/model-catalog.json
       "metadata": {},
       "models": [
         {"id": "anthropic/claude-opus-4.7"},
-        {"id": "moonshotai/kimi-k2.6"}
+        {"id": "moonshotai/kimi-k3"}
       ]
     }
   }

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-15T04:51:12Z",
+  "updated_at": "2026-07-16T19:45:30Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -105,12 +105,8 @@
           "description": ""
         },
         {
-          "id": "moonshotai/kimi-k2.6",
+          "id": "moonshotai/kimi-k3",
           "description": "recommended"
-        },
-        {
-          "id": "moonshotai/kimi-k2.7-code",
-          "description": ""
         },
         {
           "id": "minimax/minimax-m3",
@@ -248,10 +244,7 @@
           "id": "qwen/qwen3.6-35b-a3b"
         },
         {
-          "id": "moonshotai/kimi-k2.6"
-        },
-        {
-          "id": "moonshotai/kimi-k2.7-code"
+          "id": "moonshotai/kimi-k3"
         },
         {
           "id": "minimax/minimax-m3"


### PR DESCRIPTION
## Summary
The Nous Portal and OpenRouter curated model lists now offer `moonshotai/kimi-k3` (recommended) and no longer list `moonshotai/kimi-k2.6` / `moonshotai/kimi-k2.7-code`.

## Changes
- `hermes_cli/models.py`: `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]` — kimi-k3 in, kimi-k2.6 + kimi-k2.7-code out
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py` (openrouter: 39 models, nous: 31 models)
- `website/docs/reference/model-catalog.md` + zh-Hans mirror: example manifest updated to match

## Validation
| Check | Result |
|---|---|
| `moonshotai/kimi-k3` live on Nous Portal `/v1/models` | ✓ (281-model catalog) |
| `moonshotai/kimi-k3` live on OpenRouter `/api/v1/models` | ✓ (1M ctx, $3/$15 per Mtok) |
| Family matchers cover k3 (`is_moonshot_model`, `_model_name_is_kimi_family`, `_model_name_suggests_kimi`) | ✓ — schema sanitization, prompt-cache policy, and context heuristics apply with zero code changes |
| E2E: curated lists + regenerated manifest consistent, no stale k2.x | ✓ |
| `scripts/run_tests.sh tests/hermes_cli/test_models.py tests/hermes_cli/test_model_catalog.py tests/agent/test_moonshot_schema.py` | ✓ all pass |

## Infographic
![Kimi K3 Support](https://v3b.fal.media/files/b/0aa285ca/gtWTE49eNDJAvI3B6hTUM_hbVM574q.png)
