### PR TITLE
fix(gateway): stop the session API rendering the interrupt sentinel as assistant prose

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -89,6 +89,7 @@ from gateway.platforms.base import (
     is_network_accessible,
     validate_media_delivery_path,
 )
+from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.redact import redact_sensitive_text
 from gateway.readiness import collect_runtime_readiness
 
@@ -665,6 +666,23 @@ def _resolve_media_to_data_urls(text: str) -> str:
         return MEDIA_TAG_CLEANUP_RE.sub(_repl, text)
     except Exception:
         return text
+
+
+def _is_api_interrupt_sentinel(result: Dict[str, Any], text: Any) -> bool:
+    """Return whether *text* is Hermes' internal API-wait interrupt status."""
+    return (
+        bool(result.get("interrupted"))
+        and isinstance(text, str)
+        and text.strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX)
+    )
+
+
+def _api_final_response_text(result: Dict[str, Any]) -> str:
+    """Return user-facing text while keeping interrupt sentinels as metadata."""
+    text = result.get("final_response", "") or ""
+    if _is_api_interrupt_sentinel(result, text):
+        return ""
+    return _resolve_media_to_data_urls(text)
 
 
 def _redact_api_error_text(value: Any, *, limit: int | None = None) -> str:
@@ -2390,7 +2408,9 @@ class APIServerAdapter(BasePlatformAdapter):
             gateway_session_key=gateway_session_key,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
-        final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
+        final_response = _api_final_response_text(result) if isinstance(result, dict) else ""
+        completed = bool(result.get("completed", True)) if isinstance(result, dict) else True
+        interrupted = bool(result.get("interrupted")) if isinstance(result, dict) else False
         headers = {"X-Hermes-Session-Id": effective_session_id or session_id}
         if gateway_session_key:
             headers["X-Hermes-Session-Key"] = gateway_session_key
@@ -2399,6 +2419,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "object": "hermes.session.chat.completion",
                 "session_id": effective_session_id or session_id,
                 "message": {"role": "assistant", "content": final_response},
+                "completed": completed,
+                "interrupted": interrupted,
                 "usage": usage,
             },
             headers=headers,
@@ -2478,21 +2500,25 @@ class APIServerAdapter(BasePlatformAdapter):
                     tool_progress_callback=_tool_progress,
                     gateway_session_key=gateway_session_key,
                 )
-                final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
+                final_response = _api_final_response_text(result) if isinstance(result, dict) else ""
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
+                completed = bool(result.get("completed", True)) if isinstance(result, dict) else True
+                interrupted = bool(result.get("interrupted")) if isinstance(result, dict) else False
+                partial = bool(result.get("partial")) if isinstance(result, dict) else False
                 turn_messages = self._turn_transcript_messages(history, user_message, result) if isinstance(result, dict) else []
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
                     "content": final_response,
-                    "completed": True,
-                    "partial": False,
-                    "interrupted": False,
+                    "completed": completed,
+                    "partial": partial,
+                    "interrupted": interrupted,
                 }))
                 await queue.put(_event_payload("run.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
-                    "completed": True,
+                    "completed": completed,
+                    "interrupted": interrupted,
                     "messages": turn_messages,
                     "usage": usage,
                 }))
@@ -4393,6 +4419,8 @@ class APIServerAdapter(BasePlatformAdapter):
             if not isinstance(msg, dict):
                 continue
             if msg.get("role") not in {"assistant", "tool"}:
+                continue
+            if msg.get("role") == "assistant" and _is_api_interrupt_sentinel(result, msg.get("content")):
                 continue
             out.append(cls._message_response(msg))
         return out

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3078,6 +3078,58 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             return ""
         return "confirmed" if runtime else "accepted"
 
