### PR TITLE
feat(plugins): inter-plugin event bus with declared emits/listens

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -34,11 +34,13 @@ so plugin-defined tools appear alongside the built-in tools.
 from __future__ import annotations
 
 import asyncio
+import copy
 import importlib.metadata
 import importlib.util
 import inspect
 import logging
 import os
+import queue
 import sys
 import threading
 import types
@@ -224,6 +226,11 @@ HERMES_EVENT_NAMESPACE = "hermes"
 # forever. When exceeded the over-deep emit is dropped (with a warning), not
 # raised, so delivery always terminates cleanly.
 _EVENT_EMIT_DEPTH_CAP = 8
+# Maximum number of queued + currently-running events per manager generation.
+# ``emit`` never waits for capacity: a full budget drops the new event with a
+# warning so a blocked subscriber cannot back-pressure the emitter forever.
+_EVENT_PENDING_CAP = 64
+_EVENT_WORKER_STOP = object()
 
 _NS_PARENT = "hermes_plugins"
 
@@ -329,6 +336,25 @@ class PluginManifest:
     # (``hermes plugins show``); a plugin may emit/subscribe without declaring.
     emits: List[str] = field(default_factory=list)
     listens: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _EventSubscription:
+    """Host-owned subscription ledger entry."""
+
+    owner: str
+    callback: Callable
+
+
+@dataclass(frozen=True)
+class _QueuedPluginEvent:
+    """Immutable dispatch envelope consumed by the event worker."""
+
+    event: str
+    payload: Dict[str, Any]
+    subscriptions: tuple[_EventSubscription, ...]
+    depth: int
+    generation: int
 
 
 @dataclass
@@ -1204,13 +1230,15 @@ class PluginContext:
         ``ValueError`` and a logged warning — fail-closed. The ``hermes:``
         prefix is reserved for core.
 
-        Subscribers are invoked in registration order, each isolated in its
-        own ``try/except`` (one raising subscriber does not stop delivery to
-        the others). ``payload`` is passed to each callback as keyword
-        arguments (``cb(**payload)``), mirroring the hook convention.
+        Delivery is fire-and-forget through a host-owned, single-worker queue:
+        registration order is preserved, while a blocking subscriber cannot
+        stall the emitter. The queue has a bounded pending budget; a full
+        budget drops the new event with a warning. Each subscriber receives a
+        deep-copied payload and is isolated in its own ``try/except``. Awaitable
+        results are resolved through the existing loop-safe plugin path.
 
-        Returns the count of subscriber callbacks invoked (0 when there are
-        no subscribers, or when the recursion cap dropped the emit).
+        Returns the count of subscriber callbacks scheduled (0 when there are
+        no subscribers, or when the pending/recursion budget drops the emit).
         """
         plugin_key = self.manifest.key or self.manifest.name
         if not event or not isinstance(event, str):
@@ -1234,6 +1262,10 @@ class PluginContext:
                 f"bare event name; the namespace is forced to '{plugin_key}:' "
                 f"and the '{HERMES_EVENT_NAMESPACE}:' prefix is reserved for core"
             )
+        if payload is not None and not isinstance(payload, dict):
+            raise TypeError(
+                f"Plugin '{plugin_key}' emit() payload must be a dict or None"
+            )
         full_event = f"{plugin_key}:{event}"
         return self._manager._dispatch_event(full_event, payload or {})
 
@@ -1244,15 +1276,17 @@ class PluginContext:
         if core ever emits). Subscribing is unrestricted — any plugin may
         listen to any published event; only *emitting* is namespace-gated.
 
-        Callbacks are stored in registration order and invoked with the
-        emitter's payload as keyword arguments.
+        Callbacks are stored in registration order as host-owned ledger
+        entries. The owner key lets plugin unload/reload remove subscriptions
+        before any later event can invoke a zombie callback.
         """
         if not event or not isinstance(event, str):
             raise ValueError(
                 f"Plugin '{self.manifest.name}' subscribe() requires a "
                 f"non-empty event name"
             )
-        self._manager._subscriptions.setdefault(event, []).append(callback)
+        plugin_key = self.manifest.key or self.manifest.name
+        self._manager._subscribe_event(plugin_key, event, callback)
         logger.debug(
             "Plugin %s subscribed to event: %s", self.manifest.name, event,
         )
@@ -1349,12 +1383,20 @@ class PluginManager:
         # Plugin-registered auxiliary tasks: key → {key, display_name,
         # description, defaults, plugin}. See PluginContext.register_auxiliary_task.
         self._aux_tasks: Dict[str, Dict[str, Any]] = {}
-        # Inter-plugin event bus: full event name (``<plugin_key>:<event>`` or
-        # ``hermes:<event>``) → list of subscriber callbacks in registration
-        # order. See PluginContext.subscribe/emit and _dispatch_event.
-        self._subscriptions: Dict[str, List[Callable]] = {}
-        # Per-thread re-entrancy depth for event dispatch, used to cap
-        # mutually-emitting plugins (see _EVENT_EMIT_DEPTH_CAP).
+        # Inter-plugin event bus. Subscriptions are owner-tagged ledger entries
+        # so unload/reload can remove zombie callbacks. A single daemon worker
+        # preserves registration order while keeping emitters non-blocking.
+        self._subscriptions: Dict[str, List[_EventSubscription]] = {}
+        self._event_lock = threading.RLock()
+        self._event_idle = threading.Condition(self._event_lock)
+        self._event_generation = 0
+        self._event_pending_by_generation: Dict[int, int] = {0: 0}
+        self._event_queue: queue.Queue[Any] = queue.Queue(
+            maxsize=_EVENT_PENDING_CAP
+        )
+        self._event_worker: Optional[threading.Thread] = None
+        # Per-worker chain depth caps mutually-emitting plugins even though each
+        # re-entrant emit is queued rather than invoked recursively.
         self._emit_depth = threading.local()
         # Slack Block Kit action handlers registered by plugins. Each entry
         # is (matcher, callback, plugin_name); the Slack adapter wires them
@@ -1391,7 +1433,7 @@ class PluginManager:
             self._plugin_commands.clear()
             self._plugin_skills.clear()
             self._aux_tasks.clear()
