### PR TITLE
fix(auth): detect configured providers absent from registry

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1605,6 +1605,12 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     # not by the user explicitly configuring anthropic in Hermes.
     _IMPLICIT_ENV_VARS = {"CLAUDE_CODE_OAUTH_TOKEN"}
     pconfig = PROVIDER_REGISTRY.get(normalized)
+    # Fallback to ProviderDef from models.dev catalog when the provider
+    # isn't in the manually-maintained PROVIDER_REGISTRY (e.g. openrouter).
+    # Both expose .auth_type and .api_key_env_vars with the same shape.
+    if pconfig is None:
+        from hermes_cli.providers import get_provider
+        pconfig = get_provider(normalized)
     if pconfig and pconfig.auth_type == "api_key":
         for env_var in pconfig.api_key_env_vars:
             if env_var in _IMPLICIT_ENV_VARS:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "zzpigpinggai@users.noreply.github.com": "zzpigpinggai",  # PR #66017 salvage of #63617 (OpenRouter explicit-provider picker visibility)
     "sam7894604@gmail.com": "sam7894604",  # PR #55803 salvage (discord: /reasoning slash choices)
     "bryan@users.noreply.github.com": "hydraxman",  # PR #62028 salvage (copilot xhigh) — regression-test commit authored under a bare-noreply local git identity; PR author is @hydraxman
     "antydizajn@gmail.com": "antydizajn",  # PR #36043 salvage (auxiliary: route custom:<name> through named-provider arm + Palantir Bearer auth)

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -171,3 +171,24 @@ def test_env_pool_entry_counts_when_var_still_resolves(tmp_path, monkeypatch):
 
     from hermes_cli.auth import is_provider_explicitly_configured
     assert is_provider_explicitly_configured("deepseek") is True
+
+
+def test_provider_not_in_registry_but_in_models_dev(tmp_path, monkeypatch):
+    """Providers absent from PROVIDER_REGISTRY but present in the models.dev
+    catalog (e.g. openrouter) must still be detected via their env vars.
+
+    Regression: is_provider_explicitly_configured() only checked
+    PROVIDER_REGISTRY for env-var names, so providers that exist solely in
+    the models.dev catalog were never recognised as explicitly configured -
+    hiding them from the desktop model picker even when their API key was
+    set in .env.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test-key-12345678")
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+
+    from hermes_cli.auth import is_provider_explicitly_configured, PROVIDER_REGISTRY
+    # Sanity: openrouter is not in the manual registry
+    assert "openrouter" not in PROVIDER_REGISTRY
+    assert is_provider_explicitly_configured("openrouter") is True

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -188,7 +188,5 @@ def test_provider_not_in_registry_but_in_models_dev(tmp_path, monkeypatch):
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
     (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
 
-    from hermes_cli.auth import is_provider_explicitly_configured, PROVIDER_REGISTRY
-    # Sanity: openrouter is not in the manual registry
-    assert "openrouter" not in PROVIDER_REGISTRY
+    from hermes_cli.auth import is_provider_explicitly_configured
     assert is_provider_explicitly_configured("openrouter") is True


### PR DESCRIPTION
## What does this PR do?

Salvages #63617 by @zzpigpinggai onto current `main`, preserving the contributor's original fix commit and authorship. Separate follow-up commits apply the outstanding review request from @teknium1 and add the contributor's unnumbered GitHub noreply address to the release attribution map.

`is_provider_explicitly_configured()` currently checks `PROVIDER_REGISTRY` for API-key environment variables. OpenRouter is intentionally absent from that registry because registering it there changes runtime provider resolution, so `OPENROUTER_API_KEY` was ignored by the explicit-provider gate and the Desktop model picker removed the OpenRouter row while Nous was selected.

When a provider is absent from `PROVIDER_REGISTRY`, the helper now falls back to the canonical provider catalog through `hermes_cli.providers.get_provider()`. This fixes OpenRouter without undoing its deliberate registry exclusion and covers other catalog providers with the same split.

## Related Issue

Fixes #65793

Original contribution: #63617

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py`: fall back to the canonical provider definition when the explicit-provider gate cannot find a legacy registry entry.
- `tests/hermes_cli/test_auth_provider_gate.py`: retain the behavioral OpenRouter regression assertion while removing the reviewed implementation-detail assertion about registry membership.
- `scripts/release.py`: map `zzpigpinggai@users.noreply.github.com` to `zzpigpinggai` so release attribution recognizes the preserved contributor commit.
- Preserve @zzpigpinggai as the author of the implementation and regression-test commit.

## How to Test

1. Set an isolated `HERMES_HOME` and `OPENROUTER_API_KEY`, then call `is_provider_explicitly_configured("openrouter")`; it returns `True`.
2. Remove `OPENROUTER_API_KEY` in the same isolated home; the helper returns `False`.
3. Filter explicit picker rows with Nous current and both Nous/OpenRouter rows present; both rows remain visible.
4. Confirm every non-auto-resolved commit-author email in `origin/main..HEAD` appears in `scripts/release.py`'s `AUTHOR_MAP`.
5. Run `python scripts/check-windows-footguns.py --diff origin/main`.

Focused runtime and attribution probes passed on Windows 11. Pytest was not run locally due to this workstation's current test-safety restriction; full-suite coverage is left to GitHub CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11

Existing overlapping PRs reviewed: #63617, #65796, and #65821. The latter two add OpenRouter to `PROVIDER_REGISTRY`; this salvage keeps the intentional registry exclusion and fixes the explicit-provider gate at its catalog boundary instead.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior-only fix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
registry_has_openrouter=False
catalog_auth_type=api_key
catalog_env_vars=('OPENROUTER_API_KEY',)
configured_with_key=True
configured_without_key=False
explicit_picker_rows=['nous', 'openrouter']
zzpigpinggai@users.noreply.github.com -> zzpigpinggai
No Windows footguns found (3 files scanned).
```
