### PR TITLE
fix(agent): read Kimi/Moonshot top-level cached_tokens in normalize_usage (#65722)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1261,6 +1261,15 @@ def normalize_usage(
             cache_read_tokens = _to_int(
                 getattr(response_usage, "prompt_cache_hit_tokens", 0)
             )
+        if not cache_read_tokens:
+            # Kimi/Moonshot's native API (api.moonshot.cn / .ai) reports
+            # context-cache hits as a top-level usage.cached_tokens, not the
+            # OpenAI nested prompt_tokens_details.cached_tokens shape. Without
+            # this, direct Kimi sessions always showed 0 cache-hit tokens and
+            # the hits were billed at the full input rate (#65722).
+            cache_read_tokens = _to_int(
+                getattr(response_usage, "cached_tokens", 0)
+            )
         cache_write_tokens = _to_int(
             getattr(details, "cache_write_tokens", 0) if details else 0
         )

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -312,3 +312,63 @@ def test_vertex_default_model_estimates_cached_usage(monkeypatch):
 
     assert result.status == "estimated"
     assert result.amount_usd is not None and result.amount_usd > 0
+
+
+def test_normalize_usage_reads_kimi_top_level_cached_tokens():
+    """Kimi/Moonshot's native API reports context-cache hits as a top-level
+    usage.cached_tokens, not OpenAI's nested
+    prompt_tokens_details.cached_tokens and not DeepSeek's
+    prompt_cache_hit_tokens. Neither existing fallback matches that name, so
+    direct Kimi sessions normalized to cache_read_tokens=0 — the hits were
+    invisible in accounting and billed at the full input rate (#65722)."""
+    usage = SimpleNamespace(
+        prompt_tokens=3000,
+        completion_tokens=250,
+        cached_tokens=1800,
+    )
+
+    normalized = normalize_usage(usage, provider="kimi", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 1800
+    # prompt_tokens includes the cached prefix: 3000 - 1800 = fresh input
+    assert normalized.input_tokens == 1200
+    assert normalized.output_tokens == 250
+
+
+def test_kimi_fallback_does_not_override_the_nested_openai_shape():
+    """A provider that reports BOTH shapes must keep the nested value.
+
+    The new branch is last in the chain, so it only fills a genuine zero.
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        completion_tokens=100,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=400),
+        cached_tokens=999,  # must be ignored
+    )
+
+    normalized = normalize_usage(usage, provider="kimi", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 400
+
+
+def test_kimi_fallback_does_not_override_deepseek_hit_tokens():
+    usage = SimpleNamespace(
+        prompt_tokens=2000,
+        completion_tokens=100,
+        prompt_cache_hit_tokens=1500,
+        cached_tokens=999,  # must be ignored
+    )
+
+    normalized = normalize_usage(usage, provider="deepseek", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 1500
+
+
+def test_usage_without_any_cache_fields_still_normalizes():
+    usage = SimpleNamespace(prompt_tokens=500, completion_tokens=50)
+
+    normalized = normalize_usage(usage, provider="kimi", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 0
+    assert normalized.input_tokens == 500


### PR DESCRIPTION
## Problem

Kimi/Moonshot's native API reports context-cache hits as a **top-level** `usage.cached_tokens`, not OpenAI's nested `prompt_tokens_details.cached_tokens`. `normalize_usage()` never read the top-level field, so direct Kimi sessions always normalized to `cache_read_tokens=0` — cache hits were invisible in accounting and billed at the full input rate.

## Fix

One narrow fallback in the chat-completions branch of `normalize_usage()`, added **after** the existing DeepSeek `prompt_cache_hit_tokens` branch:

```python
if not cache_read_tokens:
    # Kimi/Moonshot native API: top-level usage.cached_tokens
    cache_read_tokens = _to_int(getattr(response_usage, "cached_tokens", 0))
```

Ordering keeps the existing precedence intact: the OpenAI nested shape wins first, then DeepSeek's native field, then the Kimi fallback — so no field is double-read.

## Scope (per hermes-sweeper review of the earlier revision)

- **DeepSeek dropped**: `prompt_cache_hit_tokens` is already handled on current main (#61871 / `03c0b00f4`); this PR no longer duplicates it.
- **HTTP tool removed**: the unrelated `http_request` feature that was bundled in is gone — this PR is the Kimi cache fix only. Rebuilt on current `origin/main`.

## Tests

`tests/agent/test_usage_pricing.py` (30 pass):
- Kimi top-level `cached_tokens` read
- nested `prompt_tokens_details` precedence over the Kimi field
- DeepSeek `prompt_cache_hit_tokens` precedence over the Kimi fallback

Fixes #65722

🤖 Generated with [Claude Code](https://claude.com/claude-code)