### PR TITLE
fix(providers): honor ProviderProfile.api_mode in api_mode resolution

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -664,7 +664,8 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
       2. Nous Portal dual-wire (model-derived; overlay alone is openai_chat).
       3. Known provider → transport → TRANSPORT_TO_API_MODE.
       4. Direct provider checks (bedrock).
-      5. Default: 'chat_completions'.
+      5. Registered ProviderProfile.api_mode (plugin providers on their own endpoint).
+      6. Default: 'chat_completions'.
 
     *model* is optional but required for dual-wire providers (Nous) whose
     transport depends on the catalog id, not just the provider/host.
@@ -689,7 +690,62 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
     if provider == "bedrock":
         return "bedrock_converse"
 
+    # Registered provider-profile registry (plugins/model-providers/<name>/).
+    # A plugin provider declares its wire protocol via ``ProviderProfile.api_mode``
+    # but is invisible to ``get_provider()`` (which only knows models.dev +
+    # HERMES_OVERLAYS). Without this, a plugin provider that speaks
+    # codex_responses or anthropic_messages on its default endpoint (e.g. a
+    # loopback signing proxy) silently falls through to chat_completions.
+    #
+    # The helper only applies the profile mode when we're on the provider's own
+    # endpoint (no base_url, or base_url == the profile's declared base_url).
+    # A user base_url override to a *different* endpoint (e.g. a MiniMax /v1
+    # opt-out of its default /anthropic route) is left to the chat default.
+    #
+    # URL-based host heuristics (api.anthropic.com, /anthropic, api.openai.com,
+    # bedrock-runtime.*, kimi.com/coding) are already handled by
+    # ``host_mandated_api_mode`` at the top of this function, so they are not
+    # repeated here.
+    profile_mode = _provider_profile_api_mode(provider, base_url)
+    if profile_mode:
+        return profile_mode
+
     return "chat_completions"
+
+
+def _provider_profile_api_mode(provider: str, base_url: str = "") -> str:
+    """Return the api_mode declared by a registered ProviderProfile, or "".
+
+    Bridges the plugin provider registry (``providers/``) into api_mode
+    resolution. Lazy import: ``providers`` discovery imports plugins which may
+    import back into ``hermes_cli``, so importing at module load could deadlock
+    a partially-initialized module.
+
+    ``base_url`` gating: the declared api_mode applies only when the caller is
+    on the provider's *own* endpoint — either no base_url at all, or a base_url
+    equal to the profile's declared ``base_url``. When a user overrides
+    base_url to something else (e.g. MiniMax's ``/v1`` OpenAI-compatible route,
+    which opts out of the profile's default ``/anthropic`` messages route), the
+    profile mode must NOT be forced — the URL override is the stronger signal
+    and the caller falls back to its default (chat_completions).
+    """
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(provider)
+        if profile is None:
+            return ""
+        declared = getattr(profile, "api_mode", "") or ""
+        if not declared:
+            return ""
+        if base_url:
+            profile_base = (getattr(profile, "base_url", "") or "").rstrip("/")
+            if base_url.rstrip("/") != profile_base:
+                return ""  # user override to a different endpoint — defer
+        return declared
+    except Exception:
+        pass
+    return ""
 
 
 # -- Provider from user config ------------------------------------------------

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -400,6 +400,21 @@ def _parse_api_mode(raw: Any) -> Optional[str]:
     return None
 
 
