### PR TITLE
Make fresh Codex OAuth login current

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1743,9 +1743,19 @@ class CredentialPool:
             return None, None, f"No credential #{index}."
         return None, None, f'No credential matching "{raw}".'
 
-    def add_entry(self, entry: PooledCredential) -> PooledCredential:
-        entry = replace(entry, priority=_next_priority(self._entries))
-        self._entries.append(entry)
+    def add_entry(self, entry: PooledCredential, *, make_first: bool = False) -> PooledCredential:
+        if make_first:
+            # Fresh interactive re-auth flows should be able to make the newly
+            # added credential the next fill-first selection without requiring
+            # the user to delete or exhaust older entries first. Shift existing
+            # priorities down and persist the normalized order so a subsequent
+            # `hermes auth list` / new process observes the same current entry.
+            entry = replace(entry, priority=0)
+            self._entries = [replace(existing, priority=idx + 1) for idx, existing in enumerate(self._entries)]
+            self._entries.insert(0, entry)
+        else:
+            entry = replace(entry, priority=_next_priority(self._entries))
+            self._entries.append(entry)
         self._persist()
         return entry
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -335,10 +335,14 @@ def auth_add_command(args) -> None:
             last_refresh=creds.get("last_refresh"),
         )
         first_credential = not pool.entries()
-        pool.add_entry(entry)
-        # Adding the first Codex credential should make it the active provider
-        # (the old singleton save path did this implicitly via
-        # _save_provider_state). Subsequent adds leave the active provider as-is.
+        pool.add_entry(entry, make_first=True)
+        # Fresh Codex re-auth is an explicit user repair action. Make the newly
+        # added account the next fill-first credential so a successful login
+        # immediately becomes the current entry shown by `hermes auth list` and
+        # used by new runtimes, instead of waiting for older entries to fail.
+        # Adding the first Codex credential should also make it the active
+        # provider (the old singleton save path did this implicitly via
+        # _save_provider_state).
         if first_credential:
             auth_mod.mark_provider_active_if_unset(provider)
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -454,20 +454,103 @@ def test_auth_add_codex_oauth_keeps_distinct_pool_accounts(tmp_path, monkeypatch
         "manual:device_code",
     ]
     assert [entry.label for entry in entries] == [
-        "first-codex@example.com",
         "second-codex@example.com",
+        "first-codex@example.com",
     ]
-    assert [entry.access_token for entry in entries] == [first_token, second_token]
+    assert [entry.access_token for entry in entries] == [second_token, first_token]
     assert [entry.refresh_token for entry in entries] == [
-        "first-refresh-token",
         "second-refresh-token",
+        "first-refresh-token",
     ]
+    assert pool.peek().label == "second-codex@example.com"
 
     payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
     # No singleton block — the add path is now pool-only.
     assert "openai-codex" not in payload.get("providers", {})
     # First add activated the provider; second add left it as-is.
     assert payload["active_provider"] == "openai-codex"
+
+
+def test_auth_add_codex_oauth_makes_fresh_login_current(tmp_path, monkeypatch, capsys):
+    """A fresh Codex re-auth should become the fill-first current entry."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "active_provider": "openai-codex",
+            "providers": {},
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "old-codex",
+                        "label": "older-codex@example.com",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "old-access-token",
+                        "refresh_token": "old-refresh-token",
+                    }
+                ]
+            },
+        },
+    )
+    fresh_token = _jwt_with_email("fresh-codex@example.com")
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        lambda: {
+            "tokens": {
+                "access_token": fresh_token,
+                "refresh_token": "fresh-refresh-token",
+            },
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-03-23T10:10:00Z",
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command, auth_list_command
+    from agent.credential_pool import load_pool
+
+    class _AddArgs:
+        provider = "openai-codex"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+
+    auth_add_command(_AddArgs())
+
+    pool = load_pool("openai-codex")
+    entries = pool.entries()
+    assert [entry.label for entry in entries] == [
+        "fresh-codex@example.com",
+        "older-codex@example.com",
+    ]
+    assert [entry.priority for entry in entries] == [0, 1]
+    assert pool.peek().label == "fresh-codex@example.com"
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = payload["credential_pool"]["openai-codex"]
+    assert [entry["label"] for entry in persisted] == [
+        "fresh-codex@example.com",
+        "older-codex@example.com",
+    ]
+    assert [entry["priority"] for entry in persisted] == [0, 1]
+
+    capsys.readouterr()
+
+    class _ListArgs:
+        provider = "openai-codex"
+
+    auth_list_command(_ListArgs())
+    out = capsys.readouterr().out
+    fresh_line = next(line for line in out.splitlines() if "fresh-codex@example.com" in line)
+    old_line = next(line for line in out.splitlines() if "older-codex@example.com" in line)
+    assert "←" in fresh_line
+    assert "←" not in old_line
+    assert "fresh-refresh-token" not in out
+    assert "old-refresh-token" not in out
+    assert fresh_token not in out
+    assert "old-access-token" not in out
 
 
 def test_codex_auth_status_reports_pool_only_credential(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Make a newly added interactive `openai-codex` OAuth credential the current fill-first credential.
- Preserve the default append ordering for every other provider and caller.
- Preserve first-credential provider activation while ensuring subsequent Codex reauthentication takes effect immediately.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_auth_commands.py -q` — 53 passed
- `scripts/run_tests.sh tests/agent/test_credential_pool.py -q` — 87 passed
- `python -m ruff check agent/credential_pool.py hermes_cli/auth_commands.py tests/hermes_cli/test_auth_commands.py` — passed
- Signed commit verified
- Independent functional, security, and merge-readiness reviews passed locally

## Scope
Exactly three files are changed. No token values, unrelated Kanban changes, or credential persistence-format changes are included.