### PR TITLE
fix(kanban): surface active PR respawn guards

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -482,7 +482,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_diag.add_argument(
         "--severity",
-        choices=["warning", "error", "critical"],
+        choices=["info", "warning", "error", "critical"],
         default=None,
         help="Only show diagnostics at or above this severity",
     )
@@ -1565,7 +1565,12 @@ def _cmd_show(args: argparse.Namespace) -> int:
     from hermes_cli import kanban_diagnostics as kd
     diags = kd.compute_task_diagnostics(task, events, runs)
     if diags:
-        sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}
+        sev_marker = {
+            "info": "i",
+            "warning": "⚠",
+            "error": "!!",
+            "critical": "!!!",
+        }
         print(f"\n  Diagnostics ({len(diags)}):")
         for d in diags:
             print(f"    {sev_marker.get(d.severity, '?')} [{d.severity}] {d.title}")
@@ -1785,7 +1790,12 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
 
     # Human-readable summary: grouped by task, severity-marked, with
     # suggested actions inline.
-    sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}
+    sev_marker = {
+        "info": "i",
+        "warning": "⚠",
+        "error": "!!",
+        "critical": "!!!",
+    }
     total = sum(len(dl) for dl in diags_by_task.values())
     print(
         f"{total} active diagnostic(s) across "
@@ -2280,6 +2290,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
             "auto_assigned_default": res.auto_assigned_default,
+            "respawn_guarded": [
+                {"task_id": tid, "reason": reason}
+                for (tid, reason) in res.respawn_guarded
+            ],
         }, indent=2))
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
@@ -2316,6 +2330,14 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
+        )
+    active_pr_guarded = [
+        tid for tid, reason in res.respawn_guarded if reason == "active_pr"
+    ]
+    if active_pr_guarded:
+        print(
+            "Guarded (active PR — lander action): "
+            f"{', '.join(active_pr_guarded)}"
         )
     return 0
 

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -1,11 +1,12 @@
 """Kanban diagnostics — structured, actionable distress signals for tasks.
 
-A ``Diagnostic`` is a machine-readable description of something that's wrong
-with a kanban task: a hallucinated card id, a spawn crash-loop, a task
-stuck blocked for too long, etc. Each one carries:
+A ``Diagnostic`` is a machine-readable description of noteworthy kanban task
+state: a hallucinated card id, a spawn crash-loop, a task stuck blocked for too
+long, or an intentional wait state that explains why no worker was spawned.
+Each one carries:
 
 * A **kind** (canonical code; UI/tests match on this).
-* A **severity** (``warning`` / ``error`` / ``critical``).
+* A **severity** (``info`` / ``warning`` / ``error`` / ``critical``).
 * A **title** (one-line human description) and **detail** (longer text).
 * A list of **suggested actions** — structured entries the dashboard
   turns into buttons and the CLI turns into hints.
@@ -35,10 +36,10 @@ import json
 import time
 
 
-# Severity rungs, ordered least → most urgent. The UI colors them
-# amber (warning), orange (error), red (critical). Sorted outputs put
-# critical first so operators see the worst fires at the top.
-SEVERITY_ORDER = ("warning", "error", "critical")
+# Severity rungs, ordered least → most urgent. ``info`` represents an
+# intentional state that needs operator awareness but is not a fault. Sorted
+# outputs put critical first so operators see the worst fires at the top.
+SEVERITY_ORDER = ("info", "warning", "error", "critical")
 
 
 def severity_at_or_above(severity: Optional[str], threshold: Optional[str]) -> bool:
@@ -90,7 +91,7 @@ class Diagnostic:
     """One active distress signal on a task."""
 
     kind: str
-    severity: str  # "warning" | "error" | "critical"
+    severity: str  # "info" | "warning" | "error" | "critical"
     title: str
     detail: str
     actions: list[DiagnosticAction] = field(default_factory=list)
@@ -883,8 +884,9 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
 
     Threshold: cfg["stranded_threshold_seconds"] (default 1800 = 30 min).
 
-    Catches every "task waiting for a worker that never comes" case
-    without caring WHY:
+    Catches every "task waiting for a worker that never comes" case, while
+    distinguishing the dispatcher's deliberate active-PR respawn guard from
+    actual worker/dispatcher faults:
 
     * Operator typo'd the assignee — no profile or external worker matches.
     * Profile was deleted, leaving its tasks stranded.
@@ -930,10 +932,20 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
         "created", "promoted", "reclaimed", "unblocked",
     }
     last_ready_ts = 0
-    for ev in events:
-        if _event_kind(ev) in READY_TRANSITION_KINDS:
-            t = _event_ts(ev)
-            last_ready_ts = max(last_ready_ts, t)
+    last_ready_order = -1
+    latest_guard_ts = 0
+    latest_guard_order = -1
+    latest_guard_reason = None
+    for event_order, ev in enumerate(events):
+        kind = _event_kind(ev)
+        t = _event_ts(ev)
+        if kind in READY_TRANSITION_KINDS:
+            last_ready_ts = t
+            last_ready_order = event_order
+        if kind == "respawn_guarded":
+            latest_guard_ts = t
+            latest_guard_order = event_order
+            latest_guard_reason = _parse_payload(ev).get("reason")
 
     # Fallback: if no qualifying event exists (very old task or events
     # truncated), fall back to ``created_at`` on the task row. Better
@@ -942,6 +954,45 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
         last_ready_ts = int(_task_field(task, "created_at", default=0) or 0)
     if last_ready_ts == 0:
         return []
+
+    # ``active_pr`` is an intentional lander inbox state, not a stranded
+    # worker. Only the latest guard event is authoritative: a later guard for
+    # another reason must not inherit an old PR classification. Likewise, a
+    # newer ready transition represents an explicit rerun request and clears
+    # the informational state until the dispatcher evaluates the task again.
+    if (
+        latest_guard_reason == "active_pr"
+        and latest_guard_order > last_ready_order
+        and 0 <= now - latest_guard_ts < cfg["active_pr_guard_window_seconds"]
+    ):
+        task_id = _task_field(task, "id") or ""
+        actions: list[DiagnosticAction] = []
+        if task_id:
+            actions.append(DiagnosticAction(
+                kind="cli_hint",
+                label="Review the active PR and task comments",
+                payload={"command": f"hermes kanban show {task_id}"},
+                suggested=True,
+            ))
+        return [Diagnostic(
+            kind="awaiting_lander_pr_processing",
+            severity="info",
+            title="Awaiting lander/PR processing",
+            detail=(
+                "The dispatcher deliberately skipped this ready task because "
+                "a recent task comment contains an active GitHub PR. Review "
+                "or land that PR instead of spawning a duplicate worker."
+            ),
+            actions=actions,
+            first_seen_at=latest_guard_ts,
+            last_seen_at=latest_guard_ts,
+            count=1,
+            data={
+                "guard_reason": "active_pr",
+                "guarded_at": latest_guard_ts,
+                "assignee": assignee,
+            },
+        )]
 
     age_seconds = now - last_ready_ts
     if age_seconds < threshold_seconds:
@@ -1024,6 +1075,7 @@ DIAGNOSTIC_KINDS = (
     "repeated_crashes",
     "stuck_in_blocked",
     "block_unblock_cycling",
+    "awaiting_lander_pr_processing",
     "stranded_in_ready",
 )
 
@@ -1036,6 +1088,9 @@ DEFAULT_CONFIG = {
     "spawn_failure_threshold": 2,
     "crash_threshold": 2,
     "blocked_stale_hours": 24,
+    # Mirror kanban_db._RESPAWN_GUARD_PR_WINDOW. Tests pin the values together
+    # so diagnostics cannot outlive the dispatcher's active-PR guard.
+    "active_pr_guard_window_seconds": 24 * 60 * 60,
     # Stranded-task threshold. 30 min by default — below that, the
     # signal is dominated by tasks that are about to be claimed on the
     # next dispatcher tick (default 60s) and would just be noise.
@@ -1099,7 +1154,7 @@ def compute_task_diagnostics(
     """Run every rule against a single task's state and return a
     severity-sorted list of active diagnostics.
 
