### PR TITLE
fix: keep API keys masked in status diagnostics

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -165,12 +165,12 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -5,13 +5,26 @@ from hermes_cli.status import show_status
 
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-" + "1234567890abcdef")
 
     show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_show_status_all_keeps_api_keys_masked(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    secret = "AQ." + "regression-test-secret-that-must-not-be-printed"
+    monkeypatch.setenv("GOOGLE_API_KEY", secret)
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Google / Gemini" in output
+    assert secret not in output
+    assert "..." in output.split("Google / Gemini", 1)[1].splitlines()[0]
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## Summary
- keep provider API keys redacted when `hermes status --all` is used
- keep Anthropic credentials redacted in expanded diagnostics
- add regression coverage proving `--all` never prints the raw Google key

## Security impact
`--all` expands diagnostic sections; it must not act as permission to disclose complete credentials.

## Test plan
- `python -m pytest tests/hermes_cli/test_status.py tests/hermes_cli/test_status_model_provider.py -o "addopts=" -q`
- `git diff --check`

Result: 24 passed.