### PR TITLE
fix(auth): memoize resolve_nous_access_token to collapse startup burst

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5311,6 +5311,18 @@ def _agent_key_is_usable(state: Dict[str, Any], min_ttl_seconds: int) -> bool:
     )
 
 
+# Per-process memo for resolve_nous_access_token. Startup runs
+# check_tool_availability once per managed-tool check_fn (browser, image_gen,
+# etc.), and each one independently triggers a ~15s blocking token-refresh
+# network call when the stored token is expired. On a slow/constrained host that
+# serial burst stretches startup to many minutes. A short-TTL memo collapses the
+# burst into a single network round-trip; callers that need freshness use
+# separate flows (force_fresh / refresh_nous_oauth_pure) and are unaffected.
+_RESOLVE_TOKEN_CACHE_LOCK = threading.Lock()
+_RESOLVE_TOKEN_CACHE: "tuple[float, str] | None" = None
+_RESOLVE_TOKEN_CACHE_TTL_S = 5.0
+
+
 def resolve_nous_access_token(
     *,
     timeout_seconds: float = 15.0,
@@ -5319,6 +5331,16 @@ def resolve_nous_access_token(
     refresh_skew_seconds: int = ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
 ) -> str:
     """Resolve a refresh-aware Nous Portal access token for managed tool gateways."""
+    global _RESOLVE_TOKEN_CACHE
+    # Memo: collapse the startup burst of managed-tool check_fns into one
+    # network refresh. Only cache a successful, non-forced resolution for a
+    # short window; force_fresh / error paths bypass and don't populate it.
+    if not insecure and ca_bundle is None:
+        with _RESOLVE_TOKEN_CACHE_LOCK:
+            if _RESOLVE_TOKEN_CACHE is not None:
+                cached_at, cached_token = _RESOLVE_TOKEN_CACHE
+                if (time.monotonic() - cached_at) < _RESOLVE_TOKEN_CACHE_TTL_S:
+                    return cached_token
     with _provider_state_transaction("nous") as (
         auth_store,
         state,
@@ -5430,7 +5452,11 @@ def resolve_nous_access_token(
             }
             _save_provider_state_to_source(auth_store, "nous", state, state_source_path)
             _write_shared_nous_state(state)
-            return state["access_token"]
+            resolved = state["access_token"]
+            if not insecure and ca_bundle is None:
+                with _RESOLVE_TOKEN_CACHE_LOCK:
+                    _RESOLVE_TOKEN_CACHE = (time.monotonic(), resolved)
+            return resolved
 
 
 def refresh_nous_oauth_pure(


### PR DESCRIPTION
## Problem
`check_tool_availability` runs once per managed-tool `check_fn` (browser, image_gen, etc.) during banner render. Each one independently triggers a ~15s blocking Nous Portal token-refresh network call (`resolve_nous_access_token` -> `_refresh_access_token` -> `httpx.post`) when the stored token is expired.

On a slow/constrained host (a small monitoring CT observed this) that serial burst stretched `hermes` startup to many minutes, appearing "stalled" — the user had to Ctrl-C out of it. The `httpx` client already has a 15s connect timeout, so it isn't an infinite hang; it's N×15s where N is the number of managed-tool checks.

## Fix
Add a per-process memo (5s TTL) to `resolve_nous_access_token` so the startup burst collapses into a single network round-trip. Only successful, non-forced resolutions are cached. `force_fresh` callers and `insecure`/`ca_bundle` callers bypass the cache and never populate it, so normal refresh semantics (interactive re-auth, custom TLS) are unchanged.

## Verification
- `auth.py` parses clean.
- Direct test: 3 rapid `resolve_nous_access_token()` calls (against a fake expired-token state with the network refresh monkeypatched to count) -> exactly 1 underlying refresh, identical token returned all 3 times.
- Caught and fixed a real `UnboundLocalError` (module global read before the later in-function assignment made Python treat it as local) by adding `global _RESOLVE_TOKEN_CACHE`.

## Note
This addresses the startup slowness class. The separate exit-watchdog fix (PR #65998) covers shutdown wedges; they are different bugs.
