### PR TITLE
fix: replace get_secret with os.environ.get in WeixinAdapter.__init__

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1160,11 +1160,11 @@ class WeixinAdapter(BasePlatformAdapter):
         self._poll_task: Optional[asyncio.Task] = None
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
 
-        self._account_id = str(extra.get("account_id") or get_secret("WEIXIN_ACCOUNT_ID", "")).strip()
-        self._token = str(config.token or extra.get("token") or get_secret("WEIXIN_TOKEN", "")).strip()
-        self._base_url = str(extra.get("base_url") or get_secret("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
+        self._account_id = str(extra.get("account_id") or os.environ.get("WEIXIN_ACCOUNT_ID", "")).strip()
+        self._token = str(config.token or extra.get("token") or os.environ.get("WEIXIN_TOKEN", "")).strip()
+        self._base_url = str(extra.get("base_url") or os.environ.get("WEIXIN_BASE_URL", ILINK_BASE_URL)).strip().rstrip("/")
         self._cdn_base_url = str(
-            extra.get("cdn_base_url") or get_secret("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
+            extra.get("cdn_base_url") or os.environ.get("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
         ).strip().rstrip("/")
         self._send_chunk_delay_seconds = float(
             extra.get("send_chunk_delay_seconds") or os.getenv("WEIXIN_SEND_CHUNK_DELAY_SECONDS", "1.5")


### PR DESCRIPTION
## Problem

When multiplexing is enabled (`multiplex_profiles: true`), the gateway crashes in a restart loop during startup:

```
UnscopedSecretError: get_secret('WEIXIN_CDN_BASE_URL') called with no profile secret scope active while multiplexing is on.
```

## Root Cause

`WeixinAdapter.__init__` calls `get_secret()` (lines 1163-1168) during gateway startup, before any profile secret scope is established. `get_secret()` requires a scope when multiplexing is active (fail-closed design to prevent cross-profile credential leaks).

This is inconsistent with other env var reads in the same `__init__` (lines 1169-1178), which already use `os.getenv()` directly.

## Fix

Replace the 4 `get_secret()` calls in `__init__` with `os.environ.get()`, consistent with existing patterns in the same method.

## Testing

Verified on a WSL2 deployment with `multiplex_profiles: true` and weixin credentials in `.env` — gateway now starts without error and runs stably.