+    @staticmethod
+    def _turn_completion_flags(result: Any) -> Dict[str, bool]:
+        """``completed`` / ``partial`` / ``interrupted`` for one agent turn.
+
+        The core already reports interruption in the result dict (``agent/turn_finalizer.py``,
+        ``agent/turn_recovery.py``, ``agent/codex_runtime.py``), but the session API hard-coded
+        ``completed=True`` / ``interrupted=False``, so a turn cut short by a new message was
+        advertised to clients as a clean completion.
+        """
+        is_dict = isinstance(result, dict)
+        interrupted = bool(result.get("interrupted")) if is_dict else False
+        return {
+            "completed": not interrupted,
+            "partial": bool(result.get("partial")) if is_dict else False,
+            "interrupted": interrupted,
+        }
+
+    @staticmethod
+    def _strip_interrupt_sentinel(final_response: Any, interrupted: bool) -> Any:
+        """Drop the internal wait-for-model interrupt status from user-visible assistant text.
+
+        ``agent/turn_api_call.py`` sets ``final_response`` to
+        ``Operation interrupted: waiting for model response (…)`` when a new message lands while
+        the turn is still waiting on the model. That is cancellation metadata, not prose: ACP
+        (``acp_adapter/server.py``) and the chat surfaces (``gateway/run.py``) already suppress it,
+        leaving the session API as the last surface that rendered it as if the assistant had
+        authored it. Only the sentinel is dropped — real interrupted or partial text is kept.
+        Refs #7921.
+        """
+        from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+
+        if interrupted and str(final_response).strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX):
+            return ""
+        return final_response
+
+    @staticmethod
+    def _without_interrupt_sentinel_rows(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """The same filter for the per-turn transcript carried on ``run.completed``.
+
+        A synthetic assistant row holding only the sentinel is dropped; rows with real text or
+        tool calls are preserved, so an interrupted turn still replays what the model did say.
+        """
+        from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+
+        kept: List[Dict[str, Any]] = []
+        for msg in messages:
+            if (isinstance(msg, dict) and msg.get("role") == "assistant" and not msg.get("tool_calls")
+                    and str(msg.get("content") or "").strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX)):
+                continue
+            kept.append(msg)
+        return kept
+
     @_admit_api_agent_request
     async def _handle_session_chat(self, request: "web.Request") -> "web.Response":
         """POST /api/sessions/{session_id}/chat — one synchronous agent turn."""
@@ -3092,11 +3144,14 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         effective_session_id = result.get("session_id") if is_dict else session_id
         final_response = _resolve_media_to_data_urls(
             result.get("final_response", "") if is_dict else "")
+        flags = self._turn_completion_flags(result)
+        final_response = self._strip_interrupt_sentinel(final_response, flags["interrupted"])
         headers = self._session_headers(effective_session_id or session_id, gateway_session_key)
         return web.json_response(
             {"object": "hermes.session.chat.completion",
              "session_id": effective_session_id or session_id,
              "message": {"role": "assistant", "content": final_response}, "usage": usage,
+             **flags,
              "runtime": self._effective_turn_runtime(ctx["runtime_request"], result, usage)},
             headers=headers)
 
@@ -3146,19 +3201,23 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                     tool_progress_callback=_tool_progress, active_run_id=run_id, **ctx["run_kwargs"])
                 is_dict = isinstance(result, dict)
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if is_dict else "")
+                flags = self._turn_completion_flags(result)
+                final_response = self._strip_interrupt_sentinel(final_response, flags["interrupted"])
                 effective_session_id = result.get("session_id", session_id) if is_dict else session_id
                 turn_messages = self._turn_transcript_messages(history, user_message, result) if is_dict else []
+                if flags["interrupted"]:
+                    turn_messages = self._without_interrupt_sentinel_rows(turn_messages)
                 effective_runtime = self._effective_turn_runtime(runtime_request, result, usage)
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id, "message_id": message_id,
-                    "content": final_response, "completed": True,
-                    "partial": bool(result.get("partial")) if is_dict else False,
-                    "interrupted": False, "runtime": effective_runtime}))
+                    "content": final_response, **flags, "runtime": effective_runtime}))
                 # A steer accepted after the final reply lands in result["pending_steer"]; surface
                 # it so clients can replay it rather than lose it.
                 pending_steer = result.get("pending_steer") if is_dict else None
