### PR TITLE
fix(tts): enforce Edge caller timeout

### DIFF
--- a/tests/tools/test_tts_edge_timeout.py
+++ b/tests/tools/test_tts_edge_timeout.py
@@ -1,0 +1,224 @@
+"""Regression coverage for the hard caller deadline around Edge TTS."""
+
+import asyncio
+import concurrent.futures
+import json
+import threading
+from pathlib import Path
+
+from tools import tts_tool
+
+
+def _select_edge(monkeypatch):
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+
+
+def test_edge_timeout_returns_before_cancellation_resistant_provider_finishes(tmp_path, monkeypatch):
+    provider_started = threading.Event()
+    cancellation_seen = threading.Event()
+    provider_finished = threading.Event()
+    release_provider = threading.Event()
+    tool_returned = threading.Event()
+    result_holder = {}
+    output_path = tmp_path / "out.mp3"
+
+    async def cancellation_resistant_provider(_text, path, _config):
+        provider_started.set()
+        try:
+            await asyncio.to_thread(release_provider.wait)
+        except asyncio.CancelledError:
+            cancellation_seen.set()
+            release_provider.wait()
+        Path(path).write_bytes(b"late audio")
+        provider_finished.set()
+        return path
+
+    _select_edge(monkeypatch)
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", cancellation_resistant_provider)
+    monkeypatch.setattr(tts_tool, "_edge_tts_timeout_seconds", lambda: 0.05)
+
+    def invoke_tool():
+        result_holder["result"] = json.loads(
+            tts_tool.text_to_speech_tool("hello", output_path=str(output_path))
+        )
+        tool_returned.set()
+
+    caller = threading.Thread(target=invoke_tool)
+    caller.start()
+    try:
+        assert provider_started.wait(1), "provider did not start"
+        assert tool_returned.wait(1), "caller remained joined to provider after its deadline"
+        assert not provider_finished.is_set(), "provider completed naturally before caller returned"
+        assert result_holder["result"]["success"] is False
+        assert "timed out after 0.05 seconds" in result_holder["result"]["error"]
+        assert not output_path.exists()
+    finally:
+        release_provider.set()
+        caller.join(2)
+
+    assert not caller.is_alive(), "caller did not shut down"
+    assert cancellation_seen.wait(1), "deadline did not request coroutine cancellation"
+    assert provider_finished.wait(1), "provider did not finish after test release"
+    assert not output_path.exists(), "late provider output became current-call output"
+
+
+def test_edge_timeout_registers_cleanup_before_observing_worker_completion(tmp_path, monkeypatch):
+    provider_started = threading.Event()
+    release_provider = threading.Event()
+    provider_finished = threading.Event()
+    staging_removed = threading.Event()
+    output_path = tmp_path / "out.mp3"
+    real_future_done = concurrent.futures.Future.done
+    real_unlink = tts_tool.os.unlink
+    done_checks = 0
+
+    async def cancellation_resistant_provider(_text, path, _config):
+        provider_started.set()
+        release_provider.wait()
+        Path(path).write_bytes(b"late audio")
+        provider_finished.set()
+        return path
+
+    def finish_worker_during_done_check(future):
+        nonlocal done_checks
+        done_checks += 1
+        if done_checks == 1:
+            return False
+        release_provider.set()
+        assert provider_finished.wait(1), "provider did not finish in cleanup race"
+        return real_future_done(future)
+
+    def observe_unlink(path):
+        real_unlink(path)
+        staging_removed.set()
+
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", cancellation_resistant_provider)
+    monkeypatch.setattr(concurrent.futures.Future, "done", finish_worker_during_done_check)
+    monkeypatch.setattr(tts_tool.os, "unlink", observe_unlink)
+
+    try:
+        tts_tool._run_edge_tts_with_timeout(
+            "hello", str(output_path), {}, timeout=0.01
+        )
+    except tts_tool._EdgeTTSDeadlineExceeded:
+        pass
+    else:
+        raise AssertionError("caller deadline did not expire")
+
+    assert provider_started.is_set()
+    release_provider.set()
+    assert provider_finished.wait(1), "provider did not finish after test release"
+    assert staging_removed.wait(1), "completion callback did not remove staging output"
+    assert not list(tmp_path.glob("out.mp3.edge-pending-*"))
+
+
+def test_edge_worker_drains_provider_child_tasks_before_loop_close(tmp_path, monkeypatch):
+    child_started = asyncio.Event()
+    child_cancelled = threading.Event()
+
+    async def provider_with_child(_text, path, _config):
+        async def child():
+            child_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                child_cancelled.set()
+
+        asyncio.create_task(child())
+        await child_started.wait()
+        Path(path).write_bytes(b"audio")
+        return path
+
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", provider_with_child)
+
+    output_path = tmp_path / "out.mp3"
+    tts_tool._run_edge_tts_with_timeout("hello", str(output_path), {})
+
+    assert output_path.read_bytes() == b"audio"
+    assert child_cancelled.is_set(), "worker loop closed without draining child task"
+
+
+def test_edge_timeout_does_not_wait_for_worker_loop_publication(tmp_path, monkeypatch):
+    loop_creation_allowed = threading.Event()
+    provider_started = threading.Event()
+    caller_returned = threading.Event()
+    result_holder = {}
+    real_new_event_loop = asyncio.new_event_loop
+
+    def delayed_new_event_loop():
+        assert loop_creation_allowed.wait(1), "test did not release worker-loop creation"
+        return real_new_event_loop()
+
+    async def provider(_text, path, _config):
+        provider_started.set()
+        Path(path).write_bytes(b"late audio")
+        return path
+
+    monkeypatch.setattr(asyncio, "new_event_loop", delayed_new_event_loop)
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", provider)
+
+    def invoke_helper():
+        try:
+            tts_tool._run_edge_tts_with_timeout(
+                "hello", str(tmp_path / "out.mp3"), {}, timeout=0.01
+            )
+        except tts_tool._EdgeTTSDeadlineExceeded as exc:
+            result_holder["error"] = exc
+        finally:
+            caller_returned.set()
+
+    caller = threading.Thread(target=invoke_helper)
+    caller.start()
+    try:
+        assert caller_returned.wait(0.2), "loop readiness extended the caller timeout budget"
+        assert isinstance(result_holder.get("error"), tts_tool._EdgeTTSDeadlineExceeded)
+        assert not provider_started.is_set()
+    finally:
+        loop_creation_allowed.set()
+        caller.join(1)
+
+    assert not caller.is_alive()
+    assert not provider_started.wait(0.1), "late loop publication started cancelled work"
+    assert not (tmp_path / "out.mp3").exists()
+
+
+def test_edge_provider_timeout_preserves_provider_error(tmp_path, monkeypatch):
+    calls = 0
+
+    async def provider_timeout(_text, _path, _config):
+        nonlocal calls
+        calls += 1
+        raise TimeoutError("socket handshake timed out")
+
+    _select_edge(monkeypatch)
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", provider_timeout)
+
+    result = json.loads(
+        tts_tool.text_to_speech_tool("hello", output_path=str(tmp_path / "out.mp3"))
+    )
+
+    assert result["success"] is False
+    assert "socket handshake timed out" in result["error"]
+    assert "timed out after 60 seconds" not in result["error"]
+    assert calls == 1
+
+
+def test_edge_runtime_error_does_not_retry_synthesis(tmp_path, monkeypatch):
+    calls = 0
+
+    async def provider_failure(_text, _path, _config):
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("provider runtime failure")
+
+    _select_edge(monkeypatch)
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", provider_failure)
+
+    result = json.loads(
+        tts_tool.text_to_speech_tool("hello", output_path=str(tmp_path / "out.mp3"))
+    )
+
+    assert result["success"] is False
+    assert "provider runtime failure" in result["error"]
+    assert calls == 1

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -971,6 +971,93 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
     return output_path
 
 
