### PR TITLE
fix(tui): hide npm console window during TUI dependency install on Windows

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -66,7 +66,10 @@ except ModuleNotFoundError:
 # any dependency touching ``platform.uname()`` at import time flashes a
 # visible console when this process is windowless (pythonw gateway + every
 # kanban worker).  No-op on POSIX; never raises.
-from hermes_cli._subprocess_compat import suppress_platform_ver_console
+from hermes_cli._subprocess_compat import (
+    suppress_platform_ver_console,
+    windows_hide_flags,
+)
 
 suppress_platform_ver_console()
 
@@ -2046,9 +2049,8 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         # terminal handler is Windows Terminal (Settings > For developers >
         # Terminal delegation) — even though the parent has no window of
         # its own. Same pattern as the wmic scan above; see
-        # windows_hide_flags()'s docstring.
-        from hermes_cli._subprocess_compat import windows_hide_flags
-
+        # windows_hide_flags()'s docstring. Imported at module scope: the
+        # build spawns below run even when this install block is skipped.
         def _run_tui_install() -> subprocess.CompletedProcess:
             return subprocess.run(
                 npm_install_cmd,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2096,6 +2096,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             text=True,
             encoding="utf-8",
             errors="replace",
+            creationflags=windows_hide_flags(),
         )
         if result.returncode != 0:
             combined = f"{result.stdout or ''}{result.stderr or ''}".strip()
@@ -2126,6 +2127,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             text=True,
             encoding="utf-8",
             errors="replace",
+            creationflags=windows_hide_flags(),
         )
         if result.returncode != 0:
             combined = f"{result.stdout or ''}{result.stderr or ''}".strip()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2039,6 +2039,16 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             "--progress=false",
         ]
 
+        # CREATE_NO_WINDOW: this call is spawned from the windowless
+        # pythonw.exe dashboard/gateway backend (e.g. a Windows Scheduled
+        # Task), but without this flag a console-subsystem child (npm.cmd)
+        # gets its own new console — visibly, if the user's default
+        # terminal handler is Windows Terminal (Settings > For developers >
+        # Terminal delegation) — even though the parent has no window of
+        # its own. Same pattern as the wmic scan above; see
+        # windows_hide_flags()'s docstring.
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
         def _run_tui_install() -> subprocess.CompletedProcess:
             return subprocess.run(
                 npm_install_cmd,
@@ -2049,6 +2059,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
                 encoding="utf-8",
                 errors="replace",
                 env={**os.environ, "CI": "1"},
+                creationflags=windows_hide_flags(),
             )
 
         result = _run_tui_install()

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -179,6 +179,43 @@ def test_shell_hooks_hide_hook_command_windows(monkeypatch):
 
 
 
