### PR TITLE
fix(desktop): stop auto-opening file tree on new session creation (#66059)

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -518,7 +518,13 @@ bindTreeSideVisibility('right', $fileBrowserOpen, setFileBrowserOpen)
 // rode the rail's row and vanished with it), its zone stands on its own.
 const $hasWorkspace = computed($currentCwd, cwd => Boolean(cwd.trim()))
 
-bindPaneVisibility('files', $hasWorkspace)
+// The files pane is workspace-scoped but must NOT auto-open a collapsed
+// right sidebar when the workspace becomes available — the user's own
+// $fileBrowserOpen toggle controls visibility. quiet=true skips
+// force-opening the collapsed side via revealTreePane.
+const syncFilesWorkspace = (hasWorkspace: boolean) => setTreePaneHidden('files', !hasWorkspace, true)
+syncFilesWorkspace($hasWorkspace.get())
+$hasWorkspace.listen(syncFilesWorkspace)
 // ⌘G — the review sidebar appears/disappears (and comes to the front).
 bindPaneVisibility(
   'review',

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -117,7 +117,7 @@ function toggledSet<T>(set: ReadonlySet<T>, item: T, present: boolean): Set<T> |
   return next
 }
 
-export function setTreePaneHidden(paneId: string, hidden: boolean) {
+export function setTreePaneHidden(paneId: string, hidden: boolean, quiet?: boolean) {
   const next = toggledSet($hiddenTreePanes.get(), paneId, hidden)
 
   if (!next) {
@@ -127,7 +127,10 @@ export function setTreePaneHidden(paneId: string, hidden: boolean) {
   $hiddenTreePanes.set(next)
 
   // Unhiding is an intent to SEE the pane — front it in its group.
-  if (!hidden) {
+  // quiet=true skips the reveal for workspace-scoped panes that should not
+  // force-open a collapsed side (e.g. the file tree when a workspace becomes
+  // available — the user's own toggle controls visibility).
+  if (!hidden && !quiet) {
     revealTreePane(paneId)
   }
 }


### PR DESCRIPTION
## Problem
The file tree (right sidebar file browser) force-opens the right sidebar whenever a workspace is present — including on every new session creation — even if the user had explicitly closed it.

## Root Cause
`bindPaneVisibility('files', $hasWorkspace)` called `setTreePaneHidden` which called `revealTreePane` on every unhide, and `revealTreePane` force-opened the collapsed right side via `sideOpeners['right'](true) = setFileBrowserOpen(true)`.

## Fix
Added a `quiet` parameter to `setTreePaneHidden` that skips the `revealTreePane` call, and use it for the files pane's workspace-scoping in the controller. The user's own $fileBrowserOpen toggle now fully controls visibility without being overridden by workspace state transitions.

Closes #66059