### PR TITLE
Add pre_plugin_install / pre_mcp_add lifecycle hooks

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -90,10 +90,12 @@ def _save_mcp_server(name: str, server_config: dict) -> bool:
     """Add or update a server entry in config.yaml.
 
     Returns False when a high-signal exfiltration-shaped stdio command is
-    rejected. MCP stdio servers are user-chosen local commands, so this blocks
-    shell+egress payloads rather than whitelisting command families.
+    rejected, or when a ``pre_mcp_add`` hook returns a block reason (e.g. a
+    security-scan verdict). MCP stdio servers are user-chosen local commands,
+    so this blocks shell+egress payloads rather than whitelisting command families.
     """
     issues = validate_mcp_server_entry(name, server_config)
+    # invoke_hook drops a callback that raises (fail-open), so gates must RETURN a block reason, not raise.
     for ret in invoke_hook("pre_mcp_add", name=name, server_config=server_config):
         if isinstance(ret, str):
             issues.append(ret)

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -26,6 +26,7 @@ from hermes_cli.config import (
 from hermes_cli.colors import Colors, color
 from hermes_constants import display_hermes_home
 from hermes_cli.mcp_security import validate_mcp_server_entry
+from hermes_cli.plugins import invoke_hook
 from tools.mcp_tool import _ENV_VAR_PATTERN, _env_ref_name
 
 logger = logging.getLogger(__name__)
@@ -93,6 +94,11 @@ def _save_mcp_server(name: str, server_config: dict) -> bool:
     shell+egress payloads rather than whitelisting command families.
     """
     issues = validate_mcp_server_entry(name, server_config)
+    for ret in invoke_hook("pre_mcp_add", name=name, server_config=server_config):
+        if isinstance(ret, str):
+            issues.append(ret)
+        elif isinstance(ret, (list, tuple)):
+            issues.extend(str(x) for x in ret if x)
     if issues:
         for issue in issues:
             _warning(issue)

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -481,6 +481,15 @@ def cmd_mcp_add(args):
         server_config["connect_timeout"] = raw_connect_timeout
 
     issues = validate_mcp_server_entry(name, server_config)
+    # Fire the install gate BEFORE discovery: `_probe_single_server` below
+    # connects to (and for stdio, launches) the untrusted server, so a
+    # save-time-only gate would run only after that execution. invoke_hook drops
+    # a callback that raises (fail-open), so gates must RETURN a block reason.
+    for ret in invoke_hook("pre_mcp_add", name=name, server_config=server_config):
+        if isinstance(ret, str):
+            issues.append(ret)
+        elif isinstance(ret, (list, tuple)):
+            issues.extend(str(x) for x in ret if x)
     if issues:
         for issue in issues:
             _warning(issue)

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -26,7 +26,7 @@ from hermes_cli.config import (
 from hermes_cli.colors import Colors, color
 from hermes_constants import display_hermes_home
 from hermes_cli.mcp_security import validate_mcp_server_entry
-from hermes_cli.plugins import invoke_hook
+from hermes_cli.plugins import collect_hook_block_reasons
 from tools.mcp_tool import _ENV_VAR_PATTERN, _env_ref_name
 
 logger = logging.getLogger(__name__)
@@ -95,12 +95,11 @@ def _save_mcp_server(name: str, server_config: dict) -> bool:
     so this blocks shell+egress payloads rather than whitelisting command families.
     """
     issues = validate_mcp_server_entry(name, server_config)
-    # invoke_hook drops a callback that raises (fail-open), so gates must RETURN a block reason, not raise.
-    for ret in invoke_hook("pre_mcp_add", name=name, server_config=server_config):
-        if isinstance(ret, str):
-            issues.append(ret)
-        elif isinstance(ret, (list, tuple)):
-            issues.extend(str(x) for x in ret if x)
+    # collect_hook_block_reasons also loads the trusted plugin registry — this
+    # runs from built-in commands that skip startup discovery.
+    issues.extend(
+        collect_hook_block_reasons("pre_mcp_add", name=name, server_config=server_config)
+    )
     if issues:
         for issue in issues:
             _warning(issue)
@@ -145,6 +144,11 @@ def _replace_mcp_servers(servers: Dict[str, dict]) -> Tuple[bool, List[str]]:
             issues.append(f"Server '{name}': expected an object")
             continue
         issues.extend(validate_mcp_server_entry(name, cfg))
+        # Same pre_mcp_add gate as _save_mcp_server — dashboard whole-map
+        # edits land here, not through the per-key upsert.
+        issues.extend(
+            collect_hook_block_reasons("pre_mcp_add", name=name, server_config=cfg)
+        )
 
     if issues:
         return False, issues
@@ -483,13 +487,10 @@ def cmd_mcp_add(args):
     issues = validate_mcp_server_entry(name, server_config)
     # Fire the install gate BEFORE discovery: `_probe_single_server` below
     # connects to (and for stdio, launches) the untrusted server, so a
-    # save-time-only gate would run only after that execution. invoke_hook drops
-    # a callback that raises (fail-open), so gates must RETURN a block reason.
-    for ret in invoke_hook("pre_mcp_add", name=name, server_config=server_config):
-        if isinstance(ret, str):
-            issues.append(ret)
-        elif isinstance(ret, (list, tuple)):
-            issues.extend(str(x) for x in ret if x)
+    # save-time-only gate would run only after that execution.
+    issues.extend(
+        collect_hook_block_reasons("pre_mcp_add", name=name, server_config=server_config)
+    )
     if issues:
         for issue in issues:
             _warning(issue)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2068,6 +2068,41 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
 
 
+def collect_hook_block_reasons(hook_name: str, **kwargs: Any) -> List[str]:
+    """Fire an install-gate hook and flatten returned block reasons.
+
+    Built-in management commands (``plugins install``, ``mcp add``) skip
+    startup plugin discovery, so load the trusted registry first — otherwise
+    the gate would fire against an empty registry and never block.
+
+    Deliberately fail-soft on discovery itself: a discovery failure (or
+    ``HERMES_SAFE_MODE``, which skips plugin loading entirely) means the gate
+    runs with no plugin callbacks and allows the operation — the same behavior
+    as having no gate plugin installed. Failing closed here would brick
+    ``mcp add``/``plugins install`` for every user on any discovery hiccup.
+    Callbacks that raise are dropped by invoke_hook (also fail-open), so gates
+    must RETURN a block reason, not raise.
+    """
+    try:
+        discover_plugins()
+    except Exception:
+        logger.warning(
+            "plugin discovery failed before %s gate — gate runs without "
+            "plugin callbacks (fail-open)",
+            hook_name,
+            exc_info=True,
+        )
+    reasons: List[str] = []
+    for ret in invoke_hook(hook_name, **kwargs):
+        # `if ret`: an empty string is not a block reason (matches the
+        # non-empty filter in the list branch below).
+        if isinstance(ret, str) and ret:
+            reasons.append(ret)
+        elif isinstance(ret, (list, tuple)):
+            reasons.extend(str(x) for x in ret if x)
+    return reasons
+
+
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:
     """Invoke registered middleware callbacks.
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -212,6 +212,20 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    # Install-time security gates. Fired at the sole plugin/MCP install choke
+    # points, AFTER argument parsing and reference resolution but BEFORE the
+    # artifact is trusted (plugin promoted into ~/.hermes/plugins; MCP entry
+    # written to config.yaml). A callback returns None to allow, or a non-empty
+    # str / list[str] of block reasons to REJECT — mirroring the built-in
+    # validate_mcp_server_entry() gate. Reasons abort the operation.
+    #
+    # pre_plugin_install kwargs: name: str, git_url: str, subdir: str | None,
+    #   path: str (local dir of the freshly cloned, not-yet-trusted plugin),
+    #   manifest: dict.
+    # pre_mcp_add kwargs: name: str, server_config: dict (fully resolved:
+    #   command/args/url/env/headers/connect_timeout).
+    "pre_plugin_install",
+    "pre_mcp_add",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -22,6 +22,7 @@ from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_cli.config import cfg_get
+from hermes_cli.plugins import invoke_hook
 from hermes_cli.secret_prompt import masked_secret_prompt
 
 logger = logging.getLogger(__name__)
@@ -498,6 +499,29 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
         plugin_name = manifest.get("name") or (
             subdir.rstrip("/").rsplit("/", 1)[-1] if subdir else _repo_name_from_url(git_url)
         )
+
+        # Security gate: let plugins scan the freshly cloned, not-yet-trusted
+        # artifact before it is promoted into ~/.hermes/plugins. A returned
+        # reason aborts the install (fail-closed), same contract as
+        # validate_mcp_server_entry for MCP servers.
+        gate_reasons: list[str] = []
+        for ret in invoke_hook(
+            "pre_plugin_install",
+            name=plugin_name,
+            git_url=git_url,
+            subdir=subdir,
+            path=str(tmp_target),
+            manifest=manifest,
+        ):
+            if isinstance(ret, str):
+                gate_reasons.append(ret)
+            elif isinstance(ret, (list, tuple)):
+                gate_reasons.extend(str(x) for x in ret if x)
+        if gate_reasons:
+            raise PluginOperationError(
+                f"Plugin '{plugin_name}' blocked by an install gate:\n"
+                + "\n".join(f"  - {r}" for r in gate_reasons)
+            )
 
         try:
             target = _sanitize_plugin_name(plugin_name, plugins_dir)

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -505,6 +505,7 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
         # reason aborts the install (fail-closed), same contract as
         # validate_mcp_server_entry for MCP servers.
         gate_reasons: list[str] = []
+        # invoke_hook drops a callback that raises (fail-open), so gates must RETURN a block reason, not raise.
         for ret in invoke_hook(
             "pre_plugin_install",
             name=plugin_name,

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -22,7 +22,7 @@ from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_cli.config import cfg_get
-from hermes_cli.plugins import invoke_hook
+from hermes_cli.plugins import collect_hook_block_reasons
 from hermes_cli.secret_prompt import masked_secret_prompt
 
 logger = logging.getLogger(__name__)
@@ -504,20 +504,16 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
         # artifact before it is promoted into ~/.hermes/plugins. A returned
         # reason aborts the install (fail-closed), same contract as
         # validate_mcp_server_entry for MCP servers.
-        gate_reasons: list[str] = []
-        # invoke_hook drops a callback that raises (fail-open), so gates must RETURN a block reason, not raise.
-        for ret in invoke_hook(
+        # collect_hook_block_reasons also loads the trusted plugin registry:
+        # `plugins install` is a built-in command that skips startup discovery.
+        gate_reasons = collect_hook_block_reasons(
             "pre_plugin_install",
             name=plugin_name,
             git_url=git_url,
             subdir=subdir,
             path=str(tmp_target),
             manifest=manifest,
-        ):
-            if isinstance(ret, str):
-                gate_reasons.append(ret)
-            elif isinstance(ret, (list, tuple)):
-                gate_reasons.extend(str(x) for x in ret if x)
+        )
         if gate_reasons:
             raise PluginOperationError(
                 f"Plugin '{plugin_name}' blocked by an install gate:\n"

--- a/tests/hermes_cli/test_plugins_install_hook.py
+++ b/tests/hermes_cli/test_plugins_install_hook.py
@@ -4,8 +4,13 @@ A registered ``pre_plugin_install`` callback can block an install by
 returning a reason (str, or list/tuple of strs). The install must abort
 fail-closed with ``PluginOperationError`` before the clone is promoted
 (``shutil.move``) into ``~/.hermes/plugins``. With no callback registered
-(the default), ``invoke_hook`` returns ``[]`` and the install proceeds
+(the default), the gate returns no reasons and the install proceeds
 unaffected.
+
+The gate goes through ``collect_hook_block_reasons``, which loads the
+trusted plugin registry first — ``plugins install`` is a built-in command
+that skips startup discovery, so without that load the gate would fire
+against an empty registry (the bug flagged in PR review).
 """
 
 from __future__ import annotations
@@ -14,7 +19,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import hermes_cli.plugins as plugins_mod
 from hermes_cli import plugins_cmd
+
+
+def _patch_gate(monkeypatch, returns):
+    """Patch plugins-level discovery + hook invocation for unit tests."""
+    monkeypatch.setattr(plugins_mod, "discover_plugins", lambda force=False: None)
+    monkeypatch.setattr(
+        plugins_mod,
+        "invoke_hook",
+        lambda hook_name, **kw: returns if hook_name == "pre_plugin_install" else [],
+    )
 
 
 @patch("hermes_cli.plugins_cmd.shutil.move")
@@ -30,13 +46,7 @@ def test_pre_plugin_install_block_aborts(
     mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
     mock_read_manifest.return_value = {"name": "evil"}
 
-    monkeypatch.setattr(
-        plugins_cmd,
-        "invoke_hook",
-        lambda hook_name, **kw: (
-            [["blocked by test"]] if hook_name == "pre_plugin_install" else []
-        ),
-    )
+    _patch_gate(monkeypatch, [["blocked by test"]])
 
     with pytest.raises(plugins_cmd.PluginOperationError, match="blocked by test"):
         plugins_cmd._install_plugin_core("owner/repo", force=False)
@@ -64,9 +74,59 @@ def test_no_callback_registered_install_proceeds(
     mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
     mock_read_manifest.return_value = {"name": "well-behaved"}
 
-    monkeypatch.setattr(plugins_cmd, "invoke_hook", lambda hook_name, **kw: [])
+    _patch_gate(monkeypatch, [])
 
     target, manifest, name = plugins_cmd._install_plugin_core("owner/repo", force=False)
 
     mock_move.assert_called_once()
     assert name == "well-behaved"
+
+
+@patch("hermes_cli.plugins_cmd.shutil.move")
+@patch("hermes_cli.plugins_cmd._plugins_dir")
+@patch("hermes_cli.plugins_cmd._read_manifest")
+@patch("hermes_cli.plugins_cmd.subprocess.run")
+def test_real_temp_plugin_gate_blocks_install(
+    mock_run, mock_read_manifest, mock_plugins_dir, mock_move, tmp_path, monkeypatch
+):
+    """End-to-end: a REAL plugin in a temp HERMES_HOME, loaded by the normal
+    discovery sweep (no invoke_hook patching), blocks the install.
+
+    Regression for the empty-registry bug: ``plugins install`` never ran
+    ``discover_plugins()``, so a registered gate plugin was invisible to the
+    hook and the gate silently allowed everything.
+    """
+    home = tmp_path / "home"
+    gate_dir = home / "plugins" / "gatekeeper"
+    gate_dir.mkdir(parents=True)
+    (gate_dir / "plugin.yaml").write_text(
+        "name: gatekeeper\nversion: 1.0.0\nhooks:\n  - pre_plugin_install\n"
+    )
+    (gate_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        "    ctx.register_hook(\n"
+        "        'pre_plugin_install',\n"
+        "        lambda **kw: ['blocked by gatekeeper: ' + kw.get('name', '?')],\n"
+        "    )\n"
+    )
+    (home / "config.yaml").write_text("plugins:\n  enabled:\n    - gatekeeper\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    # Keep the sweep minimal: no bundled plugins, fresh manager instance.
+    empty = tmp_path / "no-bundled"
+    empty.mkdir()
+    monkeypatch.setattr(plugins_mod, "get_bundled_plugins_dir", lambda: empty)
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", None)
+
+    plugins_dir = tmp_path / "install-target"
+    plugins_dir.mkdir()
+    mock_plugins_dir.return_value = plugins_dir
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    mock_read_manifest.return_value = {"name": "evil"}
+
+    with pytest.raises(
+        plugins_cmd.PluginOperationError, match="blocked by gatekeeper: evil"
+    ):
+        plugins_cmd._install_plugin_core("owner/repo", force=False)
+
+    mock_move.assert_not_called()

--- a/tests/hermes_cli/test_plugins_install_hook.py
+++ b/tests/hermes_cli/test_plugins_install_hook.py
@@ -1,0 +1,72 @@
+"""Tests for the ``pre_plugin_install`` gate hook in ``_install_plugin_core``.
+
+A registered ``pre_plugin_install`` callback can block an install by
+returning a reason (str, or list/tuple of strs). The install must abort
+fail-closed with ``PluginOperationError`` before the clone is promoted
+(``shutil.move``) into ``~/.hermes/plugins``. With no callback registered
+(the default), ``invoke_hook`` returns ``[]`` and the install proceeds
+unaffected.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import plugins_cmd
+
+
+@patch("hermes_cli.plugins_cmd.shutil.move")
+@patch("hermes_cli.plugins_cmd._plugins_dir")
+@patch("hermes_cli.plugins_cmd._read_manifest")
+@patch("hermes_cli.plugins_cmd.subprocess.run")
+def test_pre_plugin_install_block_aborts(
+    mock_run, mock_read_manifest, mock_plugins_dir, mock_move, tmp_path, monkeypatch
+):
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    mock_plugins_dir.return_value = plugins_dir
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    mock_read_manifest.return_value = {"name": "evil"}
+
+    monkeypatch.setattr(
+        plugins_cmd,
+        "invoke_hook",
+        lambda hook_name, **kw: (
+            [["blocked by test"]] if hook_name == "pre_plugin_install" else []
+        ),
+    )
+
+    with pytest.raises(plugins_cmd.PluginOperationError, match="blocked by test"):
+        plugins_cmd._install_plugin_core("owner/repo", force=False)
+
+    mock_move.assert_not_called()
+
+
+@patch("hermes_cli.plugins_cmd._copy_example_files")
+@patch("hermes_cli.plugins_cmd.shutil.move")
+@patch("hermes_cli.plugins_cmd._plugins_dir")
+@patch("hermes_cli.plugins_cmd._read_manifest")
+@patch("hermes_cli.plugins_cmd.subprocess.run")
+def test_no_callback_registered_install_proceeds(
+    mock_run,
+    mock_read_manifest,
+    mock_plugins_dir,
+    mock_move,
+    mock_copy_example_files,
+    tmp_path,
+    monkeypatch,
+):
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    mock_plugins_dir.return_value = plugins_dir
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    mock_read_manifest.return_value = {"name": "well-behaved"}
+
+    monkeypatch.setattr(plugins_cmd, "invoke_hook", lambda hook_name, **kw: [])
+
+    target, manifest, name = plugins_cmd._install_plugin_core("owner/repo", force=False)
+
+    mock_move.assert_called_once()
+    assert name == "well-behaved"

--- a/tests/test_mcp_add_gate.py
+++ b/tests/test_mcp_add_gate.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+from hermes_cli import mcp_config
+
+
+def test_pre_mcp_add_blocks_before_probe(monkeypatch):
+    # Regression: the gate must reject BEFORE `_probe_single_server`, which for a
+    # stdio server launches the (untrusted) command during discovery. A
+    # save-time-only gate would run after that execution.
+    probed = {"called": False}
+
+    def _fake_probe(name, cfg):
+        probed["called"] = True
+        return []
+
+    saved = {"called": False}
+
+    monkeypatch.setattr(mcp_config, "_get_mcp_servers", lambda: {})
+    monkeypatch.setattr(mcp_config, "_probe_single_server", _fake_probe)
+    monkeypatch.setattr(
+        mcp_config,
+        "invoke_hook",
+        lambda hook, **kw: [["blocked by test"]] if hook == "pre_mcp_add" else [],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        mcp_config,
+        "_save_mcp_server",
+        lambda *a, **k: saved.__setitem__("called", True) or True,
+    )
+
+    args = SimpleNamespace(
+        name="evil",
+        url=None,
+        mcp_command="node",
+        args=["/tmp/evil.js"],
+        auth=None,
+        preset=None,
+        env=None,
+        connect_timeout=None,
+    )
+    mcp_config.cmd_mcp_add(args)
+
+    assert probed["called"] is False  # rejected before discovery/launch
+    assert saved["called"] is False  # and never persisted

--- a/tests/test_mcp_add_gate.py
+++ b/tests/test_mcp_add_gate.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+import hermes_cli.plugins as plugins_mod
 from hermes_cli import mcp_config
 
 
@@ -17,11 +18,13 @@ def test_pre_mcp_add_blocks_before_probe(monkeypatch):
 
     monkeypatch.setattr(mcp_config, "_get_mcp_servers", lambda: {})
     monkeypatch.setattr(mcp_config, "_probe_single_server", _fake_probe)
+    # Gate goes through plugins.collect_hook_block_reasons — patch at the
+    # plugins module, whose globals the helper resolves.
+    monkeypatch.setattr(plugins_mod, "discover_plugins", lambda force=False: None)
     monkeypatch.setattr(
-        mcp_config,
+        plugins_mod,
         "invoke_hook",
         lambda hook, **kw: [["blocked by test"]] if hook == "pre_mcp_add" else [],
-        raising=False,
     )
     monkeypatch.setattr(
         mcp_config,

--- a/tests/test_mcp_save_hook.py
+++ b/tests/test_mcp_save_hook.py
@@ -1,20 +1,29 @@
+import hermes_cli.plugins as plugins_mod
 from hermes_cli import mcp_config
 
 
-def test_pre_mcp_add_block_rejects_save(monkeypatch):
-    # NOTE: the callback's first positional param must not be named "name" —
-    # _save_mcp_server calls invoke_hook("pre_mcp_add", name=name, ...), and a
-    # "name" positional param collides with that keyword (TypeError: got
-    # multiple values for argument 'name'). Use hook_name, matching the
-    # pre_plugin_install hook test.
+def _patch_gate(monkeypatch, returns):
+    """Patch plugins-level discovery + hook invocation.
+
+    The gate sites call ``collect_hook_block_reasons``, which resolves
+    ``discover_plugins``/``invoke_hook`` as globals of hermes_cli.plugins —
+    patch there, not on the consuming module.
+
+    NOTE: the callback's first positional param must not be named "name" —
+    the gate calls invoke_hook("pre_mcp_add", name=name, ...), and a "name"
+    positional param collides with that keyword (TypeError: got multiple
+    values for argument 'name'). Use hook_name.
+    """
+    monkeypatch.setattr(plugins_mod, "discover_plugins", lambda force=False: None)
     monkeypatch.setattr(
-        mcp_config,
+        plugins_mod,
         "invoke_hook",
-        lambda hook_name, **kw: (
-            [["mcp blocked by test"]] if hook_name == "pre_mcp_add" else []
-        ),
-        raising=False,
+        lambda hook_name, **kw: returns if hook_name == "pre_mcp_add" else [],
     )
+
+
+def test_pre_mcp_add_block_rejects_save(monkeypatch):
+    _patch_gate(monkeypatch, [["mcp blocked by test"]])
     # No IOC in this entry, so validate_mcp_server_entry alone would allow it.
     saved = mcp_config._save_mcp_server("x", {"command": "npx", "args": ["@scope/s"]})
     assert saved is False
@@ -22,14 +31,30 @@ def test_pre_mcp_add_block_rejects_save(monkeypatch):
 
 def test_pre_mcp_add_block_str_rejects_save(monkeypatch):
     # Hook callbacks may also return a bare string rather than a list — the
-    # flatten logic in _save_mcp_server must handle both shapes.
-    monkeypatch.setattr(
-        mcp_config,
-        "invoke_hook",
-        lambda hook_name, **kw: (
-            ["mcp blocked str"] if hook_name == "pre_mcp_add" else []
-        ),
-        raising=False,
-    )
+    # flatten logic in collect_hook_block_reasons must handle both shapes.
+    _patch_gate(monkeypatch, ["mcp blocked str"])
     saved = mcp_config._save_mcp_server("x", {"command": "npx", "args": ["@scope/s"]})
     assert saved is False
+
+
+def test_pre_mcp_add_block_rejects_bulk_replace(monkeypatch):
+    # Dashboard whole-map edits go through _replace_mcp_servers, NOT
+    # _save_mcp_server — the gate must fire there too (PR review finding).
+    _patch_gate(monkeypatch, [["mcp blocked by test"]])
+    ok, issues = mcp_config._replace_mcp_servers(
+        {"x": {"command": "npx", "args": ["@scope/s"]}}
+    )
+    assert ok is False
+    assert any("mcp blocked by test" in i for i in issues)
+
+
+def test_bulk_replace_proceeds_without_callbacks(monkeypatch):
+    _patch_gate(monkeypatch, [])
+    saved = {}
+    monkeypatch.setattr(mcp_config, "load_config", lambda: {})
+    monkeypatch.setattr(mcp_config, "save_config", lambda cfg: saved.update(cfg))
+    ok, issues = mcp_config._replace_mcp_servers(
+        {"x": {"command": "npx", "args": ["@scope/s"]}}
+    )
+    assert ok is True and issues == []
+    assert saved["mcp_servers"]["x"]["command"] == "npx"

--- a/tests/test_mcp_save_hook.py
+++ b/tests/test_mcp_save_hook.py
@@ -1,0 +1,35 @@
+from hermes_cli import mcp_config
+
+
+def test_pre_mcp_add_block_rejects_save(monkeypatch):
+    # NOTE: the callback's first positional param must not be named "name" —
+    # _save_mcp_server calls invoke_hook("pre_mcp_add", name=name, ...), and a
+    # "name" positional param collides with that keyword (TypeError: got
+    # multiple values for argument 'name'). Use hook_name, matching the
+    # pre_plugin_install hook test.
+    monkeypatch.setattr(
+        mcp_config,
+        "invoke_hook",
+        lambda hook_name, **kw: (
+            [["mcp blocked by test"]] if hook_name == "pre_mcp_add" else []
+        ),
+        raising=False,
+    )
+    # No IOC in this entry, so validate_mcp_server_entry alone would allow it.
+    saved = mcp_config._save_mcp_server("x", {"command": "npx", "args": ["@scope/s"]})
+    assert saved is False
+
+
+def test_pre_mcp_add_block_str_rejects_save(monkeypatch):
+    # Hook callbacks may also return a bare string rather than a list — the
+    # flatten logic in _save_mcp_server must handle both shapes.
+    monkeypatch.setattr(
+        mcp_config,
+        "invoke_hook",
+        lambda hook_name, **kw: (
+            ["mcp blocked str"] if hook_name == "pre_mcp_add" else []
+        ),
+        raising=False,
+    )
+    saved = mcp_config._save_mcp_server("x", {"command": "npx", "args": ["@scope/s"]})
+    assert saved is False

--- a/tests/test_plugins_hooks.py
+++ b/tests/test_plugins_hooks.py
@@ -1,0 +1,6 @@
+from hermes_cli.plugins import VALID_HOOKS
+
+
+def test_install_gate_hooks_are_registered_events():
+    assert "pre_plugin_install" in VALID_HOOKS
+    assert "pre_mcp_add" in VALID_HOOKS

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -371,7 +371,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Four hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call, and the install gates [`pre_plugin_install`](#pre_plugin_install) / [`pre_mcp_add`](#pre_mcp_add) can **reject** a plugin install or MCP server save by returning block reasons. All other hooks are fire-and-forget observers.
 - Observer callbacks receive `telemetry_schema_version` automatically. When present, `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are separate correlation fields. Treat `api_request_id` as an opaque identifier; do not parse its string format.
 
 ### Quick reference
@@ -395,6 +395,8 @@ def register(ctx):
 | [`transform_tool_result`](#transform_tool_result) | After any tool returns, before the result is handed back to the model | `str` to replace the result, `None` to leave unchanged |
 | [`transform_terminal_output`](#transform_terminal_output) | Inside the `terminal` tool, before truncation/ANSI-strip/redact | `str` to replace the raw output, `None` to leave unchanged |
 | [`transform_llm_output`](#transform_llm_output) | After the tool-calling loop completes, before the final response is delivered | `str` to replace the response text, `None`/empty to leave unchanged |
+| [`pre_plugin_install`](#pre_plugin_install) | After a plugin is cloned, before it is promoted into `~/.hermes/plugins` | `str` or `list[str]` of block reasons to reject the install; `None` to allow |
+| [`pre_mcp_add`](#pre_mcp_add) | Before an MCP server entry is probed/saved to config.yaml | `str` or `list[str]` of block reasons to reject the save; `None` to allow |
 
 ---
 
@@ -1278,6 +1280,81 @@ def register(ctx):
 ```
 
 The hook is guarded on a non-empty, non-interrupted response — it will not fire on stop-button interrupts or empty turns. Exceptions are logged as warnings and do not break agent execution.
+
+---
+
+### `pre_plugin_install`
+
+Install-time security gate. Fires in `hermes plugins install` (CLI, dashboard, and agent paths all route through `_install_plugin_core`) **after** the plugin repo is cloned and its manifest parsed, but **before** the clone is promoted into `~/.hermes/plugins` — so a scanner can inspect the actual files on disk while they are still untrusted.
+
+**Callback signature:**
+
+```python
+def my_callback(name: str, git_url: str, subdir: str | None, path: str, manifest: dict, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Plugin name from the manifest |
+| `git_url` | `str` | Resolved clone URL |
+| `subdir` | `str \| None` | Sub-directory within the repo, when installing `owner/repo/path` |
+| `path` | `str` | Local directory of the freshly cloned, **not-yet-trusted** plugin |
+| `manifest` | `dict` | Parsed `plugin.yaml` contents |
+
+**Return value — reject the install:** return a non-empty `str`, or a `list`/`tuple` of strings, of block reasons. Reasons from all callbacks are merged; any reason aborts the install **fail-closed** with `PluginOperationError` and the clone is discarded. Return `None` to allow.
+
+Because `plugins install` is a built-in management command, Hermes loads the trusted plugin registry right before firing this gate — your already-installed gate plugin will run even though normal startup discovery is skipped for built-in commands. A callback that *raises* is logged and skipped (fail-open, like every hook), so gates must **return** reasons, never raise. The gate is also deliberately fail-soft on discovery itself: if plugin discovery fails, or `HERMES_SAFE_MODE=1` disables plugin loading, the gate runs with no callbacks and allows the operation — identical to having no gate plugin installed.
+
+**Use cases:** malware/secret-exfiltration scanning of plugin code before it is trusted, org allow-lists for plugin sources, license checks.
+
+```python
+def scan_plugin(name, path, **kwargs):
+    findings = my_scanner.scan_directory(path)
+    if findings:
+        return [f"security scan: {f}" for f in findings]
+    return None
+
+def register(ctx):
+    ctx.register_hook("pre_plugin_install", scan_plugin)
+```
+
+---
+
+### `pre_mcp_add`
+
+Install-time security gate for MCP servers. Fires with the fully resolved server entry (command/args/url/env/headers/connect_timeout) at every path that writes `mcp_servers` to config.yaml:
+
+- `hermes mcp add` — fired **before** the discovery probe, so a block prevents the untrusted stdio command from ever being launched, and again at save time.
+- `_save_mcp_server` — per-key upserts (agent/tool paths).
+- `_replace_mcp_servers` — dashboard whole-map edits (per entry; any block rejects the whole save so a bad paste can't partially apply).
+
+**Callback signature:**
+
+```python
+def my_callback(name: str, server_config: dict, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Server name (config key) |
+| `server_config` | `dict` | Fully resolved entry: `command`/`args`/`url`/`env`/`headers`/`connect_timeout` |
+
+**Return value — reject the save:** return a non-empty `str`, or a `list`/`tuple` of strings, of block reasons. Reasons merge into the same issues list as the built-in static validation (`validate_mcp_server_entry`); any issue rejects the save. Return `None` to allow. As with `pre_plugin_install`, the trusted plugin registry is loaded before the gate fires, and raising callbacks are dropped (fail-open) — **return** reasons, never raise.
+
+**Use cases:** blocking known-bad packages or hosts, enforcing an org allow-list of MCP servers, flagging suspicious env-var exfiltration patterns beyond the built-in heuristics.
+
+```python
+BLOCKED_HOSTS = {"evil.example.com"}
+
+def vet_mcp_server(name, server_config, **kwargs):
+    url = server_config.get("url", "")
+    if any(h in url for h in BLOCKED_HOSTS):
+        return f"server '{name}' points at a blocked host"
+    return None
+
+def register(ctx):
+    ctx.register_hook("pre_mcp_add", vet_mcp_server)
+```
 
 ---
 


### PR DESCRIPTION
Two generic install-time security gates at the sole plugin/MCP install choke points, mirroring the existing validate_mcp_server_entry block-verdict contract. Lets security plugins scan a plugin/MCP server on canonical, already-parsed args (and the cloned files on disk) before it is trusted — covering CLI, dashboard, and agent paths. No new dependencies; no-op when no plugin subscribes.

- `pre_plugin_install`: `_install_plugin_core` fires it after the manifest is read but before the clone is promoted into ~/.hermes/plugins; a block reason aborts fail-closed with PluginOperationError.
- `pre_mcp_add`: fired at the pre-probe validation point in `cmd_mcp_add` (so a block prevents the discovery probe from executing the untrusted command) and again at `_save_mcp_server` as the backstop for non-probing callers (dashboard / bulk replace); block reasons merge into the same issues list as static validation.

5 commits, +216/-2. Hook-site tests included (6 passing).