### PR TITLE
fix(agent): suppress wait notices for local LLM providers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -26,7 +26,7 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
-from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
+from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout, get_provider_wait_notice_interval
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.errors import EmptyStreamError
@@ -755,6 +755,18 @@ def interruptible_api_call(agent, api_kwargs: dict):
     _call_start = time.time()
     agent._touch_activity("waiting for non-streaming API response")
 
+    # Wait-notice interval: suppress by default for local providers (where a long
+    # thinking pause is normal, not a sign of trouble).  Configurable per provider
+    # via wait_notice_interval_seconds in config.yaml.
+    _cfg_ns_notice = get_provider_wait_notice_interval(agent.provider, agent.model)
+    if _cfg_ns_notice is not None:
+        _ns_notice_interval: float = _cfg_ns_notice
+    elif agent.base_url and is_local_endpoint(agent.base_url):
+        _ns_notice_interval = float("inf")
+    else:
+        _ns_notice_interval = 30.0
+    _ns_last_notice_elapsed: float = -float("inf")  # elapsed at last notice emission
+
     t = threading.Thread(target=_call, daemon=True)
     t.start()
     _poll_count = 0
@@ -769,26 +781,31 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # usually a slow/overloaded provider, but the UI never said so).
         if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
             _elapsed = time.time() - _call_start
-            try:
-                _recovery = _codex_wait_notice_recovery(
-                    stale_timeout=_stale_timeout,
-                    ttfb_enabled=_ttfb_enabled,
-                    ttfb_timeout=_ttfb_timeout,
-                    last_event_ts=getattr(
-                        agent, "_codex_stream_last_event_ts", None
-                    ),
-                    call_start=_call_start,
-                    idle_enabled=_codex_idle_enabled,
-                    idle_timeout=_codex_idle_timeout,
-                    elapsed=_elapsed,
-                )
-                agent._emit_wait_notice(
-                    f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
-                    f"{int(_elapsed)}s with no response yet (provider may be slow "
-                    f"or overloaded{_recovery})"
-                )
-            except Exception:
-                logger.debug("wait-notice construction failed", exc_info=True)
+            agent._touch_activity(
+                f"waiting for non-streaming API response ({int(_elapsed)}s)"
+            )
+            if _elapsed >= _ns_notice_interval and _elapsed - _ns_last_notice_elapsed >= _ns_notice_interval:
+                _ns_last_notice_elapsed = _elapsed
+                try:
+                    _recovery = _codex_wait_notice_recovery(
+                        stale_timeout=_stale_timeout,
+                        ttfb_enabled=_ttfb_enabled,
+                        ttfb_timeout=_ttfb_timeout,
+                        last_event_ts=getattr(
+                            agent, "_codex_stream_last_event_ts", None
+                        ),
+                        call_start=_call_start,
+                        idle_enabled=_codex_idle_enabled,
+                        idle_timeout=_codex_idle_timeout,
+                        elapsed=_elapsed,
+                    )
+                    agent._emit_wait_notice(
+                        f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
+                        f"{int(_elapsed)}s with no response yet (provider may be slow "
+                        f"or overloaded{_recovery})"
+                    )
+                except Exception:
+                    logger.debug("wait-notice construction failed", exc_info=True)
 
         _elapsed = time.time() - _call_start
 
@@ -3615,7 +3632,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     t = threading.Thread(target=_call, daemon=True)
     t.start()
     _last_heartbeat = time.time()
-    _HEARTBEAT_INTERVAL = 30.0  # seconds between gateway activity touches
+    _HEARTBEAT_INTERVAL = 30.0  # seconds between activity-tracker ticks (never changes)
+    # Wait-notice interval: suppress by default for local providers (where a long
+    # thinking pause is normal, not a sign of trouble).  Configurable per provider
+    # via wait_notice_interval_seconds in config.yaml.
+    _cfg_notice_interval = get_provider_wait_notice_interval(agent.provider, agent.model)
+    if _cfg_notice_interval is not None:
+        _notice_interval: float = _cfg_notice_interval
+    elif agent.base_url and is_local_endpoint(agent.base_url):
+        _notice_interval = float("inf")
+    else:
+        _notice_interval = 30.0
+    _last_notice_at: float = 0.0  # last_chunk_time["t"] value when notice last fired
     while t.is_alive():
         t.join(timeout=0.3)
 
@@ -3631,11 +3659,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         if _hb_now - _last_heartbeat >= _HEARTBEAT_INTERVAL:
             _last_heartbeat = _hb_now
             _waiting_secs = int(_hb_now - last_chunk_time["t"])
-            if _waiting_secs >= _HEARTBEAT_INTERVAL:
-                # No chunks for 30s+ — rewrite the live spinner/status line
-                # so CLI/TUI/Desktop users see WHAT the wait is (slow or
-                # overloaded provider / long thinking pause) instead of an
-                # unexplained generic spinner, and WHEN recovery kicks in.
+            if _waiting_secs >= _notice_interval and _hb_now - _last_notice_at >= _notice_interval:
+                # No chunks for notice_interval+ — rewrite the live spinner so
+                # users see what the wait is and when recovery kicks in.
+                # _last_notice_at gates re-emission: next notice only after
+                # another full interval of silence (not every 30s tick).
+                _last_notice_at = _hb_now
                 if (
                     _stream_stale_timeout is not None
                     and _stream_stale_timeout != float("inf")
@@ -3647,6 +3676,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
                     f"{_waiting_secs}s with no output yet (provider may be "
                     f"slow or overloaded, or the model is thinking{_recovery})"
+                )
+            elif _waiting_secs >= _HEARTBEAT_INTERVAL:
+                # Chunks are flowing or within notice threshold — keep the
+                # activity tracker fresh but leave the live display alone.
+                agent._touch_activity(
+                    f"waiting for stream response ({_waiting_secs}s, no chunks yet)"
                 )
             else:
                 # Chunks are flowing — keep the activity tracker fresh but

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5021,7 +5021,7 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
-        "request_timeout_seconds", "stale_timeout_seconds",
+        "request_timeout_seconds", "stale_timeout_seconds", "wait_notice_interval_seconds",
         "discover_models", "extra_body", "extra_headers",
         "ssl_ca_cert", "ssl_verify",
     }

