### PR TITLE
test(desktop): cover post-draft model switching

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -137,6 +137,22 @@ describe('useModelControls', () => {
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
   })
 
+  it('uses a session created after the model controls callback was captured', async () => {
+    const requestGateway = vi.fn(async () => ({ key: 'model', value: 'claude-sonnet-4.6' }) as never)
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+    $activeSessionId.set('session-created-after-render')
+
+    await controls.selectModel({ model: 'claude-sonnet-4.6', provider: 'anthropic' })
+
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      session_id: 'session-created-after-render',
+      key: 'model',
+      value: 'claude-sonnet-4.6 --provider anthropic --session'
+    })
+  })
+
   it('session-scopes MoA preset selections so they cannot persist as the global gateway default', async () => {
     $activeSessionId.set('session-1')
     const requestGateway = vi.fn(async () => ({ key: 'model', value: 'BeastMode' }) as never)


### PR DESCRIPTION
## Summary

Adds a regression test for the Desktop model picker when its controls are created while the composer is still a draft and the live session appears later.

The test verifies that `selectModel()` reads the current `$activeSessionId` at action time and sends `config.set` to that live session. This protects the fix already present on `main`: older Desktop releases captured `activeSessionId = null`, treated later model selections as UI-only, and snapped back to the session's creation model without sending an RPC.

Related: #65743

## Test Plan

- `npm run test:ui -- src/app/session/hooks/use-model-controls.test.tsx`
- `npm run typecheck`
- `git diff --check`

## Reproduction Evidence

The same test fails against Desktop v0.18.2 with `requestGateway` call count `0`, and passes on current `main` where the callback reads `$activeSessionId.get()`.
