### PR TITLE
fix(checkpoints): serialize shared store maintenance

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -22,6 +22,8 @@ from tools.checkpoint_manager import (
     _ref_name,
     _project_meta_path,
     _touch_project,
+    _try_checkpoint_maintenance_lock,
+    _release_checkpoint_maintenance_lock,
     format_checkpoint_list,
     prune_checkpoints,
     maybe_auto_prune_checkpoints,
@@ -183,6 +185,35 @@ class TestTakeCheckpoint:
     def test_first_checkpoint(self, mgr, work_dir):
         result = mgr.ensure_checkpoint(str(work_dir), "initial")
         assert result is True
+
+    def test_contended_maintenance_does_not_fail_checkpoint(self, mgr, work_dir):
+        with (
+            patch(
+                "tools.checkpoint_manager._try_checkpoint_maintenance_lock",
+                return_value=None,
+            ),
+            patch.object(mgr, "_prune") as prune,
+            patch.object(mgr, "_enforce_size_cap") as size_cap,
+        ):
+            assert mgr.ensure_checkpoint(str(work_dir), "contended") is True
+        prune.assert_not_called()
+        size_cap.assert_not_called()
+
+    def test_maintenance_lock_is_nonblocking_and_reusable(
+        self, checkpoint_base,
+    ):
+        store = _store_path(checkpoint_base)
+        store.parent.mkdir(parents=True)
+        first = _try_checkpoint_maintenance_lock(store)
+        assert first is not None
+        try:
+            assert _try_checkpoint_maintenance_lock(store) is None
+        finally:
+            _release_checkpoint_maintenance_lock(first)
+
+        second = _try_checkpoint_maintenance_lock(store)
+        assert second is not None
+        _release_checkpoint_maintenance_lock(second)
 
     def test_dedup_same_turn(self, mgr, work_dir):
         r1 = mgr.ensure_checkpoint(str(work_dir), "first")

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -55,6 +55,7 @@ import os
 import re
 import shutil
 import subprocess
+import threading
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -62,6 +63,16 @@ from hermes_cli._subprocess_compat import windows_hide_flags
 from typing import Dict, List, Optional, Set, Tuple
 
 from utils import env_int
+
+try:  # pragma: no cover - platform dependent
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+
+try:  # pragma: no cover - platform dependent
+    import msvcrt
+except ImportError:  # pragma: no cover - Unix
+    msvcrt = None
 
 logger = logging.getLogger(__name__)
 
@@ -149,6 +160,67 @@ _MAX_FILES = 50_000
 
 # Valid git commit hash pattern: 4–40 hex chars (short or full SHA-1/SHA-256).
 _COMMIT_HASH_RE = re.compile(r'^[0-9a-fA-F]{4,64}$')
+
+# Git protects a repository from concurrent ``git gc`` processes, but the
+# checkpoint manager used to start maintenance after every snapshot without
+# coordinating sibling Hermes processes.  Paperclip can run several Hermes
+# agents against the same HERMES_HOME, so those processes repeatedly collided
+# in the shared checkpoint store and emitted fatal-looking ``gc is already
+# running`` errors.  Keep the critical maintenance pass single-owner while
+# allowing the checkpoint itself to succeed when another process is pruning.
+_checkpoint_maintenance_thread_lock = threading.Lock()
+_CHECKPOINT_MAINTENANCE_LOCK = ".maintenance.lock"
+
+
+def _try_checkpoint_maintenance_lock(store: Path):
+    """Acquire the shared checkpoint-maintenance lock without waiting.
+
+    Returns an open lock file on success and ``None`` when another thread or
+    process is already pruning.  Maintenance is opportunistic, so skipping a
+    pass is preferable to blocking an agent or launching a competing git gc.
+    """
+    if not _checkpoint_maintenance_thread_lock.acquire(blocking=False):
+        return None
+
+    lock_fd = None
+    try:
+        lock_path = store.parent / _CHECKPOINT_MAINTENANCE_LOCK
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_fd = open(lock_path, "a+", encoding="utf-8")
+        if fcntl is not None:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        elif msvcrt is not None:
+            lock_fd.seek(0)
+            if lock_fd.read(1) == "":
+                lock_fd.write("0")
+                lock_fd.flush()
+            lock_fd.seek(0)
+            getattr(msvcrt, "locking")(
+                lock_fd.fileno(), getattr(msvcrt, "LK_NBLCK"), 1
+            )
+        return lock_fd
+    except (OSError, IOError):
+        if lock_fd is not None:
+            lock_fd.close()
+        _checkpoint_maintenance_thread_lock.release()
+        return None
+
+
+def _release_checkpoint_maintenance_lock(lock_fd) -> None:
+    """Release a lock returned by :func:`_try_checkpoint_maintenance_lock`."""
+    try:
+        if fcntl is not None:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        elif msvcrt is not None:
+            lock_fd.seek(0)
+            getattr(msvcrt, "locking")(
+                lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1
+            )
+    except (OSError, IOError):
+        pass
+    finally:
+        lock_fd.close()
+        _checkpoint_maintenance_thread_lock.release()
 
 
 # ---------------------------------------------------------------------------
@@ -996,11 +1068,22 @@ class CheckpointManager:
 
         logger.debug("Checkpoint taken in %s: %s (%s)", working_dir, reason, new_sha[:8])
 
-        # Real pruning — drop old commits beyond max_snapshots.
-        self._prune(store, working_dir, ref)
-
-        # Enforce global size cap.
-        self._enforce_size_cap(store)
+        # Real pruning and git gc are shared-store maintenance.  Paperclip can
+        # run multiple Hermes processes concurrently, so only one process may
+        # maintain the store at a time.  A contending process skips this
+        # opportunistic pass instead of producing ``gc is already running``.
+        maintenance_lock = _try_checkpoint_maintenance_lock(store)
+        if maintenance_lock is None:
+            logger.debug(
+                "Checkpoint maintenance skipped — another Hermes process "
+                "holds the shared-store lock"
+            )
+        else:
+            try:
+                self._prune(store, working_dir, ref)
+                self._enforce_size_cap(store)
+            finally:
+                _release_checkpoint_maintenance_lock(maintenance_lock)
 
         return True
 


### PR DESCRIPTION
## What does this PR do?

Serializes opportunistic maintenance for Hermes' shared checkpoint Git store across threads and processes.

Paperclip and other orchestrators can launch several Hermes agents that share one `HERMES_HOME`. Each checkpoint previously called pruning and size-cap enforcement independently. When the store exceeded its size cap, multiple agents could enter `git gc --prune=now --quiet` concurrently. Git rejected all but one with `fatal: gc is already running`, producing noisy checkpoint errors even though the checkpoint and agent task could otherwise succeed.

The fix uses a non-blocking lock file next to the shared store. One process performs pruning/GC; contenders keep their completed checkpoint and skip that opportunistic maintenance pass rather than blocking or starting a competing GC.

## Related Issue

No public issue found after searching issues and pull requests for the error symptom.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/checkpoint_manager.py`
  - Add a process-safe, non-blocking maintenance lock using `fcntl.flock` on Unix and `msvcrt.locking` on Windows.
  - Keep an in-process thread lock for sibling threads.
  - Wrap `_prune` and `_enforce_size_cap` in the shared maintenance critical section.
  - Skip only maintenance when contended; the newly written checkpoint remains successful.
- `tests/tools/test_checkpoint_manager.py`
  - Verify a contended maintenance pass does not fail a checkpoint or call pruning/size-cap GC.
  - Verify the lock is non-blocking and reusable after release.

## How to Test

1. Run `/Users/IA/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_checkpoint_manager.py -q -o 'addopts='`.
2. Start multiple Hermes processes sharing one checkpoint store whose size exceeds `HERMES_CHECKPOINT_MAX_MB`.
3. Verify only one process performs maintenance, contenders log a debug-level skip, checkpoints still succeed, and no `gc is already running` errors appear.

Focused local result: `79 passed in 9.28s` on macOS 26.5.1 arm64. Python compilation and `git diff --check` also passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire `pytest tests/ -q` suite (focused checkpoint suite passed: 79 tests)
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.1 arm64

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior is documented in code/docstrings
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no workflow contract changed
- [x] Cross-platform impact considered: `fcntl` is used on Unix and `msvcrt` on Windows
- [x] Tool descriptions/schemas update is N/A

## Screenshots / Logs

Before:

```text
tools.checkpoint_manager - ERROR - Git command failed: git gc --prune=now --quiet (rc=128)
stderr=fatal: gc is already running
```

After deploying the lock under concurrent Paperclip/Hermes activity, recent checkpoint GC collision count remained `0`; focused tests passed.
