### PR TITLE
fix(slack): preserve thread context for commands

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3401,6 +3401,12 @@ class SlackAdapter(BasePlatformAdapter):
 
         # When entering a thread for the first time (no existing session),
         # fetch thread context so the agent understands the conversation.
+        #
+        # Keep recovered history separate from ``text``. Prepending it here
+        # moves a recognized command away from character zero, so downstream
+        # command routing can misclassify it as conversational text.
+        # ``channel_context`` is prepended only after command dispatch.
+        channel_context = None
         if is_thread_reply and not self._has_active_session_for_thread(
             channel_id=channel_id,
             thread_ts=event_thread_ts,
@@ -3414,7 +3420,7 @@ class SlackAdapter(BasePlatformAdapter):
                 team_id=team_id,
             )
             if thread_context:
-                text = thread_context + text
+                channel_context = thread_context
 
         # Determine message type
         msg_type = MessageType.TEXT
@@ -3752,6 +3758,7 @@ class SlackAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=thread_ts if thread_ts != ts else None,
             channel_prompt=_channel_prompt,
+            channel_context=channel_context,
             reply_to_text=reply_to_text,
             auto_skill=_auto_skill,
             metadata={

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1333,6 +1333,55 @@ class TestBangPrefixCommands:
         assert msg_event.source.thread_id == "1111111111.000001"
 
     @pytest.mark.asyncio
+    async def test_bang_queue_survives_first_thread_context_backfill(self, adapter):
+        """Backfill stays out of command text while remaining available."""
+        adapter._has_active_session_for_thread = MagicMock(return_value=False)
+        adapter._fetch_thread_context = AsyncMock(
+            return_value=(
+                "[Slack thread context — earlier messages]\n"
+                "Alice: prior request\n"
+                "[End of thread context]\n\n"
+            )
+        )
+        adapter._fetch_thread_parent_text = AsyncMock(return_value="prior request")
+
+        evt = self._make_event(
+            "!queue follow up after the current task",
+            thread_ts="1111111111.000001",
+        )
+        await adapter._handle_slack_message(evt)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/queue follow up after the current task"
+        assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.get_command() == "queue"
+        assert msg_event.get_command_args() == "follow up after the current task"
+        assert msg_event.channel_context.startswith("[Slack thread context")
+        assert "prior request" in msg_event.channel_context
+
+    @pytest.mark.asyncio
+    async def test_non_command_thread_backfill_uses_channel_context(self, adapter):
+        """Normal thread text remains separate without losing its backfill."""
+        adapter._has_active_session_for_thread = MagicMock(return_value=False)
+        adapter._fetch_thread_context = AsyncMock(
+            return_value="[Slack thread context]\nAlice: earlier note\n"
+        )
+        adapter._fetch_thread_parent_text = AsyncMock(return_value="earlier note")
+
+        evt = self._make_event(
+            "follow up",
+            thread_ts="1111111111.000001",
+        )
+        await adapter._handle_slack_message(evt)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "follow up"
+        assert msg_event.message_type == MessageType.TEXT
+        assert msg_event.channel_context == (
+            "[Slack thread context]\nAlice: earlier note\n"
+        )
+
+    @pytest.mark.asyncio
     async def test_bang_unknown_token_passes_through_unchanged(self, adapter):
         """``!nice work`` is just a casual message — must NOT be rewritten."""
         await adapter._handle_slack_message(self._make_event("!nice work"))


### PR DESCRIPTION
## What does this PR do?

Keeps normalized Slack command text routable when Hermes restores context for the first message in an existing thread after a gateway restart.

Slack thread replies use `!command` because Slack intercepts native `/command` text. Hermes normalizes a known bang command such as `!queue later` to `/queue later`, but first-entry thread backfill is currently prepended to the command text. That moves `/` away from character zero, so `MessageEvent` no longer classifies the input as a command.

This change keeps the normalized command in `MessageEvent.text` and carries recovered history in the existing `MessageEvent.channel_context` field. Command routing therefore sees the exact command and arguments, while the subsequent agent turn can still receive the Slack conversation history that the backfill was designed to preserve. Normal non-command thread messages retain their existing behavior.

This complements #30592 rather than replacing it. #30592 re-normalizes `@bot !command` after stripping the mention, protects command text from rich-block enrichment, and skips thread-context fetching for commands. This PR addresses a separate semantic edge: already-recognized commands such as plain `!queue` should preserve first-entry thread history without mixing that history into command text. If #30592 merges first, this patch may need a small textual rebase around the same adapter block.

## Related Issue

Related work: #25355, #26309, #30592, #56718.

No separate issue has been filed. The behavior is covered by a focused adapter regression on current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py`
  - Keep fetched first-thread history separate from normalized command text.
  - Pass recovered history through the existing `MessageEvent.channel_context` field.
- `tests/gateway/test_slack.py`
  - Reproduce first-entry thread backfill with a known `!queue` command.
  - Assert exact command classification and arguments.
  - Assert recovered Slack history remains available as channel context.
  - Assert normal-message backfill continues to use the recovered history.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_slack.py -q`.
2. Run `scripts/check-windows-footguns.py --diff upstream/main`.
3. In a Slack thread without an active Hermes session, send `!queue follow up after the current task`.
4. Confirm Hermes dispatches `/queue` with the exact arguments and retains earlier thread messages as channel context.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the current-main focused suite via `scripts/run_tests.sh` and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing command syntax changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — adapter-only data routing; no OS-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Attribution

- The Slack `!command` thread fallback was introduced by @teknium1 in #25355.
- Related reproductions and proposed fixes were contributed by @PavelTajdus (#26309), @cypres0099 (#30592), and @nu476 (#56718).
- This PR's `channel_context` implementation is independently scoped and does not copy their code.

## Screenshots / Logs

```text
scripts/run_tests.sh tests/gateway/test_slack.py -q
245 passed, 0 failed

python -m ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py
All checks passed!

scripts/check-windows-footguns.py --diff upstream/main
No Windows footguns found (2 files scanned).

git diff --check
passed
```