### PR TITLE
fix(skills): widen call-time skills-dir resolution to skills_sync

### DIFF
--- a/tests/tools/test_skills_sync_profile_scope.py
+++ b/tests/tools/test_skills_sync_profile_scope.py
@@ -1,0 +1,134 @@
+"""Regression: tools/skills_sync must resolve the skills dir per call, not at import.
+
+``tools/skills_sync`` binds ``HERMES_HOME`` / ``SKILLS_DIR`` / ``MANIFEST_FILE`` at
+import time. Long-lived runtimes import it once under the launch profile and later
+bind a different profile per request via ``set_hermes_home_override`` — the dashboard
+console does exactly this (``hermes_cli/web_server.py`` ``_profile_scope``, which
+retargets ``skills_tool`` and ``skill_manager_tool`` but not ``skills_sync``), and
+console ``skills opt-in|opt-out|reset|diff|list-modified`` dispatch in-process.
+
+Frozen constants therefore made these functions read and WRITE the launch profile
+while a different profile was active.
+
+Same fix as f8723c478 (skills_tool) and c6a3d412d (skill_manager_tool): resolve from
+the live profile-scoped home on every call, while an explicit monkeypatch of the
+module attribute still wins.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import hermes_constants
+import tools.skills_sync as skills_sync
+
+
+@pytest.fixture
+def two_profiles(tmp_path, monkeypatch):
+    """Import the module under profile A, then hand back both profiles.
+
+    The reload is the point: it reproduces "a long-lived process imported this
+    module while profile A was the active home", which is what freezes the
+    module-level constants.
+    """
+    a = tmp_path / "profileA"
+    b = tmp_path / "profileB"
+    a.mkdir()
+    b.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(a))
+    importlib.reload(skills_sync)
+    try:
+        yield a, b
+    finally:
+        monkeypatch.undo()
+        importlib.reload(skills_sync)
+
+
+def test_opt_out_marker_is_read_from_the_active_profile(two_profiles):
+    """is_bundled_skills_opt_out() must report the ACTIVE profile, not the launch one."""
+    a, b = two_profiles
+    # Only B has opted out.
+    (b / skills_sync.NO_BUNDLED_SKILLS_MARKER).write_text("opted out\n")
+    assert not (a / skills_sync.NO_BUNDLED_SKILLS_MARKER).exists()
+
+    token = hermes_constants.set_hermes_home_override(str(b))
+    try:
+        assert skills_sync.is_bundled_skills_opt_out() is True, (
+            "read the launch profile's home instead of the active profile's — "
+            "is_bundled_skills_opt_out() promises the active profile"
+        )
+    finally:
+        hermes_constants.reset_hermes_home_override(token)
+
+
+def test_opt_out_marker_is_written_to_the_active_profile(two_profiles):
+    """set_bundled_skills_opt_out() must not write into the launch profile."""
+    a, b = two_profiles
+
+    token = hermes_constants.set_hermes_home_override(str(b))
+    try:
+        skills_sync.set_bundled_skills_opt_out(True)
+    finally:
+        hermes_constants.reset_hermes_home_override(token)
+
+    assert (b / skills_sync.NO_BUNDLED_SKILLS_MARKER).exists(), (
+        "opt-out marker did not land in the active profile"
+    )
+    assert not (a / skills_sync.NO_BUNDLED_SKILLS_MARKER).exists(), (
+        "opt-out marker was written into the LAUNCH profile while another "
+        "profile was active — cross-profile write"
+    )
+
+
+def test_manifest_is_read_from_the_active_profile(two_profiles):
+    """_read_manifest() must consult the active profile's manifest."""
+    a, b = two_profiles
+    for home, name in ((a, "skill-from-A"), (b, "skill-from-B")):
+        manifest = home / "skills" / ".bundled_manifest"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(f"{name}:deadbeef\n")  # v2 manifest format: name:hash
+
+    token = hermes_constants.set_hermes_home_override(str(b))
+    try:
+        entries = skills_sync._read_manifest()
+    finally:
+        hermes_constants.reset_hermes_home_override(token)
+
+    assert "skill-from-B" in entries, (
+        f"read the launch profile's manifest while B was active: {sorted(entries)}"
+    )
+
+
+def test_resolvers_follow_the_active_profile(two_profiles):
+    """The call-time resolvers track the live override and restore afterwards."""
+    a, b = two_profiles
+    assert skills_sync._skills_dir() == a / "skills"
+
+    token = hermes_constants.set_hermes_home_override(str(b))
+    try:
+        assert skills_sync._hermes_home() == b
+        assert skills_sync._skills_dir() == b / "skills"
+        assert skills_sync._manifest_file() == b / "skills" / ".bundled_manifest"
+    finally:
+        hermes_constants.reset_hermes_home_override(token)
+
+    assert skills_sync._skills_dir() == a / "skills"
+
+
+def test_explicit_monkeypatch_still_wins(two_profiles, monkeypatch):
+    """An external patcher of SKILLS_DIR must override live resolution (tests rely on this)."""
+    a, b = two_profiles
+    forced = a / "forced-skills"
+    monkeypatch.setattr(skills_sync, "SKILLS_DIR", forced)
+
+    token = hermes_constants.set_hermes_home_override(str(b))
+    try:
+        assert skills_sync._skills_dir() == forced, (
+            "an explicitly patched SKILLS_DIR must take precedence over the "
+            "live profile home"
+        )
+    finally:
+        hermes_constants.reset_hermes_home_override(token)

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -39,6 +39,42 @@ logger = logging.getLogger(__name__)
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
 MANIFEST_FILE = SKILLS_DIR / ".bundled_manifest"
