### PR TITLE
fix(gateway): remap container /workspace media paths onto the host mount

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1269,6 +1269,34 @@ def _path_is_within(path: Path, root: Path) -> bool:
         return False
 
 
+def _remap_container_workspace_path(candidate: str) -> Optional[str]:
+    """Map a container-local ``/workspace/...`` path onto the host mount backing it.
+
+    A Docker-backed agent writes its artifact inside the container and then
+    naturally reports the path it wrote to (``/workspace/report.png``). MEDIA
+    delivery runs in the gateway process on the HOST, where that path does not
+    exist, so the file silently never attaches and the user sees no error.
+    Instructing the model to translate the path itself is unreliable; the
+    startup warning in ``gateway/run.py`` already documents this failure mode.
+
+    Opt-in via ``MEDIA_WORKSPACE_HOST_ROOT`` (the host directory backing the
+    container's ``/workspace`` mount); unset keeps behaviour unchanged. The
+    remapped path is realpath-fenced INSIDE that mount and must exist; callers
+    still pass the result through the full delivery validation (denylist,
+    strict-mode allowlist, recency), so the remap grants no new reach.
+    """
+    ws_root = os.environ.get("MEDIA_WORKSPACE_HOST_ROOT", "")
+    if not ws_root or not candidate.startswith("/workspace/"):
+        return None
+    root = os.path.realpath(ws_root)
+    mapped = os.path.realpath(
+        os.path.join(root, os.path.relpath(candidate, "/workspace"))
+    )
+    if mapped.startswith(root + os.sep) and os.path.isfile(mapped):
+        return mapped
+    return None
+
+
 def validate_media_delivery_path(path: str) -> Optional[str]:
     """Return a safe absolute file path for native media delivery, else None.
 
@@ -1298,6 +1326,16 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     candidate = candidate.lstrip("`\"'").rstrip("`\"',.;:)}]")
     if not candidate:
         return None
+
+    # Remap an explicit MEDIA:/workspace/... directive onto the host mount
+    # before resolution; the remapped path still runs the full gate below.
+    remapped = _remap_container_workspace_path(candidate)
+    if remapped:
+        logger.info(
+            "Remapped container media path %s to host workspace",
+            _log_safe_path(candidate),
+        )
+        candidate = remapped
 
     try:
         expanded = Path(os.path.expanduser(candidate))
@@ -3824,7 +3862,16 @@ class BasePlatformAdapter(ABC):
                 continue
             raw = match.group(0)
             expanded = os.path.expanduser(raw)
-            if os.path.isfile(expanded):
+            # Bare container paths get the same host-mount remap as explicit
+            # MEDIA: directives (see _remap_container_workspace_path).
+            remapped = _remap_container_workspace_path(expanded)
+            if remapped:
+                logger.info(
+                    "Remapped container media path %s to host workspace",
+                    _log_safe_path(raw),
+                )
+                found.append((raw, remapped))
+            elif os.path.isfile(expanded):
                 found.append((raw, expanded))
             else:
                 # The reply mentions a deliverable-looking path that does not

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -16,9 +16,51 @@ from gateway.platforms.base import (
     safe_url_for_log,
     utf16_len,
     validate_inbound_media_size,
+    validate_media_delivery_path,
     _log_safe_path,
     _prefix_within_utf16_limit,
 )
+
+
+class TestContainerWorkspaceMediaRemap:
+    """MEDIA_WORKSPACE_HOST_ROOT remaps container /workspace paths onto the host mount.
+
+    A Docker-backed agent reports the container path of its artifact
+    (/workspace/x.png); the gateway resolves paths on the HOST, so without the
+    remap the file silently never attaches. Opt-in via env; realpath-fenced.
+    """
+
+    def _workspace(self, tmp_path, monkeypatch):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        (ws / "chart.png").write_bytes(b"\x89PNG")
+        monkeypatch.setenv("MEDIA_WORKSPACE_HOST_ROOT", str(ws))
+        return ws
+
+    def test_media_directive_container_path_resolves_to_host(self, tmp_path, monkeypatch):
+        ws = self._workspace(tmp_path, monkeypatch)
+        assert validate_media_delivery_path("/workspace/chart.png") == str(ws / "chart.png")
+
+    def test_bare_path_extraction_remaps(self, tmp_path, monkeypatch):
+        ws = self._workspace(tmp_path, monkeypatch)
+        paths, _cleaned = BasePlatformAdapter.extract_local_files(
+            "here's your chart: /workspace/chart.png"
+        )
+        assert paths == [str(ws / "chart.png")]
+
+    def test_traversal_out_of_workspace_is_refused(self, tmp_path, monkeypatch):
+        self._workspace(tmp_path, monkeypatch)
+        (tmp_path / "outside.png").write_bytes(b"\x89PNG")
+        assert validate_media_delivery_path("/workspace/../outside.png") is None
+
+    def test_missing_file_is_not_remapped(self, tmp_path, monkeypatch):
+        self._workspace(tmp_path, monkeypatch)
+        assert validate_media_delivery_path("/workspace/nope.png") is None
+
+    def test_env_unset_keeps_default_behaviour(self, tmp_path, monkeypatch):
+        self._workspace(tmp_path, monkeypatch)
+        monkeypatch.delenv("MEDIA_WORKSPACE_HOST_ROOT")
+        assert validate_media_delivery_path("/workspace/chart.png") is None
 
 
 class TestInboundMediaSizeCap:


### PR DESCRIPTION
## What does this PR do?

Makes MEDIA delivery work for Docker-backed gateways when the model reports a container-local path. Today the agent writes `/workspace/chart.png` inside its sandbox and reports that path; the gateway resolves paths on the HOST, where `/workspace` does not exist, so the attachment is silently dropped (`Skipping unsafe MEDIA directive path: /workspace/chart.png`) even though the file exists on the host under the workspace bind-mount. The startup warning in `gateway/run.py` documents this gap; this PR closes it with a mechanism instead of prompting.

Opt-in via `MEDIA_WORKSPACE_HOST_ROOT` (the host directory backing the container's `/workspace` mount). When set, a shared helper remaps the fixed `/workspace/` prefix onto that mount for **both** delivery routes: explicit `MEDIA:` directives (`validate_media_delivery_path`) and bare paths in reply text (`extract_local_files`). The remapped path is realpath-fenced inside the mount, must exist, and still passes the full delivery validation (denylist, strict-mode allowlist, recency) afterwards, the remap normalizes a path into the trusted staging area and grants no new reach. Unset, behaviour is byte-for-byte unchanged.

Prompting the model to translate the path itself (skill instructions + a helper that prints the exact host path to paste) proved unreliable in our production deployment, the model skipped the translation on roughly half of runs. The boundary is the right place for the translation.

## Related Issue

Fixes #66086

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: new module-level `_remap_container_workspace_path()` helper (env-gated, realpath-fenced, must-exist); called from `validate_media_delivery_path()` (MEDIA: directive route) and `extract_local_files()` (bare-path route). Remaps log at INFO.
- `tests/gateway/test_platform_base.py`: new `TestContainerWorkspaceMediaRemap`, positive remap on both routes, traversal refused, missing file refused, env-unset behaviour unchanged.

## How to Test

1. `pytest tests/gateway/test_platform_base.py -k ContainerWorkspace`, 5 tests cover both routes plus the containment and opt-in negatives (full file: 197 passed, 2 skipped).
2. Live: run a gateway with `terminal.backend: docker`, set `MEDIA_WORKSPACE_HOST_ROOT` to the host dir backing `/workspace`, ask the bot to produce a file and reply `MEDIA:/workspace/<file>`; the attachment now uploads, and gateway.log shows `Remapped container media path /workspace/<file> to host workspace`.
3. Negative: unset the env, behaviour is unchanged (path skipped, as today). This also ran against a strict-mode (`HERMES_MEDIA_DELIVERY_STRICT=1`) production deployment: positive path attaches, `/workspace/../` traversal and nonexistent files still refuse.
