### PR TITLE
Este repo e um fork da Axtro AI do projeto open-source NousResearch/herm

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), OpenR
 
 ---
 
+## Axtro AI Fork
+
+This repository is an **Axtro AI fork** of the open-source [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) project. The `axtro/main` branch carries Axtro's own PRs layered on top of the upstream code.
+
+- **origin** (this fork): [`fernandosilvaia/hermes-agent`](https://github.com/fernandosilvaia/hermes-agent)
+- **upstream** (original project): [`NousResearch/hermes-agent`](https://github.com/NousResearch/hermes-agent)
+
+Everything below is the original upstream README, unchanged.
+
+---
+
 ## Quick Install
 
 ### Linux, macOS, WSL2, Termux


### PR DESCRIPTION
Este repo e um fork da Axtro AI do projeto open-source NousResearch/hermes-agent (branch de trabalho axtro/main). Adicione uma secao curta e nova perto do topo do README.md (logo apos o titulo/intro, antes do resto do conteudo original) explicando isso: que e um fork da Axtro, branch axtro/main tem os PRs proprios da Axtro sobre o upstream, e apontando pro remote origin (fernandosilvaia/hermes-agent) vs upstream (NousResearch/hermes-agent). Nao mude mais nada no arquivo, nao remova nada do conteudo original.

---
Criado automaticamente pelo Axtro Local Worker via Claude Code (job 13daa80d-bd0b-4d44-96a3-3302fbb1a5f5, skill pr_builder_interno, custo $0.158526).

Resumo do agente:

Pronto. Adicionei uma seção **"Axtro AI Fork"** no README.md, logo após a intro (título, badges, descrição e tabela de features) e antes do restante do conteúdo original (Quick Install).

A seção explica:
- que é um fork da Axtro AI do open-source `NousResearch/hermes-agent`;
- que a branch `axtro/main` carrega os PRs próprios da Axtro sobre o upstream;
- aponta o **origin** (`fernandosilvaia/hermes-agent`) vs **upstream** (`NousResearch/hermes-agent`) com links.

Nada mais foi alterado nem removido do conteúdo original.