+_HERMES_HOME_AT_IMPORT = HERMES_HOME
+_SKILLS_DIR_AT_IMPORT = SKILLS_DIR
+_MANIFEST_FILE_AT_IMPORT = MANIFEST_FILE
+
+
+def _hermes_home() -> Path:
+    """Return the active profile's hermes home at call time.
+
+    Long-lived runtimes (dashboard console, gateway, kanban workers) import
+    this module once under the launch HERMES_HOME and later bind a different
+    profile per request via ``set_hermes_home_override``. A module-level
+    constant cannot see that override. Keep the legacy module attributes for
+    tests and external patchers, but when they have not been patched, resolve
+    from the live profile-scoped HERMES_HOME on every call.
+    """
+    configured = Path(HERMES_HOME)
+    if configured != _HERMES_HOME_AT_IMPORT:
+        return configured
+    return get_hermes_home()
+
+
+def _skills_dir() -> Path:
+    """Return the active profile's skills directory at call time."""
+    configured = Path(SKILLS_DIR)
+    if configured != _SKILLS_DIR_AT_IMPORT:
+        return configured
+    return _hermes_home() / "skills"
+
+
+def _manifest_file() -> Path:
+    """Return the active profile's bundled-skills manifest at call time."""
+    configured = Path(MANIFEST_FILE)
+    if configured != _MANIFEST_FILE_AT_IMPORT:
+        return configured
+    return _skills_dir() / ".bundled_manifest"
+
 
 # Marker file written by `hermes profile create --no-skills` (named profiles)
 # and by the installer's `--no-skills` flag (the default ~/.hermes profile).
@@ -101,11 +137,11 @@ def _read_manifest() -> Dict[str, str]:
     Handles both v1 (plain names) and v2 (name:hash) formats.
     v1 entries get an empty hash string which triggers migration on next sync.
     """
-    if not MANIFEST_FILE.exists():
+    if not _manifest_file().exists():
         return {}
     try:
         result = {}
-        for line in MANIFEST_FILE.read_text(encoding="utf-8").splitlines():
+        for line in _manifest_file().read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if not line:
                 continue
@@ -133,7 +169,7 @@ def _read_suppressed_names() -> set:
 
         return read_suppressed_names()
     except Exception:
-        path = SKILLS_DIR / ".curator_suppressed"
+        path = _skills_dir() / ".curator_suppressed"
         if not path.exists():
             return set()
         names = set()
@@ -155,12 +191,12 @@ def _write_manifest(entries: Dict[str, str]):
     """
     import tempfile
 
-    MANIFEST_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _manifest_file().parent.mkdir(parents=True, exist_ok=True)
     data = "\n".join(f"{name}:{hash_val}" for name, hash_val in sorted(entries.items())) + "\n"
 
     try:
         fd, tmp_path = tempfile.mkstemp(
-            dir=str(MANIFEST_FILE.parent),
+            dir=str(_manifest_file().parent),
             prefix=".bundled_manifest_",
             suffix=".tmp",
         )
@@ -169,7 +205,7 @@ def _write_manifest(entries: Dict[str, str]):
                 f.write(data)
                 f.flush()
                 os.fsync(f.fileno())
-            atomic_replace(tmp_path, MANIFEST_FILE)
+            atomic_replace(tmp_path, _manifest_file())
         except BaseException:
             try:
                 os.unlink(tmp_path)
@@ -177,7 +213,7 @@ def _write_manifest(entries: Dict[str, str]):
                 pass
             raise
     except Exception as e:
