### PR TITLE
fix(desktop): guard Tailwind source scanning

### DIFF
--- a/apps/desktop/scripts/assert-dist-built.mjs
+++ b/apps/desktop/scripts/assert-dist-built.mjs
@@ -11,7 +11,7 @@
 // inherits it. It fails loud and early instead of shipping a broken bundle.
 // See issues #39484 (renderer blank page) and #41327 / #39472 (dashboard 404).
 
-import { existsSync, statSync, readdirSync } from "fs"
+import { existsSync, readFileSync, statSync, readdirSync } from "fs"
 import { join, resolve } from "path"
 import { isMain } from "./utils.mjs"
 
@@ -33,12 +33,34 @@ export function checkDistBuilt(distDir) {
   // index.html alone isn't enough — vite emits hashed JS into dist/assets.
   // An index.html with no script bundle still blank-pages.
   const assetsDir = join(distDir, "assets")
-  const hasAssets =
+  const assetNames =
     existsSync(assetsDir) &&
     statSync(assetsDir).isDirectory() &&
-    readdirSync(assetsDir).some(name => name.endsWith(".js"))
-  if (!hasAssets) {
+    readdirSync(assetsDir)
+  const hasJsBundle = assetNames && assetNames.some(name => name.endsWith(".js"))
+  if (!hasJsBundle) {
     return { ok: false, error: `dist/assets has no built JS bundle (expected vite output under ${assetsDir})` }
+  }
+
+  // A CSS file existing is not sufficient. Tailwind can emit its theme/base
+  // layers while silently scanning zero renderer files (for example when a
+  // local Git exclude hides apps/desktop/src). Electron then launches and the
+  // React tree mounts, but every pane split computes to display:block. Require
+  // a small set of structural utilities that the desktop shell always uses so
+  // a source-scan failure stops the build before electron-builder installs it.
+  const cssNames = assetNames.filter(name => name.endsWith(".css"))
+  if (cssNames.length === 0) {
+    return { ok: false, error: `dist/assets has no built CSS bundle (expected vite output under ${assetsDir})` }
+  }
+
+  const css = cssNames.map(name => readFileSync(join(assetsDir, name), "utf8")).join("\n")
+  const requiredUtilities = [".flex{display:flex}", ".flex-row{flex-direction:row}", ".min-h-0{min-height:0}"]
+  const missingUtilities = requiredUtilities.filter(rule => !css.includes(rule))
+  if (missingUtilities.length > 0) {
+    return {
+      ok: false,
+      error: `dist CSS is missing structural Tailwind utilities: ${missingUtilities.join(", ")}`
+    }
   }
 
   return { ok: true }
@@ -59,7 +81,7 @@ function main() {
     process.exit(1)
   }
 
-  console.log("✓ assert-dist-built: dist/index.html + assets present")
+  console.log("✓ assert-dist-built: renderer JS + structural CSS present")
 }
 
 if (isMain(import.meta.url)) {

--- a/apps/desktop/scripts/assert-dist-built.test.mjs
+++ b/apps/desktop/scripts/assert-dist-built.test.mjs
@@ -14,11 +14,14 @@ function makeDist(extra) {
   return { tempRoot, distDir }
 }
 
-test('checkDistBuilt passes when index.html + an assets JS bundle exist', () => {
+const structuralCss = '.flex{display:flex}.flex-row{flex-direction:row}.min-h-0{min-height:0}'
+
+test('checkDistBuilt passes when index.html + renderer JS + structural CSS exist', () => {
   const { tempRoot, distDir } = makeDist(d => {
     fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html><div id=root></div>', 'utf8')
     fs.mkdirSync(path.join(d, 'assets'))
     fs.writeFileSync(path.join(d, 'assets', 'index-abc123.js'), 'console.log(1)', 'utf8')
+    fs.writeFileSync(path.join(d, 'assets', 'index-abc123.css'), structuralCss, 'utf8')
   })
   try {
     assert.deepEqual(checkDistBuilt(distDir), { ok: true })
@@ -72,12 +75,44 @@ test('checkDistBuilt fails when assets/ has no JS bundle', () => {
     fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html>', 'utf8')
     fs.mkdirSync(path.join(d, 'assets'))
     // CSS only, no JS — still a blank page at runtime.
-    fs.writeFileSync(path.join(d, 'assets', 'index-abc123.css'), 'body{}', 'utf8')
+    fs.writeFileSync(path.join(d, 'assets', 'index-abc123.css'), structuralCss, 'utf8')
   })
   try {
     const result = checkDistBuilt(distDir)
     assert.equal(result.ok, false)
     assert.match(result.error, /no built JS bundle/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkDistBuilt fails when assets/ has no CSS bundle', () => {
+  const { tempRoot, distDir } = makeDist(d => {
+    fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html>', 'utf8')
+    fs.mkdirSync(path.join(d, 'assets'))
+    fs.writeFileSync(path.join(d, 'assets', 'index-abc123.js'), 'console.log(1)', 'utf8')
+  })
+  try {
+    const result = checkDistBuilt(distDir)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /no built CSS bundle/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkDistBuilt fails when Tailwind omitted structural utilities', () => {
+  const { tempRoot, distDir } = makeDist(d => {
+    fs.writeFileSync(path.join(d, 'index.html'), '<!doctype html>', 'utf8')
+    fs.mkdirSync(path.join(d, 'assets'))
+    fs.writeFileSync(path.join(d, 'assets', 'index-abc123.js'), 'console.log(1)', 'utf8')
+    fs.writeFileSync(path.join(d, 'assets', 'index-abc123.css'), '@layer base{body{margin:0}}', 'utf8')
+  })
+  try {
+    const result = checkDistBuilt(distDir)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /missing structural Tailwind utilities/)
+    assert.match(result.error, /\.flex\{display:flex\}/)
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1,4 +1,11 @@
-@import 'tailwindcss';
+/*
+ * Pin Tailwind's scan root to the renderer source tree. The desktop updater
+ * builds from a locally managed checkout whose Git exclude rules may hide
+ * apps/desktop/src from automatic source detection. Tailwind honors those
+ * rules, so relying on auto-detection can silently emit theme/base CSS with
+ * no utilities and package an app whose entire pane layout renders as block.
+ */
+@import 'tailwindcss' source('.');
 @plugin '@tailwindcss/typography';
 @import 'tw-shimmer';
 @import 'katex/dist/katex.min.css';


### PR DESCRIPTION
## What changed

- Pin Tailwind's source scan to the desktop renderer tree.
- Fail the desktop postbuild check when the CSS bundle is missing.
- Fail the build when stable structural utilities are absent.
- Add regression coverage for valid CSS, missing CSS, and missing utilities.

## Why

The desktop app can be built from a locally managed checkout. If local Git exclude rules hide `apps/desktop/src`, Tailwind's automatic source detection emits theme and base CSS without the layout utilities used by the renderer.

The existing postbuild check accepted that bundle because JavaScript existed. Electron launched and mounted React, but pane layouts rendered as block elements and the app was unusable.

The explicit source root removes that dependency on local Git state. The strengthened postbuild check stops the broken artifact before packaging.

## Impact

Normal desktop builds are unchanged. Invalid renderer bundles now fail closed instead of shipping an unstyled application.

## Verification

- `npx vitest run apps/desktop/scripts/assert-dist-built.test.mjs` — 7 tests passed.
- `npm --workspace apps/desktop run typecheck` — passed.
- `npm --workspace apps/desktop run build` — passed.
- Postbuild assertion confirmed renderer JavaScript and structural CSS are present.
