### PR TITLE
fix(models): add kimi-for-coding-highspeed to kimi-coding static catalog (salvage #61901)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -322,6 +322,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2.6",
         "kimi-k2.5",
         "kimi-for-coding",
+        "kimi-for-coding-highspeed",
         "kimi-k2-thinking",
         "kimi-k2-thinking-turbo",
         "kimi-k2-turbo-preview",


### PR DESCRIPTION
## Summary
The `kimi-coding` static model catalog now lists `kimi-for-coding-highspeed`, so the high-speed Coding Plan tier appears in pickers even when live model discovery is unavailable.

Salvage of #61901 by @liuhao1024 (cherry-picked with authorship preserved; PR base was stale). Fixes #61896; together with #65922 (dynamic `k3` discovery), completes #65835.

## Changes
- `hermes_cli/models.py`: `kimi-for-coding-highspeed` added to `_PROVIDER_MODELS["kimi-coding"]`, next to its sibling `kimi-for-coding`.

## Why `k3` is NOT added statically
`k3` was deliberately left out of the static floor: #65922 scoped it to the confirmed `api.kimi.com/coding` endpoint (live-discovered there, filtered elsewhere), because legacy Moonshot keys share this provider and don't serve K3. A static entry would advertise it unconditionally and defeat that scoping — its regression tests (`test_k3_live_discovery_is_scoped_to_kimi_coding_endpoint`) fail if `k3` enters the curated floor. Verified empirically before settling on this scope. `kimi-for-coding-highspeed` has no such constraint (same base model/endpoint as `kimi-for-coding`, tier-gated server-side).

## Validation
| Check | Result |
|---|---|
| Cherry-pick onto current main | clean |
| `scripts/run_tests.sh tests/hermes_cli/test_models_dev_preferred_merge.py tests/plugins/model_providers/test_kimi_profile.py tests/hermes_cli/test_models.py` | 119 passed, 0 failed |
| K3 endpoint-scoping tests still green (static list untouched for k3) | ✓ |

Credit: @liuhao1024 for the fix.

## Infographic
![kimi-for-coding-highspeed catalog entry](https://v3b.fal.media/files/b/0aa28697/BA_Q08qNbnEXEygSsw2Mm_VqAA3jOi.png)
