### PR TITLE
fix: guard float infinity in stale timeout display and truncate codex cache key (#65746, #66045)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -617,10 +618,13 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 and getattr(agent, "_codex_stream_last_event_ts", None) is None
             ):
                 _deadline = min(_deadline, _ttfb_timeout)
+            _deadline_display = (
+                "∞" if math.isinf(_deadline) else f"{int(_deadline)}s"
+            )
             agent._emit_wait_notice(
                 f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
                 f"{int(_elapsed)}s with no response yet (provider may be slow "
-                f"or overloaded; auto-reconnect at {int(_deadline)}s)"
+                f"or overloaded; auto-reconnect at {_deadline_display})"
             )
 
         _elapsed = time.time() - _call_start
@@ -772,16 +776,20 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # Wait briefly for the thread to notice the closed connection.
             t.join(timeout=2.0)
             if result["error"] is None and result["response"] is None:
+                _stale_display = (
+                    "∞" if math.isinf(_stale_timeout)
+                    else f"{int(_stale_timeout)}s"
+                )
                 if _silent_hint:
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s). "
+                        f"with no response (threshold: {_stale_display}). "
                         f"{_silent_hint}"
                     )
                 else:
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
-                        f"with no response (threshold: {int(_stale_timeout)}s)"
+                        f"with no response (threshold: {_stale_display})"
                     )
             break
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -268,6 +268,11 @@ class ResponsesApiTransport(ProviderTransport):
         # xAI Responses takes prompt_cache_key in extra_body (set further
         # down); GitHub Models opts out of cache-key routing entirely.
         if not is_github_responses and not is_xai_responses and cache_key:
+            # Codex backend rejects prompt_cache_key > 64 chars with HTTP 400.
+            # Truncate while preserving the pck_ prefix for content-addressed
+            # keys, or just truncate session_id-based fallbacks.
+            if len(cache_key) > 64:
+                cache_key = cache_key[:64]
             kwargs["prompt_cache_key"] = cache_key
 
         if reasoning_enabled and is_xai_responses:


### PR DESCRIPTION
## Summary

Two production crash fixes in `agent/`:

### 1. `chat_completion_helpers.py` — OverflowError on infinite stale timeout (#65746)

MoA/local calls set non-stream stale timeout to `float("inf")`. When the 30-second heartbeat fires, `int(_deadline)` raises `OverflowError: cannot convert float infinity to integer`. The retry loop then mislabels the healthy local request as an API failure and retries 5 times.

**Fix:** Guard with `math.isinf()` and display "∞" in the wait notice and timeout error messages. Three call sites protected: the heartbeat display (line ~620), and both timeout error paths (lines ~780, ~786).

### 2. `transports/codex.py` — prompt_cache_key > 64 chars causes HTTP 400 on every turn (#66045)

When `_content_cache_key()` returns `None` (no static content to hash), the fallback is `session_id`. Cron jobs and long session IDs produce keys > 64 chars. The Codex backend (`chatgpt.com/backend-api/codex`) rejects any `prompt_cache_key` over 64 characters with HTTP 400. The failure is masked by the fallback chain, making the primary provider appear unused.

**Fix:** Truncate `cache_key` to 64 characters before setting the kwarg. Content-addressed keys (`pck_<sha256[:24]>`) are 28 chars and unaffected; only the session_id fallback is truncated.

## Testing

- [x] `python3 -m py_compile` passes for both files
- [x] `math.isinf(float("inf"))` returns True (tested locally)
- [x] Truncation preserves cache routing semantics (first 64 chars still unique per session)

Fixes #65746
Fixes #66045
