### PR TITLE
feat(delegation): add live subagent control

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5854,6 +5854,9 @@ class AIAgent:
         # The schema-level `background` param is intentionally ignored here.
         _is_subagent = getattr(self, "_delegate_depth", 0) > 0
         return _delegate_task(
+            action=function_args.get("action", "spawn"),
+            subagent_id=function_args.get("subagent_id"),
+            instruction=function_args.get("instruction"),
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),

--- a/tests/tools/test_live_subagent_control.py
+++ b/tests/tools/test_live_subagent_control.py
@@ -1,0 +1,269 @@
+"""Focused tests for targeted live subagent control."""
+
+import json
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+from tools import delegate_tool as dt
+
+
+class Controller:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    with dt._active_subagents_lock:
+        dt._active_subagents.clear()
+    yield
+    with dt._active_subagents_lock:
+        dt._active_subagents.clear()
+
+
+def _seed(subagent_id: str, controller, *, goal: str = "task"):
+    agent = MagicMock()
+    agent.steer.return_value = True
+    dt._register_subagent(
+        {
+            "agent": agent,
+            "root_agent": controller,
+            "subagent_id": subagent_id,
+            "parent_id": None,
+            "goal": goal,
+            "status": "running",
+            "depth": 1,
+            "started_at": 1.0,
+            "tool_count": 2,
+        },
+    )
+    return agent
+
+
+def test_status_is_scoped_to_callers_delegation_tree_and_redacts_agents():
+    mine = Controller()
+    theirs = Controller()
+    _seed("subagent-mine", mine)
+    _seed("subagent-theirs", theirs)
+
+    visible = dt.list_active_subagents(controller=mine)
+
+    assert [item["subagent_id"] for item in visible] == ["subagent-mine"]
+    assert visible[0]["tool_count"] == 2
+    assert "agent" not in visible[0]
+    assert "root_agent" not in visible[0]
+
+
+def test_steer_targets_exactly_one_child():
+    controller = Controller()
+    target = _seed("subagent-target", controller)
+    sibling = _seed("subagent-sibling", controller)
+
+    assert dt.steer_subagent("subagent-target", "focus on tests", controller=controller)
+
+    target.steer.assert_called_once_with("focus on tests")
+    sibling.steer.assert_not_called()
+
+
+def test_steer_rejects_blank_instruction_and_foreign_controller():
+    owner = Controller()
+    stranger = Controller()
+    target = _seed("subagent-target", owner)
+
+    assert not dt.steer_subagent("subagent-target", "   ", controller=owner)
+    assert not dt.steer_subagent("subagent-target", "new goal", controller=stranger)
+    target.steer.assert_not_called()
+
+
+def test_steer_rejects_missing_or_failing_child_method():
+    controller = Controller()
+    missing = _seed("subagent-missing", controller)
+    missing.steer = None
+    failing = _seed("subagent-failing", controller)
+    failing.steer.side_effect = RuntimeError("child already closed")
+
+    assert not dt.steer_subagent("subagent-missing", "new goal", controller=controller)
+    assert not dt.steer_subagent("subagent-failing", "new goal", controller=controller)
+
+
+def test_unscoped_operator_control_can_target_explicit_child():
+    controller = Controller()
+    target = _seed("subagent-target", controller)
+
+    assert dt.steer_subagent("subagent-target", "operator instruction")
+    assert dt.interrupt_subagent("subagent-target")
+    target.steer.assert_called_once_with("operator instruction")
+    target.interrupt.assert_called_once()
+
+
+def test_steer_does_not_hold_registry_lock_while_calling_child():
+    controller = Controller()
+    target = _seed("subagent-target", controller)
+
+    def steer_side_effect(_instruction):
+        done = threading.Event()
+        worker = threading.Thread(
+            target=lambda: (dt._unregister_subagent("subagent-target"), done.set())
+        )
+        worker.start()
+        assert done.wait(1), "registry lock was held while child.steer() ran"
+        worker.join(timeout=1)
+        return True
+
+    target.steer.side_effect = steer_side_effect
+
+    assert dt.steer_subagent("subagent-target", "new direction", controller=controller)
+    assert dt.list_active_subagents(controller=controller) == []
+
+
+def test_interrupt_targets_one_child_and_respects_ownership():
+    owner = Controller()
+    stranger = Controller()
+    target = _seed("subagent-target", owner)
+    sibling = _seed("subagent-sibling", owner)
+
+    assert not dt.interrupt_subagent("subagent-target", controller=stranger)
+    assert dt.interrupt_subagent("subagent-target", controller=owner)
+
+    target.interrupt.assert_called_once()
+    sibling.interrupt.assert_not_called()
+
+
+def test_orchestrator_can_control_siblings_in_same_top_level_tree():
+    """The authorization boundary is the caller's top-level delegation tree."""
+    root = Controller()
+    orchestrator = Controller()
+    setattr(orchestrator, "_delegation_root_agent", root)
+    sibling = _seed("subagent-sibling", root)
+
+    visible = dt.list_active_subagents(controller=orchestrator)
+
+    assert [item["subagent_id"] for item in visible] == ["subagent-sibling"]
+    assert dt.interrupt_subagent("subagent-sibling", controller=orchestrator)
+    sibling.interrupt.assert_called_once_with(
+        "Interrupted by controller (subagent-sibling)"
+    )
+
+
+def test_delegate_task_control_status_steer_and_interrupt():
+    controller = Controller()
+    child = _seed("subagent-one", controller)
+
+    status = json.loads(dt.delegate_task(action="status", parent_agent=controller))
+    assert status["count"] == 1
+    assert status["active"][0]["subagent_id"] == "subagent-one"
+
+    steered = json.loads(
+        dt.delegate_task(
+            action="steer",
+            subagent_id="subagent-one",
+            instruction="produce a minimal patch",
+            parent_agent=controller,
+        )
+    )
+    assert steered == {
+        "action": "steer",
+        "accepted": True,
+        "subagent_id": "subagent-one",
+    }
+    child.steer.assert_called_once_with("produce a minimal patch")
+
+    interrupted = json.loads(
+        dt.delegate_task(
+            action="interrupt",
+            subagent_id="subagent-one",
+            parent_agent=controller,
+        )
+    )
+    assert interrupted["accepted"] is True
+    child.interrupt.assert_called_once()
+
+
+def test_delegate_task_steer_reaches_selected_child_next_model_iteration():
+    controller = Controller()
+    child = object.__new__(AIAgent)
+    setattr(child, "_pending_steer", None)
+    setattr(child, "_pending_steer_lock", threading.Lock())
+    dt._register_subagent({
+        "agent": child,
+        "root_agent": controller,
+        "subagent_id": "subagent-real-steer",
+        "parent_id": None,
+        "goal": "arbitrary task",
+        "status": "running",
+        "depth": 1,
+        "started_at": 1.0,
+        "tool_count": 0,
+        "last_tool": None,
+    })
+
+    result = json.loads(
+        dt.delegate_task(
+            action="steer",
+            subagent_id="subagent-real-steer",
+            instruction="change direction now",
+            parent_agent=controller,
+        )
+    )
+    messages = [
+        {"role": "tool", "content": "original result", "tool_call_id": "call-1"}
+    ]
+    child._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+
+    assert result["accepted"] is True
+    assert "original result" in messages[0]["content"]
+    assert "change direction now" in messages[0]["content"]
+    assert child._pending_steer is None
+
+
+def test_model_dispatch_forwards_live_control_arguments():
+    parent = object.__new__(AIAgent)
+    captured = {}
+
+    def fake_delegate_task(**kwargs):
+        captured.update(kwargs)
+        return "{}"
+
+    with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+        AIAgent._dispatch_delegate_task(
+            parent,
+            {
+                "action": "steer",
+                "subagent_id": "root-a:4",
+                "instruction": "use the new API",
+            },
+        )
+
+    assert captured["action"] == "steer"
+    assert captured["subagent_id"] == "root-a:4"
+    assert captured["instruction"] == "use the new API"
+    assert captured["parent_agent"] is parent
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "needle"),
+    [
+        ({"action": "unknown"}, "action must be one of"),
+        ({"action": "steer"}, "subagent_id is required"),
+        (
+            {"action": "steer", "subagent_id": "subagent-one", "instruction": " "},
+            "instruction is required",
+        ),
+        (
+            {"action": "interrupt", "subagent_id": "missing"},
+            "No controllable live subagent",
+        ),
+    ],
+)
+def test_delegate_task_control_rejects_malformed_requests(kwargs, needle):
+    result = dt.delegate_task(parent_agent=Controller(), **kwargs)
+    assert needle in result
+
+
+def test_delegate_task_schema_exposes_live_controls():
+    props = dt.DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+    assert props["action"]["enum"] == ["spawn", "status", "steer", "interrupt"]
+    assert "subagent_id" in props
+    assert "instruction" in props

