### PR TITLE
fix: cap prompt_cache_key at 64 chars to avoid OpenAI Codex 400 error (#66045)

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -265,6 +265,9 @@ class ResponsesApiTransport(ProviderTransport):
         # the cache-scope routing headers below. Falls back to session_id when
         # there is no static content to hash.
         cache_key = _content_cache_key(instructions, response_tools) or session_id
+        # OpenAI rejects prompt_cache_key > 64 chars with HTTP 400.
+        if cache_key and len(cache_key) > 64:
+            cache_key = cache_key[:64]
         # xAI Responses takes prompt_cache_key in extra_body (set further
         # down); GitHub Models opts out of cache-key routing entirely.
         if not is_github_responses and not is_xai_responses and cache_key:


### PR DESCRIPTION
**Bug:** On `openai-codex` provider, `prompt_cache_key` can exceed 64 chars. The OpenAI backend rejects >64 chars with HTTP 400, causing every codex request to fail and silently fall back.

**Fix:** After `cache_key` is built in `build_kwargs()`, cap at 64 chars. Both usage paths (line 271 kwargs and line 382 merged_extra_body) are covered.

Closes #66045