### PR TITLE
fix(context): preserve standalone engine compression arguments

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -53,6 +53,42 @@ COMPACTION_STATUS = (
 )
 
 
+def _call_context_engine_compress(
+    engine: Any,
+    messages: list,
+    *,
+    current_tokens: Optional[int],
+    focus_topic: str | None,
+    force: bool,
+) -> list:
+    """Call a context engine with only the optional keywords it supports.
+
+    Signature inspection keeps pre-``focus_topic`` plugins compatible without
+    catching a ``TypeError`` raised *inside* an engine and misreporting it as a
+    signature mismatch. It also preserves manual compression focus for engines
+    that implement the documented ``focus_topic`` argument but not the
+    built-in compressor's private ``force`` extension.
+    """
+    compress = engine.compress
+    kwargs: dict[str, Any] = {"current_tokens": current_tokens}
+    try:
+        parameters = inspect.signature(compress).parameters.values()
+    except (TypeError, ValueError):
+        # Some extension callables do not expose a Python signature. Retain
+        # compatibility with the oldest ContextEngine contract in that case.
+        return compress(messages, **kwargs)
+
+    names = {parameter.name for parameter in parameters}
+    accepts_kwargs = any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
+    )
+    if accepts_kwargs or "focus_topic" in names:
+        kwargs["focus_topic"] = focus_topic
+    if accepts_kwargs or "force" in names:
+        kwargs["force"] = force
+    return compress(messages, **kwargs)
+
+
 def _lock_api_is_absent_on_session_db(lock_db: Any) -> bool:
     """Whether the live in-memory SessionDB class structurally predates locks.
 
@@ -718,15 +754,13 @@ def compress_context(
             pass
 
     try:
-        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
-    except TypeError:
-        # Plugin context engine with strict signature that doesn't accept
-        # focus_topic / force — fall back to calling without them.
-        try:
-            compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens)
-        except BaseException:
-            _release_lock()
-            raise
+        compressed = _call_context_engine_compress(
+            agent.context_compressor,
+            messages,
+            current_tokens=approx_tokens,
+            focus_topic=focus_topic,
+            force=force,
+        )
     except BaseException:
         # ANY exception during compress() must release the lock so the
         # session isn't permanently blocked from future compression.

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -351,8 +351,8 @@ def test_abort_warning_exception_stops_lock_refresher(tmp_path: Path, monkeypatc
     assert db.try_acquire_compression_lock(parent_sid, "probe", ttl_seconds=1.0) is True
 
 
-def test_typeerror_fallback_exception_stops_lock_refresher(tmp_path: Path, monkeypatch) -> None:
-    """A strict-signature fallback failure must still release the refreshed lock."""
+def test_plugin_typeerror_stops_lock_refresher(tmp_path: Path, monkeypatch) -> None:
+    """An engine implementation TypeError must still release the refreshed lock."""
     real_try_acquire = SessionDB.try_acquire_compression_lock
 
     def _short_ttl(self, session_id: str, holder: str, ttl_seconds: float = 300.0) -> bool:
@@ -368,16 +368,14 @@ def test_typeerror_fallback_exception_stops_lock_refresher(tmp_path: Path, monke
     agent._compression_lock_ttl_seconds = 1.0
     agent._compression_lock_refresh_interval = 0.1
 
-    def _strict_signature(*_a, **_kw):
-        if "focus_topic" in _kw or "force" in _kw:
-            raise TypeError("strict signature")
-        raise RuntimeError("fallback boom")
+    def _broken_engine(*_a, **_kw):
+        raise TypeError("engine implementation bug")
 
-    agent.context_compressor.compress.side_effect = _strict_signature
+    agent.context_compressor.compress.side_effect = _broken_engine
 
     messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
 
-    with pytest.raises(RuntimeError, match="fallback boom"):
+    with pytest.raises(TypeError, match="implementation bug"):
         agent._compress_context(messages, "sys", approx_tokens=120_000)
 
     time.sleep(1.3)

--- a/tests/run_agent/test_compress_focus_plugin_fallback.py
+++ b/tests/run_agent/test_compress_focus_plugin_fallback.py
@@ -1,42 +1,17 @@
-"""Regression test: _compress_context tolerates plugin engines with strict signatures.
+"""Regression tests for context-engine compression signature compatibility.
 
 Added to ``ContextEngine.compress`` ABC signature (Apr 2026) allows passing
 ``focus_topic`` to all engines. Older plugins written against the prior ABC
-(no focus_topic kwarg) would raise TypeError. _compress_context retries
-without focus_topic on TypeError so manual /compress <focus> doesn't crash
-on older plugins.
+(no focus_topic kwarg) must keep working, while current plugins must not lose
+their manual focus merely because they omit the built-in-only ``force`` kwarg.
 """
 
