### PR TITLE
fix(cli): only mark speech-to-text messages as voice input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2994,6 +2994,17 @@ def _should_auto_attach_clipboard_image_on_paste(pasted_text: str) -> bool:
     return not pasted_text.strip()
 
 
+class VoiceTranscript(str):
+    """A user message produced by speech-to-text rather than typed.
+
+    Subclasses ``str`` so it rides the existing ``_pending_input`` queue and
+    passes every ``isinstance(..., str)`` check unchanged. ``process_loop``
+    must read the provenance off the raw queue item — the sanitizers it runs
+    next (paste-wrapper stripping, file-drop rewrites) all return plain
+    ``str``, so the marker does not survive them.
+    """
+
+
 def _strip_leaked_bracketed_paste_wrappers(text: str) -> str:
     from hermes_cli.input_sanitize import strip_leaked_bracketed_paste_wrappers
 
@@ -11381,7 +11392,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 self._attached_images.clear()
                 if hasattr(self, '_app') and self._app:
                     self._app.invalidate()
-                self._pending_input.put(transcript)
+                self._pending_input.put(VoiceTranscript(transcript))
                 submitted = True
             elif result.get("success"):
                 _cprint(f"{_DIM}No speech detected.{_RST}")
@@ -12166,7 +12177,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             except Exception:
                 pass
 
-    def chat(self, message, images: list = None) -> Optional[str]:
+    def _build_voice_prefix(self, message, voice_input: bool) -> str:
+        """Build the API-call-local prefix for a message sent in voice mode.
+
+        Provenance and conciseness are decided separately. The reply is spoken
+        aloud for as long as voice mode is on, so the conciseness instruction
+        applies to typed messages too — but only a real speech-to-text
+        transcript may claim to be voice input. Labelling typed text "Voice
+        input" let the model read it as proof that transcription was working,
+        masking STT failures (#65827).
+
+        Returns "" when voice mode is off or the message is multimodal.
+        """
+        if not (self._voice_mode and isinstance(message, str)):
+            return ""
+        provenance = "Voice input" if voice_input else "Typed input (not transcribed)"
+        return (
+            f"[{provenance} — respond concisely and conversationally, "
+            "2-3 sentences max. No code blocks or markdown.] "
+        )
+
+    def chat(self, message, images: list = None, voice_input: bool = False) -> Optional[str]:
         """
         Send a message to the agent and get a response.
         
@@ -12181,7 +12212,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         Args:
             message: The user's message (str or multimodal content list)
             images: Optional list of Path objects for attached images
-            
+            voice_input: True only when message came from speech-to-text.
+                Voice mode being active is not sufficient — the user can type
+                while it is on (#65827).
+
         Returns:
             The agent's response, or None on error
         """
@@ -12403,15 +12437,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if text_queue is not None:
                         text_queue.put(delta)
 
-            # When voice mode is active, prepend a brief instruction so the
-            # model responds concisely. The prefix is API-call-local only —
-            # run_conversation persists the original clean user message.
-            _voice_prefix = ""
-            if self._voice_mode and isinstance(message, str):
-                _voice_prefix = (
-                    "[Voice input — respond concisely and conversationally, "
-                    "2-3 sentences max. No code blocks or markdown.] "
-                )
+            # The prefix is API-call-local only — run_conversation persists the
+            # original clean user message.
+            _voice_prefix = self._build_voice_prefix(message, voice_input)
 
             def run_agent():
                 nonlocal result
@@ -15373,6 +15401,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if isinstance(user_input, tuple):
                         user_input, submit_images = user_input
 
+                    # Read speech-to-text provenance before the sanitizers below
+                    # rebuild user_input as a plain str and drop the marker.
+                    _is_voice_input = isinstance(user_input, VoiceTranscript)
+
                     if isinstance(user_input, str):
                         user_input = _strip_leaked_bracketed_paste_wrappers(user_input)
                         user_input, _had_mouse_reports = _strip_leaked_terminal_responses_with_meta(user_input)
@@ -15454,7 +15486,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     app.invalidate()  # Refresh status line
 
                     try:
-                        self.chat(user_input, images=submit_images or None)
+                        self.chat(
+                            user_input,
+                            images=submit_images or None,
+                            voice_input=_is_voice_input,
+                        )
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -392,6 +392,123 @@ class TestVoiceMessagePrefix:
 
 
 # ============================================================================
