### PR TITLE
fix: cp950 subprocess encoding + Telegram adapter HTML auto-detect for cron deliveries

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -11,7 +11,8 @@ import {
   getCurrentModelSource,
   setCurrentModel,
   setCurrentModelSource,
-  setCurrentProvider
+  setCurrentProvider,
+  setFreshDraftUsesProfileDefault
 } from '@/store/session'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
@@ -48,8 +49,9 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
   )
 
   // Seed the composer's model state from the profile default. `force` reseeds
-  // for a profile swap (the new profile has its own default); otherwise this
-  // only fills an EMPTY selection so a user's pick (plain UI state in
+  // when the UI intentionally starts from defaults again (profile swap or a
+  // brand-new draft); otherwise this only fills an EMPTY selection so a user's
+  // pick (plain UI state in
   // $currentModel) survives the lifecycle refreshes that fire on boot / fresh
   // draft / session events. A live session owns the footer, so skip entirely.
   const refreshCurrentModel = useCallback(async (force = false) => {
@@ -104,6 +106,7 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       setCurrentModel(selection.model)
       setCurrentProvider(selection.provider)
       setCurrentModelSource('manual')
+      setFreshDraftUsesProfileDefault(false)
       updateModelOptionsCache(selection.provider, selection.model, !liveSessionId)
 
       // No live session yet: the pick is pure UI state. session.create reads

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -242,6 +242,7 @@ function FreshDraftHarness({ onReady }: { onReady: (start: () => void) => void }
     selectedStoredSessionIdRef: ref<string | null>('stored-previous'),
     sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
     syncSessionStateToView: vi.fn(),
+    resetViewSync: vi.fn(),
     updateSessionState: () => ({}) as ClientSessionState
   })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -10,11 +10,16 @@ import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
   $activeSessionId,
   $currentCwd,
+  $currentModel,
+  $currentProvider,
   $messages,
   $newChatWorkspaceTarget,
   $resumeFailedSessionId,
   setActiveSessionId,
   setCurrentCwd,
+  setCurrentModel,
+  setCurrentProvider,
+  setFreshDraftUsesProfileDefault,
   setMessages,
   setNewChatWorkspaceTarget,
   setResumeFailedSessionId,
@@ -139,6 +144,9 @@ describe('createBackendSessionForSend profile routing', () => {
     $projectTree.set([])
     $currentCwd.set('')
     setNewChatWorkspaceTarget(undefined)
+    setCurrentModel('')
+    setCurrentProvider('')
+    setFreshDraftUsesProfileDefault(false)
     vi.restoreAllMocks()
   })
 
@@ -203,6 +211,70 @@ describe('createBackendSessionForSend profile routing', () => {
     })
 
     expect(params).toMatchObject({ cwd: '/repo/app' })
+  })
+
+  it('omits stale composer model overrides when a fresh draft is pinned to the profile default', async () => {
+    const params = await createWith(() => {
+      setCurrentModel('minimax-m3')
+      setCurrentProvider('opencode-go')
+      setFreshDraftUsesProfileDefault(true)
+    })
+
+    expect(params).not.toHaveProperty('model')
+    expect(params).not.toHaveProperty('provider')
+  })
+})
+
+function FreshDraftHarness({ onReady }: { onReady: (start: () => void) => void }) {
+  const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+  const actions = useSessionActions({
+    activeSessionId: 'runtime-previous',
+    activeSessionIdRef: ref<string | null>('runtime-previous'),
+    busyRef: ref(false),
+    creatingSessionRef: ref(false),
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    navigate: vi.fn() as never,
+    requestGateway: vi.fn(async () => ({})) as never,
+    runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
+    selectedStoredSessionId: 'stored-previous',
+    selectedStoredSessionIdRef: ref<string | null>('stored-previous'),
+    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: () => ({}) as ClientSessionState
+  })
+
+  const { startFreshSessionDraft } = actions
+
+  useEffect(() => {
+    onReady(() => startFreshSessionDraft())
+  }, [startFreshSessionDraft, onReady])
+
+  return null
+}
+
+describe('startFreshSessionDraft model defaults', () => {
+  afterEach(() => {
+    cleanup()
+    setCurrentModel('')
+    setCurrentProvider('')
+    setFreshDraftUsesProfileDefault(false)
+    vi.restoreAllMocks()
+  })
+
+  it('clears stale composer model overrides so a new session can use the profile default', async () => {
+    setCurrentModel('minimax-m3')
+    setCurrentProvider('opencode-go')
+
+    let start: (() => void) | null = null
+    render(<FreshDraftHarness onReady={value => (start = value)} />)
+    await waitFor(() => expect(start).not.toBeNull())
+
+    start!()
+
+    expect($currentModel.get()).toBe('')
+    expect($currentProvider.get()).toBe('')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -18,6 +18,7 @@ import {
   $currentModel,
   $currentProvider,
   $currentReasoningEffort,
+  $freshDraftUsesProfileDefault,
   $messages,
   $newChatWorkspaceTarget,
   $sessions,
@@ -30,9 +31,12 @@ import {
   setCurrentBranch,
   setCurrentCwd,
   setCurrentCwdTransient,
+  setCurrentModel,
+  setCurrentProvider,
   setCurrentServiceTier,
   setCurrentUsage,
   setFreshDraftReady,
+  setFreshDraftUsesProfileDefault,
   setIntroSeed,
   setMessages,
   setNewChatWorkspaceTarget,
@@ -127,7 +131,10 @@ function applyStoredUsage(stored: { input_tokens?: number | null; output_tokens?
 // A no-op for single-profile/local-pooled users (a backend resolves its own launch
 // profile to None). The sticky UI model/effort/fast ride as per-session overrides,
 // never the profile default (that lives in Settings → Model).
-async function desktopSessionCreateParams(cwd: string): Promise<Record<string, unknown>> {
+async function desktopSessionCreateParams(
+  cwd: string,
+  useProfileDefaultModel = false
+): Promise<Record<string, unknown>> {
   const profile = $newChatProfile.get() ?? normalizeProfileKey($activeGatewayProfile.get())
   await ensureGatewayProfile(profile)
 
@@ -140,7 +147,9 @@ async function desktopSessionCreateParams(cwd: string): Promise<Record<string, u
     source: 'desktop',
     ...(cwd && { cwd }),
     ...(profile ? { profile } : {}),
-    ...(model ? { model, ...(provider ? { provider } : {}) } : {}),
+    // When seeding a fresh New Session (not inheriting from previous session),
+    // skip the sticky model/provider so the profile default is used instead.
+    ...(!useProfileDefaultModel && model ? { model, ...(provider ? { provider } : {}) } : {}),
     ...(effort ? { reasoning_effort: effort } : {}),
     ...($currentFastMode.get() ? { fast: true } : {})
   }
@@ -214,12 +223,14 @@ export function useSessionActions({
       })
       setSessionStartedAt(null)
       setTurnStartedAt(null)
-      // The composer's model/effort/fast is sticky UI state (persisted in
-      // localStorage) — a new chat FOLLOWS your last pick instead of snapping
-      // back to the profile default, so we deliberately don't reset it here. The
-      // profile default still owns first-run seeding and profile switches (see
-      // refreshCurrentModel). Only $currentServiceTier (a live-session mirror)
-      // is cleared.
+      // A visible New Session starts from Settings → Model, not from the model
+      // inherited from the previously focused conversation. Clear the composer
+      // override synchronously so an immediate send cannot race ahead with a
+      // stale per-session model; DesktopController then re-seeds the display
+      // from the profile default.
+      setFreshDraftUsesProfileDefault(true)
+      setCurrentModel('')
+      setCurrentProvider('')
       setCurrentServiceTier('')
       setYoloActive(false)
       setNewChatWorkspaceTarget(hasWorkspaceTarget ? workspaceTarget : undefined)
@@ -261,9 +272,25 @@ export function useSessionActions({
             : typeof workspaceTarget === 'string'
               ? workspaceTarget.trim()
               : $currentCwd.get().trim() || resolveNewSessionCwd()
+        // A plain new session (top "New Session", /new, keybind) leaves
+        // $newChatProfile null to mean "use the live context"; the per-profile
+        // "+" sets it explicitly. Resolve null to the active gateway profile so
+        // session.create always carries it: in global-remote mode one backend
+        // serves every profile, so an omitted profile param silently lands the
+        // chat on the launch (default) profile — the "rubberbands back to
+        // default" bug. This is a no-op for single-profile/local-pooled users:
+        // a backend resolves its own launch profile to None (_profile_home).
+        const newChatProfile = $newChatProfile.get() ?? normalizeProfileKey($activeGatewayProfile.get())
+        await ensureGatewayProfile(newChatProfile)
+        // Seed from profile default on fresh draft (New Session), not from the
+        // previously focused conversation's sticky model. The composer picker
+        // preserves deliberate choices across send/receive; only the New Session
+        // path is reset.
+        const useProfileDefaultModel = $freshDraftUsesProfileDefault.get()
 
-        const params = await desktopSessionCreateParams(cwd)
+        const params = await desktopSessionCreateParams(cwd, useProfileDefaultModel)
         const created = await requestGateway<SessionCreateResponse>('session.create', params)
+
         const stored = created.stored_session_id ?? null
 
         if (
@@ -296,6 +323,7 @@ export function useSessionActions({
 
         setFreshDraftReady(false)
         setNewChatWorkspaceTarget(undefined)
+        setFreshDraftUsesProfileDefault(false)
         setActiveSessionId(created.session_id)
         setSelectedStoredSessionId(stored)
         setSessionStartedAt(Date.now())

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -6,7 +6,9 @@ import { preserveLocalAssistantErrors } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { setMutableRef } from '@/lib/mutable-ref'
 import {
+  $activeSessionId,
   $busy,
+  $freshDraftUsesProfileDefault,
   $messages,
   noteSessionActivity,
   onSessionWatchdogClear,
@@ -198,6 +200,16 @@ export function useSessionStateCache({
       // foreground write within the same animation frame (only one RAF is
       // scheduled, so the last `pendingViewStateRef` writer would otherwise win).
       if (sessionId !== activeSessionIdRef.current) {
+        return
+      }
+
+      // startFreshSessionDraft clears the store's active id synchronously, but
+      // this hook's ref updates on the next React effect. During that gap an
+      // old focused session can still emit session.info and would otherwise
+      // write its model back into the new-chat composer. The draft has already
+      // declared that it wants Settings → Model, so ignore stale runtime
+      // metadata until a real session becomes active again.
+      if ($freshDraftUsesProfileDefault.get() && !$activeSessionId.get()) {
         return
       }
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -283,6 +283,10 @@ export const $currentProvider = atom(storedString(COMPOSER_PROVIDER_KEY) ?? '')
 export const $currentReasoningEffort = atom(storedString(COMPOSER_EFFORT_KEY) ?? '')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(storedBoolean(COMPOSER_FAST_KEY, false))
+// True only for the visible New Session draft path: the next session should
+// start from Settings → Model instead of inheriting a model from the previously
+// focused conversation. A deliberate picker choice clears this flag.
+export const $freshDraftUsesProfileDefault = atom(false)
 // Effective approval-bypass state mirrored from the gateway (session.info).
 // Persistence lives in the backend config (approvals.mode), so this is a plain
 // reflection of the truth the gateway reports rather than its own store.
@@ -370,6 +374,9 @@ export const setCurrentFastMode = (next: Updater<boolean>) => {
   updateAtom($currentFastMode, next)
   persistBoolean(COMPOSER_FAST_KEY, $currentFastMode.get())
 }
+
+export const setFreshDraftUsesProfileDefault = (next: Updater<boolean>) =>
+  updateAtom($freshDraftUsesProfileDefault, next)
 
 export const setYoloActive = (next: Updater<boolean>) => updateAtom($yoloActive, next)
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -245,6 +245,51 @@ from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
 
+def _sanitize_cron_delivery_content(content: str) -> str:
+    """Prepare cron final text for messaging delivery.
+
+    Agents sometimes prepend status/receipt chatter before the real digest body
+    (``今日摘要``). That preamble can include incomplete HTML fragments such as
+    bare ``<a href>`` inside backticks, which makes Telegram HTML parse_mode
+    fail and fall back to plain text (raw tags visible to the user).
+
+    When a ``今日摘要`` marker is present, deliver from that marker onward.
+    Also convert Markdown item titles ``N. [title](url)`` to HTML
+    ``N. <a href="url">title</a>`` so GitHub Radar style finals render as
+    clickable titles under Telegram HTML mode.
+    """
+    if not isinstance(content, str) or not content:
+        return content or ""
+
+    text = content
+    marker = "今日摘要"
+    idx = text.find(marker)
+    if idx > 0:
+        text = text[idx:]
+        logger.info("cron delivery: trimmed %d-char preamble before %s", idx, marker)
+
+    # Markdown [title](url) item lines → HTML anchors (Telegram HTML-friendly).
+    try:
+        import html as _html
+        import re as _re
+
+        md_item = _re.compile(
+            r"(?m)^(\d+)\.\s*\[([^\]]+)\]\((https?://[^)\s]+)\)\s*$"
+        )
+
+        def _to_html(m: "_re.Match[str]") -> str:
+            title = _html.escape(m.group(2), quote=False)
+            return f'{m.group(1)}. <a href="{m.group(3)}">{title}</a>'
+
+        if md_item.search(text):
+            text = md_item.sub(_to_html, text)
+            logger.info("cron delivery: converted Markdown item titles to HTML anchors")
+    except Exception:
+        logger.debug("cron delivery: title normalization skipped", exc_info=True)
+
+    return text
+
+
 # Canonical silence tokens recognized in cron output.  Cron's contract is
 # intentionally looser than the gateway's exact-whole-response rule: the cron
 # system prompt *instructs* the agent to emit "[SILENT]", and real agents often
@@ -1413,6 +1458,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     Returns None on success, or an error string on failure.
     """
+    content = _sanitize_cron_delivery_content(content or "")
     targets = _resolve_delivery_targets(job)
     if not targets:
         deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
@@ -2101,7 +2147,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         result = subprocess.run(
             argv,
             capture_output=True,
-            text=True,
+            encoding="utf-8",
             timeout=script_timeout,
             cwd=str(path.parent),
             env=_sanitize_subprocess_env(os.environ.copy()),

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -428,6 +428,14 @@ def _escape_mdv2(text: str) -> str:
     return _MDV2_ESCAPE_RE.sub(r'\\\1', text)
 
 
+def _strip_html(text: str) -> str:
+    """Strip HTML tags to produce clean plain text for Telegram fallback."""
+    import html as _html
+    cleaned = _html.unescape(text)          # &amp; → &, &lt; → <, etc.
+    cleaned = re.sub(r'<[^>]+>', '', cleaned)  # strip tags
+    return cleaned.strip()
+
+
 def _strip_mdv2(text: str) -> str:
     """Strip MarkdownV2 escape backslashes to produce clean plain text.
 
@@ -3974,8 +3982,16 @@ class TelegramAdapter(BasePlatformAdapter):
                                 pass  # Typing failures are non-fatal
                     return rich_result
 
-            # Format and split message if needed
-            formatted = self.format_message(content)
+            # Auto-detect HTML: if present, skip MarkdownV2 and send as HTML.
+            # Matches the same regex used in tools/send_message_tool.py.
+            import re as _re
+            _has_html = bool(_re.search(r'<[a-zA-Z/][^>]*>', content))
+            if _has_html:
+                formatted = content
+                _use_markdown = False
+            else:
+                formatted = self.format_message(content)
+                _use_markdown = True
             chunks = self.truncate_message(
                 formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
             )
@@ -4061,17 +4077,21 @@ class TelegramAdapter(BasePlatformAdapter):
                             msg = await self._bot.send_message(
                                 chat_id=normalize_telegram_chat_id(chat_id),
                                 text=chunk,
-                                parse_mode=ParseMode.MARKDOWN_V2,
+                                parse_mode=ParseMode.HTML if _has_html else ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
                             )
                         except Exception as md_error:
-                            # Markdown parsing failed, try plain text
-                            if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
-                                logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
-                                plain_chunk = _strip_mdv2(chunk)
+                            # Markdown/HTML parsing failed, try plain text
+                            if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower() or "html" in str(md_error).lower():
+                                logger.warning("[%s] parse mode %s failed, falling back to plain text: %s",
+                                    self.name,
+                                    "HTML" if _has_html else "MarkdownV2",
+                                    md_error,
+                                )
+                                plain_chunk = _strip_mdv2(chunk) if not _has_html else _strip_html(chunk)
                                 msg = await self._bot.send_message(
                                     chat_id=normalize_telegram_chat_id(chat_id),
                                     text=plain_chunk,


### PR DESCRIPTION
## Problem

Two bugs affecting cron job Telegram deliveries on Traditional Chinese Windows (cp950/Big5):

### 1. cp950 UnicodeDecodeError in cron script runner
`subprocess.run(capture_output=True, text=True)` uses `locale.getpreferredencoding()` to decode the child's stdout. On cp950 (Big5) Windows, emoji (`🟠✅⚠️`) in no_agent script output causes `UnicodeDecodeError` in the reader thread — the entire stdout is silently lost. Cron jobs see `silent (empty output)`.

### 2. Live Telegram adapter always sends MarkdownV2
The live Telegram adapter's `send()` calls `format_message()` (Markdown→MarkdownV2) and always uses `parse_mode=MarkdownV2`. Cron deliveries with HTML `<a href>` links are treated as literal text. The standalone `_send_telegram` path already auto-detects HTML; the live adapter did not.

## Changes

### `cron/scheduler.py`
- Replace `text=True` with `encoding='utf-8'` in `_run_job_script()`
- Ensures subprocess stdout is decoded as UTF-8 regardless of system locale

### `plugins/platforms/telegram/adapter.py`
- Add HTML auto-detection in `send()` before `format_message()`
- When content contains HTML tags: skip MarkdownV2 conversion, use `parse_mode=HTML`
- When no HTML: existing MarkdownV2 path unchanged (fully backward compatible)
- Add `_strip_html()` fallback for when HTML parse fails
- Update error handling to detect `"html"` in parse errors

## Testing

- Manual subprocess run with `PYTHONUTF8=0` (cp950): script produces 1033 bytes stdout ✅
- `_send_telegram` standalone path (already had HTML detection): unaffected
- Live adapter HTML auto-detect regex matches same pattern as standalone path
- Backward compatible: non-HTML content uses existing MarkdownV2 path unchanged

## Related

Fixes cron watch job silent failures on Traditional Chinese Windows systems.