### PR TITLE
i18n(zh-Hant): translate the kanban wake-notification block in locales/zh-hant.yaml

### DIFF
--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -160,14 +160,14 @@ gateway:
     truncated_suffix:      "…（已截斷；如需完整輸出請在終端機執行 `hermes kanban …`）"
     no_output:             "（無輸出）"
     wake:
-      completed:           "completed"
-      gave_up:             "gave up (retries exhausted)"
-      crashed:             "crashed (worker exited); dispatcher will retry"
-      timed_out:           "timed out; dispatcher will retry"
-      blocked:             "blocked; needs attention"
-      status_default:      "status changed"
-      status_joiner:       ", "
-      message:             "[kanban] Task {task_id} {status}.\nTitle: {title}\nAssignee: @{assignee}\nBoard: {board}\n\nCheck the result or decide the next step."
+      completed:           "已完成"
+      gave_up:             "已放棄（重試次數用盡）"
+      crashed:             "崩潰（worker 異常結束），dispatcher 將重試"
+      timed_out:           "逾時，dispatcher 將重試"
+      blocked:             "受阻，需要處理"
+      status_default:      "狀態變更"
+      status_joiner:       "，"
+      message:             "[kanban] 任務 {task_id} {status}。\n標題：{title}\n負責人：@{assignee}\n看板：{board}\n\n請檢查結果或決定下一步。"
 
   personality:
     none_configured:       "`{path}/config.yaml` 中未設定人格"


### PR DESCRIPTION
## What & why

`gateway.kanban.wake.*` was the last untranslated block in `locales/zh-hant.yaml` — 8 leaves still carrying raw English while `locales/zh.yaml` (Simplified) had them fully translated. These are **user-facing**: `gateway/kanban_watchers.py` renders them via `t()` for the wake notifications delivered when a kanban task completes / gives up / crashes / times out / is blocked.

The CLI catalogs are **key-synced but not value-checked** — `tests/agent/test_i18n.py` enforces identical keys and placeholder parity, but not that values are actually translated. So an untranslated-but-present English value passes CI silently, and zh-Hant users saw English here.

## Translation

| key | before | after |
|-----|--------|-------|
| `completed` | `completed` | `已完成` |
| `gave_up` | `gave up (retries exhausted)` | `已放棄（重試次數用盡）` |
| `crashed` | `crashed (worker exited); dispatcher will retry` | `崩潰（worker 異常結束），dispatcher 將重試` |
| `timed_out` | `timed out; dispatcher will retry` | `逾時，dispatcher 將重試` |
| `blocked` | `blocked; needs attention` | `受阻，需要處理` |
| `status_default` | `status changed` | `狀態變更` |
| `status_joiner` | `, ` | `，` |
| `message` | `[kanban] Task {task_id} …` | `[kanban] 任務 {task_id} {status}。\n標題：{title}\n負責人：@{assignee}\n看板：{board}…` |

Traditional Chinese with TW conventions (逾時 / 受阻 / 狀態變更 / 負責人) and full-width punctuation, using the Simplified catalog as a reference. The `{task_id}/{status}/{title}/{assignee}/{board}` placeholders and the `dispatcher` / `worker` / `[kanban]` runtime tokens are preserved verbatim.

## Testing

- A value-level scan (zh-hant leaf == English while `zh.yaml` diverges) reports **0** remaining untranslated leaves (was 8).
- `python -m pytest tests/agent/test_i18n.py` → **47 passed** (key + placeholder parity intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