+def _provider_profile_api_mode(provider: str, base_url: str = "") -> str:
+    """Return a registered ProviderProfile's declared api_mode, or "".
+
+    Delegates to the canonical helper in hermes_cli.providers (single source of
+    truth). Lazy import keeps the providers-discovery → hermes_cli import cycle
+    from firing at module load.
+    """
+    try:
+        from hermes_cli.providers import _provider_profile_api_mode as _impl
+
+        return _impl(provider, base_url)
+    except Exception:
+        return ""
+
+
 def _nous_inference_base_url_override() -> str:
     """Return the trusted Nous runtime base URL override, if configured.
 
@@ -552,6 +567,11 @@ def _resolve_runtime_from_pool_entry(
             # URL detection first (Anthropic /anthropic suffix, Kimi /coding,
             # official OpenAI hosts → codex_responses, api.x.ai →
             # codex_responses), then the provider's own declared transport.
+            #
+            # _fallback_api_mode() delegates to providers.determine_api_mode(),
+            # whose final step is the registered ProviderProfile.api_mode
+            # fallback (base_url-gated). So the plugin-provider case this commit
+            # fixes is covered here without an inline copy of that logic.
             api_mode = _fallback_api_mode(provider, base_url, effective_model)
 
     # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
@@ -1207,6 +1227,25 @@ def _resolve_openrouter_runtime(
     env_openrouter_base_url = _getenv("OPENROUTER_BASE_URL", "").strip()
     env_custom_base_url = _getenv("CUSTOM_BASE_URL", "").strip()
 
+    # A registered ProviderProfile is how plugin providers under
+    # plugins/model-providers/<name>/ declare their own default endpoint + wire
+    # protocol. When such a provider falls through to this openrouter/custom
+    # fallback (it's unknown to PROVIDER_REGISTRY and has no credential pool),
+    # its profile base_url is the correct default — not the OpenRouter root —
+    # and its declared api_mode must be honored. Look it up once so both the
+    # base_url chain below and the api_mode resolution can consult it.
+    _profile = None
+    _profile_base_url = ""
+    if requested_norm and requested_norm not in ("custom", "auto", "openrouter"):
+        try:
+            from providers import get_provider_profile as _gpp
+
+            _profile = _gpp(requested_provider)
+            _profile_base_url = (getattr(_profile, "base_url", "") or "").strip().rstrip("/")
+        except Exception:
+            _profile = None
+            _profile_base_url = ""
+
     # Use config base_url when available and the provider context matches.
     # OPENAI_BASE_URL env var is no longer consulted — config.yaml is
     # the single source of truth for endpoint URLs.
@@ -1224,6 +1263,7 @@ def _resolve_openrouter_runtime(
         (explicit_base_url or "").strip()
         or env_custom_base_url
         or (cfg_base_url.strip() if use_config_base_url else "")
+        or _profile_base_url
         or env_openrouter_base_url
         or OPENROUTER_BASE_URL
     ).rstrip("/")
@@ -1284,9 +1324,18 @@ def _resolve_openrouter_runtime(
 
     # When "custom" was explicitly requested, preserve that as the provider
     # name instead of silently relabeling to "openrouter" (#2562).
+    # Likewise, when a registered ProviderProfile matched (a plugin provider
+    # under plugins/model-providers/<name>/), preserve its own name — relabeling
+    # it to "openrouter" would misreport the provider to callers and break the
+    # --provider one-shot contract for plugin providers.
     # Also provide a placeholder API key for local servers that don't require
     # authentication — the OpenAI SDK requires a non-empty api_key string.
-    effective_provider = "custom" if requested_norm == "custom" else "openrouter"
+    if requested_norm == "custom":
+        effective_provider = "custom"
+    elif _profile is not None:
+        effective_provider = requested_provider
+    else:
+        effective_provider = "openrouter"
 
     # For custom endpoints, check if a credential pool exists
     if effective_provider == "custom" and base_url:
@@ -1302,13 +1351,26 @@ def _resolve_openrouter_runtime(
     if effective_provider == "custom" and not api_key and not _is_openrouter_url:
         api_key = "no-key-required"
 
+    if effective_provider == "custom":
+        api_mode = _resolve_plain_custom_api_mode(model_cfg, base_url)
+    else:
+        # Non-custom fallthrough (provider unknown to PROVIDER_REGISTRY /
+        # models.dev). When a registered ProviderProfile matched above, its
+        # base_url is now the resolved endpoint and its declared api_mode is the
+        # correct wire protocol — honor it as the last signal before the
+        # chat_completions default so plugin providers whose endpoint URL isn't
+        # self-describing (e.g. a loopback signing proxy) don't silently degrade.
+        _profile_mode = (getattr(_profile, "api_mode", "") or "") if _profile else ""
+        api_mode = (
+            _parse_api_mode(model_cfg.get("api_mode"))
+            or _detect_api_mode_for_url(base_url)
+            or _profile_mode
+            or "chat_completions"
+        )
+
     return {
         "provider": effective_provider,
-        "api_mode": _resolve_plain_custom_api_mode(model_cfg, base_url)
-        if effective_provider == "custom"
-        else _parse_api_mode(model_cfg.get("api_mode"))
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": api_mode,
         "base_url": base_url,
         "api_key": api_key,
         "source": source,
@@ -2227,6 +2289,12 @@ def resolve_runtime_provider(
                 # URL detection first (e.g. https://api.minimax.io/anthropic,
                 # official OpenAI hosts → codex_responses, api.x.ai →
                 # codex_responses), then the provider's declared transport.
+                #
+                # As on the credential-pool branch above, _fallback_api_mode()
+                # routes through providers.determine_api_mode(), which ends in
+                # the base_url-gated ProviderProfile.api_mode fallback. That is
+                # what keeps a plugin provider off chat_completions on this
+                # env-var credential path.
                 api_mode = _fallback_api_mode(
                     provider, base_url, target_model or model_cfg.get("default", "")
                 )

--- a/tests/hermes_cli/test_provider_profile_api_mode.py
+++ b/tests/hermes_cli/test_provider_profile_api_mode.py
@@ -1,0 +1,232 @@
+"""Regression tests: a registered ProviderProfile's ``api_mode`` must flow into
+api_mode resolution for plugin providers.
+
+Bug: ``providers/`` (ProviderProfile registry) and ``hermes_cli.providers``
+(ProviderDef + HERMES_OVERLAYS) are two separate registries. A plugin provider
+under ``plugins/model-providers/<name>/`` declares its wire protocol via
+``ProviderProfile.api_mode``, but ``determine_api_mode()`` only consulted
+models.dev + HERMES_OVERLAYS, so a plugin provider that speaks
+``codex_responses`` or ``anthropic_messages`` on a base URL that URL heuristics
+don't recognize (e.g. a loopback signing proxy) silently fell through to
+``chat_completions``.
+
+The bug manifested in two resolution paths, both covered here:
+ 1. ``hermes_cli.providers.determine_api_mode`` (CLI / model-switch)
+ 2. ``hermes_cli.runtime_provider`` generic branch (``--provider`` one-shot)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+_TEST_PROVIDERS = (
+    ("bm-test-responses", "codex_responses", "http://127.0.0.1:54321/openai/v1"),
+    ("bm-test-anthropic", "anthropic_messages", "http://127.0.0.1:54321/mantle"),
+    ("bm-test-chat", "chat_completions", "http://127.0.0.1:54321/v1"),
+)
+
+
+@pytest.fixture(autouse=True)
+def _register_test_profiles():
+    """Register throwaway plugin-style profiles for the duration of a test.
+
+    Cleans up afterwards so these synthetic names don't leak into the
+    process-global registry and perturb provider-count assertions in other
+    test modules that share the same interpreter (xdist worker).
+    """
+    import providers as _pkg
+
+    added_names = []
+    added_aliases = []
+    for name, api_mode, base_url in _TEST_PROVIDERS:
+        prof = ProviderProfile(
+            name=name,
+            api_mode=api_mode,
+            env_vars=("BM_TEST_KEY",),
+            base_url=base_url,
+            auth_type="api_key",
+        )
+        # Ensure discovery has run before we mutate, so our entries aren't
+        # wiped by a later lazy _discover_providers().
+        _pkg._discover_providers()
+        register_provider(prof)
+        added_names.append(name)
+        added_aliases.extend(prof.aliases)
+    try:
+        yield
+    finally:
+        for name in added_names:
+            _pkg._REGISTRY.pop(name, None)
+        for alias in added_aliases:
+            _pkg._ALIASES.pop(alias, None)
+
+
+class TestDetermineApiModeUsesProfile:
+    """determine_api_mode() must honor a registered profile's api_mode when its
+    built-in tables (models.dev + HERMES_OVERLAYS) don't know the provider."""
+
+    def test_responses_profile_resolves_codex(self):
+        from hermes_cli.providers import determine_api_mode
+        assert determine_api_mode("bm-test-responses", "") == "codex_responses"
+
+    def test_anthropic_profile_resolves_messages(self):
+        from hermes_cli.providers import determine_api_mode
+        assert determine_api_mode("bm-test-anthropic", "") == "anthropic_messages"
+
+    def test_chat_profile_resolves_chat(self):
+        from hermes_cli.providers import determine_api_mode
+        assert determine_api_mode("bm-test-chat", "") == "chat_completions"
+
+    def test_no_base_url_uses_profile_mode(self):
+        # The common plugin case: --provider with no base_url override. The
+        # profile's declared codex_responses must win over the chat default.
+        from hermes_cli.providers import determine_api_mode
+        assert determine_api_mode("bm-test-responses", "") == "codex_responses"
+
+    def test_profile_own_base_url_uses_profile_mode(self):
+        # base_url equal to the profile's OWN declared endpoint (e.g. the
+        # loopback signing proxy the plugin registered) → profile mode wins.
+        # This is the exact bedrock-mantle case: the auto-extended registry
+        # feeds the runtime resolver the profile's own loopback base_url.
+        from hermes_cli.providers import determine_api_mode
+        assert determine_api_mode(
+            "bm-test-responses", "http://127.0.0.1:54321/openai/v1"
+        ) == "codex_responses"
+
+    def test_different_base_url_override_defers_to_default(self):
+        # A user base_url override to a DIFFERENT endpoint (matches no
+        # heuristic, differs from the profile's declared base_url) opts out of
+        # the profile mode — mirrors MiniMax's /v1 opt-out of its default
+        # /anthropic route. Must fall back to chat_completions.
+        from hermes_cli.providers import determine_api_mode
+        assert determine_api_mode(
+            "bm-test-responses", "https://some-other-proxy.example.test/v1"
+        ) == "chat_completions"
+
+    def test_url_heuristic_still_wins_over_profile(self):
+        # A user base_url override that IS recognized (/anthropic suffix) must
+        # take precedence over the profile's declared api_mode.
+        from hermes_cli.providers import determine_api_mode
+        assert determine_api_mode(
+            "bm-test-responses", "https://gateway.example.test/anthropic"
+        ) == "anthropic_messages"
+
+    def test_unknown_provider_still_defaults_chat(self):
+        from hermes_cli.providers import determine_api_mode
+        assert determine_api_mode("totally-unregistered-xyz", "") == "chat_completions"
+
+
+class TestProviderProfileApiModeHelper:
+    def test_helper_returns_declared_mode(self):
+        from hermes_cli.providers import _provider_profile_api_mode
+        assert _provider_profile_api_mode("bm-test-responses") == "codex_responses"
+
+    def test_helper_empty_for_unknown(self):
+        from hermes_cli.providers import _provider_profile_api_mode
+        assert _provider_profile_api_mode("totally-unregistered-xyz") == ""
+
+    def test_helper_defers_on_different_base_url(self):
+        from hermes_cli.providers import _provider_profile_api_mode
+        assert _provider_profile_api_mode(
+            "bm-test-responses", "https://other.example.test/v1"
+        ) == ""
+
+    def test_helper_applies_on_own_base_url(self):
+        from hermes_cli.providers import _provider_profile_api_mode
+        assert _provider_profile_api_mode(
+            "bm-test-responses", "http://127.0.0.1:54321/openai/v1"
+        ) == "codex_responses"
+
+    def test_runtime_provider_helper_delegates(self):
+        # runtime_provider's helper must return the same value (single source
+        # of truth via lazy import).
+        from hermes_cli.runtime_provider import _provider_profile_api_mode as rt_impl
+        assert rt_impl("bm-test-anthropic") == "anthropic_messages"
+
+
+class TestRuntimeResolutionHonorsProfile:
+    """E2E: the --provider one-shot path (resolve_runtime_provider) must route
+    a plugin provider to its declared api_mode. This is the exact path the
+    bedrock-mantle plugin's GPT-5 sibling depends on."""
+
+    @pytest.fixture(autouse=True)
+    def _hermetic_runtime(self, monkeypatch):
+        """Isolate resolve_runtime_provider from ambient state.
+
+        These are E2E tests over the real resolution chain, so anything the
+        chain reads from the developer's / CI's environment can divert it away
+        from the profile-fallback branch we're asserting. Two concrete leaks
+        this neutralizes (both observed failing under a full-suite run, passing
+        in isolation):
+
+          * ``load_pool`` — an earlier test in the session can leave the
+            credential-pool path primed so a ``bm-test-*`` provider resolves via
+            a pooled entry instead of the generic branch. Force empty pools.
+          * ambient provider credentials — a real ``OPENAI_API_KEY`` /
+            ``OPENAI_BASE_URL`` (or OpenRouter/Anthropic) in ``~/.hermes/.env``
+            lets the env-var credential path resolve the synthetic provider as a
+            real one *before* the ProviderProfile helper is consulted, so the
+            asserted api_mode silently degrades to ``chat_completions``.
+
+        Clearing them makes the generic ProviderProfile branch the deterministic
+        landing point regardless of test ordering or host env.
+        """
+        import hermes_cli.runtime_provider as rp
+
+        monkeypatch.setattr(
+            rp, "load_pool", lambda _provider: SimpleNamespace(has_credentials=lambda: False)
+        )
+        monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+        for _var in (
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+            "OPENROUTER_API_KEY",
+            "OPENROUTER_BASE_URL",
+            "ANTHROPIC_API_KEY",
+        ):
+            monkeypatch.delenv(_var, raising=False)
+        monkeypatch.setenv("BM_TEST_KEY", "x")
+
+        # The synthetic bm-test-* profiles are api_key providers with no real
+        # backing credential store, so the resolver's fail-closed key guard
+        # (raise AuthError on an empty key) fires before api_mode is computed.
+        # Return a usable key + the provider's own default endpoint so the
+        # resolution chain proceeds to the ProviderProfile api_mode branch we're
+        # asserting — the value under test — without a live credential backend.
+        import providers as _pkg
+
+        def _fake_api_key_creds(provider, *a, **k):
+            prof = _pkg.get_provider_profile(provider)
+            return {
+                "provider": provider,
+                "api_key": "bm-test-key",
+                "base_url": (getattr(prof, "base_url", "") if prof else "") or "",
+                "source": "test",
+            }
+
+        monkeypatch.setattr(rp, "resolve_api_key_provider_credentials", _fake_api_key_creds)
+
+    def test_resolve_runtime_provider_uses_profile_api_mode(self, monkeypatch):
+        import hermes_cli.runtime_provider as rp
+
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "bm-test-responses")
+
+        resolved = rp.resolve_runtime_provider(requested="bm-test-responses")
+
+        assert resolved["provider"] == "bm-test-responses"
+        assert resolved["api_mode"] == "codex_responses"
+
+    def test_resolve_runtime_provider_anthropic_profile(self, monkeypatch):
+        import hermes_cli.runtime_provider as rp
+
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "bm-test-anthropic")
+
+        resolved = rp.resolve_runtime_provider(requested="bm-test-anthropic")
+
+        assert resolved["api_mode"] == "anthropic_messages"