-            self._subscriptions.clear()
+            self._reset_event_bus()
             self._slack_action_handlers.clear()
             self._context_engine = None
         # Set the flag up front as a re-entrancy guard (a plugin's register()
@@ -1918,6 +1960,10 @@ class PluginManager:
 
         except Exception as exc:
             loaded.error = str(exc)
+            # register() may have subscribed before raising. Remove those
+            # owner-tagged entries so a failed/unloaded plugin cannot leave a
+            # callable reachable from later event dispatch.
+            self._remove_plugin_subscriptions(_plugin_id)
             logger.warning(
                 "Failed to load plugin '%s': %s",
                 manifest.name, exc, exc_info=_PLUGINS_DEBUG,
@@ -2021,18 +2067,153 @@ class PluginManager:
                 )
         return results
 
+    def _subscribe_event(
+        self,
+        owner: str,
+        event: str,
+        callback: Callable,
+    ) -> None:
+        """Add an owner-tagged event subscription in registration order."""
+        if not callable(callback):
+            raise TypeError("Event subscriber callback must be callable")
+        entry = _EventSubscription(owner=owner, callback=callback)
+        with self._event_lock:
+            self._subscriptions.setdefault(event, []).append(entry)
+
+    def _remove_plugin_subscriptions(self, owner: str) -> int:
+        """Remove every subscription owned by *owner* and return the count.
+
+        Queued dispatch envelopes re-check ledger membership before each
+        callback, so removing an owner also cancels callbacks already snapshotted
+        by an event that has not reached that subscriber yet.
+        """
+        removed = 0
+        with self._event_lock:
+            for event in list(self._subscriptions):
+                entries = self._subscriptions[event]
+                retained = [entry for entry in entries if entry.owner != owner]
+                removed += len(entries) - len(retained)
+                if retained:
+                    self._subscriptions[event] = retained
+                else:
+                    del self._subscriptions[event]
+        return removed
+
+    def _reset_event_bus(self) -> None:
+        """Cancel the current event generation and clear its subscriptions."""
+        with self._event_lock:
+            old_queue = self._event_queue
+            had_worker = self._event_worker is not None
+            self._event_generation += 1
+            self._subscriptions.clear()
+            self._event_queue = queue.Queue(maxsize=_EVENT_PENDING_CAP)
+            self._event_worker = None
+            self._event_pending_by_generation.setdefault(
+                self._event_generation, 0
+            )
+
+            # Drop work that has not started. A currently-running callback
+            # cannot be force-killed safely, but generation + ledger checks stop
+            # it before the next subscriber and prevent all queued callbacks.
+            while True:
+                try:
+                    item = old_queue.get_nowait()
+                except queue.Empty:
+                    break
+                try:
+                    if item is not _EVENT_WORKER_STOP:
+                        self._mark_event_done(item.generation)
+                finally:
+                    old_queue.task_done()
+            if had_worker:
+                old_queue.put_nowait(_EVENT_WORKER_STOP)
+            self._event_idle.notify_all()
+
+    def _ensure_event_worker_locked(self) -> None:
+        worker = self._event_worker
+        if worker is not None and worker.is_alive():
+            return
+        dispatch_queue = self._event_queue
+        worker = threading.Thread(
+            target=self._event_worker_loop,
+            args=(dispatch_queue,),
+            name="hermes-plugin-events",
+            daemon=True,
+        )
+        self._event_worker = worker
+        worker.start()
+
+    def _event_worker_loop(self, dispatch_queue: queue.Queue[Any]) -> None:
+        while True:
+            item = dispatch_queue.get()
+            try:
+                if item is _EVENT_WORKER_STOP:
+                    return
+                self._deliver_event(item)
+            finally:
+                if item is not _EVENT_WORKER_STOP:
+                    self._mark_event_done(item.generation)
+                dispatch_queue.task_done()
+
+    def _mark_event_done(self, generation: int) -> None:
+        with self._event_idle:
+            pending = self._event_pending_by_generation.get(generation, 0)
+            if pending > 0:
+                self._event_pending_by_generation[generation] = pending - 1
+            self._event_idle.notify_all()
+
+    def _deliver_event(self, item: _QueuedPluginEvent) -> None:
+        """Deliver one queued event on the host-owned worker thread."""
+        with self._event_lock:
+            if item.generation != self._event_generation:
+                return
+        previous_depth = getattr(self._emit_depth, "value", 0)
+        self._emit_depth.value = item.depth
+        try:
+            for subscription in item.subscriptions:
+                with self._event_lock:
+                    if item.generation != self._event_generation:
+                        break
+                    # Owner unload may remove this exact ledger entry after the
+                    # event was queued but before its callback starts.
+                    if not any(
+                        current is subscription
+                        for current in self._subscriptions.get(item.event, [])
+                    ):
+                        continue
+                callback = subscription.callback
+                try:
+                    # A fresh deep copy per subscriber prevents one callback
+                    # from mutating the emitter's nested values or the payload
+                    # observed by the next subscriber.
+                    owned_payload = copy.deepcopy(item.payload)
+                    result = callback(**owned_payload)
+                    resolve_plugin_command_result(result)
+                except Exception as exc:
+                    logger.warning(
+                        "Event '%s' subscriber %s raised: %s",
+                        item.event,
+                        getattr(callback, "__name__", repr(callback)),
+                        exc,
+                    )
+        finally:
+            self._emit_depth.value = previous_depth
+
+    def _wait_for_event_dispatch(self, timeout: float = 2.0) -> bool:
+        """Wait for the current event generation to become idle (test helper)."""
+        with self._event_idle:
+            generation = self._event_generation
+            return self._event_idle.wait_for(
+                lambda: self._event_pending_by_generation.get(generation, 0) == 0,
+                timeout=timeout,
+            )
+
     def _dispatch_event(self, event: str, payload: Dict[str, Any]) -> int:
-        """Deliver *event* to its subscribers; return the number invoked.
+        """Queue *event* without blocking; return subscriber count scheduled.
 
