### PR TITLE
fix: support targeted session handoff destinations

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1047,6 +1047,95 @@ class GatewayConfig:
         return "public"
 
 
+def parse_handoff_platform_ref(ref: str) -> tuple[Platform, Optional[str]]:
+    """Parse a `/handoff` destination reference.
+
+    The legacy form is just a platform name, e.g. ``slack``.  A bounded target
+    alias may be appended as ``platform:alias`` (for example ``slack:pm``).
+    The alias is intentionally narrow: it must resolve through configuration,
+    not an arbitrary prompt-supplied channel id.
+    """
+    raw = str(ref or "").strip().lower()
+    if not raw:
+        raise ValueError("platform required")
+
+    platform_name, sep, target_alias = raw.partition(":")
+    platform_name = platform_name.strip()
+    target_alias = target_alias.strip() if sep else ""
+    if not platform_name:
+        raise ValueError("platform required")
+    if sep and not target_alias:
+        raise ValueError(f"handoff target missing in '{raw}'")
+    if target_alias and not all(
+        ch.isalnum() or ch in {"_", "-"} for ch in target_alias
+    ):
+        raise ValueError(
+            f"invalid handoff target '{target_alias}' — use a configured alias"
+        )
+
+    try:
+        platform = Platform(platform_name)
+    except (ValueError, KeyError) as exc:
+        raise ValueError(f"unknown platform '{platform_name}'") from exc
+    return platform, target_alias or None
+
+
+def _configured_handoff_targets(platform_cfg: Optional[PlatformConfig]) -> Dict[str, Any]:
+    if not platform_cfg or not isinstance(platform_cfg.extra, dict):
+        return {}
+    targets = platform_cfg.extra.get("handoff_targets")
+    return targets if isinstance(targets, dict) else {}
+
+
+def resolve_handoff_destination(
+    config: GatewayConfig,
+    ref: str,
+) -> tuple[Platform, HomeChannel, Optional[str]]:
+    """Resolve a handoff reference to a concrete destination channel.
+
+    ``/handoff slack`` keeps the existing behaviour and returns Slack's
+    configured ``home_channel``.  ``/handoff slack:pm`` resolves only through
+    ``platforms.slack.extra.handoff_targets.pm``; raw channel IDs/names are not
+    accepted here.
+    """
+    platform, target_alias = parse_handoff_platform_ref(ref)
+    platform_cfg = config.platforms.get(platform)
+
+    if target_alias:
+        targets = _configured_handoff_targets(platform_cfg)
+        target = None
+        for key, value in targets.items():
+            if str(key).strip().lower() == target_alias:
+                target = value
+                break
+        if not isinstance(target, dict):
+            raise ValueError(
+                f"no handoff target '{target_alias}' configured for {platform.value}"
+            )
+        chat_id = target.get("chat_id") or target.get("id")
+        if not chat_id:
+            raise ValueError(
+                f"handoff target '{target_alias}' for {platform.value} has no chat_id"
+            )
+        return (
+            platform,
+            HomeChannel(
+                platform=platform,
+                chat_id=str(chat_id),
+                name=str(target.get("name") or f"{platform.value}:{target_alias}"),
+                thread_id=str(target["thread_id"]) if target.get("thread_id") else None,
+            ),
+            target_alias,
+        )
+
+    home = config.get_home_channel(platform)
+    if not home or not home.chat_id:
+        raise ValueError(
+            f"no home channel configured for {platform.value}; run /sethome on the desired chat first"
+        )
+    return platform, home, None
+
+
 def load_gateway_config() -> GatewayConfig:
     """
     Load gateway configuration from multiple sources.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7674,34 +7674,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _process_handoff(self, row: Dict[str, Any]) -> None:
         """Execute one handoff row. Raises on failure (caller marks failed)."""
-        from gateway.config import Platform
+        from gateway.config import resolve_handoff_destination
         from gateway.session import SessionSource, build_session_key
         from gateway.platforms.base import MessageEvent
 
         cli_session_id = row["id"]
-        platform_name = (row.get("handoff_platform") or "").strip().lower()
-        if not platform_name:
+        platform_ref = (row.get("handoff_platform") or "").strip().lower()
+        if not platform_ref:
             raise RuntimeError("handoff_platform is empty")
 
-        # Resolve platform enum
         try:
-            platform = Platform(platform_name)
-        except (ValueError, KeyError):
-            raise RuntimeError(f"unknown platform '{platform_name}'")
+            platform, home, _target_alias = resolve_handoff_destination(
+                self.config, platform_ref,
+            )
+        except ValueError as exc:
+            raise RuntimeError(str(exc)) from exc
+        platform_name = platform.value
 
         # Adapter must be live
         adapter = self.adapters.get(platform)
         if not adapter:
             raise RuntimeError(
                 f"platform '{platform_name}' is not active in this gateway"
-            )
-
-        # Home channel must be configured
-        home = self.config.get_home_channel(platform)
-        if not home or not home.chat_id:
-            raise RuntimeError(
-                f"no home channel configured for {platform_name}; "
-                f"run /sethome on the desired chat first"
             )
 
         cli_title = row.get("title") or cli_session_id[:8]

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -542,19 +542,26 @@ class CLICommandsMixin:
             _cprint("  The CLI session ends here; resume it later with /resume.")
             return True
 
-        platform_name = parts[1].strip().lower()
+        platform_ref = parts[1].strip().lower()
 
-        # Validate platform name + home channel via the live gateway config.
+        # Validate platform name + destination via the live gateway config.
+        # ``/handoff slack`` keeps the legacy home-channel behaviour, while
+        # ``/handoff slack:pm`` resolves a configured alias from
+        # platforms.slack.extra.handoff_targets.
         try:
-            from gateway.config import load_gateway_config, Platform
+            from gateway.config import (
+                load_gateway_config,
+                parse_handoff_platform_ref,
+                resolve_handoff_destination,
+            )
         except Exception as exc:  # pragma: no cover — gateway pkg always shipped
             _cprint(f"  Could not load gateway config: {exc}")
             return True
 
         try:
-            platform = Platform(platform_name)
-        except (ValueError, KeyError):
-            _cprint(f"  Unknown platform '{platform_name}'.")
+            platform, target_alias = parse_handoff_platform_ref(platform_ref)
+        except ValueError as exc:
+            _cprint(f"  {exc}")
             return True
 
         try:
@@ -565,13 +572,19 @@ class CLICommandsMixin:
 
         pcfg = gw_config.platforms.get(platform)
         if not pcfg or not pcfg.enabled:
-            _cprint(f"  Platform '{platform_name}' is not configured/enabled in the gateway.")
+            _cprint(f"  Platform '{platform.value}' is not configured/enabled in the gateway.")
             return True
 
-        home = gw_config.get_home_channel(platform)
-        if not home or not home.chat_id:
-            _cprint(f"  No home channel configured for {platform_name}.")
-            _cprint("  Set one with /sethome on the destination chat first.")
+        try:
+            _platform, home, _target_alias = resolve_handoff_destination(
+                gw_config, platform_ref,
+            )
+        except ValueError as exc:
+            if target_alias:
+                _cprint(f"  {exc}")
+            else:
+                _cprint(f"  No home channel configured for {platform.value}.")
+                _cprint("  Set one with /sethome on the destination chat first.")
             return True
 
         # Refuse mid-turn: an in-flight agent run would race with the
@@ -620,12 +633,12 @@ class CLICommandsMixin:
             session_title = self.session_id[:8]
 
         # Mark pending — gateway watcher will pick this up.
-        ok = self._session_db.request_handoff(self.session_id, platform_name)
+        ok = self._session_db.request_handoff(self.session_id, platform_ref)
         if not ok:
             _cprint("  Session is already in flight for handoff. Wait for it to settle, then retry.")
             return True
 
-        _cprint(f"  Queued handoff of '{session_title}' → {platform_name} (home: {home.name}).")
+        _cprint(f"  Queued handoff of '{session_title}' → {platform_ref} (home: {home.name}).")
         _cprint("  Waiting for the gateway to pick it up...")
 
         # Poll-block on terminal state. Tick every 0.5s; bail at ~60s.
@@ -644,7 +657,7 @@ class CLICommandsMixin:
                 last_state = current
             if current == "completed":
                 _cprint("")
-                _cprint(f"  ↻ Handoff complete. The session is now active on {platform_name}.")
+                _cprint(f"  ↻ Handoff complete. The session is now active on {platform_ref}.")
                 _cprint(f"  Resume it on this CLI later with: /resume {session_title}")
                 _cprint("")
                 # End the CLI cleanly — same exit semantics as /quit.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1879,6 +1879,8 @@ class SlashCommandCompleter(Completer):
         first arg (the platform); once one is chosen, stop.
         """
         parts = sub_text.split()
