### PR TITLE
fix(delegation): enforce child authority and completion contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -982,35 +982,37 @@ Enable/disable per platform via `hermes tools` (the curses UI) or the
 
 ## Delegation (`delegate_task`)
 
-`tools/delegate_tool.py` spawns a subagent with an isolated
-context + terminal session. By default the parent waits for the
-child's summary before continuing its own loop. With `background=true`,
-Hermes returns a delegation id immediately and the result re-enters the
-conversation later through the async-delegation completion queue.
+`tools/delegate_tool.py` spawns a subagent with an isolated context and
+terminal session. Top-level model calls request background execution
+automatically. An accepted dispatch on a routable session returns one
+delegation id immediately; stateless sessions and capacity-rejected dispatches
+run inline. A batch returns one consolidated result after every child finishes.
 
 Two shapes:
 
-- **Single:** pass `goal` (+ optional `context`, `toolsets`).
+- **Single:** pass `goal` (+ optional `context`).
 - **Batch (parallel):** pass `tasks: [...]` — each gets its own subagent
-  running concurrently. Concurrency is capped by
+  running concurrently inside one joined batch. Concurrency is capped by
   `delegation.max_concurrent_children` (default 3).
 
 Roles:
 
-- `role="leaf"` (default) — focused worker. Cannot call `delegate_task`,
-  `clarify`, `memory`, `send_message`, `execute_code`.
-- `role="orchestrator"` — retains `delegate_task` so it can spawn its
+- `role="leaf"` (default) — focused worker. Cannot call `clarify`, `cronjob`,
+  `delegate_task`, `execute_code`, `memory`, or `send_message`.
+- `role="orchestrator"` — regains only `delegate_task` so it can spawn its
   own workers. Gated by `delegation.orchestrator_enabled` (default true)
-  and bounded by `delegation.max_spawn_depth` (default 2).
+  and bounded by `delegation.max_spawn_depth` (default 1).
 
 Key config knobs (under `delegation:` in `config.yaml`):
 `max_concurrent_children`, `max_spawn_depth`, `child_timeout_seconds`,
 `orchestrator_enabled`, `subagent_auto_approve`, `inherit_mcp_toolsets`,
 `max_iterations`.
 
-Durability rule: background `delegate_task` is detached from the current
-turn but still process-local. For work that must survive process restart, use
-`cronjob` or `terminal(background=True, notify_on_complete=True)` instead.
+Durability rule: an accepted background `delegate_task` is detached from the
+current turn but still process-local. A normal new message does not cancel it;
+`/stop`, session reset, or explicit close does. For work that must survive
+process restart, use `cronjob` or
+`terminal(background=True, notify_on_complete=True)` instead.
 
 ---
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5841,12 +5841,12 @@ class AIAgent:
             _strip_model_hidden_task_fields,
             delegate_task as _delegate_task,
         )
-        # Delegations from the top-level MODEL always run in the background —
-        # the model does not get to choose. delegate_task returns immediately
-        # with a handle (one per task) and each subagent's result re-enters the
-        # conversation as a new message when it finishes. This applies to BOTH
-        # a single task and a fan-out batch (each task becomes its own
-        # independent background subagent). The one exception:
+        # Delegations from the top-level MODEL request background execution;
+        # the model does not get to choose. Routable sessions return one handle
+        # when capacity admits the dispatch. Stateless sessions and rejected
+        # background dispatches run inline instead. A fan-out batch is one unit:
+        # its children run in parallel and one consolidated result re-enters
+        # after all of them finish. The other synchronous case:
         #   - A delegation from an ORCHESTRATOR SUBAGENT (depth > 0) stays
         #     synchronous: the orchestrator needs its workers' results within
         #     its own turn to compose a summary, and a subagent doesn't own the

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -708,12 +708,15 @@ Spawn a subagent with an isolated context + terminal session.
 
 - **Single:** `delegate_task(goal, context)`.
 - **Batch:** `delegate_task(tasks=[{goal, ...}, ...])` runs children in
-  parallel, capped by `delegation.max_concurrent_children` (default 3).
-- **Background:** `delegate_task(background=true)` returns a handle
-  immediately and keeps the parent loop going; the child's result
-  re-enters the conversation as a new turn when it finishes.
-- **Roles:** `leaf` (default; cannot re-delegate) vs `orchestrator`
-  (can spawn its own workers, bounded by `delegation.max_spawn_depth`).
+  parallel as one joined batch, capped by
+  `delegation.max_concurrent_children` (default 3).
+- **Completion:** top-level model calls request background execution
+  automatically. An accepted dispatch on a routable session returns one handle
+  immediately; stateless sessions and capacity-rejected dispatches run inline.
+  A batch re-enters as one consolidated result after every child finishes.
+- **Roles:** a `leaf` cannot call `clarify`, `cronjob`, `delegate_task`,
+  `execute_code`, `memory`, or `send_message`; an `orchestrator` regains only
+  `delegate_task`, bounded by `delegation.max_spawn_depth`.
 - **Not durable.** A backgrounded child is still process-local — if the
   parent process exits, the child is lost. For work that must outlive
   the process, use `cronjob` or

--- a/tests/cli/test_cli_delegate_background_notice.py
+++ b/tests/cli/test_cli_delegate_background_notice.py
@@ -1,9 +1,10 @@
 """The CLI spells out auto-resume when a delegate_task goes to the background.
 
-A top-level ``delegate_task`` returns a handle immediately and runs the subagent
-in the background; the result re-enters the conversation as a fresh turn when it
-finishes. ``_on_tool_complete`` prints a one-line, no-spinner reassurance at
-dispatch so the idle prompt doesn't read as "nothing happened".
+An accepted top-level CLI ``delegate_task`` returns one handle immediately and
+runs the unit in the background; its result re-enters the conversation as a
+fresh turn when it finishes. ``_on_tool_complete`` prints a one-line,
+no-spinner reassurance at dispatch so the idle prompt doesn't read as
+"nothing happened". Inline fallbacks do not print that notice.
 """
 
 import json

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -606,6 +606,11 @@ def test_delegate_task_background_batch_runs_as_one_unit(monkeypatch):
     assert process_registry.completion_queue.empty()
     assert ad.active_count() == 1
 