+class _EdgeTTSDeadlineExceeded(TimeoutError):
+    """Raised only when Hermes' Edge TTS caller deadline expires."""
+
+
+def _edge_tts_timeout_seconds() -> float:
+    """Return the Edge TTS caller timeout (a narrow test seam)."""
+    return 60
+
+
+def _run_edge_tts_with_timeout(
+    text: str,
+    output_path: str,
+    tts_config: Dict[str, Any],
+    timeout: float = 60,
+) -> None:
+    """Run Edge TTS with a hard caller deadline and atomic output publish."""
+    import concurrent.futures
+
+    worker_loop = None
+    loop_ready = threading.Event()
+    cancel_requested = threading.Event()
+    staging_path = f"{output_path}.edge-pending-{uuid.uuid4().hex}"
+
+    def remove_staging(_future=None):
+        try:
+            os.unlink(staging_path)
+        except FileNotFoundError:
+            pass
+
+    def run_in_worker():
+        nonlocal worker_loop
+        worker_loop = asyncio.new_event_loop()
+        loop_ready.set()
+        try:
+            asyncio.set_event_loop(worker_loop)
+            provider_task = worker_loop.create_task(
+                _generate_edge_tts(text, staging_path, tts_config)
+            )
+            if cancel_requested.is_set():
+                provider_task.cancel()
+            return worker_loop.run_until_complete(provider_task)
+        finally:
+            try:
+                pending = asyncio.all_tasks(worker_loop)
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    worker_loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True)
+                    )
+            except Exception:
+                pass
+            worker_loop.close()
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = pool.submit(run_in_worker)
+    try:
+        try:
+            future.result(timeout=timeout)
+        except concurrent.futures.TimeoutError as exc:
+            # A provider may itself raise TimeoutError. A completed future means
+            # that exception came from the provider, not from our caller wait.
+            if future.done():
+                future.result()
+            cancel_requested.set()
+            future.cancel()
+            if loop_ready.is_set() and worker_loop is not None:
+                try:
+                    for task in asyncio.all_tasks(worker_loop):
+                        worker_loop.call_soon_threadsafe(task.cancel)
+                except RuntimeError:
+                    pass
+            raise _EdgeTTSDeadlineExceeded(
+                f"Edge TTS timed out after {timeout:g} seconds"
+            ) from exc
+        os.replace(staging_path, output_path)
+    except Exception:
+        # Register first: add_done_callback invokes immediately if completion
+        # won the race, and otherwise guarantees cleanup after a late write.
+        future.add_done_callback(remove_staging)
+        remove_staging()
+        raise
+    finally:
+        # Cancellation is cooperative. Never join a provider that suppresses it.
+        pool.shutdown(wait=False)
+
+
 # ===========================================================================
 # Provider: ElevenLabs (premium)
 # ===========================================================================