-        Mirrors :meth:`invoke_hook`: iterate subscribers in registration
-        order, isolate each in its own ``try/except`` so one raising
-        subscriber cannot break delivery to the rest, and pass the payload
-        as keyword arguments.
-
-        A subscriber may itself call ``ctx.emit`` (re-entrant dispatch). A
-        per-thread depth counter caps recursion at
-        :data:`_EVENT_EMIT_DEPTH_CAP`; over-deep emits are dropped with a
-        single warning (never raised) so delivery always terminates.
+        A single daemon worker preserves registration order. Pending work is
+        bounded per manager generation so a blocking subscriber can consume at
+        most one worker while later emits are dropped once the budget is full.
         """
         depth = getattr(self._emit_depth, "value", 0)
         if depth >= _EVENT_EMIT_DEPTH_CAP:
@@ -2042,26 +2223,41 @@ class PluginManager:
                 _EVENT_EMIT_DEPTH_CAP, event,
             )
             return 0
-        callbacks = list(self._subscriptions.get(event, []))
-        if not callbacks:
-            return 0
-        self._emit_depth.value = depth + 1
-        invoked = 0
-        try:
-            for cb in callbacks:
-                invoked += 1
-                try:
-                    cb(**payload)
-                except Exception as exc:
-                    logger.warning(
-                        "Event '%s' subscriber %s raised: %s",
-                        event,
-                        getattr(cb, "__name__", repr(cb)),
-                        exc,
-                    )
-        finally:
-            self._emit_depth.value = depth
-        return invoked
+
+        with self._event_lock:
+            subscriptions = tuple(self._subscriptions.get(event, []))
+            if not subscriptions:
+                return 0
+            generation = self._event_generation
+            pending = self._event_pending_by_generation.get(generation, 0)
+            if pending >= _EVENT_PENDING_CAP:
+                logger.warning(
+                    "Event bus pending budget (%d) exhausted while dispatching "
+                    "'%s' — dropping this emit",
+                    _EVENT_PENDING_CAP,
+                    event,
+                )
+                return 0
+            item = _QueuedPluginEvent(
+                event=event,
+                payload=dict(payload),
+                subscriptions=subscriptions,
+                depth=depth + 1,
+                generation=generation,
+            )
+            try:
+                self._event_queue.put_nowait(item)
+            except queue.Full:
+                logger.warning(
+                    "Event bus pending budget (%d) exhausted while dispatching "
+                    "'%s' — dropping this emit",
+                    _EVENT_PENDING_CAP,
+                    event,
+                )
+                return 0
+            self._event_pending_by_generation[generation] = pending + 1
+            self._ensure_event_worker_locked()
+            return len(subscriptions)
 
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
@@ -2561,13 +2757,17 @@ def get_plugin_auxiliary_tasks() -> List[Dict[str, Any]]:
 def get_plugin_subscriptions() -> Dict[str, List[Callable]]:
     """Return the inter-plugin event bus subscription registry.
 
