### PR TITLE
fix(telegram): reply to latest queued follow-up

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2115,11 +2115,24 @@ def _refresh_merged_event_trigger_metadata(
     # prompt prefix.
     if event.message_id is not None:
         existing.message_id = event.message_id
+    if event.source is not None:
+        existing.source = event.source
+    existing.raw_message = event.raw_message
+    existing.platform_update_id = event.platform_update_id
     existing.reply_to_message_id = event.reply_to_message_id
     existing.reply_to_text = event.reply_to_text
     existing.reply_to_author_id = event.reply_to_author_id
     existing.reply_to_author_name = event.reply_to_author_name
     existing.reply_to_is_own_message = event.reply_to_is_own_message
+    existing.auto_skill = event.auto_skill
+    existing.channel_prompt = event.channel_prompt
+    existing.channel_context = event.channel_context
+    # A merged event may bypass authorization only when every constituent was
+    # already trusted as internal. Never let an internal notification elevate
+    # a user-originated follow-up (or vice versa).
+    existing.internal = existing.internal and event.internal
+    existing.metadata = {**(existing.metadata or {}), **(event.metadata or {})}
+    existing.timestamp = event.timestamp
 
 
 def merge_pending_message_event(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2164,8 +2164,11 @@ def merge_pending_message_event(
             # The merged event becomes the next turn's trigger. Keep its reply
             # target and injected reply context aligned with the newest user
             # message rather than the first message that occupied the pending
-            # slot; otherwise Telegram visibly quotes a stale follow-up.
-            existing.message_id = event.message_id
+            # slot; otherwise Telegram visibly quotes a stale follow-up. A
+            # synthetic/internal follow-up may not have a platform message id;
+            # preserve the last usable anchor in that case.
+            if event.message_id is not None:
+                existing.message_id = event.message_id
             existing.reply_to_message_id = event.reply_to_message_id
             existing.reply_to_text = event.reply_to_text
             existing.reply_to_author_id = event.reply_to_author_id

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2104,6 +2104,24 @@ class EphemeralReply(str):
         return str.__str__(self)
 
 
+def _refresh_merged_event_trigger_metadata(
+    existing: MessageEvent,
+    event: MessageEvent,
+) -> None:
+    """Align a merged event's trigger and reply context with its newest input."""
+    # Synthetic/internal follow-ups may not have a platform message id; keep
+    # the last concrete anchor in that case. Reply context is still replaced
+    # so an unquoted newer message cannot inherit an older quoted-message
+    # prompt prefix.
+    if event.message_id is not None:
+        existing.message_id = event.message_id
+    existing.reply_to_message_id = event.reply_to_message_id
+    existing.reply_to_text = event.reply_to_text
+    existing.reply_to_author_id = event.reply_to_author_id
+    existing.reply_to_author_name = event.reply_to_author_name
+    existing.reply_to_is_own_message = event.reply_to_is_own_message
+
+
 def merge_pending_message_event(
     pending_messages: Dict[str, MessageEvent],
     session_key: str,
@@ -2134,6 +2152,7 @@ def merge_pending_message_event(
             existing.media_types.extend(event.media_types)
             if event.text:
                 existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
+            _refresh_merged_event_trigger_metadata(existing, event)
             return
 
         if existing_has_media or incoming_has_media:
@@ -2152,6 +2171,7 @@ def merge_pending_message_event(
                 and event.message_type != MessageType.TEXT
             ):
                 existing.message_type = event.message_type
+            _refresh_merged_event_trigger_metadata(existing, event)
             return
 
         if (
@@ -2162,18 +2182,10 @@ def merge_pending_message_event(
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
             # The merged event becomes the next turn's trigger. Keep its reply
-            # target and injected reply context aligned with the newest user
-            # message rather than the first message that occupied the pending
-            # slot; otherwise Telegram visibly quotes a stale follow-up. A
-            # synthetic/internal follow-up may not have a platform message id;
-            # preserve the last usable anchor in that case.
-            if event.message_id is not None:
-                existing.message_id = event.message_id
-            existing.reply_to_message_id = event.reply_to_message_id
-            existing.reply_to_text = event.reply_to_text
-            existing.reply_to_author_id = event.reply_to_author_id
-            existing.reply_to_author_name = event.reply_to_author_name
-            existing.reply_to_is_own_message = event.reply_to_is_own_message
+            # target and injected reply context aligned with the newest input;
+            # otherwise Telegram can visibly quote one message while the model
+            # receives stale quoted-message context from another.
+            _refresh_merged_event_trigger_metadata(existing, event)
             return
 
     pending_messages[session_key] = event
@@ -4360,12 +4372,7 @@ class BasePlatformAdapter(ABC):
                     if state.event.text
                     else event.text
                 )
-            latest_message_id = getattr(event, "message_id", None)
-            latest_anchor = latest_message_id or getattr(event, "reply_to_message_id", None)
-            if latest_message_id is not None:
-                state.event.message_id = str(latest_message_id)
-            if latest_anchor is not None and hasattr(state.event, "reply_to_message_id"):
-                state.event.reply_to_message_id = str(latest_anchor)
+            _refresh_merged_event_trigger_metadata(state.event, event)
             state.last_ts = now
 
         if state.task is not None and not state.task.done():

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2161,6 +2161,16 @@ def merge_pending_message_event(
         ):
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            # The merged event becomes the next turn's trigger. Keep its reply
+            # target and injected reply context aligned with the newest user
+            # message rather than the first message that occupied the pending
+            # slot; otherwise Telegram visibly quotes a stale follow-up.
+            existing.message_id = event.message_id
+            existing.reply_to_message_id = event.reply_to_message_id
+            existing.reply_to_text = event.reply_to_text
+            existing.reply_to_author_id = event.reply_to_author_id
+            existing.reply_to_author_name = event.reply_to_author_name
+            existing.reply_to_is_own_message = event.reply_to_is_own_message
             return
 
     pending_messages[session_key] = event

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -266,6 +266,7 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     SUPPORTED_IMAGE_DOCUMENT_TYPES,
     _TEXT_INJECT_EXTENSIONS,
+    _refresh_merged_event_trigger_metadata,
     utf16_len,
 )
 from plugins.platforms.telegram.telegram_ids import (
@@ -8191,6 +8192,7 @@ class TelegramAdapter(BasePlatformAdapter):
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
+            _refresh_merged_event_trigger_metadata(existing, event)
 
         # Cancel any pending flush and restart the timer
         prior_task = self._pending_text_batch_tasks.get(key)
@@ -8295,6 +8297,7 @@ class TelegramAdapter(BasePlatformAdapter):
             existing.media_types.extend(event.media_types)
             if event.text:
                 existing.text = self._merge_caption(existing.text, event.text)
+            _refresh_merged_event_trigger_metadata(existing, event)
 
         prior_task = self._pending_photo_batch_tasks.get(batch_key)
         if prior_task and not prior_task.done():
@@ -8603,6 +8606,7 @@ class TelegramAdapter(BasePlatformAdapter):
             existing.media_types.extend(event.media_types)
             if event.text:
                 existing.text = self._merge_caption(existing.text, event.text)
+            _refresh_merged_event_trigger_metadata(existing, event)
 
         prior_task = self._media_group_tasks.get(media_group_id)
         if prior_task:

--- a/tests/gateway/test_active_session_text_merge.py
+++ b/tests/gateway/test_active_session_text_merge.py
@@ -47,6 +47,12 @@ def _make_event(
     user_id: str = "u1",
     user_name: str | None = None,
     thread_id: str | None = None,
+    message_id: str | None = None,
+    reply_to_message_id: str | None = None,
+    reply_to_text: str | None = None,
+    reply_to_author_id: str | None = None,
+    reply_to_author_name: str | None = None,
+    reply_to_is_own_message: bool = False,
 ) -> MessageEvent:
     source = SessionSource(
         platform=Platform.TELEGRAM,
@@ -60,7 +66,12 @@ def _make_event(
         text=text,
         message_type=MessageType.TEXT,
         source=source,
-        message_id=f"msg-{text[:8]}",
+        message_id=message_id or f"msg-{text[:8]}",
+        reply_to_message_id=reply_to_message_id,
+        reply_to_text=reply_to_text,
+        reply_to_author_id=reply_to_author_id,
+        reply_to_author_name=reply_to_author_name,
+        reply_to_is_own_message=reply_to_is_own_message,
     )
 
 
@@ -153,6 +164,46 @@ async def test_debounce_buffers_rapid_text_then_flushes_to_pending():
 
     assert session_key not in adapter._text_debounce
     assert adapter._pending_messages[session_key].text == "part two\npart three"
+
+
+@pytest.mark.asyncio
+async def test_debounce_flush_keeps_latest_trigger_and_reply_context_aligned():
+    adapter = _make_adapter()
+    adapter._busy_text_debounce_seconds = 1.0
+
+    first = _make_event(
+        "first follow-up",
+        message_id="100",
+        reply_to_message_id="90",
+        reply_to_text="old quote",
+        reply_to_author_id="old-author",
+        reply_to_author_name="Old",
+        reply_to_is_own_message=True,
+    )
+    latest = _make_event(
+        "latest follow-up",
+        message_id="101",
+        reply_to_message_id="99",
+        reply_to_text="latest quote",
+        reply_to_author_id="new-author",
+        reply_to_author_name="New",
+        reply_to_is_own_message=False,
+    )
+    session_key = build_session_key(first.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    await adapter.handle_message(first)
+    await adapter.handle_message(latest)
+    assert await adapter._flush_text_debounce_now(session_key) is True
+
+    pending = adapter._pending_messages[session_key]
+    assert pending.text == "first follow-up\nlatest follow-up"
+    assert pending.message_id == "101"
+    assert pending.reply_to_message_id == "99"
+    assert pending.reply_to_text == "latest quote"
+    assert pending.reply_to_author_id == "new-author"
+    assert pending.reply_to_author_name == "New"
+    assert pending.reply_to_is_own_message is False
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -14,7 +14,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent, MessageType, merge_pending_message_event
+from gateway.platforms.base import (
+    MessageEvent,
+    MessageType,
+    _reply_anchor_for_event,
+    merge_pending_message_event,
+)
 from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
 from gateway.session import SessionSource, build_session_key
 
@@ -195,6 +200,54 @@ async def test_second_message_during_sentinel_queued_not_duplicate():
         # Let first message complete
         barrier.set()
         await task1
+
+
+def test_merge_pending_text_followups_reply_to_latest_message():
+    """A merged busy-turn reply must quote the newest user message."""
+    pending = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="u1",
+        thread_id="34457",
+    )
+    session_key = build_session_key(source)
+    first = MessageEvent(
+        text="first follow-up",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="100",
+        reply_to_message_id="50",
+        reply_to_text="older quoted message",
+        reply_to_author_id="old-author",
+        reply_to_author_name="Old Author",
+        reply_to_is_own_message=True,
+    )
+    latest = MessageEvent(
+        text="latest follow-up",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="101",
+        reply_to_message_id="60",
+        reply_to_text="latest quoted message",
+        reply_to_author_id="new-author",
+        reply_to_author_name="New Author",
+        reply_to_is_own_message=False,
+    )
+
+    merge_pending_message_event(pending, session_key, first, merge_text=True)
+    merge_pending_message_event(pending, session_key, latest, merge_text=True)
+
+    merged = pending[session_key]
+    assert merged.text == "first follow-up\nlatest follow-up"
+    assert merged.message_id == "101"
+    assert _reply_anchor_for_event(merged) == "101"
+    assert merged.reply_to_message_id == "60"
+    assert merged.reply_to_text == "latest quoted message"
+    assert merged.reply_to_author_id == "new-author"
+    assert merged.reply_to_author_name == "New Author"
+    assert merged.reply_to_is_own_message is False
 
 
 def test_merge_pending_message_event_merges_text_and_photo_followups():

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -303,11 +303,17 @@ def test_merge_pending_message_event_merges_text_and_photo_followups():
         text="first follow-up",
         message_type=MessageType.TEXT,
         source=source,
+        message_id="100",
+        reply_to_message_id="90",
+        reply_to_text="old quote",
     )
     photo_event = MessageEvent(
         text="see screenshot",
         message_type=MessageType.PHOTO,
         source=source,
+        message_id="101",
+        reply_to_message_id="99",
+        reply_to_text="latest quote",
         media_urls=["/tmp/test.png"],
         media_types=["image/png"],
     )
@@ -320,6 +326,9 @@ def test_merge_pending_message_event_merges_text_and_photo_followups():
     assert merged.text == "first follow-up\n\nsee screenshot"
     assert merged.media_urls == ["/tmp/test.png"]
     assert merged.media_types == ["image/png"]
+    assert merged.message_id == "101"
+    assert merged.reply_to_message_id == "99"
+    assert merged.reply_to_text == "latest quote"
 
 
 def test_merge_pending_message_event_promotes_document_followups_over_text():

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -250,6 +250,45 @@ def test_merge_pending_text_followups_reply_to_latest_message():
     assert merged.reply_to_is_own_message is False
 
 
+def test_merge_pending_text_followup_clears_stale_reply_context():
+    pending = {}
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+    first = MessageEvent(
+        text="first",
+        source=source,
+        message_id="100",
+        reply_to_message_id="50",
+        reply_to_text="stale quote",
+        reply_to_author_id="old-author",
+        reply_to_author_name="Old Author",
+        reply_to_is_own_message=True,
+    )
+    latest = MessageEvent(text="latest", source=source, message_id="101")
+
+    merge_pending_message_event(pending, "session", first, merge_text=True)
+    merge_pending_message_event(pending, "session", latest, merge_text=True)
+
+    merged = pending["session"]
+    assert merged.message_id == "101"
+    assert merged.reply_to_message_id is None
+    assert merged.reply_to_text is None
+    assert merged.reply_to_author_id is None
+    assert merged.reply_to_author_name is None
+    assert merged.reply_to_is_own_message is False
+
+
+def test_merge_pending_text_followup_without_id_preserves_existing_anchor():
+    pending = {}
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+    first = MessageEvent(text="first", source=source, message_id="100")
+    synthetic = MessageEvent(text="synthetic", source=source, message_id=None)
+
+    merge_pending_message_event(pending, "session", first, merge_text=True)
+    merge_pending_message_event(pending, "session", synthetic, merge_text=True)
+
+    assert pending["session"].message_id == "100"
+
+
 def test_merge_pending_message_event_merges_text_and_photo_followups():
     pending = {}
     source = SessionSource(

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -289,6 +289,47 @@ def test_merge_pending_text_followup_without_id_preserves_existing_anchor():
     assert pending["session"].message_id == "100"
 
 
+def test_merge_pending_refreshes_latest_event_provenance_without_privilege_escalation():
+    pending = {}
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+    first_raw = object()
+    latest_raw = object()
+    first = MessageEvent(
+        text="internal completion",
+        source=source,
+        raw_message=first_raw,
+        message_id="100",
+        platform_update_id=10,
+        channel_prompt="old prompt",
+        channel_context="old context",
+        internal=True,
+        metadata={"old": True, "shared": "old"},
+    )
+    latest = MessageEvent(
+        text="user follow-up",
+        source=source,
+        raw_message=latest_raw,
+        message_id="101",
+        platform_update_id=11,
+        channel_prompt="new prompt",
+        channel_context="new context",
+        internal=False,
+        metadata={"new": True, "shared": "new"},
+    )
+
+    merge_pending_message_event(pending, "session", first, merge_text=True)
+    merge_pending_message_event(pending, "session", latest, merge_text=True)
+
+    merged = pending["session"]
+    assert merged.raw_message is latest_raw
+    assert merged.platform_update_id == 11
+    assert merged.timestamp == latest.timestamp
+    assert merged.channel_prompt == "new prompt"
+    assert merged.channel_context == "new context"
+    assert merged.metadata == {"old": True, "new": True, "shared": "new"}
+    assert merged.internal is False
+
+
 def test_merge_pending_message_event_merges_text_and_photo_followups():
     pending = {}
     source = SessionSource(

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -97,6 +97,52 @@ class TestTextBatching:
         assert "split by Telegram" in dispatched.text
 
     @pytest.mark.asyncio
+    async def test_split_messages_use_latest_reply_and_trigger_metadata(self):
+        """Ingress batching must not preserve reply context from the first chunk."""
+        adapter = _make_adapter()
+        first = _make_event("first chunk")
+        first.message_id = "100"
+        first.reply_to_message_id = "50"
+        first.reply_to_text = "old quote"
+        first.reply_to_author_name = "Old Author"
+        first.reply_to_is_own_message = True
+        first.raw_message = object()
+        first.platform_update_id = 10
+        first.internal = True
+        first.metadata = {"shared": "old", "old": True}
+
+        latest = _make_event("latest chunk")
+        latest.message_id = "101"
+        latest.reply_to_message_id = "60"
+        latest.reply_to_text = "latest quote"
+        latest.reply_to_author_name = "New Author"
+        latest.reply_to_is_own_message = False
+        latest_raw = object()
+        latest.raw_message = latest_raw
+        latest.platform_update_id = 11
+        latest.internal = False
+        latest.metadata = {"shared": "new", "new": True}
+
+        adapter._enqueue_text_event(first)
+        adapter._enqueue_text_event(latest)
+
+        batched = next(iter(adapter._pending_text_batches.values()))
+        assert batched.text == "first chunk\nlatest chunk"
+        assert batched.message_id == "101"
+        assert batched.reply_to_message_id == "60"
+        assert batched.reply_to_text == "latest quote"
+        assert batched.reply_to_author_name == "New Author"
+        assert batched.reply_to_is_own_message is False
+        assert batched.raw_message is latest_raw
+        assert batched.platform_update_id == 11
+        assert batched.metadata == {"old": True, "new": True, "shared": "new"}
+        assert batched.internal is False
+
+        for task in adapter._pending_text_batch_tasks.values():
+            task.cancel()
+        await asyncio.gather(*adapter._pending_text_batch_tasks.values(), return_exceptions=True)
+
+    @pytest.mark.asyncio
     async def test_three_way_split_aggregated(self):
         """Three rapid messages should all merge."""
         adapter = _make_adapter()
@@ -219,6 +265,68 @@ class TestTextBatching:
         adapter.handle_message.assert_not_called()
         assert adapter._pending_text_batches == {}
         assert adapter._pending_text_batch_tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_ingress_media_batches_use_latest_reply_target(self):
+        """Photo bursts and Telegram albums must anchor to their newest item."""
+        adapter = _make_adapter()
+        adapter._media_batch_delay_seconds = 60
+
+        first_photo = _make_event("first caption")
+        first_photo.message_type = MessageType.PHOTO
+        first_photo.message_id = "200"
+        first_photo.reply_to_message_id = "70"
+        first_photo.reply_to_text = "old photo quote"
+        first_photo.media_urls = ["/tmp/first.jpg"]
+        first_photo.media_types = ["image/jpeg"]
+        latest_photo = _make_event("latest caption")
+        latest_photo.message_type = MessageType.PHOTO
+        latest_photo.message_id = "201"
+        latest_photo.reply_to_message_id = "80"
+        latest_photo.reply_to_text = "latest photo quote"
+        latest_photo.media_urls = ["/tmp/latest.jpg"]
+        latest_photo.media_types = ["image/jpeg"]
+
+        adapter._enqueue_photo_event("photo-batch", first_photo)
+        adapter._enqueue_photo_event("photo-batch", latest_photo)
+        photo_batch = adapter._pending_photo_batches["photo-batch"]
+        assert photo_batch.message_id == "201"
+        assert photo_batch.reply_to_message_id == "80"
+        assert photo_batch.reply_to_text == "latest photo quote"
+
+        first_album = _make_event("first album caption")
+        first_album.message_type = MessageType.PHOTO
+        first_album.message_id = "300"
+        first_album.reply_to_message_id = "90"
+        first_album.reply_to_text = "old album quote"
+        first_album.media_urls = ["/tmp/album-first.jpg"]
+        first_album.media_types = ["image/jpeg"]
+        latest_album = _make_event("latest album caption")
+        latest_album.message_type = MessageType.PHOTO
+        latest_album.message_id = "301"
+        latest_album.reply_to_message_id = "91"
+        latest_album.reply_to_text = "latest album quote"
+        latest_album.media_urls = ["/tmp/album-latest.jpg"]
+        latest_album.media_types = ["image/jpeg"]
+
+        with patch(
+            "plugins.platforms.telegram.adapter.TelegramAdapter.MEDIA_GROUP_WAIT_SECONDS",
+            60,
+        ):
+            await adapter._queue_media_group_event("album", first_album)
+            await adapter._queue_media_group_event("album", latest_album)
+        album_batch = adapter._media_group_events["album"]
+        assert album_batch.message_id == "301"
+        assert album_batch.reply_to_message_id == "91"
+        assert album_batch.reply_to_text == "latest album quote"
+
+        tasks = [
+            *adapter._pending_photo_batch_tasks.values(),
+            *adapter._media_group_tasks.values(),
+        ]
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
     @pytest.mark.asyncio
     async def test_disconnected_adapter_drops_pending_photo_flush_before_dispatch(self):


### PR DESCRIPTION
## Bug Description

When multiple Telegram follow-ups arrive while a session is busy—or are coalesced by Telegram ingress batching—Hermes can combine their text but visibly reply to an older message or inject stale quoted-message context into the model.

## Root Cause

Merged events appended newer content while retaining parts of the first event's trigger tuple. The production queue-mode debounce path, Telegram text batching, photo batching, and album/media-group batching could bypass or partially apply the original metadata refresh.

That produced mixed events such as a newest `message_id` paired with an older `reply_to_text`, author, raw update, timestamp, or trust provenance. An internal event could also leave a merged user event marked internal.

## Fix

- Centralize merged-event trigger/reply/provenance refresh.
- Apply it to direct text/media merges, queue-mode debounce and flush, Telegram ingress text batching, photo batching, and media groups.
- Advance message ID, reply ID/text/author/ownership, raw message, platform update ID, timestamp, channel context, and metadata coherently to the newest event.
- Merge metadata with newest values winning.
- Keep a merged event `internal=True` only when every constituent event was internal, preventing privilege escalation.
- Preserve the last concrete platform message ID for intentionally ID-less synthetic inputs while replacing stale quoted-message context.

## Test Plan

- [x] Regressions for newest-message anchoring, clearing stale quotes, and ID-less synthetic inputs.
- [x] End-to-end queue debounce → flush regression verifies coherent newest reply metadata.
- [x] Telegram ingress text-batching regression verifies newest trigger/reply/provenance metadata.
- [x] Photo and album/media-group batching regression verifies newest reply targets.
- [x] Mixed internal/user merge regression verifies latest raw/update/channel metadata and no privilege escalation.
- [x] Rebased onto current `origin/main` (`7cb2d2cd4`).
- [x] Focused queue/debounce/batching/pending surface: `54 passed`.
- [x] Combined current-upstream gateway suite with PR #66026: `9462 passed, 13 skipped, 15 failed`.
- [x] Untouched current `origin/main` under the same environment: `9449 passed, 13 skipped, 15 failed`.
- [x] The 15 failing node IDs are identical between baseline and combined trees; the combined tree adds 13 passing regressions and introduces no new failures.
- [x] Fresh isolated adversarial regressions: `5 passed`.
- [x] `git diff --check` and Ruff pass.

## Risk Assessment

Low-to-moderate. Accumulated content and media behavior are unchanged; only the identity, reply context, provenance, and trust state of an already-merged event are made coherent with its newest constituent.
