### PR TITLE
fix(tools): fail open on unexpected YAML linter exceptions

### DIFF
--- a/tests/tools/test_write_file_syntax_gate.py
+++ b/tests/tools/test_write_file_syntax_gate.py
@@ -14,9 +14,10 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 from tools.environments.local import LocalEnvironment
-from tools.file_operations import ShellFileOperations
+from tools.file_operations import ShellFileOperations, _lint_yaml_inproc
 
 
 @pytest.fixture
@@ -125,3 +126,79 @@ class TestFailClosedSyntaxGate:
         res = ops.write_file(str(target), content)
         assert res.error is None, res.error
         assert target.read_text() == content
+
+
+# Reporter's exact content (#65924) — a valid GitHub Actions workflow that the
+# fail-closed gate wrongly refused when an internal PyYAML error surfaced.
+_GHA_WORKFLOW = (
+    "name: Deploy\n\n"
+    "on:\n"
+    "  push:\n"
+    "    branches: [main]\n"
+    "  workflow_dispatch:\n"
+    "    inputs:\n"
+    "      environment:\n"
+    '        description: "Deployment target"\n'
+    "        required: true\n"
+    "        default: test\n"
+    "        type: choice\n"
+    "        options:\n"
+    "          - test\n"
+    "          - live\n\n"
+    "jobs:\n"
+    "  test:\n"
+    "    runs-on: ubuntu-latest\n"
+    "    steps:\n"
+    "      - uses: actions/checkout@v4\n"
+)
+
+
+def _raise_typeerror(_content):
+    # Mirrors the internal PyYAML failure from #65924 (a TypeError raised deep
+    # in yaml.parse on certain inputs), which is NOT a YAMLError.
+    raise TypeError('can only concatenate str (not "int") to str')
+
+
+class TestYamlLintInternalError:
+    """#65924: an *internal* linter/PyYAML error is not a syntax error, so the
+    fail-closed write gate must not treat it as one and refuse a valid write."""
+
+    def test_internal_typeerror_skips_not_refuses(self, monkeypatch):
+        monkeypatch.setattr(yaml, "parse", _raise_typeerror)
+        ok, msg = _lint_yaml_inproc("name: Deploy\n")
+        assert ok is True
+        assert msg == "__SKIP__"
+
+    def test_real_yaml_syntax_error_still_fails(self):
+        # The fix must not weaken detection of genuine syntax errors.
+        ok, msg = _lint_yaml_inproc('key: "unclosed\n')
+        assert ok is False
+        assert msg.startswith("YAMLError")
+
+    def test_valid_yaml_still_passes_clean(self):
+        ok, msg = _lint_yaml_inproc("a: 1\nb: [1, 2, 3]\n")
+        assert ok is True
+        assert msg == ""
+
+    def test_reporter_workflow_lints_as_valid(self):
+        ok, msg = _lint_yaml_inproc(_GHA_WORKFLOW)
+        assert ok is True, msg
+        assert msg == ""
+
+
+class TestWriteFileSurvivesInternalLintError:
+    def test_internal_yaml_error_does_not_block_write(self, ops, tmp_path: Path, monkeypatch):
+        # End-to-end: with the linter hitting an internal TypeError, write_file
+        # must still write the .yml (#65924), not refuse it.
+        monkeypatch.setattr(yaml, "parse", _raise_typeerror)
+        target = tmp_path / "deploy.yml"
+        res = ops.write_file(str(target), _GHA_WORKFLOW)
+        assert res.error is None, res.error
+        assert target.exists(), "internal linter error must not refuse a valid write"
+        assert "actions/checkout@v4" in target.read_text()
+
+    def test_reporter_workflow_writes_without_monkeypatch(self, ops, tmp_path: Path):
+        target = tmp_path / "deploy.yml"
+        res = ops.write_file(str(target), _GHA_WORKFLOW)
+        assert res.error is None, res.error
+        assert target.exists()

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -639,8 +639,14 @@ def _lint_yaml_inproc(content: str) -> tuple[bool, str]:
         return True, ""
     except _yaml.YAMLError as e:
         return False, f"YAMLError: {e}"
-    except Exception as e:  # noqa: BLE001
-        return False, f"{type(e).__name__}: {e}"
+    except Exception:  # noqa: BLE001
+        # A non-YAMLError here is an *internal* PyYAML/linter failure, not a
+        # syntax error in the user's content — e.g. a TypeError raised deep in
+        # yaml.parse on certain inputs (#65924). This linter's verdict is a
+        # fail-closed WRITE gate, and its own contract (see docstring) is that a
+        # false positive must not refuse a legitimate write. Treat an internal
+        # error like the missing-PyYAML path above: skip the lint, don't block.
+        return True, "__SKIP__"
 
 
 def _lint_toml_inproc(content: str) -> tuple[bool, str]:


### PR DESCRIPTION
## What & why

`_lint_yaml_inproc` (`tools/file_operations.py`) is a **fail-closed pre-write gate**: when it returns "not ok", `write_file`/`patch` refuse the write outright and nothing lands on disk.

#65924 reports an unexpected `TypeError` surfacing through this gate. The reporter's exact real-input trigger did **not** reproduce in this PR's PyYAML 6.0.3 environment, so this change does not claim a confirmed input-specific PyYAML root cause. Instead, it hardens the gate's existing contract: genuine YAML parse failures should block the write, while an unexpected internal linter/library exception should not be presented as user syntax failure.

Related to #65924; this PR intentionally does not auto-close the issue because the original real-input trigger remains unconfirmed.

## Fix

The function's docstring already notes that a false positive here "refuses a legitimate write outright", and the missing-PyYAML path already degrades gracefully with `(True, "__SKIP__")`. The change applies the same contract to unexpected non-parse exceptions:

```python
    except _yaml.YAMLError as e:
        return False, f"YAMLError: {e}"
    except Exception:
        return True, "__SKIP__"
```

Genuine syntax errors are unaffected: they raise `YAMLError` and still fail the gate. Unexpected non-`YAMLError` exceptions skip this optional lint pass instead of being mislabeled as user syntax errors.

## Testing

`tests/tools/test_write_file_syntax_gate.py` (+6):
- With `yaml.parse` monkeypatched to raise `TypeError`: `_lint_yaml_inproc` returns `(True, "__SKIP__")`, and end-to-end `write_file` still writes the `.yml`.
- A real YAML syntax error still returns `(False, "YAMLError: …")` (detection not weakened).
- Valid YAML still returns `(True, "")`.
- The workflow content from #65924 is independently confirmed valid and writable, but does not reproduce the reported `TypeError` in this environment.

- `python -m pytest tests/tools/test_write_file_syntax_gate.py` → **17 passed**.
- Broader `tests/tools/test_file_operations.py` + `test_file_write_safety.py` → 130 passed; the 10 failures are pre-existing macOS/Unix-only tests (`/private` symlink paths, POSIX file-mode preservation) that fail identically on pristine `main` on the Windows authoring host.

## Verification boundary

The exact real-input `TypeError` remains unreproduced. Verification covers the defensive contract at the injected internal-error seam; it does not prove that the issue's original input triggers PyYAML 6.0.3. The change stays scoped to YAML because that is the reported gate; sibling TOML/Python linters use different parser implementations and are intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
