### PR TITLE
fix(codex): surface nested error envelope in Responses type=error SSE frames (port opencode#36130)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -606,15 +606,37 @@ def _item_field(item: Any, name: str, default: Any = None) -> Any:
 def _raise_stream_error(event: Any) -> None:
     """Raise a ``_StreamErrorEvent`` from a ``type=error`` SSE frame.
 
+    The Responses spec puts the failure details at the top level of the
+    frame (``{"type": "error", "code": ..., "message": ..., "param": ...}``),
+    but the official OpenAI SDK and several OpenAI-compatible proxies wrap
+    them in an HTTP-style nested envelope instead
+    (``{"type": "error", "error": {"code": ..., "message": ..., "param": ...}}``).
+    Read the top-level fields first, then fall back to the nested envelope so
+    the error classifier sees the provider's real code/message (rate-limit vs
+    context-overflow vs entitlement) rather than the generic placeholder.
+    Port of anomalyco/opencode#36130.
+
     Imported lazily so this module stays importable from places that don't
     pull in ``run_agent`` (e.g. plugin code, doc tools).
     """
     from run_agent import _StreamErrorEvent
-    message = (_event_field(event, "message", "") or "stream emitted error event").strip()
+
+    nested = _event_field(event, "error")
+
+    def _error_field(name: str) -> Any:
+        value = _event_field(event, name)
+        if value is None and nested is not None:
+            value = _item_field(nested, name)
+        return value
+
+    raw_message = _error_field("message")
+    if raw_message is not None and not isinstance(raw_message, str):
+        raw_message = str(raw_message)
+    message = (raw_message or "stream emitted error event").strip() or "stream emitted error event"
     raise _StreamErrorEvent(
         message,
-        code=_event_field(event, "code"),
-        param=_event_field(event, "param"),
+        code=_error_field("code"),
+        param=_error_field("param"),
     )
 
 

--- a/tests/run_agent/test_codex_xai_oauth_recovery.py
+++ b/tests/run_agent/test_codex_xai_oauth_recovery.py
@@ -102,6 +102,138 @@ def test_codex_stream_wire_error_event_surfaces_stream_error_event(provider_mess
     assert excinfo.value.body["error"]["message"] == provider_message
 
 
+# ---------------------------------------------------------------------------
+# Nested error envelope on ``type=error`` SSE frames (opencode#36130 port)
+#
+# The Responses spec carries error details at the top level of the frame,
+# but the official OpenAI SDK and several OpenAI-compatible proxies wrap
+# them in an HTTP-style nested envelope:
+#   {"type": "error", "error": {"code": ..., "message": ..., "param": ...}}
+# Before the fix, _raise_stream_error only read top-level fields, so these
+# frames collapsed to the generic "stream emitted error event" placeholder
+# and the error classifier never saw the provider's real code/message.
+# ---------------------------------------------------------------------------
+
+
+def test_codex_stream_wire_error_event_nested_envelope_dict():
+    """Details nested under ``error`` (dict shape) are surfaced."""
+    from run_agent import _StreamErrorEvent
+
+    agent = _make_codex_agent()
+
+    class _ErrorCreateStream:
+        def __iter__(self_inner):
+            yield {
+                "type": "error",
+                "sequence_number": 2,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "context_length_exceeded",
+                    "message": "prompt too long",
+                    "param": "input",
+                },
+            }
+
+        def close(self_inner):
+            pass
+
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = _ErrorCreateStream()
+
+    with pytest.raises(_StreamErrorEvent) as excinfo:
+        agent._run_codex_stream({}, client=mock_client)
+
+    assert "prompt too long" in str(excinfo.value)
+    assert excinfo.value.code == "context_length_exceeded"
+    assert excinfo.value.param == "input"
+    assert excinfo.value.body["error"]["message"] == "prompt too long"
+
+
+def test_codex_stream_wire_error_event_nested_envelope_attr_style():
+    """Details nested under ``error`` (SDK attr-object shape) are surfaced."""
+    from run_agent import _StreamErrorEvent
+
+    agent = _make_codex_agent()
+
+    class _ErrorCreateStream:
+        def __iter__(self_inner):
+            yield SimpleNamespace(
+                type="error",
+                message=None,
+                code=None,
+                param=None,
+                error=SimpleNamespace(
+                    type="rate_limit_error",
+                    code="rate_limit_exceeded",
+                    message="Slow down",
+                    param=None,
+                ),
+            )
+
+        def close(self_inner):
+            pass
+
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = _ErrorCreateStream()
+
+    with pytest.raises(_StreamErrorEvent) as excinfo:
+        agent._run_codex_stream({}, client=mock_client)
+
+    assert "Slow down" in str(excinfo.value)
+    assert excinfo.value.code == "rate_limit_exceeded"
+
+
+def test_codex_stream_wire_error_event_top_level_wins_over_envelope():
+    """Top-level fields keep precedence when both shapes are present."""
+    from run_agent import _StreamErrorEvent
+
+    agent = _make_codex_agent()
+
+    class _ErrorCreateStream:
+        def __iter__(self_inner):
+            yield {
+                "type": "error",
+                "message": "top-level message",
+                "code": "top_level_code",
+                "error": {"message": "nested message", "code": "nested_code"},
+            }
+
+        def close(self_inner):
+            pass
+
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = _ErrorCreateStream()
+
+    with pytest.raises(_StreamErrorEvent) as excinfo:
+        agent._run_codex_stream({}, client=mock_client)
+
+    assert "top-level message" in str(excinfo.value)
+    assert excinfo.value.code == "top_level_code"
+
+
+def test_codex_stream_wire_error_event_null_fields_fall_back_to_placeholder():
+    """Spec-compliant frames with null fields keep the stable placeholder."""
+    from run_agent import _StreamErrorEvent
+
+    agent = _make_codex_agent()
+
+    class _ErrorCreateStream:
+        def __iter__(self_inner):
+            yield {"type": "error", "code": None, "message": None, "param": None, "error": None}
+
+        def close(self_inner):
+            pass
+
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = _ErrorCreateStream()
+
+    with pytest.raises(_StreamErrorEvent) as excinfo:
+        agent._run_codex_stream({}, client=mock_client)
+
+    assert "stream emitted error event" in str(excinfo.value)
+    assert excinfo.value.code is None
+
+
 def test_codex_stream_retries_remote_protocol_error_once():
     """Transport errors (``httpx.RemoteProtocolError``) trigger a single retry.
 


### PR DESCRIPTION
## Summary

Responses `type=error` SSE frames that carry their details in a nested `error` envelope now surface the provider's real code/message instead of collapsing to the generic `stream emitted error event` placeholder.

Port of [anomalyco/opencode#36130](https://github.com/anomalyco/opencode/pull/36130).

**Root cause:** the Responses spec puts streaming error details at the top level of the frame (`{"type": "error", "code", "message", "param"}`), but the official OpenAI SDK and several OpenAI-compatible proxies wrap them in an HTTP-style nested envelope (`{"type": "error", "error": {code, message, param}}`). `_raise_stream_error` in `agent/codex_runtime.py` only read top-level fields, so nested-envelope frames raised `_StreamErrorEvent` with the placeholder message and `code=None` — the error classifier (`classify_api_error`) never saw the real failure reason, misrouting rate-limit / context-overflow / entitlement errors into the generic-unknown retry path.

Bug proven live on current `main`:

```
_raise_stream_error({'type': 'error', 'error': {'code': 'context_length_exceeded', 'message': 'prompt too long'}})
# main:  msg='stream emitted error event' code=None
# fixed: msg='prompt too long' code='context_length_exceeded'
```

## Changes

- `agent/codex_runtime.py`: `_raise_stream_error` reads a nested `error` envelope (dict or SDK attr-object) as fallback for `message`/`code`/`param`. Top-level fields keep precedence. Null-tolerant for spec-compliant frames with explicit nulls.
- `tests/run_agent/test_codex_xai_oauth_recovery.py`: 4 regression tests — nested dict envelope, nested SDK attr-object, top-level precedence, all-null placeholder fallback.

## Adaptation notes

OpenCode's fix lands in their Effect-based `openai-responses.ts` schema (`event.error ?? event.response?.error`). Hermes' analog is the fallback Codex streaming consumer's error-frame handler; the `response.failed` path (`_format_responses_error` in `codex_responses_adapter.py`) already handles the `response.error` shape, so this PR covers the one remaining site. Existing top-level behavior (xAI entitlement frames) is regression-guarded by the 46 pre-existing tests in the same file.

## Validation

| | Before | After |
|---|---|---|
| Nested envelope frame | `stream emitted error event`, `code=None` | real message, real code |
| Classifier on nested `rate_limit_exceeded` | `FailoverReason.unknown` | `FailoverReason.rate_limit` |
| Top-level frame (xAI) | works | unchanged (precedence kept) |
| `tests/run_agent/test_codex_xai_oauth_recovery.py` | 46 passed | 50 passed |

E2E: real-import probe through `agent.codex_runtime._raise_stream_error` + `classify_api_error` under the repo venv — all 5 probes pass.

## Infographic

![nested-error-envelope](https://v3b.fal.media/files/b/0aa28b7e/V2lYwapKK2umSeXpaYqgV_RPYKGe6B.png)
