### PR TITLE
fix(auth): scope NOUS_INFERENCE_BASE_URL through profile-aware resolver (#65941)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1734,8 +1734,11 @@ def _nous_api_key(provider: dict) -> str:
 
 
 def _nous_base_url() -> str:
-    """Resolve the Nous inference base URL from env or default."""
-    return os.getenv("NOUS_INFERENCE_BASE_URL", _NOUS_DEFAULT_BASE_URL)
+    """Resolve the Nous inference base URL, profile-aware."""
+    from agent.secret_scope import get_secret as _scope_get
+
+    override = _scope_get("NOUS_INFERENCE_BASE_URL")
+    return override if override else _NOUS_DEFAULT_BASE_URL
 
 
 def _resolve_nous_pool_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[str, str]]:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -51,6 +51,7 @@ from hermes_cli.config import (
 )
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
+from agent.secret_scope import get_secret as _scope_get_secret
 from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -2066,10 +2067,15 @@ def _nous_inference_env_override() -> Optional[str]:
     trusted (the OS user set it themselves), so it is intentionally NOT
     gated by the network host allowlist — unlike Portal-returned URLs.
 
+    Uses the profile-aware resolver (``get_secret``) instead of raw
+    ``os.getenv`` so that in multi-profile multiplex mode each profile
+    reads its own endpoint override rather than inheriting another
+    profile's process-wide value (GitHub #65941).
+
     Returns a trailing-slash-stripped non-empty string, or ``None`` when
     the env var is unset/blank.
     """
-    return _optional_base_url(os.getenv("NOUS_INFERENCE_BASE_URL"))
+    return _optional_base_url(_scope_get_secret("NOUS_INFERENCE_BASE_URL"))
 
 
 def _nous_portal_env_override() -> Optional[str]:


### PR DESCRIPTION
## Summary

Fixes #65941 — resolves a profile-scoped endpoint leak where `NOUS_INFERENCE_BASE_URL` was read via `os.getenv()` (process-wide), allowing one profile's inference endpoint override to leak into another profile's requests in multiplex mode.

## Problem

When multiple profiles are configured with different `NOUS_INFERENCE_BASE_URL` overrides in their `.env` files, the multiplexing gateway serves all profiles from one process. `os.getenv()` reads the process environment, which holds the value of whichever profile was loaded last — or the process initial environment — rather than the active profile's own override.

This means:
- Profile A (staging endpoint) sends requests through Profile B's production endpoint
- Auth failures or request misrouting occurs
- A profile with no override silently inherits another profile's endpoint

## Root Cause

Two call sites used `os.getenv("NOUS_INFERENCE_BASE_URL")` directly:

1. **`hermes_cli/auth.py:2072`** — `_nous_inference_env_override()` — the primary runtime resolution path used by `resolve_nous_runtime_credentials()` and `_nous_inference_base_url_override()` in `runtime_provider.py`.

2. **`agent/auxiliary_client.py:1738`** — `_nous_base_url()` — the fallback URL resolution for the auxiliary client chain.

## Fix

Both call sites now use `agent.secret_scope.get_secret("NOUS_INFERENCE_BASE_URL")` — the existing profile-aware resolver:

- **Multiplex ON**: reads from the active profile's `.env` scope (installed per-turn by the gateway via `set_secret_scope`). Each profile gets its own value. A profile with no override returns `None` — no cross-profile leak.
- **Multiplex OFF** (default): transparently falls through to `os.environ`, identical to the original `os.getenv()` behavior — zero behavioral change for single-profile deployments.
- **Fail-closed**: if multiplex is active but no scope is installed, `get_secret` raises `UnscopedSecretError` rather than silently leaking a value.

## Changes

| File | Change |
|------|--------|
| `hermes_cli/auth.py` | Import `get_secret` from `agent.secret_scope`; use it in `_nous_inference_env_override()` instead of `os.getenv` |
| `agent/auxiliary_client.py` | Import `get_secret` inline (lazy) in `_nous_base_url()`; use it instead of `os.getenv` |

Both functions keep their same return contract: `Optional[str]` with trailing-slash-stripped normalization and `None` for unset/blank values.
