### PR TITLE
fix(acp): honor configured tool and turn budgets

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -831,7 +831,7 @@ class HermesACPAgent(acp.Agent):
             from agent.memory_manager import inject_memory_provider_tools
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
+                getattr(state.agent, "enabled_toolsets", None),
                 mcp_server_names=[server.name for server in mcp_servers],
             )
             state.agent.enabled_toolsets = enabled_toolsets

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -143,7 +143,8 @@ def _expand_acp_enabled_toolsets(
 ) -> List[str]:
     """Return ACP toolsets plus explicit MCP server toolsets for this session."""
     expanded: List[str] = []
-    for name in list(toolsets or ["hermes-acp"]):
+    base_toolsets = ["hermes-acp"] if toolsets is None else toolsets
+    for name in list(base_toolsets):
         if name and name not in expanded:
             expanded.append(name)
 
@@ -625,12 +626,25 @@ class SessionManager:
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
 
+        raw_agent_cfg = config.get("agent")
+        agent_cfg: dict = raw_agent_cfg if isinstance(raw_agent_cfg, dict) else {}
+        acp_toolsets = (
+            agent_cfg.get("acp_toolsets")
+            if "acp_toolsets" in agent_cfg
+            else ["hermes-acp"]
+        )
+        if isinstance(acp_toolsets, str):
+            acp_toolsets = [name.strip() for name in acp_toolsets.split(",") if name.strip()]
+        max_turns = agent_cfg.get("max_turns", config.get("max_turns", 90))
+
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
+                list(acp_toolsets or []),
                 mcp_server_names=configured_mcp_servers,
             ),
+            "disabled_toolsets": list(agent_cfg.get("disabled_toolsets") or []),
+            "max_iterations": int(max_turns),
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -29,6 +29,45 @@ def manager():
 
 
 class TestCreateSession:
+    def test_expand_acp_toolsets_preserves_explicit_empty_base(self):
+        assert acp_session._expand_acp_enabled_toolsets([]) == []
+        assert acp_session._expand_acp_enabled_toolsets([], ["pin-tools"]) == ["mcp-pin-tools"]
+
+    def test_make_agent_honors_acp_toolsets_and_max_turns(self, monkeypatch):
+        class FakeAgent:
+            model = "fake-model"
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        config = {
+            "model": {"default": "fake-model", "provider": "fake-provider"},
+            "agent": {
+                "acp_toolsets": [],
+                "max_turns": 3,
+                "disabled_toolsets": ["browser"],
+            },
+            "mcp_servers": {},
+        }
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {
+                "provider": requested,
+                "api_mode": "codex_app_server",
+                "base_url": "https://example.invalid",
+                "api_key": "test-key",
+            },
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
+
+        state = SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert state.agent.kwargs["enabled_toolsets"] == []
+        assert state.agent.kwargs["max_iterations"] == 3
+        assert state.agent.kwargs["disabled_toolsets"] == ["browser"]
+
     def test_create_session_returns_state(self, manager):
         state = manager.create_session(cwd="/tmp/work")
         assert isinstance(state, SessionState)


### PR DESCRIPTION
## Summary

- make ACP sessions honor `agent.max_turns` and `agent.disabled_toolsets`
- add `agent.acp_toolsets` so deployments can replace the editor-oriented `hermes-acp` base bundle
- preserve an explicitly empty ACP base toolset during dynamic MCP registration
- retain existing defaults when the new setting is absent: `hermes-acp` and 90 iterations

## Motivation

ACP is also useful for latency-sensitive embedded clients, not only editors. The hardcoded editor tool bundle exposed browser, terminal, files, skills, memory, and delegation even when an ACP client only wanted its per-session MCP server. One real 25-second client request expanded to 88 tools and six model calls before timing out.

With `agent.acp_toolsets: []`, dynamically supplied MCP toolsets remain available while the built-in editor bundle is omitted. The same request completed in one model call under the client deadline.

## Tests

- `venv/bin/python -m pytest tests/acp/ -q -o "addopts="` -> 304 passed
- independent focused review found no correctness or regression issues
- live ACP verification confirmed an empty base plus one dynamic MCP server exposed only that server’s 8 tools
- bounded live request confirmed `api_calls=2/3` with one MCP tool turn
