### PR TITLE
fix(gateway): announce "Gateway online" after any graceful shutdown

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8628,7 +8628,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if active_agents:
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
-            if self._restart_requested and self._restart_command_source is None:
+            # Write the planned-restart marker on ANY graceful shutdown, not
+            # only a requested restart. The shutdown path already warns active
+            # chats and the home channel on the way down ("Gateway shutting
+            # down"); symmetry means the home-channel "Gateway online" notice
+            # should also fire when the process comes back from a plain
+            # SIGTERM (systemctl restart, launchctl kickstart -k, host reboot,
+            # deploy bounce), not only from /restart or SIGUSR1. A
+            # chat-originated /restart keeps its precise reply lifecycle via
+            # .restart_notify.json (the command_source guard below). Unclean
+            # kills (SIGKILL, crash) never reach this writer, so a crash-boot
+            # stays silent as before. Per-platform opt-out already exists
+            # (gateway_restart_notification: false).
+            if self._restart_command_source is None:
                 try:
                     atomic_json_write(
                         _planned_restart_notification_path(),

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -170,6 +171,29 @@ async def test_gateway_stop_launchd_service_restart_keeps_nonzero_exit(tmp_path,
         await runner.stop(restart=True, service_restart=True)
 
     assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+
+
+@pytest.mark.asyncio
+async def test_plain_graceful_stop_writes_home_startup_marker(tmp_path, monkeypatch):
+    # A plain graceful stop (SIGTERM from systemctl restart / launchctl
+    # kickstart -k / host reboot) has no restart requested and no chat
+    # command source, yet must still write the planned-restart marker so
+    # the next boot posts the home-channel "Gateway online" notice.
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+
+    assert runner._restart_requested is False
+    assert runner._restart_command_source is None
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await runner.stop()
+
+    marker = tmp_path / ".restart_pending.json"
+    assert marker.exists()
+    payload = json.loads(marker.read_text())
+    assert payload["via_service"] is False
+    assert payload["detached"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Restores the warn-down / announce-back symmetry for service-managed gateways. The shutdown path warns active chats and the home channel ("Gateway shutting down") on ANY graceful shutdown, but the comeback notice ("Gateway online") only fires when the planned-restart marker was written, and the writer is gated on `_restart_requested`, i.e. a non-chat `/restart`, SIGUSR1, or the service path. A plain SIGTERM (`systemctl restart`, `launchctl kickstart -k`, host reboot, deploy bounce) therefore warns on the way down and says nothing on the way back.

One-line guard change: drop the `_restart_requested` half, so any graceful shutdown with no chat-originated `/restart` source writes the marker and the next boot broadcasts to the configured home channels. Chat-originated `/restart` keeps its precise reply lifecycle via `.restart_notify.json` (the `command_source` guard stays). Unclean kills (SIGKILL / crash) never reach the writer, so a crash-boot stays silent, same as today. Per-platform opt-out already exists (`gateway_restart_notification: false`).

## Related Issue

Fixes #66087

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: in the graceful-shutdown path, write the planned-restart notification marker whenever `_restart_command_source is None`, instead of requiring `_restart_requested` as well.

## How to Test

1. Run a gateway as a launchd/systemd service with a home channel configured (`/sethome`).
2. Restart it via the service manager (`launchctl kickstart -k <label>` / `systemctl restart <unit>`) twice: the first bounce exercises the patched shutdown, the second boot posts "Gateway online" to the home channel and gateway.log shows `Sent home-channel startup notification to <platform>:<channel>`; the marker is consumed.
3. Negative: `kill -9` the gateway, the next boot stays silent (no marker), unchanged from today. Verified live on a launchd-managed production deployment.