-        logger.debug("Failed to write skills manifest %s: %s", MANIFEST_FILE, e, exc_info=True)
+        logger.debug("Failed to write skills manifest %s: %s", _manifest_file(), e, exc_info=True)
 
 
 def _read_skill_name(skill_md: Path, fallback: str) -> str:
@@ -226,7 +262,7 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
     e.g., bundled/skills/mlops/axolotl -> ~/.hermes/skills/mlops/axolotl
     """
     rel = skill_dir.relative_to(bundled_dir)
-    return SKILLS_DIR / rel
+    return _skills_dir() / rel
 
 
 def _dir_hash(directory: Path) -> str:
@@ -304,7 +340,7 @@ def _optional_skill_index() -> Dict[str, Tuple[str, str, Path]]:
 
 def _move_to_restore_backup(path: Path, backup_root: Path) -> str:
     """Move an existing skill directory into a restore backup, preserving rel path."""
-    rel = path.relative_to(SKILLS_DIR)
+    rel = path.relative_to(_skills_dir())
     target = backup_root / rel
     target.parent.mkdir(parents=True, exist_ok=True)
     if target.exists():
@@ -337,10 +373,10 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
     restored: List[str] = []
     backed_up: List[str] = []
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    backup_root = SKILLS_DIR / ".restore-backups" / f"official-optional-{timestamp}"
+    backup_root = _skills_dir() / ".restore-backups" / f"official-optional-{timestamp}"
 
     for folder_name, install_path, src in targets:
-        dest = SKILLS_DIR / Path(*install_path.split("/"))
+        dest = _skills_dir() / Path(*install_path.split("/"))
         src_hash = _dir_hash(src)
         canonical_ok = dest.exists() and _dir_hash(dest) == src_hash
 
@@ -348,13 +384,13 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
         # or folder slug, even if curator moved it into another category.
         src_frontmatter = _read_skill_name(src / "SKILL.md", folder_name)
         matches: List[Path] = []
-        if SKILLS_DIR.exists():
-            for skill_md in sorted(SKILLS_DIR.rglob("SKILL.md")):
+        if _skills_dir().exists():
+            for skill_md in sorted(_skills_dir().rglob("SKILL.md")):
                 if is_excluded_skill_path(skill_md):
                     continue
                 candidate = skill_md.parent
                 try:
-                    candidate.relative_to(SKILLS_DIR)
+                    candidate.relative_to(_skills_dir())
                 except ValueError:
                     continue
                 candidate_name = _read_skill_name(skill_md, candidate.name)
@@ -400,7 +436,7 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
     if not optional_dir.exists():
         return []
 
-    lock_path = SKILLS_DIR / ".hub" / "lock.json"
+    lock_path = _skills_dir() / ".hub" / "lock.json"
     try:
         data = json.loads(lock_path.read_text()) if lock_path.exists() else {"version": 1, "installed": {}}
     except (json.JSONDecodeError, OSError):
@@ -423,7 +459,7 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
         except ValueError as e:
             logger.debug("Skipping optional skill with unsafe path %s: %s", src, e)
             continue
-        dest = SKILLS_DIR / Path(*install_path.split("/"))
+        dest = _skills_dir() / Path(*install_path.split("/"))
         if not dest.exists() or not dest.is_dir():
             continue
         if _dir_hash(dest) != _dir_hash(src):
@@ -493,7 +529,7 @@ def sync_skills(quiet: bool = False) -> dict:
     # empty-result shape with skipped_opt_out lets callers report "opted out"
     # instead of "synced 0 / failed". This is the default-profile counterpart
     # to seed_profile_skills()'s marker check for named profiles.
-    if (HERMES_HOME / NO_BUNDLED_SKILLS_MARKER).exists():
+    if (_hermes_home() / NO_BUNDLED_SKILLS_MARKER).exists():
         if not quiet:
             print("  (skipped — profile opted out of bundled skills via .no-bundled-skills)")
         return {
@@ -510,7 +546,7 @@ def sync_skills(quiet: bool = False) -> dict:
             "optional_provenance_backfilled": [],
         }
 
-    SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+    _skills_dir().mkdir(parents=True, exist_ok=True)
     manifest = _read_manifest()
     bundled_skills = _discover_bundled_skills(bundled_dir)
     bundled_names = {name for name, _ in bundled_skills}
@@ -696,7 +732,7 @@ def sync_skills(quiet: bool = False) -> dict:
     # Also copy DESCRIPTION.md files for categories (if not already present)
     for desc_md in bundled_dir.rglob("DESCRIPTION.md"):
         rel = desc_md.relative_to(bundled_dir)
-        dest_desc = SKILLS_DIR / rel
+        dest_desc = _skills_dir() / rel
         if not dest_desc.exists():
             try:
                 dest_desc.parent.mkdir(parents=True, exist_ok=True)
@@ -741,7 +777,7 @@ def _rmtree_writable(path: Path) -> None:
     # ``shutil.rmtree(~/.hermes)`` into a loud, recoverable ``ValueError``
     # instead of silently destroying the user's install.
     target = Path(path).resolve()
-    skills_root = SKILLS_DIR.resolve()
+    skills_root = _skills_dir().resolve()
     # Every legitimate caller passes a skill directory or its ``.bak``
     # sibling — always a strict child of the skills root. The skills root
     # itself must never be removed: a ``dest`` that collapses to
@@ -1049,11 +1085,11 @@ def set_bundled_skills_opt_out(enabled: bool) -> dict:
         dict with keys: ok (bool), changed (bool), marker (str path),
                         message (str).
     """
