### PR TITLE
fix: prevent OOM from MCP poll loop swallowing real TimeoutError (#63892)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3840,6 +3840,12 @@ def _run_on_mcp_loop(coro_or_factory, timeout: float = 30):
         try:
             return future.result(timeout=wait_timeout)
         except concurrent.futures.TimeoutError:
+            # If the future has completed, the TimeoutError is the
+            # coroutine's own exception (e.g. asyncio.wait_for expiry),
+            # NOT a poll timeout — re-raise to avoid a tight spin that
+            # leaks traceback frames and causes OOM (issue #63892).
+            if future.done():
+                raise
             continue
 
 


### PR DESCRIPTION
## Summary

Fixes a critical OOM bug in the MCP poll loop (`tools/mcp_tool.py` `_run_on_mcp_loop()`).

**Root cause:** On Python >= 3.8, `concurrent.futures.TimeoutError` is an alias for the builtin `TimeoutError`. The poll loop catches this exception to implement short-interval polling (100ms). When the MCP coroutine itself raises a real `TimeoutError` (e.g. from `asyncio.wait_for` expiry on `mcp_servers.<srv>.timeout`), the same `except` clause swallows it and continues a tight spin with no sleep.

**Impact (measured, v0.16.0 / Python 3.13.5):**
- ~420k re-raises/sec, ~576 bytes retained per iteration -> gateway RSS grows at **~108 MB/s**
- With a 4 GB memory cgroup, gateway is OOM-killed **~33 seconds** after the tool timeout fires
- Error handler is never reached — **logs are completely silent**

**Fix:** Check `future.done()` inside the `except` block. If the future has completed, the `TimeoutError` is the coroutine's own exception (not a poll timeout) — re-raise it instead of continuing.

```python
try:
    return future.result(timeout=wait_timeout)
except concurrent.futures.TimeoutError:
    if future.done():
        raise  # real TimeoutError from the coroutine
    continue   # poll timeout, keep waiting
```

Closes #63892
