### PR TITLE
fix(doctor): register vertex provider so hermes doctor recognizes Google Vertex AI (#65949)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -442,6 +442,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("AZURE_FOUNDRY_API_KEY",),
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
+    "vertex": ProviderConfig(
+        id="vertex",
+        name="Google Vertex AI",
+        auth_type="gcp_sdk",
+        inference_base_url="",  # Computed at runtime from project_id + region
+        api_key_env_vars=(),
+        base_url_env_var="",
+    ),
 }
 
 # Auto-extend PROVIDER_REGISTRY with any api-key provider registered in
@@ -1776,6 +1784,9 @@ def resolve_provider(
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
         "lmstudio": "lmstudio", "lm-studio": "lmstudio", "lm_studio": "lmstudio",
+        # Vertex aliases
+        "google-vertex": "vertex", "vertex-ai": "vertex",
+        "gcp-vertex": "vertex", "vertexai": "vertex",
         # Local server aliases — route through the generic custom provider
         "ollama": "custom", "ollama_cloud": "ollama-cloud",
         "vllm": "custom", "llamacpp": "custom",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -222,6 +222,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="bedrock_converse",
         auth_type="aws_sdk",
     ),
+    "vertex": HermesOverlay(
+        transport="openai_chat",
+        auth_type="gcp_sdk",
+    ),
 }
 
 
@@ -370,6 +374,11 @@ ALIASES: Dict[str, str] = {
     "llamacpp": "local",
     "llama.cpp": "local",
     "llama-cpp": "local",
+    # vertex
+    "google-vertex": "vertex",
+    "vertex-ai": "vertex",
+    "gcp-vertex": "vertex",
+    "vertexai": "vertex",
 }
 
 
@@ -392,6 +401,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "bedrock": "AWS Bedrock",
     "ollama-cloud": "Ollama Cloud",
     "xai-oauth": "xAI Grok OAuth (SuperGrok / Premium+)",
+    "vertex": "Google Vertex AI",
 }
 
 


### PR DESCRIPTION
## Problem

When using `model.provider: vertex` for Google Vertex AI, running `hermes doctor` fails with:

```
model.provider 'vertex' is not a recognised provider
```

Vertex AI is a valid provider that works correctly at runtime (via `runtime_provider.py` → `agent.vertex_adapter`), but it was missing from both `PROVIDER_REGISTRY` and `HERMES_OVERLAYS`.

## Root Cause

`doctor.py` builds its known-provider list from `PROVIDER_REGISTRY.keys()` + `{"openrouter", "custom", "auto"}`. Since `vertex` was never added to either:
1. `PROVIDER_REGISTRY` (auth.py) — so `resolve_provider("vertex")` raised `AuthError`
2. `HERMES_OVERLAYS` (providers.py) — so `get_provider("vertex")` returned `None`

## Fix

- **auth.py**: Added `vertex` entry to `PROVIDER_REGISTRY` with `auth_type="gcp_sdk"` (parallel to `bedrock` using `auth_type="aws_sdk"`). Empty `api_key_env_vars` and `base_url_env_var` since Vertex uses GCP ADC / service account files, not static keys.
- **providers.py**: Added `vertex` to `HERMES_OVERLAYS` (`transport="openai_chat"`, `auth_type="gcp_sdk"`) so provider metadata resolves properly.
- **providers.py**: Added vertex aliases (`google-vertex`, `vertex-ai`, `gcp-vertex`, `vertexai` → `vertex`) to `ALIASES`.
- **auth.py**: Added same aliases to `resolve_provider`'s `_PROVIDER_ALIASES` dict.
- **providers.py**: Added `"vertex": "Google Vertex AI"` to `_LABEL_OVERRIDES`.

## Testing

- 66/66 doctor tests pass
- 151/151 runtime provider resolution tests pass
- All vertex aliases resolve correctly through both `normalize_provider` and `resolve_provider`
- `get_provider("vertex")` returns a proper `ProviderDef` with `id="vertex"`
- `vertex` is now visible in `provider_catalog()`

Fixes #65949