+        if Completion is None:
+            return
         trailing_space = sub_text.endswith(" ")
         if len(parts) > 1 or (len(parts) == 1 and trailing_space):
             return
@@ -1893,19 +1895,46 @@ class SlashCommandCompleter(Completer):
             return
         for platform in platforms:
             name = platform.value
-            if not name.startswith(partial_lower):
-                continue
+            if name.startswith(partial_lower):
+                try:
+                    home = gw.get_home_channel(platform)
+                except Exception:
+                    home = None
+                meta = f"→ {home.name}" if home and getattr(home, "name", None) else "send this session here"
+                yield Completion(
+                    name,
+                    start_position=-len(partial),
+                    display=name,
+                    display_meta=meta,
+                )
+
             try:
-                home = gw.get_home_channel(platform)
+                platform_cfg = gw.platforms.get(platform)
+                raw_targets = (
+                    (platform_cfg.extra or {}).get("handoff_targets")
+                    if platform_cfg else {}
+                )
             except Exception:
-                home = None
-            meta = f"→ {home.name}" if home and getattr(home, "name", None) else "send this session here"
-            yield Completion(
-                name,
-                start_position=-len(partial),
-                display=name,
-                display_meta=meta,
-            )
+                raw_targets = {}
+            if not isinstance(raw_targets, dict):
+                continue
+            for alias, target in raw_targets.items():
+                alias_name = str(alias).strip().lower()
+                if not alias_name:
+                    continue
+                full_name = f"{name}:{alias_name}"
+                if not full_name.startswith(partial_lower):
+                    continue
+                target_name = ""
+                if isinstance(target, dict):
+                    target_name = str(target.get("name") or target.get("chat_id") or "")
+                meta = f"→ {target_name}" if target_name else "send this session to this configured target"
+                yield Completion(
+                    full_name,
+                    start_position=-len(partial),
+                    display=full_name,
+                    display_meta=meta,
+                )
 
     @staticmethod
     def _personality_completions(sub_text: str, sub_lower: str):

