### PR TITLE
fix(deepseek): clamp 'minimal' reasoning effort to 'low' instead of dropping it

### DIFF
--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -69,15 +69,25 @@ class DeepSeekProfile(ProviderProfile):
         if not enabled:
             return extra_body, top_level
 
-        # Effort mapping. Pass low/medium/high through; stronger levels → max.
-        # When no effort is set we omit reasoning_effort so DeepSeek applies
-        # its server default (currently high).
+        # Effort mapping. Pass low/medium/high through; stronger levels → max,
+        # 'minimal' → low (DeepSeek's floor). When no effort is set we omit
+        # reasoning_effort so DeepSeek applies its server default (currently
+        # high).
         if isinstance(reasoning_config, dict):
             effort = (reasoning_config.get("effort") or "").strip().lower()
             if effort in {"xhigh", "max", "ultra"}:
                 top_level["reasoning_effort"] = "max"
             elif effort in {"low", "medium", "high"}:
                 top_level["reasoning_effort"] = effort
+            elif effort == "minimal":
+                # DeepSeek's API has no 'minimal' tier — 'low' is the floor.
+                # Clamp down to the nearest supported level instead of omitting
+                # it: an omitted effort falls through to DeepSeek's server
+                # default (currently 'high'), i.e. the strongest tier — the
+                # OPPOSITE of the user's least-effort request. Mirrors both the
+                # xhigh/max → max ceiling clamp just above and the canonical
+                # minimal → low clamp used elsewhere (auxiliary/codex/xai).
+                top_level["reasoning_effort"] = "low"
 
         return extra_body, top_level
 

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -68,6 +68,19 @@ class TestDeepSeekThinkingWireShape:
         )
         assert top_level == {"reasoning_effort": "max"}
 
+    @pytest.mark.parametrize("effort", ["minimal", "MINIMAL", "  Minimal  "])
+    def test_minimal_clamps_to_low(self, deepseek_profile, effort):
+        """'minimal' has no DeepSeek tier, so it must clamp DOWN to 'low' (the
+        floor) rather than being omitted. Omitting it falls through to
+        DeepSeek's server default (currently 'high') — the strongest tier and
+        the opposite of the user's least-effort request.
+        """
+        _, top_level = deepseek_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="deepseek-v4-pro",
+        )
+        assert top_level == {"reasoning_effort": "low"}
+
     def test_explicitly_disabled_sends_disabled_marker(self, deepseek_profile):
         """``reasoning_config.enabled=False`` → ``thinking.type=disabled``.
 


### PR DESCRIPTION
## What

`minimal` reasoning effort was silently dropped by the DeepSeek profile (matched no arm → `reasoning_effort` omitted → DeepSeek fell back to its `high` default). So asking for the least reasoning gave you the most. Added the missing `minimal` → `low` clamp (the floor), matching the existing `xhigh`/`max` → `max` ceiling clamp.

## Fix

- `plugins/model-providers/deepseek/__init__.py` — add `minimal` → `low` arm.
- `tests/plugins/model_providers/test_deepseek_profile.py` — add `test_minimal_clamps_to_low`.

## Tests

`pytest tests/plugins/model_providers/test_deepseek_profile.py -q` → **32 passed**. Revert the fix and the 3 new `minimal` cases fail (effort omitted → default `high`); with the fix they assert `low`.