-    Maps each fully-qualified event name (``<plugin_key>:<event>`` or
-    ``hermes:<event>``) to its list of subscriber callbacks in registration
-    order. Triggers idempotent plugin discovery so callers can read the
-    registry before any explicit ``discover_plugins()`` call.
+    Returns a snapshot mapping each fully-qualified event name
+    (``<plugin_key>:<event>`` or ``hermes:<event>``) to subscriber callbacks in
+    registration order. Owner ledger metadata stays private to the manager.
+    Triggers idempotent plugin discovery before reading the snapshot.
     """
     manager = _ensure_plugins_discovered()
-    return manager._subscriptions
+    with manager._event_lock:
+        return {
+            event: [entry.callback for entry in entries]
+            for event, entries in manager._subscriptions.items()
+        }
 
 
 def get_plugin_toolsets() -> List[tuple]:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -216,6 +216,15 @@ VALID_HOOKS: Set[str] = {
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"
 
+# Reserved event namespace prefix — only core may publish ``hermes:<event>``.
+HERMES_EVENT_NAMESPACE = "hermes"
+
+# Max inter-plugin event dispatch recursion depth. A subscriber may itself
+# call ``ctx.emit``; this bound stops mutually-emitting plugins from looping
+# forever. When exceeded the over-deep emit is dropped (with a warning), not
+# raised, so delivery always terminates cleanly.
+_EVENT_EMIT_DEPTH_CAP = 8
+
 _NS_PARENT = "hermes_plugins"
 
 
@@ -312,6 +321,14 @@ class PluginManifest:
     # category plugin at ``plugins/image_gen/openai/`` the key is
     # ``image_gen/openai``. When empty, falls back to ``name``.
     key: str = ""
+    # Inter-plugin event bus declarations (advisory in v1 — NOT enforced).
+    # ``emits`` lists the bare event names this plugin publishes under its own
+    # ``<key>:`` namespace (e.g. ``["ping"]`` → publishes ``<key>:ping``).
+    # ``listens`` lists the fully-qualified ``<plugin>:<event>`` names this
+    # plugin subscribes to. Both are purely for discoverability
+    # (``hermes plugins show``); a plugin may emit/subscribe without declaring.
+    emits: List[str] = field(default_factory=list)
+    listens: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -1172,6 +1189,74 @@ class PluginContext:
         self._manager._hooks.setdefault(hook_name, []).append(callback)
         logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
 
+    # -- inter-plugin event bus --------------------------------------------
+
+    def emit(self, event: str, payload: Optional[dict] = None) -> int:
+        """Publish *event* to all subscribers; return the number invoked.
+
+        The event is delivered as ``<plugin_key>:<event>`` where
+        ``plugin_key`` is FORCED to this plugin's own registry key
+        (``manifest.key or manifest.name``). Pass only the bare event name —
+        a plugin may only publish under its own namespace.
+
+        Passing an already-namespaced name (anything containing ``':'``,
+        including ``hermes:x`` or a foreign ``other:x``) is rejected with a
+        ``ValueError`` and a logged warning — fail-closed. The ``hermes:``
+        prefix is reserved for core.
+
+        Subscribers are invoked in registration order, each isolated in its
+        own ``try/except`` (one raising subscriber does not stop delivery to
+        the others). ``payload`` is passed to each callback as keyword
+        arguments (``cb(**payload)``), mirroring the hook convention.
+
+        Returns the count of subscriber callbacks invoked (0 when there are
+        no subscribers, or when the recursion cap dropped the emit).
+        """
+        plugin_key = self.manifest.key or self.manifest.name
+        if not event or not isinstance(event, str):
+            logger.warning(
+                "Plugin '%s' tried to emit an invalid event name %r",
+                plugin_key, event,
+            )
+            raise ValueError(
+                f"Plugin '{plugin_key}' emit() requires a non-empty event name"
+            )
+        if ":" in event:
+            logger.warning(
+                "Plugin '%s' tried to emit namespaced/reserved event '%s' — "
+                "a plugin may only emit bare event names under its own '%s:' "
+                "namespace (the '%s:' prefix is reserved for core, and foreign "
+                "namespaces are forbidden)",
+                plugin_key, event, plugin_key, HERMES_EVENT_NAMESPACE,
+            )
+            raise ValueError(
+                f"Plugin '{plugin_key}' may not emit '{event}': emit only the "
+                f"bare event name; the namespace is forced to '{plugin_key}:' "
+                f"and the '{HERMES_EVENT_NAMESPACE}:' prefix is reserved for core"
+            )
+        full_event = f"{plugin_key}:{event}"
+        return self._manager._dispatch_event(full_event, payload or {})
+
+    def subscribe(self, event: str, callback: Callable) -> None:
+        """Subscribe *callback* to a fully-qualified event name.
+
+        *event* is the full ``<plugin_key>:<event>`` name (or ``hermes:<event>``
+        if core ever emits). Subscribing is unrestricted — any plugin may
+        listen to any published event; only *emitting* is namespace-gated.
+
+        Callbacks are stored in registration order and invoked with the
+        emitter's payload as keyword arguments.
+        """
+        if not event or not isinstance(event, str):
+            raise ValueError(
+                f"Plugin '{self.manifest.name}' subscribe() requires a "
+                f"non-empty event name"
+            )
+        self._manager._subscriptions.setdefault(event, []).append(callback)
+        logger.debug(
+            "Plugin %s subscribed to event: %s", self.manifest.name, event,
+        )
+
     # -- middleware registration -------------------------------------------
 
     def register_middleware(self, kind: str, callback: Callable) -> None:
@@ -1264,6 +1349,13 @@ class PluginManager:
         # Plugin-registered auxiliary tasks: key → {key, display_name,
         # description, defaults, plugin}. See PluginContext.register_auxiliary_task.
         self._aux_tasks: Dict[str, Dict[str, Any]] = {}
+        # Inter-plugin event bus: full event name (``<plugin_key>:<event>`` or
+        # ``hermes:<event>``) → list of subscriber callbacks in registration
+        # order. See PluginContext.subscribe/emit and _dispatch_event.
+        self._subscriptions: Dict[str, List[Callable]] = {}
+        # Per-thread re-entrancy depth for event dispatch, used to cap
+        # mutually-emitting plugins (see _EVENT_EMIT_DEPTH_CAP).
+        self._emit_depth = threading.local()
         # Slack Block Kit action handlers registered by plugins. Each entry
         # is (matcher, callback, plugin_name); the Slack adapter wires them
         # into its slack_bolt App at connect() time. ``matcher`` is whatever
@@ -1299,6 +1391,7 @@ class PluginManager:
             self._plugin_commands.clear()
             self._plugin_skills.clear()
             self._aux_tasks.clear()
+            self._subscriptions.clear()
             self._slack_action_handlers.clear()
             self._context_engine = None
         # Set the flag up front as a re-entrancy guard (a plugin's register()
@@ -1644,6 +1737,8 @@ class PluginManager:
                 path=str(plugin_dir),
                 kind=kind,
                 key=key,
+                emits=data.get("emits") or [],
+                listens=data.get("listens") or [],
             )
         except Exception as exc:
             logger.warning(
@@ -1925,6 +2020,48 @@ class PluginManager:
                     exc,
                 )
         return results
+
+    def _dispatch_event(self, event: str, payload: Dict[str, Any]) -> int:
+        """Deliver *event* to its subscribers; return the number invoked.
+
+        Mirrors :meth:`invoke_hook`: iterate subscribers in registration
+        order, isolate each in its own ``try/except`` so one raising
+        subscriber cannot break delivery to the rest, and pass the payload
+        as keyword arguments.
+
+        A subscriber may itself call ``ctx.emit`` (re-entrant dispatch). A
+        per-thread depth counter caps recursion at
+        :data:`_EVENT_EMIT_DEPTH_CAP`; over-deep emits are dropped with a
+        single warning (never raised) so delivery always terminates.
+        """
+        depth = getattr(self._emit_depth, "value", 0)
+        if depth >= _EVENT_EMIT_DEPTH_CAP:
+            logger.warning(
+                "Event bus recursion cap (%d) exceeded while dispatching '%s' "
+                "— dropping this emit to prevent an infinite loop",
+                _EVENT_EMIT_DEPTH_CAP, event,
+            )
+            return 0
+        callbacks = list(self._subscriptions.get(event, []))
+        if not callbacks:
+            return 0
+        self._emit_depth.value = depth + 1
+        invoked = 0
+        try:
+            for cb in callbacks:
+                invoked += 1
+                try:
+                    cb(**payload)
+                except Exception as exc:
+                    logger.warning(
+                        "Event '%s' subscriber %s raised: %s",
+                        event,
+                        getattr(cb, "__name__", repr(cb)),
+                        exc,
+                    )
+        finally:
+            self._emit_depth.value = depth
+        return invoked
 
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
@@ -2419,6 +2556,18 @@ def get_plugin_auxiliary_tasks() -> List[Dict[str, Any]]:
     """
     manager = _ensure_plugins_discovered()
     return [manager._aux_tasks[k] for k in sorted(manager._aux_tasks)]
+
+
+def get_plugin_subscriptions() -> Dict[str, List[Callable]]:
+    """Return the inter-plugin event bus subscription registry.
+
+    Maps each fully-qualified event name (``<plugin_key>:<event>`` or
+    ``hermes:<event>``) to its list of subscriber callbacks in registration
+    order. Triggers idempotent plugin discovery so callers can read the
+    registry before any explicit ``discover_plugins()`` call.
+    """
+    manager = _ensure_plugins_discovered()
+    return manager._subscriptions
 
 
 def get_plugin_toolsets() -> List[tuple]:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1355,6 +1355,55 @@ def _configure_context_engine() -> bool:
 # ---------------------------------------------------------------------------
 
 
