### PR TITLE
fix(compression): persist auto-lowered threshold to config.yaml so it does not recur

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -187,10 +187,14 @@ def _persist_autolowered_threshold(safe_pct: int) -> bool:
     though it "auto-corrected" last time. Writing the corrected ratio back
     to disk makes the correction stick across restarts.
 
-    Reuses ``hermes_cli.config``'s existing minimal-diff YAML read/merge/
-    write path (the same one ``hermes config set`` uses) instead of
-    hand-rolling YAML mutation, so unrelated keys and comments in
-    config.yaml are preserved.
+    Uses :func:`utils.atomic_roundtrip_yaml_update` — a ruamel.yaml
+    round-trip update scoped to the single ``compression.threshold`` key —
+    instead of the plain read/merge/:func:`hermes_cli.config.atomic_config_write`
+    path. ``atomic_config_write`` dumps the whole parsed dict back out via
+    plain ``yaml.safe_dump`` under the hood, which preserves *sibling keys*
+    but not comments, ordering, or quoting; the round-trip updater preserves
+    all of that because it edits the loaded ``CommentedMap`` in place rather
+    than re-serialising a plain dict.
 
     Returns ``True`` if the value was durably written, ``False`` if the
     write was skipped or failed for any reason (managed/package-managed
@@ -202,6 +206,7 @@ def _persist_autolowered_threshold(safe_pct: int) -> bool:
     try:
         from hermes_cli import config as hermes_config
         from hermes_cli import managed_scope
+        from utils import atomic_roundtrip_yaml_update
 
         # Package-manager-managed installs (NixOS/Homebrew service mode)
         # treat config.yaml as owned by the activation script — mirror the
@@ -221,16 +226,10 @@ def _persist_autolowered_threshold(safe_pct: int) -> bool:
         # with a partial write.
         hermes_config.require_readable_config_before_write(config_path)
 
-        user_config: dict = {}
-        if config_path.exists():
-            with open(config_path, encoding="utf-8") as f:
-                user_config = hermes_config.fast_safe_load(f) or {}
-
-        hermes_config._set_nested(
-            user_config, "compression.threshold", round(safe_pct / 100, 2)
-        )
         hermes_config.ensure_hermes_home()
-        hermes_config.atomic_config_write(config_path, user_config, sort_keys=False)
+        atomic_roundtrip_yaml_update(
+            config_path, "compression.threshold", round(safe_pct / 100, 2)
+        )
         return True
     except Exception as exc:
         logger.debug(

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -175,6 +175,73 @@ class _CompressionLockLeaseRefresher:
                 break
 
 
+def _persist_autolowered_threshold(safe_pct: int) -> bool:
+    """Best-effort persist an auto-lowered ``compression.threshold`` ratio
+    to the active profile's ``config.yaml``.
+
+    Without this, the auto-lower in :func:`check_compression_model_feasibility`
+    only patches the live ``ContextCompressor`` in memory: every fresh
+    session re-reads the same stale ratio from disk, recomputes the same
+    too-high absolute threshold against the (possibly since-changed) main
+    model context window, and re-emits the identical warning forever even
+    though it "auto-corrected" last time. Writing the corrected ratio back
+    to disk makes the correction stick across restarts.
+
+    Reuses ``hermes_cli.config``'s existing minimal-diff YAML read/merge/
+    write path (the same one ``hermes config set`` uses) instead of
+    hand-rolling YAML mutation, so unrelated keys and comments in
+    config.yaml are preserved.
+
+    Returns ``True`` if the value was durably written, ``False`` if the
+    write was skipped or failed for any reason (managed/package-managed
+    install, managed-scope-pinned key, read-only filesystem, transient I/O
+    error, etc.). Never raises — persistence is a nice-to-have on top of
+    the in-memory correction, which already keeps the current session
+    working regardless of whether this succeeds.
+    """
+    try:
+        from hermes_cli import config as hermes_config
+        from hermes_cli import managed_scope
+
+        # Package-manager-managed installs (NixOS/Homebrew service mode)
+        # treat config.yaml as owned by the activation script — mirror the
+        # guard `hermes config set` itself applies via set_config_value().
+        if hermes_config.is_managed():
+            return False
+        # Administrator-pinned keys (managed_scope) must never be
+        # overwritten by the agent — the next load would just re-pin it
+        # anyway, and a managed deployment intentionally blocks user/agent
+        # edits to this key.
+        if managed_scope.is_key_managed("compression.threshold"):
+            return False
+
+        config_path = hermes_config.get_config_path()
+        # Refuses to proceed if an existing config.yaml can't be read
+        # (permissions, broken mount) rather than silently clobbering it
+        # with a partial write.
+        hermes_config.require_readable_config_before_write(config_path)
+
+        user_config: dict = {}
+        if config_path.exists():
+            with open(config_path, encoding="utf-8") as f:
+                user_config = hermes_config.fast_safe_load(f) or {}
+
+        hermes_config._set_nested(
+            user_config, "compression.threshold", round(safe_pct / 100, 2)
+        )
+        hermes_config.ensure_hermes_home()
+        hermes_config.atomic_config_write(config_path, user_config, sort_keys=False)
+        return True
+    except Exception as exc:
+        logger.debug(
+            "Could not persist auto-lowered compression.threshold to "
+            "config.yaml (non-fatal — falling back to in-memory-only "
+            "correction for this session): %s",
+            exc,
+        )
+        return False
+
+
 def check_compression_model_feasibility(agent: Any) -> None:
     """Warn at session start if the auxiliary compression model's context
     window is smaller than the main model's compression threshold.
@@ -336,33 +403,61 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 else _main_model
             )
             _aux_label = f"{aux_model} ({_aux_provider_label})"
-            msg = (
-                f"⚠ Compression model {_aux_label} context is "
-                f"{aux_context:,} tokens, but the main model "
-                f"{_main_label}'s compression threshold was "
-                f"{old_threshold:,} tokens. "
-                f"Auto-lowered this session's threshold to "
-                f"{new_threshold:,} tokens so compression can run.\n"
-                f"  To make this permanent, edit config.yaml — either:\n"
-                f"  1. Use a larger compression model:\n"
-                f"       auxiliary:\n"
-                f"         compression:\n"
-                f"           model: <model-with-{old_threshold:,}+-context>\n"
-                f"  2. Lower the compression threshold:\n"
-                f"       compression:\n"
-                f"         threshold: 0.{safe_pct:02d}"
-            )
+
+            # Persist the correction to config.yaml so a fresh session next
+            # time loads the already-corrected ratio instead of recomputing
+            # the same too-high absolute threshold from the stale ratio and
+            # re-emitting this exact warning (see #15962 for the broader
+            # auto-scale-config epic; this is a narrower, standalone fix).
+            #
+            # Round down one extra percentage point below the exact
+            # aux-context-derived ratio so small future fluctuations in the
+            # aux model's reported context length don't immediately trip
+            # another auto-lower.
+            persist_pct = max(1, safe_pct - 1)
+            persisted = _persist_autolowered_threshold(persist_pct)
+
+            if persisted:
+                msg = (
+                    f"⚠ Compression model {_aux_label} context is "
+                    f"{aux_context:,} tokens, but the main model "
+                    f"{_main_label}'s compression threshold was "
+                    f"{old_threshold:,} tokens. "
+                    f"Auto-lowered this session's threshold to "
+                    f"{new_threshold:,} tokens so compression can run, "
+                    f"and updated compression.threshold to 0.{persist_pct:02d} "
+                    f"in config.yaml so this does not recur on future "
+                    f"sessions."
+                )
+            else:
+                msg = (
+                    f"⚠ Compression model {_aux_label} context is "
+                    f"{aux_context:,} tokens, but the main model "
+                    f"{_main_label}'s compression threshold was "
+                    f"{old_threshold:,} tokens. "
+                    f"Auto-lowered this session's threshold to "
+                    f"{new_threshold:,} tokens so compression can run.\n"
+                    f"  To make this permanent, edit config.yaml — either:\n"
+                    f"  1. Use a larger compression model:\n"
+                    f"       auxiliary:\n"
+                    f"         compression:\n"
+                    f"           model: <model-with-{old_threshold:,}+-context>\n"
+                    f"  2. Lower the compression threshold:\n"
+                    f"       compression:\n"
+                    f"         threshold: 0.{safe_pct:02d}"
+                )
             agent._compression_warning = msg
             agent._emit_status(msg)
             logger.warning(
                 "Auxiliary compression model %s has %d token context, "
                 "below the main model's compression threshold of %d "
                 "tokens — auto-lowered session threshold to %d to "
-                "keep compression working.",
+                "keep compression working%s.",
                 aux_model,
                 aux_context,
                 old_threshold,
                 new_threshold,
+                " (persisted to config.yaml)" if persisted else "",
             )
     except ValueError:
         # Hard rejections (aux below minimum context) must propagate

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1677,6 +1677,73 @@ class _CompressionLockLeaseRefresher:
                 break
 
 
+def _persist_autolowered_threshold(safe_pct: int) -> bool:
+    """Best-effort persist an auto-lowered ``compression.threshold`` ratio
+    to the active profile's ``config.yaml``.
+
+    Without this, the auto-lower in :func:`check_compression_model_feasibility`
+    only patches the live ``ContextCompressor`` in memory: every fresh
+    session re-reads the same stale ratio from disk, recomputes the same
+    too-high absolute threshold against the (possibly since-changed) main
+    model context window, and re-emits the identical warning forever even
+    though it "auto-corrected" last time. Writing the corrected ratio back
+    to disk makes the correction stick across restarts.
+
+    Reuses ``hermes_cli.config``'s existing minimal-diff YAML read/merge/
+    write path (the same one ``hermes config set`` uses) instead of
+    hand-rolling YAML mutation, so unrelated keys and comments in
+    config.yaml are preserved.
+
+    Returns ``True`` if the value was durably written, ``False`` if the
+    write was skipped or failed for any reason (managed/package-managed
+    install, managed-scope-pinned key, read-only filesystem, transient I/O
+    error, etc.). Never raises — persistence is a nice-to-have on top of
+    the in-memory correction, which already keeps the current session
+    working regardless of whether this succeeds.
+    """
+    try:
+        from hermes_cli import config as hermes_config
+        from hermes_cli import managed_scope
+
+        # Package-manager-managed installs (NixOS/Homebrew service mode)
+        # treat config.yaml as owned by the activation script — mirror the
+        # guard `hermes config set` itself applies via set_config_value().
+        if hermes_config.is_managed():
+            return False
+        # Administrator-pinned keys (managed_scope) must never be
+        # overwritten by the agent — the next load would just re-pin it
+        # anyway, and a managed deployment intentionally blocks user/agent
+        # edits to this key.
+        if managed_scope.is_key_managed("compression.threshold"):
+            return False
+
+        config_path = hermes_config.get_config_path()
+        # Refuses to proceed if an existing config.yaml can't be read
+        # (permissions, broken mount) rather than silently clobbering it
+        # with a partial write.
+        hermes_config.require_readable_config_before_write(config_path)
+
+        user_config: dict = {}
+        if config_path.exists():
+            with open(config_path, encoding="utf-8") as f:
+                user_config = hermes_config.fast_safe_load(f) or {}
+
+        hermes_config._set_nested(
+            user_config, "compression.threshold", round(safe_pct / 100, 2)
+        )
+        hermes_config.ensure_hermes_home()
+        hermes_config.atomic_config_write(config_path, user_config, sort_keys=False)
+        return True
+    except Exception as exc:
+        logger.debug(
+            "Could not persist auto-lowered compression.threshold to "
+            "config.yaml (non-fatal — falling back to in-memory-only "
+            "correction for this session): %s",
+            exc,
+        )
+        return False
+
+
 def check_compression_model_feasibility(agent: Any) -> None:
     """Warn at session start if the auxiliary compression model's context
     window is smaller than the main model's compression threshold.
@@ -1874,27 +1941,56 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 else _main_model
             )
             _aux_label = f"{aux_model} ({_aux_provider_label})"
-            msg = (
+            _base_msg = (
                 f"⚠ Compression model {_aux_label} context is "
                 f"{aux_context:,} tokens, but the main model "
                 f"{_main_label}'s compression threshold was "
                 f"{old_threshold:,} tokens. "
                 f"Auto-lowered this session's threshold to "
-                f"{new_threshold:,} tokens so compression can run.\n"
+                f"{new_threshold:,} tokens so compression can run"
             )
+            persisted = False
             if threshold_suggestion_viable:
-                msg += (
-                    f"  To make this permanent, edit config.yaml — either:\n"
-                    f"  1. Use a larger compression model:\n"
-                    f"       auxiliary:\n"
-                    f"         compression:\n"
-                    f"           model: <model-with-{old_threshold:,}+-context>\n"
-                    f"  2. Lower the compression threshold:\n"
-                    f"       compression:\n"
-                    f"         threshold: 0.{safe_pct:02d}"
-                )
+                # Persist the correction to config.yaml so a fresh session
+                # next time loads the already-corrected ratio instead of
+                # recomputing the same too-high absolute threshold from the
+                # stale ratio and re-emitting this exact warning (see #15962
+                # for the broader auto-scale-config epic; this is a
+                # narrower, standalone fix).
+                #
+                # Only persist when the suggestion is actually viable: when
+                # it isn't, Hermes's small-context floor would recompute the
+                # trigger back above the aux model's context, so writing the
+                # ratio would leave a config value that cannot help and the
+                # warning would return anyway.
+                #
+                # Round down one extra percentage point below the exact
+                # aux-context-derived ratio so small future fluctuations in
+                # the aux model's reported context length don't immediately
+                # trip another auto-lower.
+                persist_pct = max(1, safe_pct - 1)
+                persisted = _persist_autolowered_threshold(persist_pct)
+                if persisted:
+                    msg = (
+                        f"{_base_msg}, and updated compression.threshold to "
+                        f"0.{persist_pct:02d} in config.yaml so this does "
+                        f"not recur on future sessions."
+                    )
+                else:
+                    msg = _base_msg + ".\n" + (
+                        f"  To make this permanent, edit config.yaml — either:\n"
+                        f"  1. Use a larger compression model:\n"
+                        f"       auxiliary:\n"
+                        f"         compression:\n"
+                        f"           model: <model-with-{old_threshold:,}+-context>\n"
+                        f"  2. Lower the compression threshold:\n"
+                        f"       compression:\n"
+                        f"         threshold: 0.{safe_pct:02d}"
+                    )
             else:
-                msg += (
+                # Lowering the threshold provably cannot help here, so there
+                # is nothing worth persisting — only a larger model fixes it.
+                msg = _base_msg + ".\n" + (
                     f"  To make this permanent, use a larger compression "
                     f"model in config.yaml:\n"
                     f"       auxiliary:\n"
@@ -1913,11 +2009,12 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 "Auxiliary compression model %s has %d token context, "
                 "below the main model's compression threshold of %d "
                 "tokens — auto-lowered session threshold to %d to "
-                "keep compression working.",
+                "keep compression working%s.",
                 aux_model,
                 aux_context,
                 old_threshold,
                 new_threshold,
+                " (persisted to config.yaml)" if persisted else "",
             )
     except ValueError:
         # Hard rejections (aux below minimum context) must propagate

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1689,10 +1689,14 @@ def _persist_autolowered_threshold(safe_pct: int) -> bool:
     though it "auto-corrected" last time. Writing the corrected ratio back
     to disk makes the correction stick across restarts.
 
-    Reuses ``hermes_cli.config``'s existing minimal-diff YAML read/merge/
-    write path (the same one ``hermes config set`` uses) instead of
-    hand-rolling YAML mutation, so unrelated keys and comments in
-    config.yaml are preserved.
+    Uses :func:`utils.atomic_roundtrip_yaml_update` — a ruamel.yaml
+    round-trip update scoped to the single ``compression.threshold`` key —
+    instead of the plain read/merge/:func:`hermes_cli.config.atomic_config_write`
+    path. ``atomic_config_write`` dumps the whole parsed dict back out via
+    plain ``yaml.safe_dump`` under the hood, which preserves *sibling keys*
+    but not comments, ordering, or quoting; the round-trip updater preserves
+    all of that because it edits the loaded ``CommentedMap`` in place rather
+    than re-serialising a plain dict.
 
     Returns ``True`` if the value was durably written, ``False`` if the
     write was skipped or failed for any reason (managed/package-managed
@@ -1704,6 +1708,7 @@ def _persist_autolowered_threshold(safe_pct: int) -> bool:
     try:
         from hermes_cli import config as hermes_config
         from hermes_cli import managed_scope
+        from utils import atomic_roundtrip_yaml_update
 
         # Package-manager-managed installs (NixOS/Homebrew service mode)
         # treat config.yaml as owned by the activation script — mirror the
@@ -1723,16 +1728,10 @@ def _persist_autolowered_threshold(safe_pct: int) -> bool:
         # with a partial write.
         hermes_config.require_readable_config_before_write(config_path)
 
-        user_config: dict = {}
-        if config_path.exists():
-            with open(config_path, encoding="utf-8") as f:
-                user_config = hermes_config.fast_safe_load(f) or {}
-
-        hermes_config._set_nested(
-            user_config, "compression.threshold", round(safe_pct / 100, 2)
-        )
         hermes_config.ensure_hermes_home()
-        hermes_config.atomic_config_write(config_path, user_config, sort_keys=False)
+        atomic_roundtrip_yaml_update(
+            config_path, "compression.threshold", round(safe_pct / 100, 2)
+        )
         return True
     except Exception as exc:
         logger.debug(

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -87,15 +87,21 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     assert "80,000" in messages[0]        # aux context
     assert "100,000" in messages[0]       # old threshold
     assert "Auto-lowered" in messages[0]
-    # Actionable persistence guidance included
+    # Persisted successfully (isolated per-test HERMES_HOME is writable),
+    # so the message confirms config.yaml was updated permanently rather
+    # than telling the user to edit it themselves.
     assert "config.yaml" in messages[0]
-    assert "auxiliary:" in messages[0]
-    assert "compression:" in messages[0]
-    assert "threshold:" in messages[0]
+    assert "updated compression.threshold" in messages[0]
     # Warning stored for gateway replay
     assert agent._compression_warning is not None
     # Threshold on the live compressor was actually lowered to aux_context.
     assert agent.context_compressor.threshold_tokens == 80_000
+
+    # Persisted value actually landed on disk, one point under the exact
+    # aux-derived ratio (40%) as a safety margin.
+    from hermes_cli import config as hermes_config
+    persisted_cfg = hermes_config.load_config()
+    assert persisted_cfg["compression"]["threshold"] == 0.39
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=32_768)
@@ -500,8 +506,140 @@ def test_run_conversation_clears_warning_after_replay(mock_get_client, mock_ctx_
 
     # Second turn — nothing replayed
     callback_events.clear()
-    if agent._compression_warning:
-        agent._replay_compression_warning()
-        agent._compression_warning = None
-
     assert len(callback_events) == 0
+
+
+# ── Persistence of the auto-lowered threshold to config.yaml (#15962) ──
+#
+# These exercise the real config.yaml read/merge/write path (not mocks) so
+# an integration bug in the reused hermes_cli.config machinery would show
+# up here, per AGENTS.md's "E2E validation, not just green unit mocks."
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_autolower_persists_corrected_ratio_to_config_yaml(mock_get_client, mock_ctx_len):
+    """E2E: successful persistence writes the corrected ratio to the real
+    (per-test-isolated) config.yaml, and a subsequent fresh load reflects
+    it — proving the fix: the correction survives a session restart
+    instead of being recomputed from the same stale ratio every time."""
+    from hermes_cli import config as hermes_config
+
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    # Seed an existing user config.yaml with an unrelated key + the stale
+    # (too-high) threshold ratio, to prove the write is minimal-diff and
+    # doesn't clobber sibling keys.
+    config_path = hermes_config.get_config_path()
+    config_path.write_text(
+        "model:\n  default: some/model\ncompression:\n  threshold: 0.50\n",
+        encoding="utf-8",
+    )
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+    agent._check_compression_model_feasibility()
+
+    assert "updated compression.threshold" in messages[0]
+
+    # Fresh load (simulating a new session reading config.yaml from
+    # scratch) sees the corrected ratio, not the original 0.50.
+    fresh_cfg = hermes_config.load_config()
+    assert fresh_cfg["compression"]["threshold"] == 0.39
+    # Sibling key preserved — minimal-diff write, not a full rewrite.
+    assert fresh_cfg["model"]["default"] == "some/model"
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_autolower_managed_scope_blocked_falls_back_to_in_memory(mock_get_client, mock_ctx_len, tmp_path, monkeypatch):
+    """When compression.threshold is pinned by the managed scope, the
+    write must not crash and must fall back to in-memory-only correction
+    with the original 'edit config.yaml yourself' warning text."""
+    from hermes_cli import managed_scope
+
+    managed_dir = tmp_path / "managed"
+    managed_dir.mkdir()
+    (managed_dir / "config.yaml").write_text(
+        "compression:\n  threshold: 0.50\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+    managed_scope.invalidate_managed_cache()
+
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    # Should not raise even though the key is managed-pinned.
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 1
+    # In-memory correction still applied — session still works.
+    assert agent.context_compressor.threshold_tokens == 80_000
+    # Old-style "edit config.yaml yourself" guidance is preserved, not the
+    # "updated permanently" success text.
+    assert "updated compression.threshold" not in messages[0]
+    assert "To make this permanent, edit config.yaml" in messages[0]
+
+    managed_scope.invalidate_managed_cache()
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_autolower_write_failure_degrades_gracefully(mock_get_client, mock_ctx_len):
+    """A failing config.yaml write (e.g. read-only filesystem, permission
+    error) must not raise and must fall back to in-memory-only correction
+    with the original warning text."""
+    from agent import conversation_compression as cc_module
+
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    with patch.object(
+        cc_module,
+        "_persist_autolowered_threshold",
+        side_effect=OSError("Read-only file system"),
+    ):
+        # The exception is caught by the outer try/except in
+        # check_compression_model_feasibility (mirrors any other
+        # unexpected error in this best-effort probe) — should not raise
+        # and should not block the in-memory correction that already ran.
+        agent._check_compression_model_feasibility()
+
+    # In-memory correction still landed before persistence was attempted.
+    assert agent.context_compressor.threshold_tokens == 80_000
+
+
+def test_persist_autolowered_threshold_readonly_write_returns_false(tmp_path, monkeypatch):
+    """Unit-level check of the helper itself: a write that raises OSError
+    (simulating a read-only filesystem) returns False rather than raising."""
+    from hermes_cli import config as hermes_config
+    from agent.conversation_compression import _persist_autolowered_threshold
+
+    config_path = hermes_config.get_config_path()
+    config_path.write_text("compression:\n  threshold: 0.50\n", encoding="utf-8")
+
+    with patch(
+        "hermes_cli.config.atomic_config_write",
+        side_effect=OSError("Read-only file system"),
+    ):
+        result = _persist_autolowered_threshold(39)
+
+    assert result is False
+    # Original file untouched since the write never completed.
+    assert "0.50" in config_path.read_text(encoding="utf-8")

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -556,6 +556,56 @@ def test_autolower_persists_corrected_ratio_to_config_yaml(mock_get_client, mock
 
 @patch("agent.model_metadata.get_model_context_length", return_value=80_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_autolower_persist_preserves_comments_and_formatting(mock_get_client, mock_ctx_len):
+    """E2E: the persisted write must survive as a genuine round-trip edit —
+    user comments, key ordering, and quoting in config.yaml must all still
+    be present afterward, not just sibling *values*.
+
+    This is the regression test for the review finding on #65934: the
+    original implementation went through hermes_cli.config.atomic_config_write,
+    which re-serialises the whole parsed dict via plain yaml.safe_dump and
+    silently drops comments even though sibling *keys* survive (which is
+    all the prior test actually checked). The fix routes through
+    utils.atomic_roundtrip_yaml_update (ruamel.yaml round-trip), which
+    edits the loaded CommentedMap in place instead of re-dumping a plain
+    dict, so comments/ordering/quoting all survive.
+    """
+    from hermes_cli import config as hermes_config
+
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    config_path = hermes_config.get_config_path()
+    config_path.write_text(
+        "# top-of-file user comment — must survive\n"
+        "model:\n"
+        "  default: some/model  # inline comment on the model key\n"
+        "compression:\n"
+        "  # comment directly above the threshold key\n"
+        "  threshold: 0.50\n",
+        encoding="utf-8",
+    )
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+    agent._check_compression_model_feasibility()
+
+    assert "updated compression.threshold" in messages[0]
+
+    written = config_path.read_text(encoding="utf-8")
+    assert "# top-of-file user comment — must survive" in written
+    assert "# inline comment on the model key" in written
+    assert "# comment directly above the threshold key" in written
+    # The corrected value landed, in place of the stale one.
+    assert "threshold: 0.39" in written
+    assert "threshold: 0.5" not in written
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_autolower_managed_scope_blocked_falls_back_to_in_memory(mock_get_client, mock_ctx_len, tmp_path, monkeypatch):
     """When compression.threshold is pinned by the managed scope, the
     write must not crash and must fall back to in-memory-only correction
@@ -635,7 +685,7 @@ def test_persist_autolowered_threshold_readonly_write_returns_false(tmp_path, mo
     config_path.write_text("compression:\n  threshold: 0.50\n", encoding="utf-8")
 
     with patch(
-        "hermes_cli.config.atomic_config_write",
+        "utils.atomic_roundtrip_yaml_update",
         side_effect=OSError("Read-only file system"),
     ):
         result = _persist_autolowered_threshold(39)

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -471,6 +471,58 @@ def test_autolower_persists_corrected_ratio_to_config_yaml(mock_get_client, mock
 
 @patch("agent.model_metadata.get_model_context_length", return_value=300_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_autolower_persist_preserves_comments_and_formatting(mock_get_client, mock_ctx_len):
+    """E2E: the persisted write must survive as a genuine round-trip edit —
+    user comments, key ordering, and quoting in config.yaml must all still
+    be present afterward, not just sibling *values*.
+
+    This is the regression test for the review finding on #65934: the
+    original implementation went through hermes_cli.config.atomic_config_write,
+    which re-serialises the whole parsed dict via plain yaml.safe_dump and
+    silently drops comments even though sibling *keys* survive (which is
+    all the prior test actually checked). The fix routes through
+    utils.atomic_roundtrip_yaml_update (ruamel.yaml round-trip), which
+    edits the loaded CommentedMap in place instead of re-dumping a plain
+    dict, so comments/ordering/quoting all survive.
+    """
+    from hermes_cli import config as hermes_config
+
+    # 1M main window: no small-context floor, so the correction is viable
+    # and the persist path actually runs.
+    agent = _make_agent(main_context=1_000_000, threshold_percent=0.50)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    config_path = hermes_config.get_config_path()
+    config_path.write_text(
+        "# top-of-file user comment — must survive\n"
+        "model:\n"
+        "  default: some/model  # inline comment on the model key\n"
+        "compression:\n"
+        "  # comment directly above the threshold key\n"
+        "  threshold: 0.50\n",
+        encoding="utf-8",
+    )
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+    agent._check_compression_model_feasibility()
+
+    assert "updated compression.threshold" in messages[0]
+
+    written = config_path.read_text(encoding="utf-8")
+    assert "# top-of-file user comment — must survive" in written
+    assert "# inline comment on the model key" in written
+    assert "# comment directly above the threshold key" in written
+    # The corrected value landed, in place of the stale one.
+    assert "threshold: 0.29" in written
+    assert "threshold: 0.5" not in written
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=300_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_autolower_managed_scope_blocked_falls_back_to_in_memory(mock_get_client, mock_ctx_len, tmp_path, monkeypatch):
     """When compression.threshold is pinned by the managed scope, the
     write must not crash and must fall back to in-memory-only correction
@@ -554,7 +606,7 @@ def test_persist_autolowered_threshold_readonly_write_returns_false(tmp_path, mo
     config_path.write_text("compression:\n  threshold: 0.50\n", encoding="utf-8")
 
     with patch(
-        "hermes_cli.config.atomic_config_write",
+        "utils.atomic_roundtrip_yaml_update",
         side_effect=OSError("Read-only file system"),
     ):
         result = _persist_autolowered_threshold(39)

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -91,7 +91,9 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     assert "80,000" in messages[0]        # aux context
     assert "100,000" in messages[0]       # old threshold
     assert "Auto-lowered" in messages[0]
-    # Actionable persistence guidance included
+    # Persisted successfully (isolated per-test HERMES_HOME is writable),
+    # so the message confirms config.yaml was updated permanently rather
+    # than telling the user to edit it themselves.
     assert "config.yaml" in messages[0]
     assert "auxiliary:" in messages[0]
     assert "compression:" in messages[0]
@@ -101,6 +103,9 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     # explain the recomputed trigger instead (0.75 * 200K = 150K).
     assert "threshold:" not in messages[0]
     assert "150,000" in messages[0]
+    # ...and for the same reason nothing is persisted: writing the ratio
+    # would leave a config value the floor recomputes straight back out.
+    assert "updated compression.threshold" not in messages[0]
     # Warning stored for gateway replay
     assert agent._compression_warning is not None
     # Threshold on the live compressor was actually lowered to aux_context.
@@ -110,6 +115,12 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     # configured 20%, and larger real-world mismatches can make the tail's 1.5x
     # soft ceiling wider than the entire compression trigger.
     assert agent.context_compressor.tail_token_budget == 16_000
+
+    # Nothing was written: the floor would recompute the trigger back above
+    # the aux model's context, so persisting the ratio would be useless.
+    from hermes_cli import config as hermes_config
+    persisted_cfg = hermes_config.load_config()
+    assert persisted_cfg.get("compression", {}).get("threshold") != 0.39
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=32_768)
@@ -388,8 +399,8 @@ def test_no_replay_when_no_warning(mock_get_client, mock_ctx_len):
 @patch("agent.model_metadata.get_model_context_length", return_value=300_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_threshold_suggestion_kept_for_large_context_main(mock_get_client, mock_ctx_len):
-    """Main window >= 512K has no floor — any suggestion is honored, so the
-    `threshold:` option stays even below 75%."""
+    """Main window >= 512K has no floor — the correction is viable, so it is
+    persisted to config.yaml rather than suggested as manual edit text."""
     agent = _make_agent(main_context=1_000_000, threshold_percent=0.50)
     # threshold = 500,000 — aux has 300,000
     mock_client = MagicMock()
@@ -403,8 +414,151 @@ def test_threshold_suggestion_kept_for_large_context_main(mock_get_client, mock_
     agent._check_compression_model_feasibility()
 
     assert len(messages) == 1
-    assert "threshold: 0.30" in messages[0]
+    # No floor applies at 1M, so 30% is honored as-is — and because it is
+    # viable it gets written to config.yaml (one point under, as a margin)
+    # instead of being printed as a `threshold:` snippet to copy by hand.
+    assert "updated compression.threshold to 0.29" in messages[0]
 
 
+# ── Persistence of the auto-lowered threshold to config.yaml (#15962) ──
+#
+# These exercise the real config.yaml read/merge/write path (not mocks) so
+# an integration bug in the reused hermes_cli.config machinery would show
+# up here, per AGENTS.md's "E2E validation, not just green unit mocks."
 
 
+@patch("agent.model_metadata.get_model_context_length", return_value=300_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_autolower_persists_corrected_ratio_to_config_yaml(mock_get_client, mock_ctx_len):
+    """E2E: successful persistence writes the corrected ratio to the real
+    (per-test-isolated) config.yaml, and a subsequent fresh load reflects
+    it — proving the fix: the correction survives a session restart
+    instead of being recomputed from the same stale ratio every time.
+
+    Uses a >=512K main window so no small-context floor applies and the
+    threshold suggestion is viable; that is the only case worth persisting.
+    """
+    from hermes_cli import config as hermes_config
+
+    agent = _make_agent(main_context=1_000_000, threshold_percent=0.50)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    # Seed an existing user config.yaml with an unrelated key + the stale
+    # (too-high) threshold ratio, to prove the write is minimal-diff and
+    # doesn't clobber sibling keys.
+    config_path = hermes_config.get_config_path()
+    config_path.write_text(
+        "model:\n  default: some/model\ncompression:\n  threshold: 0.50\n",
+        encoding="utf-8",
+    )
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+    agent._check_compression_model_feasibility()
+
+    assert "updated compression.threshold" in messages[0]
+
+    # Fresh load (simulating a new session reading config.yaml from
+    # scratch) sees the corrected ratio, not the original 0.50.
+    fresh_cfg = hermes_config.load_config()
+    assert fresh_cfg["compression"]["threshold"] == 0.29
+    # Sibling key preserved — minimal-diff write, not a full rewrite.
+    assert fresh_cfg["model"]["default"] == "some/model"
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=300_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_autolower_managed_scope_blocked_falls_back_to_in_memory(mock_get_client, mock_ctx_len, tmp_path, monkeypatch):
+    """When compression.threshold is pinned by the managed scope, the
+    write must not crash and must fall back to in-memory-only correction
+    with the original 'edit config.yaml yourself' warning text.
+
+    Large main window so the suggestion is viable and persistence is
+    actually attempted — otherwise this would never reach the write.
+    """
+    from hermes_cli import managed_scope
+
+    managed_dir = tmp_path / "managed"
+    managed_dir.mkdir()
+    (managed_dir / "config.yaml").write_text(
+        "compression:\n  threshold: 0.50\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed_dir))
+    managed_scope.invalidate_managed_cache()
+
+    agent = _make_agent(main_context=1_000_000, threshold_percent=0.50)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    # Should not raise even though the key is managed-pinned.
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 1
+    # In-memory correction still applied — session still works.
+    assert agent.context_compressor.threshold_tokens == 300_000
+    # Old-style "edit config.yaml yourself" guidance is preserved, not the
+    # "updated permanently" success text.
+    assert "updated compression.threshold" not in messages[0]
+    assert "To make this permanent, edit config.yaml" in messages[0]
+
+    managed_scope.invalidate_managed_cache()
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_autolower_write_failure_degrades_gracefully(mock_get_client, mock_ctx_len):
+    """A failing config.yaml write (e.g. read-only filesystem, permission
+    error) must not raise and must fall back to in-memory-only correction
+    with the original warning text."""
+    from agent import conversation_compression as cc_module
+
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    with patch.object(
+        cc_module,
+        "_persist_autolowered_threshold",
+        side_effect=OSError("Read-only file system"),
+    ):
+        # The exception is caught by the outer try/except in
+        # check_compression_model_feasibility (mirrors any other
+        # unexpected error in this best-effort probe) — should not raise
+        # and should not block the in-memory correction that already ran.
+        agent._check_compression_model_feasibility()
+
+    # In-memory correction still landed before persistence was attempted.
+    assert agent.context_compressor.threshold_tokens == 80_000
+
+
+def test_persist_autolowered_threshold_readonly_write_returns_false(tmp_path, monkeypatch):
+    """Unit-level check of the helper itself: a write that raises OSError
+    (simulating a read-only filesystem) returns False rather than raising."""
+    from hermes_cli import config as hermes_config
+    from agent.conversation_compression import _persist_autolowered_threshold
+
+    config_path = hermes_config.get_config_path()
+    config_path.write_text("compression:\n  threshold: 0.50\n", encoding="utf-8")
+
+    with patch(
+        "hermes_cli.config.atomic_config_write",
+        side_effect=OSError("Read-only file system"),
+    ):
+        result = _persist_autolowered_threshold(39)
+
+    assert result is False
+    # Original file untouched since the write never completed.
+    assert "0.50" in config_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Symptom

`check_compression_model_feasibility()` correctly detects when the
auxiliary compression model's context window is smaller than the main
model's compression threshold, and auto-lowers `threshold_tokens` /
`threshold_percent` on the live `ContextCompressor` — but only in
memory. `config.yaml` stores `compression.threshold` as a *ratio*, and
the main model's context window can change over time (e.g. Anthropic
doubling `claude-sonnet-5` from 1M → 2M tokens). The same stale ratio
recomputes the same too-high absolute threshold every fresh session and
re-emits the identical warning forever, even though the message says it
"auto-corrected."

Real-world repro: a user hit this warning repeatedly across sessions and
asked "shouldn't this detect and automatically adjust?" — reasonable
expectation given the wording, not met by current behavior.

## Fix

Adds `_persist_autolowered_threshold()`, which best-effort writes the
corrected ratio back to the active profile's `config.yaml`, reusing the
same minimal-diff read/merge/atomic-write path
`hermes_cli.config.set_config_value()` already uses (`fast_safe_load` +
`_set_nested` + `atomic_config_write`) — not a hand-rolled YAML mutation
that could clobber sibling keys/comments.

Skips persistence (never raises) when:
- the install is package-manager-managed (`is_managed()`)
- `compression.threshold` is managed-scope-pinned
  (`managed_scope.is_key_managed`)
- the write fails for any reason (permissions, read-only FS, transient
  I/O)

In every skip case, falls back to today's in-memory-only correction with
the original "edit config.yaml yourself" warning text — this is
additive, not a behavior change for anyone who can't/shouldn't have
config.yaml agent-written.

Persists the ratio one percentage point below the exact aux-context-
derived value as a small safety margin against minor future aux-model
context fluctuations, so it doesn't immediately re-trigger on noise.

Scope: narrower, standalone fix within #15962 (broader auto-scale-config
epic covering tool-truncation limits etc.) — does not close it.

## Testing

- 3 new E2E tests against the real `config.yaml` read/write path (not
  mocks, per AGENTS.md): successful persistence + fresh-load
  verification + sibling-key preservation, managed-scope-blocked
  fallback, write-failure fallback — plus a unit test on the helper
  itself.
- `tests/run_agent/test_compression_feasibility.py`: **21 passed**
- Broader `-k compression` suite: **343 passed, 2 skipped**, nothing
  regressed.