+    # A normal new parent turn interrupts the old parent turn, but an accepted
+    # detached batch must not inherit that turn-local flag.
+    parent._interrupt_requested = True
+    time.sleep(0.2)
+
     # Release the children; the whole batch joins and emits ONE event.
     gate.set()
     evt = _drain_one()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -106,6 +106,7 @@ class TestDelegateRequirements(unittest.TestCase):
         desc = overrides["description"]
         tasks_desc = overrides["parameters"]["properties"]["tasks"]["description"]
         role_desc = overrides["parameters"]["properties"]["role"]["description"]
+        background_desc = overrides["parameters"]["properties"]["background"]["description"]
 
         # Top-level description names the user's concurrency limit explicitly.
         self.assertIn(f"up to {max_children}", desc)
@@ -115,9 +116,36 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn(f"up to {max_children}", tasks_desc)
         # role parameter description names the spawn-depth limit.
         self.assertIn(f"max_spawn_depth={max_depth}", role_desc)
+        # Completion semantics must match the runtime: routable sessions can
+        # detach, stateless API sessions fall back to synchronous execution,
+        # and a batch re-enters as one consolidated result only after every
+        # child finishes.
+        self.assertIn("routable sessions", desc)
+        self.assertIn("stateless api sessions", desc.lower())
+        self.assertIn("synchronously", desc)
+        self.assertIn("one consolidated result", desc)
+        self.assertIn("all children finish", desc)
+        self.assertIn("capacity", desc)
+        self.assertIn("routable sessions", background_desc)
+        self.assertIn("stateless api sessions", background_desc.lower())
+        self.assertIn("synchronous", background_desc)
+        # Model callers cannot select child toolsets. Children inherit the
+        # parent's permitted toolsets, so no schema description should suggest
+        # a model-facing toolsets argument exists.
+        self.assertNotIn("toolsets", desc)
+        self.assertNotIn("toolsets", tasks_desc)
+        # Every runtime-blocked child tool must be named in the model-facing
+        # contract so the parent does not delegate work the child cannot do.
+        from tools.delegate_tool import DELEGATE_BLOCKED_TOOLS
+        leaf_blocked = ", ".join(sorted(DELEGATE_BLOCKED_TOOLS))
+        orchestrator_blocked = ", ".join(
+            sorted(DELEGATE_BLOCKED_TOOLS - {"delegate_task"})
+        )
+        self.assertIn(f"CANNOT call: {leaf_blocked}", desc)
+        self.assertIn(f"still CANNOT call: {orchestrator_blocked}", desc)
         # The misleading "default 3" / "default 2" wording is gone from
         # every dynamic surface (model-facing).
-        for surface in (desc, tasks_desc, role_desc):
+        for surface in (desc, tasks_desc, role_desc, background_desc):
             self.assertNotIn("default 3", surface)
             self.assertNotIn("default 2", surface)
 
@@ -200,6 +228,96 @@ class TestStripBlockedTools(unittest.TestCase):
                     f"but was not stripped",
                 )
 
