### PR TITLE
fix(pricing): strip apac./au. Bedrock region prefixes so cost isn't unknown

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -884,15 +884,18 @@ def _normalize_bedrock_model_name(model: str) -> str:
     """Normalize a Bedrock model id to its bare foundation-model form.
 
     Bedrock cross-region inference profiles prefix the foundation model id
-    with a region scope (``us.`` / ``global.`` / ``eu.`` / ``ap.`` / ``jp.``),
-    e.g. ``us.anthropic.claude-opus-4-7``.  The pricing table is keyed on the
-    bare ``anthropic.claude-*`` id, so the prefix must be stripped before the
-    lookup or every cross-region session prices as unknown.  Mirrors the
-    prefix list in ``bedrock_adapter.is_anthropic_bedrock_model``.  Also
-    normalizes dot-notation version numbers (``4.7`` → ``4-7``).
+    with a region scope (``us.`` / ``global.`` / ``eu.`` / ``apac.`` / ``au.``),
+    e.g. ``us.anthropic.claude-opus-4-7`` or ``apac.anthropic.claude-*``.  The
+    pricing table is keyed on the bare ``anthropic.claude-*`` id, so the prefix
+    must be stripped before the lookup or every cross-region session prices as
+    unknown.  Asia-Pacific uses ``apac.`` (not ``ap.``) and Australia ``au.`` —
+    a bare ``ap.`` never matches an ``apac.*`` id, so those geographies priced
+    as unknown.  Mirrors the prefix list in
+    ``bedrock_adapter.is_anthropic_bedrock_model``.  Also normalizes
+    dot-notation version numbers (``4.7`` → ``4-7``).
     """
     name = model.lower().strip()
-    for prefix in ("us.", "global.", "eu.", "ap.", "jp."):
+    for prefix in ("us.", "global.", "eu.", "apac.", "ap.", "au.", "jp."):
         if name.startswith(prefix):
             name = name[len(prefix):]
             break

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -349,16 +349,20 @@ def test_bedrock_claude_rows_all_carry_cache_pricing():
 
 
 def test_bedrock_cross_region_profile_prefix_resolves_to_pricing():
-    """Cross-region inference profiles (us./global./eu. prefixes) must resolve
-    to the same pricing entry as the bare foundation-model id.  Without prefix
-    normalization, ``us.anthropic.claude-*`` sessions price as unknown.
+    """Cross-region inference profiles must resolve to the same pricing entry
+    as the bare foundation-model id.  Without prefix normalization a scoped
+    ``<region>.anthropic.claude-*`` session prices as unknown.
+
+    Asia-Pacific (``apac.``) and Australia (``au.``) are included because AWS
+    uses the full ``apac.`` prefix, not ``ap.`` — a bare ``ap.`` never matches
+    an ``apac.*`` id, so those geographies previously priced as unknown.
     """
     bedrock_url = "https://bedrock-runtime.us-east-1.amazonaws.com"
     bare = get_pricing_entry(
         "anthropic.claude-sonnet-4-5", provider="bedrock", base_url=bedrock_url
     )
     assert bare is not None
-    for prefix in ("us.", "global.", "eu."):
+    for prefix in ("us.", "global.", "eu.", "apac.", "au."):
         scoped = get_pricing_entry(
             f"{prefix}anthropic.claude-sonnet-4-5",
             provider="bedrock",


### PR DESCRIPTION
## What

`_normalize_bedrock_model_name` stripped `("us.", "global.", "eu.", "ap.", "jp.")`
before the Bedrock pricing lookup, but AWS's Asia-Pacific cross-region inference
profiles are prefixed **`apac.`** (and Australia **`au.`**), not `ap.`. A bare
`ap.` never matches an `apac.*` id (`"apac.".startswith("ap.")` is `False`), so
`apac.anthropic.claude-*` / `au.anthropic.claude-*` kept the prefix, missed the
bare `anthropic.claude-*` pricing key, and every Asia-Pacific / Australia Bedrock
session priced as **unknown** — no cost estimate for two whole geographies, while
`us./eu./global.` worked.

The same list is duplicated in `bedrock_adapter.is_anthropic_bedrock_model`
(fixed for the prompt-caching gate by the open #46297) and in
`anthropic_adapter._is_bedrock_model_id` (benign there — its dot-replace is
already guarded by `startswith("claude-")`). This fixes the cost-lookup copy #46297
doesn't touch.

## Fix

- `agent/usage_pricing.py` — add `apac.` and `au.` to the region-prefix strip
  list in `_normalize_bedrock_model_name` (+ docstring).

## Tests

`pytest tests/agent/test_usage_pricing.py -q` → **27 passed**. Extended the
existing `test_bedrock_cross_region_profile_prefix_resolves_to_pricing` to cover
`apac.`/`au.`; revert the fix and it fails with `scoped == None` for `apac.`
(prices as unknown).