### PR TITLE
fix(auxiliary): _read_main_model falls back to model.model like the rest of the codebase

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2198,8 +2198,9 @@ def _refresh_nous_recommended_model(
 def _read_main_model() -> str:
     """Read the user's configured main model from config.yaml.
 
-    config.yaml model.default is the single source of truth for the active
-    model. Environment variables are no longer consulted.
+    config.yaml model.default (falling back to model.model, which some
+    ``hermes auth`` paths write instead) is the source of truth for the
+    active model. Environment variables are no longer consulted.
 
     Runtime override: when an AIAgent is active with a CLI/gateway-provided
     model that differs from config.yaml, ``set_runtime_main()`` records the
@@ -2217,9 +2218,12 @@ def _read_main_model() -> str:
         if isinstance(model_cfg, str) and model_cfg.strip():
             return model_cfg.strip()
         if isinstance(model_cfg, dict):
-            default = model_cfg.get("default", "")
-            if isinstance(default, str) and default.strip():
-                return default.strip()
+            # Some auth flows write the model under ``model.model`` instead
+            # of ``model.default`` — accept both, like fallback_cmd does.
+            for key in ("default", "model"):
+                value = model_cfg.get(key, "")
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
     except Exception:
         pass
     return ""

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2640,6 +2640,39 @@ class TestAuxiliaryFallbackLayering:
         assert mock_openai.call_args.kwargs["api_key"] == "codex-oauth-token"
 
 
+class TestReadMainModel:
+    """_read_main_model reads model.default, falling back to model.model."""
+
+    def _read(self, config):
+        import agent.auxiliary_client as mod
+        with patch.object(mod, "_RUNTIME_MAIN_MODEL", ""), \
+             patch("hermes_cli.config.load_config", return_value=config):
+            return mod._read_main_model()
+
+    def test_reads_model_default(self):
+        assert self._read({"model": {"default": "gpt-5.3-codex"}}) == "gpt-5.3-codex"
+
+    def test_falls_back_to_model_model(self):
+        """Some ``hermes auth`` paths write model.model without model.default."""
+        assert self._read({"model": {"model": "gpt-5.3-codex"}}) == "gpt-5.3-codex"
+
+    def test_default_wins_over_model(self):
+        assert self._read(
+            {"model": {"default": "picked-model", "model": "auth-model"}}
+        ) == "picked-model"
+
+    def test_blank_default_falls_back_to_model(self):
+        assert self._read(
+            {"model": {"default": "  ", "model": "auth-model"}}
+        ) == "auth-model"
+
+    def test_string_model_cfg(self):
+        assert self._read({"model": "bare-model"}) == "bare-model"
+
+    def test_empty_config_returns_empty(self):
+        assert self._read({}) == ""
+
+
 class TestTryMainAgentModelFallback:
     """_try_main_agent_model_fallback resolves the user's main provider+model as a safety net."""
 


### PR DESCRIPTION
## What does this PR do?

`_read_main_model()` in `agent/auxiliary_client.py` reads only `model.default` from config.yaml, while the rest of the codebase reads `model.default or model.model` (see `hermes_cli/fallback_cmd.py`'s `_extract_fallback_from_model_cfg`, `hermes_cli/dump.py`, `hermes_cli/kanban_diagnostics.py`).

Configs that carry `model.model` without `model.default` (written by some `hermes auth` paths) leave the auxiliary chain's main-model slot empty. Symptom: `"openai-codex requested without a model"` warnings and full aux-chain fallthrough — and that warning text itself tells the user to set `model.model`, which `_read_main_model` then ignores.

This PR adds the same two-key fallback (`default` first, then `model`) so the function matches both the rest of the codebase and its own error message.

## Related Issue

No existing issue found (searched issues and PRs for `_read_main_model`, `model.model`, and the warning text).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` — `_read_main_model()` now checks `model.default` then `model.model`; docstring updated.
- `tests/agent/test_auxiliary_client.py` — new `TestReadMainModel` class: 6 regression tests covering the fallback, precedence (`default` wins), blank-`default` fallback, bare-string `model:` config, and empty config.

## How to Test

1. Set config.yaml to have `model.model: <some-model>` with no `model.default` (and `model.provider: openai-codex`).
2. Before this fix: auxiliary calls log `openai-codex requested without a model` and fall through the aux chain.
3. After this fix: the model resolves from `model.model` and the aux chain uses it.
4. `python -m pytest tests/agent/test_auxiliary_client.py -k TestReadMainModel` — 6 passed against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)