### PR TITLE
fix(desktop/windows): free all venv holders on Update hand-off

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -512,7 +512,7 @@ pub(crate) async fn wait_for_install_locks_free(install_root: &Path, app: &AppHa
                     format_locked_paths(&locked)
                 ),
             );
-            force_kill_other_hermes();
+            force_kill_other_hermes_for(Some(install_root));
             tokio::time::sleep(Duration::from_millis(800)).await;
             let locked_after_kill = locked_paths(&lock_targets);
             if locked_after_kill.is_empty() {
@@ -570,21 +570,31 @@ fn format_locked_paths(paths: &[PathBuf]) -> String {
     paths.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
 }
 
-/// Force-kill any `hermes.exe` other than this process. Windows-only; a no-op
-/// elsewhere (POSIX has no mandatory-lock contention). We can't selectively
-/// target "the backend" by PID here — the desktop already exited and we never
-/// knew its children — so we kill the whole `hermes.exe` image tree via
-/// taskkill, excluding our own PID.
+/// Force-kill Hermes-related processes that still hold the install open.
+/// Windows-only; a no-op elsewhere (POSIX has no mandatory-lock contention).
+///
+/// Targets:
+///   1. Every `hermes.exe` image other than this process (legacy behavior).
+///   2. Every process whose ExecutablePath lives under `<install>/venv/` —
+///      gateways and slash workers run as `python(w).exe` from the venv, so
+///      taskkill /IM hermes.exe alone left them alive and the subsequent
+///      `hermes update` either aborted (exit 2) or half-mutated the venv.
 ///
 /// Safe w.r.t. our own update child: this runs inside the install-lock wait,
 /// which completes BEFORE we spawn `venv\Scripts\hermes.exe update`. And a
 /// desktop the user relaunches mid-update will NOT have spawned a backend —
 /// `startHermes()` in the desktop gates local-backend startup on our
 /// update-in-progress marker and parks until we finish (#50238). So the only
-/// hermes.exe images here are stragglers from the old desktop — exactly what
-/// we want gone. (`/FI PID ne <self>` also spares this Tauri process, though it
-/// isn't named hermes.exe.)
+/// hermes/venv images here are stragglers from the old desktop — exactly what
+/// we want gone.
 fn force_kill_other_hermes() {
+    force_kill_other_hermes_for(None);
+}
+
+/// Same as [`force_kill_other_hermes`], optionally scoped to a specific
+/// install root so we only kill that install's venv interpreters (avoids
+/// collateral damage if another Hermes tree is also present).
+fn force_kill_other_hermes_for(install_root: Option<&Path>) {
     if !cfg!(target_os = "windows") {
         return;
     }
@@ -600,6 +610,51 @@ fn force_kill_other_hermes() {
                 "hermes.exe",
                 "/FI",
                 &format!("PID ne {my_pid}"),
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+
+        // Kill venv python(w).exe holders. Prefer a scoped PowerShell filter
+        // when we know the install root; otherwise fall back to a broader
+        // "CommandLine contains hermes-agent\venv" match.
+        let script = if let Some(root) = install_root {
+            let root_s = root.display().to_string().replace('\'', "''");
+            format!(
+                "$ErrorActionPreference='SilentlyContinue'; \
+                 $root = [IO.Path]::GetFullPath('{root_s}'); \
+                 $venv = Join-Path $root 'venv'; \
+                 Get-CimInstance Win32_Process | Where-Object {{ \
+                   $_.ProcessId -ne {my_pid} -and ( \
+                     ($_.ExecutablePath -and $_.ExecutablePath.StartsWith($venv, [StringComparison]::OrdinalIgnoreCase)) -or \
+                     ($_.CommandLine -and $_.CommandLine -match [regex]::Escape($venv)) \
+                   ) \
+                 }} | ForEach-Object {{ \
+                   taskkill /F /T /PID $_.ProcessId 2>$null \
+                 }}"
+            )
+        } else {
+            format!(
+                "$ErrorActionPreference='SilentlyContinue'; \
+                 Get-CimInstance Win32_Process | Where-Object {{ \
+                   $_.ProcessId -ne {my_pid} -and $_.CommandLine -and ( \
+                     $_.CommandLine -match 'hermes-agent[\\\\/]venv' -or \
+                     $_.CommandLine -match 'tui_gateway' -or \
+                     ($_.CommandLine -match 'hermes_cli\\.main' -and $_.CommandLine -match 'gateway') \
+                   ) \
+                 }} | ForEach-Object {{ \
+                   taskkill /F /T /PID $_.ProcessId 2>$null \
+                 }}"
+            )
+        };
+        let _ = std::process::Command::new("powershell.exe")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                &script,
             ])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -595,6 +595,19 @@ fn should_use_global_hermes_kill(install_root: Option<&Path>) -> bool {
     install_root.is_none()
 }
 
+#[cfg(test)]
+fn is_same_install_holder(executable: &Path, install_root: &Path) -> bool {
+    let exe = executable.to_string_lossy().replace('/', "\\").to_ascii_lowercase();
+    let root = install_root
+        .to_string_lossy()
+        .replace('/', "\\")
+        .trim_end_matches('\\')
+        .to_ascii_lowercase();
+    let under_root = exe.starts_with(&format!("{root}\\"));
+    under_root
+        && (exe.starts_with(&format!("{root}\\venv\\")) || exe.ends_with("\\hermes.exe"))
+}
+
 /// Same as [`force_kill_other_hermes`], optionally scoped to a specific
 /// install root so we only kill that install's venv interpreters (avoids
 /// collateral damage if another Hermes tree is also present).
@@ -634,7 +647,10 @@ fn force_kill_other_hermes_for(install_root: Option<&Path>) {
                  $venv = Join-Path $root 'venv'; \
                  Get-CimInstance Win32_Process | Where-Object {{ \
                    $_.ProcessId -ne {my_pid} -and ( \
-                     ($_.ExecutablePath -and $_.ExecutablePath.StartsWith($venv, [StringComparison]::OrdinalIgnoreCase)) -or \
+                     ($_.ExecutablePath -and ( \
+                       $_.ExecutablePath.StartsWith($venv + '\\', [StringComparison]::OrdinalIgnoreCase) -or \
+                       ($_.ExecutablePath.StartsWith($root + '\\', [StringComparison]::OrdinalIgnoreCase) -and $_.Name -ieq 'Hermes.exe') \
+                     )) -or \
                      ($_.CommandLine -and $_.CommandLine -match [regex]::Escape($venv)) \
                    ) \
                  }} | ForEach-Object {{ \
@@ -1210,6 +1226,27 @@ mod tests {
 
         assert!(!marker.exists());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scoped_holder_matching_includes_venv_and_packaged_desktop_only() {
+        let root = Path::new(r"C:\Users\max\AppData\Local\hermes");
+        assert!(is_same_install_holder(
+            Path::new(r"C:\Users\max\AppData\Local\hermes\venv\Scripts\python.exe"),
+            root
+        ));
+        assert!(is_same_install_holder(
+            Path::new(r"C:/Users/max/AppData/Local/hermes/apps/desktop/release/win-unpacked/Hermes.exe"),
+            root
+        ));
+        assert!(!is_same_install_holder(
+            Path::new(r"D:/other-hermes/apps/desktop/release/win-unpacked/Hermes.exe"),
+            root
+        ));
+        assert!(!is_same_install_holder(
+            Path::new(r"C:\Users\max\AppData\Local\hermes-old\venv\Scripts\python.exe"),
+            root
+        ));
     }
 
     #[test]

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -591,6 +591,10 @@ fn force_kill_other_hermes() {
     force_kill_other_hermes_for(None);
 }
 
+fn should_use_global_hermes_kill(install_root: Option<&Path>) -> bool {
+    install_root.is_none()
+}
+
 /// Same as [`force_kill_other_hermes`], optionally scoped to a specific
 /// install root so we only kill that install's venv interpreters (avoids
 /// collateral damage if another Hermes tree is also present).
@@ -601,19 +605,23 @@ fn force_kill_other_hermes_for(install_root: Option<&Path>) {
     #[cfg(target_os = "windows")]
     {
         let my_pid = std::process::id();
-        // /FI excludes our own PID; /T kills the tree; /F forces.
-        let _ = std::process::Command::new("taskkill")
-            .args([
-                "/F",
-                "/T",
-                "/IM",
-                "hermes.exe",
-                "/FI",
-                &format!("PID ne {my_pid}"),
-            ])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
+        // The legacy no-root caller has no install boundary, so preserve its
+        // broad image cleanup. With a root, the scoped CIM query below also
+        // catches venv\Scripts\hermes.exe without touching other installs.
+        if should_use_global_hermes_kill(install_root) {
+            let _ = std::process::Command::new("taskkill")
+                .args([
+                    "/F",
+                    "/T",
+                    "/IM",
+                    "hermes.exe",
+                    "/FI",
+                    &format!("PID ne {my_pid}"),
+                ])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status();
+        }
 
         // Kill venv python(w).exe holders. Prefer a scoped PowerShell filter
         // when we know the install root; otherwise fall back to a broader
@@ -1098,6 +1106,18 @@ fn emit_log(app: &AppHandle, stage: Option<&str>, stream: LogStream, line: &str)
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn scoped_cleanup_skips_global_image_kill() {
+        assert!(!should_use_global_hermes_kill(Some(Path::new(
+            r"C:\Hermes"
+        ))));
+    }
+
+    #[test]
+    fn legacy_cleanup_keeps_global_image_kill_without_root() {
+        assert!(should_use_global_hermes_kill(None));
+    }
 
     #[test]
     fn venv_hermes_is_under_install_root() {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -159,6 +159,7 @@ import {
   writeSandboxMarker
 } from './windows-sandbox-fallback'
 import { installWindowsSystemCaTrust } from './windows-system-ca'
+import { forceKillVenvHolders, listVenvHolders } from './windows-venv-holders'
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
@@ -2510,8 +2511,31 @@ async function releaseBackendLock(updateRoot, tag) {
     forceKillProcessTree(pid)
   }
 
+  // Gateways / slash workers / other profiles are NOT in hermesProcess or the
+  // backend pool — they still hold venv\Scripts\hermes.exe and .pyd files open
+  // on Windows. Without this sweep the Update button aborts after 15s with
+  // "another process is holding the Hermes install open" whenever a gateway
+  // (e.g. Telegram Sophie) is running. hermes update itself pauses/resumes
+  // gateways after hand-off; we must free the shim *before* spawning the
+  // updater. Skip our own Electron PID so we don't suicide mid-handoff.
+  const skipPids = new Set<number>([process.pid, ...pids])
+  try {
+    const external = listVenvHolders(updateRoot, { skipPids })
+    if (external.length) {
+      rememberLog(
+        `[${tag}] force-killing ${external.length} external venv holder(s): ` +
+          external.map(h => `${h.pid}/${h.name}`).join(', ')
+      )
+      forceKillVenvHolders(external, { forceKillProcessTree })
+    }
+  } catch (err) {
+    rememberLog(`[${tag}] external venv-holder sweep failed: ${err && err.message ? err.message : err}`)
+  }
+
   const shim = venvHermesShimPath(updateRoot)
-  const deadlineMs = Date.now() + 15000
+  // Gateways + multi-profile backends can take longer than 15s to unload
+  // native modules on a loaded Windows box; give the OS a full 45s.
+  const deadlineMs = Date.now() + 45000
 
   while (Date.now() < deadlineMs) {
     if (!isShimLocked(shim)) {
@@ -2541,6 +2565,19 @@ async function releaseBackendLock(updateRoot, tag) {
       forceKillProcessTree(pid)
     }
 
+    // Re-sweep external holders each pass — a gateway can race-restart from a
+    // scheduled task or an orphan supervisor between iterations.
+    try {
+      const again = listVenvHolders(updateRoot, {
+        skipPids: new Set([process.pid, ...stragglers])
+      })
+      if (again.length) {
+        forceKillVenvHolders(again, { forceKillProcessTree })
+      }
+    } catch {
+      void 0
+    }
+
     await new Promise(r => setTimeout(r, 300))
   }
 
@@ -2552,7 +2589,7 @@ async function releaseBackendLock(updateRoot, tag) {
   // the update loudly and keeping the app running is strictly better than a
   // bricked install that needs manual venv surgery.
   rememberLog(
-    `[${tag}] venv shim still locked after 15s; aborting hand-off (something outside this app holds the venv)`
+    `[${tag}] venv shim still locked after 45s; aborting hand-off (something outside this app holds the venv)`
   )
 
   return { unlocked: false }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -159,8 +159,8 @@ import {
   writeSandboxMarker
 } from './windows-sandbox-fallback'
 import { installWindowsSystemCaTrust } from './windows-system-ca'
-import { forceKillVenvHolders, listVenvHolders } from './windows-venv-holders'
 import { readWindowsUserEnvVar } from './windows-user-env'
+import { forceKillVenvHolders, listVenvHolders } from './windows-venv-holders'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
 import { resolvePickerDefaultPath } from './wsl-path-bridge'
@@ -2467,6 +2467,55 @@ async function releaseBackendLockForUpdate(updateRoot) {
   return releaseBackendLock(updateRoot, 'updates')
 }
 
+function countLiveActiveSessionLeases(hermesHome: string): number {
+  const roots = new Set<string>([hermesHome])
+  const profilesDir = path.join(hermesHome, 'profiles')
+
+  if (path.basename(path.dirname(hermesHome)).toLowerCase() === 'profiles') {
+    roots.add(path.dirname(hermesHome))
+  } else if (fs.existsSync(profilesDir)) {
+    roots.add(profilesDir)
+  }
+
+  let count = 0
+
+  for (const root of roots) {
+    const homes =
+      path.basename(root).toLowerCase() === 'profiles'
+        ? fs
+            .readdirSync(root, { withFileTypes: true })
+            .filter(e => e.isDirectory())
+            .map(e => path.join(root, e.name))
+        : [root]
+
+    for (const home of homes) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(path.join(home, 'runtime', 'active_sessions.json'), 'utf8'))
+        const entries = Array.isArray(parsed) ? parsed : parsed?.entries
+
+        for (const entry of Array.isArray(entries) ? entries : []) {
+          const pid = Number(entry?.pid)
+
+          if (!Number.isInteger(pid) || pid <= 0) {
+            continue
+          }
+
+          try {
+            process.kill(pid, 0)
+            count += 1
+          } catch {
+            // Stale lease: the owning process is gone.
+          }
+        }
+      } catch {
+        // Missing/corrupt registry is not evidence of active work.
+      }
+    }
+  }
+
+  return count
+}
+
 // Shared backend teardown + venv-shim unlock wait. Used by BOTH the self-update
 // hand-off and the desktop uninstaller — they have the identical Windows
 // problem: the desktop's backend (and the grandchildren IT spawned — a hermes
@@ -2519,8 +2568,10 @@ async function releaseBackendLock(updateRoot, tag) {
   // gateways after hand-off; we must free the shim *before* spawning the
   // updater. Skip our own Electron PID so we don't suicide mid-handoff.
   const skipPids = new Set<number>([process.pid, ...pids])
+
   try {
     const external = listVenvHolders(updateRoot, { skipPids })
+
     if (external.length) {
       rememberLog(
         `[${tag}] force-killing ${external.length} external venv holder(s): ` +
@@ -2571,6 +2622,7 @@ async function releaseBackendLock(updateRoot, tag) {
       const again = listVenvHolders(updateRoot, {
         skipPids: new Set([process.pid, ...stragglers])
       })
+
       if (again.length) {
         forceKillVenvHolders(again, { forceKillProcessTree })
       }
@@ -2605,7 +2657,7 @@ async function releaseBackendLock(updateRoot, tag) {
 //
 // Detection (checkUpdates / commit changelog / "N behind") stays in the UI;
 // only this apply action changed.
-async function applyUpdates(opts = {}) {
+async function applyUpdates(opts: { force?: boolean; dirtyStrategy?: string } = {}) {
   if (updateInFlight) {
     throw new Error('An update is already in progress.')
   }
@@ -2659,6 +2711,21 @@ async function applyUpdates(opts = {}) {
       return { ok: true, manual: true, command, hermesRoot: updateRoot }
     }
 
+    const updateRoot = resolveUpdateRoot()
+
+    if (IS_WINDOWS && !opts.force) {
+      const activeSessions = countLiveActiveSessionLeases(HERMES_HOME)
+      const holders = listVenvHolders(updateRoot, { skipPids: new Set([process.pid]) })
+
+      if (activeSessions > 0 || holders.length > 0) {
+        const message =
+          `${activeSessions} active session(s) and ${holders.length} install process(es) will be interrupted. ` +
+          'Disk state, wiki, configuration and session history are kept; gateways pause and restart after the update.'
+
+        return { ok: false, busy: true, activeSessions, holders: holders.length, message }
+      }
+    }
+
     emitUpdateProgress({
       stage: 'restart',
       message:
@@ -2667,7 +2734,6 @@ async function applyUpdates(opts = {}) {
     })
     repairMacUpdaterHelper(updater)
 
-    const updateRoot = resolveUpdateRoot()
     const { branch: configuredBranch } = readDesktopUpdateConfig()
     const branch = await resolveHealedBranch(updateRoot, configuredBranch || DEFAULT_UPDATE_BRANCH)
     const updaterArgs = ['--update', '--branch', branch]

--- a/apps/desktop/electron/windows-venv-holders.test.ts
+++ b/apps/desktop/electron/windows-venv-holders.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  isVenvHolderProcess,
-  normalizeWinPath,
-  selectVenvHolders
-} from './windows-venv-holders'
+import { isVenvHolderProcess, normalizeWinPath, selectVenvHolders } from './windows-venv-holders'
 
 const ROOT = 'C:\\Users\\TestUser\\AppData\\Local\\hermes\\hermes-agent'
 
@@ -36,10 +32,7 @@ describe('isVenvHolderProcess', () => {
         {
           pid: 7,
           exe: 'C:\\Users\\TestUser\\AppData\\Local\\Programs\\Python\\Python311\\python.exe',
-          cmdline:
-            'python.exe -m hermes_cli.main --profile sophie gateway run ' +
-            ROOT +
-            '\\venv\\Lib\\site-packages'
+          cmdline: 'python.exe -m hermes_cli.main --profile sophie gateway run ' + ROOT + '\\venv\\Lib\\site-packages'
         },
         ROOT
       )

--- a/apps/desktop/electron/windows-venv-holders.test.ts
+++ b/apps/desktop/electron/windows-venv-holders.test.ts
@@ -6,7 +6,7 @@ import {
   selectVenvHolders
 } from './windows-venv-holders'
 
-const ROOT = 'C:\\Users\\si\\AppData\\Local\\hermes\\hermes-agent'
+const ROOT = 'C:\\Users\\TestUser\\AppData\\Local\\hermes\\hermes-agent'
 
 describe('normalizeWinPath', () => {
   it('lowercases and unifies separators', () => {
@@ -35,7 +35,7 @@ describe('isVenvHolderProcess', () => {
       isVenvHolderProcess(
         {
           pid: 7,
-          exe: 'C:\\Users\\si\\AppData\\Local\\Programs\\Python\\Python311\\python.exe',
+          exe: 'C:\\Users\\TestUser\\AppData\\Local\\Programs\\Python\\Python311\\python.exe',
           cmdline:
             'python.exe -m hermes_cli.main --profile sophie gateway run ' +
             ROOT +

--- a/apps/desktop/electron/windows-venv-holders.test.ts
+++ b/apps/desktop/electron/windows-venv-holders.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isVenvHolderProcess,
+  normalizeWinPath,
+  selectVenvHolders
+} from './windows-venv-holders'
+
+const ROOT = 'C:\\Users\\si\\AppData\\Local\\hermes\\hermes-agent'
+
+describe('normalizeWinPath', () => {
+  it('lowercases and unifies separators', () => {
+    expect(normalizeWinPath('C:/Users/SI/AppData/Local/hermes/hermes-agent/')).toBe(
+      'c:\\users\\si\\appdata\\local\\hermes\\hermes-agent'
+    )
+  })
+})
+
+describe('isVenvHolderProcess', () => {
+  it('matches venv python.exe by path', () => {
+    expect(
+      isVenvHolderProcess(
+        {
+          pid: 42,
+          exe: ROOT + '\\venv\\Scripts\\python.exe',
+          cmdline: ROOT + '\\venv\\Scripts\\python.exe -m hermes_cli.main gateway run'
+        },
+        ROOT
+      )
+    ).toBe(true)
+  })
+
+  it('matches base python trampoline that imports the venv via cmdline', () => {
+    expect(
+      isVenvHolderProcess(
+        {
+          pid: 7,
+          exe: 'C:\\Users\\si\\AppData\\Local\\Programs\\Python\\Python311\\python.exe',
+          cmdline:
+            'python.exe -m hermes_cli.main --profile sophie gateway run ' +
+            ROOT +
+            '\\venv\\Lib\\site-packages'
+        },
+        ROOT
+      )
+    ).toBe(true)
+  })
+
+  it('matches tui_gateway slash_worker under install cwd', () => {
+    expect(
+      isVenvHolderProcess(
+        {
+          pid: 9,
+          exe: ROOT + '\\venv\\Scripts\\python.exe',
+          cmdline: 'python.exe -m tui_gateway.slash_worker --session-key x',
+          cwd: ROOT
+        },
+        ROOT
+      )
+    ).toBe(true)
+  })
+
+  it('skips listed pids and unrelated processes', () => {
+    expect(
+      isVenvHolderProcess(
+        {
+          pid: 1,
+          exe: ROOT + '\\venv\\Scripts\\python.exe',
+          cmdline: 'x'
+        },
+        ROOT,
+        new Set([1])
+      )
+    ).toBe(false)
+
+    expect(
+      isVenvHolderProcess(
+        {
+          pid: 2,
+          exe: 'C:\\Windows\\System32\\notepad.exe',
+          cmdline: 'notepad'
+        },
+        ROOT
+      )
+    ).toBe(false)
+  })
+})
+
+describe('selectVenvHolders', () => {
+  it('dedupes and filters', () => {
+    const holders = selectVenvHolders(
+      [
+        {
+          pid: 10,
+          name: 'python.exe',
+          exe: ROOT + '\\venv\\Scripts\\python.exe',
+          cmdline: 'gateway'
+        },
+        {
+          pid: 10,
+          name: 'python.exe',
+          exe: ROOT + '\\venv\\Scripts\\python.exe',
+          cmdline: 'gateway'
+        },
+        { pid: 11, name: 'notepad.exe', exe: 'C:\\Windows\\notepad.exe', cmdline: 'n' }
+      ],
+      ROOT
+    )
+
+    expect(holders).toEqual([
+      {
+        pid: 10,
+        name: 'python.exe',
+        exe: ROOT + '\\venv\\Scripts\\python.exe',
+        cmdline: 'gateway'
+      }
+    ])
+  })
+})

--- a/apps/desktop/electron/windows-venv-holders.ts
+++ b/apps/desktop/electron/windows-venv-holders.ts
@@ -60,6 +60,7 @@ export function isVenvHolderProcess(
   }
 
   const root = normalizeWinPath(installRoot)
+
   if (!root) {
     return false
   }
@@ -67,7 +68,11 @@ export function isVenvHolderProcess(
   const venvPrefix = root + '\\venv\\'
   const rootPrefix = root + '\\'
   const exeNorm = normalizeWinPath(exe || '')
-  const cmdlineLow = String(cmdline || '').toLowerCase().replace(/\//g, '\\')
+
+  const cmdlineLow = String(cmdline || '')
+    .toLowerCase()
+    .replace(/\//g, '\\')
+
   const cwdLow = normalizeWinPath(cwd || '') + '\\'
 
   if (exeNorm && (exeNorm === root + '\\venv' || exeNorm.startsWith(venvPrefix))) {
@@ -112,6 +117,7 @@ export function selectVenvHolders(
 
   for (const row of rows || []) {
     const pid = Number(row.pid)
+
     if (
       !isVenvHolderProcess(
         {
@@ -137,6 +143,7 @@ export function selectVenvHolders(
 
   // Stable, unique by pid.
   const seen = new Set<number>()
+
   return out.filter(h => {
     if (seen.has(h.pid)) {
       return false
@@ -201,6 +208,7 @@ export function listVenvHolders(
   }
 
   raw = String(raw || '').trim()
+
   if (!raw) {
     return []
   }

--- a/apps/desktop/electron/windows-venv-holders.ts
+++ b/apps/desktop/electron/windows-venv-holders.ts
@@ -1,0 +1,262 @@
+/**
+ * Windows venv-holder discovery + force-kill for self-update hand-off.
+ *
+ * The desktop used to only tree-kill backends it owns (hermesProcess /
+ * backendPool). Gateways, slash workers, stray terminals and other profiles
+ * keep `venv\Scripts\hermes.exe` / `.pyd` files mandatory-locked on Windows,
+ * so the Update button aborted after 15s with "another process is holding the
+ * Hermes install open" — even though the user had no second Hermes window.
+ *
+ * This module enumerates every process whose executable lives under the
+ * install's venv (or whose command line / cwd references that venv or the
+ * install root with hermes_cli), then taskkill /T /F each PID. Pure helpers
+ * are injectable for unit tests; live discovery uses PowerShell CIM.
+ */
+
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+
+import { hiddenWindowsChildOptions } from './windows-child-options'
+
+export type VenvHolder = {
+  pid: number
+  name: string
+  exe: string
+  cmdline: string
+}
+
+/**
+ * Normalize a Windows path for prefix comparison: lower-case, forward slashes
+ * collapsed to backslashes, trailing separator stripped.
+ */
+export function normalizeWinPath(p: string): string {
+  return String(p || '')
+    .replace(/\//g, '\\')
+    .replace(/\\+$/, '')
+    .toLowerCase()
+}
+
+/**
+ * Decide whether a process is holding the given Hermes install open.
+ * Mirrors hermes_cli.main._detect_venv_python_processes matching rules.
+ */
+export function isVenvHolderProcess(
+  {
+    pid,
+    exe,
+    cmdline,
+    cwd
+  }: {
+    pid: number
+    exe?: string | null
+    cmdline?: string | null
+    cwd?: string | null
+  },
+  installRoot: string,
+  skipPids: Set<number> = new Set()
+): boolean {
+  if (!Number.isInteger(pid) || pid <= 0 || skipPids.has(pid)) {
+    return false
+  }
+
+  const root = normalizeWinPath(installRoot)
+  if (!root) {
+    return false
+  }
+
+  const venvPrefix = root + '\\venv\\'
+  const rootPrefix = root + '\\'
+  const exeNorm = normalizeWinPath(exe || '')
+  const cmdlineLow = String(cmdline || '').toLowerCase().replace(/\//g, '\\')
+  const cwdLow = normalizeWinPath(cwd || '') + '\\'
+
+  if (exeNorm && (exeNorm === root + '\\venv' || exeNorm.startsWith(venvPrefix))) {
+    return true
+  }
+
+  if (venvPrefix.slice(0, -1) && cmdlineLow.includes(venvPrefix.slice(0, -1))) {
+    return true
+  }
+
+  if (cmdlineLow.includes('hermes_cli.main') || cmdlineLow.includes('tui_gateway')) {
+    if (cmdlineLow.includes(rootPrefix.slice(0, -1)) || cwdLow.startsWith(rootPrefix)) {
+      return true
+    }
+  }
+
+  // Packaged/console hermes.exe living under the install (not only the venv).
+  if (exeNorm.endsWith('\\hermes.exe') && exeNorm.startsWith(rootPrefix)) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Parse a PowerShell-emitted JSON array of {pid,name,exe,cmdline,cwd} into
+ * holder records for this install.
+ */
+export function selectVenvHolders(
+  rows: Array<{
+    pid?: number | string
+    name?: string
+    exe?: string
+    cmdline?: string
+    cwd?: string
+  }>,
+  installRoot: string,
+  skipPids: Iterable<number> = []
+): VenvHolder[] {
+  const skip = new Set(Array.from(skipPids).filter(n => Number.isInteger(n)))
+  const out: VenvHolder[] = []
+
+  for (const row of rows || []) {
+    const pid = Number(row.pid)
+    if (
+      !isVenvHolderProcess(
+        {
+          pid,
+          exe: row.exe,
+          cmdline: row.cmdline,
+          cwd: row.cwd
+        },
+        installRoot,
+        skip
+      )
+    ) {
+      continue
+    }
+
+    out.push({
+      pid,
+      name: String(row.name || path.basename(String(row.exe || '')) || 'unknown'),
+      exe: String(row.exe || ''),
+      cmdline: String(row.cmdline || '').slice(0, 200)
+    })
+  }
+
+  // Stable, unique by pid.
+  const seen = new Set<number>()
+  return out.filter(h => {
+    if (seen.has(h.pid)) {
+      return false
+    }
+
+    seen.add(h.pid)
+
+    return true
+  })
+}
+
+const LIST_HOLDERS_PS = `
+$ErrorActionPreference = 'SilentlyContinue'
+$procs = Get-CimInstance Win32_Process | ForEach-Object {
+  [pscustomobject]@{
+    pid = $_.ProcessId
+    name = $_.Name
+    exe = $_.ExecutablePath
+    cmdline = $_.CommandLine
+    cwd = $null
+  }
+}
+$procs | ConvertTo-Json -Compress -Depth 3
+`.trim()
+
+/**
+ * Live enumeration of processes holding `installRoot`'s venv open.
+ * Returns [] off Windows or on discovery failure (caller still has the
+ * shim lock probe as the real gate).
+ */
+export function listVenvHolders(
+  installRoot: string,
+  {
+    skipPids = [],
+    isWindows = process.platform === 'win32',
+    execFileSyncImpl = execFileSync
+  }: {
+    skipPids?: Iterable<number>
+    isWindows?: boolean
+    execFileSyncImpl?: typeof execFileSync
+  } = {}
+): VenvHolder[] {
+  if (!isWindows || !installRoot) {
+    return []
+  }
+
+  let raw = ''
+
+  try {
+    raw = execFileSyncImpl(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', LIST_HOLDERS_PS],
+      hiddenWindowsChildOptions({
+        encoding: 'utf8',
+        timeout: 20000,
+        windowsHide: true,
+        maxBuffer: 16 * 1024 * 1024
+      }) as any
+    ) as unknown as string
+  } catch {
+    return []
+  }
+
+  raw = String(raw || '').trim()
+  if (!raw) {
+    return []
+  }
+
+  let parsed: any
+
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+
+  const rows = Array.isArray(parsed) ? parsed : parsed ? [parsed] : []
+
+  return selectVenvHolders(rows, installRoot, skipPids)
+}
+
+/**
+ * Force-kill every holder process tree. Best-effort; failures are ignored —
+ * the caller's shim-unlock poll is the real gate.
+ */
+export function forceKillVenvHolders(
+  holders: VenvHolder[],
+  {
+    isWindows = process.platform === 'win32',
+    execFileSyncImpl = execFileSync,
+    forceKillProcessTree
+  }: {
+    isWindows?: boolean
+    execFileSyncImpl?: typeof execFileSync
+    forceKillProcessTree?: (pid: number) => void
+  } = {}
+): number[] {
+  if (!isWindows) {
+    return []
+  }
+
+  const killed: number[] = []
+
+  for (const h of holders) {
+    try {
+      if (forceKillProcessTree) {
+        forceKillProcessTree(h.pid)
+      } else {
+        execFileSyncImpl(
+          'taskkill',
+          ['/PID', String(h.pid), '/T', '/F'],
+          hiddenWindowsChildOptions({ stdio: 'ignore', windowsHide: true }) as any
+        )
+      }
+
+      killed.push(h.pid)
+    } catch {
+      // Already gone / access denied — unlock wait decides success.
+    }
+  }
+
+  return killed
+}

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -68,16 +68,18 @@ export function UpdatesOverlay() {
   const behind = status?.behind ?? 0
   const updateAvailable = status?.updateAvailable || behind > 0
 
-  const phase: 'idle' | 'applying' | 'manual' | 'guiSkew' | 'error' =
+  const phase: 'idle' | 'applying' | 'busyConfirm' | 'manual' | 'guiSkew' | 'error' =
     apply.stage === 'manual'
       ? 'manual'
-      : apply.stage === 'guiSkew'
-        ? 'guiSkew'
-        : apply.applying || apply.stage === 'restart'
-          ? 'applying'
-          : apply.stage === 'error'
-            ? 'error'
-            : 'idle'
+      : apply.stage === 'busyConfirm'
+        ? 'busyConfirm'
+        : apply.stage === 'guiSkew'
+          ? 'guiSkew'
+          : apply.applying || apply.stage === 'restart'
+            ? 'applying'
+            : apply.stage === 'error'
+              ? 'error'
+              : 'idle'
 
   const handleClose = (next: boolean) => {
     if (phase === 'applying') {
@@ -98,6 +100,10 @@ export function UpdatesOverlay() {
     void install()
   }
 
+  const handleForcedInstall = () => {
+    void applyUpdates({ force: true })
+  }
+
   return (
     <Dialog onOpenChange={handleClose} open={open}>
       {/* This dialog has no inputs, so Radix's default autofocus would land on
@@ -108,6 +114,14 @@ export function UpdatesOverlay() {
         showCloseButton={phase !== 'applying'}
       >
         {phase === 'applying' && <ApplyingView apply={apply} isBackend={isBackend} />}
+
+        {phase === 'busyConfirm' && (
+          <BusyConfirmView
+            message={apply.message}
+            onCancel={() => handleClose(false)}
+            onConfirm={handleForcedInstall}
+          />
+        )}
 
         {phase === 'manual' && (
           <ManualView command={apply.command ?? null} message={apply.message} onDone={() => handleClose(false)} />
@@ -261,9 +275,42 @@ function IdleView({
         <Button className="font-medium" onClick={onLater} type="button" variant="text">
           {u.maybeLater}
         </Button>
+        {target === 'client' && (
+          <p className="text-center text-xs text-muted-foreground">
+            Updating briefly pauses gateways and interrupts agents that are still running.
+          </p>
+        )}
       </div>
 
       {remaining > 0 && <p className="text-center text-xs text-muted-foreground">{u.moreChanges(remaining)}</p>}
+    </div>
+  )
+}
+
+function BusyConfirmView({
+  message,
+  onCancel,
+  onConfirm
+}: {
+  message: string
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  return (
+    <div className="grid gap-5 px-6 pb-6 pt-7 pr-8">
+      <div className="flex flex-col items-center gap-3 text-center">
+        <AlertCircle className="size-8 text-amber-500" />
+        <DialogTitle className="text-center text-xl">Hermes is still working</DialogTitle>
+        <DialogDescription className="text-center text-sm">{message}</DialogDescription>
+      </div>
+      <div className="grid gap-2">
+        <Button className="font-semibold" onClick={onConfirm} size="lg">
+          Update anyway
+        </Button>
+        <Button className="font-medium" onClick={onCancel} type="button" variant="text">
+          Not now
+        </Button>
+      </div>
     </div>
   )
 }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -318,6 +318,7 @@ export type DesktopUpdateDirtyStrategy = 'abort' | 'stash' | 'force'
 
 export interface DesktopUpdateApplyOptions {
   dirtyStrategy?: DesktopUpdateDirtyStrategy
+  force?: boolean
 }
 
 export interface DesktopUpdateApplyResult {
@@ -325,6 +326,9 @@ export interface DesktopUpdateApplyResult {
   branch?: string
   error?: string
   message?: string
+  busy?: boolean
+  activeSessions?: number
+  holders?: number
   /** True when no staged updater exists (CLI install) and the user should run
    *  `hermes update` themselves. `command` is the exact line to run. */
   manual?: boolean
@@ -356,6 +360,7 @@ export interface DesktopUpdateApplyResult {
 export type DesktopUpdateStage =
   | 'idle'
   | 'prepare'
+  | 'busyConfirm'
   | 'fetch'
   | 'pull'
   | 'pydeps'

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -274,6 +274,23 @@ describe('applyUpdates terminal state', () => {
     delete (globalThis as unknown as { window?: unknown }).window
   })
 
+  it('lands on confirmation instead of interrupting active agents', async () => {
+    applyMock.mockResolvedValue({
+      ok: false,
+      busy: true,
+      activeSessions: 2,
+      holders: 3,
+      message: '2 active sessions will be interrupted.'
+    })
+
+    const result = await applyUpdates()
+
+    expect(result.busy).toBe(true)
+    expect($updateApply.get().applying).toBe(false)
+    expect($updateApply.get().stage).toBe('busyConfirm')
+    expect($updateApply.get().message).toMatch(/interrupted/)
+  })
+
   it('holds the restart view when a relauncher hands off (no close, no toast)', async () => {
     applyMock.mockResolvedValue({ ok: true, handedOff: true })
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -375,6 +375,17 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
   try {
     const result = await bridge.apply(opts)
 
+    if (result?.busy) {
+      $updateApply.set({
+        ...IDLE,
+        applying: false,
+        stage: 'busyConfirm',
+        message: result.message ?? 'Active Hermes work will be interrupted by this update.'
+      })
+
+      return result
+    }
+
     // CLI install with no staged updater: not an error — the user just runs
     // `hermes update` themselves. Land on a dedicated manual state so the
     // overlay shows the command + copy button instead of a dead retry loop.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9220,6 +9220,34 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
             return False, f"venv python missing ({venv_python})"
         return True, ""
 
+    # uv/Windows venvs record the base interpreter under pyvenv.cfg `home=`.
+    # If that directory (or python.exe inside it) vanished, the venv shim
+    # still exists but every launch falls over — classic "desktop restarts
+    # pointing at C:\Users\...\Python311\python.exe" half-update brick.
+    # Force the repair lane so we recreate the venv against a live base.
+    if _is_windows():
+        try:
+            cfg_path = venv_dir / "pyvenv.cfg"
+            if cfg_path.exists():
+                home_val = ""
+                for raw in cfg_path.read_text(encoding="utf-8", errors="replace").splitlines():
+                    if "=" not in raw:
+                        continue
+                    key, value = raw.split("=", 1)
+                    if key.strip().lower() == "home":
+                        home_val = value.strip().strip('"')
+                        break
+                if home_val:
+                    home_path = Path(home_val)
+                    base_py = home_path / "python.exe"
+                    if not home_path.is_dir() or not base_py.exists():
+                        return (
+                            False,
+                            f"venv base interpreter missing ({base_py})",
+                        )
+        except Exception as exc:
+            logger.debug("pyvenv.cfg base-home probe failed: %s", exc)
+
     # Core web/serve imports plus their newest transitive deps. Import (not
     # just metadata) — a package can have intact dist-info but a missing
     # module after an interrupted uninstall/install cycle.
@@ -9852,12 +9880,41 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # and app.asar — a non-desktop venv python holding a .pyd would sail
     # through and corrupt the sync (the exact failure this guard exists for).
     # --force-venv is the explicit escape hatch.
+    #
+    # Gateway / desktop-updater mode is different: the desktop has already
+    # quit and asked us to free the install, and gateways were just paused
+    # above. Any remaining holders are stragglers (slash workers, orphaned
+    # pythons). Force-kill them once and re-probe; only abort if they survive.
     if _is_windows() and not getattr(args, "force_venv", False):
         _venv_holders = _detect_venv_python_processes()
         if _venv_holders:
-            print(_format_venv_python_holders_message(_venv_holders))
-            _resume_windows_gateways_after_update(_windows_gateway_resume)
-            sys.exit(2)
+            if gateway_mode:
+                print(
+                    f"→ Force-stopping {len(_venv_holders)} remaining venv holder(s) "
+                    "before dependency sync..."
+                )
+                try:
+                    from gateway.status import terminate_pid
+                except Exception:
+                    terminate_pid = None  # type: ignore[assignment]
+                for pid, _name, _cmd in _venv_holders:
+                    try:
+                        if terminate_pid is not None:
+                            terminate_pid(int(pid), force=True)
+                        else:
+                            subprocess.run(
+                                ["taskkill", "/F", "/T", "/PID", str(pid)],
+                                check=False,
+                                capture_output=True,
+                            )
+                    except Exception:
+                        pass
+                _time.sleep(1.0)
+                _venv_holders = _detect_venv_python_processes()
+            if _venv_holders:
+                print(_format_venv_python_holders_message(_venv_holders))
+                _resume_windows_gateways_after_update(_windows_gateway_resume)
+                sys.exit(2)
 
     # Try git-based update first, fall back to ZIP download on Windows
     # when git file I/O is broken (antivirus, NTFS filter drivers, etc.)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9282,6 +9282,32 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
     return True, ""
 
 
+def _venv_requires_recreation() -> bool:
+    """Return whether repair must replace the venv instead of syncing it."""
+    venv_dir = PROJECT_ROOT / "venv"
+    bin_dir = "Scripts" if _is_windows() else "bin"
+    python_name = "python.exe" if _is_windows() else "python"
+    if not (venv_dir / bin_dir / python_name).exists():
+        return True
+    if not _is_windows():
+        return False
+    try:
+        cfg_path = venv_dir / "pyvenv.cfg"
+        if not cfg_path.exists():
+            return False
+        for raw in cfg_path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if "=" not in raw:
+                continue
+            key, value = raw.split("=", 1)
+            if key.strip().lower() != "home":
+                continue
+            home_path = Path(value.strip().strip('"'))
+            return not home_path.is_dir() or not (home_path / "python.exe").exists()
+    except Exception as exc:
+        logger.debug("pyvenv.cfg recreation probe failed: %s", exc)
+    return False
+
+
 def _detect_venv_python_processes(
     *, exclude_pids: set[int] | None = None
 ) -> list[tuple[int, str, str]]:
@@ -10134,19 +10160,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 from hermes_cli.managed_uv import ensure_uv
 
                 repair_uv = ensure_uv()
-                # A managed install whose venv is gone entirely (interrupted
-                # repair after the old venv was moved aside) needs the venv
-                # recreated before dependencies can be installed into it.
-                venv_python_missing = not (
-                    PROJECT_ROOT
-                    / "venv"
-                    / ("Scripts" if _is_windows() else "bin")
-                    / ("python.exe" if _is_windows() else "python")
-                ).exists()
-                if venv_python_missing and repair_uv:
+                # A missing shim or dead pyvenv.cfg base cannot be fixed by
+                # syncing packages into the existing venv; recreate it first.
+                recreate_venv = _venv_requires_recreation()
+                if recreate_venv and repair_uv:
                     print("→ Recreating virtual environment...")
                     subprocess.run(
-                        [repair_uv, "venv", "venv"],
+                        [repair_uv, "venv", "--clear", "venv"],
                         cwd=PROJECT_ROOT,
                         check=False,
                     )

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -119,6 +119,28 @@ def test_venv_health_probe_failure_reports_healthy(tmp_path):
     assert healthy is True
 
 
+def test_venv_requires_recreation_when_windows_base_interpreter_is_missing(tmp_path):
+    _fake_venv_python(tmp_path, windows=True)
+    missing_home = tmp_path / "removed-python311"
+    (tmp_path / "venv" / "pyvenv.cfg").write_text(f"home = {missing_home}\n", encoding="utf-8")
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        cli_main, "_is_windows", return_value=True
+    ):
+        assert cli_main._venv_requires_recreation() is True
+
+
+def test_venv_does_not_recreate_when_windows_base_interpreter_exists(tmp_path):
+    _fake_venv_python(tmp_path, windows=True)
+    base_home = tmp_path / "Python311"
+    base_home.mkdir()
+    (base_home / "python.exe").write_bytes(b"")
+    (tmp_path / "venv" / "pyvenv.cfg").write_text(f"home = {base_home}\n", encoding="utf-8")
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.object(
+        cli_main, "_is_windows", return_value=True
+    ):
+        assert cli_main._venv_requires_recreation() is False
+
+
 # ---------------------------------------------------------------------------
 # _detect_venv_python_processes
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Desktop Update hand-off now discovers and force-kills **all** processes holding the install venv open (gateways, slash workers, trampoline pythons), not only backends owned by the current Electron window. Wait extended to 45s.
- Tauri `hermes-setup --update` straggler cleanup also reaps venv `python(w).exe` holders, not only `hermes.exe`.
- `hermes update --gateway` force-stops remaining venv holders after gateway pause instead of immediately exiting 2.
- Venv health probe treats a missing base interpreter (`pyvenv.cfg` home) as unhealthy so repair recreates the runtime instead of leaving a bricked desktop pointing at a dead system Python path.

## Root cause
On Windows, Telegram/multi-profile gateways run as `venv\Scripts\python.exe` and keep `hermes.exe` / `.pyd` files mandatory-locked. Clicking **Update** stopped only the desktop-owned backends, so the shim stayed locked and the UI aborted: *\"another process is holding the Hermes install open\"*. Partial updates could leave a broken runtime tied to `C:\Users\...\Python311\python.exe`.

## Test plan
- [x] `vitest` `electron/windows-venv-holders.test.ts` (6 tests)
- [x] Manual unit probe: missing `pyvenv.cfg` home → unhealthy + recreate path
- [ ] Click desktop **Update** with at least one gateway running; window should hand off without the 15s abort
- [ ] Updater completes; desktop relaunches; backend ready; profiles (incl. Sophie) work
- [ ] No manual `hermes-maj.ps1` / repair path required