### PR TITLE
fix(desktop): keep background tiles from clobbering model state

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -362,9 +362,11 @@ export function useSessionActions({
         createdThisRun.add(stored)
         // Seed the sidebar + per-runtime cache, but DON'T steal the primary
         // selection — this session lives in the tile. Prime it with the create
-        // runtime so the tile skips a redundant resume.
+        // runtime so the tile skips a redundant resume. Runtime metadata is
+        // cached only; applying it to the shared view would make this
+        // background session overwrite the primary chat's selected model.
         upsertOptimisticSession(created, stored, null, null)
-        const runtimeInfo = applyRuntimeInfo(created.info)
+        const runtimeInfo = applyRuntimeInfo(created.info, { syncView: false })
         updateSessionState(created.session_id, state => (runtimeInfo ? { ...state, ...runtimeInfo } : state), stored)
 
         openSessionTile(stored, dir)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
 import { $activeGatewayProfile } from '@/store/profile'
+import { $currentModel, $currentProvider, setCurrentModel, setCurrentProvider } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import {
@@ -31,6 +32,26 @@ describe('applyRuntimeInfo approval mode', () => {
 
     expect(approvalModeForProfile('work')).toBe('smart')
     expect(approvalModeForProfile('default')).toBe('smart')
+  })
+})
+
+describe('applyRuntimeInfo view syncing', () => {
+  beforeEach(() => {
+    setCurrentModel('anthropic/claude-opus-4.8')
+    setCurrentProvider('anthropic')
+  })
+
+  afterEach(() => {
+    setCurrentModel('')
+    setCurrentProvider('')
+  })
+
+  it('can cache background runtime metadata without clobbering the focused model', () => {
+    const state = applyRuntimeInfo({ model: 'gpt-5.6-sol', provider: 'openai-codex' }, { syncView: false })
+
+    expect(state).toMatchObject({ model: 'gpt-5.6-sol', provider: 'openai-codex' })
+    expect($currentModel.get()).toBe('anthropic/claude-opus-4.8')
+    expect($currentProvider.get()).toBe('anthropic')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -259,12 +259,26 @@ type SessionRuntimeStatePatch = Partial<
   >
 >
 
-export function applyRuntimeInfo(info: SessionRuntimeInfo | undefined): SessionRuntimeStatePatch | null {
+export interface ApplyRuntimeInfoOptions {
+  /** Keep a background session out of the shared foreground-view atoms. */
+  syncView?: boolean
+}
+
+export function applyRuntimeInfo(
+  info: SessionRuntimeInfo | undefined,
+  { syncView = true }: ApplyRuntimeInfoOptions = {}
+): SessionRuntimeStatePatch | null {
   if (!info) {
     return null
   }
 
   const sessionState: SessionRuntimeStatePatch = {}
+
+  const setView = <T>(setter: (value: T) => void, value: T) => {
+    if (syncView) {
+      setter(value)
+    }
+  }
 
   reportBackendContract(info.desktop_contract)
 
@@ -279,52 +293,52 @@ export function applyRuntimeInfo(info: SessionRuntimeInfo | undefined): SessionR
   reportInstallMethodWarning(info.install_warning)
 
   if (typeof info.model === 'string') {
-    setCurrentModel(info.model)
+    setView(setCurrentModel, info.model)
     sessionState.model = info.model
   }
 
   if (typeof info.provider === 'string') {
-    setCurrentProvider(info.provider)
+    setView(setCurrentProvider, info.provider)
     sessionState.provider = info.provider
   }
 
   if (info.cwd) {
-    setCurrentCwd(info.cwd)
+    setView(setCurrentCwd, info.cwd)
     sessionState.cwd = info.cwd
   }
 
   if (info.branch !== undefined) {
-    setCurrentBranch(info.branch || '')
+    setView(setCurrentBranch, info.branch || '')
     sessionState.branch = info.branch || ''
   }
 
   if (typeof info.personality === 'string') {
     const personality = normalizePersonalityValue(info.personality)
-    setCurrentPersonality(personality)
+    setView(setCurrentPersonality, personality)
     sessionState.personality = personality
   }
 
   if (typeof info.reasoning_effort === 'string') {
-    setCurrentReasoningEffort(info.reasoning_effort)
+    setView(setCurrentReasoningEffort, info.reasoning_effort)
     sessionState.reasoningEffort = info.reasoning_effort
   }
 
   if (typeof info.service_tier === 'string') {
-    setCurrentServiceTier(info.service_tier)
+    setView(setCurrentServiceTier, info.service_tier)
     sessionState.serviceTier = info.service_tier
   }
 
   if (typeof info.fast === 'boolean') {
-    setCurrentFastMode(info.fast)
+    setView(setCurrentFastMode, info.fast)
     sessionState.fast = info.fast
   }
 
   if (typeof info.yolo === 'boolean') {
-    setYoloActive(info.yolo)
+    setView(setYoloActive, info.yolo)
     sessionState.yolo = info.yolo
   }
 
-  if (info.usage) {
+  if (syncView && info.usage) {
     setCurrentUsage(current => ({ ...current, ...info.usage }))
   }
 


### PR DESCRIPTION
## Summary

- Prevent background session tiles from overwriting the foreground chat's selected model/provider and related runtime state.
- Add an explicit cache-only mode to `applyRuntimeInfo` and use it when priming a new split tile.
- Add regression coverage for background runtime metadata not clobbering the focused model.

## Root cause

`openNewSessionTile` calls `applyRuntimeInfo` while the new session is still a background tile. `applyRuntimeInfo` previously wrote directly to the shared foreground atoms, so the tile's model (commonly the profile default, such as GPT-5.6 Sol with High reasoning) replaced the model selected in the active conversation.

## Test plan

- `vitest run --project ui src/app/session/hooks/use-session-actions/utils.test.ts src/app/session/hooks/use-session-state-cache.test.tsx src/app/session/hooks/use-model-controls.test.tsx src/app/shell/model-menu-panel.test.tsx`
  - 4 files, 26 tests passed
- ESLint on all changed desktop files: passed
- Prettier check and `git diff --check`: passed
- Full TypeScript check was attempted but is blocked by the existing installed dependency set missing `@assistant-ui/core` / `@assistant-ui/react` typings; no errors were reported from the changed files before the unrelated repository-wide failures.
