### PR TITLE
fix(desktop): pane-tab "Close" removes the tab instead of only minimizing (fixes #65985)

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -39,9 +39,8 @@ import {
   $narrowViewport,
   $treeDragging,
   activateTreePane,
-  closeTreePane,
+  closePaneTab,
   collapseTreePane,
-  dismissTreePane,
   isCollapsePane,
   moveTreePane,
   restoreTreePane,
@@ -119,7 +118,10 @@ function ZoneMenu({
               const paneId = closable?.()
 
               if (paneId) {
-                closeTreePane(paneId)
+                // #65985: route through the SAME closePaneTab as middle-click /
+                // the tab ✕, so "Close" on a tool-panel tab (terminal/logs)
+                // REMOVES it instead of merely running its collapse closer.
+                closePaneTab(paneId)
               }
             }}
           >
@@ -268,10 +270,11 @@ export function TreeGroup({
   // MAIN strands the whole app behind a strip.
   const minimizable = !shown.some(id => paneChrome(paneFor(id)).uncloseable)
 
-  // Tab ✕: a tool panel (terminal/logs) is REMOVED from the layout (comes back
-  // via its toggle); everything else routes through its Close (a session tile
-  // closes the session, a store-bound pane collapses).
-  const closeTab = (paneId: string) => (isCollapsePane(paneId) ? dismissTreePane(paneId) : closeTreePane(paneId))
+  // Tab ✕ / middle-click / ⌘-click: routed through the store's shared
+  // closePaneTab — a tool panel (terminal/logs) is REMOVED from the layout
+  // (comes back via its toggle); everything else routes through its Close (a
+  // session tile closes the session, a store-bound pane collapses).
+  const closeTab = closePaneTab
 
   // Collapse/restore a tool panel (or plain minimize elsewhere) — the header
   // chevron + tap gesture, routed so ⌃`/the titlebar toggle stay truthful.

--- a/apps/desktop/src/components/pane-shell/tree/store.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Regression harness for #65985 — the outer Terminal/Logs pane-tab context-menu
+ * "Close" only minimized the zone (tab stayed visible); only the undiscoverable
+ * middle-click actually removed the tab.
+ *
+ * Root cause: the context menu called `closeTreePane`, which for a TOOL PANEL
+ * (terminal/logs — a collapse pane bound via `bindPaneCollapse`) runs the
+ * registered closer, and that closer only toggles the pane's open store off
+ * (collapse to a rail). Middle-click / the tab ✕ instead routed collapse panes
+ * to `dismissTreePane`, which removes them from the layout.
+ *
+ * The fix funnels BOTH gestures through one store route, `closePaneTab`, so the
+ * context-menu "Close" removes the tab exactly like middle-click. We assert that
+ * routing at the store level (the cleanest layer — it is a pure store action).
+ *
+ * Fresh module state per test (localStorage + resetModules) because
+ * `markCollapsePane` / `registerPaneCloser` mutate module-level maps.
+ */
+async function loadTree() {
+  const tree = await import('@/components/pane-shell/tree/store')
+  const model = await import('@/components/pane-shell/tree/model')
+
+  const paneIds = () => model.allPaneIds(tree.$layoutTree.get()!)
+
+  return { model, paneIds, tree }
+}
+
+describe('#65985 closePaneTab — context-menu Close removes tool-panel tabs', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('REMOVES a terminal/logs collapse pane from the layout, without running its collapse closer', async () => {
+    const { model, paneIds, tree } = await loadTree()
+
+    // Mirror bindPaneCollapse('terminal', …): a collapse pane whose registered
+    // closer only MINIMIZES (toggles its open store off) — it never removes the
+    // tab. This is exactly the closer that made the old context menu no-op.
+    const collapse = vi.fn()
+    tree.markCollapsePane('terminal')
+    tree.registerPaneCloser('terminal', collapse)
+
+    tree.declareDefaultTree(model.split('row', [model.group(['workspace']), model.group(['terminal'])], [3, 1]))
+    expect(paneIds()).toContain('terminal')
+
+    // The context-menu "Close" route (same one middle-click / the ✕ now use).
+    tree.closePaneTab('terminal')
+
+    // Tab is GONE from the layout — not merely collapsed…
+    expect(paneIds()).not.toContain('terminal')
+    // …and it did NOT take the minimize path (the collapse closer never ran).
+    expect(collapse).not.toHaveBeenCalled()
+  })
+
+  it('matches the middle-click removal path (dismissTreePane) for a collapse pane', async () => {
+    const { model, paneIds, tree } = await loadTree()
+    tree.markCollapsePane('logs')
+    tree.registerPaneCloser('logs', vi.fn())
+
+    tree.declareDefaultTree(model.split('row', [model.group(['workspace']), model.group(['logs'])], [3, 1]))
+
+    // closePaneTab (context menu) and dismissTreePane (the real middle-click
+    // removal path) leave the SAME surviving panes.
+    tree.closePaneTab('logs')
+    const afterContextMenuClose = paneIds()
+
+    tree.declareDefaultTree(model.split('row', [model.group(['workspace']), model.group(['logs'])], [3, 1]))
+    tree.dismissTreePane('logs')
+    const afterMiddleClick = paneIds()
+
+    expect(afterContextMenuClose).toEqual(afterMiddleClick)
+    expect(afterContextMenuClose).not.toContain('logs')
+  })
+
+  it('leaves OTHER tab kinds (a session tile / store-bound pane) on their Close route — closer runs, tab stays', async () => {
+    const { model, paneIds, tree } = await loadTree()
+
+    // A non-collapse pane with a registered closer (e.g. a session tile / a
+    // store-bound pane). closePaneTab must route it through closeTreePane, whose
+    // closer OWNS the close — the pane is NOT dismissed from the tree here.
+    const closeSession = vi.fn()
+    tree.registerPaneCloser('session-tile:abc', closeSession)
+
+    tree.declareDefaultTree(
+      model.split('row', [model.group(['workspace']), model.group(['session-tile:abc'])], [3, 1])
+    )
+
+    tree.closePaneTab('session-tile:abc')
+
+    expect(closeSession).toHaveBeenCalledTimes(1)
+    // Behavior for this tab kind is unchanged — its closer decides, the tree
+    // still holds the pane (the fix is scoped to collapse panes only).
+    expect(paneIds()).toContain('session-tile:abc')
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -453,6 +453,26 @@ export function closeTreePane(paneId: string) {
 }
 
 /**
+ * The tab-CLOSE route shared by every "close this tab" gesture — the header ✕ /
+ * middle-click / ⌘-click AND the zone context menu's "Close". A TOOL PANEL
+ * (terminal/logs — a collapse pane) is REMOVED from the layout (it comes back
+ * via its toggle); everything else routes through its Close (a session tile
+ * closes the session, a store-bound pane collapses). Keeping this in ONE place
+ * is what makes the context-menu "Close" agree with middle-click (#65985): a
+ * collapse pane's registered closer only minimizes, so routing it through
+ * `closeTreePane` would leave the tab behind.
+ */
+export function closePaneTab(paneId: string) {
+  if (isCollapsePane(paneId)) {
+    dismissTreePane(paneId)
+
+    return
+  }
+
+  closeTreePane(paneId)
+}
+
+/**
  * POSITIONAL side collapse — the titlebar's left/right sidebar toggles (and
  * ⌘B / ⌘J). Everything on that side of the MAIN zone in the root row hides
  * together, whatever panes live there (this is what makes the buttons agree


### PR DESCRIPTION
## What & why

In the tree/tiling layout, the context-menu **Close** on the outer **Terminal**/**Logs** pane tabs only collapsed the tool zone to a rail and left the tab behind — even though it's labeled "Close", has no visible ✕, and the *only* gesture that actually removed the tab was an undiscoverable **middle-click**.

Fixes #65985.

## Root cause

The zone context menu's **Close** called `closeTreePane(paneId)`, which runs a collapse pane's *registered closer* — terminal/logs register one that just toggles the tool zone off (→ minimize). Middle-click / ⌘-click / the tab ✕ instead used a local `closeTab` that routed collapse panes to `dismissTreePane` (real removal). So the two gestures disagreed, and the visible menu command was the one that didn't work.

## Fix

Extract the removal logic into one exported `closePaneTab(paneId)` in the tree store — a collapse pane (terminal/logs) is **removed** via `dismissTreePane`; everything else routes through `closeTreePane` (a session tile closes its session, a store-bound pane collapses) — and route **both** the middle-click/✕ path and the context-menu **Close** through it. Now "Close" agrees with middle-click.

**Scope:** behavior changes only for collapse panes' menu Close. Middle-click is unchanged (it already did exactly this). Session tiles / previews / store-bound (non-collapse) panes still hit `closeTreePane` as before; the chevron minimize/restore and the uncloseable-workspace gate are untouched.

## Testing

`apps/desktop/src/components/pane-shell/tree/store.test.ts` (3):
- a collapse pane's `closePaneTab` removes it from the tree **and never calls its collapse closer** (proves removal, not minimize);
- it leaves the **same surviving panes** as the middle-click `dismissTreePane` reference;
- a non-collapse session tile still **runs its closer once and stays** (other tab kinds unaffected).

Verified on Windows: `npm run typecheck` clean; `vitest run` on the new test → **3 passed**; `eslint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
