### PR TITLE
fix(desktop): preserve manual pinned session order

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/sessions-section-order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section-order.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { sessionEntriesForSection } from './sessions-section-order'
+
+const session = (id: string, lastActive: number): SessionInfo =>
+  ({
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: lastActive,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    source: 'desktop',
+    started_at: lastActive,
+    title: id,
+    tool_call_count: 0
+  }) as SessionInfo
+
+describe('sessionEntriesForSection', () => {
+  it('preserves the persisted user order for pinned sessions', () => {
+    const older = session('older', 1)
+    const newer = session('newer', 2)
+
+    expect(sessionEntriesForSection([older, newer], true).map(entry => entry.session.id)).toEqual(['older', 'newer'])
+  })
+
+  it('keeps the activity ordering used by regular session lists', () => {
+    const older = session('older', 1)
+    const newer = session('newer', 2)
+
+    expect(sessionEntriesForSection([older, newer], false).map(entry => entry.session.id)).toEqual(['newer', 'older'])
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/sessions-section-order.ts
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section-order.ts
@@ -1,0 +1,8 @@
+import type { SessionInfo } from '@/hermes'
+import { flattenSessionsWithBranches, type SidebarSessionEntry } from '@/lib/session-branch-tree'
+
+export function sessionEntriesForSection(sessions: readonly SessionInfo[], pinned: boolean): SidebarSessionEntry[] {
+  // Pins are already in the user's persisted order. The branch flattener sorts
+  // top-level groups by activity, which would undo a successful drag reorder.
+  return pinned ? sessions.map(session => ({ session })) : flattenSessionsWithBranches(sessions)
+}

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -23,6 +23,7 @@ import {
 import { ReorderableList, useSortableBindings } from './reorderable-list'
 import { SidebarSessionSkeletons } from './section-states'
 import { SidebarSessionRow } from './session-row'
+import { sessionEntriesForSection } from './sessions-section-order'
 import { VirtualSessionList } from './virtual-session-list'
 
 export const VIRTUALIZE_THRESHOLD = 25
@@ -189,7 +190,7 @@ export function SidebarSessionsSection({
   // The flat recents/pinned list is the only place sessions reorder by hand;
   // grouped/tree views always sort by creation date and never drag.
   const sessionsDraggable = sortable && !!onReorderSessions
-  const displayEntries = useMemo(() => flattenSessionsWithBranches(sessions), [sessions])
+  const displayEntries = useMemo(() => sessionEntriesForSection(sessions, pinned), [pinned, sessions])
 
   const renderRow = (session: SessionInfo, draggable: boolean, branchStem?: string) => {
     const rowProps = {

--- a/apps/desktop/src/store/layout-pinned-order.test.ts
+++ b/apps/desktop/src/store/layout-pinned-order.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { reorderedPinnedSessionIds } from './layout'
+
+describe('reorderedPinnedSessionIds', () => {
+  it('persists an exact visible reorder', () => {
+    expect(reorderedPinnedSessionIds(['a', 'b', 'c'], ['c', 'a', 'b'])).toEqual(['c', 'a', 'b'])
+  })
+
+  it('reorders visible pins while preserving stale or unresolved durable pins', () => {
+    expect(reorderedPinnedSessionIds(['a', 'stale', 'b', 'c'], ['c', 'a', 'b'])).toEqual(['c', 'a', 'b', 'stale'])
+  })
+
+  it('ignores duplicate and unpinned ids from the rendered order', () => {
+    expect(reorderedPinnedSessionIds(['a', 'b'], ['b', 'b', 'not-pinned', 'a'])).toEqual(['b', 'a'])
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -322,12 +322,22 @@ export function unpinSession(sessionId: string) {
 // Replace the whole pinned order at once (drag-reorder hands back the new order
 // rather than a single move). Keep only ids that are actually pinned so a stale
 // row can't smuggle an unpinned id into the store.
+export function reorderedPinnedSessionIds(prev: string[], ids: string[]): string[] {
+  const pinned = new Set(prev)
+  const seen = new Set<string>()
+  const visibleOrder = ids.filter(id => pinned.has(id) && !seen.has(id) && Boolean(seen.add(id)))
+
+  // The rendered list can contain fewer rows than the durable pin store after
+  // compression/lineage dedup or when an old pin is temporarily unresolved.
+  // Keep those hidden ids, but do not let them veto reordering the visible rows.
+  return [...visibleOrder, ...prev.filter(id => !seen.has(id))]
+}
+
 export function setPinnedSessionOrder(ids: string[]) {
   const prev = $pinnedSessionIds.get()
-  const pinned = new Set(prev)
-  const next = ids.filter(id => pinned.has(id))
+  const next = reorderedPinnedSessionIds(prev, ids)
 
-  if (next.length === prev.length && !arraysEqual(prev, next)) {
+  if (!arraysEqual(prev, next)) {
     $pinnedSessionIds.set(next)
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes pinned sessions snapping back after drag reordering in Hermes Desktop.

Two independent paths were undoing or rejecting the user's order:

1. `SidebarSessionsSection` passed pinned rows through `flattenSessionsWithBranches()`, which sorts top-level entries by activity and therefore overwrote the persisted drag order at render time.
2. `setPinnedSessionOrder()` rejected a visible reorder whenever the durable pin store also contained an unresolved or deduplicated pin that was not currently rendered.

Pinned sections now render in their already-persisted order, while regular session sections retain activity ordering. Visible pin reorders are persisted without dropping unresolved durable pins.

## Related Issue

Related to #47728.

This is intentionally narrower than open PR #43661: that PR redesigns native drag-to-pin/unpin and positional drop UX, while this PR fixes the current dnd-kit reorder path's render and persistence invariants. At the latest reviewed head of #43661, both affected current-main code paths were unchanged.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve the incoming persisted order when rendering the Pinned section.
- Keep activity-based branch ordering for regular Sessions.
- Reorder visible pinned IDs while retaining unresolved/deduplicated durable pins.
- Ignore duplicate and unpinned IDs supplied by the rendered drag order.
- Add five regression tests covering render ordering and persistence behavior.

## How to Test

1. Pin multiple sessions and drag an older session above a newer active session.
2. Release the row and confirm the Pinned section keeps the chosen order instead of snapping back to activity order.
3. Repeat while the durable pin list contains an unresolved/hidden pin; confirm visible rows reorder and the hidden pin remains stored.
4. Run:

   ```bash
   npm --prefix apps/desktop run typecheck
   npm --prefix apps/desktop exec vitest run --environment jsdom src/store/layout-pinned-order.test.ts src/app/chat/sidebar/sessions-section-order.test.ts
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and PRs, including #43661.
- [x] My PR contains only changes related to this bug fix.
- [x] Desktop typecheck passes.
- [x] I've added regression tests for the bug (5/5 pass).
- [x] I've tested on macOS 26.4.1 (Apple Silicon) using a packaged Hermes Desktop build.

### Documentation & Housekeeping

- [x] Documentation update: N/A (internal behavior fix).
- [x] `cli-config.yaml.example`: N/A (no config changes).
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A (no architecture/workflow changes).
- [x] Cross-platform impact considered: the change is pure TypeScript ordering logic with no platform-specific APIs.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

Regression verification:

```text
Test Files  2 passed (2)
Tests       5 passed (5)
Desktop TypeScript typecheck: PASS
ESLint: PASS
Prettier: PASS
git diff --check: PASS
```

The fix was also verified manually in the packaged macOS Desktop app: pinned rows no longer snap back after release.
