### PR TITLE
fix(memory): add action to required parameters in tool schema

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1124,7 +1124,7 @@ MEMORY_SCHEMA = {
                 },
             },
         },
-        "required": ["target"],
+        "required": ["target", "action"],
     },
 }
 


### PR DESCRIPTION
The memory tool's OpenAI function-calling schema declares action as optional in the single-operation call shape, which lets malformed tool calls pass schema validation and fail deep inside memory_tool(). This fixes the issue by adding 'action' to the required parameters list. Fixes #64291.