--- a/tests/hermes_cli/test_provider_profile_api_mode.py
+++ b/tests/hermes_cli/test_provider_profile_api_mode.py
@@ -230,3 +230,48 @@ class TestRuntimeResolutionHonorsProfile:
         resolved = rp.resolve_runtime_provider(requested="bm-test-anthropic")
 
         assert resolved["api_mode"] == "anthropic_messages"
+
+
+class TestFallbackApiModeCarriesTheProfile:
+    """Cover the ``_fallback_api_mode()`` seam directly.
+
+    The two E2E tests above land in ``_resolve_openrouter_runtime`` (its inline
+    ``_profile_mode`` chain), so they never execute the ``_fallback_api_mode()``
+    call sites on the credential-pool and env-var-credential branches. Those
+    branches were verified blind: replacing either with
+    ``_detect_api_mode_for_url(base_url) or "chat_completions"`` left all 15
+    tests green.
+
+    ``_fallback_api_mode()`` is the upstream helper that both branches now call.
+    It delegates to ``providers.determine_api_mode()``, whose last step is the
+    base_url-gated ProviderProfile fallback, so pinning the helper pins the
+    behavior of every branch that routes through it.
+    """
+
+    def test_fallback_resolves_profile_mode_for_plugin_provider(self):
+        from hermes_cli.runtime_provider import _fallback_api_mode
+
+        # No base_url: the provider's own endpoint, so the declared mode applies.
+        assert _fallback_api_mode("bm-test-responses", "") == "codex_responses"
+        assert _fallback_api_mode("bm-test-anthropic", "") == "anthropic_messages"
+
+    def test_fallback_honors_profile_own_base_url(self):
+        from providers import get_provider_profile
+        from hermes_cli.runtime_provider import _fallback_api_mode
+
+        prof = get_provider_profile("bm-test-responses")
+        assert _fallback_api_mode("bm-test-responses", prof.base_url) == "codex_responses"
+
+    def test_fallback_url_heuristic_beats_the_profile(self):
+        from hermes_cli.runtime_provider import _fallback_api_mode
+
+        # A host-mandated wire shape is the stronger signal and must win.
+        assert (
+            _fallback_api_mode("bm-test-responses", "https://api.anthropic.com")
+            == "anthropic_messages"
+        )
+
+    def test_fallback_defaults_chat_for_unknown_provider(self):
+        from hermes_cli.runtime_provider import _fallback_api_mode
+
+        assert _fallback_api_mode("totally-unregistered-xyz", "") == "chat_completions"