-from unittest.mock import MagicMock
+import pytest
+
+from agent.conversation_compression import _call_context_engine_compress
 
 
-from run_agent import AIAgent
-
-
-def _make_agent_with_engine(engine):
-    agent = object.__new__(AIAgent)
-    agent.context_compressor = engine
-    agent.session_id = "sess-1"
-    agent.model = "test-model"
-    agent.platform = "cli"
-    agent.logs_dir = MagicMock()
-    agent.quiet_mode = True
-    agent._todo_store = MagicMock()
-    agent._todo_store.format_for_injection.return_value = ""
-    agent._memory_manager = None
-    agent._session_db = None
-    agent._cached_system_prompt = None
-    agent.log_prefix = ""
-    agent._vprint = lambda *a, **kw: None
-    agent._last_flushed_db_idx = 0
-    # Stub the few AIAgent methods _compress_context uses.
-    agent._invalidate_system_prompt = lambda *a, **kw: None
-    agent._build_system_prompt = lambda *a, **kw: "new-system-prompt"
-    agent.commit_memory_session = lambda *a, **kw: None
-    return agent
-
-
-def test_compress_context_falls_back_when_engine_rejects_focus_topic():
+def test_compress_context_supports_engine_without_focus_topic():
     """Older plugins without focus_topic in compress() signature don't crash."""
     captured_kwargs = []
 
@@ -51,7 +26,6 @@ def test_compress_context_falls_back_when_engine_rejects_focus_topic():
             return [messages[0], messages[-1]]
 
     engine = _StrictOldPluginEngine()
-    agent = _make_agent_with_engine(engine)
 
     messages = [
         {"role": "user", "content": "one"},
@@ -60,15 +34,61 @@ def test_compress_context_falls_back_when_engine_rejects_focus_topic():
         {"role": "assistant", "content": "four"},
     ]
 
-    # Directly invoke the compression call site — this is the line that
-    # used to blow up with TypeError under focus_topic+strict plugin.
-    try:
-        compressed = engine.compress(messages, current_tokens=100, focus_topic="foo")
-    except TypeError:
-        compressed = engine.compress(messages, current_tokens=100)
+    compressed = _call_context_engine_compress(
+        engine,
+        messages,
+        current_tokens=100,
+        focus_topic="foo",
+        force=True,
+    )
 
-    # Fallback succeeded: engine was called once without focus_topic.
+    # The older engine is called once with only the keyword it declares.
     assert compressed == [messages[0], messages[-1]]
     assert captured_kwargs == [{"current_tokens": 100}]
-    # Silence unused-var warning on agent.
-    assert agent.context_compressor is engine
+
+
+def test_compress_context_preserves_focus_for_engine_without_force_keyword():
+    captured_kwargs = []
+
+    class _DocumentedPluginEngine:
+        def compress(self, messages, current_tokens=None, focus_topic=None):
+            captured_kwargs.append(
+                {"current_tokens": current_tokens, "focus_topic": focus_topic}
+            )
+            return messages
+
+    messages = [{"role": "user", "content": "keep the release decision"}]
+    compressed = _call_context_engine_compress(
+        _DocumentedPluginEngine(),
+        messages,
+        current_tokens=100,
+        focus_topic="release decision",
+        force=True,
+    )
+
+    assert compressed is messages
+    assert captured_kwargs == [
+        {"current_tokens": 100, "focus_topic": "release decision"}
+    ]
+
+
+def test_compress_context_does_not_mask_internal_type_error():
+    calls = 0
+
+    class _BrokenPluginEngine:
+        def compress(self, messages, current_tokens=None, focus_topic=None):
+            del messages, current_tokens, focus_topic
+            nonlocal calls
+            calls += 1
+            raise TypeError("engine implementation bug")
+
+    with pytest.raises(TypeError, match="implementation bug"):
+        _call_context_engine_compress(
+            _BrokenPluginEngine(),
+            [],
+            current_tokens=100,
+            focus_topic="release decision",
+            force=False,
+        )
+
+    assert calls == 1

--- a/website/docs/developer-guide/context-engine-plugin.md
+++ b/website/docs/developer-guide/context-engine-plugin.md
@@ -17,22 +17,38 @@ Only **one** context engine can be active at a time. Selection is config-driven:
 ```yaml
 # config.yaml
 context:
-  engine: "compressor"    # default built-in
-  engine: "lcm"           # activates a plugin engine named "lcm"
+  engine: "lcm"  # activates a plugin engine named "lcm"; default: "compressor"
 ```
 
-Plugin engines are **never auto-activated** — the user must explicitly set `context.engine` to the plugin's name.
+Plugin engines are **never auto-activated** — the user must explicitly set
+`context.engine` to the plugin's name.
 
-## Directory structure
+## Plugin structure
 
-Each context engine lives in `plugins/context_engine/<name>/`:
+Third-party context engines should be standalone Hermes plugins with the
+manifest and entry point at the repository root:
 
 ```
-plugins/context_engine/lcm/
-├── __init__.py      # exports the ContextEngine subclass
-├── plugin.yaml      # metadata (name, description, version)
-└── ...              # any other modules your engine needs
+hermes-context-lcm/
+├── __init__.py       # register(ctx) entry point
+├── plugin.yaml       # plugin metadata
+├── engine.py         # ContextEngine implementation
+└── after-install.md  # optional setup instructions
 ```
