### PR TITLE
fix(auth): support NOUS_API_KEY alongside Nous Portal OAuth

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -104,7 +104,7 @@ class _OpenAIProxy:
 
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
-from agent.credential_pool import load_pool
+from agent.credential_pool import AUTH_TYPE_API_KEY, load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -1762,6 +1762,13 @@ def _resolve_nous_pool_runtime_api(*, force_refresh: bool = False) -> Optional[t
 
     if entry is None:
         return None
+
+    if getattr(entry, "auth_type", None) == AUTH_TYPE_API_KEY:
+        api_key = _pool_runtime_api_key(entry)
+        base_url = _pool_runtime_base_url(entry, _NOUS_DEFAULT_BASE_URL)
+        if not api_key or not base_url:
+            return None
+        return api_key, base_url
 
     state = {
         "agent_key": getattr(entry, "agent_key", None),

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -241,9 +241,10 @@ class PooledCredential:
 
     @property
     def runtime_api_key(self) -> str:
-        if self.provider == "nous":
+        if self.provider == "nous" and self.auth_type == AUTH_TYPE_OAUTH:
             # Nous stores the runtime inference credential in agent_key for
-            # compatibility. It must be a NAS invoke JWT.
+            # OAuth compatibility. It must be a NAS invoke JWT. Direct API-key
+            # credentials use access_token like every other API-key provider.
             for token, expires_at in (
                 (self.agent_key, self.agent_key_expires_at),
                 (self.access_token, self.expires_at),
@@ -2384,7 +2385,7 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         return changed, active_sources
 
     pconfig = PROVIDER_REGISTRY.get(provider)
-    if not pconfig or pconfig.auth_type != AUTH_TYPE_API_KEY:
+    if not pconfig or not pconfig.api_key_env_vars:
         return changed, active_sources
 
     env_url = ""

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -182,6 +182,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_NOUS_INFERENCE_URL,
         client_id=DEFAULT_NOUS_CLIENT_ID,
         scope=DEFAULT_NOUS_SCOPE,
+        api_key_env_vars=("NOUS_API_KEY",),
     ),
     "openai-codex": ProviderConfig(
         id="openai-codex",
@@ -1611,7 +1612,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     if pconfig is None:
         from hermes_cli.providers import get_provider
         pconfig = get_provider(normalized)
-    if pconfig and pconfig.auth_type == "api_key":
+    if pconfig and pconfig.api_key_env_vars:
         for env_var in pconfig.api_key_env_vars:
             if env_var in _IMPLICIT_ENV_VARS:
                 continue
@@ -1871,9 +1872,10 @@ def resolve_provider(
     except Exception as e:
         logger.debug("Could not pre-read active auth provider: %s", e)
 
-    # Auto-detect API-key providers by checking their env vars
+    # Auto-detect providers with API-key credentials, including providers whose
+    # primary interactive auth flow is OAuth (for example Nous).
     for pid, pconfig in PROVIDER_REGISTRY.items():
-        if pconfig.auth_type != "api_key":
+        if not pconfig.api_key_env_vars:
             continue
         # GitHub tokens are commonly present for repo/tool access but should not
         # hijack inference auto-selection unless the user explicitly chooses

--- a/hermes_cli/nous_auth_keepalive.py
+++ b/hermes_cli/nous_auth_keepalive.py
@@ -54,7 +54,7 @@ def _refresh_selected_pool_entry(
     pool exists but no entry can be used, and None when no Nous pool exists.
     """
     try:
-        from agent.credential_pool import load_pool
+        from agent.credential_pool import AUTH_TYPE_API_KEY, load_pool
 
         pool = load_pool("nous")
     except Exception as exc:
@@ -72,6 +72,9 @@ def _refresh_selected_pool_entry(
 
     if entry is None:
         return False
+
+    if getattr(entry, "auth_type", None) == AUTH_TYPE_API_KEY:
+        return bool(getattr(entry, "runtime_api_key", None))
 
     access_expiring = _is_expiring(
         getattr(entry, "expires_at", None),

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -57,6 +57,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     "nous": HermesOverlay(
         transport="openai_chat",
         auth_type="oauth_device_code",
+        extra_env_vars=("NOUS_API_KEY",),
         base_url_override="https://inference-api.nousresearch.com/v1",
     ),
     "openai-codex": HermesOverlay(

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 from hermes_cli import auth as auth_mod
 from agent.credential_pool import (
+    AUTH_TYPE_OAUTH,
     CredentialPool,
     PooledCredential,
     credential_pool_matches_provider,
@@ -1709,7 +1710,11 @@ def resolve_runtime_provider(
         # non-runtime contexts like `hermes auth list`). If the key is
         # expired/missing, refresh the selected pool entry before falling back
         # to singleton auth resolution.
-        if provider == "nous" and entry is not None:
+        if (
+            provider == "nous"
+            and entry is not None
+            and getattr(entry, "auth_type", AUTH_TYPE_OAUTH) == AUTH_TYPE_OAUTH
+        ):
             min_ttl = max(60, env_int("HERMES_NOUS_MIN_KEY_TTL_SECONDS", 1800))
             nous_state = {
                 "agent_key": getattr(entry, "agent_key", None),

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1292,6 +1292,38 @@ class TestVisionClientFallback:
 
 
 class TestAuxiliaryPoolAwareness:
+    def test_resolve_nous_api_key_pool_entry_without_refresh(self):
+        class _Entry:
+            provider = "nous"
+            auth_type = "api_key"
+            access_token = "direct-nous-api-key"
+            inference_base_url = "https://inference.pool.example/v1"
+
+        class _Pool:
+            refresh_called = False
+
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+            def try_refresh_current(self):
+                self.refresh_called = True
+                raise AssertionError("direct API keys must not be refreshed")
+
+        pool = _Pool()
+        with patch("agent.auxiliary_client.load_pool", return_value=pool):
+            from agent.auxiliary_client import _resolve_nous_pool_runtime_api
+
+            runtime = _resolve_nous_pool_runtime_api(force_refresh=True)
+
+        assert runtime == (
+            "direct-nous-api-key",
+            "https://inference.pool.example/v1",
+        )
+        assert pool.refresh_called is False
+
     def test_try_nous_uses_pool_entry(self):
         pooled_token = _jwt_with_claims({
             "scope": "inference:invoke",

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1323,6 +1323,23 @@ def test_load_pool_missing_env_does_not_overwrite_other_process_seed(tmp_path, m
     assert persisted[0]["source"] == "env:MINIMAX_API_KEY"
 
 
+def test_load_pool_seeds_nous_api_key_alongside_oauth_support(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("NOUS_API_KEY", "test-nous-key")
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("nous")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.source == "env:NOUS_API_KEY"
+    assert entry.auth_type == "api_key"
+    assert entry.runtime_api_key == "test-nous-key"
+    assert entry.runtime_base_url == "https://inference-api.nousresearch.com/v1"
+
+
 def test_load_pool_migrates_nous_provider_state(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -61,6 +61,11 @@ class TestProviderRegistry:
         assert pconfig.base_url_env_var == "XAI_BASE_URL"
         assert pconfig.inference_base_url == "https://api.x.ai/v1"
 
+    def test_nous_dual_auth_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["nous"]
+        assert pconfig.auth_type == "oauth_device_code"
+        assert pconfig.api_key_env_vars == ("NOUS_API_KEY",)
+
     def test_nvidia_env_vars(self):
         pconfig = PROVIDER_REGISTRY["nvidia"]
         assert pconfig.api_key_env_vars == ("NVIDIA_API_KEY",)
@@ -315,6 +320,10 @@ class TestResolveProvider:
     def test_auto_detects_deepinfra_key(self, monkeypatch):
         monkeypatch.setenv("DEEPINFRA_API_KEY", "test-di-key")
         assert resolve_provider("auto") == "deepinfra"
+
+    def test_auto_detects_nous_api_key(self, monkeypatch):
+        monkeypatch.setenv("NOUS_API_KEY", "test-nous-key")
+        assert resolve_provider("auto") == "nous"
 
     def test_openrouter_takes_priority_over_glm(self, monkeypatch):
         """OpenRouter API key should win over GLM in auto-detection."""

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -18,9 +18,14 @@ def _write_auth_store(tmp_path, payload: dict) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _clean_anthropic_env(monkeypatch):
-    """Strip Anthropic env vars so CI secrets don't leak into tests."""
-    for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+def _clean_provider_env(monkeypatch):
+    """Strip provider env vars so CI secrets don't leak into tests."""
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "NOUS_API_KEY",
+    ):
         monkeypatch.delenv(key, raising=False)
 
 
@@ -72,6 +77,15 @@ def test_returns_true_when_anthropic_env_var_set(tmp_path, monkeypatch):
 
     from hermes_cli.auth import is_provider_explicitly_configured
     assert is_provider_explicitly_configured("anthropic") is True
+
+
+def test_returns_true_when_nous_api_key_set(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("NOUS_API_KEY", "test-nous-key")
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("nous") is True
 
 
 def test_claude_code_oauth_token_does_not_count_as_explicit(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_model_catalog.py
+++ b/tests/hermes_cli/test_model_catalog.py
@@ -485,6 +485,39 @@ class TestIntegrationWithModelsModule:
         assert nous_row is not None, "nous row must appear when authed"
         assert nous_row["models"] == expected
 
+    def test_picker_nous_row_appears_with_api_key_only(self, monkeypatch):
+        """NOUS_API_KEY should expose Nous models without an OAuth login."""
+        import importlib
+        from hermes_cli import model_catalog
+        importlib.reload(model_catalog)
+        try:
+            from hermes_cli.model_switch import list_picker_providers
+            from hermes_cli.models import get_curated_nous_model_ids
+
+            active_home = Path(os.environ["HERMES_HOME"])
+            (active_home / "auth.json").write_text(
+                json.dumps({"providers": {}, "credential_pool": {}})
+            )
+            monkeypatch.setenv("NOUS_API_KEY", "test-nous-key")
+
+            with patch.object(
+                model_catalog, "_fetch_manifest", return_value=_valid_manifest()
+            ), patch("hermes_cli.models.check_nous_free_tier", return_value=False), patch(
+                "hermes_cli.models.union_with_portal_free_recommendations",
+                side_effect=lambda ids, *a, **k: (ids, {}),
+            ), patch(
+                "hermes_cli.models.union_with_portal_paid_recommendations",
+                side_effect=lambda ids, *a, **k: (ids, {}),
+            ):
+                expected = get_curated_nous_model_ids()
+                picker = list_picker_providers(max_models=99)
+        finally:
+            model_catalog.reset_cache()
+
+        nous_row = next((row for row in picker if row["slug"] == "nous"), None)
+        assert nous_row is not None
+        assert nous_row["models"] == expected
+
     def test_picker_max_models_cap_semantics(self, tmp_path, monkeypatch):
         """The cap argument has three distinct meanings on the real slicing
         path: ``None`` = unlimited (the cap-removal fix, #48297), ``0`` = no

--- a/tests/hermes_cli/test_nous_auth_keepalive.py
+++ b/tests/hermes_cli/test_nous_auth_keepalive.py
@@ -1,6 +1,26 @@
 from hermes_cli import nous_auth_keepalive as keepalive
 
 
+def test_keepalive_accepts_api_key_without_refresh(monkeypatch):
+    class _Entry:
+        auth_type = "api_key"
+        runtime_api_key = "test-nous-key"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+        def try_refresh_current(self):
+            raise AssertionError("API keys must not use OAuth refresh")
+
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: _Pool())
+
+    assert keepalive.refresh_nous_auth_keepalive_once() is True
+
+
 def test_keepalive_refreshes_stale_pool_entry(monkeypatch):
     class _Entry:
         access_token = "pooled-access-token"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -116,6 +116,34 @@ def test_resolve_runtime_provider_nous_pool_uses_env_base_url_override(monkeypat
     assert resolved["base_url"] == "https://ai.wildebeest-newton.ts.net/v1"
 
 
+def test_resolve_runtime_provider_uses_nous_api_key_without_oauth(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "providers": {}})
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("NOUS_API_KEY", "test-nous-key")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        rp,
+        "_agent_key_is_usable",
+        lambda *args, **kwargs: pytest.fail("API keys must not use OAuth JWT checks"),
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_nous_runtime_credentials",
+        lambda **kwargs: pytest.fail("API keys must not invoke Nous OAuth resolution"),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="nous")
+
+    assert resolved["provider"] == "nous"
+    assert resolved["api_key"] == "test-nous-key"
+    assert resolved["base_url"] == "https://inference-api.nousresearch.com/v1"
+    assert resolved["source"] == "env:NOUS_API_KEY"
+
+
 def test_resolve_runtime_provider_anthropic_pool_respects_config_base_url(monkeypatch):
     class _Entry:
         access_token = "pool-token"


### PR DESCRIPTION
## Summary

- support `NOUS_API_KEY` alongside the existing Nous Portal OAuth flow
- seed injected Nous API keys into the credential pool and expose Nous in provider/model selection
- bypass OAuth JWT validation and refresh logic for direct API-key entries, including the background keepalive

## Ephemeral environment injection

This fixes container and other ephemeral deployments where Hermes starts without persisted Nous Portal OAuth state and receives the credential only through its process environment:

```sh
NOUS_API_KEY=<injected-secret> hermes gateway run
```

The image and generated configuration can be recreated on every deployment. The secret is injected at runtime by the service/container environment rather than written into the image or preconfigured through an interactive OAuth login.

Before this change, Nous was registered primarily as `oauth_device_code`, so the injected key was not handled consistently as a usable API-key credential. The Nous keepalive then treated the direct key like an OAuth entry, attempted an OAuth refresh, and marked it `exhausted`. Selecting a Nous model consequently failed with:

```text
Could not resolve credentials for provider 'Nous Portal': Hermes is not logged into Nous Portal.
```

With this change, `NOUS_API_KEY` behaves like other injected provider keys such as `XAI_API_KEY`: it is discovered from the environment, hydrated into the runtime pool, and never sent through Nous OAuth refresh/JWT validation. Persisted pool data retains the environment source metadata rather than embedding the secret.

## Verification

- `473 passed` across the focused auth, credential-pool, model-catalog, keepalive, and runtime-provider suites
- verified in an ephemeral Fedora 44 container with `NOUS_API_KEY` injected into the systemd-managed Hermes gateway
- direct Nous `/v1/models` returned HTTP 200
- runtime resolved `provider=nous`, `source=env:NOUS_API_KEY`, and the keepalive left the API-key entry usable