### PR TITLE
fix(cli): resolve model-provider plugins in /model --provider

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -786,4 +786,28 @@ def resolve_provider_full(
     except Exception:
         pass
 
+    # 4. Plugin ProviderProfile registry (model-provider plugins)
+    try:
+        from providers import get_provider_profile as _get_plugin_profile
+        profile = _get_plugin_profile(canonical)
+        if profile is not None and profile.auth_type == "api_key":
+            _api_mode_to_transport = {
+                "chat_completions": "openai_chat",
+                "codex_responses": "codex_responses",
+                "anthropic_messages": "anthropic_messages",
+                "bedrock_converse": "bedrock_converse",
+            }
+            transport = _api_mode_to_transport.get(profile.api_mode, "openai_chat")
+            return ProviderDef(
+                id=canonical,
+                name=profile.display_name or canonical,
+                transport=transport,
+                api_key_env_vars=profile.env_vars,
+                base_url=profile.base_url,
+                auth_type=profile.auth_type,
+                source="plugin",
+            )
+    except Exception:
+        pass
+
     return None

--- a/tests/hermes_cli/test_provider_plugin_resolution.py
+++ b/tests/hermes_cli/test_provider_plugin_resolution.py
@@ -1,0 +1,109 @@
+"""Tests for provider resolution fallback to the ProviderProfile plugin registry.
+
+The step-4 fallback in resolve_provider_full() lets model-provider plugins
+registered via register_provider() be discovered by /model --provider without
+requiring a HERMES_OVERLAYS entry.
+"""
+
+import pytest
+
+import providers as _providers_mod
+from hermes_cli.providers import resolve_provider_full
+from providers.base import ProviderProfile
+
+
+def _mock_plugin_profile(name):
+    return ProviderProfile(
+        name="testplugin",
+        display_name="Test Plugin",
+        base_url="https://test.example.com/v1",
+        env_vars=("TEST_KEY",),
+        fallback_models=("model-a", "model-b"),
+    )
+
+
+def _mock_oauth_profile(name):
+    return ProviderProfile(
+        name="testoauth",
+        base_url="https://oauth.example.com/v1",
+        auth_type="oauth_device_code",
+    )
+
+
+def _mock_codex_profile(name):
+    return ProviderProfile(
+        name="testplugin",
+        base_url="https://test.example.com/v1",
+        api_mode="codex_responses",
+    )
+
+
+def _mock_minimal_profile(name):
+    return ProviderProfile(
+        name="minimalplugin",
+        base_url="https://minimal.example.com/v1",
+    )
+
+
+class TestPluginProviderResolution:
+    def test_plugin_provider_resolves(self, monkeypatch):
+        """A registered plugin provider with auth_type=api_key is resolved."""
+        monkeypatch.setattr(
+            _providers_mod, "get_provider_profile",
+            lambda name: _mock_plugin_profile(name) if name == "testplugin" else None,
+        )
+
+        result = resolve_provider_full("testplugin")
+        assert result is not None
+        assert result.id == "testplugin"
+        assert result.name == "Test Plugin"
+        assert result.transport == "openai_chat"
+        assert result.base_url == "https://test.example.com/v1"
+        assert result.api_key_env_vars == ("TEST_KEY",)
+        assert result.auth_type == "api_key"
+        assert result.source == "plugin"
+
+    def test_plugin_provider_custom_api_mode(self, monkeypatch):
+        """A plugin with api_mode=codex_responses maps to correct transport."""
+        monkeypatch.setattr(
+            _providers_mod, "get_provider_profile",
+            lambda name: _mock_codex_profile(name) if name == "testplugin" else None,
+        )
+
+        result = resolve_provider_full("testplugin")
+        assert result is not None
+        assert result.transport == "codex_responses"
+
+    def test_unknown_provider_returns_none(self):
+        """A provider not in any registry returns None (no crash)."""
+        result = resolve_provider_full("nonexistent_xyz_123456")
+        assert result is None
+
+    def test_existing_provider_still_resolves(self):
+        """Built-in providers (openrouter) still resolve normally."""
+        result = resolve_provider_full("openrouter")
+        assert result is not None
+        assert result.id == "openrouter"
+        assert result.transport == "openai_chat"
+
+    def test_plugin_oauth_provider_skipped(self, monkeypatch):
+        """A plugin with auth_type=oauth_device_code is NOT resolved
+        (only api_key plugins get the fallback)."""
+        monkeypatch.setattr(
+            _providers_mod, "get_provider_profile",
+            lambda name: _mock_oauth_profile(name) if name == "testoauth" else None,
+        )
+
+        result = resolve_provider_full("testoauth")
+        assert result is None
+
+    def test_empty_display_name_falls_back_to_id(self, monkeypatch):
+        """When display_name is empty, the provider id is used as name."""
+        monkeypatch.setattr(
+            _providers_mod, "get_provider_profile",
+            lambda name: _mock_minimal_profile(name) if name == "minimalplugin" else None,
+        )
+
+        result = resolve_provider_full("minimalplugin")
+        assert result is not None
+        assert result.name == "minimalplugin"


### PR DESCRIPTION
resolve_provider_full() only checked HERMES_OVERLAYS and models.dev, ignoring providers registered by plugins via register_provider(). Add a fallback step that queries the ProviderProfile registry so plugin providers are discoverable by /model --provider.

## What does this PR do?

Model-provider plugins registered via `register_provider()` (e.g. under
`plugins/model-providers/`) return "Unknown provider" from `/model --provider`
because `resolve_provider_full()` only checks `HERMES_OVERLAYS` and
`models.dev`. The `ProviderProfile` registry — where these plugins live —
was never consulted during resolution.

This adds a final fallback step that queries `get_provider_profile()` when all
other resolution steps fail. If a matching profile is found with
`auth_type="api_key"`, a `ProviderDef` is constructed from the profile's
metadata (`base_url`, `env_vars`, `api_mode` → `transport`). This mirrors the
auto-discovery already done for `CANONICAL_PROVIDERS` in `models.py` — the
picker could see plugin providers; now resolution can too.

The change is intentionally narrow: it only activates for `api_key` providers
(not oauth/aws_sdk/external_process), is wrapped in try/except so it can
never break existing resolution, and uses a lazy import so it adds zero
overhead when not needed.

## Related Issue

Fixes # (N/A — no existing issue)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/providers.py` — Added step 4 in `resolve_provider_full()`: falls
  back to `get_provider_profile()` from the plugin registry, maps `api_mode` →
  `transport`, constructs a `ProviderDef` with `source="plugin"`. Wrapped in
  try/except to never break existing resolution.
- `tests/hermes_cli/test_provider_plugin_resolution.py` — 6 tests covering:
  plugin resolution, custom api_mode mapping, unknown provider → None,
  existing providers intact (openrouter), oauth providers skipped,
  display_name fallback to id.

## How to Test

1. Add a model-provider plugin under `plugins/model-providers/<name>/` whose
   `__init__.py` calls `register_provider(ProviderProfile(name="<name>",
   base_url="..."))`.
2. Start Hermes CLI and run `/model --provider <name>`.
3. Provider should resolve and show its model list instead of
   "Unknown provider '<name>'".
4. Existing providers (openrouter, anthropic, etc.) must still resolve
   normally — no regression.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure Python logic, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A