### PR TITLE
fix(telegram): prevent duplicate finals after failed edit

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -173,6 +173,10 @@ class GatewayStreamConsumer:
         self._last_edit_overflowed = False
         self._fallback_final_send = False
         self._fallback_prefix = ""
+        # True only when the last edit response proves the tracked preview no
+        # longer exists. In that case an empty continuation must recover by
+        # sending the complete final answer rather than trusting cached text.
+        self._fallback_preview_missing = False
         # True when fallback is sending only the missing tail after a partial
         # Telegram overflow delivery.  In that case the already-visible prefix
         # is intentional content, not a stale preview to delete.
@@ -348,6 +352,7 @@ class GatewayStreamConsumer:
         self._last_sent_text = ""
         self._fallback_final_send = False
         self._fallback_prefix = ""
+        self._fallback_preview_missing = False
         self._fallback_preserve_partial_messages = False
         self._segment_preview_message_ids = set()
         # #29346: a tool/segment boundary means what we delivered was an interim
@@ -990,6 +995,16 @@ class GatewayStreamConsumer:
         final_text = self._clean_for_display(text)
         continuation = self._continuation_text(final_text)
         self._fallback_final_send = False
+        if (
+            not continuation.strip()
+            and final_text.strip()
+            and self._fallback_preview_missing
+        ):
+            # The cached visible prefix is no longer trustworthy: the platform
+            # explicitly reported that the preview was deleted/missing. Recover
+            # with the complete answer even though the local text cache matches.
+            continuation = final_text
+            self._fallback_preview_missing = False
         if not continuation.strip():
             # Some platforms treat a successful streaming preview as durable
             # delivery. Telegram clients can instead lose or retain only part
@@ -1151,6 +1166,7 @@ class GatewayStreamConsumer:
         self._final_content_delivered = True
         self._last_sent_text = chunks[-1]
         self._fallback_prefix = ""
+        self._fallback_preview_missing = False
         self._fallback_preserve_partial_messages = False
 
     async def _send_empty_fallback_final(self, final_text: str) -> str:
@@ -1224,6 +1240,19 @@ class GatewayStreamConsumer:
         self._fallback_preserve_partial_messages = False
         self._notify_new_message()
         return "delivered"
+
+    @staticmethod
+    def _edit_failure_proves_preview_missing(result_or_exc: Any) -> bool:
+        """Return True only when an edit failure confirms the preview is gone."""
+        error = str(getattr(result_or_exc, "error", None) or result_or_exc).lower()
+        markers = (
+            "message to edit not found",
+            "message not found",
+            "message_id_invalid",
+            "message id invalid",
+            "message has been deleted",
+        )
+        return any(marker in error for marker in markers)
 
     @staticmethod
     def _send_failure_may_have_delivered(result_or_exc: Any) -> bool:
@@ -1793,6 +1822,7 @@ class GatewayStreamConsumer:
                     )
                     if result.success:
                         self._already_sent = True
+                        self._fallback_preview_missing = False
                         # Record any continuation fragments an oversized edit
                         # split off, so fresh-final can clean them all up.
                         self._track_preview_ids_from_result(result)
@@ -1824,6 +1854,9 @@ class GatewayStreamConsumer:
                         self._flood_strikes = 0
                         return True
                     else:
