### PR TITLE
fix(desktop): ignore stale remote connection attempts

### DIFF
--- a/apps/desktop/electron/backend-connection-state.test.ts
+++ b/apps/desktop/electron/backend-connection-state.test.ts
@@ -6,6 +6,43 @@ import { createBackendConnectionState } from './backend-connection-state'
 
 type FakeProcess = { id: string }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(next => {
+    resolve = next
+  })
+
+  return { promise, resolve }
+}
+
+test('an invalidated remote attempt cannot publish a late descriptor', async () => {
+  const state = createBackendConnectionState<FakeProcess, string>()
+  const oldProbe = deferred<string>()
+  const oldAttempt = state.startAttempt()
+
+  const oldResult = oldProbe.promise.then(descriptor => {
+    if (!state.isCurrentAttempt(oldAttempt)) {
+      throw new Error('Hermes backend start was superseded by a newer connection attempt.')
+    }
+
+    return descriptor
+  })
+
+  state.setPromise(oldAttempt, oldResult)
+  state.invalidate()
+
+  const newAttempt = state.startAttempt()
+  const newResult = Promise.resolve('https://new.example')
+
+  state.setPromise(newAttempt, newResult)
+  assert.equal(await newResult, 'https://new.example')
+
+  oldProbe.resolve('https://old.example')
+  await assert.rejects(oldResult, /superseded by a newer connection attempt/)
+  assert.equal(state.getPromise(), newResult)
+})
+
 test('a stale backend exit cannot clear a newer connection attempt', () => {
   const state = createBackendConnectionState<FakeProcess, string>()
   const oldAttempt = state.startAttempt()

--- a/apps/desktop/electron/backend-connection-state.ts
+++ b/apps/desktop/electron/backend-connection-state.ts
@@ -29,6 +29,10 @@ export function createBackendConnectionState<TProcess, TConnection>() {
       return true
     },
 
+    isCurrentAttempt(attempt: BackendConnectionAttempt<TConnection>): boolean {
+      return attempt.generation === generation
+    },
+
     attachProcess(
       attempt: BackendConnectionAttempt<TConnection>,
       nextProcess: TProcess

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6744,9 +6744,18 @@ async function startHermes() {
     // override on the active profile is honored (falls back to env / global).
     const remote = await resolveRemoteBackend(primaryProfileKey())
 
+    if (!backendConnectionState.isCurrentAttempt(connectionAttempt)) {
+      throw new Error('Hermes backend start was superseded by a newer connection attempt.')
+    }
+
     if (remote) {
       await advanceBootProgress('backend.remote', `Connecting to remote Hermes backend at ${remote.baseUrl}`, 24)
       await waitForHermes(remote.baseUrl, remote.token)
+
+      if (!backendConnectionState.isCurrentAttempt(connectionAttempt)) {
+        throw new Error('Hermes backend start was superseded by a newer connection attempt.')
+      }
+
       updateBootProgress({
         phase: 'backend.ready',
         message: 'Remote Hermes backend is ready',


### PR DESCRIPTION
## What does this PR do?

Stops an old remote connection check from returning after the user changes settings or starts a newer connection attempt.

The connection generation is checked after remote settings are resolved and again after the remote health check.

## Related Issue

Fixes #65938

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Add a small helper that checks whether a connection attempt is still current.
- Reject late remote results from an invalidated attempt.
- Add a regression test that keeps the newer promise intact.

## How to Test

1. Run `npm run --prefix apps/desktop test:desktop:platforms` — 428 passed, 1 skipped.
2. Run `npm run --prefix apps/desktop typecheck`.
3. Run ESLint and Prettier on the three changed Electron files.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] This PR contains only this fix
- [ ] I've run the full Python test suite — N/A; this is a Desktop-only change
- [x] I've added a regression test
- [x] I've tested on macOS 26.5.2

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] Config example update — N/A
- [x] Architecture or workflow docs update — N/A
- [x] Cross-platform impact considered; no platform-specific API was added
- [x] Tool schema update — N/A

## Screenshots / Logs

N/A — behavior-only fix.