### PR TITLE
fix(cron): isolate task workspace context

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2536,8 +2536,10 @@ def init_agent(
         except Exception as _ce_err:
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
+    from agent.runtime_cwd import resolve_tool_cwd
+
     agent._subdirectory_hints = SubdirectoryHintTracker(
-        working_dir=os.getenv("TERMINAL_CWD") or None,
+        working_dir=resolve_tool_cwd() or None,
     )
     agent._user_turn_count = 0
     # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
 from typing import Optional
 
-from agent.runtime_cwd import resolve_agent_cwd
+from agent.runtime_cwd import resolve_agent_cwd, resolve_tool_cwd
 from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS,
     ORG_ACTIVE_MARKER,
@@ -1027,7 +1027,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
     per process. Used only for non-local backends where the agent's tools
     operate on a different machine than the host Hermes runs on.
     """
-    cwd_hint = os.getenv("TERMINAL_CWD", "")
+    cwd_hint = resolve_tool_cwd()
     cache_key = (env_type, cwd_hint)
     cached = _BACKEND_PROBE_CACHE.get(cache_key)
     if cached is not None:

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -6,8 +6,8 @@ gateway/cron startup). The local-CLI backend deliberately leaves it unset and
 relies on the launch dir. Reading it in one place keeps the system prompt, the
 tool surfaces, and context-file discovery agreeing on where the agent lives.
 
-Multi-session gateways can pin a logical cwd via the `_SESSION_CWD`
-contextvar; CLI/cron fall through to `TERMINAL_CWD`/launch cwd.
+Gateway sessions and cron jobs can pin a logical cwd via the `_SESSION_CWD`
+contextvar; local CLI calls fall through to `TERMINAL_CWD`/launch cwd.
 """
 
 import logging
@@ -21,6 +21,12 @@ logger = logging.getLogger(__name__)
 _UNSET: Any = object()
 
 _SESSION_CWD: ContextVar = ContextVar("HERMES_SESSION_CWD", default=_UNSET)
+_SESSION_CWD_AUTHORITATIVE: ContextVar = ContextVar(
+    "HERMES_SESSION_CWD_AUTHORITATIVE", default=False
+)
+_SESSION_CWD_AUTHORITY_SCOPE: ContextVar = ContextVar(
+    "HERMES_SESSION_CWD_AUTHORITY_SCOPE", default=None
+)
 
 # The Python package/source root (this file lives at <root>/agent/runtime_cwd.py).
 # When a backend is launched from, or self-spawns into, this tree (the desktop
@@ -46,8 +52,26 @@ def set_session_cwd(cwd: str | None) -> Token:
     return _SESSION_CWD.set((cwd or "").strip())
 
 
+def set_authoritative_session_cwd(cwd: str | None) -> tuple[Token, Token, Token]:
+    """Pin a cwd that command dispatch must prefer over cached session state."""
+    cwd_token = set_session_cwd(cwd)
+    authority_token = _SESSION_CWD_AUTHORITATIVE.set(True)
+    scope_token = _SESSION_CWD_AUTHORITY_SCOPE.set(object())
+    return cwd_token, authority_token, scope_token
+
+
+def reset_authoritative_session_cwd(tokens: tuple[Token, Token, Token]) -> None:
+    """Restore state captured by :func:`set_authoritative_session_cwd`."""
+    cwd_token, authority_token, scope_token = tokens
+    _SESSION_CWD_AUTHORITY_SCOPE.reset(scope_token)
+    _SESSION_CWD_AUTHORITATIVE.reset(authority_token)
+    _SESSION_CWD.reset(cwd_token)
+
+
 def clear_session_cwd() -> None:
     _SESSION_CWD.set("")
+    _SESSION_CWD_AUTHORITATIVE.set(False)
+    _SESSION_CWD_AUTHORITY_SCOPE.set(None)
 
 
 def _session_cwd_override() -> str:
@@ -57,13 +81,50 @@ def _session_cwd_override() -> str:
     return str(value).strip()
 
 
-def resolve_agent_cwd() -> Path:
+def resolve_authoritative_tool_cwd() -> str:
+    """Return the context cwd only when command dispatch must treat it as fixed."""
+    if not _SESSION_CWD_AUTHORITATIVE.get():
+        return ""
+    return _session_cwd_override()
+
+
+def resolve_authoritative_cwd_scope() -> object | None:
+    """Return the active authority scope used to validate live cwd records."""
+    if not _SESSION_CWD_AUTHORITATIVE.get():
+        return None
+    return _SESSION_CWD_AUTHORITY_SCOPE.get()
+
+
+def resolve_tool_cwd() -> str:
+    """Return the task-local cwd, falling back to the legacy process carrier.
+
+    Tool backends may use remote or container paths that do not exist on the
+    Hermes host, so this accessor deliberately does not validate the path.
+    """
     override = _session_cwd_override()
     if override:
-        p = Path(override).expanduser()
-        if p.is_dir():
-            return p
-        logger.warning("configured working directory does not exist: %s", override)
+        return override
+    return os.environ.get("TERMINAL_CWD", "").strip()
+
+
+def resolve_session_cwd() -> Path | None:
+    """Return the validated task-local cwd, without falling back to process env."""
+    override = _session_cwd_override()
+    if not override:
+        return None
+    p = Path(override).expanduser()
+    return p if p.is_dir() else None
+
+
+def resolve_agent_cwd() -> Path:
+    authoritative_cwd = resolve_authoritative_tool_cwd()
+    if authoritative_cwd:
+        # Preserve the intended task path even if it disappears mid-run. Users
+        # should get a cwd error, never silent execution in another workspace.
+        return Path(authoritative_cwd).expanduser()
+    session_cwd = resolve_session_cwd()
+    if session_cwd is not None:
+        return session_cwd
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         p = Path(raw).expanduser()
@@ -74,6 +135,14 @@ def resolve_agent_cwd() -> Path:
 
 
 def resolve_context_cwd() -> Path | None:
+    # An authoritative task path must remain authoritative even if it disappears
+    # after job admission. Returning the missing path makes discovery yield no
+    # project files; returning None would fall back to the scheduler process cwd
+    # and inject unrelated AGENTS.md instructions.
+    authoritative_cwd = resolve_authoritative_tool_cwd()
+    if authoritative_cwd:
+        return Path(authoritative_cwd).expanduser()
+
     # None means "no configured cwd": build_context_files_prompt then falls back
     # to the launch dir (os.getcwd()), correct for a local CLI launched inside a
     # real project. A configured path is validated here (previously it was passed

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -32,6 +32,7 @@ from agent.display import (
     redact_tool_args_for_display as _redact_tool_args_for_display,
     _detect_tool_failure,
 )
+from agent.runtime_cwd import resolve_tool_cwd
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
     _is_multimodal_tool_result,
@@ -616,9 +617,7 @@ def _begin_tool_execution(
         try:
             command = function_args.get("command", "")
             if _is_destructive_command(command):
-                cwd = function_args.get("workdir") or os.getenv(
-                    "TERMINAL_CWD", os.getcwd()
-                )
+                cwd = function_args.get("workdir") or resolve_tool_cwd() or os.getcwd()
                 agent._checkpoint_mgr.ensure_checkpoint(
                     cwd, f"before terminal: {command[:60]}"
                 )

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -423,28 +423,18 @@ def _consume_interrupted_flag(job_id: str) -> bool:
         return False
 
 
-# Sequential (env-mutating) cron jobs — workdir jobs that touch
-# process-global runtime state — must run one at a time, but must NOT block the
-# ticker thread.  A persistent single-thread executor preserves ordering across
-# ticks while keeping dispatch fire-and-forget, the same as the parallel pool.
+# Workdir jobs retain their historical single-thread scheduling. Task-local cwd
+# removes the correctness need for serialization, but keeping ordering unchanged
+# avoids coupling a concurrency change to the workspace-isolation fix.
 _sequential_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 
 
 class _ReadWriteLock:
     """Writer-preferring readers-writer lock.
 
-    Guards the process-global ``os.environ["TERMINAL_CWD"]`` override that a
-    workdir cron job applies for the whole of its agent run.  Workdir jobs are
-    writers: they mutate the shared env and need exclusive access.  Workdir-less
-    jobs are readers: they only observe ``TERMINAL_CWD`` (indirectly, via the
-    terminal / file / code-exec tools), so any number of them may run
-    concurrently with each other, but none may run alongside a writer — that is
-    exactly what stops a workdir-less job from picking up another job's workdir
-    override and running its commands in the wrong directory.
-
-    Writer preference bounds the wait for a workdir job (dispatched on the
-    single-thread sequential pool) so a stream of workdir-less readers cannot
-    starve it.
+    Task-local cwd makes this unnecessary for correctness. The compatibility
+    barrier remains so workdir jobs retain their historical exclusion and
+    ordering relative to workdir-less jobs.
     """
 
     def __init__(self) -> None:
@@ -481,8 +471,7 @@ class _ReadWriteLock:
             self._cond.notify_all()
 
 
-# Serializes the per-job TERMINAL_CWD override against every other concurrently
-# running cron job.  See _ReadWriteLock and run_job for the usage contract.
+# Preserves the prior workdir-vs-workdir-less overlap contract.
 _terminal_cwd_lock = _ReadWriteLock()
 
 
@@ -2771,6 +2760,14 @@ def run_job(
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+    _job_workdir = (job.get("workdir") or "").strip() or None
+    if _job_workdir and not Path(_job_workdir).is_dir():
+        error = (
+            "Configured workdir does not exist or is not a directory: "
+            f"{_job_workdir}"
+        )
+        logger.error("Job '%s': %s", job_id, error)
+        return False, "", "", error
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
@@ -2801,14 +2798,6 @@ def run_job(
         # paths. For no_agent jobs this is passed as the subprocess cwd so the
         # Python process cwd is NEVER mutated — avoiding the global-side-effect
         # bug where os.chdir() leaks into concurrent gateway sessions (#69396).
-        _job_workdir = (job.get("workdir") or "").strip() or None
-        if _job_workdir and not Path(_job_workdir).is_dir():
-            logger.warning(
-                "Job '%s': configured workdir %r no longer exists — running without it",
-                job_id, _job_workdir,
-            )
-            _job_workdir = None
-
         try:
             ok, output = _run_job_script_with_claim_heartbeat(
                 job, script_path, workdir=_job_workdir,
@@ -3008,14 +2997,9 @@ def run_job(
 
     agent = None
 
-    # Mark this as a cron session so the approval system can apply cron_mode.
-    # This env var is process-wide and persists for the lifetime of the
-    # scheduler process — every job this process runs is a cron job.
-    os.environ["HERMES_CRON_SESSION"] = "1"
-
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
-    from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
+    from gateway.session_context import set_session_vars, _VAR_MAP
 
     # Cron execution is an internal scheduler context, not a live inbound
     # gateway message. Do not seed HERMES_SESSION_* contextvars from the
@@ -3042,82 +3026,46 @@ def run_job(
     # letting set_session_vars handle the _SESSION_CWD ContextVar set/clear
     # via its existing machinery (clear_session_vars calls clear_session_cwd
     # internally). This avoids a separate import/set/clear dance (#69396).
-    _job_workdir = (job.get("workdir") or "").strip() or None
-    if _job_workdir and not Path(_job_workdir).is_dir():
-        logger.warning(
-            "Job '%s': configured workdir %r no longer exists — running without it",
-            job_id, _job_workdir,
-        )
-        _job_workdir = None
-
-    _ctx_tokens = set_session_vars(
-        platform="",
-        chat_id="",
-        chat_name="",
-        # A cron job cannot receive a completion after its turn ends. We clear the
-        # HERMES_SESSION_* routing keys just below, so an async delegation's
-        # completion event carries session_key="" — _enrich_async_delegation_routing
-        # cannot resolve it and _inject_watch_notification drops it ("no routing
-        # metadata"). And by the time a child finishes, run_job has already shipped
-        # the job's final response via _deliver_result; there is no turn left to
-        # re-enter. (Worse, get_current_session_key() can fall back to the ambient
-        # os.environ HERMES_SESSION_KEY, which risks routing a cron subagent's output
-        # into an unrelated user chat.)
-        #
-        # Declaring the channel stateless routes delegate_task to its existing
-        # inline/synchronous path, so results return within the job's own turn.
-        # See declare_stateless_channel(). Upstream: #53027, #63142.
-        async_delivery=False,
-        cwd=_job_workdir or "",
-    )
     _cron_delivery_vars = (
         "HERMES_CRON_AUTO_DELIVER_PLATFORM",
         "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
         "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
     )
-    for _var_name in _cron_delivery_vars:
-        _VAR_MAP[_var_name].set("")
-
-    # Per-job working directory — _SESSION_CWD was already set via
-    # set_session_vars(cwd=...) above. Here we only handle the
-    # process-global TERMINAL_CWD env var, which is serialized by
-    # _terminal_cwd_lock to avoid leaking into concurrent jobs.
-    #
-    # os.environ["TERMINAL_CWD"] is process-global, so this override is
-    # serialized by _terminal_cwd_lock (acquired just below): a workdir job
-    # holds it as a writer for its whole run, excluding every other job, while
-    # workdir-less jobs hold it as readers and stay parallel with each other.
-    # The sequential pool only keeps workdir jobs from overlapping EACH OTHER;
-    # the lock is what additionally keeps a concurrently-firing workdir-less
-    # parallel-pool job from observing this override and running its shell /
-    # file / code-exec commands in the wrong directory.  For workdir-less jobs
-    # we leave TERMINAL_CWD untouched — preserves the original behaviour
-    # (skip_context_files=True, tools use whatever cwd the scheduler has).
-    #
-    # The critical path (resolve_context_cwd / build_context_files_prompt)
-    # checks _SESSION_CWD first, so gateway sessions with no override see
-    # their own cwd, not the cron's workdir (#69396).
-
-    # Snapshot the current env value BEFORE acquiring the lock so the finally
-    # below can always restore it, even if an exception fires before we set the
-    # override inside the try.  This read can't leak the lock (it precedes the
-    # acquire) and is a no-op for workdir-less jobs (they never mutate the env).
-    _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
-
+    # Preserve historical scheduling order while all execution state is
+    # task-local. Bind only after acquiring the compatibility barrier so a
+    # cancelled wait cannot leak cron identity or cwd into its caller.
+    _ctx_tokens = None
+    _delivery_tokens = []
+    _cwd_scope_token = None
+    _cwd_tokens = None
     _holds_cwd_write = _job_workdir is not None
     if _holds_cwd_write:
         _terminal_cwd_lock.acquire_write()
     else:
         _terminal_cwd_lock.acquire_read()
 
-    # Everything after the acquire MUST live inside this try, so the finally
-    # below always releases the lock even if the env override or any later
-    # statement raises.  A leaked writer would deadlock the whole scheduler
-    # (every future job blocks on acquire_*); a leaked reader blocks all
-    # future writers.  Acquire itself can't leak (it either blocks or returns).
     try:
+        from agent.runtime_cwd import set_session_cwd
+
+        # set_session_vars currently owns its cwd binding without exposing its
+        # token. Capture the exact outer value separately so nested cron runs
+        # restore their caller rather than clearing it.
+        _cwd_scope_token = set_session_cwd(_job_workdir or "")
+        _ctx_tokens = set_session_vars(
+            source="cron",
+            platform="",
+            chat_id="",
+            chat_name="",
+            async_delivery=False,
+            cwd=_job_workdir or "",
+        )
+        for _var_name in _cron_delivery_vars:
+            _delivery_tokens.append(_VAR_MAP[_var_name].set(""))
+
         if _job_workdir:
-            os.environ["TERMINAL_CWD"] = _job_workdir
+            from agent.runtime_cwd import set_authoritative_session_cwd
+
+            _cwd_tokens = set_authoritative_session_cwd(_job_workdir)
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
 
         # Re-read .env and config.yaml fresh every run so provider/key
@@ -3745,26 +3693,23 @@ def run_job(
         return False, output, "", error_msg
 
     finally:
-        # Restore TERMINAL_CWD to whatever it was before this job ran.  We
-        # only ever mutate it when the job has a workdir; see the setup block
-        # at the top of run_job for the serialization guarantee.
-        if _job_workdir:
-            if _prior_terminal_cwd == "_UNSET_":
-                os.environ.pop("TERMINAL_CWD", None)
+        try:
+            if _cwd_tokens is not None:
+                from agent.runtime_cwd import reset_authoritative_session_cwd
+
+                reset_authoritative_session_cwd(_cwd_tokens)
+            if _ctx_tokens is not None:
+                for _token in reversed(_ctx_tokens):
+                    _token.var.reset(_token)
+            if _cwd_scope_token is not None:
+                _cwd_scope_token.var.reset(_cwd_scope_token)
+            for _token in reversed(_delivery_tokens):
+                _token.var.reset(_token)
+        finally:
+            if _holds_cwd_write:
+                _terminal_cwd_lock.release_write()
             else:
-                os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
-        # Release the cwd lock now that the env is restored, so a waiting
-        # workdir job (or queued reader) can proceed without seeing the override.
-        if _holds_cwd_write:
-            _terminal_cwd_lock.release_write()
-        else:
-            _terminal_cwd_lock.release_read()
-        # Clean up ContextVar session/delivery state for this job.
-        # clear_session_vars also clears _SESSION_CWD internally, so no
-        # separate clear_session_cwd() call is needed.
-        clear_session_vars(_ctx_tokens)
-        for _var_name in _cron_delivery_vars:
-            _VAR_MAP[_var_name].set("")
+                _terminal_cwd_lock.release_read()
         if _session_db:
             # Compression can rotate the live agent onto a continuation while
             # this run is in flight. Finalize that continuation, not the stale
@@ -4193,12 +4138,9 @@ def tick(
             body."""
             return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
 
-        # Partition due jobs: those with a per-job workdir mutate
-        # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so
-        # they queue on the single-thread sequential pool to run one at a time.
-        # That alone only keeps workdir jobs from overlapping EACH OTHER;
-        # run_job's _terminal_cwd_lock is what additionally stops a concurrently
-        # firing workdir-less parallel-pool job from observing the override.
+        # Preserve the historical partition while cwd state is task-local:
+        # workdir jobs queue in submission order and workdir-less jobs remain
+        # parallel.
         sequential_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
         parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
 

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -66,6 +66,11 @@ def session_context_engaged() -> bool:
     """
     return _session_context_engaged
 
+
+def session_context_bound() -> bool:
+    """True when this task has explicitly bound a live session context."""
+    return bool(_SESSION_CONTEXT_BOUND.get())
+
 # ---------------------------------------------------------------------------
 # Per-task session variables
 # ---------------------------------------------------------------------------
@@ -93,6 +98,9 @@ _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=
 _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
 _SESSION_PROFILE: ContextVar = ContextVar("HERMES_SESSION_PROFILE", default=_UNSET)
+_SESSION_CONTEXT_BOUND: ContextVar = ContextVar(
+    "HERMES_SESSION_CONTEXT_BOUND", default=False
+)
 
 # Whether the current session's delivery channel can route an ASYNC completion
 # back to the agent AFTER the current turn ends (i.e. wake a fresh turn).
@@ -207,6 +215,7 @@ def set_session_vars(
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_PROFILE.set(profile),
         _SESSION_ASYNC_DELIVERY.set(bool(async_delivery)),
+        _SESSION_CONTEXT_BOUND.set(True),
     ]
     try:
         from agent.runtime_cwd import set_session_cwd
@@ -249,6 +258,7 @@ def clear_session_vars(tokens: list) -> None:
     # behavior (CLI / unaware paths), not be mistaken for an opted-out
     # stateless adapter.
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
+    _SESSION_CONTEXT_BOUND.set(False)
     try:
         from agent.runtime_cwd import clear_session_cwd
 
@@ -297,6 +307,7 @@ def reset_session_vars() -> None:
     # same inheritance-leak reason as the mapped vars above — see clear_session_vars,
     # which resets this var on the handler-exit path for the symmetric concern.
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
+    _SESSION_CONTEXT_BOUND.set(False)
     try:
         from agent.runtime_cwd import clear_session_cwd
 

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -51,6 +51,28 @@ class TestResolveContextCwd:
         assert resolve_context_cwd() == Path(os.path.expanduser("~"))
 
 
+    def test_missing_authoritative_cwd_never_falls_back_for_context(
+        self, monkeypatch, tmp_path
+    ):
+        from agent.prompt_builder import build_context_files_prompt
+
+        process_dir = tmp_path / "foreign-process-workspace"
+        process_dir.mkdir()
+        (process_dir / "AGENTS.md").write_text(
+            "FOREIGN_CONTEXT_SENTINEL", encoding="utf-8"
+        )
+        missing = tmp_path / "deleted-cron-workspace"
+        monkeypatch.chdir(process_dir)
+
+        tokens = rt.set_authoritative_session_cwd(str(missing))
+        try:
+            resolved = resolve_context_cwd()
+            assert resolved == missing
+            prompt = build_context_files_prompt(cwd=str(resolved), skip_soul=True)
+            assert "FOREIGN_CONTEXT_SENTINEL" not in prompt
+        finally:
+            rt.reset_authoritative_session_cwd(tokens)
+
 
 class TestSessionCwdOverride:
     """The #29531 per-session arm: a contextvar cwd wins over TERMINAL_CWD so a
@@ -67,6 +89,48 @@ class TestSessionCwdOverride:
         finally:
             rt._SESSION_CWD.reset(token)
 
+    def test_terminal_and_file_tools_follow_session_cwd(self, monkeypatch, tmp_path):
+        from tools import file_tools, terminal_tool
+
+        session_dir = tmp_path / "session"
+        process_dir = tmp_path / "process"
+        session_dir.mkdir()
+        process_dir.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(process_dir))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        token = set_session_cwd(str(session_dir))
+        try:
+            assert terminal_tool._get_env_config()["cwd"] == str(session_dir)
+            assert file_tools._configured_terminal_cwd() == str(session_dir)
+        finally:
+            rt._SESSION_CWD.reset(token)
+
+    def test_execute_code_follows_session_cwd(self, monkeypatch, tmp_path):
+        from tools.code_execution_tool import _resolve_child_cwd
+
+        session_dir = tmp_path / "session"
+        process_dir = tmp_path / "process"
+        staging_dir = tmp_path / "staging"
+        session_dir.mkdir()
+        process_dir.mkdir()
+        staging_dir.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(process_dir))
+
+        token = set_session_cwd(str(session_dir))
+        try:
+            assert _resolve_child_cwd("project", str(staging_dir)) == str(session_dir)
+        finally:
+            rt._SESSION_CWD.reset(token)
+
+    def test_empty_session_cwd_falls_back_to_terminal_cwd(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        token = set_session_cwd("")
+        try:
+            assert resolve_agent_cwd() == tmp_path
+            assert resolve_context_cwd() == tmp_path
+        finally:
+            rt._SESSION_CWD.reset(token)
 
     def test_clear_session_cwd_restores_terminal_cwd(self, monkeypatch, tmp_path):
         other = tmp_path / "other"

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -65,7 +65,7 @@ class TestNormalizeWorkdir:
     def test_file_not_dir_rejected(self, tmp_path):
         from cron.jobs import _normalize_workdir
         f = tmp_path / "file.txt"
-        f.write_text("hi")
+        f.write_text("hi", encoding="utf-8")
         with pytest.raises(ValueError, match="not a directory"):
             _normalize_workdir(str(f))
 
@@ -133,6 +133,68 @@ class TestCronjobToolWorkdir:
         assert "absolute" in desc.lower()
 
 
+class TestNoAgentWorkdirIsolation:
+    def test_no_agent_passes_subprocess_cwd_without_chdir(self, tmp_path, monkeypatch):
+        import os
+        import cron.scheduler as sched
+
+        process_cwd = tmp_path / "gateway"
+        workdir = tmp_path / "script-workdir"
+        process_cwd.mkdir()
+        workdir.mkdir()
+        monkeypatch.chdir(process_cwd)
+        observed = {}
+
+        def fake_script(job, script_path, workdir=None):
+            observed["process_cwd"] = os.getcwd()
+            observed["subprocess_cwd"] = workdir
+            return True, "ok"
+
+        monkeypatch.setattr(sched, "_run_job_script_with_claim_heartbeat", fake_script)
+        job = {
+            "id": "script-job",
+            "name": "script-job",
+            "no_agent": True,
+            "script": "watchdog.py",
+            "workdir": str(workdir),
+        }
+
+        success, *_ = sched.run_job(job)
+        assert success is True
+        assert observed["process_cwd"] == str(process_cwd)
+        assert observed["subprocess_cwd"] == str(workdir)
+        assert os.getcwd() == str(process_cwd)
+
+    def test_script_child_uses_explicit_cwd_without_changing_process_cwd(
+        self, tmp_path, monkeypatch
+    ):
+        import os
+        import cron.scheduler as sched
+
+        process_cwd = tmp_path / "gateway"
+        workdir = tmp_path / "script-workdir"
+        process_cwd.mkdir()
+        workdir.mkdir()
+        monkeypatch.chdir(process_cwd)
+        result_path = tmp_path / "child-cwd.txt"
+        scripts_dir = sched._get_hermes_home() / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        script_path = scripts_dir / "record_cwd.py"
+        script_path.write_text(
+            "import os\n"
+            f"open({str(result_path)!r}, 'w', encoding='utf-8').write(os.getcwd())\n",
+            encoding="utf-8",
+        )
+
+        success, output = sched._run_job_script(
+            str(script_path), workdir=str(workdir)
+        )
+
+        assert success is True, output
+        assert result_path.read_text(encoding="utf-8") == str(workdir)
+        assert os.getcwd() == str(process_cwd)
+
+
 # ---------------------------------------------------------------------------
 # scheduler.tick(): workdir partition
 # ---------------------------------------------------------------------------
@@ -166,15 +228,33 @@ class TestRunJobTerminalCwd:
 
         class FakeAgent:
             def __init__(self, **kwargs):
+                from agent.runtime_cwd import (
+                    resolve_agent_cwd,
+                    resolve_authoritative_tool_cwd,
+                )
+
                 observed["skip_context_files"] = kwargs.get("skip_context_files")
                 observed["load_soul_identity"] = kwargs.get("load_soul_identity")
                 observed["terminal_cwd_during_init"] = os.environ.get(
                     "TERMINAL_CWD", "_UNSET_"
                 )
+                observed["resolved_cwd_during_init"] = str(resolve_agent_cwd())
+                observed["authoritative_cwd_during_init"] = (
+                    resolve_authoritative_tool_cwd()
+                )
 
             def run_conversation(self, *_a, **_kw):
+                from agent.runtime_cwd import (
+                    resolve_agent_cwd,
+                    resolve_authoritative_tool_cwd,
+                )
+
                 observed["terminal_cwd_during_run"] = os.environ.get(
                     "TERMINAL_CWD", "_UNSET_"
+                )
+                observed["resolved_cwd_during_run"] = str(resolve_agent_cwd())
+                observed["authoritative_cwd_during_run"] = (
+                    resolve_authoritative_tool_cwd()
                 )
                 return {"final_response": "done", "messages": []}
 
@@ -212,6 +292,154 @@ class TestRunJobTerminalCwd:
         import dotenv
         monkeypatch.setattr(dotenv, "load_dotenv", lambda *_a, **_kw: True)
 
+    def test_workdir_is_task_local_and_does_not_mutate_process_env(
+        self, tmp_path, monkeypatch
+    ):
+        import os
+        import threading
+        import cron.scheduler as sched
+        from agent.runtime_cwd import resolve_agent_cwd, set_session_cwd
+
+        # Simulate a concurrent gateway session whose logical workspace is
+        # already pinned in its own context. The cron run must temporarily see
+        # its job workdir without changing process-global environment state.
+        gateway_cwd = tmp_path / "gateway"
+        cron_cwd = tmp_path / "cron"
+        gateway_cwd.mkdir()
+        cron_cwd.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", "/gateway-process-cwd")
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        gateway_token = set_session_cwd(str(gateway_cwd))
+
+        observed: dict = {}
+        self._install_stubs(monkeypatch, observed)
+
+        job = {
+            "id": "abc",
+            "name": "wd-job",
+            "workdir": str(cron_cwd),
+            "schedule_display": "manual",
+        }
+
+        result = []
+
+        def run_cron_job():
+            from agent.runtime_cwd import resolve_authoritative_tool_cwd
+
+            result.append(sched.run_job(job))
+            observed["authoritative_cwd_after_run"] = (
+                resolve_authoritative_tool_cwd()
+            )
+
+        worker = threading.Thread(target=run_cron_job)
+        worker.start()
+        worker.join(timeout=10)
+        assert not worker.is_alive()
+        success, _output, response, error = result[0]
+        assert success is True, f"run_job failed: error={error!r} response={response!r}"
+
+        assert observed["skip_context_files"] is False
+        assert observed["load_soul_identity"] is True
+        assert observed["resolved_cwd_during_init"] == str(cron_cwd.resolve())
+        assert observed["resolved_cwd_during_run"] == str(cron_cwd.resolve())
+        assert observed["authoritative_cwd_during_init"] == str(cron_cwd.resolve())
+        assert observed["authoritative_cwd_during_run"] == str(cron_cwd.resolve())
+        assert observed["authoritative_cwd_after_run"] == ""
+
+        # A per-job workdir must never leak through process-global state. A
+        # sibling gateway task can otherwise inherit a persona/repository cwd.
+        assert observed["terminal_cwd_during_init"] == "/gateway-process-cwd"
+        assert observed["terminal_cwd_during_run"] == "/gateway-process-cwd"
+        assert os.environ["TERMINAL_CWD"] == "/gateway-process-cwd"
+        assert "HERMES_CRON_SESSION" not in os.environ
+        assert resolve_agent_cwd() == gateway_cwd
+        gateway_token.var.reset(gateway_token)
+
+    def test_nested_run_restores_outer_session_cwd(self, tmp_path, monkeypatch):
+        import cron.scheduler as sched
+        from agent.runtime_cwd import resolve_session_cwd
+        from gateway.session_context import (
+            clear_session_vars,
+            get_session_env,
+            set_session_vars,
+        )
+
+        outer_cwd = tmp_path / "outer"
+        cron_cwd = tmp_path / "cron"
+        outer_cwd.mkdir()
+        cron_cwd.mkdir()
+        observed: dict = {}
+        self._install_stubs(monkeypatch, observed)
+        outer_tokens = set_session_vars(
+            source="slack",
+            platform="slack",
+            chat_id="outer-chat",
+            cwd=str(outer_cwd),
+        )
+        try:
+            success, *_ = sched.run_job(
+                {
+                    "id": "nested",
+                    "name": "nested-wd-job",
+                    "workdir": str(cron_cwd),
+                    "schedule_display": "manual",
+                }
+            )
+            assert success is True
+            assert resolve_session_cwd() == outer_cwd
+            assert get_session_env("HERMES_SESSION_SOURCE") == "slack"
+            assert get_session_env("HERMES_SESSION_PLATFORM") == "slack"
+            assert get_session_env("HERMES_SESSION_CHAT_ID") == "outer-chat"
+        finally:
+            clear_session_vars(outer_tokens)
+
+    def test_lock_acquire_failure_does_not_bind_cron_cwd(self, tmp_path, monkeypatch):
+        import cron.scheduler as sched
+        from agent.runtime_cwd import resolve_session_cwd, set_session_cwd
+
+        outer_cwd = tmp_path / "outer"
+        cron_cwd = tmp_path / "cron"
+        outer_cwd.mkdir()
+        cron_cwd.mkdir()
+        observed: dict = {}
+        self._install_stubs(monkeypatch, observed)
+        outer_token = set_session_cwd(str(outer_cwd))
+        monkeypatch.setattr(
+            sched._terminal_cwd_lock,
+            "acquire_write",
+            lambda: (_ for _ in ()).throw(RuntimeError("lock interrupted")),
+        )
+        try:
+            with pytest.raises(RuntimeError, match="lock interrupted"):
+                sched.run_job(
+                    {
+                        "id": "lock-failure",
+                        "name": "lock-failure-job",
+                        "workdir": str(cron_cwd),
+                        "schedule_display": "manual",
+                    }
+                )
+            assert resolve_session_cwd() == outer_cwd
+        finally:
+            outer_token.var.reset(outer_token)
+
+    def test_missing_workdir_fails_closed(self, tmp_path):
+        import cron.scheduler as sched
+
+        missing = tmp_path / "deleted-workspace"
+        success, _output, _response, error = sched.run_job(
+            {
+                "id": "missing-workdir",
+                "name": "missing-workdir-job",
+                "workdir": str(missing),
+                "schedule_display": "manual",
+            }
+        )
+
+        assert success is False
+        assert error is not None
+        assert str(missing) in error
+        assert "does not exist" in error
 
     def test_no_workdir_leaves_terminal_cwd_untouched(self, monkeypatch):
         """When workdir is absent, run_job must not touch TERMINAL_CWD at all —

--- a/tests/gateway/test_session_context_inheritance.py
+++ b/tests/gateway/test_session_context_inheritance.py
@@ -33,6 +33,7 @@ import pytest
 import gateway.session_context as sc
 from gateway.session_context import (
     _SESSION_ASYNC_DELIVERY,
+    _SESSION_CONTEXT_BOUND,
     _UNSET,
     _VAR_MAP,
     async_delivery_supported,
@@ -71,10 +72,12 @@ def _isolate_session_context():
     saved_env = {k: os.environ.get(k) for k in SESSION_VARS}
     saved_ctx = {name: var.get() for name, var in _VAR_MAP.items()}
     saved_async = _SESSION_ASYNC_DELIVERY.get()
+    saved_bound = _SESSION_CONTEXT_BOUND.get()
     saved_engaged = sc._session_context_engaged
     for var in _VAR_MAP.values():
         var.set(_UNSET)
     _SESSION_ASYNC_DELIVERY.set(_UNSET)
+    _SESSION_CONTEXT_BOUND.set(False)
     sc._session_context_engaged = True  # a concurrent multi-session host is engaged
     try:
         yield
@@ -82,6 +85,7 @@ def _isolate_session_context():
         for var, val in zip(_VAR_MAP.values(), saved_ctx.values()):
             var.set(val)
         _SESSION_ASYNC_DELIVERY.set(saved_async)
+        _SESSION_CONTEXT_BOUND.set(saved_bound)
         sc._session_context_engaged = saved_engaged
         for k, v in saved_env.items():
             if v is None:

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -308,6 +308,7 @@ class TestExtractCwdFromOutput:
         env._extract_cwd_from_output(result)
 
         assert env.cwd == "/home/user"
+        assert result["cwd"] == "/home/user"
         assert marker not in result["output"]
 
 

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -121,6 +121,31 @@ class TestResolveChildCwd(unittest.TestCase):
             self.assertEqual(_resolve_child_cwd("project", "/tmp/staging"), os.getcwd())
 
 
+    def test_project_authoritative_context_beats_task_record(self):
+        import tempfile
+        from agent.runtime_cwd import (
+            reset_authoritative_session_cwd,
+            set_authoritative_session_cwd,
+        )
+        import tools.terminal_tool as terminal_tool
+
+        with tempfile.TemporaryDirectory() as cron_cwd, tempfile.TemporaryDirectory() as stale_cwd:
+            task_id = "default"
+            with patch.object(
+                terminal_tool,
+                "_session_cwd",
+                {task_id: stale_cwd},
+                create=False,
+            ):
+                tokens = set_authoritative_session_cwd(cron_cwd)
+                try:
+                    self.assertEqual(
+                        _resolve_child_cwd("project", "/tmp/staging", task_id=task_id),
+                        cron_cwd,
+                    )
+                finally:
+                    reset_authoritative_session_cwd(tokens)
+
     def test_project_stale_record_falls_through_to_override(self):
         """A recorded directory that no longer exists is skipped; the
         registered override is the next rung."""

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -373,14 +373,14 @@ class TestCronWithGatewayOrigin:
 
     def test_cron_with_telegram_origin_uses_cron_mode_not_gateway(self, monkeypatch):
         """Cron + contextvar platform=telegram + cron_mode=deny → BLOCKED, not pending."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="telegram", chat_id="123")
+        tokens = set_session_vars(source="cron", platform="telegram", chat_id="123")
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
@@ -395,14 +395,14 @@ class TestCronWithGatewayOrigin:
 
     def test_cron_with_telegram_origin_approve_mode_allows(self, monkeypatch):
         """Cron + contextvar platform=telegram + cron_mode=approve → allowed via cron path."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="discord", chat_id="456")
+        tokens = set_session_vars(source="cron", platform="discord", chat_id="456")
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="approve"):
@@ -413,3 +413,22 @@ class TestCronWithGatewayOrigin:
         finally:
             clear_session_vars(tokens)
 
+    def test_cron_with_telegram_origin_combined_guard_uses_cron_mode(self, monkeypatch):
+        """check_all_command_guards must also honor cron_mode over gateway classification."""
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+        tokens = set_session_vars(source="cron", platform="telegram", chat_id="789")
+        try:
+            from unittest.mock import patch as mock_patch
+            with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+                result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+                assert not result["approved"]
+                assert "BLOCKED" in result["message"]
+                assert result.get("status") != "approval_required"
+        finally:
+            clear_session_vars(tokens)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -212,6 +212,96 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("depth limit", result["error"].lower())
 
+    def test_child_tools_inherit_authoritative_parent_cwd(self):
+        import tempfile
+        from agent.runtime_cwd import (
+            reset_authoritative_session_cwd,
+            resolve_authoritative_tool_cwd,
+            set_authoritative_session_cwd,
+        )
+        import tools.terminal_tool as terminal_tool
+
+        parent = _make_mock_parent(depth=0)
+        parent._current_task_id = "default"
+        seen = {}
+        with tempfile.TemporaryDirectory() as cron_cwd, tempfile.TemporaryDirectory() as stale_cwd:
+            with patch.object(
+                terminal_tool,
+                "_session_cwd",
+                {"default": stale_cwd},
+                create=False,
+            ), patch("run_agent.AIAgent") as MockAgent:
+                mock_child = MagicMock()
+
+                def run_child(**kwargs):
+                    seen["authoritative"] = resolve_authoritative_tool_cwd()
+                    seen["command_cwd"] = terminal_tool._resolve_command_cwd(
+                        workdir=None,
+                        default_cwd="/default",
+                        session_key=kwargs["task_id"],
+                    )
+                    return {
+                        "final_response": "done",
+                        "completed": True,
+                        "api_calls": 1,
+                    }
+
+                mock_child.run_conversation.side_effect = run_child
+                MockAgent.return_value = mock_child
+                tokens = set_authoritative_session_cwd(cron_cwd)
+                try:
+                    result = json.loads(
+                        delegate_task(goal="Check cwd", parent_agent=parent)
+                    )
+                finally:
+                    reset_authoritative_session_cwd(tokens)
+
+        self.assertEqual(result["results"][0]["status"], "completed")
+        self.assertEqual(seen["authoritative"], cron_cwd)
+        self.assertEqual(seen["command_cwd"], cron_cwd)
+
+    def test_child_inherits_interactive_parent_live_cwd(self):
+        import tempfile
+        import agent.runtime_cwd as runtime_cwd
+        from agent.runtime_cwd import set_session_cwd
+        import tools.terminal_tool as terminal_tool
+
+        parent = _make_mock_parent(depth=0)
+        parent._current_task_id = "parent-task"
+        seen = {}
+        with tempfile.TemporaryDirectory() as configured_cwd, tempfile.TemporaryDirectory() as live_cwd:
+            with patch.object(
+                terminal_tool,
+                "_session_cwd",
+                {"parent-task": live_cwd},
+                create=False,
+            ), patch("run_agent.AIAgent") as MockAgent:
+                mock_child = MagicMock()
+
+                def run_child(**kwargs):
+                    seen["command_cwd"] = terminal_tool._resolve_command_cwd(
+                        workdir=None,
+                        default_cwd="/default",
+                        session_key=kwargs["task_id"],
+                    )
+                    return {
+                        "final_response": "done",
+                        "completed": True,
+                        "api_calls": 1,
+                    }
+
+                mock_child.run_conversation.side_effect = run_child
+                MockAgent.return_value = mock_child
+                token = set_session_cwd(configured_cwd)
+                try:
+                    result = json.loads(
+                        delegate_task(goal="Check live cwd", parent_agent=parent)
+                    )
+                finally:
+                    runtime_cwd._SESSION_CWD.reset(token)
+
+        self.assertEqual(result["results"][0]["status"], "completed")
+        self.assertEqual(seen["command_cwd"], live_cwd)
 
     def test_child_inherits_runtime_credentials(self):
         parent = _make_mock_parent(depth=0)
@@ -1626,6 +1716,53 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
+
+
+def test_workspace_hint_prefers_task_local_cwd(monkeypatch, tmp_path):
+    import agent.runtime_cwd as runtime_cwd
+    from agent.runtime_cwd import set_session_cwd
+    from tools.delegate_tool import _resolve_workspace_hint
+
+    process_dir = tmp_path / "process"
+    session_dir = tmp_path / "session"
+    process_dir.mkdir()
+    session_dir.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(process_dir))
+    parent = MagicMock()
+    parent._subdirectory_hints = None
+    parent.terminal_cwd = None
+    parent.cwd = None
+
+    token = set_session_cwd(str(session_dir))
+    try:
+        assert _resolve_workspace_hint(parent) == str(session_dir)
+    finally:
+        runtime_cwd._SESSION_CWD.reset(token)
+
+
+def test_workspace_hint_does_not_fall_back_from_missing_authoritative_cwd(
+    monkeypatch, tmp_path
+):
+    from agent.runtime_cwd import (
+        reset_authoritative_session_cwd,
+        set_authoritative_session_cwd,
+    )
+    from tools.delegate_tool import _resolve_workspace_hint
+
+    stale_dir = tmp_path / "stale"
+    stale_dir.mkdir()
+    missing_dir = tmp_path / "deleted"
+    monkeypatch.setenv("TERMINAL_CWD", str(stale_dir))
+    parent = MagicMock()
+    parent._subdirectory_hints = None
+    parent.terminal_cwd = str(stale_dir)
+    parent.cwd = str(stale_dir)
+
+    tokens = set_authoritative_session_cwd(str(missing_dir))
+    try:
+        assert _resolve_workspace_hint(parent) is None
+    finally:
+        reset_authoritative_session_cwd(tokens)
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -31,13 +31,16 @@ def _isolated_cwd(tmp_path, monkeypatch):
     decoy = tmp_path / "decoy"
     workspace.mkdir()
     decoy.mkdir()
-    (workspace / "target.py").write_text("WORKSPACE_ORIGINAL\n")
-    (decoy / "target.py").write_text("DECOY_ORIGINAL\n")
+    (workspace / "target.py").write_text(
+        "WORKSPACE_ORIGINAL\n", encoding="utf-8"
+    )
+    (decoy / "target.py").write_text("DECOY_ORIGINAL\n", encoding="utf-8")
     # Process cwd = decoy, analogous to "main repo" while the terminal is in
     # the worktree.
     monkeypatch.chdir(decoy)
     # No session cwd recorded yet (fresh-session condition).
     monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    monkeypatch.setattr(terminal_tool, "_session_cwd_authority_scopes", {})
     return workspace, decoy
 
 
@@ -77,6 +80,58 @@ def test_live_tracking_cwd_wins_over_relative_terminal_cwd(_isolated_cwd, monkey
     resolved = ft._resolve_path_for_task("target.py", task_id="default")
 
     assert resolved == (workspace / "target.py")
+
+
+def test_authoritative_context_cwd_beats_stale_default_record(tmp_path, monkeypatch):
+    from agent.runtime_cwd import (
+        reset_authoritative_session_cwd,
+        set_authoritative_session_cwd,
+    )
+
+    cron_cwd = tmp_path / "cron"
+    stale_cwd = tmp_path / "stale"
+    cron_cwd.mkdir()
+    stale_cwd.mkdir()
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {"default": str(stale_cwd)})
+
+    tokens = set_authoritative_session_cwd(str(cron_cwd))
+    try:
+        assert ft._authoritative_workspace_root("default") == str(cron_cwd)
+        assert ft._resolve_path_for_task("target.py", "default") == cron_cwd / "target.py"
+    finally:
+        reset_authoritative_session_cwd(tokens)
+
+
+def test_authoritative_host_cwd_maps_to_docker_workspace(monkeypatch):
+    from agent.runtime_cwd import (
+        reset_authoritative_session_cwd,
+        set_authoritative_session_cwd,
+    )
+
+    config = {
+        "env_type": "docker",
+        "cwd": "/workspace",
+        "host_cwd": "/mnt/project",
+        "docker_mount_cwd_to_workspace": True,
+    }
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    monkeypatch.setattr(terminal_tool, "_session_cwd_authority_scopes", {})
+
+    tokens = set_authoritative_session_cwd("/mnt/project")
+    try:
+        assert terminal_tool._resolve_command_cwd(
+            workdir=None,
+            default_cwd="/workspace",
+            session_key="default",
+            config=config,
+        ) == "/workspace"
+        assert ft._resolve_path_for_task("child.txt", "default") == PurePosixPath(
+            "/workspace/child.txt"
+        )
+    finally:
+        reset_authoritative_session_cwd(tokens)
 
 
 def test_absolute_terminal_cwd_used_verbatim(_isolated_cwd, monkeypatch):
@@ -220,11 +275,12 @@ def _two_worktree_sessions(tmp_path, monkeypatch):
     main = tmp_path / "main"
     for d in (wt_a, wt_b, main):
         d.mkdir()
-        (d / "target.py").write_text(f"{d.name}\n")
+        (d / "target.py").write_text(f"{d.name}\n", encoding="utf-8")
     monkeypatch.chdir(main)
     monkeypatch.delenv("TERMINAL_CWD", raising=False)
     monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
     monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    monkeypatch.setattr(terminal_tool, "_session_cwd_authority_scopes", {})
     monkeypatch.setattr(ft, "_file_ops_cache", {})
     # Both sessions register their worktree cwd (TUI/desktop registration path;
     # registration seeds each session's record).

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -226,6 +226,54 @@ class TestExtractCwdFromOutputWindowsMsys:
 
         assert env.cwd == str(new_dir)
 
+    def test_command_result_survives_interleaved_shared_cwd_mutation(
+        self, monkeypatch, tmp_path
+    ):
+        """Normalization must use this command's marker, never shared self.cwd."""
+        original = tmp_path / "starting"
+        original.mkdir()
+        expected = tmp_path / "expected"
+        expected.mkdir()
+        foreign = tmp_path / "foreign"
+        foreign.mkdir()
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        with patch.object(
+            LocalEnvironment, "init_session", autospec=True, return_value=None
+        ):
+            env = LocalEnvironment(cwd=str(original), timeout=10)
+
+        base_extract = BaseEnvironment._extract_cwd_from_output
+
+        def extract_then_interleave(instance, result):
+            base_extract(instance, result)
+            # Deterministic interleaving: another command mutates the shared
+            # environment after this command's marker has been captured.
+            instance.cwd = str(foreign)
+
+        marker = env._cwd_marker
+        result = {
+            "output": f"x\n{marker}/c/right{marker}\n",
+            "returncode": 0,
+            "_hermes_previous_cwd": str(original),
+        }
+
+        def normalize(path):
+            return str(expected) if path == "/c/right" else str(foreign)
+
+        with (
+            patch.object(
+                BaseEnvironment,
+                "_extract_cwd_from_output",
+                new=extract_then_interleave,
+            ),
+            patch.object(local_mod, "_msys_to_windows_path", side_effect=normalize),
+        ):
+            env._extract_cwd_from_output(result)
+
+        assert result["cwd"] == str(expected)
+        assert env.cwd == str(expected)
+
 
 # ---------------------------------------------------------------------------
 # MSYS_NO_PATHCONV — native Windows command flags (#56700)

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -31,6 +31,31 @@ def _isolate_approval_state(monkeypatch):
     yield
 
 
+@pytest.mark.parametrize("platform", ["slack", "api_server"])
+def test_bound_gateway_with_empty_source_beats_stale_process_cron_flag(
+    monkeypatch, platform
+):
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    tokens = set_session_vars(source="", platform=platform)
+    try:
+        assert approval._is_cron_approval_context() is False
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_task_local_cron_source_needs_no_process_flag(monkeypatch):
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    tokens = set_session_vars(source="cron", platform="")
+    try:
+        assert approval._is_cron_approval_context() is True
+    finally:
+        clear_session_vars(tokens)
+
+
 class TestRequestToolApproval:
     def test_session_cached_approval_short_circuits(self, monkeypatch):
         monkeypatch.setattr(approval, "is_approved", lambda sk, pk: True)

--- a/tests/tools/test_session_cwd_store.py
+++ b/tests/tools/test_session_cwd_store.py
@@ -15,6 +15,7 @@ import tools.terminal_tool as tt
 @pytest.fixture(autouse=True)
 def _clean_store(monkeypatch):
     monkeypatch.setattr(tt, "_session_cwd", {})
+    monkeypatch.setattr(tt, "_session_cwd_authority_scopes", {})
     monkeypatch.setattr(tt, "_task_env_overrides", {})
 
 
@@ -75,7 +76,7 @@ class TestPostCommandDualWrite:
             def execute(self, command, **kwargs):
                 # Simulate the env's own post-command tracking (marker parse).
                 self.cwd = "/new/dir"
-                return {"output": "", "returncode": 0}
+                return {"output": "", "returncode": 0, "cwd": self.cwd}
 
         result = self._run(monkeypatch, "sess-a", FakeEnv())
         assert result["exit_code"] == 0
@@ -187,7 +188,7 @@ class TestCommandCwdReadsTheRecord:
                 self.last_cwd_arg = kwargs.get("cwd")
                 if command.startswith("cd "):
                     self.cwd = command[3:]
-                return {"output": "", "returncode": 0}
+                return {"output": "", "returncode": 0, "cwd": self.cwd}
 
         fake = FakeEnv()
         monkeypatch.setattr(tt, "_active_environments", {"sess-a": fake})

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -3,7 +3,16 @@
 import json
 from types import SimpleNamespace
 
+import pytest
+
 import tools.terminal_tool as terminal_tool
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd_registries(monkeypatch):
+    """Keep cwd values and their authority-scope tags isolated together."""
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    monkeypatch.setattr(terminal_tool, "_session_cwd_authority_scopes", {})
 
 
 def _minimal_terminal_config(cwd="/default"):
@@ -141,3 +150,146 @@ def test_safe_getcwd_falls_back_to_home_when_no_terminal_cwd(monkeypatch):
     monkeypatch.delenv("TERMINAL_CWD", raising=False)
     monkeypatch.setattr(terminal_tool.os.path, "expanduser", lambda p: "/home/me")
     assert terminal_tool._safe_getcwd() == "/home/me"
+
+
+def test_authoritative_context_cwd_overrides_stale_session_record(monkeypatch):
+    import agent.runtime_cwd as runtime_cwd
+
+    monkeypatch.setattr(
+        terminal_tool, "_session_cwd", {"default": "/workspace/stale-persona"}
+    )
+    tokens = runtime_cwd.set_authoritative_session_cwd("/workspace/cron-job")
+    try:
+        assert terminal_tool._resolve_command_cwd(
+            workdir=None,
+            default_cwd="/workspace/config",
+            session_key="default",
+        ) == "/workspace/cron-job"
+    finally:
+        runtime_cwd.reset_authoritative_session_cwd(tokens)
+
+
+def test_authoritative_context_accepts_live_cwd_recorded_in_same_scope():
+    import agent.runtime_cwd as runtime_cwd
+    import tools.file_tools as file_tools
+    from tools.code_execution_tool import _resolve_child_cwd
+
+    task_id = "cron-live-cwd"
+    tokens = runtime_cwd.set_authoritative_session_cwd("/workspace/cron-job")
+    try:
+        terminal_tool.record_session_cwd(task_id, "/workspace/cron-job/packages/api")
+        assert terminal_tool._resolve_command_cwd(
+            workdir=None,
+            default_cwd="/workspace/config",
+            session_key=task_id,
+        ) == "/workspace/cron-job/packages/api"
+        assert file_tools._authoritative_workspace_root(task_id) == (
+            "/workspace/cron-job/packages/api"
+        )
+        assert _resolve_child_cwd("project", "/staging", task_id) == (
+            "/workspace/cron-job/packages/api"
+        )
+    finally:
+        terminal_tool.clear_session_cwd(task_id)
+        runtime_cwd.reset_authoritative_session_cwd(tokens)
+
+
+def test_authoritative_host_cwd_maps_to_workspace_for_docker_dispatch(monkeypatch):
+    import agent.runtime_cwd as runtime_cwd
+
+    calls = []
+
+    class FakeEnv:
+        env = {}
+        cwd = "/workspace"
+
+        def execute(self, command, **kwargs):
+            calls.append((command, kwargs))
+            return {"output": "ok", "returncode": 0, "cwd": self.cwd}
+
+    config = _minimal_terminal_config(cwd="/workspace")
+    config.update(
+        {
+            "env_type": "docker",
+            "docker_image": "python:3.12",
+            "host_cwd": "/mnt/project",
+            "docker_mount_cwd_to_workspace": True,
+            "docker_volumes": [],
+        }
+    )
+    monkeypatch.setattr(terminal_tool, "_active_environments", {"default": FakeEnv()})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_check_all_guards",
+        lambda command, env_type, **kwargs: {"approved": True},
+    )
+
+    tokens = runtime_cwd.set_authoritative_session_cwd("/mnt/project")
+    try:
+        result = json.loads(terminal_tool.terminal_tool(command="pwd"))
+    finally:
+        runtime_cwd.reset_authoritative_session_cwd(tokens)
+
+    assert result["exit_code"] == 0
+    assert calls == [
+        ("pwd", {"timeout": 60, "cwd": "/workspace", "bounded_capture": True})
+    ]
+
+
+def test_authoritative_cwd_preserves_backend_native_semantics():
+    import agent.runtime_cwd as runtime_cwd
+
+    tokens = runtime_cwd.set_authoritative_session_cwd("/mnt/project")
+    try:
+        assert terminal_tool._resolve_command_cwd(
+            workdir=None,
+            default_cwd="/root",
+            config={"env_type": "docker", "docker_mount_cwd_to_workspace": False},
+        ) == "/root"
+        assert terminal_tool._resolve_command_cwd(
+            workdir=None,
+            default_cwd="~",
+            config={"env_type": "ssh"},
+        ) == "/mnt/project"
+    finally:
+        runtime_cwd.reset_authoritative_session_cwd(tokens)
+
+
+def test_authoritative_record_uses_command_result_not_shared_env_cwd(monkeypatch):
+    import agent.runtime_cwd as runtime_cwd
+
+    class FakeEnv:
+        env = {}
+        cwd = "/cron/root"
+
+        def execute(self, command, **kwargs):
+            self.cwd = "/foreign/session"
+            return {"output": "ok", "returncode": 0, "cwd": "/cron/root/subdir"}
+
+    monkeypatch.setattr(terminal_tool, "_active_environments", {"default": FakeEnv()})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: _minimal_terminal_config(cwd="/cron/root"),
+    )
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_check_all_guards",
+        lambda command, env_type, **kwargs: {"approved": True},
+    )
+
+    tokens = runtime_cwd.set_authoritative_session_cwd("/cron/root")
+    try:
+        result = json.loads(terminal_tool.terminal_tool(command="cd subdir"))
+        assert result["exit_code"] == 0
+        assert terminal_tool.get_authoritative_session_cwd(None) == (
+            "/cron/root/subdir"
+        )
+    finally:
+        terminal_tool.clear_session_cwd("default")
+        runtime_cwd.reset_authoritative_session_cwd(tokens)

--- a/tests/tools/test_vercel_sandbox_environment.py
+++ b/tests/tools/test_vercel_sandbox_environment.py
@@ -290,7 +290,7 @@ class TestFileSync:
         self, make_env, vercel_sdk, monkeypatch, tmp_path
     ):
         src = tmp_path / "token.txt"
-        src.write_text("secret-token")
+        src.write_text("secret-token", encoding="utf-8")
         monkeypatch.setattr(
             "tools.credential_files.get_credential_file_mounts",
             lambda: [
@@ -317,7 +317,7 @@ class TestFileSync:
         self, make_env, vercel_sdk, monkeypatch, tmp_path
     ):
         src = tmp_path / "token.txt"
-        src.write_text("secret-token")
+        src.write_text("secret-token", encoding="utf-8")
         monkeypatch.setattr(
             "tools.credential_files.get_credential_file_mounts",
             lambda: [
@@ -331,13 +331,17 @@ class TestFileSync:
         monkeypatch.setattr("tools.credential_files.iter_cache_files", lambda **kwargs: [])
 
         env = make_env()
-        src.write_text("updated-secret-token")
+        src.write_text("updated-secret-token", encoding="utf-8")
         monkeypatch.setenv("HERMES_FORCE_FILE_SYNC", "1")
         vercel_sdk.current.run_command_side_effects.append(_cwd_result("hello"))
 
         result = env.execute("echo hello")
 
-        assert result == {"output": "hello\n", "returncode": 0}
+        assert result == {
+            "output": "hello\n",
+            "returncode": 0,
+            "cwd": "/vercel/sandbox",
+        }
         assert vercel_sdk.current.write_files_calls[-1] == [
             {
                 "path": "/home/vercel/.hermes/credentials/token.txt",
@@ -351,7 +355,7 @@ class TestFileSync:
         hermes_home = tmp_path / ".hermes"
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         src = tmp_path / "token.txt"
-        src.write_text("host-token")
+        src.write_text("host-token", encoding="utf-8")
         monkeypatch.setattr(
             "tools.credential_files.get_credential_file_mounts",
             lambda: [
@@ -400,7 +404,7 @@ class TestFileSync:
         self, make_env, vercel_sdk, monkeypatch, tmp_path
     ):
         src = tmp_path / "token.txt"
-        src.write_text("host-token")
+        src.write_text("host-token", encoding="utf-8")
         monkeypatch.setattr(
             "tools.credential_files.get_credential_file_mounts",
             lambda: [
@@ -480,7 +484,11 @@ class TestExecute:
 
         result = env.execute("echo hello")
 
-        assert result == {"output": "hello\n", "returncode": 0}, label
+        assert result == {
+            "output": "hello\n",
+            "returncode": 0,
+            "cwd": "/vercel/sandbox",
+        }, label
         assert original.closed == 1
         assert vercel_sdk.current is replacement
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -224,6 +224,24 @@ def _get_session_platform() -> str:
         return os.getenv("HERMES_SESSION_PLATFORM", "") or ""
 
 
+def _is_cron_approval_context() -> bool:
+    """Return task-local cron identity, with legacy env fallback when unbound."""
+    try:
+        from gateway.session_context import (
+            get_session_env,
+            session_context_bound,
+        )
+
+        source = get_session_env("HERMES_SESSION_SOURCE", "") or ""
+        if session_context_bound():
+            return source == "cron"
+    except Exception:
+        source = os.getenv("HERMES_SESSION_SOURCE", "") or ""
+    if source:
+        return source == "cron"
+    return env_var_enabled("HERMES_CRON_SESSION")
+
+
 def _is_gateway_approval_context() -> bool:
     """True when this call is inside a gateway/API session.
 
@@ -238,7 +256,7 @@ def _is_gateway_approval_context() -> bool:
     fall through to the gateway branch would submit a pending approval
     with no listener and block the job indefinitely.
     """
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_approval_context():
         return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
@@ -2899,7 +2917,7 @@ def _run_approval_gate(
 
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_approval_context():
             if _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
@@ -3427,7 +3445,7 @@ def check_all_command_guards(command: str, env_type: str,
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_approval_context():
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
@@ -3878,7 +3896,7 @@ def check_execute_code_guard(code: str, env_type: str,
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
     # Cron: no user is present to approve arbitrary code.
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_approval_context():
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1841,6 +1841,18 @@ def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
     """
     if mode != "project":
         return staging_dir
+    from agent.runtime_cwd import resolve_authoritative_tool_cwd
+    from tools.terminal_tool import get_authoritative_session_cwd
+
+    live_authoritative_cwd = get_authoritative_session_cwd(task_id)
+    if live_authoritative_cwd:
+        return live_authoritative_cwd
+    authoritative_cwd = resolve_authoritative_tool_cwd()
+    if authoritative_cwd:
+        # Keep the intended cron path even if it disappears mid-run. Passing a
+        # missing cwd fails closed in Popen instead of executing in another
+        # session's recorded workspace.
+        return os.path.expanduser(authoritative_cwd)
     if task_id:
         # 1. The session's cwd record — IS the session's `cd` state.
         try:
@@ -1860,6 +1872,11 @@ def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
             session_cwd = None
         if session_cwd and os.path.isdir(session_cwd):
             return session_cwd
+    from agent.runtime_cwd import resolve_session_cwd
+
+    context_cwd = resolve_session_cwd()
+    if context_cwd is not None:
+        return str(context_cwd)
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         expanded = os.path.expanduser(raw)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -869,8 +869,21 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
     teaching subagents a fake container path while still helping them avoid
     guessing `/workspace/...` for local repo tasks.
     """
+    from agent.runtime_cwd import (
+        resolve_authoritative_tool_cwd,
+        resolve_tool_cwd,
+    )
+
+    authoritative = resolve_authoritative_tool_cwd()
+    if authoritative:
+        try:
+            text = os.path.abspath(os.path.expanduser(authoritative))
+        except Exception:
+            return None
+        return text if os.path.isabs(text) and os.path.isdir(text) else None
+
     candidates = [
-        os.getenv("TERMINAL_CWD"),
+        resolve_tool_cwd(),
         getattr(
             getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None
         ),
@@ -2123,16 +2136,28 @@ def _run_single_child(
 
         child_task_id = _subagent_id or f"subagent-{task_index}-{_uuid.uuid4().hex[:8]}"
         parent_task_id = getattr(parent_agent, "_current_task_id", None)
-        # Seed the child's session-cwd record from the parent's (cwd rearch):
-        # children share the parent's container, and today they inherit the
-        # parent's live env.cwd implicitly. Seeding at spawn preserves that
-        # starting directory while keeping the child's subsequent `cd`s
-        # isolated in its own record (a child's cd no longer bleeds back into
-        # the parent once readers flip to the record store).
+        # Seed the child's isolated session-cwd record from the resolved parent
+        # workspace, not the shared/default record. The task-local authoritative
+        # cron cwd must win over stale terminal state.
         try:
-            from tools.terminal_tool import get_session_cwd, record_session_cwd
+            from agent.runtime_cwd import (
+                resolve_authoritative_tool_cwd,
+                resolve_tool_cwd,
+            )
+            from tools.terminal_tool import (
+                get_authoritative_session_cwd,
+                get_session_cwd,
+                record_session_cwd,
+            )
 
-            record_session_cwd(child_task_id, get_session_cwd(parent_task_id))
+            parent_cwd = (
+                get_authoritative_session_cwd(parent_task_id)
+                or resolve_authoritative_tool_cwd()
+                or get_session_cwd(parent_task_id)
+                or resolve_tool_cwd()
+            )
+            if parent_cwd:
+                record_session_cwd(child_task_id, parent_cwd)
         except Exception as e:
             logger.debug("Child cwd seed failed: %s", e)
         wall_start = time.time()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1073,6 +1073,10 @@ class BaseEnvironment(ABC):
         cwd_path = output[first + len(marker) : last].strip()
         if cwd_path:
             self.cwd = cwd_path
+            # Carry the cwd parsed from THIS command alongside its result. The
+            # shared environment's mutable self.cwd may be overwritten by a
+            # concurrent session before the caller records session state.
+            result["cwd"] = cwd_path
 
         # Strip the marker line AND the \n we injected before it.
         # The wrapper emits: printf '\n__MARKER__%s__MARKER__\n'
@@ -1162,7 +1166,12 @@ class BaseEnvironment(ABC):
         result = self._wait_for_process(
             proc, timeout=effective_timeout, bounded_capture=bounded_capture
         )
+        # Keep the command's own starting cwd available to backend-specific
+        # normalization. A shared environment's mutable self.cwd may already
+        # belong to another concurrent session by the time parsing runs.
+        result["_hermes_previous_cwd"] = effective_cwd
         self._update_cwd(result)
+        result.pop("_hermes_previous_cwd", None)
 
         return result
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1594,18 +1594,26 @@ class LocalEnvironment(BaseEnvironment):
         Always defers to the base class for stripping the marker text from
         ``result["output"]`` so output formatting is identical.
         """
-        # Snapshot pre-existing cwd, defer to base for parsing + marker
-        # stripping, then validate / normalize whatever it assigned.
-        prev_cwd = self.cwd
+        # Snapshot the command's own starting cwd (BaseEnvironment.execute
+        # supplies it explicitly); direct parser callers fall back to the
+        # current value for compatibility. The parsed marker in result["cwd"]
+        # is authoritative for this command — never re-read shared self.cwd.
+        previous_cwd = result.get("_hermes_previous_cwd", self.cwd)
         super()._extract_cwd_from_output(result)
-        if self.cwd != prev_cwd:
-            normalized = _msys_to_windows_path(self.cwd) if _IS_WINDOWS else self.cwd
-            if normalized and os.path.isdir(normalized):
-                self.cwd = normalized
-            else:
-                # Stale / non-existent path — keep previous cwd; _run_bash
-                # will resolve a safe fallback on the next call if needed.
-                self.cwd = prev_cwd
+        parsed_cwd = result.get("cwd")
+        if not isinstance(parsed_cwd, str) or not parsed_cwd:
+            return
+
+        normalized = _msys_to_windows_path(parsed_cwd) if _IS_WINDOWS else parsed_cwd
+        if normalized and os.path.isdir(normalized):
+            command_cwd = normalized
+        else:
+            # Stale / non-existent marker — preserve this command's own starting
+            # cwd, not whichever session most recently mutated the shared env.
+            command_cwd = previous_cwd
+
+        result["cwd"] = command_cwd
+        self.cwd = command_cwd
 
     def cleanup(self):
         """Clean up temp files."""

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -240,14 +240,10 @@ def _sentinel_free_abs_cwd(raw: str | None) -> str | None:
 
 
 def _configured_terminal_cwd() -> str | None:
-    """Return ``$TERMINAL_CWD`` only when it names a real directory anchor.
+    """Return a task-local or configured cwd when it is an absolute anchor."""
+    from agent.runtime_cwd import resolve_tool_cwd
 
-    Sentinel values (see ``_TERMINAL_CWD_SENTINELS``) and relative paths are
-    rejected — a relative anchor is meaningless without knowing which cwd it is
-    relative to, which is exactly the ambiguity that misroutes worktree edits.
-    Only an absolute, sentinel-free value is honored.
-    """
-    return _sentinel_free_abs_cwd(os.environ.get("TERMINAL_CWD"))
+    return _sentinel_free_abs_cwd(resolve_tool_cwd())
 
 
 def _registered_task_cwd_override(task_id: str = "default") -> str | None:
@@ -269,26 +265,59 @@ def _registered_task_cwd_override(task_id: str = "default") -> str | None:
     return _sentinel_free_abs_cwd(overrides.get("cwd"))
 
 
-def _authoritative_workspace_root(task_id: str = "default") -> str | None:
-    """Best-effort absolute workspace root for divergence checks.
+def _backend_native_workspace_root(
+    root: str | None,
+    task_id: str = "default",
+    *,
+    authoritative_host: bool = False,
+) -> str | None:
+    """Map a host cwd to the path used by the active container backend.
 
-    Resolution:
-
-      1. The session's own cwd RECORD (``terminal_tool.get_session_cwd``) —
-         written on every completed terminal command and seeded by workspace
-         registration, keyed by the raw session id. Because the record is
-         per-session, one session's ``cd`` can never leak into another
-         session's resolution.
-      2. A registered task/session cwd override (TUI/Desktop/ACP sessions
-         register a raw-keyed cwd before any tool runs). Normally already
-         mirrored into the record at registration; kept as a direct fallback
-         so a cleared/never-written record still resolves the workspace.
-      3. A sentinel-free absolute ``$TERMINAL_CWD`` (the worktree path set by
-         ``cli.py``/``main.py`` for ``-w`` sessions).
-
-    Returns ``None`` only when there is genuinely no reliable anchor, in which
-    case callers fall back to the process cwd.
+    Terminal dispatch already sanitizes host-only paths (for example a Docker
+    auto-mounted ``/home/user/project``) to its backend-native cwd
+    (``/workspace``). File tools must apply the same mapping before resolving a
+    relative path, including before the first terminal command records a live
+    container cwd.
     """
+    if not root or not _uses_container_paths(task_id):
+        return root
+    try:
+        from tools.terminal_tool import (
+            _get_env_config,
+            _map_cwd_to_backend,
+        )
+
+        config = _get_env_config()
+        default_cwd = _sentinel_free_abs_cwd(config.get("cwd"))
+        if default_cwd:
+            return _map_cwd_to_backend(
+                root,
+                default_cwd,
+                config,
+                authoritative_host=authoritative_host,
+            )
+    except Exception:
+        pass
+    return root
+
+
+def _authoritative_workspace_root(task_id: str = "default") -> str | None:
+    """Resolve workspace: live fixed scope, cron root, session, override, config."""
+    from agent.runtime_cwd import resolve_authoritative_tool_cwd
+    from tools.terminal_tool import get_authoritative_session_cwd
+
+    live_context_root = _sentinel_free_abs_cwd(
+        get_authoritative_session_cwd(task_id)
+    )
+    if live_context_root:
+        return _backend_native_workspace_root(live_context_root, task_id)
+    context_root = _sentinel_free_abs_cwd(resolve_authoritative_tool_cwd())
+    if context_root:
+        return _backend_native_workspace_root(
+            context_root,
+            task_id,
+            authoritative_host=True,
+        )
     try:
         from tools.terminal_tool import get_session_cwd
 
@@ -296,11 +325,11 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
     except Exception:
         recorded = None
     if recorded:
-        return recorded
+        return _backend_native_workspace_root(recorded, task_id)
     registered = _registered_task_cwd_override(task_id)
     if registered:
-        return registered
-    return _configured_terminal_cwd()
+        return _backend_native_workspace_root(registered, task_id)
+    return _backend_native_workspace_root(_configured_terminal_cwd(), task_id)
 
 
 def _resolve_base_dir(

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -38,6 +38,7 @@ import json
 import logging
 import os
 import platform
+import posixpath
 import re
 import time
 import threading
@@ -1150,6 +1151,7 @@ _task_env_overrides: Dict[str, Dict[str, Any]] = {}
 # file_tools and _resolve_command_cwd to read this store, then delete the
 # env-side tracking + ownership guards.
 _session_cwd: Dict[str, str] = {}
+_session_cwd_authority_scopes: Dict[str, object] = {}
 _session_cwd_lock = threading.Lock()
 
 
@@ -1165,9 +1167,15 @@ def record_session_cwd(session_key: Optional[str], cwd: Optional[str]) -> None:
     if not isinstance(cwd, str) or not cwd.strip():
         return
     key = str(session_key or "default")
+    from agent.runtime_cwd import resolve_authoritative_cwd_scope
+
+    authority_scope = resolve_authoritative_cwd_scope()
     with _session_cwd_lock:
-        if _session_cwd.get(key) != cwd:
-            _session_cwd[key] = cwd
+        _session_cwd[key] = cwd
+        if authority_scope is None:
+            _session_cwd_authority_scopes.pop(key, None)
+        else:
+            _session_cwd_authority_scopes[key] = authority_scope
 
 
 def get_session_cwd(session_key: Optional[str]) -> Optional[str]:
@@ -1182,10 +1190,25 @@ def get_session_cwd(session_key: Optional[str]) -> Optional[str]:
         return _session_cwd.get(key)
 
 
+def get_authoritative_session_cwd(session_key: Optional[str]) -> Optional[str]:
+    """Return a live cwd recorded inside the current authoritative scope."""
+    from agent.runtime_cwd import resolve_authoritative_cwd_scope
+
+    authority_scope = resolve_authoritative_cwd_scope()
+    if authority_scope is None:
+        return None
+    key = str(session_key or "default")
+    with _session_cwd_lock:
+        if _session_cwd_authority_scopes.get(key) is authority_scope:
+            return _session_cwd.get(key)
+    return None
+
+
 def clear_session_cwd(session_key: str) -> None:
     """Drop a session's cwd record (session teardown)."""
     with _session_cwd_lock:
         _session_cwd.pop(session_key, None)
+        _session_cwd_authority_scopes.pop(session_key, None)
 
 
 def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
@@ -1371,6 +1394,53 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return False
 
 
+def _map_cwd_to_backend(
+    candidate: str,
+    default_cwd: str,
+    config: Optional[Dict[str, Any]] = None,
+    *,
+    authoritative_host: bool = False,
+) -> str:
+    """Translate a host cwd into the active backend's native path.
+
+    Docker's explicit host-cwd mount is authoritative even when the host path
+    lives outside the usual ``/home``/``/Users`` prefixes (for example
+    ``/mnt/project``). Descendants preserve their relative suffix beneath the
+    backend mount root. Other unusable container paths retain the historical
+    fallback to ``default_cwd``.
+    """
+    if not config:
+        return candidate
+    env_type = str(config.get("env_type") or "").lower()
+    if env_type == "docker" and config.get("docker_mount_cwd_to_workspace"):
+        host_cwd = str(config.get("host_cwd") or "").strip()
+        if host_cwd:
+            try:
+                host_norm = os.path.normcase(
+                    os.path.normpath(os.path.expanduser(host_cwd))
+                )
+                candidate_norm = os.path.normcase(
+                    os.path.normpath(os.path.expanduser(candidate))
+                )
+                relative = os.path.relpath(candidate_norm, host_norm)
+                if relative == ".":
+                    return default_cwd
+                if (
+                    relative != os.pardir
+                    and not relative.startswith(os.pardir + os.sep)
+                    and not os.path.isabs(relative)
+                ):
+                    return posixpath.normpath(
+                        posixpath.join(default_cwd, relative.replace(os.sep, "/"))
+                    )
+            except (OSError, ValueError):
+                pass
+    if env_type in _CONTAINER_BACKENDS:
+        if authoritative_host or _is_unusable_container_cwd(candidate):
+            return default_cwd
+    return candidate
+
+
 # One-shot guard for the config-fallback bridge below.  Purely an
 # optimization: after the first attempt either TERMINAL_ENV is set (bridge
 # succeeded — merged config always carries terminal.backend) or the import
@@ -1459,16 +1529,18 @@ def _get_env_config() -> Dict[str, Any]:
     else:
         default_cwd = "/root"
 
-    # Read TERMINAL_CWD but sanity-check it for container backends.
-    # If Docker cwd passthrough is explicitly enabled, remap the host path to
-    # /workspace and track the original host path separately. Otherwise keep the
-    # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    from agent.runtime_cwd import resolve_tool_cwd
+
+    configured_cwd = resolve_tool_cwd() or None
+
+    # Prefer the task-local cwd when a gateway/cron session pinned one; fall
+    # back to the startup environment for CLI and legacy callers.
+    cwd = configured_cwd or os.getenv("TERMINAL_CWD", default_cwd)
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = configured_cwd or os.getenv("TERMINAL_CWD") or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -2166,6 +2238,7 @@ def _resolve_command_cwd(
     workdir: Optional[str],
     default_cwd: str,
     session_key: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Return the cwd for a command. Explicit ``workdir=`` overrides everything.
 
@@ -2178,6 +2251,23 @@ def _resolve_command_cwd(
     """
     if workdir:
         return workdir
+
+    def _backend_native_cwd(candidate: str) -> str:
+        return _map_cwd_to_backend(candidate, default_cwd, config)
+
+    live_authoritative_cwd = get_authoritative_session_cwd(session_key)
+    if live_authoritative_cwd:
+        return _backend_native_cwd(live_authoritative_cwd)
+    from agent.runtime_cwd import resolve_authoritative_tool_cwd
+
+    authoritative_cwd = resolve_authoritative_tool_cwd()
+    if authoritative_cwd:
+        return _map_cwd_to_backend(
+            authoritative_cwd,
+            default_cwd,
+            config,
+            authoritative_host=True,
+        )
     return get_session_cwd(session_key) or default_cwd
 
 
@@ -2546,6 +2636,7 @@ def terminal_tool(
                 workdir=workdir,
                 default_cwd=cwd,
                 session_key=session_key,
+                config=config,
             )
             try:
                 if env_type == "local":
@@ -2806,6 +2897,7 @@ def terminal_tool(
                         workdir=workdir,
                         default_cwd=cwd,
                         session_key=session_key,
+                        config=config,
                     )
                     execute_kwargs = {
                         "timeout": effective_timeout,
@@ -2847,13 +2939,13 @@ def terminal_tool(
                 # Got a result
                 break
 
-            # Dual-write (cwd rearch step 1): the env's post-command tracking
-            # (marker parse / local sync) has just updated env.cwd with the
-            # directory this command finished in. That cwd belongs to THIS
-            # session — record it under the session key so the durable record
-            # never depends on the shared env surviving or on who drives the
-            # env next.
-            record_session_cwd(session_key, getattr(env, "cwd", None))
+            # Record the cwd parsed from this command's own marker. Reading the
+            # shared environment's mutable env.cwd here races another session
+            # using the same container/shell and can mis-tag its cwd as ours.
+            command_result_cwd = (
+                result.get("cwd") if isinstance(result, dict) else None
+            )
+            record_session_cwd(session_key, command_result_cwd)
 
             # Extract output
             output = result.get("output", "")


### PR DESCRIPTION
## Summary

Fix cron `workdir` isolation so concurrent gateway/profile sessions and cron jobs do not share process-global cwd or cron-policy state.

### Behavior

- Binds cron cwd and cron approval identity with task-local `ContextVar` state.
- Removes per-job mutations of process-global `TERMINAL_CWD` and `HERMES_CRON_SESSION`.
- Propagates cwd context through cron watchdog, heartbeat, tool-executor, and delegation thread boundaries.
- Resolves terminal, file, code-execution, prompt/context, checkpoint, and delegated-child cwd from the same task-local source.
- Preserves explicit terminal `workdir=` precedence and interactive terminal `cd` tracking.
- Uses scope-tagged live cwd records so a cron starts from its configured root but can intentionally `cd` during the run without accepting stale records from another session.
- Restores nested session/delivery/cwd ContextVars exactly on success, error, and lock-acquisition failure.
- Passes explicit cwd to no-agent scripts without changing the scheduler process cwd.
- Fails closed when a configured cron workdir no longer exists.
- Preserves backend-native Docker/container cwd mapping and SSH/local cwd semantics, including arbitrary Docker host mount roots.
- Records cwd from each command's own marker/result rather than shared mutable environment state.
- Keeps deleted authoritative workdirs fail-closed for command and context-file discovery.
- Preserves existing cron scheduling/serialization behavior.

## Root cause

`cron.scheduler.run_job()` wrote each job's workspace into process-wide environment state. Concurrent gateway/profile work could then resolve prompts and relative terminal/file operations against another job's directory. The process-wide cron marker could also leak cron approval policy into interactive sessions.

## Verification

- Canonical focused suite: `628 passed, 0 failed` across cron, runtime-cwd, prompt, tool-executor context propagation, approval, terminal, file, code-execution, delegation, environment-marker, session-store, and Windows/MSYS coverage.
- Order-sensitive affected modules in one pytest process: `269 passed, 0 failed`.
- Ruff passed on all changed Python files.
- `scripts/check-windows-footguns.py --diff upstream/main` passed.
- `git diff --check upstream/main...HEAD` passed.
- Independent reviews found Docker host/backend cwd mapping and paired test-state isolation gaps; both now have focused regressions in the passing suites above.