+def test_tui_dependency_install_hides_npm_window(tmp_path, monkeypatch):
+    """The TUI npm-install call (main.py, gated by _tui_need_npm_install) was
+    spawned with no creationflags at all — not even the weaker
+    windows_hide_flags() used elsewhere in this same file. On a system where
+    Windows Terminal is the default terminal-delegation handler, an
+    unflagged console-subsystem child (npm.cmd) gets its own new, VISIBLE
+    console even though the parent is a windowless pythonw.exe Scheduled
+    Task — confirmed empirically on a live Windows install 2026-07-16."""
+    from hermes_cli import main as main_mod
+    from hermes_cli import _subprocess_compat
+
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tui_dir / "dist" / "entry.js").parent.mkdir(parents=True)
+    (tui_dir / "dist" / "entry.js").write_text("console.log('tui')")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"C:/bin/{name}.cmd")
+    monkeypatch.setattr(_subprocess_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(_subprocess_compat, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="", returncode=0)
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    npm_calls = _spawns(captured, "install", "--workspace", "ui-tui")
+    assert len(npm_calls) == 1, captured
+    assert npm_calls[0][1].get("creationflags") == _CREATE_NO_WINDOW
 
 
 

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -218,6 +218,60 @@ def test_tui_dependency_install_hides_npm_window(tmp_path, monkeypatch):
     assert npm_calls[0][1].get("creationflags") == _CREATE_NO_WINDOW
 
 
+def test_tui_build_hides_npm_window_when_install_is_skipped(tmp_path, monkeypatch):
+    """The build spawn must still be hidden when the install block is skipped.
+
+    Regression test for two things at once:
+
+    1. The reviewer's outstanding ask -- assert the normal non-Termux
+       `npm run build` spawn is hidden, not just the install spawn.
+    2. An UnboundLocalError this test would have caught: `windows_hide_flags`
+       used to be imported *inside* the `_tui_need_npm_install(...)` branch
+       while being referenced by the build spawns outside it. Python compiles
+       the name as a function-local for the whole function, so on the common
+       path (dependencies already installed -> install skipped -> import never
+       runs) the build spawn raised
+       `UnboundLocalError: cannot access local variable 'windows_hide_flags'`
+       on every platform. The pre-existing test forced
+       `_tui_need_npm_install -> True`, so it never exercised this path.
+    """
+    from hermes_cli import main as main_mod
+    from hermes_cli import _subprocess_compat
+
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tui_dir / "dist" / "entry.js").parent.mkdir(parents=True)
+    (tui_dir / "dist" / "entry.js").write_text("console.log('tui')")
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    # The path that was broken: nothing to install, but a build still runs.
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"C:/bin/{name}.cmd")
+    monkeypatch.setattr(_subprocess_compat, "IS_WINDOWS", True)
+    monkeypatch.setattr(_subprocess_compat, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="", returncode=0)
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    # Before the fix this raised UnboundLocalError instead of returning.
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    install_calls = _spawns(captured, "install", "--workspace", "ui-tui")
+    assert not install_calls, "install should have been skipped in this scenario"
+
+    build_calls = _spawns(captured, "run", "build")
+    assert build_calls, f"expected an npm run build spawn, got: {captured}"
+    for cmd, kwargs in build_calls:
+        assert kwargs.get("creationflags") == _CREATE_NO_WINDOW, (cmd, kwargs)
+
+
 
 # ── #56747 GUI-reachable exec paths + provider transports (PR #56877) ──────
 #


### PR DESCRIPTION
## Summary

The TUI dependency npm-install `subprocess.run()` call had no `creationflags` at all, unlike every other Windows-facing subprocess call in this codebase, which use `windows_hide_flags()` for exactly this purpose (see `hermes_cli/_subprocess_compat.py` and the extensive existing coverage in `tests/test_windows_subprocess_no_window_flags.py`).

## The bug

On a system where **Windows Terminal is set as the default terminal-delegation handler** (`HKCU\Console\%%Startup\DelegationTerminal`), an unflagged console-subsystem child process (`npm.cmd`) gets its own new, **visible** console window — even when spawned from an already-windowless `pythonw.exe` parent (e.g. a Windows Scheduled Task running the dashboard headlessly).

Confirmed empirically on a live Windows install: a Windows Terminal window appeared in lockstep with every dashboard restart that triggered this install path (`_tui_need_npm_install()` returning `True`), and disappeared entirely once `windows_hide_flags()` was added to the call.

## Fix

Adds `creationflags=windows_hide_flags()` to the `subprocess.run()` call in `_make_tui_argv()` (`hermes_cli/main.py`), matching the exact pattern already used for every other Windows subprocess spawn in this codebase.

## Test

Adds `test_tui_dependency_install_hides_npm_window` to `tests/test_windows_subprocess_no_window_flags.py` — the existing canonical home for this contract across the codebase (16 other tests assert the same property for git/gh/ffmpeg/taskkill/wmic/etc. spawns). Verified to fail against the pre-fix code and pass against the fix.

## Note for maintainers

While diagnosing this, I also found that `_tui_need_npm_install()`'s lockfile comparison checks the **entire monorepo lockfile** (web, desktop, tests-js, ui-tui all together), not just the packages relevant to a `--workspace ui-tui`-scoped install. On my test install this meant 619 packages showed as "missing" (desktop's Electron deps, web's CodeMirror deps, etc.) purely because they were never meant to be installed by the TUI-scoped call in the first place — so `_tui_need_npm_install()` returns `True` on effectively every invocation regardless of whether the TUI's own deps are actually up to date. I didn't attempt a fix for that here since it would mean partially reimplementing npm's own dependency resolution/hoisting logic, which felt too risky to get fully right without much more test coverage than I could responsibly add in this PR — flagging it in case it's useful, happy to open a separate issue with the full diagnostic if that's more useful than a PR comment.