### PR TITLE
fix(backup): restore snapshots through SQLite

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -276,6 +276,26 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
             return False
 
 
+def _restore_db(src: Path, dst: Path) -> bool:
+    """Restore a SQLite snapshot without replacing a live database file."""
+    source_conn = None
+    destination_conn = None
+    try:
+        source_conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
+        destination_conn = sqlite3.connect(str(dst))
+        source_conn.backup(destination_conn)
+        shutil.copymode(src, dst)
+        return True
+    except sqlite3.Error as exc:
+        logger.error("Failed to restore SQLite database %s: %s", dst, exc)
+        return False
+    finally:
+        if destination_conn is not None:
+            destination_conn.close()
+        if source_conn is not None:
+            source_conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Backup
 # ---------------------------------------------------------------------------
@@ -1013,11 +1033,10 @@ def restore_quick_snapshot(
 
         try:
             if dst.suffix == ".db":
-                # Atomic-ish replace for databases
-                tmp = dst.parent / f".{dst.name}.snap_restore"
-                shutil.copy2(src, tmp)
-                dst.unlink(missing_ok=True)
-                shutil.move(str(tmp), str(dst))
+                # Restore through SQLite so live WAL connections remain
+                # attached to this database and immediately see the snapshot.
+                if not _restore_db(src, dst):
+                    continue
             else:
                 shutil.copy2(src, dst)
             restored += 1

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1527,6 +1527,54 @@ class TestQuickSnapshot:
         conn.close()
         assert len(rows) == 1
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    def test_restore_missing_state_db_preserves_snapshot_permissions(self, hermes_home):
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        snapshot_db = hermes_home / "state-snapshots" / snap_id / "state.db"
+        snapshot_db.chmod(0o600)
+        (hermes_home / "state.db").unlink()
+
+        assert restore_quick_snapshot(snap_id, hermes_home=hermes_home) is True
+        assert (hermes_home / "state.db").stat().st_mode & 0o777 == 0o600
+
+    def test_restore_state_db_while_session_db_is_open(self, tmp_path):
+        """A live WAL connection must see the restored database and stay usable."""
+        from hermes_cli.backup import create_quick_snapshot, restore_quick_snapshot
+        from hermes_state import SessionDB
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        (home / "config.yaml").write_text("model: {}\n")
+
+        db_path = home / "state.db"
+        live_db = SessionDB(db_path)
+        try:
+            live_db.create_session("saved", "cli")
+            assert live_db._conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+
+            snap_id = create_quick_snapshot(hermes_home=home)
+            live_db.create_session("newer", "cli")
+
+            assert restore_quick_snapshot(snap_id, hermes_home=home) is True
+            assert live_db.get_session("saved") is not None
+            assert live_db.get_session("newer") is None
+
+            # Restoring must not leave the live connection pointing at an
+            # unlinked database file.
+            live_db.create_session("after-restore", "cli")
+        finally:
+            live_db.close()
+
+        reopened = SessionDB(db_path)
+        try:
+            assert reopened.get_session("saved") is not None
+            assert reopened.get_session("newer") is None
+            assert reopened.get_session("after-restore") is not None
+        finally:
+            reopened.close()
+
     def test_restore_nonexistent(self, hermes_home):
         from hermes_cli.backup import restore_quick_snapshot
         assert restore_quick_snapshot("nonexistent", hermes_home=hermes_home) is False


### PR DESCRIPTION
## What does this PR do?

Restores quick snapshots through SQLite instead of replacing an open database file.

Live WAL connections now see the restored data immediately, stay usable, and keep the snapshot file permissions.

## Related Issue

Fixes #65942

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Copy snapshot pages with SQLite's backup API.
- Preserve the snapshot database permissions.
- Add live-WAL and missing-database permission regressions.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_backup.py` — 155 passed.
2. Run Ruff on the changed files.
3. Run `scripts/check-windows-footguns.py --all` — 768 files passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] This PR contains only this fix
- [ ] I've run the full test suite; the focused backup suite above passed
- [x] I've added regression tests
- [x] I've tested on macOS 26.5.2

### Documentation & Housekeeping

- [x] Documentation update — N/A
- [x] Config example update — N/A
- [x] Architecture or workflow docs update — N/A
- [x] Cross-platform impact considered; the Windows checker passed
- [x] Tool schema update — N/A

## Screenshots / Logs

N/A — behavior-only fix.