### PR TITLE
fix(auth): scope the Nous inference endpoint override

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2063,13 +2063,15 @@ def _nous_inference_env_override() -> Optional[str]:
     """Return the user-set ``NOUS_INFERENCE_BASE_URL`` override, if any.
 
     This is the documented dev/staging escape hatch. The env source is
-    trusted (the OS user set it themselves), so it is intentionally NOT
-    gated by the network host allowlist — unlike Portal-returned URLs.
+    trusted (the active profile set it), so it is intentionally NOT gated by
+    the network host allowlist — unlike Portal-returned URLs.
 
     Returns a trailing-slash-stripped non-empty string, or ``None`` when
     the env var is unset/blank.
     """
-    return _optional_base_url(os.getenv("NOUS_INFERENCE_BASE_URL"))
+    from agent.secret_scope import get_secret
+
+    return _optional_base_url(get_secret("NOUS_INFERENCE_BASE_URL"))
 
 
 def _nous_portal_env_override() -> Optional[str]:

--- a/tests/hermes_cli/test_nous_inference_url_validation.py
+++ b/tests/hermes_cli/test_nous_inference_url_validation.py
@@ -189,28 +189,58 @@ class TestEnvOverrideNotGated:
     """The documented dev/staging env-var override must keep working.
 
     ``NOUS_INFERENCE_BASE_URL`` is read by ``resolve_nous_runtime_credentials``
-    via ``os.getenv`` — that path doesn't pass through the validator
-    (env values are trusted because the user set them themselves).
-    Verify the env-var read site does NOT consult the validator, so a
-    user running against a non-allowlisted staging host via env is not
-    inadvertently broken by this fix.
+    through the profile-aware secret resolver. Profile values remain trusted
+    user configuration and do not pass through the network validator.
     """
 
-    def test_env_override_path_does_not_call_validator(self):
-        """In resolve_nous_runtime_credentials, the env override is
-        read via os.getenv directly, not via the validator. Grep the
-        source to confirm: the env line should NOT mention the
-        validator."""
+    def test_single_profile_env_override_is_not_gated(self, monkeypatch):
+        """A single-profile staging override remains supported."""
         import hermes_cli.auth as _auth_mod
-        from pathlib import Path
-        source = Path(_auth_mod.__file__).read_text(encoding="utf-8")
-        # Find the env-override read line.
-        for line in source.splitlines():
-            if "NOUS_INFERENCE_BASE_URL" in line and "os.getenv" in line:
-                assert "_validate_nous_inference_url_from_network" not in line, (
-                    "env override path must not gate through the network "
-                    "validator — it would break documented dev/staging use."
-                )
+
+        override = "https://staging-profile.example/v1/"
+        monkeypatch.setenv("NOUS_INFERENCE_BASE_URL", override)
+
+        assert _auth_mod._nous_inference_env_override() == override.rstrip("/")
+
+    def test_missing_profile_override_does_not_use_process_endpoint(
+        self, monkeypatch
+    ):
+        """A profile without an override must not inherit another profile's URL."""
+        import hermes_cli.auth as auth
+        from agent import secret_scope
+
+        monkeypatch.setenv(
+            "NOUS_INFERENCE_BASE_URL",
+            "https://foreign-profile.example/v1",
+        )
+        secret_scope.set_multiplex_active(True)
+        scope_token = secret_scope.set_secret_scope({})
+        try:
+            assert auth._nous_inference_env_override() is None
+        finally:
+            secret_scope.reset_secret_scope(scope_token)
+            secret_scope.set_multiplex_active(False)
+
+    def test_profile_override_wins_over_process_endpoint(self, monkeypatch):
+        """The active profile's endpoint remains a supported runtime override."""
+        import hermes_cli.auth as auth
+        from agent import secret_scope
+
+        monkeypatch.setenv(
+            "NOUS_INFERENCE_BASE_URL",
+            "https://foreign-profile.example/v1",
+        )
+        secret_scope.set_multiplex_active(True)
+        scope_token = secret_scope.set_secret_scope(
+            {"NOUS_INFERENCE_BASE_URL": "https://active-profile.example/v1"}
+        )
+        try:
+            assert auth._nous_inference_env_override() == (
+                "https://active-profile.example/v1"
+            )
+        finally:
+            secret_scope.reset_secret_scope(scope_token)
+            secret_scope.set_multiplex_active(False)
 
 
 class TestHealsPoisonedStoredValue:


### PR DESCRIPTION
## What does this PR do?

Prevents a Nous request from inheriting another profile's process-wide inference endpoint in multiplex mode.

The endpoint override now uses the existing profile-aware resolver. Normal single-profile staging overrides still work.

## Related Issue

Fixes #65941

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Read `NOUS_INFERENCE_BASE_URL` from the active profile scope.
- Keep single-profile and profile-specific overrides working.
- Add behavior tests for missing and present profile overrides.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_nous_inference_url_validation.py tests/hermes_cli/test_auth_nous_provider.py` — 101 passed.
2. Run Ruff on the changed files.
3. Run `scripts/check-windows-footguns.py --all` — 768 files passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] This PR contains only this fix
- [ ] I've run the full test suite; the focused Nous auth suites above passed
- [x] I've added regression tests
- [x] I've tested on macOS 26.5.2

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] Config example update — N/A
- [x] Architecture or workflow docs update — N/A
- [x] Cross-platform impact considered; the Windows checker passed
- [x] Tool schema update — N/A

## Screenshots / Logs

N/A — behavior-only fix.