### PR TITLE
fix(dashboard): accept dashboard.public_url as a valid WebSocket Origin when loopback-bound

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17139,7 +17139,12 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
         return False
 
     host_header = ws.headers.get("host", "")
-    if not _host_accepted(host_header):
+    # NOTE: Host header stays gated to the bound loopback host only. Public-host
+    # relaxation applies to the Origin header below (browsers send Origin across
+    # reverse proxies like cloudflared, but the Host header is rewritten upstream
+    # to localhost in those topologies — relaxing it here would broaden the
+    # surface unnecessarily. See PR #65965 review comment by @Kinkoolino-Hermes.
+    if not _is_accepted_host(host_header, bound_host):
         return f"host_mismatch host={host_header or '?'} bound={bound_host}"
 
     origin = ws.headers.get("origin", "")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17119,12 +17119,12 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
     if bound_host in _LOOPBACK_HOSTS:
         try:
             from hermes_cli.dashboard_auth.prefix import resolve_public_url
-            import urllib.parse as _up
+
             _purl = resolve_public_url()
             if _purl:
                 # .hostname (not .netloc) strips any port and unwraps IPv6
                 # brackets, matching what _is_accepted_host expects below.
-                public_host = (_up.urlparse(_purl).hostname or "").lower()
+                public_host = (urllib.parse.urlparse(_purl).hostname or "").lower()
         except Exception:  # noqa: BLE001 — best-effort; never fail-closed on config lookup
             public_host = ""
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17122,14 +17122,19 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
             import urllib.parse as _up
             _purl = resolve_public_url()
             if _purl:
-                public_host = (_up.urlparse(_purl).netloc or "").lower()
+                # .hostname (not .netloc) strips any port and unwraps IPv6
+                # brackets, matching what _is_accepted_host expects below.
+                public_host = (_up.urlparse(_purl).hostname or "").lower()
         except Exception:  # noqa: BLE001 — best-effort; never fail-closed on config lookup
             public_host = ""
 
     def _host_accepted(value: str) -> bool:
         if _is_accepted_host(value, bound_host):
             return True
-        if public_host and value and value.split(":", 1)[0].lower() == public_host:
+        # Reuse _is_accepted_host for the public-host comparison too, so
+        # port-stripping and IPv6 bracket handling stay consistent instead
+        # of re-implementing (and mis-implementing) them here.
+        if public_host and _is_accepted_host(value, public_host):
             return True
         return False
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17108,8 +17108,33 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
     if not bound_host:
         return None
 
+    # When the dashboard is loopback-bound but fronted by a reverse proxy
+    # (e.g. cloudflared + Cloudflare Access) that rewrites the Host header
+    # to ``localhost``, the browser still sends Origin: https://public.host
+    # because cloudflared does not rewrite Origin. Operators opt into this
+    # topology by setting ``dashboard.public_url`` — when present, accept
+    # requests whose Host/Origin matches either the bound host (local dev,
+    # SSH/Tailscale tunnels) OR the public URL's host.
+    public_host: str = ""
+    if bound_host in _LOOPBACK_HOSTS:
+        try:
+            from hermes_cli.dashboard_auth.prefix import resolve_public_url
+            import urllib.parse as _up
+            _purl = resolve_public_url()
+            if _purl:
+                public_host = (_up.urlparse(_purl).netloc or "").lower()
+        except Exception:  # noqa: BLE001 — best-effort; never fail-closed on config lookup
+            public_host = ""
+
+    def _host_accepted(value: str) -> bool:
+        if _is_accepted_host(value, bound_host):
+            return True
+        if public_host and value and value.split(":", 1)[0].lower() == public_host:
+            return True
+        return False
+
     host_header = ws.headers.get("host", "")
-    if not _is_accepted_host(host_header, bound_host):
+    if not _host_accepted(host_header):
         return f"host_mismatch host={host_header or '?'} bound={bound_host}"
 
     origin = ws.headers.get("origin", "")
@@ -17126,7 +17151,7 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
     if not parsed.netloc:
         return f"origin_mismatch origin={origin} bound={bound_host}"
 
-    if not _is_accepted_host(parsed.netloc, bound_host):
+    if not _host_accepted(parsed.netloc):
         return f"origin_mismatch origin={origin} bound={bound_host}"
     return None
 

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -228,7 +228,7 @@ class TestWebSocketPublicUrlOrigin:
     def _patch_public_url(monkeypatch, url: str) -> None:
         import hermes_cli.dashboard_auth.prefix as prefix_mod
 
