### PR TITLE
fix(cron): wrap MCP discovery with suppress_interactive_oauth for HTTP/OAuth servers

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3235,9 +3235,27 @@ def run_job(
         # ticks short-circuit on already-connected servers inside
         # register_mcp_servers(). Non-fatal on failure: a broken MCP server
         # shouldn't kill an otherwise-working cron job. See #4219.
+        #
+        # suppress_interactive_oauth mirrors the desktop/gateway startup path
+        # (hermes_cli.mcp_startup._discover_mcp_tools_without_interactive_oauth).
+        # Without it, a gateway process launched from a terminal reports a live
+        # TTY — so _is_interactive() returns True in the cron thread pool. When
+        # an HTTP/OAuth MCP server's cached token is expired or unusable, the
+        # SDK enters the authorization-code (browser-redirect) flow instead of
+        # failing fast. The callback listener binds a port and waits for a
+        # browser redirect that never arrives (no interactive user), hanging
+        # until connect_timeout expires, then the server silently fails to
+        # register. Stdio MCP servers are unaffected — they don't use OAuth.
+        # See #65889.
         try:
-            from tools.mcp_tool import discover_mcp_tools
-            _mcp_tools = discover_mcp_tools()
+            from contextlib import nullcontext as _nullctx
+            try:
+                from tools.mcp_oauth import suppress_interactive_oauth as _suppress_oauth
+            except Exception:
+                _suppress_oauth = _nullctx
+            with _suppress_oauth():
+                from tools.mcp_tool import discover_mcp_tools
+                _mcp_tools = discover_mcp_tools()
             if _mcp_tools:
                 logger.info(
                     "Job '%s': %d MCP tool(s) available",


### PR DESCRIPTION
## Summary

Fixes #65889 — HTTP/OAuth MCP servers (slack, google-workspace) not loading in cron sessions.

## Root Cause

The cron scheduler calls `discover_mcp_tools()` without wrapping it in `suppress_interactive_oauth()`, unlike every other non-interactive entry point (desktop/gateway startup, CLI `hermes mcp test`).

When the gateway process is launched from a terminal:
1. `sys.stdin.isatty()` returns `True` process-wide (including cron worker threads)
2. `tools/mcp_oauth.py:_is_interactive()` returns `True` in cron context
3. For HTTP/OAuth MCP servers with expired/unusable cached tokens, the SDK enters the authorization-code (browser-redirect) flow
4. `tools/mcp_oauth.py:_redirect_handler` calls `_raise_if_non_interactive()`, but since `_is_interactive()` returns `True`, it does **not** raise
5. The callback listener binds a localhost port and waits for a browser redirect that never arrives (no interactive user)
6. Hangs until `connect_timeout` (default 60s) expires -> server silently fails to register
7. No `mcp-<name>` toolset alias is created -> `validate_toolset("slack")` returns `False` -> `get_tool_definitions(..., quiet_mode=True)` silently drops the tools

Stdio MCP servers (jira, tompero) are unaffected — they don't use OAuth.

## The Fix

Wrap the `discover_mcp_tools()` call in `cron/scheduler.py` with `suppress_interactive_oauth()`, mirroring the pattern already used in:
- `hermes_cli/mcp_startup.py:_discover_mcp_tools_without_interactive_oauth()` (desktop/gateway startup)
- `hermes_cli/web_server.py` (dashboard OAuth login uses `force_interactive_oauth`)

The `suppress_interactive_oauth()` context manager sets a ContextVar (`_oauth_interactive_enabled=False`) that propagates across `asyncio.run_coroutine_threadsafe` to the MCP event loop thread where the OAuth flow actually runs.

## Verification

- All 212 MCP tool tests pass (`tests/tools/test_mcp_tool.py`)
- All cron scheduler MCP init tests pass (`tests/cron/test_scheduler_mcp_init.py`)
- No existing behavior changed for stdio MCP servers