### PR TITLE
fix(desktop): add send-on-stop dictation shortcut

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -37,6 +37,7 @@ const FOCUS_EVENT = 'hermes:composer-focus'
 const INSERT_EVENT = 'hermes:composer-insert'
 const INSERT_REFS_EVENT = 'hermes:composer-insert-refs'
 const SUBMIT_EVENT = 'hermes:composer-submit'
+const DICTATION_TOGGLE_EVENT = 'hermes:composer-dictation-toggle'
 const VOICE_TOGGLE_EVENT = 'hermes:composer-voice-toggle'
 
 interface SubmitDetail {
@@ -45,6 +46,13 @@ interface SubmitDetail {
 }
 
 let activeTarget: ComposerTarget = 'main'
+let nextDictationOwnerId = 1
+let dictationOwner: ComposerDictationOwner | null = null
+
+export interface ComposerDictationOwner {
+  id: number
+  target: ComposerTarget
+}
 
 const resolve = (target: ComposerTarget | 'active') => (target === 'active' ? activeTarget : target)
 
@@ -134,6 +142,52 @@ export const requestComposerSubmit = (
 
 export const onComposerSubmitRequest = (handler: (detail: SubmitDetail) => void) =>
   subscribe<SubmitDetail>(SUBMIT_EVENT, handler)
+
+export const createComposerDictationOwner = (target: ComposerTarget): ComposerDictationOwner => ({
+  id: nextDictationOwnerId++,
+  target
+})
+
+export const claimComposerDictation = (owner: ComposerDictationOwner): boolean => {
+  if (dictationOwner && dictationOwner.id !== owner.id) {
+    return false
+  }
+
+  dictationOwner = owner
+
+  return true
+}
+
+export const ownsComposerDictation = (owner: ComposerDictationOwner): boolean => dictationOwner?.id === owner.id
+
+export const releaseComposerDictation = (owner: ComposerDictationOwner) => {
+  if (dictationOwner?.id === owner.id) {
+    dictationOwner = null
+  }
+}
+
+/** Toggle ONE composer's push-to-talk dictation. Once capture starts, ownership
+ * stays pinned through stop/transcription so a focus change cannot redirect the
+ * second press into another composer. */
+export const requestDictationToggle = (target: ComposerTarget | 'active' = 'active') => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const requestedTarget = resolve(target)
+  const ownerAtRequest = dictationOwner
+
+  window.setTimeout(() => {
+    const routedTarget = ownerAtRequest?.target ?? dictationOwner?.target ?? requestedTarget
+
+    window.dispatchEvent(
+      new CustomEvent<{ target: ComposerTarget }>(DICTATION_TOGGLE_EVENT, { detail: { target: routedTarget } })
+    )
+  }, 0)
+}
+
+export const onComposerDictationToggleRequest = (handler: (target: ComposerTarget) => void) =>
+  subscribe<{ target: ComposerTarget }>(DICTATION_TOGGLE_EVENT, ({ target }) => handler(target))
 
 /** Toggle ONE composer's voice conversation — the `composer.voice` hotkey
  *  (Ctrl+B) reaches the composer that owns voice. Defaults to the active

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.tsx
@@ -1,0 +1,145 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { markActiveComposer, requestDictationToggle } from '../focus'
+
+import { useComposerVoice } from './use-composer-voice'
+
+const recorder = vi.hoisted(() => ({
+  cancel: vi.fn(),
+  dictate: vi.fn(),
+  options: null as null | {
+    onIdle?: () => void
+    onTranscript: (text: string, submit: boolean) => void
+  },
+  status: 'idle' as 'idle' | 'recording' | 'transcribing'
+}))
+
+const conversation = vi.hoisted(() => ({
+  end: vi.fn(),
+  level: 0,
+  muted: false,
+  status: 'idle' as const,
+  stopTurn: vi.fn(),
+  toggleMute: vi.fn()
+}))
+
+vi.mock('./use-voice-recorder', () => ({
+  useVoiceRecorder: (options: {
+    onIdle?: () => void
+    onTranscript: (text: string, submit: boolean) => void
+  }) => {
+    recorder.options = options
+
+    return {
+      cancel: recorder.cancel,
+      dictate: recorder.dictate,
+      voiceActivityState: { elapsedSeconds: 0, level: 0, status: recorder.status },
+      voiceStatus: recorder.status
+    }
+  }
+}))
+
+vi.mock('./use-voice-conversation', () => ({ useVoiceConversation: () => conversation }))
+vi.mock('./use-auto-speak-replies', () => ({ useAutoSpeakReplies: () => undefined }))
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+vi.mock('@/store/composer-input-history', () => ({ resetBrowseState: vi.fn() }))
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
+vi.mock('@/store/session', () => ({ $messages: { get: () => [] } }))
+vi.mock('@/store/voice-prefs', () => ({
+  $autoSpeakReplies: { get: () => false },
+  setAutoSpeakReplies: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      assistant: { thread: { readAloudFailed: 'Read aloud failed' } },
+      settings: { config: { autosaveFailed: 'Autosave failed' } }
+    }
+  })
+}))
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  recorder.options = null
+  recorder.status = 'idle'
+  recorder.cancel.mockImplementation(() => recorder.options?.onIdle?.())
+  markActiveComposer('main')
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function renderVoice(target = 'main', initialScopeKey = 'session-1') {
+  const insertText = vi.fn()
+  const submitDraft = vi.fn()
+
+  const hook = renderHook(
+    ({ scopeKey }) =>
+      useComposerVoice({
+        busy: false,
+        clearDraft: vi.fn(),
+        dictationEnabled: true,
+        dictationScopeKey: scopeKey,
+        disabled: false,
+        focusInput: vi.fn(),
+        insertText,
+        maxRecordingSeconds: 60,
+        onSubmit: vi.fn().mockResolvedValue(true),
+        onTranscribeAudio: vi.fn().mockResolvedValue('spoken words'),
+        sessionId: scopeKey,
+        submitDraft,
+        target
+      }),
+    { initialProps: { scopeKey: initialScopeKey } }
+  )
+
+  return { ...hook, insertText, submitDraft }
+}
+
+describe('useComposerVoice dictation hotkey', () => {
+  it('pins the active composer through the second press, then submits', () => {
+    const { insertText, submitDraft } = renderVoice()
+
+    act(() => requestDictationToggle())
+    act(() => vi.runOnlyPendingTimers())
+    expect(recorder.dictate).toHaveBeenLastCalledWith(true)
+
+    markActiveComposer('tile:other')
+    act(() => requestDictationToggle())
+    act(() => vi.runOnlyPendingTimers())
+    expect(recorder.dictate).toHaveBeenCalledTimes(2)
+    expect(recorder.dictate).toHaveBeenLastCalledWith(true)
+
+    act(() => recorder.options?.onTranscript('spoken words', true))
+    expect(insertText).toHaveBeenCalledWith('spoken words')
+    expect(submitDraft).toHaveBeenCalledOnce()
+    expect(insertText.mock.invocationCallOrder[0]).toBeLessThan(submitDraft.mock.invocationCallOrder[0])
+  })
+
+  it('ignores requests routed to another mounted composer', () => {
+    renderVoice('tile:one')
+
+    act(() => requestDictationToggle('main'))
+    act(() => vi.runOnlyPendingTimers())
+
+    expect(recorder.dictate).not.toHaveBeenCalled()
+  })
+
+  it('cancels and rejects a stale transcript when the session changes', () => {
+    const { insertText, rerender, submitDraft } = renderVoice('main', 'session-a')
+
+    act(() => requestDictationToggle('main'))
+    act(() => vi.runOnlyPendingTimers())
+    const staleTranscript = recorder.options?.onTranscript
+
+    rerender({ scopeKey: 'session-b' })
+
+    expect(recorder.cancel).toHaveBeenCalledOnce()
+    act(() => staleTranscript?.('wrong session', true))
+    expect(insertText).not.toHaveBeenCalled()
+    expect(submitDraft).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -8,8 +8,15 @@ import { notifyError } from '@/store/notifications'
 import { $messages } from '@/store/session'
 import { $autoSpeakReplies, setAutoSpeakReplies } from '@/store/voice-prefs'
 
-import type { ComposerTarget } from '../focus'
-import { onComposerVoiceToggleRequest } from '../focus'
+import type { ComposerDictationOwner, ComposerTarget } from '../focus'
+import {
+  claimComposerDictation,
+  createComposerDictationOwner,
+  onComposerDictationToggleRequest,
+  onComposerVoiceToggleRequest,
+  ownsComposerDictation,
+  releaseComposerDictation
+} from '../focus'
 import type { ChatBarProps } from '../types'
 
 import { useAutoSpeakReplies } from './use-auto-speak-replies'
@@ -19,6 +26,8 @@ import { useVoiceRecorder } from './use-voice-recorder'
 interface UseComposerVoiceArgs {
   busy: boolean
   clearDraft: () => void
+  dictationEnabled: boolean
+  dictationScopeKey: string | null
   disabled: boolean
   focusInput: () => void
   insertText: (text: string) => void
@@ -26,6 +35,7 @@ interface UseComposerVoiceArgs {
   onSubmit: ChatBarProps['onSubmit']
   onTranscribeAudio: ChatBarProps['onTranscribeAudio']
   sessionId: string | null | undefined
+  submitDraft: () => void
   /** This composer's focus-bus key — voice toggles targeting another
    *  composer (or the active one, when not us) are ignored. */
   target: ComposerTarget
@@ -40,6 +50,8 @@ interface UseComposerVoiceArgs {
 export function useComposerVoice({
   busy,
   clearDraft,
+  dictationEnabled,
+  dictationScopeKey,
   disabled,
   focusInput,
   insertText,
@@ -47,18 +59,56 @@ export function useComposerVoice({
   onSubmit,
   onTranscribeAudio,
   sessionId,
+  submitDraft,
   target
 }: UseComposerVoiceArgs) {
   const { t } = useI18n()
   const [voiceConversationActive, setVoiceConversationActive] = useState(false)
   const lastSpokenIdRef = useRef<string | null>(null)
+  const dictationOwnerRef = useRef<ComposerDictationOwner | null>(null)
+  dictationOwnerRef.current ??= createComposerDictationOwner(target)
+  const dictationOwner = dictationOwnerRef.current
+  const claimedScopeRef = useRef<{ key: string | null } | null>(null)
+  const currentScopeKeyRef = useRef(dictationScopeKey)
+  const insertTextRef = useRef(insertText)
+  const submitDraftRef = useRef(submitDraft)
+  currentScopeKeyRef.current = dictationScopeKey
+  insertTextRef.current = insertText
+  submitDraftRef.current = submitDraft
 
-  const { dictate, voiceActivityState, voiceStatus } = useVoiceRecorder({
+  const releaseDictation = useCallback(() => {
+    claimedScopeRef.current = null
+    releaseComposerDictation(dictationOwner)
+  }, [dictationOwner])
+
+  const { cancel: cancelRecorder, dictate: toggleRecorder, voiceActivityState, voiceStatus } = useVoiceRecorder({
     focusInput,
     maxRecordingSeconds,
-    onTranscript: insertText,
+    onIdle: releaseDictation,
+    onTranscript: (text, submit) => {
+      const claimedScope = claimedScopeRef.current
+
+      // A session switch cancels capture, but transcription may already be in
+      // flight. Never let a stale completion write into the newly active chat.
+      if (
+        !claimedScope ||
+        !ownsComposerDictation(dictationOwner) ||
+        claimedScope.key !== currentScopeKeyRef.current
+      ) {
+        return
+      }
+
+      insertTextRef.current(text)
+
+      if (submit) {
+        submitDraftRef.current()
+      }
+    },
     onTranscribeAudio
   })
+
+  const cancelRecorderRef = useRef(cancelRecorder)
+  cancelRecorderRef.current = cancelRecorder
 
   const pendingResponse = () => {
     const messages = $messages.get()
@@ -127,6 +177,53 @@ export function useComposerVoice({
     }
   }, [conversation, disabled, voiceConversationActive])
 
+  const toggleDictation = useCallback(
+    (submitOnStop = false) => {
+      // The owner may always finish its capture, even if the composer became
+      // disabled while recording. Starting follows the microphone button.
+      if (ownsComposerDictation(dictationOwner)) {
+        toggleRecorder(submitOnStop)
+
+        return
+      }
+
+      if (disabled || !dictationEnabled || voiceConversationActive || voiceStatus !== 'idle') {
+        return
+      }
+
+      if (claimComposerDictation(dictationOwner)) {
+        claimedScopeRef.current = { key: currentScopeKeyRef.current }
+        toggleRecorder(submitOnStop)
+      }
+    },
+    [dictationEnabled, dictationOwner, disabled, toggleRecorder, voiceConversationActive, voiceStatus]
+  )
+
+  useEffect(
+    () => onComposerDictationToggleRequest(toggled => toggled === target && toggleDictation(true)),
+    [target, toggleDictation]
+  )
+
+  useEffect(() => {
+    const claimedScope = claimedScopeRef.current
+
+    if (
+      claimedScope &&
+      claimedScope.key !== dictationScopeKey &&
+      ownsComposerDictation(dictationOwner)
+    ) {
+      cancelRecorderRef.current()
+    }
+  }, [dictationOwner, dictationScopeKey])
+
+  useEffect(
+    () => () => {
+      cancelRecorderRef.current()
+      releaseComposerDictation(dictationOwner)
+    },
+    [dictationOwner]
+  )
+
   useEffect(
     () => onComposerVoiceToggleRequest(toggled => toggled === target && toggleVoiceConversation()),
     [target, toggleVoiceConversation]
@@ -157,7 +254,7 @@ export function useComposerVoice({
 
   return {
     conversation,
-    dictate,
+    dictate: toggleDictation,
     endConversation,
     handleToggleAutoSpeak,
     startConversation,

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx
@@ -1,0 +1,144 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useVoiceRecorder } from './use-voice-recorder'
+
+const mic = vi.hoisted(() => ({
+  cancel: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn()
+}))
+
+const notifications = vi.hoisted(() => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: () => ({
+    handle: { cancel: mic.cancel, start: mic.start, stop: mic.stop },
+    level: 0,
+    recording: false
+  })
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      notifications: {
+        voice: {
+          noSpeechDetected: 'No speech detected',
+          recordingFailed: 'Recording failed',
+          transcriptionFailed: 'Transcription failed',
+          transcriptionUnavailable: 'Transcription unavailable',
+          tryRecordingAgain: 'Try again',
+          unavailable: 'Unavailable'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/notifications', () => notifications)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mic.start.mockResolvedValue(undefined)
+  mic.stop.mockResolvedValue({
+    audio: new Blob(['voice'], { type: 'audio/webm' }),
+    durationMs: 500,
+    heardSpeech: true
+  })
+})
+
+function renderRecorder(onTranscribeAudio = vi.fn().mockResolvedValue('transcribed words')) {
+  const focusInput = vi.fn()
+  const onIdle = vi.fn()
+  const onTranscript = vi.fn()
+
+  const hook = renderHook(() =>
+    useVoiceRecorder({
+      focusInput,
+      maxRecordingSeconds: 60,
+      onIdle,
+      onTranscript,
+      onTranscribeAudio
+    })
+  )
+
+  return { ...hook, focusInput, onIdle, onTranscript, onTranscribeAudio }
+}
+
+describe('useVoiceRecorder dictation delivery', () => {
+  it('starts on the first toggle and marks the stopped transcript for submission on the second', async () => {
+    const { onTranscript, result } = renderRecorder()
+
+    act(() => result.current.dictate())
+    await waitFor(() => expect(mic.start).toHaveBeenCalledOnce())
+
+    act(() => result.current.dictate(true))
+
+    await waitFor(() => expect(onTranscript).toHaveBeenCalledWith('transcribed words', true))
+    expect(mic.stop).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the on-screen dictation toggle transcript-only', async () => {
+    const { onTranscript, result } = renderRecorder()
+
+    act(() => result.current.dictate())
+    await waitFor(() => expect(mic.start).toHaveBeenCalledOnce())
+    act(() => result.current.dictate())
+
+    await waitFor(() => expect(onTranscript).toHaveBeenCalledWith('transcribed words', false))
+  })
+
+  it('never submits an empty transcription', async () => {
+    const { onTranscript, result } = renderRecorder(vi.fn().mockResolvedValue('   '))
+
+    act(() => result.current.dictate())
+    await waitFor(() => expect(mic.start).toHaveBeenCalledOnce())
+    act(() => result.current.dictate(true))
+
+    await waitFor(() => expect(notifications.notify).toHaveBeenCalledOnce())
+    expect(onTranscript).not.toHaveBeenCalled()
+  })
+
+  it('queues a fast second press while microphone startup is still pending', async () => {
+    let resolveStart: (() => void) | undefined
+    mic.start.mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          resolveStart = resolve
+        })
+    )
+    const { onTranscript, result } = renderRecorder()
+
+    act(() => result.current.dictate())
+    act(() => result.current.dictate(true))
+
+    expect(mic.start).toHaveBeenCalledOnce()
+    expect(mic.stop).not.toHaveBeenCalled()
+
+    await act(async () => resolveStart?.())
+
+    await waitFor(() => expect(onTranscript).toHaveBeenCalledWith('transcribed words', true))
+    expect(mic.start).toHaveBeenCalledOnce()
+    expect(mic.stop).toHaveBeenCalledOnce()
+  })
+
+  it('returns to idle and releases ownership after an asynchronous recorder error', async () => {
+    const { onIdle, result } = renderRecorder()
+
+    act(() => result.current.dictate())
+    await waitFor(() => expect(mic.start).toHaveBeenCalledOnce())
+    const startOptions = mic.start.mock.calls[0]?.[0] as { onError?: (error: Error) => void }
+
+    act(() => startOptions.onError?.(new Error('device disconnected')))
+
+    await waitFor(() => expect(result.current.voiceStatus).toBe('idle'))
+    expect(onIdle).toHaveBeenCalledOnce()
+
+    act(() => result.current.dictate())
+    await waitFor(() => expect(mic.start).toHaveBeenCalledTimes(2))
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
@@ -11,23 +11,36 @@ interface VoiceRecorderOptions {
   maxRecordingSeconds: number
   onTranscribeAudio?: (audio: Blob) => Promise<string>
   focusInput: () => void
-  onTranscript: (text: string) => void
+  onIdle?: () => void
+  onTranscript: (text: string, submit: boolean) => void
 }
+
+type RecorderPhase = 'cancelling' | 'idle' | 'recording' | 'starting' | 'stopping' | 'transcribing'
 
 export function useVoiceRecorder({
   maxRecordingSeconds,
   onTranscribeAudio,
   focusInput,
+  onIdle,
   onTranscript
 }: VoiceRecorderOptions) {
   const { t } = useI18n()
   const voiceCopy = t.notifications.voice
-  const { handle, level, recording } = useMicRecorder(voiceCopy)
+  const { handle, level } = useMicRecorder(voiceCopy)
   const [voiceStatus, setVoiceStatus] = useState<VoiceStatus>('idle')
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
   const startedAtRef = useRef(0)
   const intervalRef = useRef<number | null>(null)
   const timeoutRef = useRef<number | null>(null)
+  const phaseRef = useRef<RecorderPhase>('idle')
+  const generationRef = useRef(0)
+  const pendingStopRef = useRef<boolean | null>(null)
+  const mountedRef = useRef(true)
+  const handleRef = useRef(handle)
+  const callbacksRef = useRef({ focusInput, onIdle, onTranscript, onTranscribeAudio, voiceCopy })
+  handleRef.current = handle
+  callbacksRef.current = { focusInput, onIdle, onTranscript, onTranscribeAudio, voiceCopy }
+  const cancellationPending = () => phaseRef.current === 'cancelling'
 
   const clearTimers = () => {
     if (intervalRef.current) {
@@ -41,69 +54,195 @@ export function useVoiceRecorder({
     }
   }
 
-  useEffect(() => () => clearTimers(), [])
+  const finish = () => {
+    phaseRef.current = 'idle'
+    pendingStopRef.current = null
 
-  const stop = async () => {
+    if (mountedRef.current) {
+      setVoiceStatus('idle')
+    }
+
+    callbacksRef.current.onIdle?.()
+  }
+
+  useEffect(
+    () => {
+      mountedRef.current = true
+
+      return () => {
+        mountedRef.current = false
+        generationRef.current += 1
+        phaseRef.current = 'idle'
+        pendingStopRef.current = null
+        clearTimers()
+        handleRef.current.cancel()
+      }
+    },
+    []
+  )
+
+  const stop = async (submitTranscript = false) => {
+    if (phaseRef.current === 'starting') {
+      pendingStopRef.current = (pendingStopRef.current ?? false) || submitTranscript
+
+      return
+    }
+
+    if (phaseRef.current !== 'recording') {
+      return
+    }
+
+    phaseRef.current = 'stopping'
     clearTimers()
+    const generation = generationRef.current
     const result = await handle.stop()
 
+    if (generation !== generationRef.current) {
+      return
+    }
+
     if (!result) {
-      setVoiceStatus('idle')
+      finish()
 
       return
     }
 
-    if (!onTranscribeAudio) {
-      setVoiceStatus('idle')
+    const transcribe = callbacksRef.current.onTranscribeAudio
+
+    if (!transcribe) {
+      finish()
 
       return
     }
 
+    phaseRef.current = 'transcribing'
     setVoiceStatus('transcribing')
 
     try {
-      const transcript = (await onTranscribeAudio(result.audio)).trim()
+      const transcript = (await transcribe(result.audio)).trim()
+
+      if (generation !== generationRef.current) {
+        return
+      }
 
       if (!transcript) {
-        notify({ kind: 'warning', title: voiceCopy.noSpeechDetected, message: voiceCopy.tryRecordingAgain })
+        const copy = callbacksRef.current.voiceCopy
+
+        notify({ kind: 'warning', title: copy.noSpeechDetected, message: copy.tryRecordingAgain })
       } else {
-        onTranscript(transcript)
+        callbacksRef.current.onTranscript(transcript, submitTranscript)
       }
     } catch (error) {
-      notifyError(error, voiceCopy.transcriptionFailed)
+      if (generation === generationRef.current) {
+        notifyError(error, callbacksRef.current.voiceCopy.transcriptionFailed)
+      }
     } finally {
-      setVoiceStatus('idle')
-      focusInput()
+      if (generation === generationRef.current) {
+        finish()
+        callbacksRef.current.focusInput()
+      }
     }
   }
 
   const start = async () => {
-    if (!onTranscribeAudio) {
-      notify({ kind: 'warning', title: voiceCopy.unavailable, message: voiceCopy.transcriptionUnavailable })
+    if (phaseRef.current !== 'idle') {
+      return
+    }
+
+    if (!callbacksRef.current.onTranscribeAudio) {
+      const copy = callbacksRef.current.voiceCopy
+
+      notify({ kind: 'warning', title: copy.unavailable, message: copy.transcriptionUnavailable })
+      finish()
 
       return
     }
 
+    const generation = ++generationRef.current
+    phaseRef.current = 'starting'
+    setVoiceStatus('recording')
+
     try {
-      await handle.start({ onError: error => notifyError(error, voiceCopy.recordingFailed) })
+      await handle.start({
+        onError: error => {
+          if (generation !== generationRef.current) {
+            return
+          }
+
+          notifyError(error, callbacksRef.current.voiceCopy.recordingFailed)
+          generationRef.current += 1
+          clearTimers()
+          finish()
+        }
+      })
+
+      if (generation !== generationRef.current) {
+        handle.cancel()
+
+        if (cancellationPending()) {
+          finish()
+        }
+
+        return
+      }
+
+      phaseRef.current = 'recording'
       startedAtRef.current = Date.now()
       setElapsedSeconds(0)
-      setVoiceStatus('recording')
       intervalRef.current = window.setInterval(() => setElapsedSeconds((Date.now() - startedAtRef.current) / 1000), 250)
       const cap = Math.max(1, Math.min(Math.trunc(maxRecordingSeconds), 600))
       timeoutRef.current = window.setTimeout(() => void stop(), cap * 1000)
+      const pendingStop = pendingStopRef.current
+
+      if (pendingStop !== null) {
+        pendingStopRef.current = null
+        void stop(pendingStop)
+      }
     } catch (error) {
-      setVoiceStatus('idle')
-      notifyError(error, voiceCopy.recordingFailed)
+      if (generation !== generationRef.current) {
+        if (cancellationPending()) {
+          finish()
+        }
+
+        return
+      }
+
+      notifyError(error, callbacksRef.current.voiceCopy.recordingFailed)
+      finish()
     }
   }
 
-  const dictate = () => {
-    if (recording) {
-      void stop()
-    } else if (voiceStatus === 'idle') {
+  const dictate = (submitTranscript = false) => {
+    if (phaseRef.current === 'idle') {
       void start()
+    } else if (phaseRef.current === 'starting') {
+      pendingStopRef.current = (pendingStopRef.current ?? false) || submitTranscript
+    } else if (phaseRef.current === 'recording') {
+      void stop(submitTranscript)
     }
+  }
+
+  const cancel = () => {
+    const phase = phaseRef.current
+
+    if (phase === 'idle' || phase === 'cancelling') {
+      return
+    }
+
+    clearTimers()
+    pendingStopRef.current = null
+    generationRef.current += 1
+    handle.cancel()
+
+    if (phase === 'starting') {
+      // The permission/getUserMedia promise cannot be aborted. Keep ownership
+      // until it settles, then immediately tear down the stream in start().
+      phaseRef.current = 'cancelling'
+
+      return
+    }
+
+    finish()
   }
 
   const voiceActivityState: VoiceActivityState = {
@@ -112,5 +251,5 @@ export function useVoiceRecorder({
     status: voiceStatus
   }
 
-  return { dictate, voiceActivityState, voiceStatus }
+  return { cancel, dictate, voiceActivityState, voiceStatus }
 }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -676,6 +676,8 @@ export function ChatBar({
   } = useComposerVoice({
     busy,
     clearDraft,
+    dictationEnabled: state.voice.enabled,
+    dictationScopeKey: activeQueueSessionKey,
     disabled,
     focusInput,
     insertText,
@@ -683,6 +685,7 @@ export function ChatBar({
     onSubmit,
     onTranscribeAudio,
     sessionId,
+    submitDraft,
     target: scope.target
   })
 

--- a/apps/desktop/src/app/hooks/use-keybinds.test.tsx
+++ b/apps/desktop/src/app/hooks/use-keybinds.test.tsx
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { IS_MAC } from '@/lib/keybinds/combo'
+import { resetAllBindings } from '@/store/keybinds'
+
+import { useKeybinds } from './use-keybinds'
+
+const composerRequests = vi.hoisted(() => ({
+  focus: vi.fn(),
+  toggleDictation: vi.fn(),
+  toggleVoice: vi.fn()
+}))
+
+vi.mock('../chat/composer/focus', () => ({
+  requestComposerFocus: composerRequests.focus,
+  requestDictationToggle: composerRequests.toggleDictation,
+  requestVoiceToggle: composerRequests.toggleVoice
+}))
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
+
+vi.mock('@/themes/context', () => ({
+  useTheme: () => ({ resolvedMode: 'light', setMode: vi.fn() })
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resetAllBindings()
+})
+
+function dictationKeydown(repeat = false): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    code: 'KeyD',
+    metaKey: IS_MAC,
+    ctrlKey: !IS_MAC,
+    repeat,
+    shiftKey: true
+  })
+}
+
+describe('useKeybinds dictation dispatch', () => {
+  it('dispatches Ctrl+Shift+D once and swallows OS key-repeat', () => {
+    const { unmount } = renderHook(() =>
+      useKeybinds({
+        openNewSessionTab: vi.fn(),
+        startFreshSession: vi.fn(),
+        toggleCommandCenter: vi.fn(),
+        toggleSelectedPin: vi.fn()
+      })
+    )
+
+    const first = dictationKeydown()
+    window.dispatchEvent(first)
+    expect(first.defaultPrevented).toBe(true)
+    expect(composerRequests.toggleDictation).toHaveBeenCalledOnce()
+
+    const repeated = dictationKeydown(true)
+    window.dispatchEvent(repeated)
+    expect(repeated.defaultPrevented).toBe(true)
+    expect(composerRequests.toggleDictation).toHaveBeenCalledOnce()
+
+    unmount()
+  })
+})

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -43,7 +43,7 @@ import {
 import { openNewSessionInNewWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
-import { requestComposerFocus, requestVoiceToggle } from '../chat/composer/focus'
+import { requestComposerFocus, requestDictationToggle, requestVoiceToggle } from '../chat/composer/focus'
 import {
   AGENTS_ROUTE,
   ARTIFACTS_ROUTE,
@@ -124,6 +124,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
 
     'composer.focus': () => requestComposerFocus('main'),
     'composer.modelPicker': () => setModelPickerOpen(true),
+    'composer.dictation': requestDictationToggle,
     'composer.voice': requestVoiceToggle,
 
     'nav.commandPalette': toggleCommandPalette,
@@ -243,6 +244,14 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
       const actionId = $comboIndex.get().get(combo)
 
       if (!actionId) {
+        return
+      }
+
+      // Holding the push-to-talk chord must not let OS key-repeat turn the
+      // initial start into an immediate stop-and-send.
+      if (event.repeat && actionId === 'composer.dictation') {
+        event.preventDefault()
+
         return
       }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -242,6 +242,7 @@ export const en: Translations = {
       'workspace.newWorktree': 'New worktree',
       'composer.focus': 'Focus composer',
       'composer.modelPicker': 'Open model picker',
+      'composer.dictation': 'Start / stop dictation and send',
       'composer.voice': 'Start / stop voice conversation',
       'view.toggleSidebar': 'Toggle sessions sidebar',
       'view.toggleRightSidebar': 'Toggle file browser',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -193,6 +193,12 @@ export const ja = defineLocale({
     openStarmap: 'メモリグラフを開く'
   },
 
+  keybinds: {
+    actions: {
+      'composer.dictation': '音声入力を開始 / 停止して送信'
+    }
+  },
+
   language: {
     label: '言語',
     description: 'デスクトップインターフェイスの言語を選択します。',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -187,6 +187,12 @@ export const zhHant = defineLocale({
     openStarmap: '開啟記憶圖譜'
   },
 
+  keybinds: {
+    actions: {
+      'composer.dictation': '開始 / 停止聽寫並傳送'
+    }
+  },
+
   language: {
     label: '語言',
     description: '選擇桌面介面的語言。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -237,6 +237,7 @@ export const zh: Translations = {
       'workspace.newWorktree': '新建工作树',
       'composer.focus': '聚焦输入框',
       'composer.modelPicker': '打开模型选择器',
+      'composer.dictation': '开始 / 停止听写并发送',
       'composer.voice': '开始 / 停止语音对话',
       'view.toggleSidebar': '切换会话侧边栏',
       'view.toggleRightSidebar': '切换文件浏览器',

--- a/apps/desktop/src/lib/keybinds/actions.test.ts
+++ b/apps/desktop/src/lib/keybinds/actions.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { keybindAction } from './actions'
+
+describe('composer dictation keybind', () => {
+  it('ships on Ctrl+Shift+D off macOS through the cross-platform mod chord', () => {
+    expect(keybindAction('composer.dictation')?.defaults).toEqual(['mod+shift+d'])
+  })
+})

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -56,6 +56,7 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // ── Composer ─────────────────────────────────────────────────────────────
   { id: 'composer.focus', category: 'composer', defaults: [] },
   { id: 'composer.modelPicker', category: 'composer', defaults: [] },
+  { id: 'composer.dictation', category: 'composer', defaults: ['mod+shift+d'] },
   // Voice conversation toggle. Matches the documented `voice.record_key`
   // (Ctrl+B). On macOS that's literally ⌃B — distinct from the ⌘B sidebar
   // toggle. Off macOS `ctrl` folds to `mod`, which IS the ⌘B/Ctrl+B sidebar


### PR DESCRIPTION
## What does this PR do?

Adds a dedicated Ctrl/Cmd+Shift+D action for one-shot dictation in Hermes Desktop:

- First press starts recording in the active composer.
- Second press stops, transcribes, inserts the transcript into the current draft, and submits it through the existing composer pipeline.
- The on-screen microphone button keeps its existing transcript-to-draft behavior.
- Dictation ownership stays pinned to the composer that started it, and a session change cancels stale capture so a transcript cannot land in another chat.
- OS key repeat, delayed microphone startup, empty transcripts, and asynchronous recorder errors are handled safely.

## How to test

1. Configure speech-to-text and focus a chat composer.
2. Press Ctrl+Shift+D on Windows/Linux (Cmd+Shift+D on macOS) and speak.
3. Press the shortcut again and confirm the transcript is sent automatically.
4. Confirm the microphone button still stops into the draft without sending.
5. Start dictation, switch composer/session, and confirm no stale transcript is inserted or sent there.

## Validation

- Focused desktop UI regressions: 10/10 passing
- Desktop TypeScript checks: passing
- Changed-file ESLint: passing
- Production desktop build: passing
- Tested on Windows 11

The full UI run passes 1,347 tests. Its remaining five failures are in three unrelated upstream test files and reproduce on clean main (locale-specific number punctuation plus existing skills/messaging timeouts).