+                # Both advertised terminal events carry the same completion state, so a client that
+                # only listens for run.completed sees the interruption too (review note on #65970).
                 completed_payload = {
-                    "session_id": effective_session_id, "message_id": message_id, "completed": True,
+                    "session_id": effective_session_id, "message_id": message_id, **flags,
                     "messages": turn_messages, "usage": usage, "runtime": effective_runtime}
                 if pending_steer:
                     completed_payload["pending_steer"] = pending_steer

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,5 +1,7 @@
 """Focused tests for API server session-control endpoints."""
 
+import json
+
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -252,6 +254,35 @@ async def test_session_chat_loads_history_and_preserves_session_headers(auth_ada
 
 
 @pytest.mark.asyncio
+async def test_session_chat_returns_interrupt_as_metadata_not_assistant_text(adapter, session_db):
+    session_id = session_db.create_session("interrupted-session", "api_server")
+    sentinel = "Operation interrupted: waiting for model response (18.8s elapsed)."
+    mock_run = AsyncMock(return_value=(
+        {
+            "final_response": sentinel,
+            "session_id": session_id,
+            "completed": False,
+            "interrupted": True,
+        },
+        {"total_tokens": 0},
+    ))
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", mock_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "continue"},
+            )
+            assert resp.status == 200
+            payload = await resp.json()
+
+    assert payload["message"]["content"] == ""
+    assert payload["completed"] is False
+    assert payload["interrupted"] is True
+
+
+@pytest.mark.asyncio
 async def test_session_chat_accepts_multimodal_message(auth_adapter, session_db):
     session_id = session_db.create_session("image-session", "api_server")
     image_payload = [
@@ -338,6 +369,55 @@ async def test_session_chat_stream_emits_lifecycle_events_and_keepalive_safe_sha
     assert "event: assistant.completed" in body
     assert "event: run.completed" in body
     assert "event: done" in body
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_emits_interrupt_as_metadata_not_assistant_text(adapter, session_db):
+    session_id = session_db.create_session("interrupted-stream-session", "api_server")
+    sentinel = "Operation interrupted: waiting for model response (18.8s elapsed)."
+
+    async def fake_run(**kwargs):
+        return {
+            "final_response": sentinel,
+            "session_id": session_id,
+            "completed": False,
+            "interrupted": True,
+            "messages": [
+                {"role": "user", "content": "continue"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"id": "call_1", "function": {"name": "terminal", "arguments": "{}"}}],
+                },
+                {"role": "tool", "content": "cancelled", "tool_call_id": "call_1"},
+                {"role": "assistant", "content": sentinel},
+            ],
+        }, {"total_tokens": 0}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "continue"},
+            )
+            assert resp.status == 200
+            body = await resp.text()
+
+    events = {}
+    for block in body.split("\n\n"):
+        lines = block.splitlines()
+        event = next((line.removeprefix("event: ") for line in lines if line.startswith("event: ")), None)
+        data = next((line.removeprefix("data: ") for line in lines if line.startswith("data: ")), None)
+        if event and data:
+            events[event] = json.loads(data)
+
+    assert sentinel not in body
+    assert events["assistant.completed"]["content"] == ""
+    assert events["assistant.completed"]["completed"] is False
+    assert events["assistant.completed"]["interrupted"] is True
+    assert events["run.completed"]["completed"] is False
+    assert events["run.completed"]["interrupted"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -891,3 +891,136 @@ async def test_patch_session_still_rejects_unknown_fields(adapter, session_db):
         resp = await cli.patch(f"/api/sessions/{session_id}", json={"nonsense": 1})
         assert resp.status == 400, await resp.text()
         assert (await resp.json())["error"]["code"] == "unsupported_session_field"
+
+
+# ---------------------------------------------------------------------------
+# The wait-for-model interrupt sentinel is cancellation metadata, not assistant
+# prose. ACP and the chat surfaces already suppress it; the session API was the
+# last surface rendering it as a fake assistant reply. Refs #7921, #31658.
+# ---------------------------------------------------------------------------
+
+_INTERRUPT_SENTINEL = "Operation interrupted: waiting for model response (1.7s elapsed)."
+
+
+def _sse_event(body: str, event_name: str):
+    """Payload of the ``event_name`` block in an SSE body, or ``None``."""
+    import json as _json
+
+    payload = None
+    for block in body.split("\n\n"):
+        if f"event: {event_name}" in block:
+            for line in block.splitlines():
+                if line.startswith("data: "):
+                    payload = _json.loads(line[len("data: "):])
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_session_chat_hides_interrupt_sentinel_and_reports_metadata(adapter, session_db):
+    """An interrupted turn must not be delivered as a fake assistant reply."""
+    session_id = session_db.create_session("interrupt-session", "api_server")
+
+    async def fake_run(**kwargs):
+        return {
+            "final_response": _INTERRUPT_SENTINEL, "session_id": session_id,
+            "interrupted": True, "partial": True,
+        }, {"total_tokens": 3}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(f"/api/sessions/{session_id}/chat", json={"message": "hi"})
+            assert resp.status == 200, await resp.text()
+            payload = await resp.json()
+
+    assert payload["message"]["content"] == ""
+    assert payload["interrupted"] is True
+    assert payload["completed"] is False
+    assert payload["partial"] is True
+
+
+@pytest.mark.asyncio
+async def test_session_chat_keeps_real_text_from_an_interrupted_turn(adapter, session_db):
+    """Only the sentinel is dropped — real partial prose from an interrupted turn survives."""
+    session_id = session_db.create_session("interrupt-real-text", "api_server")
+
+    async def fake_run(**kwargs):
+        return {
+            "final_response": "I found three matches so far", "session_id": session_id,
+            "interrupted": True, "partial": True,
+        }, {"total_tokens": 4}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(f"/api/sessions/{session_id}/chat", json={"message": "search"})
+            payload = await resp.json()
+
+    assert payload["message"]["content"] == "I found three matches so far"
+    assert payload["interrupted"] is True
+    assert payload["completed"] is False
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_terminal_events_agree_on_completion_state(adapter, session_db):
+    """``assistant.completed`` and ``run.completed`` must advertise the same completion state,
+    so a client listening to only one of them still sees the interruption."""
+    session_id = session_db.create_session("interrupt-stream", "api_server")
+
+    async def fake_run(**kwargs):
+        kwargs["stream_delta_callback"]("Looking that up")
+        return {
+            "final_response": _INTERRUPT_SENTINEL, "session_id": session_id,
+            "interrupted": True, "partial": True,
+            "messages": [
+                {"role": "user", "content": "look it up"},
+                {"role": "assistant", "content": "Looking that up"},
+                {"role": "assistant", "content": _INTERRUPT_SENTINEL},
+            ],
+        }, {"total_tokens": 5}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream", json={"message": "look it up"})
+            assert resp.status == 200
+            body = await resp.text()
+
+    assistant = _sse_event(body, "assistant.completed")
+    run_completed = _sse_event(body, "run.completed")
+    assert assistant is not None and run_completed is not None, body
+
+    assert assistant["content"] == ""
+    for payload in (assistant, run_completed):
+        assert payload["interrupted"] is True, payload
+        assert payload["completed"] is False, payload
+        assert payload["partial"] is True, payload
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_transcript_drops_only_the_sentinel_row(adapter, session_db):
+    """``run.completed.messages`` omits the synthetic sentinel row, keeping real assistant text."""
+    session_id = session_db.create_session("interrupt-transcript", "api_server")
+
+    async def fake_run(**kwargs):
+        return {
+            "final_response": _INTERRUPT_SENTINEL, "session_id": session_id, "interrupted": True,
+            "messages": [
+                {"role": "user", "content": "summarize"},
+                {"role": "assistant", "content": "Here is what I have so far"},
+                {"role": "assistant", "content": _INTERRUPT_SENTINEL},
+            ],
+        }, {"total_tokens": 5}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream", json={"message": "summarize"})
+            body = await resp.text()
+
+    messages = _sse_event(body, "run.completed")["messages"]
+    contents = [m.get("content") for m in messages]
+    assert "Here is what I have so far" in contents, messages
+    assert all(_INTERRUPT_SENTINEL not in str(c) for c in contents), messages


### PR DESCRIPTION
## What

`/api/sessions/{session_id}/chat` and `/chat/stream` no longer render Hermes' internal
`Operation interrupted: waiting for model response (...)` sentinel as assistant prose.

- Both routes drop the sentinel from the user-visible assistant text and expose
  `completed` / `partial` / `interrupted` metadata instead.
- The two terminal SSE events (`assistant.completed` and `run.completed`) now advertise the same
  completion state, so a client listening to only one of them still sees the interruption.
- `run.completed.messages` omits a synthetic assistant transcript row holding only the sentinel,
  while preserving real interrupted or partial assistant text.

This mirrors what the other surfaces already do — `acp_adapter/server.py:899` and
`gateway/run.py:666`: cancellation status belongs in metadata, not in the user-visible transcript.

## Why

When a new message interrupts a turn while Hermes is waiting for a model response, the core
reports it in the result dict (`agent/turn_finalizer.py`, `agent/turn_recovery.py`,
`agent/codex_runtime.py`). The session API ignored that: it hard-coded `"completed": True` and
`"interrupted": False`, and passed `final_response` straight through. Remote/Desktop clients
therefore showed a fake assistant reply *and* were told the turn had completed cleanly.

`gateway/platforms/api_server.py` is the only surface left that never imported
`INTERRUPT_WAITING_FOR_MODEL_PREFIX` — ACP, `gateway/run.py` and `tui_gateway` all suppress it.

## Note: this branch was rewritten against current `main`

The original July branch went stale when `api_server.py` was split (8082 -> 3964 lines) into
`api_server_openai_routes.py`, `api_server_room_dispatch.py`, `api_server_room_grants.py` and
`api_server_run_idempotency.py`. Rebasing produced conflicts larger than the change itself, so
the fix was rewritten from scratch against current `main` (`79445a496c`).

Both the defect and @teknium1's review point survived that refactor. The change is now
**63 lines of implementation** (+133 of tests) instead of the previous 974, and the pagination
work from the old branch is dropped — `partial` has since landed on `assistant.completed` in
`main` on its own.

@teknium1's review point is addressed: `run.completed` now carries `partial` alongside
`completed` and `interrupted`, and a new SSE test asserts both terminal events agree.

## Tests

- `scripts/run_tests.sh tests/gateway/test_session_api.py` — **24 passed** (20 pre-existing + 4 new)
- **Mutation check** — reverting only `gateway/platforms/api_server.py` to `origin/main` and
  re-running makes exactly the 4 new tests fail while the 20 pre-existing ones still pass, so the
  new tests pin the behavior rather than passing vacuously.
- `ruff check gateway/platforms/api_server.py tests/gateway/test_session_api.py` — passed
- Full `tests/gateway/` run — one file fails: `tests/gateway/test_scale_to_zero.py`
  (`test_suspend_self_posts_suspend_for_this_machine`,
  `test_suspend_self_non_2xx_is_false_not_raise`), both with `OSError: AF_UNIX path too long`.
  They reproduce identically on a clean `origin/main` checkout at `79445a496c` — a socket-path
  length property of my working directory, not a regression from this change.

## Platform tested

- Linux / WSL2

Related: #7921, #31658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LvZmiAfu51EpWVihHkMCC