+# Voice input provenance (#65827) — exercises the real cli.py code
+# ============================================================================
+
+class TestVoiceInputProvenance:
+    """Only a real speech-to-text transcript may be labelled voice input.
+
+    Voice mode stays on while the user types, so the mode flag alone cannot
+    tell the model where a message came from (#65827).
+    """
+
+    @patch("cli._cprint")
+    @patch("cli.os.unlink")
+    @patch("cli.os.path.isfile", return_value=True)
+    @patch("hermes_cli.config.load_config", return_value={"stt": {}})
+    @patch("tools.voice_mode.transcribe_recording",
+           return_value={"success": True, "transcript": "hello world"})
+    @patch("tools.voice_mode.play_beep")
+    def test_transcript_is_queued_tagged_as_voice(
+        self, _beep, _tr, _cfg, _isf, _unl, _cp
+    ):
+        """The STT path tags what it queues so process_loop can tell it apart."""
+        from cli import VoiceTranscript
+
+        recorder = MagicMock()
+        recorder.stop.return_value = "/tmp/test.wav"
+        cli = _make_voice_cli(_voice_recording=True, _voice_recorder=recorder)
+
+        cli._voice_stop_and_transcribe()
+
+        queued = cli._pending_input.get_nowait()
+        assert isinstance(queued, VoiceTranscript)
+        # Still an ordinary string value to every existing consumer.
+        assert queued == "hello world"
+        assert isinstance(queued, str)
+
+    def test_typed_input_is_not_tagged_as_voice(self):
+        """A plain queued string (what the Enter handler puts) is not voice."""
+        from cli import VoiceTranscript
+
+        cli = _make_voice_cli()
+        cli._pending_input.put("typed by hand")
+
+        assert not isinstance(cli._pending_input.get_nowait(), VoiceTranscript)
+
+    def test_tag_survives_the_pending_input_queue(self):
+        """process_loop reads provenance off the queue item, so it must survive."""
+        from cli import VoiceTranscript
+
+        cli = _make_voice_cli()
+        cli._pending_input.put(VoiceTranscript("spoken"))
+
+        assert isinstance(cli._pending_input.get_nowait(), VoiceTranscript)
+
+    def test_real_transcript_is_marked_voice_input(self):
+        """A genuine transcript keeps the voice-input label."""
+        cli = _make_voice_cli(_voice_mode=True)
+
+        prefix = cli._build_voice_prefix("what's the weather", voice_input=True)
+
+        assert prefix.startswith("[Voice input")
+
+    def test_typed_message_in_voice_mode_is_not_marked_voice_input(self):
+        """Regression for #65827: typing while voice mode is on claimed STT.
+
+        Before the fix the prefix was chosen from ``self._voice_mode`` alone,
+        so a typed message arrived labelled "[Voice input", and the model read
+        it as evidence that transcription had started working.
+        """
+        cli = _make_voice_cli(_voice_mode=True)
+
+        prefix = cli._build_voice_prefix("no, that was typed", voice_input=False)
+
+        assert not prefix.startswith("[Voice input")
+        assert "not transcribed" in prefix
+
+    def test_typed_and_voice_prefixes_are_distinguishable(self):
+        """The model must be able to tell the two provenances apart."""
+        cli = _make_voice_cli(_voice_mode=True)
+
+        spoken = cli._build_voice_prefix("same text", voice_input=True)
+        typed = cli._build_voice_prefix("same text", voice_input=False)
+
+        assert spoken != typed
+
+    def test_typed_message_in_voice_mode_keeps_conciseness_instruction(self):
+        """The reply is still spoken aloud, so brevity guidance must remain."""
+        cli = _make_voice_cli(_voice_mode=True)
+
+        prefix = cli._build_voice_prefix("still spoken back to me", voice_input=False)
+
+        assert "respond concisely and conversationally" in prefix
+        assert "No code blocks or markdown." in prefix
+
+    def test_no_prefix_when_voice_mode_off(self):
+        """Outside voice mode nothing is prepended, transcript or not."""
+        cli = _make_voice_cli(_voice_mode=False)
+
+        assert cli._build_voice_prefix("hello", voice_input=False) == ""
+        assert cli._build_voice_prefix("hello", voice_input=True) == ""
+
+    def test_no_prefix_for_multimodal_content(self):
+        """Multimodal content lists are left alone."""
+        cli = _make_voice_cli(_voice_mode=True)
+        message = [{"type": "text", "text": "describe this"}, {"type": "image_url"}]
+
+        assert cli._build_voice_prefix(message, voice_input=True) == ""
+
+    def test_chat_defaults_to_not_voice(self):
+        """Callers that cannot know provenance must not claim voice input."""
+        import inspect
+
+        from cli import HermesCLI
+
+        assert inspect.signature(HermesCLI.chat).parameters["voice_input"].default is False
+
+
+# ============================================================================
 # _vprint force parameter (Minor fix)
 # ============================================================================
 