+def cmd_show(name: str) -> None:
+    """Show details for a single plugin, including declared emits/listens.
+
+    Resolves *name* against every discoverable plugin (bundled + user +
+    entrypoint) by either its display name or its registry key, then reads
+    its ``plugin.yaml`` to surface the advisory event-bus declarations
+    (``emits`` / ``listens``) alongside the basic metadata.
+    """
+    from rich.console import Console
+
+    console = Console()
+    entries = _discover_all_plugins()
+    match = None
+    for entry in entries:
+        # entry = (name, version, description, source, dir_path, key)
+        if entry[0] == name or entry[5] == name:
+            match = entry
+            break
+
+    if match is None:
+        console.print(f"[red]Plugin '{name}' not found.[/red]")
+        console.print("[dim]List installed plugins:[/dim] hermes plugins list")
+        sys.exit(1)
+
+    pname, version, description, source, dir_path, key = match
+    manifest = _read_manifest(Path(dir_path)) if dir_path else {}
+    emits = manifest.get("emits") or []
+    listens = manifest.get("listens") or []
+
+    enabled = _get_enabled_set()
+    disabled = _get_disabled_set()
+    status = _plugin_status(pname, enabled, disabled, key=key)
+
+    console.print()
+    console.print(f"[bold]{pname}[/bold]" + (f" [dim]v{version}[/dim]" if version else ""))
+    if description:
+        console.print(description)
+    console.print(f"[dim]Status:[/dim] {status}")
+    console.print(f"[dim]Source:[/dim] {source}")
+    console.print(f"[dim]Key:[/dim] {key}")
+    console.print(
+        "[dim]Emits:[/dim] " + (", ".join(emits) if emits else "[dim](none)[/dim]")
+    )
+    console.print(
+        "[dim]Listens:[/dim] " + (", ".join(listens) if listens else "[dim](none)[/dim]")
+    )
+    console.print()
+
+
 def cmd_toggle() -> None:
     """Interactive composite UI — general plugins + provider plugin categories."""
     from rich.console import Console
@@ -2035,6 +2084,8 @@ def plugins_command(args) -> None:
         cmd_disable(args.name)
     elif action in {"list", "ls"}:
         cmd_list(args)
+    elif action in {"show", "info"}:
+        cmd_show(args.name)
     elif action is None:
         cmd_toggle()
     else:

--- a/hermes_cli/subcommands/plugins.py
+++ b/hermes_cli/subcommands/plugins.py
@@ -103,4 +103,12 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
         "disable", help="Disable a plugin without removing it"
     )
     plugins_disable.add_argument("name", help="Plugin name to disable")
+
+    plugins_show = plugins_subparsers.add_parser(
+        "show",
+        aliases=["info"],
+        help="Show details for a single plugin (including emits/listens)",
+    )
+    plugins_show.add_argument("name", help="Plugin name or key to show")
+
     plugins_parser.set_defaults(func=cmd_plugins)