-    marker = HERMES_HOME / NO_BUNDLED_SKILLS_MARKER
+    marker = _hermes_home() / NO_BUNDLED_SKILLS_MARKER
     existed = marker.exists()
     try:
         if enabled:
-            HERMES_HOME.mkdir(parents=True, exist_ok=True)
+            _hermes_home().mkdir(parents=True, exist_ok=True)
             marker.write_text(
                 "This profile opted out of bundled-skill seeding "
                 "(`hermes skills opt-out`).\n"
@@ -1087,7 +1123,7 @@ def set_bundled_skills_opt_out(enabled: bool) -> dict:
 
 def is_bundled_skills_opt_out() -> bool:
     """Return True if the active profile carries the opt-out marker."""
-    return (HERMES_HOME / NO_BUNDLED_SKILLS_MARKER).exists()
+    return (_hermes_home() / NO_BUNDLED_SKILLS_MARKER).exists()
 
 
 def remove_pristine_bundled_skills(dry_run: bool = False) -> dict:


### PR DESCRIPTION

Closes #65828.

`tools/skills_sync` is the third module in the lineage of #40677 — `f8723c478` fixed `skills_tool`, `c6a3d412d` widened the same fix to `skill_manager_tool`, and `skills_sync` has the identical import-time binding with no call-time resolver.

`_profile_scope` (`hermes_cli/web_server.py`) documents the seam and hand-retargets two modules:

> `tools.skills_tool` and `tools.skill_manager_tool` bind `SKILLS_DIR` at import time, so the override CANNOT reach them.

`skills_sync` is not among them, and the dashboard console reaches it **in-process**: `console_engine.py` allowlists `skills opt-in|opt-out|reset|diff|list-modified` → `cmd_skills` → `skills_hub.skills_command` → lazy `from tools.skills_sync import ...` (`:1152`, `:1195`, `:1222`, `:1337`). Hub `install`/`update`/`uninstall` are unaffected — those correctly use a fresh profile-scoped subprocess (`web_server.py:12501`).

### Reproduced

With the module imported under profile A and profile B active:

```
skills_sync.HERMES_HOME        : .../profileA   <- frozen at import
active home                    : .../profileB

is_bundled_skills_opt_out()    -> False   # B HAS the marker; docstring promises the ACTIVE profile
set_bundled_skills_opt_out(True) -> wrote the marker into A, not B
```

`reset_bundled_skill()` is the sharp edge: its strict-child delete guard is computed from the frozen `SKILLS_DIR` (`skills_sync.py:744`) — the check that exists so a collapsed `dest` can't "wipe every installed skill".

The binding is **order-dependent**: the first console skills command to run inside a profile scope binds correctly; every later one under a different profile does not. That's likely why it has survived — it presents as intermittent.

### Fix

The established pattern from both prior commits: keep the module attributes for tests and external patchers, snapshot at import, resolve live otherwise. `seed_profile_skills` already works around this caching with a subprocess (*"Uses subprocess because sync_skills() caches HERMES_HOME at module level"*) — that covers seeding only, not the console.

### Tests

`tests/tools/test_skills_sync_profile_scope.py` — behavioral, per AGENTS.md's ban on reading source in tests. Reloads the module under profile A, activates B, and asserts on real reads/writes. All 5 fail against the unfixed module; existing `test_skills_sync.py` + `test_skills_list_modified_diff.py` (75 tests) stay green.

### Note on AGENTS.md:1193

> "Module-level constants are fine — they cache `get_hermes_home()` at import time, which is AFTER `_apply_profile_override()` sets the env var."

True for the one-shot CLI, not for the `set_hermes_home_override` ContextVar in long-lived processes — which is the seam `_profile_scope` exists to paper over. Happy to correct it here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)