### PR TITLE
fix(webhook): preserve profile-scoped reply delivery

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -748,6 +748,8 @@ class WebhookAdapter(BasePlatformAdapter):
                 ),
                 "payload": payload,
             }
+            if profile and isinstance(profile, str):
+                delivery["profile"] = profile
             logger.info(
                 "[webhook] direct-deliver event=%s route=%s target=%s msg_len=%d delivery=%s",
                 event_type,
@@ -805,6 +807,8 @@ class WebhookAdapter(BasePlatformAdapter):
                 route_config.get("deliver_extra", {}), payload
             ),
         }
+        if profile and isinstance(profile, str):
+            deliver_config["profile"] = profile
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now
         self._delivery_info_order.append((now, session_chat_id))
@@ -1295,18 +1299,26 @@ class WebhookAdapter(BasePlatformAdapter):
                 success=False, error=f"Unknown platform: {platform_name}"
             )
 
-        # Default adapters first; multiplex may park Slack/etc. only on a
-        # secondary profile (self._profile_adapters). Fall back so webhook
-        # deliver:slack still works when default has slack disabled.
-        adapter = self.gateway_runner.adapters.get(target_platform)
-        if not adapter:
-            for _prof, amap in (getattr(self.gateway_runner, "_profile_adapters", None) or {}).items():
-                if not isinstance(amap, dict):
-                    continue
-                cand = amap.get(target_platform)
-                if cand is not None:
-                    adapter = cand
-                    break
+        # A /p/<profile>/ webhook must deliver through that exact profile.
+        # Unprefixed routes retain the legacy default-then-secondary fallback.
+        profile = delivery.get("profile")
+        if isinstance(profile, str) and profile:
+            adapter = self.gateway_runner._authorization_adapter(
+                target_platform, profile
+            )
+        else:
+            adapter = self.gateway_runner.adapters.get(target_platform)
+            if not adapter:
+                profile_adapters = (
+                    getattr(self.gateway_runner, "_profile_adapters", None) or {}
+                )
+                for _prof, amap in profile_adapters.items():
+                    if not isinstance(amap, dict):
+                        continue
+                    cand = amap.get(target_platform)
+                    if cand is not None:
+                        adapter = cand
+                        break
         if not adapter:
             return SendResult(
                 success=False,
@@ -1317,7 +1329,12 @@ class WebhookAdapter(BasePlatformAdapter):
         extra = delivery.get("deliver_extra", {})
         chat_id = extra.get("chat_id", "")
         if not chat_id:
-            home = self.gateway_runner.config.get_home_channel(target_platform)
+            if isinstance(profile, str) and profile:
+                home = getattr(
+                    getattr(adapter, "config", None), "home_channel", None
+                )
+            else:
+                home = self.gateway_runner.config.get_home_channel(target_platform)
             if home:
                 chat_id = home.chat_id
             else:

--- a/tests/gateway/test_webhook_profile_delivery.py
+++ b/tests/gateway/test_webhook_profile_delivery.py
@@ -1,0 +1,230 @@
+"""Profile isolation contracts for webhook reply delivery."""
+
+import asyncio
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
+
+
+class _RecordingTarget:
+    def __init__(self, config: PlatformConfig):
+        self.config = config
+        self.calls: list[tuple[str, str, object]] = []
+
+    async def send(self, chat_id, content, metadata=None):
+        self.calls.append((chat_id, content, metadata))
+        return SendResult(success=True)
+
+
+class _Runner(GatewayAuthorizationMixin):
+    def __init__(self, default_target=None, coder_target=None):
+        default_config = PlatformConfig(
+            enabled=True,
+            home_channel=HomeChannel(
+                platform=Platform.TELEGRAM,
+                chat_id="default-home",
+                name="Default home",
+            ),
+        )
+        self.config = GatewayConfig(
+            multiplex_profiles=True,
+            platforms={Platform.TELEGRAM: default_config},
+        )
+        self.adapters = {Platform.TELEGRAM: default_target} if default_target else {}
+        self._profile_adapters = {
+            "coder": ({Platform.TELEGRAM: coder_target} if coder_target else {})
+        }
+
+
+def _target(*, home_chat_id: str | None) -> _RecordingTarget:
+    home = None
+    if home_chat_id is not None:
+        home = HomeChannel(
+            platform=Platform.TELEGRAM,
+            chat_id=home_chat_id,
+            name="Profile home",
+        )
+    return _RecordingTarget(PlatformConfig(enabled=True, home_channel=home))
+
+
+def _adapter(route: dict, runner: _Runner) -> WebhookAdapter:
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"host": "127.0.0.1", "port": 0, "routes": {"r": route}},
+        )
+    )
+    adapter.gateway_runner = runner
+    return adapter
+
+
+def _app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_post("/p/{profile}/webhooks/{route_name}", adapter._handle_webhook)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+@pytest.fixture
+def served_profiles(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex: [("default", None), ("coder", None)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_profiled_deliver_only_uses_only_url_profile_adapter(
+    served_profiles,
+):
+    default_target = _target(home_chat_id="default-home")
+    coder_target = _target(home_chat_id="coder-home")
+    adapter = _adapter(
+        {
+            "secret": _INSECURE_NO_AUTH,
+            "deliver": "telegram",
+            "deliver_only": True,
+            "deliver_extra": {
+                "chat_id": "destination",
+                "profile": "{requested_profile}",
+            },
+            "prompt": "{message}",
+        },
+        _Runner(default_target, coder_target),
+    )
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/p/coder/webhooks/r",
+            json={"message": "hello", "requested_profile": "default"},
+            headers={"X-GitHub-Delivery": "profiled-direct"},
+        )
+
+    assert response.status == 200
+    assert coder_target.calls == [("destination", "hello", None)]
+    assert default_target.calls == []
+
+
+@pytest.mark.asyncio
+async def test_default_profile_url_uses_only_default_adapter(served_profiles):
+    default_target = _target(home_chat_id="default-home")
+    coder_target = _target(home_chat_id="coder-home")
+    adapter = _adapter(
+        {
+            "secret": _INSECURE_NO_AUTH,
+            "deliver": "telegram",
+            "deliver_only": True,
+            "deliver_extra": {
+                "chat_id": "destination",
+                "profile": "{requested_profile}",
+            },
+            "prompt": "{message}",
+        },
+        _Runner(default_target, coder_target),
+    )
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/p/default/webhooks/r",
+            json={"message": "hello", "requested_profile": "coder"},
+            headers={"X-GitHub-Delivery": "profiled-default"},
+        )
+
+    assert response.status == 200
+    assert default_target.calls == [("destination", "hello", None)]
+    assert coder_target.calls == []
+
+
+@pytest.mark.asyncio
+async def test_profiled_agent_reply_uses_named_profiles_home_channel(
+    served_profiles,
+):
+    default_target = _target(home_chat_id="default-home")
+    coder_target = _target(home_chat_id="coder-home")
+    adapter = _adapter(
+        {
+            "secret": _INSECURE_NO_AUTH,
+            "deliver": "telegram",
+            "prompt": "{message}",
+        },
+        _Runner(default_target, coder_target),
+    )
+    received = []
+
+    async def _capture(event):
+        received.append(event)
+
+    adapter.handle_message = _capture
+
+    async with TestClient(TestServer(_app(adapter))) as client:
+        response = await client.post(
+            "/p/coder/webhooks/r",
+            json={"message": "question"},
+            headers={"X-GitHub-Delivery": "profiled-agent"},
+        )
+        await asyncio.sleep(0)
+
+    assert response.status == 202
+    assert len(received) == 1
+    result = await adapter.send(received[0].source.chat_id, "answer")
+
+    assert result.success is True
+    assert coder_target.calls == [("coder-home", "answer", None)]
+    assert default_target.calls == []
+
+
+@pytest.mark.asyncio
+async def test_named_profile_with_no_target_adapter_fails_closed():
+    default_target = _target(home_chat_id="default-home")
+    adapter = _adapter(
+        {},
+        _Runner(default_target=default_target, coder_target=None),
+    )
+
+    result = await adapter._deliver_cross_platform(
+        "telegram",
+        "secret",
+        {"profile": "coder", "deliver_extra": {"chat_id": "destination"}},
+    )
+
+    assert result.success is False
+    assert default_target.calls == []
+
+
+@pytest.mark.asyncio
+async def test_named_profile_with_no_home_does_not_use_default_home():
+    default_target = _target(home_chat_id="default-home")
+    coder_target = _target(home_chat_id=None)
+    adapter = _adapter({}, _Runner(default_target, coder_target))
+
+    result = await adapter._deliver_cross_platform(
+        "telegram", "secret", {"profile": "coder", "deliver_extra": {}}
+    )
+
+    assert result.success is False
+    assert coder_target.calls == []
+    assert default_target.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_default", [True, False])
+async def test_unprefixed_delivery_keeps_default_then_secondary_fallback(with_default):
+    default_target = _target(home_chat_id="default-home") if with_default else None
+    coder_target = _target(home_chat_id="coder-home")
+    adapter = _adapter({}, _Runner(default_target, coder_target))
+
+    result = await adapter._deliver_cross_platform(
+        "telegram", "legacy", {"deliver_extra": {"chat_id": "destination"}}
+    )
+
+    assert result.success is True
+    expected = default_target if with_default else coder_target
+    assert expected.calls == [("destination", "legacy", None)]
+    if with_default:
+        assert coder_target.calls == []


### PR DESCRIPTION
## What does this PR do?

Keeps the validated URL profile when a webhook sends a reply to another platform.

A named profile now uses only its own adapter and home channel. Unprefixed webhooks keep the existing default-then-secondary fallback.

## Related Issue

Fixes #65939

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Save the validated profile in direct and agent reply delivery state.
- Resolve named-profile delivery through that exact profile.
- Fail closed when its adapter or home channel is missing.
- Prevent rendered payload data from replacing the URL profile.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_webhook_profile_delivery.py tests/gateway/test_webhook_deliver_only.py tests/gateway/test_webhook_adapter.py` — 116 passed.
2. Run Ruff on the changed files.
3. Run `scripts/check-windows-footguns.py --all` — 768 files passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] This PR contains only this fix
- [ ] I've run the full test suite; the focused gateway suites above passed
- [x] I've added regression tests
- [x] I've tested on macOS 26.5.2

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] Config example update — N/A
- [x] Architecture or workflow docs update — N/A
- [x] Cross-platform impact considered; the Windows checker passed
- [x] Tool schema update — N/A

## Screenshots / Logs

N/A — behavior-only fix.