--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -69,6 +69,40 @@ def get_provider_stale_timeout(
     return _coerce_timeout(provider_config.get("stale_timeout_seconds"))
 
 
+def get_provider_wait_notice_interval(
+    provider_id: str, model: str | None = None
+) -> float | None:
+    """Return configured wait-notice interval in seconds, or None to use default.
+
+    Reads ``wait_notice_interval_seconds`` from the provider (or model-specific)
+    config block.  Set to ``inf`` / a very large value to suppress notices
+    entirely for a provider.
+    """
+    if not provider_id:
+        return None
+
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly()
+    except Exception:
+        return None
+
+    providers = config.get("providers", {}) if isinstance(config, dict) else {}
+    provider_config = (
+        providers.get(provider_id, {}) if isinstance(providers, dict) else {}
+    )
+    if not isinstance(provider_config, dict):
+        return None
+
+    model_config = _get_model_config(provider_config, model)
+    if model_config is not None:
+        interval = _coerce_timeout(model_config.get("wait_notice_interval_seconds"))
+        if interval is not None:
+            return interval
+
+    return _coerce_timeout(provider_config.get("wait_notice_interval_seconds"))
+
+
 def _get_model_config(
     provider_config: dict[str, object], model: str | None
 ) -> dict[str, object] | None:


### PR DESCRIPTION
## Problem

The wait-notice feature added in #64775 fires every 30 s whenever a provider returns no output chunks. For remote cloud providers this works well — it surfaces slow/overloaded backends and tells the user when auto-reconnect will kick in.

For **local LLM servers** (llama.cpp, Ollama, LM Studio — anything on localhost or RFC-1918) the notice is misleading noise:

- The stale-stream reconnect watchdog is already disabled for local endpoints (`_stream_stale_timeout = 900s`, never triggers for a healthy local server), so the "auto-reconnect" framing implies a problem that isn't happening.
- Local models — especially large MoE or reasoning models at high context — can legitimately produce no output for **2–5+ minutes** during prefill or extended thinking. The repeated "provider may be slow or overloaded" wording implies a connectivity problem when there is none.
- Each notice is appended as a **new child node** in the CLI thinking display rather than updating the same spinner line, so a single long-thinking turn produces a stack of identical entries:

```
⏳ waiting on /path/to/model.gguf — 30s with no output yet (provider may be slow or overloaded, or the model is thinking)
⏳ waiting on /path/to/model.gguf — 60s with no output yet (provider may be slow or overloaded, or the model is thinking)
⏳ waiting on /path/to/model.gguf — 90s with no output yet ...
```

## Fix

Two changes:

**1. Decouple notice emission from endpoint type** using `is_local_endpoint()` directly, with a configurable interval:

- Per-provider config key: `wait_notice_interval_seconds` (added to the provider config allowlist)
- Per-endpoint default: **`inf` for local providers** (suppress), **30 s for remote** (original behaviour unchanged)
- The env-var approach from the first draft has been removed per `AGENTS.md` — configuration is through `config.yaml` only

**2. Prevent re-emission stacking** — once the notice threshold is crossed, the check `_waiting_secs >= _notice_interval` remains permanently true, so without a gate the notice would fire on every subsequent 30 s heartbeat tick. A `_last_notice_at` timestamp ensures the next notice only fires after another full `_notice_interval` of silence has elapsed since the previous one.

The heartbeat loop tick (`_HEARTBEAT_INTERVAL = 30 s`) is **not changed** — it still fires every 30 s to keep the gateway activity tracker alive.

## Changes

- `agent/chat_completion_helpers.py` — both streaming and non-streaming wait loops:
  - compute `_notice_interval` / `_ns_notice_interval` using `is_local_endpoint(agent.base_url)` before entering the loop
  - gate `_emit_wait_notice` on both the threshold and a re-emission guard (`_last_notice_at` / `_ns_last_notice_elapsed`)
  - non-streaming path: explicitly calls `_touch_activity` on every 30 s tick so the gateway heartbeat is preserved even when the notice is suppressed
- `hermes_cli/timeouts.py` — adds `get_provider_wait_notice_interval()`, following the same config-lookup pattern as `get_provider_stale_timeout()`
- `hermes_cli/config.py` — adds `wait_notice_interval_seconds` to the provider config allowlist

## Configuration examples

Raise the threshold to 5 minutes for a local provider:
```yaml
providers:
  custom:
    wait_notice_interval_seconds: 300
```

Suppress entirely (same as the local default, useful to make the intent explicit):
```yaml
providers:
  custom:
    wait_notice_interval_seconds: inf
```

Remote providers (Anthropic, OpenAI, etc.) are unaffected — they keep the 30 s default unless explicitly configured otherwise.