-    Sorting: critical first, then error, then warning; ties broken by
+    Sorting: critical first, then error, warning, and info; ties broken by the
     most-recent ``last_seen_at``.
     """
     now_ts = int(now if now is not None else time.time())

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1106,7 +1106,7 @@
 
   // -------------------------------------------------------------------------
   // Attention strip — surfaces every task with active diagnostics,
-  // severity-marked (warning/error/critical). Collapsed by default; click
+  // severity-marked (info/warning/error/critical). Collapsed by default; click
   // Show to expand into per-task rows with Open buttons. Dismissible
   // per session via state flag.
   // -------------------------------------------------------------------------
@@ -1120,12 +1120,13 @@
         else if (t.warnings && t.warnings.count > 0) out.push(t);
       }
     }
-    // Sort: highest severity first (critical > error > warning), then by
+    // Sort: highest severity first (critical > error > warning > info), then by
     // most recent latest_at.
     const sevIdx = function (s) {
-      if (s === "critical") return 3;
-      if (s === "error") return 2;
-      if (s === "warning") return 1;
+      if (s === "critical") return 4;
+      if (s === "error") return 3;
+      if (s === "warning") return 2;
+      if (s === "info") return 1;
       return 0;
     };
     out.sort(function (a, b) {
@@ -1149,11 +1150,12 @@
     );
     if (dismissed || diagTasks.length === 0) return null;
     // Pick the highest severity present so we can colour the strip.
-    let topSev = "warning";
+    let topSev = "info";
     for (const td of diagTasks) {
       const s = (td.warnings && td.warnings.highest_severity) || "warning";
       if (s === "critical") { topSev = "critical"; break; }
       if (s === "error" && topSev !== "critical") topSev = "error";
+      if (s === "warning" && topSev === "info") topSev = "warning";
     }
     return h("div", {
       className: cn(
@@ -1163,7 +1165,8 @@
     },
       h("div", { className: "hermes-kanban-attention-bar" },
         h("span", { className: "hermes-kanban-attention-icon" },
-          topSev === "critical" ? "!!!" : topSev === "error" ? "!!" : "⚠"),
+          topSev === "critical" ? "!!!" : topSev === "error" ? "!!" :
+          topSev === "warning" ? "⚠" : "i"),
         h("span", { className: "hermes-kanban-attention-text" },
           diagTasks.length === 1
             ? tx(t, "taskNeedsAttention", "1 task needs attention")
@@ -1195,7 +1198,8 @@
                 ),
               },
                 h("span", { className: "hermes-kanban-attention-row-sev" },
-                  sev === "critical" ? "!!!" : sev === "error" ? "!!" : "⚠"),
+                  sev === "critical" ? "!!!" : sev === "error" ? "!!" :
+                  sev === "warning" ? "⚠" : "i"),
                 h("span", { className: "hermes-kanban-attention-row-id" }, task.id),
                 h("span", { className: "hermes-kanban-attention-row-title" },
                   task.title || tx(t, "untitled", "(untitled)")),
@@ -1390,7 +1394,8 @@
       h("div", { className: "hermes-kanban-diag-header" },
         h("span", { className: "hermes-kanban-diag-sev" },
           diag.severity === "critical" ? "!!!" :
-          diag.severity === "error" ? "!!" : "\u26a0"),
+          diag.severity === "error" ? "!!" :
+          diag.severity === "warning" ? "\u26a0" : "i"),
         h("span", { className: "hermes-kanban-diag-title" },
           diag.title),
       ),
@@ -1467,6 +1472,9 @@
     const { t } = useI18n();
     const diags = props.diagnostics || [];
     const hasOpenDiags = diags.length > 0;
+    const infoOnly = hasOpenDiags && diags.every(function (d) {
+      return d.severity === "info";
+    });
     const [open, setOpen] = useState(hasOpenDiags);
     useEffect(function () {
       if (hasOpenDiags) setOpen(true);
@@ -1480,8 +1488,11 @@
       h("div", { className: "hermes-kanban-section-head-row" },
         h("span", { className: "hermes-kanban-section-head" },
           hasOpenDiags
-            ? h("span", { className: "hermes-kanban-section-head-warning" },
-                `\u26a0 ${tx(t, "diagnostics", "Diagnostics")} (${diags.length})`)
+            ? h("span", {
+                className: infoOnly
+                  ? "hermes-kanban-section-head-info"
+                  : "hermes-kanban-section-head-warning",
+              }, `${infoOnly ? "i" : "\u26a0"} ${tx(t, "diagnostics", "Diagnostics")} (${diags.length})`)
             : tx(t, "diagnostics", "Diagnostics"),
         ),
         h("button", {
@@ -2706,7 +2717,8 @@
                     `Click to open for details.`
                   ),
                 }, t.warnings.highest_severity === "critical" ? "!!!" :
-                   t.warnings.highest_severity === "error" ? "!!" : "⚠")
+                   t.warnings.highest_severity === "error" ? "!!" :
+                   t.warnings.highest_severity === "warning" ? "⚠" : "i")
               : null,
             t.priority > 0
               ? h(Badge, { className: "hermes-kanban-priority",

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -1199,6 +1199,7 @@
 }
 
 /* Recovery section header — amber accent when the task has warnings. */
+.hermes-kanban-section-head-info { color: #75b9ff; }
 .hermes-kanban-section-head-warning { color: #ff9e3b; }
 .hermes-kanban-section-head-row {
   display: flex;
@@ -1334,7 +1335,7 @@
 
 /* ---------------------------------------------------------------------- */
 /* Diagnostics — generic, severity-coloured distress signals on tasks.    */
-/* Three rungs: warning (amber), error (orange), critical (red).          */
+/* Four rungs: info (blue), warning (amber), error (orange), critical.    */
 /* ---------------------------------------------------------------------- */
 
 /* Severity token variables so every diagnostic-coloured surface uses the */
@@ -1343,17 +1344,23 @@
 .hermes-kanban-attention,
 .hermes-kanban-warning-badge,
 .hermes-kanban-attention-row {
+  --hermes-diag-info: #75b9ff;
   --hermes-diag-warning: #ff9e3b;
   --hermes-diag-error:   #ff6b3d;
   --hermes-diag-critical: #ff4d4d;
 }
 
 /* Warning-badge severity variants (overrides the base colour). */
+.hermes-kanban-warning-badge--info    { color: var(--hermes-diag-info); }
 .hermes-kanban-warning-badge--warning { color: var(--hermes-diag-warning); }
 .hermes-kanban-warning-badge--error   { color: var(--hermes-diag-error); font-weight: 700; }
 .hermes-kanban-warning-badge--critical { color: var(--hermes-diag-critical); font-weight: 700; }
 
 /* Attention-strip severity variants. */
+.hermes-kanban-attention--info {
+  border-color: rgba(117, 185, 255, 0.35);
+  background: rgba(117, 185, 255, 0.06);
+}
 .hermes-kanban-attention--warning {
   border-color: rgba(255, 158, 59, 0.35);
   background: rgba(255, 158, 59, 0.06);
@@ -1366,6 +1373,7 @@
   border-color: rgba(255, 77, 77, 0.55);
   background: rgba(255, 77, 77, 0.10);
 }
+.hermes-kanban-attention--info .hermes-kanban-attention-icon { color: var(--hermes-diag-info); }
 .hermes-kanban-attention--error .hermes-kanban-attention-icon { color: var(--hermes-diag-error); }
 .hermes-kanban-attention--critical .hermes-kanban-attention-icon { color: var(--hermes-diag-critical); }
 
@@ -1375,6 +1383,7 @@
   min-width: 1.5rem;
   font-weight: 600;
 }
+.hermes-kanban-attention-row--info .hermes-kanban-attention-row-sev { color: var(--hermes-diag-info); }
 .hermes-kanban-attention-row--warning .hermes-kanban-attention-row-sev { color: var(--hermes-diag-warning); }
 .hermes-kanban-attention-row--error    .hermes-kanban-attention-row-sev { color: var(--hermes-diag-error); font-weight: 700; }
 .hermes-kanban-attention-row--critical .hermes-kanban-attention-row-sev { color: var(--hermes-diag-critical); font-weight: 700; }
@@ -1394,6 +1403,10 @@
   flex-direction: column;
   gap: 0.4rem;
 }
+.hermes-kanban-diag--info {
+  border-left-color: var(--hermes-diag-info);
+  background: rgba(117, 185, 255, 0.05);
+}
 .hermes-kanban-diag--error {
   border-left-color: var(--hermes-diag-error);
   background: rgba(255, 107, 61, 0.06);
@@ -1411,6 +1424,7 @@
   font-weight: 700;
   min-width: 1.5rem;
 }
+.hermes-kanban-diag--info    .hermes-kanban-diag-sev { color: var(--hermes-diag-info); }
 .hermes-kanban-diag--warning .hermes-kanban-diag-sev { color: var(--hermes-diag-warning); }
 .hermes-kanban-diag--error    .hermes-kanban-diag-sev { color: var(--hermes-diag-error); }
 .hermes-kanban-diag--critical .hermes-kanban-diag-sev { color: var(--hermes-diag-critical); }

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -8,6 +8,7 @@ operator footgun that only manifests in long-running setups.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 import tempfile
@@ -114,6 +115,56 @@ def test_cli_invalid_max_in_progress_silently_disables(isolated_kanban_home, mon
             f"invalid max_in_progress={bad_val!r} should fall through to None, "
             f"got {captured.get('max_in_progress')!r}"
         )
+
+
+def test_cli_dispatch_surfaces_active_pr_guard(
+    isolated_kanban_home, monkeypatch, capsys
+):
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(
+        kanban_db,
+        "dispatch_once",
+        lambda conn, **kw: kanban_db.DispatchResult(
+            respawn_guarded=[
+                ("t_active1", "active_pr"),
+                ("t_quota1", "rate_limit_cooldown"),
+            ]
+        ),
+    )
+
+    args = argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=False)
+    assert kb_cli._cmd_dispatch(args) == 0
+
+    out = capsys.readouterr().out
+    assert "Guarded (active PR — lander action): t_active1" in out
+    assert "Guarded (active PR — lander action): t_quota1" not in out
+
+
+def test_cli_dispatch_json_includes_respawn_guard_bucket(
+    isolated_kanban_home, monkeypatch, capsys
+):
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(
+        kanban_db,
+        "dispatch_once",
+        lambda conn, **kw: kanban_db.DispatchResult(
+            respawn_guarded=[("t_active1", "active_pr")]
+        ),
+    )
+
+    args = argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=True)
+    assert kb_cli._cmd_dispatch(args) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["respawn_guarded"] == [
+        {"task_id": "t_active1", "reason": "active_pr"}
+    ]
 
 
 def test_kanban_swarm_uses_existing_humanizer_skill():

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -491,6 +491,69 @@ def test_stranded_in_ready_fires_when_age_exceeds_threshold():
     assert stranded[0].data["assignee"] == "demo"
 
 
+def test_active_pr_respawn_guard_is_info_not_stranded_error():
+    """An active-PR guard is a deliberate lander inbox state, not a worker
+    failure, even when the task has been ready long enough to otherwise be
+    classified as an error.
+    """
+    now = 100_000
+    task = _task(status="ready", assignee="engineer", claim_lock=None)
+    events = [
+        _event("created", ts=now - 4 * 3600),
+        _event("respawn_guarded", ts=now - 60, reason="active_pr"),
+    ]
+
+    diags = kd.compute_task_diagnostics(task, events, [], now=now)
+
+    assert [d.kind for d in diags] == ["awaiting_lander_pr_processing"]
+    diag = diags[0]
+    assert diag.severity == "info"
+    assert diag.title == "Awaiting lander/PR processing"
+    assert diag.data["guard_reason"] == "active_pr"
+    assert "stranded_in_ready" not in {d.kind for d in diags}
+
+
+def test_active_pr_info_expires_with_dispatcher_guard_window():
+    """A historical guard event must not mask a genuinely stranded card once
+    the dispatcher's 24-hour active-PR window has elapsed.
+    """
+    now = 200_000
+    task = _task(status="ready", assignee="engineer", claim_lock=None)
+    events = [
+        _event("created", ts=now - 30 * 3600),
+        _event("respawn_guarded", ts=now - 25 * 3600, reason="active_pr"),
+    ]
+
+    diags = kd.compute_task_diagnostics(task, events, [], now=now)
+
+    assert [d.kind for d in diags] == ["stranded_in_ready"]
+    assert diags[0].severity == "critical"
+
+
+def test_active_pr_diagnostic_window_matches_dispatcher_guard():
+    assert (
+        kd.DEFAULT_CONFIG["active_pr_guard_window_seconds"]
+        == kb._RESPAWN_GUARD_PR_WINDOW
+    )
+
+
+def test_active_pr_info_clears_on_newer_ready_transition():
+    """A deliberate rerun after the guard event must not inherit stale PR
+    state; normal stranded timing starts from that newer transition.
+    """
+    now = 100_000
+    task = _task(status="ready", assignee="engineer", claim_lock=None)
+    events = [
+        _event("created", ts=now - 4 * 3600),
+        # Event timestamps have one-second resolution, so ordering must still
+        # clear the guard when both state changes land in the same second.
+        _event("respawn_guarded", ts=now - 10 * 60, reason="active_pr"),
+        _event("unblocked", ts=now - 10 * 60),
+    ]
+
+    assert kd.compute_task_diagnostics(task, events, [], now=now) == []
+
+
 def test_stranded_in_ready_silent_below_threshold():
     """A ready task only 10 min old should NOT fire."""
     now = 100_000
@@ -765,11 +828,14 @@ def test_config_from_runtime_config_handles_empty_input():
 
 
 def test_severity_at_or_above_uses_threshold_semantics():
+    assert kd.severity_at_or_above("info", "info") is True
+    assert kd.severity_at_or_above("warning", "info") is True
     assert kd.severity_at_or_above("warning", "warning") is True
     assert kd.severity_at_or_above("error", "warning") is True
     assert kd.severity_at_or_above("critical", "warning") is True
     assert kd.severity_at_or_above("critical", "error") is True
     assert kd.severity_at_or_above("warning", "error") is False
     assert kd.severity_at_or_above("error", "critical") is False
+    assert kd.severity_at_or_above("info", "warning") is False
     assert kd.severity_at_or_above("mystery", "warning") is False
     assert kd.severity_at_or_above("warning", None) is True


### PR DESCRIPTION
## Summary

- surface active-PR respawn guards in `hermes kanban dispatch` as `Guarded (active PR — lander action): t_x`
- expose the full `respawn_guarded` reason bucket in dispatch JSON, including dry runs
- classify current active-PR guard events as an info-level `awaiting_lander_pr_processing` diagnostic instead of `stranded_in_ready`
- expire that informational classification with the dispatcher's 24-hour PR guard window and honor canonical event ordering for same-second reruns
- render the new info severity consistently in CLI and Kanban dashboard surfaces

This is the current-main replacement for stale PR #46269. The existing contributor branch allows maintainer edits in GitHub metadata, but the authenticated maintainer account cannot push to that fork (HTTP 403), so it could not be updated in place. Maintainers can close #46269 in favor of this PR.

## Verification

- `python -m pytest -q tests/hermes_cli/test_kanban_diagnostics.py` — 52 passed
- `python -m pytest -q tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py` — 6 passed
- `python -m pytest -q tests/hermes_cli/test_kanban_cli.py` — 47 passed
- `python -m pytest -q tests/hermes_cli/test_kanban_db.py` — 230 passed
- `python -m pytest -q tests/plugins/test_kanban_dashboard_plugin.py` — 110 passed, 1 upstream deprecation warning
- `python -m ruff check .` — passed
- `python scripts/check-windows-footguns.py --all` — passed (768 files)
- `node --check plugins/kanban/dashboard/dist/index.js` — passed
- `uv build --wheel --out-dir /tmp/hermes-agent-t_dbf30199-pr46269-dist` — passed; wheel payload assertions passed
- `git diff --check origin/main` — passed

## Scope

Six files changed. Respawn-guard semantics in `kanban_db.py` are unchanged.
