### PR TITLE
Fix/alibaba coding plan models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -507,9 +507,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # Alibaba Coding Plan — same platform as alibaba (DashScope coding-intl),
     # separate provider ID with its own base_url_env_var.
     "alibaba-coding-plan": [
-        "qwen3.7-max",
+        "qwen3.7-plus",
         "qwen3.6-plus",
         "qwen3.5-plus",
+        "qwen3-max-2026-01-23",
         "qwen3-coder-plus",
         "qwen3-coder-next",
         "kimi-k2.5",


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Update the `alibaba-coding-plan` model list in `_PROVIDER_MODELS` to match the [official documentation](https://www.alibabacloud.com/help/en/model-studio/coding-plan). The current model list is out of sync:

- `qwen3.7-max` is not supported by the Coding Plan — the correct model is `qwen3.7-plus`
- `qwen3-max-2026-01-23` is supported but was missing from the list

This is a minimal, targeted change — only the model names are updated. The endpoint URL and provider configuration remain unchanged.

In fact, Alibaba Cloud's Coding Plan has a China edition with the same model support but a different base URL.

I've noticed several PRs and issues attempting to fix this problem, but none of them seem to distinguish between these two easily confusable variants.

You can check the [China edition's official documentation](https://help.aliyun.com/zh/model-studio/coding-plan) 

Compare with the [international Coding Plan documentation](https://www.alibabacloud.com/help/en/model-studio/coding-plan)

My suggestion is that we should at least update the supported model list, since it is definitively wrong.

## Related Issue

issue[#44662](https://github.com/NousResearch/hermes-agent/issues/44662)

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `hermes_cli/models.py`: replace `qwen3.7-max` with `qwen3.7-plus`; add `qwen3-max-2026-01-23` to the `alibaba-coding-plan` model list

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Configure `alibaba-coding-plan` provider with valid credentials
2. Run `hermes model` and verify the available models show `qwen3.7-plus` and `qwen3-max-2026-01-23`
3. Verify `qwen3.7-max` no longer appears in the list
4. Run `pytest tests/hermes_cli/test_runtime_provider_resolution.py -q` — all 151 tests pass

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A