### PR TITLE
fix(title): honor auxiliary.title_generation.enabled to disable auto titles (salvage #37349)

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -9,6 +9,8 @@ import threading
 from typing import Callable, Optional
 
 from agent.auxiliary_client import call_llm
+from hermes_cli.config import load_config_readonly
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +50,17 @@ def _title_language() -> str:
         return ""
 
 
+def _auto_title_enabled() -> bool:
+    """Return whether automatic session title generation is enabled."""
+    try:
+        config = load_config_readonly()
+        title_config = (config.get("auxiliary") or {}).get("title_generation") or {}
+        return is_truthy_value(title_config.get("enabled"), default=True)
+    except Exception:
+        logger.debug("Failed to read title_generation.enabled", exc_info=True)
+        return True
+
+
 def generate_title(
     user_message: str,
     assistant_response: str,
@@ -66,6 +79,10 @@ def generate_title(
     ``AIAgent._emit_auxiliary_failure`` so the user sees a warning instead
     of silently accumulating untitled sessions.
     """
+    if not _auto_title_enabled():
+        logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
+        return None
+
     # Truncate long messages to keep the request small
     user_snippet = user_message[:500] if user_message else ""
     assistant_snippet = assistant_response[:500] if assistant_response else ""
@@ -244,6 +261,10 @@ def maybe_auto_title(
     - No title is already set
     """
     if not session_db or not session_id or not user_message or not assistant_response:
+        return
+
+    if not _auto_title_enabled():
+        logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
         return
 
     # Count user messages in history to detect first exchange.

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -9,8 +9,6 @@ import threading
 from typing import Callable, Optional
 
 from agent.auxiliary_client import call_llm
-from hermes_cli.config import load_config_readonly
-from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +51,12 @@ def _title_language() -> str:
 def _auto_title_enabled() -> bool:
     """Return whether automatic session title generation is enabled."""
     try:
+        # Lazy imports, matching _title_language(): title_generator is imported
+        # from agent code paths where a module-level hermes_cli import risks
+        # circularity, and the read-only loader avoids config-migration writes.
+        from hermes_cli.config import load_config_readonly
+        from utils import is_truthy_value
+
         config = load_config_readonly()
         title_config = (config.get("auxiliary") or {}).get("title_generation") or {}
         return is_truthy_value(title_config.get("enabled"), default=True)
@@ -263,16 +267,18 @@ def maybe_auto_title(
     if not session_db or not session_id or not user_message or not assistant_response:
         return
 
-    if not _auto_title_enabled():
-        logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
-        return
-
     # Count user messages in history to detect first exchange.
     # conversation_history includes the exchange that just happened,
     # so for a first exchange we expect exactly 1 user message
     # (or 2 counting system). Be generous: generate on first 2 exchanges.
     user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
     if user_msg_count > 2:
+        return
+
+    # Config read comes after the cheap first-exchange guard so the file
+    # isn't touched on every subsequent turn of a long session.
+    if not _auto_title_enabled():
+        logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
         return
 
     thread = threading.Thread(

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -526,6 +526,14 @@ prompt_caching:
 #     model: ""
 #     timeout: 30
 #
+#   # Automatic session title generation after the first exchange
+#   title_generation:
+#     enabled: true          # set false to disable auto-title generation
+#     provider: "auto"
+#     model: ""
+#     timeout: 30
+#     language: ""           # empty = match the user's language; or e.g. "English"
+#
 #   # Session search — summarizes matching past sessions
 #   session_search:
 #     provider: "auto"

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1643,6 +1643,7 @@ DEFAULT_CONFIG = {
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
         },
         "title_generation": {
+            "enabled": True,
             "provider": "auto",
             "model": "",
             "base_url": "",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -363,6 +363,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "s96919@gmail.com": "s96919",
     "yakimenkoleksander228@gmail.com": "doxe0x",
     "a54983334@163.com": "Code-suphub",
     "78542984+Code-suphub@users.noreply.github.com": "Code-suphub",

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -210,6 +210,18 @@ class TestGenerateTitle:
         user_content = captured_kwargs["messages"][1]["content"]
         assert len(user_content) < 1100  # 500 + 500 + formatting
 
+    def test_skips_when_title_generation_disabled(self):
+        """auxiliary.title_generation.enabled=false disables automatic titles."""
+        config = {"auxiliary": {"title_generation": {"enabled": False}}}
+
+        with (
+            patch("agent.title_generator.load_config_readonly", return_value=config),
+            patch("agent.title_generator.call_llm") as mock_call_llm,
+        ):
+            assert generate_title("question", "answer") is None
+
+        mock_call_llm.assert_not_called()
+
 
 class TestAutoTitleSession:
     """Tests for auto_title_session() — the sync worker function."""
@@ -346,6 +358,23 @@ class TestMaybeAutoTitle:
                 main_runtime=None,
                 title_callback=None,
             )
+
+    def test_skips_when_title_generation_disabled(self):
+        """Disabled title generation should not even start the background worker."""
+        db = MagicMock()
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        config = {"auxiliary": {"title_generation": {"enabled": False}}}
+
+        with (
+            patch("agent.title_generator.load_config_readonly", return_value=config),
+            patch("agent.title_generator.auto_title_session") as mock_auto,
+        ):
+            maybe_auto_title(db, "sess-1", "hello", "hi there", history)
+
+        mock_auto.assert_not_called()
 
     def test_forwards_failure_callback_to_worker(self):
         """maybe_auto_title must forward failure_callback into the thread."""

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -215,7 +215,7 @@ class TestGenerateTitle:
         config = {"auxiliary": {"title_generation": {"enabled": False}}}
 
         with (
-            patch("agent.title_generator.load_config_readonly", return_value=config),
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
             patch("agent.title_generator.call_llm") as mock_call_llm,
         ):
             assert generate_title("question", "answer") is None
@@ -369,7 +369,7 @@ class TestMaybeAutoTitle:
         config = {"auxiliary": {"title_generation": {"enabled": False}}}
 
         with (
-            patch("agent.title_generator.load_config_readonly", return_value=config),
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
             patch("agent.title_generator.auto_title_session") as mock_auto,
         ):
             maybe_auto_title(db, "sess-1", "hello", "hi there", history)

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -36,6 +36,7 @@ def test_title_generation_present_in_default_config():
     """
     assert "title_generation" in DEFAULT_CONFIG["auxiliary"]
     tg = DEFAULT_CONFIG["auxiliary"]["title_generation"]
+    assert tg["enabled"] is True
     assert tg["provider"] == "auto"
     assert tg["model"] == ""
     assert tg["timeout"] > 0

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -958,6 +958,10 @@ $ hermes model
 
 Select a task, pick a provider (OAuth flows open a browser; API-key providers prompt), pick a model. The change persists to `auxiliary.<task>.*` in `config.yaml`. Same machinery as the main-model picker — no extra syntax to learn.
 
+If you do not want Hermes to auto-generate titles after the first exchange, set
+`auxiliary.title_generation.enabled: false`. Manual titles still work through
+`/title` and `hermes sessions rename`.
+
 ### Video Tutorial
 
 <div style={{position: 'relative', width: '100%', aspectRatio: '16 / 9', marginBottom: '1.5rem'}}>
@@ -1070,6 +1074,7 @@ auxiliary:
   # Auto-generated session titles. Empty language follows the conversation;
   # set e.g. "English" or "Japanese" to pin titles to one language.
   title_generation:
+    enabled: true              # set false to disable auto-title generation
     provider: "auto"
     model: ""
     base_url: ""


### PR DESCRIPTION
## Summary
`auxiliary.title_generation.enabled: false` now actually disables automatic session titling — closing the gap where our own docs (web-pentest skill) recommended a config key that no code read.

Salvages #37349 by @s96919 (earliest and cleanest of three competing PRs), cherry-picked onto current main with authorship preserved.

## Changes
- `agent/title_generator.py`: `_auto_title_enabled()` gates both `maybe_auto_title()` (the single funnel all four surfaces — CLI, gateway, TUI, ACP — go through) and `generate_title()` (@s96919). Follow-up: lazy config imports matching the `_title_language()` pattern, flag checked after the cheap first-exchange guard so config isn't read every turn (ours).
- `hermes_cli/config.py`: `enabled: True` default in `DEFAULT_CONFIG` (deep-merge handles existing installs; no version bump needed).
- Tests: disabled-flag coverage for both entry points + DEFAULT_CONFIG invariant.
- Docs: `configuration.md` + `cli-config.yaml.example`.

## Validation
| | Before | After |
|---|---|---|
| `enabled: false` in config.yaml | ignored, titles generated | no thread spawned, no LLM call (live E2E, real config file) |
| key absent | titles generated | unchanged (default true; string "false" also honored) |
| `tests/agent/test_title_generator.py` + `test_aux_config.py` | — | all pass via run_tests.sh |

Competing PRs #42098 and #41760 will be closed with credit — #42098 gated only part of the funnel and invented an alias key; #41760 copy-pasted per-call-site gating and missed the ACP surface entirely.

## Infographic

![title-generation-kill-switch](https://v3b.fal.media/files/b/0aa28f3e/BpxQ5LfjI_5WmDyU37qRB_IFJPt5P2.png)
