### PR TITLE
fix(cli): model wizard recognises auth.json credential-pool keys (#65977)

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -141,7 +141,7 @@ def _model_flow_openrouter(config, current_model=""):
         auth_type="api_key",
         api_key_env_vars=("OPENROUTER_API_KEY",),
     )
-    existing_key = get_env_value("OPENROUTER_API_KEY") or ""
+    existing_key = _resolve_existing_api_key("openrouter", pconfig)
     if not existing_key:
         print("Get one at: https://openrouter.ai/keys")
         print()
@@ -1906,12 +1906,10 @@ def _model_flow_kimi(config, current_model=""):
     key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
     base_url_env = pconfig.base_url_env_var or ""
 
-    # Step 1: Check / prompt for API key
-    existing_key = ""
-    for ev in pconfig.api_key_env_vars:
-        existing_key = get_env_value(ev) or os.getenv(ev, "")
-        if existing_key:
-            break
+    # Step 1: Check / prompt for API key.
+    # Resolves from ~/.hermes/.env → os.environ → credential pool (auth.json)
+    # so keys added via `hermes auth` are recognised (issue #65977).
+    existing_key = _resolve_existing_api_key(provider_id, pconfig)
 
     existing_key, abort = _prompt_api_key(
         pconfig, existing_key, provider_id=provider_id
@@ -1992,11 +1990,7 @@ def _model_flow_stepfun(config, current_model=""):
     key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
     base_url_env = pconfig.base_url_env_var or ""
 
-    existing_key = ""
-    for ev in pconfig.api_key_env_vars:
-        existing_key = get_env_value(ev) or os.getenv(ev, "")
-        if existing_key:
-            break
+    existing_key = _resolve_existing_api_key(provider_id, pconfig)
 
     existing_key, abort = _prompt_api_key(
         pconfig, existing_key, provider_id=provider_id
@@ -2530,6 +2524,34 @@ def _select_zai_endpoint(current_base: str) -> str:
     return options[selected][1].rstrip("/")
 
 
+def _resolve_existing_api_key(
+    provider_id: str, pconfig
+) -> str:
+    """Resolve an existing API key for a provider, checking sources in order.
+
+    1. ~/.hermes/.env (preferred for rotation)
+    2. os.environ (shell exports, CI injections)
+    3. credential pool in auth.json (keys stored via ``hermes auth``)
+
+    Returns empty string when no key is found in any source.
+    Mirrors ``_resolve_api_key_provider_secret`` in hermes_cli/auth.py.
+    """
+    from hermes_cli.config import get_env_value
+
+    for ev in pconfig.api_key_env_vars:
+        val = get_env_value(ev) or os.getenv(ev, "")
+        if val:
+            return val
+    try:
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+
+        resolved, _source = _resolve_api_key_provider_secret(provider_id, pconfig)
+        return (resolved or "").strip()
+    except Exception:
+        pass
+    return ""
+
+
 def _model_flow_api_key_provider(config, provider_id, current_model=""):
     """Generic flow for API-key providers (z.ai, MiniMax, OpenCode, etc.)."""
     from hermes_cli.main import _prompt_api_key
@@ -2556,12 +2578,12 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
     key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
     base_url_env = pconfig.base_url_env_var or ""
 
-    # Check / prompt for API key
-    existing_key = ""
-    for ev in pconfig.api_key_env_vars:
-        existing_key = get_env_value(ev) or os.getenv(ev, "")
-        if existing_key:
-            break
+    # Check / prompt for API key.
+    # Resolves from ~/.hermes/.env → os.environ → credential pool (auth.json).
+    # The pool fallback covers keys added via `hermes auth` (e.g. Moonshot /
+    # DeepSeek) so the wizard doesn't prompt for a new key when one is
+    # already working (issue NousResearch/hermes-agent#65977).
+    existing_key = _resolve_existing_api_key(provider_id, pconfig)
 
     existing_key, abort = _prompt_api_key(
         pconfig, existing_key, provider_id=provider_id

--- a/tests/hermes_cli/test_model_wizard_credential_pool_fallback.py
+++ b/tests/hermes_cli/test_model_wizard_credential_pool_fallback.py
@@ -1,0 +1,161 @@
+"""Tests for the model wizard's credential-pool fallback.
+
+Covers the fix for NousResearch/hermes-agent#65977: `hermes model` only
+checked .env / os.environ when deciding if a provider was already
+configured, so a working key in `auth.json`'s credential pool (added via
+`hermes auth`, e.g. Moonshot / DeepSeek) was invisible to the wizard and
+it prompted for a new key.
+
+The fix adds `_resolve_existing_api_key` in hermes_cli.model_setup_flows,
+which checks .env → os.environ → credential pool, in that order. The
+wizard flows (`_model_flow_kimi`, `_model_flow_stepfun`,
+`_model_flow_api_key_provider`, `_model_flow_openrouter`) now use this
+helper instead of hand-rolling env-only checks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_pconfig(provider_id="deepseek", env_vars=None):
+    """Minimal ProviderConfig for testing (registry-free where possible)."""
+    from hermes_cli.auth import ProviderConfig
+
+    return ProviderConfig(
+        id=provider_id,
+        name=provider_id.title(),
+        auth_type="api_key",
+        api_key_env_vars=tuple(env_vars or [f"{provider_id.upper()}_API_KEY"]),
+    )
+
+
+@pytest.fixture
+def isolated_hermes_home(tmp_path, monkeypatch):
+    """Isolated ~/.hermes with cleared env vars and pool, get_env_value cache
+    invalidated."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    for key in [
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENROUTER_API_KEY",
+        "ZAI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "KIMI_API_KEY",
+        "KIMI_CODING_API_KEY",
+        "STEPFUN_API_KEY",
+        "ANTHROPIC_TOKEN",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    return home
+
+
+class TestResolveExistingApiKeyCredentialPoolFallback:
+    """`_resolve_existing_api_key` must surface a credential-pool entry when
+    no .env / os.environ value is present."""
+
+    def test_pool_key_returned_when_env_empty(self, isolated_hermes_home):
+        """When .env and os.environ are both empty but auth.json's pool has a
+        key for the provider, the helper returns it (issue #65977)."""
+        from hermes_cli.model_setup_flows import _resolve_existing_api_key
+
+        pconfig = _make_pconfig("deepseek", ["DEEPSEEK_API_KEY"])
+
+        with patch(
+            "hermes_cli.auth._resolve_api_key_provider_secret",
+            return_value=("sk-pool-deepseek-xyz", "credential_pool:deepseek"),
+        ):
+            result = _resolve_existing_api_key("deepseek", pconfig)
+
+        assert result == "sk-pool-deepseek-xyz"
+
+    def test_env_value_takes_priority_over_pool(self, isolated_hermes_home, monkeypatch):
+        """A key in os.environ must win over a credential-pool entry so a
+        deliberate rotation via shell export isn't shadowed."""
+        from hermes_cli.model_setup_flows import _resolve_existing_api_key
+
+        pconfig = _make_pconfig("deepseek", ["DEEPSEEK_API_KEY"])
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-env-takes-priority")
+
+        with patch(
+            "hermes_cli.auth._resolve_api_key_provider_secret",
+            return_value=("sk-pool-should-not-win", "credential_pool:deepseek"),
+        ) as mock_pool_resolver:
+            result = _resolve_existing_api_key("deepseek", pconfig)
+
+        assert result == "sk-env-takes-priority"
+        # Pool resolver must not even fire when env already has a value.
+        mock_pool_resolver.assert_not_called()
+
+    def test_returns_empty_when_no_source_has_key(self, isolated_hermes_home):
+        """When env, os.environ, and pool are all empty, returns ''. The
+        wizard will then fall through to the new-key prompt."""
+        from hermes_cli.model_setup_flows import _resolve_existing_api_key
+
+        pconfig = _make_pconfig("deepseek", ["DEEPSEEK_API_KEY"])
+
+        with patch(
+            "hermes_cli.auth._resolve_api_key_provider_secret",
+            return_value=("", ""),
+        ):
+            result = _resolve_existing_api_key("deepseek", pconfig)
+
+        assert result == ""
+
+    def test_pool_resolver_exception_does_not_break_wizard(
+        self, isolated_hermes_home
+    ):
+        """If the credential pool lookup raises, the helper must return ''
+        (so the wizard prompts for a new key) rather than propagating."""
+        from hermes_cli.model_setup_flows import _resolve_existing_api_key
+
+        pconfig = _make_pconfig("deepseek", ["DEEPSEEK_API_KEY"])
+
+        with patch(
+            "hermes_cli.auth._resolve_api_key_provider_secret",
+            side_effect=RuntimeError("pool read failed"),
+        ):
+            result = _resolve_existing_api_key("deepseek", pconfig)
+
+        assert result == ""
+
+    def test_existing_key_reaches_prompt_api_key(self, isolated_hermes_home, monkeypatch):
+        """Integration: _model_flow_api_key_provider passes the pool key
+        through to _prompt_api_key so the wizard's K/R/C offer fires instead
+        of the 'No API key configured' first-time flow."""
+        from hermes_cli.model_setup_flows import _model_flow_api_key_provider
+
+        pconfig = _make_pconfig("deepseek", ["DEEPSEEK_API_KEY"])
+        monkeypatch.setattr(
+            "hermes_cli.auth.PROVIDER_REGISTRY",
+            {"deepseek": pconfig},
+        )
+
+        captured = {}
+
+        def fake_prompt_api_key(pconfig, existing_key, provider_id=""):
+            captured["existing_key"] = existing_key
+            captured["provider_id"] = provider_id
+            return existing_key, True  # abort
+
+        monkeypatch.setattr("hermes_cli.main._prompt_api_key", fake_prompt_api_key)
+
+        with patch.object(
+            __import__("hermes_cli.model_setup_flows", fromlist=["_resolve_existing_api_key"]),
+            "_resolve_existing_api_key",
+            return_value="sk-pool-deepseek-abc",
+        ):
+            config = {"model": {}}
+            _model_flow_api_key_provider(config, "deepseek")
+
+        # Must see the pool key — not empty / blank.
+        assert captured["existing_key"] == "sk-pool-deepseek-abc"
+        assert captured["provider_id"] == "deepseek"


### PR DESCRIPTION
## Problem

`hermes model` only checked ~/.hermes/.env and os.environ when deciding if a provider was already configured. A working key stored in `auth.json` via `hermes auth` (e.g. Moonshot, DeepSeek) was invisible to the wizard — it prompted the user to enter a new key.

## Root Cause

Four wizard flows hand-rolled the same env-only lookup:
- `_model_flow_kimi` (Moonshot / Kimi Coding)
- `_model_flow_stepfun` (StepFun)
- `_model_flow_api_key_provider` (generic, used by z.ai, MiniMax, etc.)
- `_model_flow_openrouter` (OpenRouter standalone)

None fell back to the credential pool. The runtime resolver `_resolve_api_key_provider_secret` in auth.py already had the correct three-tier lookup, but the wizard bypassed it.

## Fix

1. Extract shared helper `_resolve_existing_api_key(provider_id, pconfig)` that checks `.env` → os.environ → credential pool, mirroring the order in `_resolve_api_key_provider_secret`.
2. Replace all 4 wizard flows' inline env-only lookups with the helper.
3. Add 5 regression tests.

## Testing

```
$ pytest tests/hermes_cli/test_model_wizard_credential_pool_fallback.py -v
5 passed in 0.27s
```

Closes #65977.