--- a/tests/gateway/test_handoff_targets.py
+++ b/tests/gateway/test_handoff_targets.py
@@ -1,0 +1,183 @@
+"""Targeted tests for Desktop/TUI → gateway handoff destinations.
+
+The legacy `/handoff slack` path must keep using Slack's configured home
+channel, while `/handoff slack:pm` routes through a configured alias instead of
+mutating the global home channel.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from gateway.config import (
+    GatewayConfig,
+    HomeChannel,
+    Platform,
+    PlatformConfig,
+    parse_handoff_platform_ref,
+    resolve_handoff_destination,
+)
+from gateway.run import GatewayRunner
+
+
+PM_ID = "C_PM"
+PMO_ID = "C_PMO"
+
+
+def _slack_config() -> GatewayConfig:
+    return GatewayConfig(
+        platforms={
+            Platform.SLACK: PlatformConfig(
+                enabled=True,
+                token="fake-token",
+                home_channel=HomeChannel(
+                    platform=Platform.SLACK,
+                    chat_id=PMO_ID,
+                    name="#pmo",
+                ),
+                extra={
+                    "reply_in_thread": True,
+                    "handoff_targets": {
+                        "pm": {
+                            "chat_id": PM_ID,
+                            "name": "#pm",
+                        }
+                    },
+                },
+            )
+        }
+    )
+
+
+class _FakeAdapter:
+    def __init__(self) -> None:
+        self.created_parent_chat_id = None
+        self.created_thread_name = None
+        self.sent = None
+
+    async def create_handoff_thread(self, parent_chat_id: str, name: str):
+        self.created_parent_chat_id = parent_chat_id
+        self.created_thread_name = name
+        return "1700000000.000001"
+
+    async def send(self, chat_id: str, content: str, metadata=None):
+        self.sent = {
+            "chat_id": chat_id,
+            "content": content,
+            "metadata": metadata,
+        }
+        return SimpleNamespace(success=True)
+
+
+class _FakeSessionStore:
+    def __init__(self) -> None:
+        self.created_source = None
+        self.switch_call = None
+
+    def get_or_create_session(self, source):
+        self.created_source = source
+        return SimpleNamespace(id="destination")
+
+    def switch_session(self, session_key: str, cli_session_id: str):
+        self.switch_call = (session_key, cli_session_id)
+        return SimpleNamespace(id=cli_session_id)
+
+
+def _runner(config: GatewayConfig, adapter: _FakeAdapter) -> Any:
+    runner = cast(Any, GatewayRunner.__new__(GatewayRunner))
+    runner.config = config
+    runner.adapters = {Platform.SLACK: adapter}
+    runner.session_store = _FakeSessionStore()
+    runner.evicted = []
+    runner.released = []
+    runner.synthetic_event = None
+    runner._evict_cached_agent = lambda session_key: runner.evicted.append(session_key)
+
+    def _release_running_agent_state(session_key, *, run_generation=None):
+        runner.released.append((session_key, run_generation))
+        return True
+
+    runner._release_running_agent_state = _release_running_agent_state
+
+    async def _handle_message(event):
+        runner.synthetic_event = event
+        return "handoff ready"
+
+    runner._handle_message = _handle_message
+    return runner
+
+
+def test_resolve_handoff_destination_defaults_to_home_channel():
+    platform, home, alias = resolve_handoff_destination(_slack_config(), "slack")
+
+    assert platform is Platform.SLACK
+    assert alias is None
+    assert home.chat_id == PMO_ID
+    assert home.name == "#pmo"
+
+
+def test_resolve_handoff_destination_uses_configured_alias():
+    platform, home, alias = resolve_handoff_destination(_slack_config(), "slack:pm")
+
+    assert platform is Platform.SLACK
+    assert alias == "pm"
+    assert home.chat_id == PM_ID
+    assert home.name == "#pm"
+
+
+def test_parse_handoff_platform_ref_rejects_raw_channel_targets():
+    with pytest.raises(ValueError, match="invalid handoff target"):
+        parse_handoff_platform_ref("slack:#pm")
+
+
+@pytest.mark.asyncio
+async def test_process_handoff_routes_legacy_slack_to_home_channel():
+    adapter = _FakeAdapter()
+    runner = _runner(_slack_config(), adapter)
+
+    await GatewayRunner._process_handoff(
+        runner,
+        {"id": "cli-session", "title": "Desktop Session", "handoff_platform": "slack"},
+    )
+
+    assert adapter.created_parent_chat_id == PMO_ID
+    assert adapter.sent["chat_id"] == PMO_ID
+    assert runner.session_store.created_source.chat_id == PMO_ID
+    assert runner.session_store.created_source.chat_name == "#pmo"
+    assert runner.session_store.created_source.thread_id == "1700000000.000001"
+    assert runner.session_store.switch_call[1] == "cli-session"
+
+
+@pytest.mark.asyncio
+async def test_process_handoff_routes_explicit_slack_pm_to_pm_target():
+    adapter = _FakeAdapter()
+    runner = _runner(_slack_config(), adapter)
+
+    await GatewayRunner._process_handoff(
+        runner,
+        {"id": "cli-session", "title": "Desktop Session", "handoff_platform": "slack:pm"},
+    )
+
+    assert adapter.created_parent_chat_id == PM_ID
+    assert adapter.sent["chat_id"] == PM_ID
+    assert runner.session_store.created_source.chat_id == PM_ID
+    assert runner.session_store.created_source.chat_name == "#pm"
+    assert runner.session_store.created_source.thread_id == "1700000000.000001"
+    assert runner.session_store.switch_call[1] == "cli-session"
+
+
+@pytest.mark.asyncio
+async def test_process_handoff_fails_unknown_configured_target():
+    adapter = _FakeAdapter()
+    runner = _runner(_slack_config(), adapter)
+
+    with pytest.raises(RuntimeError, match="no handoff target 'missing'"):
+        await GatewayRunner._process_handoff(
+            runner,
+            {"id": "cli-session", "title": "Desktop Session", "handoff_platform": "slack:missing"},
+        )
+
+    assert adapter.created_parent_chat_id is None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -892,13 +892,17 @@ def _reap_idle_sessions() -> None:
 def _max_live_sessions() -> int:
     try:
         from hermes_cli.active_sessions import coerce_max_concurrent_sessions
+        from hermes_cli.config import DEFAULT_CONFIG
 
         cfg = _load_cfg() or {}
-        raw = cfg.get("max_live_sessions")
-        if raw is None:
+        missing = object()
+        raw = cfg.get("max_live_sessions", missing)
+        if raw is missing:
             gateway_cfg = cfg.get("gateway")
-            if isinstance(gateway_cfg, dict):
+            if isinstance(gateway_cfg, dict) and "max_live_sessions" in gateway_cfg:
                 raw = gateway_cfg.get("max_live_sessions")
+        if raw is missing:
+            raw = DEFAULT_CONFIG.get("max_live_sessions", 16)
         coerced = coerce_max_concurrent_sessions(raw, key="max_live_sessions")
         return int(coerced) if coerced else 0
     except Exception:
@@ -6702,21 +6706,26 @@ def _(rid, params: dict) -> dict:
             "session busy — wait for the current turn to finish, then retry the handoff",
         )
 
-    platform_name = (params.get("platform", "") or "").strip().lower()
-    if not platform_name:
+    platform_ref = (params.get("platform", "") or "").strip().lower()
+    if not platform_ref:
         return _err(rid, 4023, "platform required")
 
-    # Validate against the live gateway config — an unconfigured platform or a
-    # missing home channel would leave the handoff pending forever, so reject
-    # up front with a clear, actionable message (mirrors cli.py).
+    # Validate against the live gateway config — an unconfigured platform,
+    # missing home channel, or unknown explicit target would leave the handoff
+    # pending forever, so reject up front with a clear actionable message
+    # (mirrors cli.py).
     try:
-        from gateway.config import Platform, load_gateway_config
+        from gateway.config import (
+            load_gateway_config,
+            parse_handoff_platform_ref,
+            resolve_handoff_destination,
+        )
     except Exception as e:  # pragma: no cover — gateway pkg always ships
         return _err(rid, 5021, f"could not load gateway config: {e}")
     try:
-        platform = Platform(platform_name)
-    except (ValueError, KeyError):
-        return _err(rid, 4024, f"unknown platform '{platform_name}'")
+        platform, target_alias = parse_handoff_platform_ref(platform_ref)
+    except ValueError as e:
+        return _err(rid, 4024, str(e))
     try:
         gw_config = load_gateway_config()
     except Exception as e:
@@ -6726,16 +6735,21 @@ def _(rid, params: dict) -> dict:
         return _err(
             rid,
             4025,
-            f"platform '{platform_name}' is not configured/enabled in the gateway",
+            f"platform '{platform.value}' is not configured/enabled in the gateway",
         )
-    home = gw_config.get_home_channel(platform)
-    if not home or not home.chat_id:
-        return _err(
-            rid,
-            4026,
-            f"no home channel configured for {platform_name} — set one with "
-            "/sethome on the destination chat first",
+    try:
+        _platform, home, _target_alias = resolve_handoff_destination(
+            gw_config, platform_ref,
         )
+    except ValueError as e:
+        if target_alias:
+            msg = str(e)
+        else:
+            msg = (
+                f"no home channel configured for {platform.value} — set one with "
+                "/sethome on the destination chat first"
+            )
+        return _err(rid, 4026, msg)
 
     # The watcher transfers a persisted DB row, so make sure one exists even
     # for a brand-new empty chat (mirrors the CLI's set_session_title stub).
@@ -6748,7 +6762,7 @@ def _(rid, params: dict) -> dict:
         try:
             if not db.get_session(key):
                 db.set_session_title(key, f"handoff-{key[:8]}")
-            ok = db.request_handoff(key, platform_name)
+            ok = db.request_handoff(key, platform_ref)
         except Exception as e:
             return _err(rid, 5007, str(e))
 
@@ -6763,7 +6777,7 @@ def _(rid, params: dict) -> dict:
         {
             "queued": True,
             "session_key": key,
-            "platform": platform_name,
+            "platform": platform_ref,
             "home_name": home.name,
         },
     )


### PR DESCRIPTION
## Summary
- add configured handoff target aliases such as `slack:pm` without changing legacy platform-home behavior
- route CLI/TUI handoff requests through destination validation while preserving `/handoff slack` as the default Slack home path
- resolve the persisted handoff reference at the gateway watcher boundary before creating the handoff thread/session

## Tests
- `uv run --no-project --with pytest --with pytest-asyncio --with PyYAML --with httpx --with python-dotenv python -m pytest -q -o addopts='' tests/gateway/test_handoff_targets.py tests/hermes_cli/test_session_handoff.py tests/gateway/test_handoff_watcher_async_db.py tests/tui_gateway/test_protocol.py` — 105 passed in 3.27s
- `uv run --no-project --with PyYAML python -m py_compile gateway/config.py gateway/run.py hermes_cli/cli_commands_mixin.py hermes_cli/commands.py tui_gateway/server.py tests/gateway/test_handoff_targets.py`
- `git diff --check origin/main...HEAD`
- staged diff secret scan: `secret_scan_hits []`

Linear: IN-689
