### PR TITLE
feat(models): add k3 to kimi-coding and kimi-coding-cn model lists

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -318,6 +318,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "minimaxai/minimax-m3",
     ],
     "kimi-coding": [
+        "k3",
         "kimi-k2.7-code",
         "kimi-k2.6",
         "kimi-k2.5",
@@ -328,6 +329,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "kimi-coding-cn": [
+        "k3",
         "kimi-k2.6",
         "kimi-k2.5",
         "kimi-k2-thinking",


### PR DESCRIPTION
## Summary

PR #65913 added `moonshotai/kimi-k3` to the Nous Portal and OpenRouter curated `_RECOMMENDED_MODELS` lists, and commit `311a5b0a5` added the `_endpoint_scoped_context_length` detection for `k3` on `api.kimi.com/coding` (1M context window).

However, `k3` was never added to the **static** `_PROVIDER_MODELS` lists for the `kimi-coding` and `kimi-coding-cn` providers. This means `k3` does not appear in:

- The desktop GUI model selector
- The TUI model picker
- `hermes model` interactive selection
- Any UI surface that derives its entries from `_PROVIDER_MODELS`

The model is fully functional when set manually in `config.yaml` (model discovery + 1M context detection both work), but it is simply not listed in the picker.

## Changes

Add `"k3"` as the first entry in both the `kimi-coding` and `kimi-coding-cn` model lists in `_PROVIDER_MODELS`.

## Verification

```python
# Before: k3 missing from kimi-coding models
>>> "k3" in _PROVIDER_MODELS["kimi-coding"]
False

# After: k3 present
>>> "k3" in _PROVIDER_MODELS["kimi-coding"]
True
>>> "k3" in _PROVIDER_MODELS["kimi-coding-cn"]
True
```

Confirmed working with a `sk-kimi-*` key against `api.kimi.com/coding` — K3 responds correctly with 1M context via the Anthropic Messages endpoint.