@@ -2507,13 +2594,14 @@ def text_to_speech_tool(
             if edge_available:
                 logger.info("Generating speech with Edge TTS...")
                 try:
-                    import concurrent.futures
-                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                        pool.submit(
-                            lambda: asyncio.run(_generate_edge_tts(text, file_str, tts_config))
-                        ).result(timeout=60)
-                except RuntimeError:
-                    asyncio.run(_generate_edge_tts(text, file_str, tts_config))
+                    _run_edge_tts_with_timeout(
+                        text,
+                        file_str,
+                        tts_config,
+                        timeout=_edge_tts_timeout_seconds(),
+                    )
+                except _EdgeTTSDeadlineExceeded as e:
+                    return tool_error(str(e), success=False)
             elif _check_neutts_available():
                 logger.info("Edge TTS not available, falling back to NeuTTS (local)...")
                 provider = "neutts"


### PR DESCRIPTION
## Summary

- run Edge TTS on a dedicated event-loop worker and stop waiting when the 60-second caller timeout expires
- publish generated audio atomically from a per-call staging path, so a provider that finishes after timeout cannot publish stale output
- request coroutine cancellation without waiting for worker-loop readiness, while preserving cancellation for a loop that is published after the caller has already timed out
- preserve provider `TimeoutError` provenance and remove the broad `RuntimeError` retry that could synthesize the same request twice

## Caller-latency contract

The caller waits at most the configured 60-second `Future.result` timeout plus ordinary local scheduling and exception-handling overhead. The timeout path performs no additional bounded wait for worker-loop readiness. Cancellation is cooperative: the caller returns an Edge TTS timeout error even if the provider ignores cancellation or the worker loop has not yet been created.

This is a caller-latency guarantee, not a process-exit guarantee. `ThreadPoolExecutor` workers are non-daemon threads tracked by CPython, and CPython's `_python_exit` hook joins them during interpreter shutdown. A permanently wedged or cancellation-resistant provider can therefore still delay process exit after the caller has already received its timeout error. The narrow fix deliberately does not replace CPython's executor/thread lifecycle.

## Related shared-bridge limitation

`model_tools.py:_run_async` has the same `loop_ready.wait(timeout=1.0)` overshoot pattern. This patch does not change that helper: Edge TTS additionally requires a per-call staging path, atomic output publication, and its own configurable deadline, so folding the repair into the shared bridge would turn a narrow provider fix into a broader refactor. The shared-helper overshoot should be tracked separately.

## Why the broad `RuntimeError` retry was removed

The previous code caught any `RuntimeError` around the executor path and retried the complete synthesis with `asyncio.run`. Provider code can raise `RuntimeError` after doing work, so that catch could invoke Edge TTS twice and obscure the original provider failure. The new helper owns its event loop and only converts its own caller-deadline exception; provider `RuntimeError` and provider `TimeoutError` propagate through the existing tool error handling without retry.

## Verification

- isolated-copy production-path regression against base `f0ff8d50970c35b67484056af9e913a6e6ba7e49`: RED (`baseline caller stayed joined after deadline`)
- focused regression file: 6 passed
- focused regression file repeated 15 times: 90 passed total
- `scripts/run_tests.sh tests/tools/ -k tts -q`: 279 selected tests passed
- Ruff and `git diff --check`: passed
