### PR TITLE
fix(auth): isolate credential pool env fallbacks

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -16,7 +16,11 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
-from agent.secret_scope import get_secret as _get_secret
+from agent.secret_scope import (
+    current_secret_scope as _current_secret_scope,
+    get_secret as _get_secret,
+    is_multiplex_active as _is_multiplex_active,
+)
 from agent.credential_persistence import (
     is_borrowed_credential_source,
     sanitize_borrowed_credential_payload,
@@ -2165,6 +2169,13 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
     # processes (Codex CLI, test scripts, etc.) should not override deliberate
     # changes to the .env file.
     def _get_env_prefer_dotenv(key: str) -> str:
+        # A profile scope is authoritative. Falling through to os.environ here
+        # can seed one profile's pool with another profile's credential.
+        # Unscoped multiplex reads must also keep the secret_scope fail-closed
+        # behavior instead of bypassing it through the legacy env fallback.
+        if _current_secret_scope() is not None or _is_multiplex_active():
+            return str(_get_secret(key, "") or "").strip()
+
         env_file = load_env()
         raw = env_file.get(key, "").strip()
         env_val = os.environ.get(key, "").strip()

--- a/tests/tools/test_credential_pool_env_fallback.py
+++ b/tests/tools/test_credential_pool_env_fallback.py
@@ -107,6 +107,73 @@ class TestCredentialPoolSeedsFromDotEnv:
         assert active_sources == set()
         assert entries == []
 
+    def test_profile_scope_does_not_fall_back_to_process_env(
+        self, isolated_hermes_home, monkeypatch
+    ):
+        """A missing profile key must not borrow another profile's env key."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "synthetic-foreign-profile-key")
+
+        from agent import secret_scope
+        from agent.credential_pool import _seed_from_env
+
+        secret_scope.set_multiplex_active(True)
+        scope_token = secret_scope.set_secret_scope({})
+        try:
+            entries = []
+            changed, active_sources = _seed_from_env("openrouter", entries)
+        finally:
+            secret_scope.reset_secret_scope(scope_token)
+            secret_scope.set_multiplex_active(False)
+
+        assert changed is False
+        assert active_sources == set()
+        assert entries == []
+
+    def test_profile_scope_seeds_its_own_key(
+        self, isolated_hermes_home, monkeypatch
+    ):
+        """The isolation guard must still seed the active profile's key."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "synthetic-foreign-profile-key")
+
+        from agent import secret_scope
+        from agent.credential_pool import _seed_from_env
+
+        secret_scope.set_multiplex_active(True)
+        scope_token = secret_scope.set_secret_scope(
+            {"OPENROUTER_API_KEY": "synthetic-active-profile-key"}
+        )
+        try:
+            entries = []
+            changed, active_sources = _seed_from_env("openrouter", entries)
+        finally:
+            secret_scope.reset_secret_scope(scope_token)
+            secret_scope.set_multiplex_active(False)
+
+        assert changed is True
+        assert active_sources == {"env:OPENROUTER_API_KEY"}
+        assert len(entries) == 1
+        assert entries[0].access_token == "synthetic-active-profile-key"
+
+    def test_unscoped_multiplex_does_not_bypass_fail_closed_for_op_reference(
+        self, isolated_hermes_home, monkeypatch
+    ):
+        """A resolved process value must not bypass the missing-scope error."""
+        _write_env_file(
+            isolated_hermes_home,
+            OPENROUTER_API_KEY="op://Example/Profile/key",
+        )
+        monkeypatch.setenv("OPENROUTER_API_KEY", "synthetic-resolved-foreign-key")
+
+        from agent import secret_scope
+        from agent.credential_pool import _seed_from_env
+
+        secret_scope.set_multiplex_active(True)
+        try:
+            with pytest.raises(secret_scope.UnscopedSecretError):
+                _seed_from_env("openrouter", [])
+        finally:
+            secret_scope.set_multiplex_active(False)
+
     def test_dotenv_wins_over_stale_os_environ(self, isolated_hermes_home, monkeypatch):
         """Regression for #20591: a fresh key rotated into ~/.hermes/.env must
         win over a stale value inherited from os.environ (parent shell export


### PR DESCRIPTION
## What does this PR do?

Prevents credential pool seeding from borrowing an API key from the shared process environment while profile multiplexing is active.

The active profile scope is now final. Single-profile .env and shell behavior stays unchanged.

## Related Issue

Fixes #65940

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Use the profile-aware secret reader when a profile scope is active.
- Keep unscoped multiplex reads fail-closed.
- Add tests for missing, present, and unresolved 1Password profile keys.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_credential_pool_env_fallback.py tests/agent/test_secret_scope.py` — 30 passed.
2. Run Ruff on the changed files.
3. Run `scripts/check-windows-footguns.py --all` — 768 files passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] This PR contains only this fix
- [ ] I've run the full test suite; the focused auth suites above passed
- [x] I've added regression tests
- [x] I've tested on macOS 26.5.2

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] Config example update — N/A
- [x] Architecture or workflow docs update — N/A
- [x] Cross-platform impact considered; the Windows checker passed
- [x] Tool schema update — N/A

## Screenshots / Logs

N/A — behavior-only fix.