+                        self._fallback_preview_missing = (
+                            self._edit_failure_proves_preview_missing(result)
+                        )
                         if (
                             finalize
                             and is_turn_final

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1227,9 +1227,15 @@ class GatewayStreamConsumer:
 
     @staticmethod
     def _send_failure_may_have_delivered(result_or_exc: Any) -> bool:
-        """Return True for timeout failures where retrying may duplicate."""
+        """Return True for post-connect timeouts where retrying may duplicate."""
         error = str(getattr(result_or_exc, "error", None) or result_or_exc).lower()
         name = result_or_exc.__class__.__name__.lower()
+        compact_error = re.sub(r"[^a-z]", "", error)
+        # A connection timeout occurs before any request reaches the platform,
+        # so retrying cannot duplicate delivery. Keep this aligned with
+        # BasePlatformAdapter._is_timeout_error and _is_retryable_error.
+        if "connecttimeout" in name or "connecttimeout" in compact_error:
+            return False
         is_timeout = (
             "timeout" in error
             or "timed out" in error

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1228,11 +1228,20 @@ class GatewayStreamConsumer:
     @staticmethod
     def _send_failure_may_have_delivered(result_or_exc: Any) -> bool:
         """Return True for timeout failures where retrying may duplicate."""
-        if getattr(result_or_exc, "retryable", None) is True:
-            return False
         error = str(getattr(result_or_exc, "error", None) or result_or_exc).lower()
         name = result_or_exc.__class__.__name__.lower()
-        return "timeout" in error or "timed out" in error or "timeout" in name
+        is_timeout = (
+            "timeout" in error
+            or "timed out" in error
+            or "timeout" in name
+        )
+        if is_timeout:
+            # ``retryable`` means another idempotent request may be attempted;
+            # it does not mean the first request definitely failed before
+            # reaching the platform. Telegram marks transport timeouts
+            # retryable even when the server may already have applied the edit.
+            return True
+        return False
 
     def _fallback_flood_retry_delay(self, result: Any) -> float | None:
         """Return a bounded retry delay for a fallback send, if safe to retry."""
@@ -1806,6 +1815,25 @@ class GatewayStreamConsumer:
                         self._flood_strikes = 0
                         return True
                     else:
+                        if (
+                            finalize
+                            and is_turn_final
+                            and self._visible_prefix() == text
+                            and self._send_failure_may_have_delivered(result)
+                        ):
+                            # The complete answer is already visible in the last
+                            # streaming frame, and a timeout cannot tell us
+                            # whether Telegram applied this cosmetic final edit
+                            # before the acknowledgement was lost. Treat that
+                            # outcome as delivered instead of fresh-sending the
+                            # same answer and best-effort deleting the preview —
+                            # during the same degraded connection the delete can
+                            # fail, leaving two identical messages on screen.
+                            self._already_sent = True
+                            self._final_response_sent = True
+                            self._final_content_delivered = True
+                            self._fallback_final_send = False
+                            return True
                         immediate_final_fallback = False
                         if (
                             finalize

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1057,6 +1057,7 @@ class GatewayStreamConsumer:
                     and self._last_sent_text
                     and self.cfg.cursor
                     and self._last_sent_text.endswith(self.cfg.cursor)
+                    and self._flood_strikes == 0
                 ):
                     clean_text = self._last_sent_text[:-len(self.cfg.cursor)]
                     try:
@@ -1849,7 +1850,17 @@ class GatewayStreamConsumer:
                             self._last_sent_text = ""
                             self._notify_new_message()
                         else:
-                            self._last_sent_text = text
+                            raw_response = getattr(result, "raw_response", None)
+                            visible_content = (
+                                raw_response.get("visible_content")
+                                if isinstance(raw_response, dict)
+                                else None
+                            )
+                            self._last_sent_text = (
+                                visible_content
+                                if isinstance(visible_content, str)
+                                else text
+                            )
                         # Successful edit — reset flood strike counter
                         self._flood_strikes = 0
                         return True

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1231,10 +1231,13 @@ class GatewayStreamConsumer:
         error = str(getattr(result_or_exc, "error", None) or result_or_exc).lower()
         name = result_or_exc.__class__.__name__.lower()
         compact_error = re.sub(r"[^a-z]", "", error)
-        # A connection timeout occurs before any request reaches the platform,
-        # so retrying cannot duplicate delivery. Keep this aligned with
-        # BasePlatformAdapter._is_timeout_error and _is_retryable_error.
-        if "connecttimeout" in name or "connecttimeout" in compact_error:
+        # ConnectTimeout and PoolTimeout both occur before a request reaches
+        # the platform, so retrying cannot duplicate delivery. Keep this aligned
+        # with the transport's pre-send timeout semantics.
+        if any(
+            timeout_kind in name or timeout_kind in compact_error
+            for timeout_kind in ("connecttimeout", "pooltimeout")
+        ):
             return False
         is_timeout = (
             "timeout" in error

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4486,13 +4486,21 @@ class TelegramAdapter(BasePlatformAdapter):
             _is_transient = any(m in err_str for m in _transient_markers)
             if _is_transient:
                 safe_error = _redact_telegram_error_text(e)
+                error_type = e.__class__.__name__
                 logger.warning(
                     "[%s] Transient network error editing message %s (will retry): %s",
                     self.name,
                     message_id,
                     safe_error,
                 )
-                return SendResult(success=False, error=safe_error, retryable=True)
+                # Preserve the exception kind after redaction so the stream
+                # consumer can distinguish a safe-to-retry ConnectTimeout from
+                # an ambiguous read/write timeout that may already have landed.
+                return SendResult(
+                    success=False,
+                    error=f"{error_type}: {safe_error}",
+                    retryable=True,
+                )
             safe_error = _redact_telegram_error_text(e)
             logger.error(
                 "[%s] Failed to edit Telegram message %s: %s",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -592,10 +592,12 @@ class TelegramAdapter(BasePlatformAdapter):
     # budget while the completed answer remains undelivered. Move directly to
     # the final fallback path instead.
     FALLBACK_ON_FINAL_EDIT_FLOOD: bool = True
-    # A failed final edit can leave Telegram clients with only a partial or
-    # non-durable preview. Commit empty-tail fallbacks as a fresh final message
-    # instead of trusting the preview as completed delivery.
-    RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK: bool = True
+    # A completed edit preview is already a durable Telegram message.  Fresh-
+    # sending the same text and then best-effort deleting that preview can leave
+    # duplicates whenever cleanup fails, especially during the same degraded
+    # connection that caused finalization to fail.  Keep a complete preview in
+    # place; the fallback still sends any genuinely missing tail.
+    RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK: bool = False
 
     # Adaptive text-batch ingress: short messages need a tighter delay so the
     # first token reaches the agent fast.  Numbers tuned for "feels instant":

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4487,6 +4487,20 @@ class TelegramAdapter(BasePlatformAdapter):
             if _is_transient:
                 safe_error = _redact_telegram_error_text(e)
                 error_type = e.__class__.__name__
+                cause = e.__cause__ or e.__context__
+                seen_causes: set[int] = set()
+                while cause is not None and id(cause) not in seen_causes:
+                    seen_causes.add(id(cause))
+                    cause_type = cause.__class__.__name__
+                    if cause_type in {
+                        "ConnectTimeout",
+                        "PoolTimeout",
+                        "ReadTimeout",
+                        "WriteTimeout",
+                    }:
+                        error_type = cause_type
+                        break
+                    cause = cause.__cause__ or cause.__context__
                 logger.warning(
                     "[%s] Transient network error editing message %s (will retry): %s",
                     self.name,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4343,6 +4343,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # (#48648).  The full content is delivered when finalize=True.
         _preview_key = (str(chat_id), str(message_id))
         _saturated_preview = False
+        _preview_raw_response = None
         if finalize:
             # Any saturation state for this message is finished with — the
             # final edit always delivers real (full) content.
@@ -4354,6 +4355,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             content = self._truncate_stream_overflow_preview(content)
             _saturated_preview = True
+            _preview_raw_response = {
+                "preview_truncated": True,
+                "visible_content": content,
+            }
             # Saturated-preview dedup: past the cap, every progressive edit
             # truncates to the same text. Re-sending it is a visual no-op that
             # still burns flood budget (Telegram counts the request and answers
@@ -4361,7 +4366,11 @@ class TelegramAdapter(BasePlatformAdapter):
             # stream trips flood control (200s+ penalties) and hangs the final
             # delivery. Skip silently until finalize.
             if self._last_overflow_preview.get(_preview_key) == content:
-                return SendResult(success=True, message_id=message_id)
+                return SendResult(
+                    success=True,
+                    message_id=message_id,
+                    raw_response=_preview_raw_response,
+                )
         elif not finalize:
             # Content shrank back under the cap (segment break / new message
             # id) — clear stale saturation state so dedup can't mask a real
@@ -4377,7 +4386,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = content
-                return SendResult(success=True, message_id=message_id)
+                return SendResult(
+                    success=True,
+                    message_id=message_id,
+                    raw_response=_preview_raw_response,
+                )
 
             formatted = self.format_message(content)
             try:
@@ -4426,14 +4439,28 @@ class TelegramAdapter(BasePlatformAdapter):
                 truncated = self._truncate_stream_overflow_preview(content)
                 if self._last_overflow_preview.get(_preview_key) == truncated:
                     # Saturated-preview dedup (see pre-flight path above).
-                    return SendResult(success=True, message_id=message_id)
+                    return SendResult(
+                        success=True,
+                        message_id=message_id,
+                        raw_response={
+                            "preview_truncated": True,
+                            "visible_content": truncated,
+                        },
+                    )
                 await self._bot.edit_message_text(
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     text=truncated,
                 )
                 self._last_overflow_preview[_preview_key] = truncated
-                return SendResult(success=True, message_id=message_id)
+                return SendResult(
+                    success=True,
+                    message_id=message_id,
+                    raw_response={
+                        "preview_truncated": True,
+                        "visible_content": truncated,
+                    },
+                )
             # Flood control / RetryAfter — short waits are retried inline,
             # long waits return a failure immediately so streaming can fall back
             # to a normal final send instead of leaving a truncated partial.

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -138,6 +138,7 @@ async def test_turn_final_flood_keeps_complete_preview_without_fresh_resend():
 
     adapter.send.assert_not_awaited()
     adapter.delete_message.assert_not_awaited()
+    assert adapter.edit_message.await_count == 1
     assert consumer.message_id == "preview-1"
     assert consumer.final_response_sent is True
     assert consumer.final_content_delivered is True

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -27,6 +27,9 @@ def _adapter() -> MagicMock:
 async def test_turn_final_flood_immediately_delivers_missing_tail():
     """A short visible preview must not suppress the completed answer."""
     adapter = _adapter()
+    adapter.RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK = (
+        TelegramAdapter.RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK
+    )
     adapter.edit_message.return_value = SendResult(
         success=False,
         error="Flood control exceeded. Retry in 180 seconds",
@@ -97,15 +100,17 @@ async def test_non_opt_in_adapter_keeps_adaptive_final_edit_retry():
 
 
 @pytest.mark.asyncio
-async def test_turn_final_flood_commits_empty_tail_as_fresh_message():
-    """Telegram gets a durable final even when the internal tail is empty."""
+async def test_turn_final_flood_keeps_complete_preview_without_fresh_resend():
+    """Telegram must not send-then-delete when the whole answer is already visible."""
     adapter = _adapter()
+    adapter.RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK = (
+        TelegramAdapter.RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK
+    )
     adapter.edit_message.return_value = SendResult(
         success=False,
         error="Flood control exceeded. Retry in 30 seconds",
         retry_after=30.0,
     )
-    adapter.send.return_value = SendResult(success=True, message_id="final-1")
 
     consumer = GatewayStreamConsumer(
         adapter,
@@ -131,11 +136,9 @@ async def test_turn_final_flood_commits_empty_tail_as_fresh_message():
 
     await consumer._send_fallback_final(final_text)
 
-    adapter.send.assert_awaited_once()
-    assert adapter.send.await_args.kwargs["content"] == final_text
-    assert adapter.send.await_args.kwargs["metadata"] == {"notify": True}
-    adapter.delete_message.assert_awaited_once_with("chat-1", "preview-1")
-    assert consumer.message_id == "final-1"
+    adapter.send.assert_not_awaited()
+    adapter.delete_message.assert_not_awaited()
+    assert consumer.message_id == "preview-1"
     assert consumer.final_response_sent is True
     assert consumer.final_content_delivered is True
 

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -277,17 +277,22 @@ async def test_telegram_connect_timeout_preserves_safe_retry_classification():
     class ConnectTimeout(Exception):
         pass
 
+    class TimedOut(Exception):
+        pass
+
+    connect_timeout = ConnectTimeout("connection timed out")
+    wrapped_timeout = TimedOut("timed out")
+    wrapped_timeout.__cause__ = connect_timeout
+
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
     bot = MagicMock()
-    bot.edit_message_text = AsyncMock(
-        side_effect=ConnectTimeout("connection timed out")
-    )
+    bot.edit_message_text = AsyncMock(side_effect=wrapped_timeout)
     adapter._bot = bot
 
     result = await adapter.edit_message("123", "456", "Final answer", finalize=False)
 
     assert result.success is False
-    assert result.error == "ConnectTimeout: connection timed out"
+    assert result.error == "ConnectTimeout: timed out"
     assert result.retryable is True
     assert GatewayStreamConsumer._send_failure_may_have_delivered(result) is False
 
@@ -350,4 +355,13 @@ def test_connect_timeout_is_not_treated_as_ambiguous_delivery():
 
     assert GatewayStreamConsumer._send_failure_may_have_delivered(
         ConnectTimeout("connection timed out")
+    ) is False
+
+
+def test_pool_timeout_is_not_treated_as_ambiguous_delivery():
+    class PoolTimeout(Exception):
+        pass
+
+    assert GatewayStreamConsumer._send_failure_may_have_delivered(
+        PoolTimeout("connection pool exhausted")
     ) is False

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -273,6 +273,26 @@ async def test_telegram_long_flood_result_keeps_retry_after():
 
 
 @pytest.mark.asyncio
+async def test_telegram_connect_timeout_preserves_safe_retry_classification():
+    class ConnectTimeout(Exception):
+        pass
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    bot = MagicMock()
+    bot.edit_message_text = AsyncMock(
+        side_effect=ConnectTimeout("connection timed out")
+    )
+    adapter._bot = bot
+
+    result = await adapter.edit_message("123", "456", "Final answer", finalize=False)
+
+    assert result.success is False
+    assert result.error == "ConnectTimeout: connection timed out"
+    assert result.retryable is True
+    assert GatewayStreamConsumer._send_failure_may_have_delivered(result) is False
+
+
+@pytest.mark.asyncio
 async def test_ambiguous_empty_tail_timeout_preserves_duplicate_suppression():
     adapter = _adapter()
     adapter.send.return_value = SimpleNamespace(
@@ -322,3 +342,12 @@ def test_timeout_exception_is_treated_as_ambiguous_delivery():
     assert GatewayStreamConsumer._send_failure_may_have_delivered(
         TimedOut("request timed out")
     ) is True
+
+
+def test_connect_timeout_is_not_treated_as_ambiguous_delivery():
+    class ConnectTimeout(Exception):
+        pass
+
+    assert GatewayStreamConsumer._send_failure_may_have_delivered(
+        ConnectTimeout("connection timed out")
+    ) is False

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -141,6 +141,48 @@ async def test_turn_final_flood_commits_empty_tail_as_fresh_message():
 
 
 @pytest.mark.asyncio
+async def test_turn_final_timeout_with_complete_preview_does_not_fresh_resend():
+    """An ambiguous final-edit timeout must not duplicate a complete preview.
+
+    Telegram may apply an edit server-side but time out before returning the
+    acknowledgement.  If the last streaming frame already contains the entire
+    answer, treating that timeout as a confirmed failure enters the fresh-final
+    fallback and can leave two identical messages when preview cleanup also
+    fails on the degraded connection.
+    """
+    adapter = _adapter()
+    adapter.edit_message.return_value = SendResult(
+        success=False,
+        error="Timed out",
+        retryable=True,
+    )
+
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-1",
+        StreamConsumerConfig(cursor=" ▉"),
+    )
+    final_text = "The complete answer"
+    consumer._message_id = "preview-1"
+    consumer._preview_message_ids = {"preview-1"}
+    consumer._last_sent_text = f"{final_text} ▉"
+    consumer._already_sent = True
+
+    ok = await consumer._send_or_edit(
+        final_text,
+        finalize=True,
+        is_turn_final=True,
+    )
+
+    assert ok is True
+    assert consumer._fallback_final_send is False
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+    adapter.send.assert_not_awaited()
+    adapter.delete_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_empty_tail_commit_honors_retry_after(monkeypatch):
     adapter = _adapter()
     adapter.send.side_effect = [

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -144,6 +144,39 @@ async def test_turn_final_flood_keeps_complete_preview_without_fresh_resend():
 
 
 @pytest.mark.asyncio
+async def test_confirmed_missing_preview_recovers_with_full_final_send():
+    adapter = _adapter()
+    adapter.edit_message.return_value = SendResult(
+        success=False,
+        error="Bad Request: message to edit not found",
+        retryable=False,
+    )
+    adapter.send.return_value = SendResult(success=True, message_id="fresh-final")
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+    consumer._already_sent = True
+    consumer._message_id = "deleted-preview"
+    consumer._last_sent_text = "Final answer"
+
+    edit_succeeded = await consumer._send_or_edit(
+        "Final answer",
+        finalize=True,
+        is_turn_final=True,
+    )
+
+    assert edit_succeeded is False
+    assert consumer._fallback_final_send is True
+    assert consumer._fallback_preview_missing is True
+
+    await consumer._send_fallback_final("Final answer")
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.kwargs["content"] == "Final answer"
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
 async def test_turn_final_timeout_with_complete_preview_does_not_fresh_resend():
     """An ambiguous final-edit timeout must not duplicate a complete preview.
 

--- a/tests/gateway/test_telegram_overflow_partial.py
+++ b/tests/gateway/test_telegram_overflow_partial.py
@@ -8,7 +8,7 @@ import pytest
 from gateway.config import PlatformConfig
 from gateway.platforms.base import SendResult
 from plugins.platforms.telegram.adapter import TelegramAdapter
-from gateway.stream_consumer import GatewayStreamConsumer
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 
 
 def _message(message_id: int | str) -> SimpleNamespace:
@@ -136,5 +136,62 @@ async def test_stream_consumer_fallback_sends_tail_after_partial_overflow():
     assert adapter.send.await_args.kwargs["content"] == "world"
     assert adapter.send.await_args.kwargs["metadata"] == {"thread_id": "77", "notify": True}
     adapter.delete_message.assert_not_awaited()
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_tracks_saturated_preview_and_recovers_after_timeout(
+    telegram_adapter,
+):
+    """A truncated progressive edit must never count as the complete final answer."""
+    content = "word " * 120
+    telegram_adapter._bot.edit_message_text = AsyncMock(return_value=True)
+    real_edit = telegram_adapter.edit_message
+
+    async def edit_then_timeout(*args, **kwargs):
+        if kwargs.get("finalize"):
+            return SendResult(
+                success=False,
+                error="TimedOut: Timed out",
+                retryable=True,
+            )
+        return await real_edit(*args, **kwargs)
+
+    telegram_adapter.edit_message = edit_then_timeout
+    telegram_adapter.send = AsyncMock(
+        return_value=SendResult(success=True, message_id="fresh-final")
+    )
+    telegram_adapter.delete_message = AsyncMock(return_value=True)
+
+    consumer = GatewayStreamConsumer(
+        telegram_adapter,
+        "12345",
+        config=StreamConsumerConfig(cursor=""),
+    )
+    consumer._already_sent = True
+    consumer._message_id = "201"
+
+    assert await consumer._send_or_edit(content, finalize=False) is True
+    visible_preview = telegram_adapter._bot.edit_message_text.await_args.kwargs["text"]
+    assert len(visible_preview) < len(content)
+    assert consumer._last_sent_text == visible_preview
+
+    assert await consumer._send_or_edit(
+        content,
+        finalize=True,
+        is_turn_final=True,
+    ) is False
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is False
+    assert consumer._fallback_final_send is True
+
+    await consumer._send_fallback_final(content)
+
+    delivered = "".join(
+        call.kwargs["content"]
+        for call in telegram_adapter.send.await_args_list
+    )
+    assert delivered == content
     assert consumer.final_response_sent is True
     assert consumer.final_content_delivered is True


### PR DESCRIPTION
## Bug Description

Telegram can leave duplicate assistant finals after streaming when the final edit encounters an ambiguous timeout or flood-control failure. A second failure mode could silently drop the tail of responses longer than Telegram's 4,096-UTF-16-unit edit limit.

## Root Cause

The final-delivery fallback treated a failed final edit as if the visible preview were not delivered, even when its tracked visible prefix already equaled the complete answer. Post-connect timeouts are ambiguous because Telegram may apply `editMessageText` before the acknowledgement is lost.

A later adversarial review found that saturated progressive previews were truncated by the Telegram adapter but reported as ordinary successful edits. The stream consumer therefore recorded the full requested text as visible. If final overflow delivery then timed out, Hermes could falsely mark the complete answer delivered while only the truncated preview was on screen.

PTB also wraps HTTPX timeout classes, so checking only the outer exception lost the distinction between safe pre-delivery connect/pool failures and ambiguous read/write failures.

## Fix

- Keep a complete visible preview after ambiguous final-edit timeouts or flood control instead of fresh-sending the same answer.
- Avoid a second cursor-stripping edit after an immediate flood fallback.
- Report the exact visible truncated preview through `SendResult.raw_response` and track that value in the stream consumer.
- Recover the complete final answer when a saturated preview is incomplete and final delivery times out.
- Preserve wrapped HTTPX timeout kinds by traversing exception causes/contexts with cycle protection.
- Keep `ConnectTimeout`/`PoolTimeout` safely retryable while treating read/write timeouts as ambiguous.
- Recover with a complete send when Telegram affirmatively reports the preview deleted/missing.
- Preserve existing missing-tail recovery for genuinely incomplete previews.

## Test Plan

- [x] Red/green integration regression using the real Telegram truncating adapter path and an ambiguous final timeout.
- [x] Regression proving flood fallback does not spend a second edit attempt.
- [x] Regressions for ambiguous timeout, flood control, confirmed deleted preview, incomplete-preview tail delivery, and wrapped timeout classification.
- [x] Rebased onto current `origin/main` (`7cb2d2cd4`).
- [x] Focused final-delivery/overflow/stream-consumer surface: `227 passed`.
- [x] Combined current-upstream gateway suite with PR #66027: `9462 passed, 13 skipped, 15 failed`.
- [x] Untouched current `origin/main` under the same environment: `9449 passed, 13 skipped, 15 failed`.
- [x] The 15 failing node IDs are identical between baseline and combined trees; the combined tree adds 13 passing regressions and introduces no new failures.
- [x] Fresh isolated adversarial regressions: `5 passed`.
- [x] `git diff --check` and Ruff pass.

## Risk Assessment

Low-to-moderate. The change affects only Telegram streaming finalization, timeout classification, and the consumer's accounting of what a successful edit actually displayed. Complete previews remain duplicate-safe; truncated/missing previews retain full-answer recovery.