### PR DESCRIPTION
## What does this PR do?

Voice mode stays active while you type, but the `[Voice input ...]` prefix in `chat()` was selected from `self._voice_mode` alone. Every message sent while voice mode was on therefore reached the model labelled as a speech-to-text transcript, so the model had no way to tell a real transcript from typed text. In the reported case it took a typed troubleshooting message as evidence that transcription had started working, when it hadn't.

A transcript is only produced in one place (`_voice_stop_and_transcribe`), so that's where I tag it. `VoiceTranscript` is a `str` subclass, which is what keeps the change small: it rides the existing `_pending_input` queue and satisfies every `isinstance(..., str)` check unchanged, so none of the other producers or consumers need to learn a new payload shape. `process_loop` reads the tag off the raw queue item and passes it to `chat(voice_input=...)`. That read has to happen where it does — the sanitizers immediately after it (paste-wrapper stripping, file-drop rewrites) return plain `str` and the subclass doesn't survive them.

One thing worth a second opinion: that prefix was doing two jobs at once, provenance *and* conciseness. The reply is still spoken aloud for as long as voice mode is on, so I kept the brevity instruction for typed messages and only changed the label to `Typed input (not transcribed)`. The issue suggested either leaving typed messages unmarked or giving each message explicit provenance; I went with explicit provenance, since dropping the prefix entirely would make spoken replies to typed messages long again. The prefix for a real transcript is byte-for-byte what it was before, and `chat()` defaults to `voice_input=False` so no caller can claim voice input by accident.

## Related Issue

Fixes #65827

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: add a `VoiceTranscript(str)` marker for messages that came from speech-to-text.
- `cli.py` (`_voice_stop_and_transcribe`): tag the transcript when queueing it.
- `cli.py` (`process_loop`): read the tag off the queue item before the sanitizers flatten it, and pass it through to `chat()`.
- `cli.py` (`chat`): new `voice_input` parameter, defaulting to `False`.
- `cli.py` (`_build_voice_prefix`): pulled the prefix construction out of `chat()` into its own method so it can be tested directly, and picked the provenance label from `voice_input` rather than `_voice_mode`.
- `tests/tools/test_voice_cli_integration.py`: new `TestVoiceInputProvenance` covering both paths.

## How to Test

No microphone needed — the STT call is mocked, so the reproduction is deterministic:

```
pytest tests/tools/test_voice_cli_integration.py::TestVoiceInputProvenance -q
```

To watch it catch the original bug, change the provenance line in `_build_voice_prefix` back to the old behaviour:

```python
provenance = "Voice input"
```

`test_typed_message_in_voice_mode_is_not_marked_voice_input` and `test_typed_and_voice_prefixes_are_distinguishable` then fail with the reported symptom, a typed message arriving as `[Voice input — respond concisely ...]`.

Manually, against a real session: start `hermes`, turn on voice mode, record a message, then type a follow-up without leaving voice mode. The recorded one reaches the agent as `[Voice input — ...]`, the typed one as `[Typed input (not transcribed) — ...]`. Session history is unaffected either way; the prefix stays API-call-local as before.

The existing `TestVoiceMessagePrefix` tests re-implement the prefix logic inline rather than calling into `cli.py`, so they pass either way — the new tests exercise the real methods.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected suites rather than the whole tree: `tests/cli/`, `tests/tools/test_voice_cli_integration.py`, `tests/tools/test_clipboard.py` and the voice/prefix/persist tests in `tests/run_agent/`. `tests/cli/` has 13 failures on Windows (symlink privileges, and source-reading tests that hit `cp1252`), but the set is identical with and without this change, and they reproduce on a clean `main`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings only; no user-facing docs describe this prefix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python, no platform-specific paths; reported on macOS, fixed and tested on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
