### PR TITLE
fix(desktop): honor Copilot model capabilities

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -304,15 +304,10 @@ class ResponsesApiTransport(ProviderTransport):
         if request_overrides:
             kwargs.update(request_overrides)
 
-        # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
-        # supported: service_tier") — hit when ``/fast`` priority-processing
-        # mode lingers from a prior model in the same session, or when a
-        # user explicitly sets ``agent.service_tier`` in config.yaml.  The
-        # main-loop guard (``resolve_fast_mode_overrides`` only returns
-        # ``service_tier`` for OpenAI fast-eligible models) doesn't cover
-        # those leak paths, so strip defensively when targeting xAI.  See
-        # #28490 for the original report.
-        if is_xai_responses:
+        # GitHub Copilot and xAI Responses reject ``service_tier``. This can
+        # linger after a provider/model switch or arrive from persistent config,
+        # so strip it at the transport boundary regardless of the caller.
+        if is_github_responses or is_xai_responses:
             kwargs.pop("service_tier", None)
 
         # Forward per-request timeout to the SDK so OpenAI/Anthropic clients

--- a/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
@@ -10,7 +10,7 @@ import {
 import { $modelPresets, getModelPreset } from '@/store/model-presets'
 import { $activeSessionId } from '@/store/session'
 
-import { type FastControl, ModelEditSubmenu } from './model-edit-submenu'
+import { type FastControl, ModelEditSubmenu, resolveReasoningEffort } from './model-edit-submenu'
 
 // Radix calls these on open; jsdom doesn't implement them.
 beforeAll(() => {
@@ -30,7 +30,12 @@ afterEach(() => {
 })
 
 // Render the submenu inside an open menu/sub so its content (switches) mounts.
-function renderSubmenu(opts: { fastControl: FastControl; reasoning: boolean; requestGateway: () => Promise<unknown> }) {
+function renderSubmenu(opts: {
+  fastControl: FastControl
+  reasoning: boolean
+  reasoningEfforts?: string[]
+  requestGateway: () => Promise<unknown>
+}) {
   return render(
     <DropdownMenu open>
       <DropdownMenuContent>
@@ -44,6 +49,7 @@ function renderSubmenu(opts: { fastControl: FastControl; reasoning: boolean; req
             onSelectModel={vi.fn()}
             provider="p1"
             reasoning={opts.reasoning}
+            reasoningEfforts={opts.reasoningEfforts}
             requestGateway={opts.requestGateway as never}
           />
         </DropdownMenuSub>
@@ -85,5 +91,28 @@ describe('ModelEditSubmenu no-session guard', () => {
     fireEvent.click(screen.getByRole('switch'))
 
     expect(requestGateway).toHaveBeenCalledWith('config.set', { key: 'fast', session_id: 'sess1', value: 'fast' })
+  })
+})
+
+describe('Copilot reasoning capabilities', () => {
+  const efforts = ['none', 'low', 'medium', 'high', 'xhigh', 'max']
+
+  it('shows only provider-supported effort choices', () => {
+    renderSubmenu({
+      fastControl: { kind: 'none' },
+      reasoning: true,
+      reasoningEfforts: efforts,
+      requestGateway: vi.fn().mockResolvedValue({})
+    })
+
+    expect(screen.getByText('Max')).not.toBeNull()
+    expect(screen.getByText('Extra High')).not.toBeNull()
+    expect(screen.queryByText('Ultra')).toBeNull()
+    expect(screen.queryByText('Minimal')).toBeNull()
+  })
+
+  it('preserves supported Max and clamps unsupported Ultra', () => {
+    expect(resolveReasoningEffort('max', efforts)).toBe('max')
+    expect(resolveReasoningEffort('ultra', efforts)).toBe('medium')
   })
 })

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -90,6 +90,8 @@ interface ModelEditSubmenuProps {
   provider: string
   /** Whether this model supports reasoning effort. */
   reasoning: boolean
+  /** Exact provider-supported effort values, when known. */
+  reasoningEfforts?: readonly string[]
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
 }
 
@@ -101,13 +103,19 @@ export function ModelEditSubmenu({
   onSelectModel,
   provider,
   reasoning,
+  reasoningEfforts,
   requestGateway
 }: ModelEditSubmenuProps) {
   const { t } = useI18n()
   const copy = t.shell.modelOptions
   const activeSessionId = useStore($activeSessionId)
 
-  const effortValue = normalizeEffort(effort)
+  const effortValue = normalizeEffort(resolveReasoningEffort(effort, reasoningEfforts))
+
+  const effortOptions = reasoningEfforts?.length
+    ? EFFORT_OPTIONS.filter(option => reasoningEfforts.includes(option.value))
+    : EFFORT_OPTIONS
+
   const thinkingOn = isThinkingEnabled(effort)
 
   // Editing always records the model's global preset; the active model also gets
@@ -215,7 +223,7 @@ export function ModelEditSubmenu({
               <DropdownMenuSeparator className="mx-0" />
               <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.effort}</DropdownMenuLabel>
               <DropdownMenuRadioGroup onValueChange={value => void patchReasoning(value)} value={effortValue}>
-                {EFFORT_OPTIONS.map(option => (
+                {effortOptions.map(option => (
                   <DropdownMenuRadioItem
                     className={dropdownMenuRow}
                     key={option.value}
@@ -237,6 +245,24 @@ export function ModelEditSubmenu({
 function isThinkingEnabled(effort: string): boolean {
   // Empty = Hermes default (medium) = on; only an explicit "none" is off.
   return normalize(effort || 'medium') !== 'none'
+}
+
+export function resolveReasoningEffort(effort: string, supported?: readonly string[]): string {
+  const value = normalize(effort || 'medium')
+
+  if (value === 'none' || !supported?.length || supported.includes(value)) {
+    return value
+  }
+
+  if (value === 'xhigh' && supported.includes('high')) {
+    return 'high'
+  }
+
+  if (value === 'minimal' && supported.includes('low')) {
+    return 'low'
+  }
+
+  return supported.includes('medium') ? 'medium' : supported[0]
 }
 
 function normalizeEffort(effort: string): string {

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -45,7 +45,7 @@ import {
 } from '@/store/session'
 import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
 
-import { ModelEditSubmenu, resolveFastControl } from './model-edit-submenu'
+import { ModelEditSubmenu, resolveFastControl, resolveReasoningEffort } from './model-edit-submenu'
 
 // Lets the host dropdown (model-pill) hand the panel a way to dismiss itself so
 // clicking a model row commits + closes, while the hover-revealed edit submenu
@@ -172,7 +172,10 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
 
     await applyModelPreset(
       {
-        effort: (caps?.reasoning ?? true) ? (preset.effort ?? 'medium') : undefined,
+        effort:
+          (caps?.reasoning ?? true)
+            ? resolveReasoningEffort(preset.effort ?? 'medium', caps?.reasoning_efforts)
+            : undefined,
         fast: (caps?.fast ?? false) ? (preset.fast ?? false) : undefined
       },
       { failMessage: t.shell.modelOptions.updateFailed, request: requestGateway, sessionId: activeSessionId }
@@ -253,7 +256,8 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                 // defaults when unset). Row label AND submenu read from these so
                 // they never disagree.
                 const preset = modelPresets[modelPresetKey(group.provider.slug, family.id)] ?? {}
-                const effEffort = isCurrent ? currentReasoningEffort : (preset.effort ?? '')
+                const requestedEffort = isCurrent ? currentReasoningEffort : (preset.effort ?? '')
+                const effEffort = resolveReasoningEffort(requestedEffort, caps?.reasoning_efforts)
                 const effFast = isCurrent ? currentFastMode : (preset.fast ?? false)
 
                 const fastControl = resolveFastControl(
@@ -312,6 +316,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                       onSelectModel={nextModel => switchTo(nextModel, group.provider.slug)}
                       provider={group.provider.slug}
                       reasoning={caps?.reasoning ?? true}
+                      reasoningEfforts={caps?.reasoning_efforts}
                       requestGateway={requestGateway}
                     />
                   </DropdownMenuSub>

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -278,6 +278,7 @@ export interface ModelOptionProvider {
 export interface ModelCapabilities {
   fast: boolean
   reasoning: boolean
+  reasoning_efforts?: string[]
 }
 
 export interface ModelOptionsResponse {

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -260,15 +260,15 @@ def build_models_payload(
 
 
 def _apply_capabilities(rows: list[dict]) -> None:
-    """Attach a ``{model: {fast, reasoning}}`` map to each provider row.
+    """Attach per-model option support to each provider row.
 
-    `fast` mirrors ``model_supports_fast_mode`` (the same gate the runtime
-    enforces). `reasoning` comes from the models.dev catalog when known and
-    defaults to True otherwise — the effort dial is broadly accepted and a
-    no-op on models that ignore it, whereas hiding it from a capable-but-
-    uncatalogued model is the worse failure.
+    `fast` mirrors ``model_supports_fast_mode`` except on provider routes that
+    reject its request parameter. `reasoning` comes from the models.dev catalog
+    when known and defaults to True otherwise — the effort dial is broadly
+    accepted and a no-op on models that ignore it, whereas hiding it from a
+    capable-but-uncatalogued model is the worse failure.
     """
-    from hermes_cli.models import model_supports_fast_mode
+    from hermes_cli.models import github_model_reasoning_efforts, model_supports_fast_mode
 
     try:
         from agent.models_dev import get_model_capabilities
@@ -277,7 +277,8 @@ def _apply_capabilities(rows: list[dict]) -> None:
 
     for row in rows:
         slug = row.get("slug") or ""
-        caps: dict[str, dict[str, bool]] = {}
+        is_copilot = str(slug).strip().lower() in {"copilot", "copilot-acp"}
+        caps: dict[str, dict] = {}
 
         for model in row.get("models") or []:
             reasoning = True
@@ -289,10 +290,17 @@ def _apply_capabilities(rows: list[dict]) -> None:
                 except Exception:
                     reasoning = True
 
-            caps[model] = {
-                "fast": bool(model_supports_fast_mode(model)),
+            model_caps: dict[str, object] = {
+                # Copilot rejects OpenAI's service_tier=priority even for GPT
+                # models, so its picker must not expose the parameter toggle.
+                "fast": bool(model_supports_fast_mode(model)) and not is_copilot,
                 "reasoning": reasoning,
             }
+            if is_copilot:
+                efforts = github_model_reasoning_efforts(model)
+                if efforts:
+                    model_caps["reasoning_efforts"] = efforts
+            caps[model] = model_caps
 
         row["capabilities"] = caps
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -29,6 +29,7 @@ COPILOT_BASE_URL = "https://api.githubcopilot.com"
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
 COPILOT_EDITOR_VERSION = "vscode/1.104.1"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
+COPILOT_REASONING_EFFORTS_GPT56 = ["none", "low", "medium", "high", "xhigh", "max"]
 COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 
 def _urlopen_model_catalog_request(req: urllib.request.Request, *, timeout: float):
@@ -3459,6 +3460,8 @@ def _github_reasoning_efforts_for_model_id(model_id: str) -> list[str]:
     if raw.startswith(("openai/o1", "openai/o3", "openai/o4", "o1", "o3", "o4")):
         return list(COPILOT_REASONING_EFFORTS_O_SERIES)
     normalized = normalize_copilot_model_id(model_id).lower()
+    if normalized.startswith("gpt-5.6"):
+        return list(COPILOT_REASONING_EFFORTS_GPT56)
     if normalized.startswith("gpt-5"):
         return list(COPILOT_REASONING_EFFORTS_GPT5)
     return []

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -906,9 +906,8 @@ class TestCodexTransportXaiServiceTierStrip:
             "non-xAI codex_responses providers must keep service_tier"
         )
 
-    def test_github_responses_preserves_service_tier(self, transport):
-        """GitHub Models (Copilot) is another codex_responses surface
-        that should not be affected by the xAI strip."""
+    def test_github_responses_strips_service_tier(self, transport):
+        """Copilot rejects OpenAI Priority Processing with HTTP 400."""
         kw = transport.build_kwargs(
             model="gpt-5.5",
             messages=[{"role": "user", "content": "hi"}],
@@ -916,7 +915,7 @@ class TestCodexTransportXaiServiceTierStrip:
             is_github_responses=True,
             request_overrides={"service_tier": "priority"},
         )
-        assert kw.get("service_tier") == "priority"
+        assert "service_tier" not in kw
 
 
 class TestPreflightSlashEnumStrip:

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 from hermes_cli.inventory import (
     ConfigContext,
+    _apply_capabilities,
     build_models_payload,
     load_picker_context,
 )
@@ -211,6 +212,18 @@ def test_build_models_payload_does_not_call_provider_model_ids():
          patch("hermes_cli.models.provider_model_ids") as mock_pm:
         build_models_payload(ctx)
     mock_pm.assert_not_called()
+
+
+def test_copilot_capabilities_hide_fast_and_publish_exact_efforts():
+    rows = [{"slug": "copilot", "models": ["gpt-5.6-sol"]}]
+
+    _apply_capabilities(rows)
+
+    assert rows[0]["capabilities"]["gpt-5.6-sol"] == {
+        "fast": False,
+        "reasoning": True,
+        "reasoning_efforts": ["none", "low", "medium", "high", "xhigh", "max"],
+    }
 
 
 def test_build_models_payload_uses_cached_nous_tier_by_default():

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -343,6 +343,11 @@ class TestFetchApiModels:
 
 
 class TestGithubReasoningEfforts:
+    def test_gpt56_fallback_matches_copilot_capabilities(self):
+        assert github_model_reasoning_efforts("gpt-5.6-sol") == [
+            "none", "low", "medium", "high", "xhigh", "max",
+        ]
+
     def test_gpt5_supports_minimal_to_high(self):
         catalog = [{
             "id": "gpt-5.4",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2028,6 +2028,12 @@ class TestBuildApiKwargs:
 
         assert agent._github_models_reasoning_extra_body() == {"effort": "xhigh"}
 
+    def test_core_responses_preserves_gpt56_max(self, agent):
+        agent.model = "gpt-5.6-sol"
+        agent.reasoning_config = {"enabled": True, "effort": "max"}
+
+        assert agent._github_models_reasoning_extra_body() == {"effort": "max"}
+
     def test_reasoning_omitted_for_non_reasoning_copilot_model(self, agent):
         agent.base_url = "https://api.githubcopilot.com"
         agent.model = "gpt-4.1"


### PR DESCRIPTION
## Summary

- expose provider-supported Copilot reasoning efforts in the Desktop model menu
- preserve GPT-5.6 Sol `xhigh` and `max` instead of downgrading them
- hide unsupported Copilot Fast, Ultra, and Minimal controls
- strip stale `service_tier` overrides at the Copilot Responses transport boundary

## Verification

- `python -m pytest -q tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_inventory.py tests/plugins/model_providers/test_copilot_profile.py tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent.py` - 648 passed
- `npm test` - 1,743 passed, 1 skipped
- `npm run typecheck` - passed
- `npm run build` - passed
- live model-options payload reports Fast disabled and efforts `none`, `low`, `medium`, `high`, `xhigh`, `max` for `gpt-5.6-sol`
