### PR TITLE
fix(weixin): anchor fire-and-forget inbound-message tasks against GC

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1158,6 +1158,7 @@ class WeixinAdapter(BasePlatformAdapter):
         self._poll_session: Optional[aiohttp.ClientSession] = None
         self._send_session: Optional[aiohttp.ClientSession] = None
         self._poll_task: Optional[asyncio.Task] = None
+        self._background_tasks: set[asyncio.Task] = set()
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
 
         self._account_id = str(extra.get("account_id") or get_secret("WEIXIN_ACCOUNT_ID", "")).strip()
@@ -1335,6 +1336,21 @@ class WeixinAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[%s] Disconnected", self.name)
 
+    def _track_task(self, task: asyncio.Task) -> asyncio.Task:
+        """Hold a strong reference to a fire-and-forget task until it finishes.
+
+        asyncio keeps only a weak reference to the result of ``create_task``,
+        so a still-pending handler with no other referent can be
+        garbage-collected mid-flight — silently dropping the inbound message it
+        was processing. Anchoring it in a set (discarded on completion, so the
+        set never grows unbounded) is the same mitigation yuanbao's
+        ``_track_task`` and the gateway's ``_restart_task``/``_background_tasks``
+        already use.
+        """
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
+
     async def _poll_loop(self) -> None:
         assert self._poll_session is not None
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
@@ -1385,7 +1401,9 @@ class WeixinAdapter(BasePlatformAdapter):
                     _save_sync_buf(self._hermes_home, self._account_id, sync_buf)
 
                 for message in response.get("msgs") or []:
-                    asyncio.create_task(self._process_message_safe(message))
+                    self._track_task(
+                        asyncio.create_task(self._process_message_safe(message))
+                    )
             except asyncio.CancelledError:
                 break
             except Exception as exc:
@@ -1436,7 +1454,11 @@ class WeixinAdapter(BasePlatformAdapter):
         context_token = str(message.get("context_token") or "").strip()
         if context_token:
             self._token_store.set(self._account_id, sender_id, context_token)
-        asyncio.create_task(self._maybe_fetch_typing_ticket(sender_id, context_token or None))
+        self._track_task(
+            asyncio.create_task(
+                self._maybe_fetch_typing_ticket(sender_id, context_token or None)
+            )
+        )
 
         media_paths: List[str] = []
         media_types: List[str] = []

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1205,3 +1205,77 @@ class TestWeixinApiTimeout:
             )
         )
         assert result == {"ret": 0, "msgs": [], "get_updates_buf": "buf-123"}
+
+
+class TestWeixinInboundTaskAnchoring:
+    """Fire-and-forget inbound-message tasks must hold a strong reference.
+
+    asyncio keeps only a weak reference to a bare ``create_task`` result, so a
+    still-pending handler with no other referent can be garbage-collected
+    mid-flight — silently dropping the message it was processing. The poll loop
+    must route dispatch through ``_track_task`` so the task is anchored until it
+    finishes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_track_task_anchors_then_releases(self):
+        adapter = _make_adapter()
+        release = asyncio.Event()
+
+        async def _work():
+            await release.wait()
+
+        task = adapter._track_task(asyncio.create_task(_work()))
+        # Held while pending → not GC-eligible.
+        assert task in adapter._background_tasks
+        release.set()
+        await task
+        await asyncio.sleep(0)  # let the done-callback run
+        # Discarded on completion → the set never grows unbounded.
+        assert task not in adapter._background_tasks
+
+    @pytest.mark.asyncio
+    async def test_poll_loop_anchors_inbound_message_task(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._running = True
+        adapter._poll_session = AsyncMock()
+
+        release = asyncio.Event()
+        processed = []
+
+        async def _fake_process(message):
+            processed.append(message)
+            await release.wait()  # stay pending so the anchor is observable
+
+        monkeypatch.setattr(adapter, "_process_message_safe", _fake_process)
+
+        calls = {"n": 0}
+
+        async def _fake_get_updates(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return {"ret": 0, "errcode": 0, "msgs": [{"id": "m1"}],
+                        "get_updates_buf": ""}
+            adapter._running = False  # break the loop on the next poll
+            return {"ret": 0, "errcode": 0, "msgs": [], "get_updates_buf": ""}
+
+        monkeypatch.setattr(weixin, "_get_updates", _fake_get_updates)
+        monkeypatch.setattr(weixin, "_load_sync_buf", lambda *a, **k: "")
+        monkeypatch.setattr(weixin, "_save_sync_buf", lambda *a, **k: None)
+
+        await adapter._poll_loop()
+
+        # The dispatched task is anchored at create time — before it even runs —
+        # so a bare create_task would instead leave it GC-eligible with no
+        # referent.
+        assert len(adapter._background_tasks) == 1
+        # Let the anchored task run up to its release.wait() suspension.
+        await asyncio.sleep(0)
+        assert processed == [{"id": "m1"}]
+        assert len(adapter._background_tasks) == 1  # still pending, still held
+
+        release.set()
+        for task in list(adapter._background_tasks):
+            await task
+        await asyncio.sleep(0)
+        assert len(adapter._background_tasks) == 0


### PR DESCRIPTION
## What

The Weixin poll loop dispatched every inbound message with a bare
`asyncio.create_task(self._process_message_safe(message))` and never kept the
returned task. asyncio holds only a **weak** reference to a task, so a
still-pending handler with no other referent can be garbage-collected
mid-flight — silently dropping the user's message (never processed, never
answered). The per-message typing-ticket task had the same shape, and
`WeixinAdapter` had no task-tracking at all — unlike `yuanbao._track_task`, the
gateway's `_restart_task`/`_background_tasks`, and the merged mcp-oauth
"anchor 401 handler task to prevent GC mid-flight" fix.

## Fix

- `gateway/platforms/weixin.py` — add a `_background_tasks` set + `_track_task`
  helper (adds the task, discards it on completion so the set stays bounded);
  route both fire-and-forget `create_task` sites (inbound-message dispatch and
  the typing-ticket fetch) through it.
- `tests/gateway/test_weixin.py` — add `TestWeixinInboundTaskAnchoring`.

## Tests

`pytest tests/gateway/test_weixin.py tests/gateway/test_weixin_typing.py -q` →
**84 passed**. Revert the fix and the two new tests fail: `_track_task` must
hold a strong reference while the task is pending and release it on completion,
and the poll loop must anchor the inbound-message task at create time (a bare
`create_task` leaves it GC-eligible with no referent).