--- a/tests/tools/test_live_subagent_control.py
+++ b/tests/tools/test_live_subagent_control.py
@@ -2,12 +2,15 @@
 
 import json
 import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from run_agent import AIAgent
+from tools import async_delegation as ad
 from tools import delegate_tool as dt
+from tools.process_registry import process_registry
 
 
 class Controller:
@@ -240,6 +243,169 @@ def test_model_dispatch_forwards_live_control_arguments():
     assert captured["subagent_id"] == "root-a:4"
     assert captured["instruction"] == "use the new API"
     assert captured["parent_agent"] is parent
+
+
+def test_model_dispatch_end_to_end_spawn_status_steer_interrupt_and_cleanup(request):
+    """Exercise the complete model-facing control path without a network LLM call."""
+
+    class Parent(AIAgent):
+        _delegate_depth = 0
+        _active_children = []
+        _active_children_lock = threading.RLock()
+        _current_task_id = None
+        _current_turn_id = "turn-e2e"
+        _memory_manager = None
+        _session_db = None
+        provider = "test"
+        model = "test-model"
+        session_id = "session-e2e"
+        session_estimated_cost_usd = 0.0
+        session_cost_source = "none"
+        session_cost_status = "unknown"
+
+        def _touch_activity(self, desc):
+            del desc
+
+    class ControlledChild:
+        def __init__(self, parent):
+            self._subagent_id = "subagent-e2e"
+            self._parent_subagent_id = None
+            self._delegation_root_agent = parent
+            self._delegate_depth = 1
+            self._delegate_role = "leaf"
+            self._active_children = []
+            self._active_children_lock = threading.RLock()
+            self._pending_steer = None
+            self._pending_steer_lock = threading.Lock()
+            self._interrupt_requested = False
+            self._interrupt_message = None
+            self._interrupt_thread_signal_pending = False
+            self._execution_thread_id = None
+            self._tool_worker_threads = set()
+            self._tool_worker_threads_lock = threading.Lock()
+            self._steer_seen = threading.Event()
+            self._closed = threading.Event()
+            self.seen_instruction = None
+            self.model = "test-model"
+            self.session_id = "child-session-e2e"
+            self.session_prompt_tokens = 0
+            self.session_completion_tokens = 0
+            self.session_reasoning_tokens = 0
+            self.session_estimated_cost_usd = 0.0
+            self.quiet_mode = True
+
+        steer = AIAgent.steer
+        interrupt = AIAgent.interrupt
+        _drain_pending_steer = AIAgent._drain_pending_steer
+
+        def get_activity_summary(self):
+            return {
+                "api_call_count": 1,
+                "max_iterations": 8,
+                "current_tool": "e2e_wait",
+                "last_activity_desc": "waiting for live control",
+            }
+
+        def run_conversation(self, **_kwargs):
+            deadline = time.monotonic() + 5
+            while not self._interrupt_requested and time.monotonic() < deadline:
+                instruction = self._drain_pending_steer()
+                if instruction:
+                    self.seen_instruction = instruction
+                    self._steer_seen.set()
+                time.sleep(0.01)
+            return {
+                "final_response": "interrupted after live control",
+                "completed": False,
+                "interrupted": self._interrupt_requested,
+                "api_calls": 1,
+                "messages": [],
+            }
+
+        def close(self):
+            self._closed.set()
+
+    parent = object.__new__(Parent)
+    child = ControlledChild(parent)
+    credentials = {
+        "model": None,
+        "provider": None,
+        "base_url": None,
+        "api_key": None,
+        "api_mode": None,
+        "request_overrides": None,
+        "max_output_tokens": None,
+        "command": None,
+        "args": None,
+    }
+
+    ad._reset_for_tests()
+    request.addfinalizer(ad._reset_for_tests)
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    with (
+        patch.object(dt, "_build_child_agent", return_value=child),
+        patch.object(dt, "_resolve_delegation_credentials", return_value=credentials),
+        patch("gateway.session_context.async_delivery_supported", return_value=True),
+    ):
+        spawned = json.loads(
+            AIAgent._dispatch_delegate_task(parent, {"goal": "e2e task"})
+        )
+        assert spawned["status"] == "dispatched"
+
+        deadline = time.monotonic() + 3
+        active = []
+        while time.monotonic() < deadline:
+            active = json.loads(
+                AIAgent._dispatch_delegate_task(parent, {"action": "status"})
+            )["active"]
+            if active:
+                break
+            time.sleep(0.01)
+        assert [record["subagent_id"] for record in active] == ["subagent-e2e"]
+
+        steered = json.loads(
+            AIAgent._dispatch_delegate_task(
+                parent,
+                {
+                    "action": "steer",
+                    "subagent_id": "subagent-e2e",
+                    "instruction": "use the revised constraint",
+                },
+            )
+        )
+        assert steered["accepted"] is True
+        assert child._steer_seen.wait(timeout=3)
+        assert child.seen_instruction == "use the revised constraint"
+
+        interrupted = json.loads(
+            AIAgent._dispatch_delegate_task(
+                parent,
+                {"action": "interrupt", "subagent_id": "subagent-e2e"},
+            )
+        )
+        assert interrupted["accepted"] is True
+        assert child._closed.wait(timeout=3)
+
+        final_status = json.loads(
+            AIAgent._dispatch_delegate_task(parent, {"action": "status"})
+        )
+        assert final_status["active"] == []
+
+        deadline = time.monotonic() + 3
+        completion = None
+        while time.monotonic() < deadline:
+            if not process_registry.completion_queue.empty():
+                candidate = process_registry.completion_queue.get_nowait()
+                if candidate.get("delegation_id") == spawned["delegation_id"]:
+                    completion = candidate
+                    break
+            time.sleep(0.01)
+        assert completion is not None
+        assert completion["status"] == "interrupted", json.dumps(
+            completion, default=str
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/tui_gateway/test_subagent_control_rpc.py
+++ b/tests/tui_gateway/test_subagent_control_rpc.py
@@ -1,0 +1,43 @@
+"""JSON-RPC tests for operator-facing live subagent controls."""
+
+from unittest.mock import patch
+
+from tui_gateway import server
+
+
+def test_subagent_steer_rpc_targets_one_live_child():
+    with patch("tools.delegate_tool.steer_subagent", return_value=True) as steer:
+        result = server._methods["subagent.steer"](
+            1,
+            {"subagent_id": "child-7", "instruction": "Focus on the failing test"},
+        )
+
+    assert result["result"] == {"accepted": True, "subagent_id": "child-7"}
+    steer.assert_called_once_with("child-7", "Focus on the failing test")
+
+
+def test_subagent_steer_rpc_rejects_malformed_input_without_lookup():
+    with patch("tools.delegate_tool.steer_subagent") as steer:
+        missing_id = server._methods["subagent.steer"](
+            1, {"instruction": "new direction"}
+        )
+        missing_instruction = server._methods["subagent.steer"](
+            2, {"subagent_id": "child-7", "instruction": "   "}
+        )
+
+    assert missing_id["error"] == {"code": 4000, "message": "subagent_id required"}
+    assert missing_instruction["error"] == {
+        "code": 4000,
+        "message": "instruction required",
+    }
+    steer.assert_not_called()
+
+
+def test_subagent_steer_rpc_keeps_operator_scope_unrestricted():
+    """The TUI RPC intentionally does not pass a model delegation controller."""
+    with patch("tools.delegate_tool.steer_subagent", return_value=False) as steer:
+        server._methods["subagent.steer"](
+            1, {"subagent_id": "selected-child", "instruction": "stop exploring"}
+        )
+
+    steer.assert_called_once_with("selected-child", "stop exploring")

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -724,11 +724,15 @@ def dispatch_async_delegation_batch(
         status = "error"
         try:
             combined = runner() or {}
-            # Batch status: completed unless every child errored/was interrupted.
+            # Preserve a clean operator-initiated interruption as interrupted.
+            # Otherwise a batch is completed unless every child failed or was
+            # interrupted, matching the existing mixed-result behavior.
             child_results = combined.get("results") or []
-            if child_results and all(
-                (r.get("status") not in ("completed", "success"))
-                for r in child_results
+            child_statuses = [r.get("status") for r in child_results]
+            if child_statuses and all(s == "interrupted" for s in child_statuses):
+                status = "interrupted"
+            elif child_results and all(
+                (s not in ("completed", "success")) for s in child_statuses
             ):
                 status = "error"
             else:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -179,39 +179,80 @@ def _unregister_subagent(subagent_id: str) -> None:
         _active_subagents.pop(subagent_id, None)
 
 
-def interrupt_subagent(subagent_id: str) -> bool:
-    """Request that a single running subagent stop at its next iteration boundary.
+def _controller_owns(record: Dict[str, Any], controller: Any) -> bool:
+    """Return whether *controller* owns the delegation tree for *record*.
 
-    Does not hard-kill the worker thread (Python can't); sets the child's
-    interrupt flag which propagates to in-flight tools and recurses into
-    grandchildren via AIAgent.interrupt().  Returns True if a matching
-    subagent was found.
+    Operator-facing callers pass ``None`` and may inspect/control every live
+    child in the process. Model-facing callers pass their AIAgent instance and
+    are restricted to the tree rooted at that top-level agent.
     """
+    if controller is None:
+        return True
+    # Children inherit this exact object reference from their parent. Keep the
+    # identity check strict so an equal-looking value cannot cross tree bounds.
+    controller_root = getattr(controller, "_delegation_root_agent", controller)
+    return record.get("root_agent") is controller_root
+
+
+def interrupt_subagent(subagent_id: str, controller: Any = None) -> bool:
+    """Request that one running subagent stop at its next iteration boundary."""
     with _active_subagents_lock:
         record = _active_subagents.get(subagent_id)
-    if not record:
-        return False
-    agent = record.get("agent")
+        if record is not None and not _controller_owns(record, controller):
+            record = None
+        agent = record.get("agent") if record else None
     if agent is None:
         return False
     try:
-        agent.interrupt(f"Interrupted via TUI ({subagent_id})")
+        reason = (
+            f"Interrupted via TUI ({subagent_id})"
+            if controller is None
+            else f"Interrupted by controller ({subagent_id})"
+        )
+        agent.interrupt(reason)
     except Exception as exc:
         logger.debug("interrupt_subagent(%s) failed: %s", subagent_id, exc)
         return False
     return True
 
 
-def list_active_subagents() -> List[Dict[str, Any]]:
-    """Snapshot of the currently running subagent tree.
+def steer_subagent(subagent_id: str, instruction: str, controller: Any = None) -> bool:
+    """Inject an instruction into one live subagent's next model iteration.
 
-    Each record: {subagent_id, parent_id, depth, goal, model, started_at,
-    tool_count, status}.  Safe to call from any thread — returns a copy.
+    The registry lock protects lookup only. Calling ``AIAgent.steer`` after
+    releasing it avoids deadlocking against concurrent completion and
+    unregistration. The captured agent remains valid if that race occurs.
     """
+    if not instruction or not instruction.strip():
+        return False
+    with _active_subagents_lock:
+        record = _active_subagents.get(subagent_id)
+        if record is not None and not _controller_owns(record, controller):
+            record = None
+        agent = record.get("agent") if record else None
+    if agent is None:
+        return False
+    steer = getattr(agent, "steer", None)
+    if not callable(steer):
+        return False
+    try:
+        return bool(steer(instruction))
+    except Exception as exc:
+        logger.debug("steer_subagent(%s) failed: %s", subagent_id, exc)
+        return False
+
+
+def list_active_subagents(controller: Any = None) -> List[Dict[str, Any]]:
+    """Snapshot running subagents visible to an optional tree controller."""
     with _active_subagents_lock:
         return [
-            {k: v for k, v in r.items() if k != "agent"}
-            for r in _active_subagents.values()
+            {
+                key: value
+                for key, value in record.items()
+                if key not in {"agent", "root_agent"}
+            }
+            for record in _active_subagents.values()
+            if _controller_owns(record, controller)
         ]
 
 
@@ -1370,6 +1411,11 @@ def _build_child_agent(
     # for _run_single_child / interrupt_subagent to look up by id.
     child._subagent_id = subagent_id
     child._parent_subagent_id = parent_subagent_id
+    setattr(
+        child,
+        "_delegation_root_agent",
+        getattr(parent_agent, "_delegation_root_agent", parent_agent),
+    )
     child._subagent_goal = goal
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
     # Stable sidebar marker: delegate subagent sessions must stay out of
@@ -1887,6 +1933,7 @@ def _run_single_child(
                 "status": "running",
                 "tool_count": 0,
                 "agent": child,
+                "root_agent": getattr(child, "_delegation_root_agent", parent_agent),
             }
         )
 
@@ -2378,6 +2425,55 @@ def _recover_tasks_from_json_string(
     return parsed, None
 
 
+def _delegate_control(
+    action: str,
+    *,
+    subagent_id: Optional[str],
+    instruction: Optional[str],
+    parent_agent: Any,
+) -> str:
+    """Handle model-facing controls for the caller's delegation tree."""
+    if action == "status":
+        active = list_active_subagents(controller=parent_agent)
+        active.sort(
+            key=lambda item: (
+                item.get("depth", 0),
+                item.get("started_at", 0),
+                item.get("subagent_id", ""),
+            )
+        )
+        return json.dumps({"active": active, "count": len(active)})
+
+    if action not in {"steer", "interrupt"}:
+        return tool_error(
+            "action must be one of: spawn, status, steer, interrupt."
+        )
+    if not subagent_id or not subagent_id.strip():
+        return tool_error(f"subagent_id is required for action={action!r}.")
+
+    if action == "steer":
+        if not instruction or not instruction.strip():
+            return tool_error("instruction is required for action='steer'.")
+        accepted = steer_subagent(
+            subagent_id.strip(), instruction, controller=parent_agent
+        )
+    else:
+        accepted = interrupt_subagent(subagent_id.strip(), controller=parent_agent)
+
+    if not accepted:
+        return tool_error(
+            f"No controllable live subagent found with id {subagent_id!r}. "
+            "Call delegate_task(action='status') to list this session's active children."
+        )
+    return json.dumps(
+        {
+            "action": action,
+            "accepted": True,
+            "subagent_id": subagent_id.strip(),
+        }
+    )
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -2386,6 +2482,9 @@ def delegate_task(
     role: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
+    action: str = "spawn",
+    subagent_id: Optional[str] = None,
+    instruction: Optional[str] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
@@ -2403,6 +2502,15 @@ def delegate_task(
     """
     if parent_agent is None:
         return tool_error("delegate_task requires a parent agent context.")
+
+    action = (action or "spawn").strip().lower()
+    if action != "spawn":
+        return _delegate_control(
+            action,
+            subagent_id=subagent_id,
+            instruction=instruction,
+            parent_agent=parent_agent,
+        )
 
     # Operator-controlled kill switch — lets the TUI freeze new fan-out
     # when a runaway tree is detected, without interrupting already-running
@@ -3267,10 +3375,15 @@ def _build_top_level_description() -> str:
         )
 
     return (
-        "Spawn one or more subagents to work on tasks in isolated contexts. "
+        "Spawn or control subagents working in isolated contexts. "
         "Each subagent gets its own conversation, terminal session, and toolset. "
         "Only the final summary is returned -- intermediate tool results "
         "never enter your context window.\n\n"
+        "LIVE CONTROL: use action='status' to list this session's running "
+        "children and recent tool activity, action='steer' with subagent_id "
+        "and instruction to redirect one child, or action='interrupt' with "
+        "subagent_id to stop one child. Controls are scoped to this session's "
+        "delegation tree.\n\n"
         "TWO MODES (one of 'goal' or 'tasks' is required):\n"
         "1. Single task: provide 'goal' (+ optional context, toolsets).\n"
         f"2. Batch (parallel): provide 'tasks' array with up to {max_children} "
@@ -3417,6 +3530,23 @@ DELEGATE_TASK_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["spawn", "status", "steer", "interrupt"],
+                "description": (
+                    "Operation to perform. Defaults to 'spawn'. Use 'status' "
+                    "to list active children, 'steer' to inject a new "
+                    "instruction, or 'interrupt' to stop one child."
+                ),
+            },
+            "subagent_id": {
+                "type": "string",
+                "description": "Target id for action='steer' or 'interrupt'.",
+            },
+            "instruction": {
+                "type": "string",
+                "description": "New direction to inject for action='steer'.",
+            },
             "goal": {
                 "type": "string",
                 "description": (
@@ -3526,6 +3656,9 @@ registry.register(
     toolset="delegation",
     schema=DELEGATE_TASK_SCHEMA,
     handler=lambda args, **kw: delegate_task(
+        action=args.get("action", "spawn"),
+        subagent_id=args.get("subagent_id"),
+        instruction=args.get("instruction"),
         goal=args.get("goal"),
         context=args.get("context"),
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8592,6 +8592,23 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"found": ok, "subagent_id": subagent_id})
 
 
+@method("subagent.steer")
+def _(rid, params: dict) -> dict:
+    from tools.delegate_tool import steer_subagent
+
+    subagent_id = str(params.get("subagent_id") or "").strip()
+    instruction = str(params.get("instruction") or "").strip()
+    if not subagent_id:
+        return _err(rid, 4000, "subagent_id required")
+    if not instruction:
+        return _err(rid, 4000, "instruction required")
+    accepted = steer_subagent(subagent_id, instruction)
+    return _ok(
+        rid,
+        {"accepted": accepted, "subagent_id": subagent_id},
+    )
+
+
 # ── Spawn-tree snapshots: TUI-written, disk-persisted ────────────────
 # The TUI is the source of truth for subagent state (it assembles payloads
 # from the event stream).  On turn-complete it posts the final tree here;

--- a/ui-tui/src/components/agentsOverlay.tsx
+++ b/ui-tui/src/components/agentsOverlay.tsx
@@ -726,9 +726,9 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
     })
       .then(raw => {
         const r = asRpcResult<SubagentSteerResponse>(raw)
-        setFlash(r?.accepted ? `steered ${target.item.id}` : `not running: ${target.item.id}`)
+        setFlash(r?.accepted ? `instruction queued for ${target.item.id}` : `not running: ${target.item.id}`)
       })
-      .catch(() => setFlash(`steer failed: ${target.item.id}`))
+      .catch(() => setFlash(`instruction failed: ${target.item.id}`))
   }
 
   const killOne = (id: string) =>
@@ -736,16 +736,16 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
       interrupt(id)
         .then(raw => {
           const r = asRpcResult<SubagentInterruptResponse>(raw)
-          setFlash(r?.found ? `killing ${id}` : `not found: ${id}`)
+          setFlash(r?.found ? `stopping ${id}` : `not found: ${id}`)
         })
-        .catch(() => setFlash(`kill failed: ${id}`))
+        .catch(() => setFlash(`stop failed: ${id}`))
     })
 
   const killSubtree = (node: SubagentNode) =>
     guardLive(() => {
       const ids = [node.item.id, ...descendantIds(node)]
       ids.forEach(id => interrupt(id).catch(() => {}))
-      setFlash(`killing subtree · ${ids.length} node${ids.length === 1 ? '' : 's'}`)
+      setFlash(`stopping subtree · ${ids.length} node${ids.length === 1 ? '' : 's'}`)
     })
 
   const togglePause = () =>
@@ -754,7 +754,7 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
         .then(raw => {
           const r = asRpcResult<DelegationPauseResponse>(raw)
           applyDelegationStatus({ paused: r?.paused })
-          setFlash(r?.paused ? 'spawning paused' : 'spawning resumed')
+          setFlash(r?.paused ? 'new subagent spawning paused · running agents continue' : 'new subagent spawning resumed')
         })
         .catch(() => setFlash('pause failed'))
     })
@@ -787,7 +787,7 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
       if (key.escape) {
         setSteerTarget(null)
         setSteerText('')
-        setFlash('steer cancelled')
+        setFlash('instruction cancelled')
       }
 
       return
@@ -822,7 +822,7 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
       return killSubtree(selected)
     }
 
-    if (ch === 'e' && selected) {
+    if (ch === 'i' && selected) {
       return guardLive(() => {
         if (selected.item.status !== 'running') {
           setFlash(`not running: ${selected.item.id}`)
@@ -935,7 +935,7 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
 
   const controlsHint = replayMode
     ? ' · controls locked'
-    : ` · e steer · x kill · X subtree · p ${delegation.paused ? 'resume' : 'pause'}`
+    : ` · i instruct · x stop · X stop subtree · p ${delegation.paused ? 'resume spawns' : 'pause spawns'}`
 
   // ── Rendering ──────────────────────────────────────────────────────
 
@@ -1000,7 +1000,7 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
 
         {steerTarget ? (
           <Box flexDirection="column">
-            <Text color={t.color.label}>Steer {steerTarget.item.id}</Text>
+            <Text color={t.color.label}>New instruction for {steerTarget.item.id}</Text>
             <Box>
               <Text color={t.color.label}>{'> '}</Text>
               <TextInput

--- a/ui-tui/src/components/agentsOverlay.tsx
+++ b/ui-tui/src/components/agentsOverlay.tsx
@@ -12,7 +12,12 @@ import { patchOverlayState } from '../app/overlayStore.js'
 import { $spawnDiff, $spawnHistory, clearDiffPair, type SpawnSnapshot } from '../app/spawnHistoryStore.js'
 import { useTurnSelector } from '../app/turnStore.js'
 import type { GatewayClient } from '../gatewayClient.js'
-import type { DelegationPauseResponse, DelegationStatusResponse, SubagentInterruptResponse } from '../gatewayTypes.js'
+import type {
+  DelegationPauseResponse,
+  DelegationStatusResponse,
+  SubagentInterruptResponse,
+  SubagentSteerResponse
+} from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
 import {
   buildSubagentTree,
@@ -33,6 +38,7 @@ import type { Theme } from '../theme.js'
 import type { SubagentNode, SubagentProgress } from '../types.js'
 
 import { OverlayScrollbar } from './overlayScrollbar.js'
+import { TextInput } from './textInput.js'
 
 // ── Types + lookup tables ────────────────────────────────────────────
 
@@ -608,6 +614,8 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
   const [cursor, setCursor] = useState(0)
   const [flash, setFlash] = useState<string>('')
   const [now, setNow] = useState(() => Date.now())
+  const [steerTarget, setSteerTarget] = useState<SubagentNode | null>(null)
+  const [steerText, setSteerText] = useState('')
   // cc-style view switching: list = full-width row picker, detail = full-width
   // scrollable pane.  Two panes side-by-side in Ink fought Yoga flex.
   const [mode, setMode] = useState<'detail' | 'list'>('list')
@@ -700,6 +708,29 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
 
   const interrupt = (id: string) => gw.request<SubagentInterruptResponse>('subagent.interrupt', { subagent_id: id })
 
+  const submitSteer = (instruction: string) => {
+    const target = steerTarget
+    const cleaned = instruction.trim()
+
+    if (!target || !cleaned) {
+      setFlash('steer instruction cannot be empty')
+
+      return
+    }
+
+    setSteerTarget(null)
+    setSteerText('')
+    gw.request<SubagentSteerResponse>('subagent.steer', {
+      instruction: cleaned,
+      subagent_id: target.item.id
+    })
+      .then(raw => {
+        const r = asRpcResult<SubagentSteerResponse>(raw)
+        setFlash(r?.accepted ? `steered ${target.item.id}` : `not running: ${target.item.id}`)
+      })
+      .catch(() => setFlash(`steer failed: ${target.item.id}`))
+  }
+
   const killOne = (id: string) =>
     guardLive(() => {
       interrupt(id)
@@ -752,6 +783,16 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
   const scrollDetail = (dy: number) => detailScrollRef.current?.scrollBy(dy)
 
   useInput((ch, key) => {
+    if (steerTarget) {
+      if (key.escape) {
+        setSteerTarget(null)
+        setSteerText('')
+        setFlash('steer cancelled')
+      }
+
+      return
+    }
+
     if (ch === 'q') {
       return closeWithCleanup()
     }
@@ -779,6 +820,19 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
 
     if (ch === 'X' && selected) {
       return killSubtree(selected)
+    }
+
+    if (ch === 'e' && selected) {
+      return guardLive(() => {
+        if (selected.item.status !== 'running') {
+          setFlash(`not running: ${selected.item.id}`)
+
+          return
+        }
+
+        setSteerTarget(selected)
+        setSteerText('')
+      })
     }
 
     if (mode === 'detail') {
@@ -881,7 +935,7 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
 
   const controlsHint = replayMode
     ? ' · controls locked'
-    : ` · x kill · X subtree · p ${delegation.paused ? 'resume' : 'pause'}`
+    : ` · e steer · x kill · X subtree · p ${delegation.paused ? 'resume' : 'pause'}`
 
   // ── Rendering ──────────────────────────────────────────────────────
 
@@ -944,7 +998,22 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
       <Box flexDirection="column" marginTop={1}>
         {flash ? <Text color={t.color.accent}>{flash}</Text> : null}
 
-        {mode === 'list' ? (
+        {steerTarget ? (
+          <Box flexDirection="column">
+            <Text color={t.color.label}>Steer {steerTarget.item.id}</Text>
+            <Box>
+              <Text color={t.color.label}>{'> '}</Text>
+              <TextInput
+                columns={Math.max(20, cols - 6)}
+                focus
+                onChange={setSteerText}
+                onSubmit={submitSteer}
+                value={steerText}
+              />
+            </Box>
+            <Text color={t.color.muted}>Enter send · Esc cancel</Text>
+          </Box>
+        ) : mode === 'list' ? (
           <Text color={t.color.muted}>
             ↑↓/jk move · g/G top/bottom · Enter/→ open detail{controlsHint} · s sort:{SORT_LABEL[sort]} · f filter:
             {FILTER_LABEL[filter]}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -590,6 +590,11 @@ export interface SubagentInterruptResponse {
   subagent_id?: string
 }
 
+export interface SubagentSteerResponse {
+  accepted?: boolean
+  subagent_id?: string
+}
+
 // ── Spawn-tree snapshots ─────────────────────────────────────────────
 
 export interface SpawnTreeListEntry {

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -30,6 +30,43 @@ delegate_task(tasks=[
 ])
 ```
 
+## Control Running Subagents
+
+`delegate_task` can also inspect, redirect, or stop subagents while they are
+running. The API calls these actions `status`, `steer`, and `interrupt`.
+
+First list the active children that the current agent is allowed to control:
+
+```python
+delegate_task(action="status")
+```
+
+The result includes each live child's stable `subagent_id` and recent activity.
+Use that ID to redirect one child without stopping it:
+
+```python
+delegate_task(
+    action="steer",
+    subagent_id="<id from status>",
+    instruction="Stop editing the API client and focus on reproducing the timeout."
+)
+```
+
+Or request that only that child stop:
+
+```python
+delegate_task(action="interrupt", subagent_id="<id from status>")
+```
+
+`steer` queues the instruction for the child's next model iteration.
+`interrupt` requests a cooperative stop, so it may not be instantaneous while
+the child is inside a model or tool call.
+
+Model-originated controls are scoped to the caller's top-level delegation tree.
+An agent can coordinate children and sibling branches in that tree, but it
+cannot inspect or control a subagent from another delegation tree. The trusted
+TUI operator controls described below are not model-scoped.
+
 ## How Subagent Context Works
 
 :::warning Critical: Subagents Know Nothing
@@ -213,8 +250,17 @@ The TUI ships a `/agents` overlay (alias `/tasks`) that turns recursive `delegat
 
 - Live tree view of running and recently-finished subagents, grouped by parent
 - Per-branch cost, token, and file-touched rollups
-- Kill and pause controls — cancel a specific subagent mid-flight without interrupting its siblings
+- Instruct a selected running subagent with `i`
+- Stop one selected subagent with `x`, or its entire subtree with `X`
+- Pause or resume new spawning with `p`; children already running continue
 - Post-hoc review: step through each subagent's turn-by-turn history even after they've returned to the parent
+
+| Key | Action |
+|-----|--------|
+| `i` | Enter a new instruction for the selected running subagent |
+| `x` | Stop the selected subagent |
+| `X` | Stop the selected subagent and all of its descendants |
+| `p` | Pause or resume new subagent spawning; running subagents are unaffected |
 
 The classic CLI just prints `/agents` as a text summary; the TUI is where the overlay shines. See [TUI — Slash commands](/user-guide/tui#slash-commands).
 

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -113,7 +113,7 @@ All slash commands work unchanged. A few are TUI-owned — they produce richer o
 | `/skin` | Live preview — theme change applies as you browse |
 | `/details` | Toggle verbose tool-call details (global or per-section) |
 | `/usage` | Rich token / cost / context panel |
-| `/agents` (alias `/tasks`) | Observability overlay — live subagent tree with kill/pause controls, per-branch cost / token / file rollups, turn-by-turn history |
+| `/agents` (alias `/tasks`) | Live subagent tree with instruct (`i`), stop selected/subtree (`x`/`X`), spawn pause/resume (`p`), per-branch cost / token / file rollups, and turn-by-turn history |
 | `/reload` | Re-reads `~/.hermes/.env` into the running TUI process so newly added API keys take effect without a restart |
 | `/mouse [on\|off\|toggle\|wheel\|buttons\|all]` | Pick a mouse tracking preset at runtime (also persists to `display.mouse_tracking` in `config.yaml`). `wheel` (1000+1006) keeps scroll-wheel scrolling without the hover events that make tmux spam "No image in clipboard" over the prompt row; `buttons` adds drag-to-select; `all` is the default with hover-driven UI. |
 


### PR DESCRIPTION
## What does this PR do?

Adds live control for asynchronously delegated subagents. A model can inspect its live delegation tree, steer a running child, or interrupt it without blocking the parent turn. Trusted TUI operators can perform the same actions through `/agents`.

The implementation extends the existing `delegate_task` tool rather than adding another core tool, and reuses the production `AIAgent.steer()` and `AIAgent.interrupt()` paths. Existing calls remain compatible because `spawn` is still the default action.

Model-driven control is scoped to the caller's top-level delegation tree. This intentionally permits coordination across sibling branches in the same tree while rejecting leaked child IDs from another tree. Trusted operator RPCs are not model-scoped.

## Related Issue

Related to #47302. Supersedes #47480, whose web-specific PTY worker is replaced by generalized Hermes-core delegation control.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Extend `delegate_task` with `spawn`, `status`, `steer`, and `interrupt` actions while preserving existing spawn behavior.
- Assign stable child IDs and track live-child ownership, hierarchy, lifecycle state, and deterministic status output.
- Scope model control to one top-level delegation tree and deny cross-tree access.
- Forward live-control context through production model-tool dispatch.
- Add trusted `subagent.list`, `subagent.steer`, and `subagent.interrupt` gateway RPCs.
- Add `/agents` controls for steering a selected child, interrupting a child or subtree, and pausing/resuming spawning.
- Preserve a clean operator-initiated interruption as overall asynchronous status `interrupted`.
- Add lifecycle, malformed-input, authorization, race, nesting, sibling-control, dispatch, RPC, real steering, interruption, completion-delivery, and cleanup tests.

## How to Test

1. Run the focused Python suite:
   ```bash
   scripts/run_tests.sh tests/tools/test_live_subagent_control.py tests/tools/test_async_delegation.py tests/tui_gateway/test_subagent_control_rpc.py
   ```
   Result after rebasing onto current `main`: **46 passed, 0 failed**.
2. Validate the TUI:
   ```bash
   cd ui-tui
   npm run typecheck
   npm run lint -- --no-cache
   ```
3. Spawn a child, call `delegate_task(action="status")`, then steer or interrupt it using the returned stable child ID. Trusted TUI users can perform the same operations from `/agents`.

### Broader suite context

A full repository run before the final rebase produced **42,563 passed, 34 failed**. Of those failures, 33 reproduced on an untouched baseline checkout. The remaining cache-timing failure passed immediately in isolation. The focused affected suites and TUI validation above pass after the final rebase.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the tool schema and TUI controls are self-describing
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

```text
46 passed, 0 failed
TUI typecheck: passed
TUI lint: passed
git diff --check: passed
```