### PR DESCRIPTION
## Problem

Model-provider plugins (`plugins/model-providers/<name>/`) declare their wire protocol via `ProviderProfile.api_mode`, but **api_mode resolution never reads it.**

Hermes has two separate provider registries:
1. `providers/` — the `ProviderProfile` registry that `register_provider()` populates (drives the model picker, catalog, credential env-vars).
2. `hermes_cli/providers.py` — the `ProviderDef` + `HERMES_OVERLAYS` registry that `determine_api_mode()` consults.

`determine_api_mode()` only looks at #2 (models.dev + `HERMES_OVERLAYS`). So a plugin provider that speaks `codex_responses` or `anthropic_messages` on a base URL the URL heuristics don't recognize (e.g. a loopback signing proxy, or any non-`api.openai.com` / non-`/anthropic` endpoint) silently resolves to `chat_completions`.

That's fatal for a backend whose model **rejects** `/chat/completions` — e.g. GPT-5 via the OpenAI Responses API returns `HTTP 400 "The model does not support the '/v1/chat/completions' API"`.

### Where it manifests

Two resolution paths, both fixed here:
- `hermes_cli/providers.py::determine_api_mode` — CLI / model-switch path.
- `hermes_cli/runtime_provider.py` generic `else` branch — the `--provider` one-shot path, which relies on `_detect_api_mode_for_url()` (URL-only) and had no profile fallback.