+    def test_mixed_composite_is_subtracted_at_child_assembly(self):
+        """A mixed platform bundle must not re-expose blocked leaf tools.
+
+        ``hermes-cli`` contains both allowed tools and every sensitive
+        delegate tool, so it cannot be dropped wholesale. Child construction
+        must instead pass exact one-tool deny toolsets to AIAgent, where
+        model_tools applies them after resolving the composite.
+        """
+        import model_tools
+
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["hermes-cli"]
+        parent.disabled_toolsets = ["browser"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Inspect safely",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                role="leaf",
+            )
+
+        _, kwargs = MockAgent.call_args
+        disabled = kwargs["disabled_toolsets"]
+        self.assertIn("browser", disabled)
+        for toolset_name in (
+            "clarify",
+            "cronjob",
+            "delegation",
+            "code_execution",
+            "memory",
+        ):
+            self.assertIn(toolset_name, disabled)
+
+        definitions = model_tools.get_tool_definitions(
+            enabled_toolsets=kwargs["enabled_toolsets"],
+            disabled_toolsets=disabled,
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        names = {item["function"]["name"] for item in definitions}
+        self.assertTrue(names & {"terminal", "read_file", "web_search"})
+        self.assertTrue(DELEGATE_BLOCKED_TOOLS.isdisjoint(names))
+
+    def test_orchestrator_composite_regains_only_delegate_task(self):
+        import model_tools
+
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["hermes-cli"]
+        parent.disabled_toolsets = ["delegation", "browser"]
+
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._get_orchestrator_enabled", return_value=True),
+            patch("tools.delegate_tool._get_max_spawn_depth", return_value=2),
+        ):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Coordinate safely",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                role="orchestrator",
+            )
+
+        _, kwargs = MockAgent.call_args
+        disabled = kwargs["disabled_toolsets"]
+        self.assertNotIn("delegation", disabled)
+        definitions = model_tools.get_tool_definitions(
+            enabled_toolsets=kwargs["enabled_toolsets"],
+            disabled_toolsets=disabled,
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        names = {item["function"]["name"] for item in definitions}
+        self.assertIn("delegate_task", names)
+        self.assertTrue(
+            (DELEGATE_BLOCKED_TOOLS - {"delegate_task"}).isdisjoint(names)
+        )
+
 
 class TestDelegateTask(unittest.TestCase):
     def test_no_parent_agent(self):
@@ -241,6 +359,29 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(result["results"][0]["status"], "completed")
         self.assertEqual(result["results"][0]["summary"], "Done!")
         mock_run.assert_called_once()
+
+    @patch("tools.async_delegation.dispatch_async_delegation_batch")
+    @patch("gateway.session_context.async_delivery_supported", return_value=False)
+    @patch("tools.delegate_tool._run_single_child")
+    def test_stateless_background_falls_back_to_inline_results(
+        self, mock_run, _mock_supported, mock_dispatch
+    ):
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Inline result",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+        }
+        parent = _make_mock_parent()
+
+        result = json.loads(
+            delegate_task(goal="Review files", background=True, parent_agent=parent)
+        )
+
+        self.assertEqual(result["results"][0]["summary"], "Inline result")
+        self.assertIn("SYNCHRONOUSLY", result["note"])
+        mock_dispatch.assert_not_called()
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode(self, mock_run):
@@ -334,7 +475,7 @@ class TestDelegateTask(unittest.TestCase):
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_ignores_toplevel_goal(self, mock_run):
-        """When tasks array is provided, top-level goal/context/toolsets are ignored."""
+        """When tasks array is provided, top-level goal/context are ignored."""
         mock_run.return_value = {
             "task_index": 0, "status": "completed",
             "summary": "Done", "api_calls": 1, "duration_seconds": 1.0

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -2,9 +2,12 @@
 """
 Async (background) delegation registry.
 
-Backs ``delegate_task(background=true)``: the parent agent dispatches a
-subagent that runs on a module-level daemon executor and returns a handle
-immediately, so the user and the model can keep working while the child runs.
+Backs accepted background dispatches from ``delegate_task``. The caller first
+checks that the session can route a detached completion; this registry can
+still reject a dispatch when its pool is at capacity. An accepted unit runs on
+a module-level daemon executor and returns one handle immediately. Stateless
+sessions and capacity-rejected dispatches are executed inline by
+``delegate_tool`` instead.
 
 When the child finishes, a completion event is pushed onto the SHARED
 ``process_registry.completion_queue`` with ``type="async_delegation"``. The
@@ -22,8 +25,9 @@ that rail rather than reaching into a running agent loop:
     two largest files in the repo.
 
 The completion payload carries a RICH, self-contained task-source block (the
-original goal, the context the parent supplied, toolsets, model, dispatch
-time, status, and the full result summary). When the result re-enters the
+original goal, the context the parent supplied, trusted internal tool metadata,
+model, dispatch time, status, and the full result summary). Tool metadata is
+not a model-controlled child-authority input. When the result re-enters the
 conversation the parent may be deep in unrelated context and won't remember
 why the subagent existed; the block lets it either use the result or
 re-dispatch if the world has moved on.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2,14 +2,17 @@
 """
 Delegate Tool -- Subagent Architecture
 
-Spawns child AIAgent instances with isolated context, restricted toolsets,
-and their own terminal sessions. Supports single-task and batch (parallel)
-modes. The parent blocks until all children complete.
+Spawns child AIAgent instances with isolated context, parent-bounded tool
+access, and their own terminal sessions. Supports single-task and batch
+(parallel) modes. Top-level model calls request background dispatch on
+routable sessions; stateless sessions, capacity-rejected dispatches, and
+orchestrator children run synchronously. A batch is one unit that joins all
+children and returns one consolidated result.
 
 Each child gets:
   - A fresh conversation (no parent history)
   - Its own task_id (own terminal session, file ops cache)
-  - A restricted toolset (configurable, with blocked tools always stripped)
+  - The parent's permitted tools, with blocked child tools always stripped
   - A focused system prompt built from the delegated goal + context
 
 The parent's context only sees the delegation call and the summary result,
@@ -783,6 +786,27 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     return [t for t in toolsets if t not in blocked_toolset_names]
 
 
+def _blocked_toolsets_for_role(role: str) -> List[str]:
+    """Return one-tool deny toolsets for a delegated child role.
+
+    ``_strip_blocked_tools`` can remove fully blocked toolsets, but it must keep
+    mixed platform bundles such as ``hermes-cli`` because those also contain
+    useful tools. Passing these exact deny toolsets to AIAgent lets
+    ``model_tools`` subtract blocked names *after* composite expansion, and the
+    restriction survives later registry/MCP refreshes through the agent's
+    stored ``disabled_toolsets``.
+    """
+    blocked_names = set(DELEGATE_BLOCKED_TOOLS)
+    if role == "orchestrator":
+        blocked_names.discard("delegate_task")
+    return sorted(
+        name
+        for name, defn in TOOLSETS.items()
+        if defn.get("tools")
+        and set(defn.get("tools", ())).issubset(blocked_names)
+    )
+
+
 def _emit_parent_console(parent_agent, line: str) -> None:
     """Emit a human-readable progress line to the parent's console.
 
@@ -1136,6 +1160,23 @@ def _build_child_agent(
     else:
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
 
+    raw_parent_disabled = getattr(parent_agent, "disabled_toolsets", None)
+    if isinstance(raw_parent_disabled, (list, tuple, set)):
+        inherited_disabled = [str(name) for name in raw_parent_disabled]
+    else:
+        inherited_disabled = []
+    if effective_role == "orchestrator":
+        # Role grants delegate_task explicitly, matching the unconditional
+        # delegation toolset re-add below.
+        inherited_disabled = [
+            name for name in inherited_disabled if name != "delegation"
+        ]
+    child_disabled_toolsets = list(
+        dict.fromkeys(
+            inherited_disabled + _blocked_toolsets_for_role(effective_role)
+        )
+    )
+
     # Orchestrators retain the 'delegation' toolset that _strip_blocked_tools
     # removed.  The re-add is unconditional on parent-toolset membership because
     # orchestrator capability is granted by role, not inherited — see the
@@ -1331,6 +1372,7 @@ def _build_child_agent(
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         fallback_model=parent_fallback,
         enabled_toolsets=child_toolsets,
+        disabled_toolsets=child_disabled_toolsets,
         quiet_mode=True,
         ephemeral_system_prompt=child_prompt,
         log_prefix=f"[subagent-{task_index}]",
@@ -2391,12 +2433,12 @@ def delegate_task(
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context and role)
+      - Batch:  provide tasks array [{goal, context, role}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
-    'leaf' (default) cannot; 'orchestrator' retains the delegation
-    toolset and can spawn its own workers, bounded by
+    'leaf' (default) cannot; 'orchestrator' regains ``delegate_task``
+    and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
 
     Returns JSON with results array, one entry per task.
@@ -2416,11 +2458,9 @@ def delegate_task(
     # Normalise the top-level role once; per-task overrides re-normalise.
     top_role = _normalize_role(role)
 
-    # Background (async) delegation now applies to BOTH single tasks and
-    # batches. A batch simply becomes N independent async dispatches: each
-    # child runs on the daemon executor and re-enters the conversation via
-    # the completion queue on its own, carrying its own handle. There's no
-    # combined "wait for all" — fan-out is exactly N background subagents.
+    # Background (async) delegation applies to BOTH single tasks and batches.
+    # A batch is one async dispatch whose runner joins all children and emits
+    # one consolidated completion after every child finishes.
     background = is_truthy_value(background, default=False) if background is not None else False
 
     # Depth limit — configurable via delegation.max_spawn_depth,
@@ -2552,7 +2592,7 @@ def delegate_task(
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
 
-    def _execute_and_aggregate() -> dict:
+    def _execute_and_aggregate(*, honor_parent_interrupt: bool = True) -> dict:
         """Run all built children (1 or N), join on them, aggregate results,
         fire subagent_stop hooks + cost rollup, and return the combined result
         dict. Used by BOTH the synchronous path and the background runner. In
@@ -2599,7 +2639,10 @@ def delegate_task(
 
                 pending = set(futures.keys())
                 while pending:
-                    if getattr(parent_agent, "_interrupt_requested", False) is True:
+                    if (
+                        honor_parent_interrupt
+                        and getattr(parent_agent, "_interrupt_requested", False) is True
+                    ):
                         # Parent interrupted — collect whatever finished and
                         # abandon the rest.  Children already received the
                         # interrupt signal; we just can't wait forever.
@@ -2889,7 +2932,7 @@ def delegate_task(
                     pass
 
         def _batch_runner():
-            return _execute_and_aggregate()
+            return _execute_and_aggregate(honor_parent_interrupt=False)
 
         def _batch_interrupt():
             for _c in _child_agents:
@@ -3243,6 +3286,10 @@ def _build_top_level_description() -> str:
         orchestrator_on = _get_orchestrator_enabled()
     except Exception:
         orchestrator_on = True
+    leaf_blocked = ", ".join(sorted(DELEGATE_BLOCKED_TOOLS))
+    orchestrator_blocked = ", ".join(
+        sorted(DELEGATE_BLOCKED_TOOLS - {"delegate_task"})
+    )
 
     if max_depth >= 2 and orchestrator_on:
         nesting_clause = (
@@ -3268,20 +3315,22 @@ def _build_top_level_description() -> str:
 
     return (
         "Spawn one or more subagents to work on tasks in isolated contexts. "
-        "Each subagent gets its own conversation, terminal session, and toolset. "
+        "Each subagent gets its own conversation and terminal session, and "
+        "inherits only tools permitted for the parent. "
         "Only the final summary is returned -- intermediate tool results "
         "never enter your context window.\n\n"
         "TWO MODES (one of 'goal' or 'tasks' is required):\n"
-        "1. Single task: provide 'goal' (+ optional context, toolsets).\n"
+        "1. Single task: provide 'goal' (+ optional context).\n"
         f"2. Batch (parallel): provide 'tasks' array with up to {max_children} "
         f"items concurrently for this user (configured via "
         f"delegation.max_concurrent_children in config.yaml). {nesting_clause}\n\n"
-        "BOTH MODES RUN IN THE BACKGROUND. delegate_task returns immediately — "
-        "you and the user keep working, and each subagent's full result "
-        "re-enters the conversation as its own new message when it finishes. A "
-        "batch is just N independent background subagents (N handles, each "
-        "completes on its own). Do NOT wait or poll; just continue with other "
-        "work after dispatching.\n\n"
+        "EXECUTION: Top-level delegations request background execution on "
+        "routable sessions and normally return immediately. Stateless API "
+        "sessions and dispatches rejected for background capacity run "
+        "synchronously inside the current turn. "
+        "A batch runs children in parallel and emits one consolidated result "
+        "after all children finish. Do not wait or poll after a background "
+        "dispatch; continue with other work.\n\n"
         "WHEN TO USE delegate_task:\n"
         "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
         "- Tasks that would flood your context with intermediate data\n"
@@ -3312,10 +3361,10 @@ def _build_top_level_description() -> str:
         "status) and verify it yourself — fetch the URL, stat the file, read "
         "back the content — before telling the user the operation succeeded.\n"
         "- Leaf subagents (role='leaf', the default) CANNOT call: "
-        "delegate_task, clarify, memory, send_message, execute_code.\n"
+        f"{leaf_blocked}.\n"
         "- Orchestrator subagents (role='orchestrator') retain "
-        "delegate_task so they can spawn their own workers, but still "
-        "cannot use clarify, memory, send_message, or execute_code. "
+        "delegate_task so they can spawn their own workers, but still CANNOT call: "
+        f"{orchestrator_blocked}. "
         f"Orchestrators are bounded by max_spawn_depth={max_depth} for this "
         f"user and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
@@ -3335,7 +3384,7 @@ def _build_tasks_param_description() -> str:
         f"Batch mode: tasks to run in parallel (up to {max_children} for this "
         f"user, set via delegation.max_concurrent_children). Each gets "
         "its own subagent with isolated context and terminal session. "
-        "When provided, top-level goal/context/toolsets are ignored."
+        "When provided, top-level goal/context are ignored."
     )
 
 
@@ -3464,12 +3513,11 @@ DELEGATE_TASK_SCHEMA = {
             "background": {
                 "type": "boolean",
                 "description": (
-                    "DEPRECATED / IGNORED. Single-task delegations always run "
-                    "in the background automatically — you do not need to (and "
-                    "cannot) opt in or out. The result re-enters the "
-                    "conversation as a new message when the subagent finishes; "
-                    "just continue working in the meantime. Setting this has no "
-                    "effect; the parameter remains only for backward "
+                    "DEPRECATED / IGNORED for model calls. Top-level delegations "
+                    "request background execution automatically on routable "
+                    "sessions when capacity permits; stateless API sessions and "
+                    "capacity-rejected dispatches fall back to synchronous execution. "
+                    "Setting this has no effect and remains only for backward "
                     "compatibility."
                 ),
             },
@@ -3486,9 +3534,9 @@ from tools.registry import registry, tool_error
 def _model_background_value(args: dict, parent_agent=None) -> bool:
     """Background flag for the MODEL-facing dispatch path (registry fallback).
 
-    Delegations from the top-level agent always run in the background — the
+    Delegations from the top-level agent request background execution — the
     model does not choose. This applies to both a single task and a fan-out
-    batch (each task becomes its own independent background subagent). The one
+    batch (the batch joins into one consolidated completion). The one
     exception is a delegation from an orchestrator subagent (depth > 0), which
     needs its workers' results within its own turn. The live path is
     ``run_agent._dispatch_delegate_task``; this lambda mirrors it for the rare

--- a/website/docs/guides/delegation-patterns.md
+++ b/website/docs/guides/delegation-patterns.md
@@ -6,7 +6,7 @@ description: "When and how to use subagent delegation — patterns for parallel 
 
 # Delegation & Parallel Work
 
-Hermes can spawn isolated child agents to work on tasks in parallel. Each subagent gets its own conversation, terminal session, and toolset. Only the final summary comes back — intermediate tool calls never enter your context window.
+Hermes can spawn isolated child agents to work on tasks in parallel. Each subagent gets its own conversation and terminal session, with tool authority bounded by the parent. Only the final summary comes back. Intermediate tool calls never enter your context window.
 
 For the full feature reference, see [Subagent Delegation](/user-guide/features/delegation).
 
@@ -25,7 +25,7 @@ For the full feature reference, see [Subagent Delegation](/user-guide/features/d
 - Mechanical multi-step work with logic between steps → `execute_code`
 - Tasks needing user interaction → subagents can't use `clarify`
 - Quick file edits → do them directly
-- Durable long-running work that must outlive the current turn → `cronjob` or `terminal(background=True, notify_on_complete=True)`. `delegate_task` is **synchronous**: if the parent turn is interrupted, active children are cancelled and their work is discarded.
+- Durable long-running work that must survive session or process loss → `cronjob` or `terminal(background=True, notify_on_complete=True)`. Delegate execution detaches only when the session is routable and background capacity is available, and it is not durable across process loss.
 
 ---
 
@@ -49,22 +49,19 @@ delegate_task(tasks=[
     {
         "goal": "Research WebAssembly outside the browser in 2025",
         "context": "Focus on: runtimes (Wasmtime, Wasmer), cloud/edge use cases, WASI progress",
-        "toolsets": ["web"]
     },
     {
         "goal": "Research RISC-V server chip adoption",
         "context": "Focus on: server chips shipping, cloud providers adopting, software ecosystem",
-        "toolsets": ["web"]
     },
     {
         "goal": "Research practical quantum computing applications",
         "context": "Focus on: error correction breakthroughs, real-world use cases, key companies",
-        "toolsets": ["web"]
     }
 ])
 ```
 
-All three run concurrently. Each subagent searches the web independently and returns a summary. The parent agent then synthesizes them into a coherent briefing.
+All three run concurrently. The batch returns one consolidated result after every child finishes, then the parent agent synthesizes the summaries into a coherent briefing.
 
 ---
 
@@ -88,7 +85,6 @@ delegate_task(
     Test command: pytest tests/auth/ -v
     Focus on: SQL injection, JWT validation, password hashing, session management.
     Fix issues found and verify tests pass.""",
-    toolsets=["terminal", "file"]
 )
 ```
 
@@ -131,7 +127,6 @@ delegate_task(tasks=[
         New format: return APIResponse(data=result, status=200).to_dict()
         Import: from src.responses import APIResponse
         Run tests after: pytest tests/handlers/ -v""",
-        "toolsets": ["terminal", "file"]
     },
     {
         "goal": "Update all client SDK methods to handle the new response format",
@@ -140,7 +135,6 @@ delegate_task(tasks=[
         Old parsing: result = response.json()["data"]
         New parsing: result = response.json()["data"] (same key, but add status code checking)
         Also update sdk/python/tests/test_client.py""",
-        "toolsets": ["terminal", "file"]
     },
     {
         "goal": "Update API documentation to reflect the new response format",
@@ -148,7 +142,6 @@ delegate_task(tasks=[
         Docs at: docs/api/. Format: Markdown with code examples.
         Update all response examples from old format to new format.
         Add a 'Response Format' section to docs/api/overview.md explaining the schema.""",
-        "toolsets": ["terminal", "file"]
     }
 ])
 ```
@@ -192,7 +185,6 @@ delegate_task(
     extracted web pages about AI funding, acquisitions, and IPOs in Q1 2026.
     Write a structured market report: key deals, trends, notable players,
     and outlook. Focus on deals over $100M.""",
-    toolsets=["terminal", "file"]
 )
 ```
 
@@ -200,25 +192,18 @@ This is often the most efficient pattern: `execute_code` handles the 10+ sequent
 
 ---
 
-## Toolset Selection
+## Child Tool Authority
 
-Choose toolsets based on what the subagent needs:
+Model calls cannot choose a child's toolsets. A leaf inherits the parent's permitted toolsets after Hermes blocks `clarify`, `cronjob`, `delegate_task`, `execute_code`, `memory`, and `send_message`. An orchestrator regains only `delegate_task`. When automatic [Tool Search](/user-guide/features/tool-search) is enabled, large inherited catalogs are deferred behind a small discovery bridge.
 
-| Task type | Toolsets | Why |
-|-----------|----------|-----|
-| Web research | `["web"]` | web_search + web_extract only |
-| Code work | `["terminal", "file"]` | Shell access + file operations |
-| Full-stack | `["terminal", "file", "web"]` | Everything except messaging |
-| Read-only analysis | `["file"]` | Can only read files, no shell |
-
-Restricting toolsets keeps the subagent focused and prevents accidental side effects (like a research subagent running shell commands).
+Keep the task focused through a narrow goal, exact paths, explicit constraints, and a bounded output contract. Restrict an entire session or scheduled job through its trusted toolset configuration when stronger authority reduction is required.
 
 ---
 
 ## Constraints
 
 - **Default 3 parallel tasks**: batches default to 3 concurrent subagents (configurable via `delegation.max_concurrent_children` in config.yaml, no hard ceiling, only a floor of 1)
-- **Nested delegation is opt-in**: leaf subagents (default) cannot call `delegate_task`, `clarify`, `memory`, or `execute_code`. Orchestrator subagents (`role="orchestrator"`) retain `delegate_task` for further delegation, but only when `delegation.max_spawn_depth` is raised above the default of 1 (floor 1, no ceiling); the other three remain blocked. Disable globally via `delegation.orchestrator_enabled: false`.
+- **Nested delegation is opt-in**: leaf subagents (default) cannot call `clarify`, `cronjob`, `delegate_task`, `execute_code`, `memory`, or `send_message`. Orchestrator subagents (`role="orchestrator"`) regain only `delegate_task`, and only when `delegation.max_spawn_depth` is raised above the default of 1 (floor 1, no ceiling). Disable orchestration globally via `delegation.orchestrator_enabled: false`.
 
 ### Tuning Concurrency and Depth
 
@@ -237,8 +222,8 @@ delegation:
 
 - **Separate terminals** — each subagent gets its own terminal session with separate working directory and state
 - **No conversation history** — subagents see only the `goal` and `context` the parent agent passes when calling `delegate_task`
-- **Default 50 iterations** — set `max_iterations` lower for simple tasks to save cost
-- **Not durable** — `delegate_task` is synchronous and runs inside the parent turn. If the parent is interrupted (new user message, `/stop`, `/new`), all active children are cancelled (`status="interrupted"`) and their work is discarded. For work that must outlive the current turn, use `cronjob` or `terminal(background=True, notify_on_complete=True)`.
+- **Default 50 iterations** — configure `delegation.max_iterations` globally; model calls cannot override it per task
+- **Channel-dependent completion** — routable sessions request background dispatch for top-level delegates. An accepted dispatch returns immediately; capacity-rejected dispatches and stateless API sessions run synchronously inside the current turn. A normal new message does not cancel an accepted background delegation, but `/stop`, session reset, or explicit close does. A batch emits one consolidated result after every child finishes. Running children are not durable across process loss; use `cronjob` or a tracked background process when they must survive it.
 
 ---
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -6,7 +6,7 @@ description: "Spawn isolated child agents for parallel workstreams with delegate
 
 # Subagent Delegation
 
-The `delegate_task` tool spawns child AIAgent instances with isolated context, restricted toolsets, and their own terminal sessions. Each child gets a fresh conversation and works independently — only its final summary enters the parent's context.
+The `delegate_task` tool spawns child AIAgent instances with isolated context, parent-bounded tool access, and their own terminal sessions. Each child gets a fresh conversation and works independently. Only its final summary enters the parent's context.
 
 ## Single Task
 
@@ -14,7 +14,6 @@ The `delegate_task` tool spawns child AIAgent instances with isolated context, r
 delegate_task(
     goal="Debug why tests fail",
     context="Error: assertion in test_foo.py line 42",
-    toolsets=["terminal", "file"]
 )
 ```
 
@@ -24,9 +23,9 @@ Up to 3 concurrent subagents by default (configurable, no hard ceiling):
 
 ```python
 delegate_task(tasks=[
-    {"goal": "Research topic A", "toolsets": ["web"]},
-    {"goal": "Research topic B", "toolsets": ["web"]},
-    {"goal": "Fix the build", "toolsets": ["terminal", "file"]}
+    {"goal": "Research topic A"},
+    {"goal": "Research topic B"},
+    {"goal": "Fix the build"}
 ])
 ```
 
@@ -66,17 +65,14 @@ delegate_task(tasks=[
     {
         "goal": "Research the current state of WebAssembly in 2025",
         "context": "Focus on: browser support, non-browser runtimes, language support",
-        "toolsets": ["web"]
     },
     {
         "goal": "Research the current state of RISC-V adoption in 2025",
         "context": "Focus on: server chips, embedded systems, software ecosystem",
-        "toolsets": ["web"]
     },
     {
         "goal": "Research quantum computing progress in 2025",
         "context": "Focus on: error correction breakthroughs, practical applications, key players",
-        "toolsets": ["web"]
     }
 ])
 ```
@@ -93,7 +89,6 @@ delegate_task(
     The project uses Flask, PyJWT, and bcrypt.
     Focus on: SQL injection, JWT validation, password handling, session management.
     Fix any issues found and run the test suite (pytest tests/auth/).""",
-    toolsets=["terminal", "file"]
 )
 ```
 
@@ -113,7 +108,6 @@ delegate_task(
     - Other prints -> logger.info(...)
     Don't change print() in test files or CLI output.
     Run pytest after to verify nothing broke.""",
-    toolsets=["terminal", "file"]
 )
 ```
 
@@ -125,7 +119,8 @@ When you provide a `tasks` array, subagents run in **parallel** using a thread p
 - **Thread pool:** Uses `ThreadPoolExecutor` with the configured concurrency limit as max workers
 - **Progress display:** In CLI mode, a tree-view shows tool calls from each subagent in real-time with per-task completion lines. In gateway mode, progress is batched and relayed to the parent's progress callback
 - **Result ordering:** Results are sorted by task index to match input order regardless of completion order
-- **Interrupt propagation:** Interrupting the parent (e.g., sending a new message) interrupts all active children
+- **Batch completion:** The batch emits one consolidated result only after every child finishes
+- **Interrupt propagation:** Synchronous children remain attached to the parent turn and are interrupted with it. Accepted background batches are owned by the async registry; a normal new message does not cancel them, while `/stop`, session reset, and explicit close do.
 
 Single-task delegation runs directly without thread pool overhead.
 
@@ -157,34 +152,25 @@ delegation:
 
 If omitted, subagents use the same model as the parent.
 
-## Toolset Selection Tips
+## Child Tool Authority
 
-The `toolsets` parameter controls what tools the subagent has access to. Choose based on the task:
+Model calls cannot choose a child's toolsets. Each subagent inherits the parent's permitted toolsets, after Hermes removes tools that children must never use. Automatic [Tool Search](/user-guide/features/tool-search) keeps large inherited catalogs behind a small discovery bridge when enabled.
 
-| Toolset Pattern | Use Case |
-|----------------|----------|
-| `["terminal", "file"]` | Code work, debugging, file editing, builds |
-| `["web"]` | Research, fact-checking, documentation lookup |
-| `["terminal", "file", "web"]` | Full-stack tasks (default) |
-| `["file"]` | Read-only analysis, code review without execution |
-| `["terminal"]` | System administration, process management |
-
-Certain toolsets are blocked for subagents regardless of what you specify:
-- `delegation` — blocked for leaf subagents (the default). Retained for `role="orchestrator"` children, bounded by `max_spawn_depth` — see [Depth Limit and Nested Orchestration](#depth-limit-and-nested-orchestration) below.
+Certain tools remain blocked for subagents:
+- `delegate_task` — blocked for leaf subagents (the default). Restored for `role="orchestrator"` children, bounded by `max_spawn_depth` — see [Depth Limit and Nested Orchestration](#depth-limit-and-nested-orchestration) below.
 - `clarify` — subagents cannot interact with the user
 - `memory` — no writes to shared persistent memory
-- `code_execution` — children should reason step-by-step
+- `execute_code` — children should reason step-by-step
+- `send_message` — no cross-platform messages in the parent's name
+- `cronjob` — no scheduling more work in the parent's name
 
 ## Max Iterations
 
-Each subagent has an iteration limit (default: 50) that controls how many tool-calling turns it can take:
+Each subagent has an operator-controlled iteration limit (default: 50) that controls how many model turns it can take. Model calls cannot override this budget per task. Configure it in `config.yaml`:
 
-```python
-delegate_task(
-    goal="Quick file check",
-    context="Check if /etc/nginx/nginx.conf exists and print its first 10 lines",
-    max_iterations=10  # Simple task, don't need many turns
-)
+```yaml
+delegation:
+  max_iterations: 30
 ```
 
 ## Child Timeout
@@ -233,7 +219,7 @@ delegate_task(
 ```
 
 - `role="leaf"` (default): child cannot delegate further — identical to the flat-delegation behavior.
-- `role="orchestrator"`: child retains the `delegation` toolset. Gated by `delegation.max_spawn_depth` (default **1** = flat, so `role="orchestrator"` is a no-op at defaults). Raise `max_spawn_depth` to 2 to allow orchestrator children to spawn leaf grandchildren; 3+ for deeper trees. There is no upper ceiling — cost is the practical limit.
+- `role="orchestrator"`: child regains `delegate_task`. It still cannot call `clarify`, `cronjob`, `execute_code`, `memory`, or `send_message`. Orchestration is gated by `delegation.max_spawn_depth` (default **1** = flat, so `role="orchestrator"` is a no-op at defaults). Raise `max_spawn_depth` to 2 to allow orchestrator children to spawn leaf grandchildren; 3+ for deeper trees. There is no upper ceiling — cost is the practical limit.
 - `delegation.orchestrator_enabled: false`: global kill switch that forces every child to `leaf` regardless of the `role` parameter.
 
 **Cost warning:** With `max_spawn_depth: 3` and `max_concurrent_children: 3`, the tree can reach 3×3×3 = 27 concurrent leaf agents. Each extra level multiplies spend — raise `max_spawn_depth` intentionally.
@@ -241,13 +227,13 @@ delegate_task(
 ## Lifetime and Durability
 
 :::warning Background completion durability is not durable execution
-By default, `delegate_task` runs **inside the parent's current turn** and blocks until every child finishes. With `background=true`, the child may continue after that turn returns while the owning session and Hermes process remain alive:
+Top-level model delegation requests background execution automatically. On routable CLI, TUI, and messaging sessions, an accepted dispatch returns immediately and the result re-enters the owning conversation later. If the background pool is at capacity, Hermes runs the delegation synchronously inside that turn. Stateless API sessions also run synchronously because they cannot route a completion after the HTTP turn ends. A batch always returns one consolidated result after every child finishes.
 
-- If the parent is interrupted (user sends a new message, `/stop`, `/new`), all active children are cancelled and return `status="interrupted"`. Their in-progress work is discarded.
+- A normal new user message does not cancel an accepted background delegation. `/stop`, `/new`, explicit close, or session reset cancels its running children.
 - Explicit session close/reset interrupts that session's background children. Closing a TUI viewer of a gateway-owned session does not kill the gateway's work.
 - A Hermes process restart does **not** resume a running child. Its attempt becomes `unknown` because Hermes cannot prove which side effects happened.
 - A child that completed before restart but whose result was not delivered is restored and routed back through the owning session's normal checks.
-- Cancelled children return a structured result (`status="interrupted"`, `exit_reason="interrupted"`), but because the parent was interrupted too, that result often never makes it into a user-visible reply.
+- Cancelled children return a structured result (`status="interrupted"`, `exit_reason="interrupted"`), but because the owner may also have been interrupted, that result may never make it into a user-visible reply.
 
 For **durable execution** that must survive session closure or process restart, use:
 
@@ -259,8 +245,8 @@ For **durable execution** that must survive session closure or process restart, 
 
 - Each subagent gets its **own terminal session** (separate from the parent)
 - **Nested delegation is opt-in** — only `role="orchestrator"` children can delegate further, and only when `max_spawn_depth` is raised from its default of 1 (flat). Disable globally with `orchestrator_enabled: false`.
-- Leaf subagents **cannot** call: `delegate_task`, `clarify`, `memory`, `execute_code`. Orchestrator subagents retain `delegate_task` but still cannot use the other three.
-- **Interrupt propagation** — interrupting the parent interrupts all active children (including grandchildren under orchestrators)
+- Leaf subagents **cannot** call: `clarify`, `cronjob`, `delegate_task`, `execute_code`, `memory`, or `send_message`. Orchestrator subagents retain `delegate_task` but still cannot use the other five.
+- **Interrupt propagation** — synchronous children follow the parent turn; accepted background batches are cancelled through `/stop`, session reset, or explicit close rather than by an ordinary new message
 - Only the final summary enters the parent's context, keeping token usage efficient
 - Subagents inherit the parent's **API key, provider configuration, and credential pool** (enabling key rotation on rate limits)
 

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -644,16 +644,22 @@ here; full developer notes live in `AGENTS.md`, user-facing docs under
 
 ### Delegation (`delegate_task`)
 
-Synchronous subagent spawn — the parent waits for the child's summary
-before continuing its own loop. Isolated context + terminal session.
+Spawn a subagent with an isolated context + terminal session.
 
 - **Single:** `delegate_task(goal, context)`.
 - **Batch:** `delegate_task(tasks=[{goal, ...}, ...])` runs children in
-  parallel, capped by `delegation.max_concurrent_children` (default 3).
-- **Roles:** `leaf` (default; cannot re-delegate) vs `orchestrator`
-  (can spawn its own workers, bounded by `delegation.max_spawn_depth`).
-- **Not durable.** If the parent is interrupted, the child is
-  cancelled. For work that must outlive the turn, use `cronjob` or
+  parallel as one joined batch, capped by
+  `delegation.max_concurrent_children` (default 3).
+- **Completion:** top-level model calls request background execution
+  automatically. An accepted dispatch on a routable session returns one handle
+  immediately; stateless sessions and capacity-rejected dispatches run inline.
+  A batch re-enters as one consolidated result after every child finishes.
+- **Roles:** a `leaf` cannot call `clarify`, `cronjob`, `delegate_task`,
+  `execute_code`, `memory`, or `send_message`; an `orchestrator` regains only
+  `delegate_task`, bounded by `delegation.max_spawn_depth`.
+- **Not durable.** A backgrounded child is still process-local — if the
+  parent process exits, the child is lost. For work that must outlive
+  the process, use `cronjob` or
   `terminal(background=True, notify_on_complete=True)`.
 
 Config: `delegation.*` in `config.yaml`.


### PR DESCRIPTION
## Summary

- Enforce delegated-child blocked tools after mixed/composite toolset expansion by carrying exact deny toolsets into child agent construction.
- Preserve inherited parent denials while allowing an explicitly enabled orchestrator to regain only `delegate_task`.
- Keep accepted background batches detached from the old parent turn's normal interrupt flag while preserving explicit async cancellation.
- Correct the model-facing schema, internal guidance, bundled skill, and English docs to match actual routable, stateless, capacity-fallback, and joined-batch behavior.
- Add regressions for stateless inline fallback, composite tool authority, orchestrator authority, and detached batch interruption.

## Root causes

`_strip_blocked_tools()` operated at toolset granularity. Mixed platform bundles such as `hermes-cli` contain useful tools and blocked tools, so the bundle survived and exposed blocked leaf capabilities after expansion. Child construction now passes one-tool deny toolsets through `disabled_toolsets`, which `model_tools` subtracts after composite resolution and retains across tool refreshes.

The shared batch aggregator also polled `parent_agent._interrupt_requested` in both synchronous and accepted background execution. Accepted background batches now disable that turn-local check and rely on the async registry's explicit interrupt callback.

## Verification

- `python -m pytest tests/tools/test_delegate.py tests/tools/test_async_delegation.py tests/tools/test_delegate_composite_toolsets.py tests/tools/test_delegate_toolset_scope.py tests/cli/test_cli_delegate_background_notice.py tests/gateway/test_async_delivery_capability.py tests/gateway/test_session_context_inheritance.py -q` (221 passed)
- `python -m pytest tests/tools/test_tool_search.py tests/tools/test_refresh_agent_mcp_tools.py -q` (52 passed)
- `uv run --frozen --extra dev ruff check run_agent.py tools/delegate_tool.py tools/async_delegation.py tests/tools/test_delegate.py tests/tools/test_async_delegation.py tests/cli/test_cli_delegate_background_notice.py`
- `npm run build` in `website/` (successful static builds for all locales; existing broken-link warnings remain warnings)
- `git diff --check`
- Independent blocker-retirement review: `SHIP`

No model, provider, deployment, or runtime configuration was changed.