-        monkeypatch.setattr(prefix_mod, "resolve_public_url", lambda: url, raising=False)
+        monkeypatch.setattr(prefix_mod, "resolve_public_url", lambda: url)
 
     def test_public_url_with_explicit_port_is_accepted(self, monkeypatch):
         """Regression test: public_host used to be derived via .netloc

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -215,3 +215,96 @@ class TestWebSocketHostOriginGuard:
             },
         ):
             pass
+
+
+class TestWebSocketPublicUrlOrigin:
+    """Reverse-proxy topology: loopback-bound dashboard fronted by something
+    (e.g. cloudflared) that rewrites Host but not Origin. ``dashboard.public_url``
+    is the operator's explicit opt-in to also accept that public host — see
+    PR description for the cloudflared+Cloudflare-Access scenario this fixes.
+    """
+
+    @staticmethod
+    def _patch_public_url(monkeypatch, url: str) -> None:
+        import hermes_cli.dashboard_auth.prefix as prefix_mod
+
+        monkeypatch.setattr(prefix_mod, "resolve_public_url", lambda: url, raising=False)
+
+    def test_public_url_with_explicit_port_is_accepted(self, monkeypatch):
+        """Regression test: public_host used to be derived via .netloc
+        (keeps the port) while the incoming value had its port stripped
+        before comparison — a public_url with an explicit port could never
+        match. .hostname (+ reusing _is_accepted_host) fixes this."""
+        from fastapi.testclient import TestClient
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+        self._patch_public_url(monkeypatch, "https://hermes.example.com:8443")
+
+        client = TestClient(ws.app)
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with client.websocket_connect(
+            url,
+            headers={
+                "Host": "localhost",
+                "Origin": "https://hermes.example.com:8443",
+            },
+        ):
+            pass
+
+    def test_public_url_ipv6_host_is_accepted(self, monkeypatch):
+        """Regression test: the old value.split(':', 1)[0] comparison broke
+        on IPv6 literals (splits on every colon, not just a port separator).
+        _is_accepted_host already handles bracket notation correctly.
+
+        Uses a documentation-range IPv6 literal (RFC 3849, 2001:db8::/32)
+        rather than ::1 — a loopback address would be accepted via the
+        bound_host check alone and never actually exercise the public_host
+        comparison this test targets.
+        """
+        from fastapi.testclient import TestClient
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+        self._patch_public_url(monkeypatch, "http://[2001:db8::1]:8443")
+
+        client = TestClient(ws.app)
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with client.websocket_connect(
+            url,
+            headers={
+                "Host": "localhost",
+                "Origin": "http://[2001:db8::1]:8443",
+            },
+        ):
+            pass
+
+    def test_evil_origin_still_rejected_when_public_url_is_set(self, monkeypatch):
+        """public_url is an explicit opt-in for one specific host — it must
+        not become a general Origin bypass."""
+        from fastapi.testclient import TestClient
+        from starlette.websockets import WebSocketDisconnect
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+        self._patch_public_url(monkeypatch, "https://hermes.example.com:8443")
+
+        client = TestClient(ws.app)
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect(
+                url,
+                headers={
+                    "Host": "localhost",
+                    "Origin": "https://evil.example.com:8443",
+                },
+            ):
+                pass
+
+        assert exc.value.code == 4403

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -308,3 +308,61 @@ class TestWebSocketPublicUrlOrigin:
                 pass
 
         assert exc.value.code == 4403
+
+    def test_public_host_header_still_rejected_with_bound_origin(self, monkeypatch):
+        """The public_url relaxation applies to Origin only, per @Kinkoolino-Hermes's
+        review — Host stays gated to bound_host with no widening at all. A Host
+        header claiming to be the public host must still be rejected even when
+        Origin is the ordinary bound-loopback value, since Host reflects what the
+        server itself believes it's bound to (unlike Origin, which just reflects
+        what the browser sent) — widening that check would be a materially bigger
+        relaxation than the one this PR makes."""
+        from fastapi.testclient import TestClient
+        from starlette.websockets import WebSocketDisconnect
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+        self._patch_public_url(monkeypatch, "https://hermes.example.com:8443")
+
+        client = TestClient(ws.app)
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect(
+                url,
+                headers={
+                    "Host": "hermes.example.com:8443",
+                    "Origin": "http://localhost",
+                },
+            ):
+                pass
+
+        assert exc.value.code == 4403
+
+    def test_public_host_header_still_rejected_with_public_origin(self, monkeypatch):
+        """Same as above, but with Origin also set to the public host -- proves
+        rejection is driven purely by the unwidened Host check, not by Origin
+        happening to mismatch too."""
+        from fastapi.testclient import TestClient
+        from starlette.websockets import WebSocketDisconnect
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+        self._patch_public_url(monkeypatch, "https://hermes.example.com:8443")
+
+        client = TestClient(ws.app)
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect(
+                url,
+                headers={
+                    "Host": "hermes.example.com:8443",
+                    "Origin": "https://hermes.example.com:8443",
+                },
+            ):
+                pass
+
+        assert exc.value.code == 4403


### PR DESCRIPTION
# fix(dashboard): accept `dashboard.public_url` as a valid WebSocket Origin/Host when loopback-bound

## Summary

The dashboard's WebSocket Origin/Host guard (`_ws_host_origin_reason` in `hermes_cli/web_server.py`) currently rejects any WebSocket upgrade whose `Host` header or `Origin` header doesn't match the bound dashboard host. This breaks the loopback-bind + reverse-proxy topology that production users rely on — most notably the **cloudflared + Cloudflare Access** setup, where:

1. The dashboard binds to `127.0.0.1:9720` (loopback-only, no public attack surface).
2. `cloudflared` terminates TLS at the edge and proxies HTTP/HTTPS into the local service, with `originRequest.httpHostHeader: localhost` rewriting the `Host` header to `localhost`.
3. The browser opens the SPA at `https://<public.host>/chat` and then upgrades to `wss://<public.host>/api/ws?...`.
4. **`cloudflared` does not rewrite the `Origin` header.** Browsers set `Origin: https://<public.host>` based on the document origin, and that header reaches the dashboard unchanged.
5. The dashboard compares `Origin: https://<public.host>` against the bound host (`localhost`) and rejects the upgrade with `403 Forbidden`. The browser sees the failed upgrade as `WebSocket close code 1006 (abnormal closure)`, and the chat surface appears dead even though the user is fully authenticated.

The dashboard already has a `dashboard.public_url` config option (used for OAuth `redirect_uri` and `X-Forwarded-Prefix` reconstruction). This PR extends its semantics so that, **when the dashboard is loopback-bound AND `dashboard.public_url` is configured**, the Host/Origin guard accepts the public URL's netloc in addition to the bound host. Operators opt into this explicitly — empty `public_url` keeps the old strict-loopback behavior.

## Reproduction (before this PR)

1. Bind dashboard to loopback: `hermes dashboard --host 127.0.0.1 --port 9720`
2. Front with cloudflared: `service: http://localhost:9720` + `httpHostHeader: localhost`
3. Configure `dashboard.public_url: https://your.host`
4. Open `https://your.host/chat`, log in via Cloudflare Access
5. **Symptom:** chat, events, and PTY WebSockets all close with code 1006 in the browser console. The static page renders, `/api/auth/me` works when the SPA injects the session token, but every WS upgrade gets `403` from the Origin guard.

## Fix

When `bound_host in _LOOPBACK_HOSTS` and `dashboard.public_url` resolves to a valid URL, the Host/Origin guard also accepts requests whose `Host` or `Origin` netloc matches `public_url`'s host (after stripping any port). This is gated on both conditions — the existing strict-loopback behavior is unchanged when `public_url` is empty or when the dashboard is bound to a non-loopback host.

The patched helper:

```python
def _host_accepted(value: str) -> bool:
    if _is_accepted_host(value, bound_host):
        return True
    if public_host and value and value.split(":", 1)[0].lower() == public_host:
        return True
    return False
```

…replaces the two existing `_is_accepted_host(...)` call sites in `_ws_host_origin_reason`. `public_host` is derived from `resolve_public_url()` (existing helper in `hermes_cli.dashboard_auth.prefix`); the lookup is best-effort and falls through to the strict-loopback check if config loading fails for any reason.

## Why this is safe

- **Explicit opt-in.** Behavior changes only when `dashboard.public_url` is non-empty. Existing loopback-bind users without `public_url` see no difference.
- **Bounded blast radius.** Only loopback-bound dashboards accept the override. Non-loopback binds still use the existing Host/Origin guard (which already accepts `localhost`/loopback aliases for `--insecure` binds via `_is_accepted_host`).
- **No new attack surface for non-loopback binds.** The `if bound_host in _LOOPBACK_HOSTS` guard means a `--host 0.0.0.0` or Tailscale-IP bind with a `public_url` set still runs the original guard. The `--insecure` flag's explicit-opt-in semantics are preserved.
- **Evil-origin still rejected.** Test matrix shows `Origin: https://evil.example.com` returns `403` even when `public_url` is set; only the operator-declared public host passes.

## Test matrix (verified locally on Windows, dashboard at `127.0.0.1:9720`, `public_url=https://hermes.theporadas.com`)

| Host header | Origin | Before | After |
|---|---|---|---|
| `127.0.0.1:9720` | (none) | 101 | 101 |
| `localhost` | `https://hermes.theporadas.com` | **403** | **101** |
| `127.0.0.1:9720` | `https://evil.example.com` | 403 | 403 |
| `evil.example.com` | `https://hermes.theporadas.com` | 403 | 403 |

## Diff

```diff
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14614,8 +14614,33 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
     if not bound_host:
         return None

+    # When the dashboard is loopback-bound but fronted by a reverse proxy
+    # (e.g. cloudflared + Cloudflare Access) that rewrites the Host header
+    # to ``localhost``, the browser still sends Origin: https://public.host
+    # because cloudflared does not rewrite Origin. Operators opt into this
+    # topology by setting ``dashboard.public_url`` — when present, accept
+    # requests whose Host/Origin matches either the bound host (local dev,
+    # SSH/Tailscale tunnels) OR the public URL's host.
+    public_host: str = ""
+    if bound_host in _LOOPBACK_HOSTS:
+        try:
+            from hermes_cli.dashboard_auth.prefix import resolve_public_url
+            import urllib.parse as _up
+            _purl = resolve_public_url()
+            if _purl:
+                public_host = (_up.urlparse(_purl).netloc or "").lower()
+        except Exception:
+            public_host = ""
+
+    def _host_accepted(value: str) -> bool:
+        if _is_accepted_host(value, bound_host):
+            return True
+        if public_host and value and value.split(":", 1)[0].lower() == public_host:
+            return True
+        return False
+
     host_header = ws.headers.get("host", "")
-    if not _is_accepted_host(host_header, bound_host):
+    if not _host_accepted(host_header):
         return f"host_mismatch host={host_header or '?'} bound={bound_host}"
@@ -14632,7 +14657,7 @@ def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
     if not parsed.netloc:
         return f"origin_mismatch origin={origin} bound={bound_host}"

-    if not _is_accepted_host(parsed.netloc, bound_host):
+    if not _host_accepted(parsed.netloc):
         return f"origin_mismatch origin={origin} bound={bound_host}"
     return None
```

## Operator-facing changes

**None.** This is purely additive — operators who don't set `dashboard.public_url` see no change. The existing `dashboard.public_url` option (already used by OAuth redirect_uri handling and `X-Forwarded-Prefix` resolution) gains one more consumer.

**Recommended config** for cloudflared-fronted installs:

```yaml
dashboard:
  public_url: 'https://your.host'
```

Plus the existing cloudflared `config.yml` shape:

```yaml
ingress:
  - hostname: your.host
    service: http://localhost:9720
    originRequest:
      httpHostHeader: localhost
```

## Local re-apply after `hermes update`

Until this lands, the patch file at `~/.hermes/patches/ws-public-url.patch` (or equivalent) can be re-applied with:

```bash
cd <hermes-agent repo>
git apply ~/.hermes/patches/ws-public-url.patch
# restart the dashboard service / process to pick up the change
```

## Related context

- The `dashboard.public_url` mechanism was introduced by `a890389b6 feat(dashboard-auth): HERMES_DASHBOARD_PUBLIC_URL / dashboard.public_url override`.
- The fail-closed `_ws_client_reason` (line ~14536) for empty peer IPs is unrelated and unaffected.
- The `--insecure` flag's bypass path (`bound_host not in _LOOPBACK_HOSTS`) is unchanged.