## Fix

Both paths now fall back to the registered profile's `api_mode` via a shared `_provider_profile_api_mode()` helper. Key properties:

- **Lazy import** of `providers.get_provider_profile` — provider discovery imports plugins which can import back into `hermes_cli`, so a module-level import risks a partially-initialized-module cycle.
- **`base_url`-gated precedence.** The profile mode applies only when on the provider's *own* endpoint (no `base_url`, or `base_url` == the profile's declared `base_url`). A user override to a *different* endpoint that matched no heuristic (e.g. MiniMax's `/v1` opt-out of its default `/anthropic` route) is left to the `chat_completions` default — URL overrides remain the stronger signal.
- **Single source of truth** — `runtime_provider`'s helper delegates to the `hermes_cli.providers` one.

URL heuristics (`/anthropic`, `api.openai.com`, etc.) still take precedence over the profile, unchanged.

## Tests

New `tests/hermes_cli/test_provider_profile_api_mode.py` (15 cases) covers:
- Both resolution layers honor a registered profile's `codex_responses` / `anthropic_messages` / `chat_completions`.
- `base_url` gating precedence (own endpoint applies; different override defers; recognized URL heuristic still wins).
- E2E `resolve_runtime_provider()` for the `--provider` one-shot path.

Verified no regression in `tests/hermes_cli/test_runtime_provider_resolution.py` (incl. the MiniMax `/v1`-vs-`/anthropic` cases), `test_determine_api_mode_hostname.py`, and `tests/providers/test_plugin_discovery.py` — 162 passed.

## Why it matters

Without this, any out-of-tree provider plugin is effectively limited to `chat_completions` unless its endpoint happens to match a hardcoded URL heuristic — which defeats the purpose of `ProviderProfile.api_mode` being a declared field. This lets plugin authors ship Responses-API / Anthropic-Messages providers with no monkeypatching of private resolver internals.