+
+For example:
+
+```yaml title="plugin.yaml"
+manifest_version: 1
+name: context-lcm
+version: "0.1.0"
+description: Lossless context management for Hermes Agent
+```
+
+The in-tree `plugins/context_engine/<name>/` layout is reserved for engines
+bundled with Hermes. It is useful when contributing to Hermes itself, but users
+should not have to modify a managed Hermes checkout to install a third-party
+engine.
 
 ## The ContextEngine ABC
 
@@ -69,6 +85,12 @@ class LCMEngine(ContextEngine):
         prioritise preserving information related to it, others may ignore it.
         """
 ```
+
+Hermes passes optional compression keywords only when the engine declares
+them. Engines using the current documented signature receive `focus_topic`;
+older engines without it remain compatible. A `TypeError` raised inside the
+engine is treated as an implementation error and is not retried with a
+different signature.
 
 ### Class attributes your engine must maintain
 
@@ -127,21 +149,68 @@ Engine tools are injected into the agent's tool list at startup and dispatched a
 
 ## Registration
 
-### Via directory (recommended)
+### Via a standalone plugin (recommended for third parties)
 
-Place your engine in `plugins/context_engine/<name>/`. The `__init__.py` must export a `ContextEngine` subclass. The discovery system finds and instantiates it automatically.
+Export a `register(ctx)` function from the repository's root `__init__.py` and
+register one engine instance:
 
-### Via general plugin system
+```python title="__init__.py"
+from .engine import LCMEngine
 
-A general plugin can also register a context engine:
-
-```python
 def register(ctx):
-    engine = LCMEngine(context_length=200000)
-    ctx.register_context_engine(engine)
+    ctx.register_context_engine(LCMEngine(context_length=200000))
 ```
 
-Only one engine can be registered. A second plugin attempting to register is rejected with a warning.
+Plugin loading and engine selection are separate. Enabling the plugin makes
+the implementation available; setting `context.engine` selects it.
+
+### Via the bundled-engine directory
+
+Place your engine in `plugins/context_engine/<name>/`. The `__init__.py` must
+export a `ContextEngine` subclass. The discovery system finds and instantiates
+it automatically.
+
+Use this layout only for an engine intended to ship as part of Hermes itself.
+
+Only one engine can be registered. A second plugin attempting to register one
+is rejected with a warning.
+
+## Install and activate a third-party engine
+
+Install from a Git repository and enable the plugin in the active Hermes
+profile:
+
+```bash
+hermes plugins install owner/hermes-context-lcm --enable
+hermes config set context.engine lcm
+hermes gateway restart
+```
+
+The config value must match the engine's `name` property, not necessarily the
+Git repository or manifest name. Start a new session after changing engines;
+existing sessions may retain the engine instance created at session startup.
+
+If the plugin provides its own setup command, run it after installation instead
+of setting its config by hand. Use `hermes plugins list` to confirm that the
+plugin is installed and enabled.
+
+Updates do not modify the selected engine, but a running gateway must reload
+the plugin code:
+
+```bash
+hermes plugins update context-lcm
+hermes gateway restart
+```
+
+Before disabling or removing an active context engine, select the built-in
+compressor so Hermes is never configured to use an unavailable engine:
+
+```bash
+hermes config set context.engine compressor
+hermes plugins disable context-lcm
+hermes plugins remove context-lcm
+hermes gateway restart
+```
 
 ## Lifecycle
 


### PR DESCRIPTION
## Summary

- forward only the optional compression keywords a context-engine plugin declares
- preserve `/compress <focus>` for engines that implement the documented `focus_topic` argument but not the built-in-only `force` extension
- propagate implementation `TypeError`s instead of masking them with a second, reduced-argument call
- document the supported standalone context-engine install, activation, update, restart, and removal flow

## Why

Hermes currently calls every engine with `focus_topic` and `force`, catches any `TypeError`, and retries with only `current_tokens`. That keeps older strict-signature plugins alive, but it also drops manual focus for current third-party engines and can execute a broken compressor twice while hiding its original error.

Signature-aware forwarding preserves backward compatibility without conflating an engine bug with an unsupported keyword. The documentation update makes the standalone route explicit for third-party engines, which aligns with the repository policy that external integrations should not be added under the core `plugins/` tree.

This was exercised while building a standalone local embedding context engine that uses the existing `ContextEngine` and `register_context_engine()` surfaces; no product-specific code is added to Hermes core.

## Validation

- `uv run --python 3.11 --with pytest python -m pytest -q tests/run_agent/test_compress_focus_plugin_fallback.py tests/run_agent/test_plugin_context_engine_init.py tests/agent/test_context_engine.py tests/agent/test_compress_focus.py tests/agent/test_compression_concurrent_fork.py` — 64 passed
- `uvx ruff check agent/conversation_compression.py tests/run_agent/test_compress_focus_plugin_fallback.py tests/agent/test_compression_concurrent_fork.py` — passed
- `npm run build` from `website/` — Docusaurus production build passed for English and Simplified Chinese
- `git diff --check` — passed