--- a/tests/hermes_cli/test_plugin_event_bus.py
+++ b/tests/hermes_cli/test_plugin_event_bus.py
@@ -4,7 +4,10 @@ Covers:
   - Two plugins communicate via emit/subscribe; emit returns listener count
   - Namespace is FORCED to the emitting plugin's own key
   - Namespace spoofing (hermes:, foreign, already-colon'd) is rejected
-  - Per-callback isolation: one raising subscriber does not break the rest
+  - Non-blocking bounded delivery for synchronous subscribers
+  - Per-callback isolation and deep-copied payload ownership
+  - Async subscribers resolved through the loop-safe host path
+  - Owner unload / generation reset cancel zombie callbacks
   - Recursion cap: mutually-emitting plugins terminate + warn
   - Manifest emits/listens parsed as optional advisory fields
   - `hermes plugins show` output includes emits/listens
@@ -12,7 +15,9 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import threading
 
 import pytest
 
@@ -40,6 +45,10 @@ def _fresh_manager() -> PluginManager:
     return manager
 
 
+def _drain(manager: PluginManager) -> None:
+    assert manager._wait_for_event_dispatch(timeout=2.0)
+
+
 # ── 1. Two plugins communicate ───────────────────────────────────────────────
 
 
@@ -56,6 +65,7 @@ def test_two_plugins_communicate():
     # A subscribes to b:ping; B emits the bare name "ping".
     ctx_a.subscribe("b:ping", on_ping)
     count = ctx_b.emit("ping", {"n": 42})
+    _drain(manager)
 
     assert count == 1  # one listener invoked
     assert received == [{"n": 42}]
@@ -75,6 +85,7 @@ def test_emit_none_payload_delivers_empty_kwargs():
     seen = []
     ctx_a.subscribe("b:ping", lambda **p: seen.append(p))
     count = ctx_b.emit("ping")  # payload omitted
+    _drain(manager)
 
     assert count == 1
     assert seen == [{}]
@@ -96,6 +107,7 @@ def test_namespace_forced_to_emitter_key():
     ctx_a.subscribe("a:ping", lambda **p: delivered_events.append("a:ping"))
 
     ctx_b.emit("ping")
+    _drain(manager)
 
     # Delivered under the emitter's own key ("b"), never "a".
     assert delivered_events == ["b:ping"]
@@ -110,6 +122,7 @@ def test_namespace_falls_back_to_name_when_key_empty():
     got = []
     ctx.subscribe("plugin_named:evt", lambda **p: got.append(p))
     count = ctx.emit("evt", {"v": 1})
+    _drain(manager)
     assert count == 1
     assert got == [{"v": 1}]
 
@@ -184,12 +197,175 @@ def test_per_callback_isolation(caplog):
 
     with caplog.at_level(logging.WARNING):
         count = ctx_b.emit("ping", {"ok": True})
+        _drain(manager)
 
     # Both listeners were invoked despite the first raising.
     assert count == 2
     assert received == [{"ok": True}]
     assert any("subscriber exploded" in r.message or "raised" in r.message
                for r in caplog.records)
+
+
+def test_emit_returns_before_blocking_subscriber_finishes():
+    manager = _fresh_manager()
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+    entered = threading.Event()
+    release = threading.Event()
+    emit_returned = threading.Event()
+    result = {}
+
+    def blocking(**payload):
+        entered.set()
+        release.wait(timeout=2.0)
+
+    def call_emit():
+        result["count"] = ctx_b.emit("ping")
+        emit_returned.set()
+
+    ctx_a.subscribe("b:ping", blocking)
+    emitter = threading.Thread(target=call_emit)
+    emitter.start()
+    try:
+        assert emit_returned.wait(timeout=1.0)
+        assert entered.wait(timeout=1.0)
+    finally:
+        release.set()
+        emitter.join(timeout=2.0)
+    _drain(manager)
+    assert result["count"] == 1
+
+
+def test_pending_budget_drops_new_event_without_blocking(monkeypatch, caplog):
+    from hermes_cli import plugins as plugins_mod
+
+    monkeypatch.setattr(plugins_mod, "_EVENT_PENDING_CAP", 1)
+    manager = _fresh_manager()
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocking(**payload):
+        entered.set()
+        release.wait(timeout=2.0)
+
+    ctx_a.subscribe("b:ping", blocking)
+    assert ctx_b.emit("ping") == 1
+    assert entered.wait(timeout=1.0)
+    try:
+        with caplog.at_level(logging.WARNING):
+            assert ctx_b.emit("ping") == 0
+    finally:
+        release.set()
+    _drain(manager)
+    assert "pending budget" in caplog.text
+
+
+def test_each_subscriber_receives_deep_copied_payload():
+    manager = _fresh_manager()
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+    original = {"nested": {"value": 1}}
+    observed = []
+
+    def mutate(**payload):
+        payload["nested"]["value"] = 99
+
+    def observe(**payload):
+        observed.append(payload["nested"]["value"])
+
+    ctx_a.subscribe("b:ping", mutate)
+    ctx_a.subscribe("b:ping", observe)
+    assert ctx_b.emit("ping", original) == 2
+    _drain(manager)
+
+    assert original == {"nested": {"value": 1}}
+    assert observed == [1]
+
+
+def test_async_subscriber_is_awaited():
+    manager = _fresh_manager()
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+    observed = []
+
+    async def on_ping(**payload):
+        await asyncio.sleep(0)
+        observed.append(payload["value"])
+
+    ctx_a.subscribe("b:ping", on_ping)
+    assert ctx_b.emit("ping", {"value": 7}) == 1
+    _drain(manager)
+    assert observed == [7]
+
+
+def test_remove_plugin_subscriptions_cancels_owner_entries():
+    manager = _fresh_manager()
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+    observed = []
+
+    ctx_a.subscribe("b:ping", lambda **payload: observed.append(payload))
+    manager._remove_plugin_subscriptions("a")
+
+    assert ctx_b.emit("ping", {"value": 1}) == 0
+    _drain(manager)
+    assert observed == []
+    assert "b:ping" not in manager._subscriptions
+
+
+def test_owner_removal_cancels_callback_already_snapshotted_in_queue():
+    manager = _fresh_manager()
+    ctx_gate = _make_ctx(manager, "gate", key="gate")
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+    entered = threading.Event()
+    release = threading.Event()
+    observed = []
+
+    def blocking(**payload):
+        entered.set()
+        release.wait(timeout=2.0)
+
+    ctx_gate.subscribe("b:ping", blocking)
+    ctx_a.subscribe("b:ping", lambda **payload: observed.append(payload))
+    assert ctx_b.emit("ping", {"value": 1}) == 2
+    assert entered.wait(timeout=1.0)
+    manager._remove_plugin_subscriptions("a")
+    release.set()
+    _drain(manager)
+
+    assert observed == []
+
+
+def test_event_bus_reset_cancels_queued_generation():
+    manager = _fresh_manager()
+    ctx_gate = _make_ctx(manager, "gate", key="gate")
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+    entered = threading.Event()
+    release = threading.Event()
+    observed = []
+
+    def blocking(**payload):
+        entered.set()
+        release.wait(timeout=2.0)
+
+    ctx_gate.subscribe("b:ping", blocking)
+    ctx_a.subscribe("b:ping", lambda **payload: observed.append(payload))
+    assert ctx_b.emit("ping", {"value": 1}) == 2
+    assert entered.wait(timeout=1.0)
+    old_worker = manager._event_worker
+
+    manager._reset_event_bus()
+    release.set()
+    assert old_worker is not None
+    old_worker.join(timeout=2.0)
+
+    assert not old_worker.is_alive()
+    assert observed == []
+    assert manager._subscriptions == {}
 
 
 # ── 5. Recursion cap ─────────────────────────────────────────────────────────
@@ -217,6 +393,7 @@ def test_recursion_cap_terminates(caplog):
     with caplog.at_level(logging.WARNING):
         # Kick off the loop — must terminate, not hang or RecursionError.
         result = ctx_b.emit("ping")
+        _drain(manager)
 
     # Returned cleanly.
     assert result == 1

--- a/tests/hermes_cli/test_plugin_event_bus.py
+++ b/tests/hermes_cli/test_plugin_event_bus.py
@@ -1,0 +1,354 @@
+"""Tests for the inter-plugin event bus (PluginContext.emit / subscribe).
+
+Covers:
+  - Two plugins communicate via emit/subscribe; emit returns listener count
+  - Namespace is FORCED to the emitting plugin's own key
+  - Namespace spoofing (hermes:, foreign, already-colon'd) is rejected
+  - Per-callback isolation: one raising subscriber does not break the rest
+  - Recursion cap: mutually-emitting plugins terminate + warn
+  - Manifest emits/listens parsed as optional advisory fields
+  - `hermes plugins show` output includes emits/listens
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from hermes_cli.plugins import (
+    _EVENT_EMIT_DEPTH_CAP,
+    PluginContext,
+    PluginManager,
+    PluginManifest,
+    get_plugin_subscriptions,
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+def _make_ctx(manager: PluginManager, name: str, key: str = "") -> PluginContext:
+    """Build a PluginContext for *name* wired to *manager*."""
+    manifest = PluginManifest(name=name, key=key)
+    return PluginContext(manifest, manager)
+
+
+def _fresh_manager() -> PluginManager:
+    manager = PluginManager()
+    manager._discovered = True  # skip auto-discovery
+    return manager
+
+
+# ── 1. Two plugins communicate ───────────────────────────────────────────────
+
+
+def test_two_plugins_communicate():
+    manager = _fresh_manager()
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+
+    received = []
+
+    def on_ping(**payload):
+        received.append(payload)
+
+    # A subscribes to b:ping; B emits the bare name "ping".
+    ctx_a.subscribe("b:ping", on_ping)
+    count = ctx_b.emit("ping", {"n": 42})
+
+    assert count == 1  # one listener invoked
+    assert received == [{"n": 42}]
+
+
+def test_emit_with_no_subscribers_returns_zero():
+    manager = _fresh_manager()
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+    assert ctx_b.emit("ping", {"x": 1}) == 0
+
+
+def test_emit_none_payload_delivers_empty_kwargs():
+    manager = _fresh_manager()
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+
+    seen = []
+    ctx_a.subscribe("b:ping", lambda **p: seen.append(p))
+    count = ctx_b.emit("ping")  # payload omitted
+
+    assert count == 1
+    assert seen == [{}]
+
+
+# ── 2. Namespace is forced to the emitter's own key ──────────────────────────
+
+
+def test_namespace_forced_to_emitter_key():
+    manager = _fresh_manager()
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+
+    delivered_events = []
+
+    # Subscribe to what we expect the fully-qualified name to be.
+    ctx_a.subscribe("b:ping", lambda **p: delivered_events.append("b:ping"))
+    # A wrong-namespace subscription must NOT fire.
+    ctx_a.subscribe("a:ping", lambda **p: delivered_events.append("a:ping"))
+
+    ctx_b.emit("ping")
+
+    # Delivered under the emitter's own key ("b"), never "a".
+    assert delivered_events == ["b:ping"]
+    # Registry stores it under the forced full name.
+    assert "b:ping" in manager._subscriptions
+
+
+def test_namespace_falls_back_to_name_when_key_empty():
+    manager = _fresh_manager()
+    # No key → namespace derives from name.
+    ctx = _make_ctx(manager, "plugin_named", key="")
+    got = []
+    ctx.subscribe("plugin_named:evt", lambda **p: got.append(p))
+    count = ctx.emit("evt", {"v": 1})
+    assert count == 1
+    assert got == [{"v": 1}]
+
+
+# ── 3. Namespace spoofing is rejected (fail-closed) ──────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad_event",
+    [
+        "hermes:x",   # reserved core prefix
+        "a:x",        # foreign namespace
+        "b:x",        # even the plugin's own colon'd name — must pass bare only
+        "other:evt",
+        ":x",
+        "x:",
+    ],
+)
+def test_emit_rejects_namespaced_names(bad_event):
+    manager = _fresh_manager()
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+
+    fired = []
+    # Subscribe to every plausible delivery target so we can prove no delivery.
+    for name in (bad_event, f"b:{bad_event}", "hermes:x", "a:x", "b:x"):
+        ctx_b.subscribe(name, lambda **p: fired.append(name))
+
+    with pytest.raises(ValueError):
+        ctx_b.emit(bad_event)
+
+    assert fired == []  # nothing delivered
+
+
+def test_emit_rejects_empty_event():
+    manager = _fresh_manager()
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+    with pytest.raises(ValueError):
+        ctx_b.emit("")
+
+
+def test_subscribe_is_unrestricted():
+    """Any plugin may subscribe to any event, including hermes: and foreign."""
+    manager = _fresh_manager()
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    got = []
+    # None of these raise — only emit is namespace-gated.
+    ctx_a.subscribe("hermes:core_event", lambda **p: got.append("hermes"))
+    ctx_a.subscribe("b:ping", lambda **p: got.append("b"))
+    assert "hermes:core_event" in manager._subscriptions
+    assert "b:ping" in manager._subscriptions
+
+
+# ── 4. Per-callback isolation ────────────────────────────────────────────────
+
+
+def test_per_callback_isolation(caplog):
+    manager = _fresh_manager()
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+
+    received = []
+
+    def boom(**payload):
+        raise RuntimeError("subscriber exploded")
+
+    def good(**payload):
+        received.append(payload)
+
+    # Registration order: raising subscriber first, healthy one second.
+    ctx_a.subscribe("b:ping", boom)
+    ctx_a.subscribe("b:ping", good)
+
+    with caplog.at_level(logging.WARNING):
+        count = ctx_b.emit("ping", {"ok": True})
+
+    # Both listeners were invoked despite the first raising.
+    assert count == 2
+    assert received == [{"ok": True}]
+    assert any("subscriber exploded" in r.message or "raised" in r.message
+               for r in caplog.records)
+
+
+# ── 5. Recursion cap ─────────────────────────────────────────────────────────
+
+
+def test_recursion_cap_terminates(caplog):
+    manager = _fresh_manager()
+    ctx_a = _make_ctx(manager, "plugin_a", key="a")
+    ctx_b = _make_ctx(manager, "plugin_b", key="b")
+
+    calls = {"a": 0, "b": 0}
+
+    # A hears b:ping and re-emits a:ping; B hears a:ping and re-emits b:ping.
+    def a_on_bping(**payload):
+        calls["a"] += 1
+        ctx_a.emit("ping")
+
+    def b_on_aping(**payload):
+        calls["b"] += 1
+        ctx_b.emit("ping")
+
+    ctx_a.subscribe("b:ping", a_on_bping)
+    ctx_b.subscribe("a:ping", b_on_aping)
+
+    with caplog.at_level(logging.WARNING):
+        # Kick off the loop — must terminate, not hang or RecursionError.
+        result = ctx_b.emit("ping")
+
+    # Returned cleanly.
+    assert result == 1
+    # Bounded by the depth cap — nowhere near unbounded.
+    assert calls["a"] + calls["b"] <= _EVENT_EMIT_DEPTH_CAP + 1
+    # Exactly the recursion-cap warning fired.
+    assert any("recursion cap" in r.message.lower() for r in caplog.records)
+
+
+# ── 6. Manifest emits/listens parsed as optional ─────────────────────────────
+
+
+def test_manifest_emits_listens_default_empty():
+    m = PluginManifest(name="plain")
+    assert m.emits == []
+    assert m.listens == []
+
+
+def test_manifest_emits_listens_present():
+    m = PluginManifest(
+        name="declar",
+        key="declar",
+        emits=["ping", "pong"],
+        listens=["other:ready"],
+    )
+    assert m.emits == ["ping", "pong"]
+    assert m.listens == ["other:ready"]
+
+
+def test_manifest_parse_reads_emits_listens(tmp_path):
+    """_parse_manifest picks up optional emits/listens from plugin.yaml."""
+    import yaml
+
+    plugin_dir = tmp_path / "myplug"
+    plugin_dir.mkdir()
+    manifest_file = plugin_dir / "plugin.yaml"
+    manifest_file.write_text(
+        yaml.safe_dump(
+            {
+                "name": "myplug",
+                "emits": ["ping"],
+                "listens": ["other:evt"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager = _fresh_manager()
+    manifest = manager._parse_manifest(manifest_file, plugin_dir, "user", "")
+    assert manifest is not None
+    assert manifest.emits == ["ping"]
+    assert manifest.listens == ["other:evt"]
+
+
+def test_manifest_parse_absent_emits_listens(tmp_path):
+    import yaml
+
+    plugin_dir = tmp_path / "bare"
+    plugin_dir.mkdir()
+    manifest_file = plugin_dir / "plugin.yaml"
+    manifest_file.write_text(
+        yaml.safe_dump({"name": "bare"}), encoding="utf-8"
+    )
+
+    manager = _fresh_manager()
+    manifest = manager._parse_manifest(manifest_file, plugin_dir, "user", "")
+    assert manifest is not None
+    assert manifest.emits == []
+    assert manifest.listens == []
+
+
+# ── Module-level accessor ────────────────────────────────────────────────────
+
+
+def test_get_plugin_subscriptions_accessor(monkeypatch):
+    from hermes_cli import plugins as plugins_mod
+
+    fresh = _fresh_manager()
+    monkeypatch.setattr(plugins_mod, "_ensure_plugins_discovered", lambda force=False: fresh)
+
+    ctx = _make_ctx(fresh, "plugin_a", key="a")
+    ctx.subscribe("b:ping", lambda **p: None)
+
+    subs = get_plugin_subscriptions()
+    assert "b:ping" in subs
+    assert len(subs["b:ping"]) == 1
+
+
+# ── 7. plugins show output includes emits/listens ────────────────────────────
+
+
+def test_plugins_show_includes_emits_listens(tmp_path, monkeypatch, capsys):
+    import yaml
+    from hermes_cli import plugins_cmd
+
+    plugin_dir = tmp_path / "showplug"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "showplug",
+                "version": "1.2.3",
+                "description": "a demo plugin",
+                "emits": ["ping", "pong"],
+                "listens": ["other:ready"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # entry = (name, version, description, source, dir_path, key)
+    entry = ("showplug", "1.2.3", "a demo plugin", "user", str(plugin_dir), "showplug")
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: [entry])
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+
+    plugins_cmd.cmd_show("showplug")
+
+    out = capsys.readouterr().out
+    assert "showplug" in out
+    assert "Emits:" in out
+    assert "ping" in out
+    assert "pong" in out
+    assert "Listens:" in out
+    assert "other:ready" in out
+
+
+def test_plugins_show_not_found_exits(monkeypatch, capsys):
+    from hermes_cli import plugins_cmd
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: [])
+    with pytest.raises(SystemExit):
+        plugins_cmd.cmd_show("nope")
+    out = capsys.readouterr().out
+    assert "not found" in out.lower()


### PR DESCRIPTION
## What & why

Gives plugins a first-class, namespaced pub/sub event bus so plugin↔plugin interaction is a declared, testable contract instead of ad-hoc imports.

Addresses #64164 (sub-issue 03/14 of #64182). The issue intentionally remains open as the feature-design discussion thread. The surface is additive: when no plugin calls `emit` or `subscribe`, existing behavior is unchanged.

## Interface (`PluginContext`)

```python
ctx.emit("thing_happened", payload={...})
ctx.subscribe("otherplugin:thing_happened", callback)
```

- Emission is forced into the emitter's own `<plugin_key>:` namespace.
- Any event name containing `:` is rejected fail-closed, preventing foreign or reserved `hermes:` namespace spoofing.
- Subscriptions use fully-qualified event names and remain unrestricted.
- Optional advisory `emits:` / `listens:` manifest fields are shown by `hermes plugins show <name>`.

## Delivery and safety contract

Follow-up commit `71de44d5a` implements the round-2 correction from #64164:

- **Bounded, non-blocking delivery:** `emit()` snapshots subscribers and enqueues the event without waiting for callbacks. A host-owned single daemon worker preserves registration order. The per-generation pending budget is capped at 64; once full, new events are dropped with a warning instead of back-pressuring the emitter.
- **Lifecycle ownership:** each subscription is an owner-tagged ledger entry. Failed plugin registration removes entries immediately. Force rediscovery increments the event generation, clears subscriptions, drops queued work, and stops the previous worker after any currently-running callback returns. Queued envelopes re-check ledger membership before each callback, so owner removal cancels callbacks already snapshotted but not yet started.
- **Payload ownership:** each subscriber receives its own `deepcopy` of the payload. A subscriber cannot mutate the emitter's nested values or the payload seen by the next subscriber.
- **Async callbacks:** awaitable callback results use the existing loop-safe plugin result resolver; coroutine objects are not silently dropped.
- **Recursion cap:** re-entrant event chains retain the depth cap of 8 even though each step is queued.
- **Isolation:** callback failures are logged independently and do not stop later subscribers.

Hermes currently has force rediscovery rather than a standalone hot-unload command; the owner ledger and private owner-removal path establish the cancellation contract without adding speculative public unload API.

## Verification

`tests/hermes_cli/test_plugin_event_bus.py` now covers:

- two-plugin delivery and namespace enforcement;
- namespace spoof rejection;
- non-blocking behavior with a blocked synchronous subscriber;
- pending-budget exhaustion;
- deep-copy isolation for nested payloads;
- awaited async subscribers;
- owner removal after an event was already queued;
- generation reset cancelling queued callbacks;
- callback isolation and recursion termination;
- manifest parsing, accessor compatibility, and `plugins show` output.

Canonical affected sweep:

```text
scripts/run_tests.sh tests/hermes_cli/test_plugin*.py -q
344 passed, 0 failed (12 files)
```

Additional checks:

```text
ruff check: passed
py_compile: passed
git diff --check: passed
```

No live provider or network service is involved in this in-process event-bus path.

🤖 Generated with Claude Code and Hermes Agent
