### PR TITLE
fix(desktop): hide Windows updater console during handoff

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2520,7 +2520,10 @@ async function applyUpdates(opts = {}) {
 
     // Detached so the updater outlives this process — it needs us GONE before
     // `hermes update` will run (the venv shim is locked while we live).
-    const child = spawn(updater, updaterArgs, {
+    const child = spawn(
+      updater,
+      updaterArgs,
+      hiddenWindowsChildOptions({
       cwd: HERMES_HOME,
       env: {
         ...process.env,
@@ -2528,10 +2531,9 @@ async function applyUpdates(opts = {}) {
         PATH: pathWithHermesManagedNode(venvBin)
       },
       detached: true,
-      stdio: 'ignore',
-      windowsHide: false
-    })
-
+      stdio: 'ignore'
+      })
+    )
     child.unref()
 
     // Write the update-in-progress marker IMMEDIATELY — before the 2.5s
@@ -2598,18 +2600,20 @@ async function handOffWindowsBootstrapRecovery(reason) {
 
   await releaseBackendLockForUpdate(updateRoot)
 
-  const child = spawn(updater, updaterArgs, {
-    cwd: HERMES_HOME,
-    env: {
-      ...process.env,
-      HERMES_HOME,
-      PATH: pathWithHermesManagedNode(venvBin)
-    },
-    detached: true,
-    stdio: 'ignore',
-    windowsHide: false
-  })
-
+  const child = spawn(
+    updater,
+    updaterArgs,
+    hiddenWindowsChildOptions({
+      cwd: HERMES_HOME,
+      env: {
+        ...process.env,
+        HERMES_HOME,
+        PATH: pathWithHermesManagedNode(venvBin)
+      },
+      detached: true,
+      stdio: 'ignore'
+    })
+  )
   child.unref()
 
   // Same marker pre-write as applyUpdates — see comment there. The recovery

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -126,6 +126,7 @@ import {
   sandboxPreflight
 } from './update-relaunch'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
+import { spawnUpdaterProcess } from './updater-process'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import {
   computeWindowOptions,
@@ -2520,10 +2521,7 @@ async function applyUpdates(opts = {}) {
 
     // Detached so the updater outlives this process — it needs us GONE before
     // `hermes update` will run (the venv shim is locked while we live).
-    const child = spawn(
-      updater,
-      updaterArgs,
-      hiddenWindowsChildOptions({
+    const child = spawnUpdaterProcess(updater, updaterArgs, {
       cwd: HERMES_HOME,
       env: {
         ...process.env,
@@ -2532,9 +2530,7 @@ async function applyUpdates(opts = {}) {
       },
       detached: true,
       stdio: 'ignore'
-      })
-    )
-    child.unref()
+    })
 
     // Write the update-in-progress marker IMMEDIATELY — before the 2.5s
     // quit dwell. The Tauri updater won't write its own marker for several
@@ -2600,21 +2596,16 @@ async function handOffWindowsBootstrapRecovery(reason) {
 
   await releaseBackendLockForUpdate(updateRoot)
 
-  const child = spawn(
-    updater,
-    updaterArgs,
-    hiddenWindowsChildOptions({
-      cwd: HERMES_HOME,
-      env: {
-        ...process.env,
-        HERMES_HOME,
-        PATH: pathWithHermesManagedNode(venvBin)
-      },
-      detached: true,
-      stdio: 'ignore'
-    })
-  )
-  child.unref()
+  const child = spawnUpdaterProcess(updater, updaterArgs, {
+    cwd: HERMES_HOME,
+    env: {
+      ...process.env,
+      HERMES_HOME,
+      PATH: pathWithHermesManagedNode(venvBin)
+    },
+    detached: true,
+    stdio: 'ignore'
+  })
 
   // Same marker pre-write as applyUpdates — see comment there. The recovery
   // hand-off has the same window where the renderer can respawn a backend

--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import type { SpawnOptions } from 'node:child_process'
+
+import { test } from 'vitest'
+
+import { spawnUpdaterProcess } from './updater-process'
+
+test('spawnUpdaterProcess hides the updater console and detaches the child on Windows', () => {
+  const calls: Array<{ args: string[]; command: string; options: SpawnOptions }> = []
+  let unrefCalls = 0
+
+  const child = {
+    pid: 4242,
+    unref: () => {
+      unrefCalls += 1
+    }
+  }
+
+  const result = spawnUpdaterProcess(
+    'hermes-setup.exe',
+    ['--update', '--branch', 'main'],
+    { cwd: 'C:\\Hermes', detached: true, stdio: 'ignore' },
+    {
+      isWindows: true,
+      spawnProcess: (command, args, options) => {
+        calls.push({ args, command, options })
+
+        return child
+      }
+    }
+  )
+
+  assert.equal(result, child)
+  assert.equal(unrefCalls, 1)
+  assert.deepEqual(calls, [
+    {
+      args: ['--update', '--branch', 'main'],
+      command: 'hermes-setup.exe',
+      options: { cwd: 'C:\\Hermes', detached: true, stdio: 'ignore', windowsHide: true }
+    }
+  ])
+})
+
+test('spawnUpdaterProcess preserves updater options off Windows', () => {
+  let capturedOptions: SpawnOptions | undefined
+
+  spawnUpdaterProcess(
+    'hermes-setup',
+    ['--update'],
+    { detached: true, stdio: 'ignore' },
+    {
+      isWindows: false,
+      spawnProcess: (_command, _args, options) => {
+        capturedOptions = options
+
+        return { unref: () => {} }
+      }
+    }
+  )
+
+  assert.deepEqual(capturedOptions, { detached: true, stdio: 'ignore' })
+})

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -1,0 +1,36 @@
+import { spawn, type SpawnOptions } from 'node:child_process'
+
+import { hiddenWindowsChildOptions } from './windows-child-options'
+
+export interface UpdaterChild {
+  pid?: number
+  unref: () => void
+}
+
+export interface SpawnUpdaterProcessDeps {
+  isWindows?: boolean
+  spawnProcess?: (command: string, args: string[], options: SpawnOptions) => UpdaterChild
+}
+
+/**
+ * Spawn the detached installer used for update and bootstrap-recovery handoffs.
+ * The helper owns both hidden-console selection and unref semantics so every
+ * updater handoff follows the same behavior and can be tested without Electron.
+ */
+export function spawnUpdaterProcess(
+  updater: string,
+  updaterArgs: string[],
+  options: SpawnOptions,
+  deps: SpawnUpdaterProcessDeps = {}
+): UpdaterChild {
+  const isWindows = deps.isWindows ?? process.platform === 'win32'
+  const spawnOptions = hiddenWindowsChildOptions(options, isWindows) as SpawnOptions
+
+  const child = deps.spawnProcess
+    ? deps.spawnProcess(updater, updaterArgs, spawnOptions)
+    : spawn(updater, updaterArgs, spawnOptions)
+
+  child.unref()
+
+  return child
+}


### PR DESCRIPTION
## What does this PR do?

Stops `hermes-setup.exe` from flashing a visible console window when Hermes Desktop hands off an in-app update or Windows bootstrap recovery.

Both updater launch sites explicitly set `windowsHide: false`, overriding the Desktop child-process helper that normally hides Windows console children. This PR routes both handoffs through a small `spawnUpdaterProcess()` seam that applies `hiddenWindowsChildOptions()` and preserves the existing detached/unref behavior.

This salvages closed PR #56907 by @kyssta-exe. The salvaged commit is credited to the original human PR author @kyssta-exe, followed by a current-main adaptation with behavioral TypeScript coverage. PR #61899 overlaps the two visibility changes but also bundles update-race work that still has unresolved review blockers; this PR intentionally isolates only the console-flash fix from #56884.

## Related Issue

Fixes #56884

Supersedes closed PR #56907. Overlaps the console-visibility portion of #61899 without taking its update-race changes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replace both Desktop updater `spawn()` sites in `apps/desktop/electron/main.ts` with `spawnUpdaterProcess()`.
- Add `apps/desktop/electron/updater-process.ts` to apply hidden Windows child options and unref updater children consistently.
- Add behavioral tests for Windows `windowsHide: true`, detached options, argument forwarding, child unref, and unchanged non-Windows options.
- Do not restore the old source-regex test from #56907; current project policy requires executing the behavior instead of inspecting `main.ts` text.

## How to Test

1. From `apps/desktop`, run `vitest run --project electron electron/updater-process.test.ts electron/windows-child-options.test.ts`.
2. Run `eslint electron/main.ts electron/updater-process.ts electron/updater-process.test.ts` and `tsc -p tsconfig.electron.json --noEmit`.
3. On packaged Windows Desktop, trigger an in-app update and a bootstrap-recovery handoff and confirm `hermes-setup.exe` starts without a visible console flash.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this Desktop TypeScript-only change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: native Windows focused Electron tests, lint, and TypeScript checks; packaged updater smoke remains for review

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the helper is a no-op off Windows and that behavior is covered
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused Electron coverage: 14/14 tests passed.

Desktop Electron TypeScript check and targeted ESLint check passed.

The full Electron suite on native Windows reached 428 passed / 1 skipped / 4 failed. The same four failures reproduce on untouched `origin/main` in existing POSIX-path/Bash tests (`update-relaunch.test.ts` and `windows-hermes-path.test.ts`); they are unrelated to this diff.

