### PR TITLE
fix dashboard post-login target validation

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -388,6 +388,14 @@ def _validate_post_login_target(raw: str) -> str:
         return ""
     from urllib.parse import unquote
     decoded = unquote(raw)
+    # WHATWG URL parsing treats backslashes as authority separators for
+    # special schemes. A seemingly relative ``/\\evil.example`` therefore
+    # resolves cross-origin in browsers. Controls are stripped or normalized
+    # inconsistently across clients, so neither belongs in a redirect target.
+    if "\\" in decoded or any(
+        ord(char) < 0x20 or ord(char) == 0x7F for char in decoded
+    ):
+        return ""
     if not decoded.startswith("/") or decoded.startswith("//"):
         return ""
     # Don't loop back to login pages or auth flow.

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -850,6 +850,21 @@ class TestValidatePostLoginTarget:
         assert _validate_post_login_target("//evil.com") == ""
         assert _validate_post_login_target("%2F%2Fevil.com") == ""
 
+    @pytest.mark.parametrize(
+        "target",
+        (
+            "/\\evil.example",
+            "%2F%5Cevil.example",
+            "/sessions\x00ignored",
+            "%2Fsessions%0Aignored",
+            "/sessions\x7fignored",
+        ),
+    )
+    def test_rejects_browser_normalized_authorities_and_controls(self, target):
+        from hermes_cli.dashboard_auth.routes import _validate_post_login_target
+
+        assert _validate_post_login_target(target) == ""
+
     def test_rejects_login_loop(self):
         from hermes_cli.dashboard_auth.routes import _validate_post_login_target
         assert _validate_post_login_target("/login") == ""

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -342,6 +342,19 @@ class TestPasswordLoginRoute:
         # Malicious absolute URL dropped → lands at root.
         assert resp.json()["next"] == "/"
 
+    def test_browser_normalized_authority_next_is_dropped(self, gated_app):
+        resp = gated_app.post(
+            "/auth/password-login",
+            json={
+                "provider": "testpw",
+                "username": "admin",
+                "password": "hunter2",
+                "next": "/\\evil.example",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["next"] == "/"
+
     def test_route_is_public_unauthenticated(self, gated_app):
         # The login route itself must be reachable without a session —
         # otherwise you could never log in.


### PR DESCRIPTION
## What changed

Reject backslashes and C0/DEL control characters after decoding dashboard post-login targets. Add direct validator coverage and a complete password-login regression that proves a browser-normalized authority falls back to `/`.

## Root cause

The same-origin validator rejected absolute and protocol-relative URLs but accepted `/\\evil.example`. WHATWG URL parsing treats backslashes as authority separators for special schemes, so a browser resolves that value to an external origin after authentication.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_password_login.py tests/hermes_cli/test_dashboard_auth_401_reauth.py` — 77 passed
- `uv run ruff check` on the three changed files
- `git diff --check`

This also preserves the current `main` behavior that routes a sole password provider and legacy `/auth/login?provider=<password-provider>` URLs to the password form.