### PR TITLE
🐛 fix(desktop): restore dialog and action menu controls

### DIFF
--- a/apps/desktop/src/app/overlays/panel.test.tsx
+++ b/apps/desktop/src/app/overlays/panel.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { PanelRowMenu } from './panel'
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.releasePointerCapture ??= () => undefined
+  Element.prototype.setPointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+describe('PanelRowMenu', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('opens its actions menu when the trigger has a tooltip', async () => {
+    const onSelect = vi.fn()
+
+    render(<PanelRowMenu items={[{ label: 'Rename', onSelect }]} />)
+
+    const trigger = screen.getByRole('button', { name: 'Actions' })
+
+    fireEvent.pointerMove(trigger, { pointerType: 'mouse' })
+    expect((await screen.findByRole('tooltip')).textContent).toContain('Actions')
+
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false, pointerType: 'mouse' })
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rename' }))
+
+    expect(onSelect).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/app/overlays/panel.tsx
+++ b/apps/desktop/src/app/overlays/panel.tsx
@@ -217,8 +217,8 @@ export function PanelRowMenu({ items, label = 'Actions' }: { items: PanelMenuIte
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Tip label={label}>
+      <Tip label={label}>
+        <DropdownMenuTrigger asChild>
           <Button
             aria-label={label}
             className="size-5 rounded-[4px] bg-transparent text-(--ui-text-tertiary) opacity-0 transition-colors duration-100 hover:bg-(--ui-control-active-background) hover:text-foreground focus-visible:opacity-100 focus-visible:ring-0 group-hover/row:opacity-100 data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground data-[state=open]:opacity-100 [&_svg]:size-3.5!"
@@ -227,8 +227,8 @@ export function PanelRowMenu({ items, label = 'Actions' }: { items: PanelMenuIte
           >
             <Codicon name="kebab-vertical" size="0.875rem" />
           </Button>
-        </Tip>
-      </DropdownMenuTrigger>
+        </DropdownMenuTrigger>
+      </Tip>
       <DropdownMenuContent align="end" className="w-40" sideOffset={6}>
         {items.map(item => (
           <DropdownMenuItem

--- a/apps/desktop/src/app/starmap/share-controls.test.tsx
+++ b/apps/desktop/src/app/starmap/share-controls.test.tsx
@@ -1,0 +1,24 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ShareControls } from './share-controls'
+
+describe('ShareControls', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('opens its dialog when the trigger has a tooltip', async () => {
+    render(<ShareControls shareCode="map-code" />)
+
+    const trigger = screen.getByRole('button', { name: 'Import / export map' })
+
+    fireEvent.pointerMove(trigger, { pointerType: 'mouse' })
+    expect((await screen.findByRole('tooltip')).textContent).toContain('Import / export map')
+
+    fireEvent.click(trigger)
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByRole('heading', { name: 'Import / export map' })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/starmap/share-controls.tsx
+++ b/apps/desktop/src/app/starmap/share-controls.tsx
@@ -76,8 +76,8 @@ export function ShareControls({ imported = false, onImport, onResetMap, shareCod
         }}
         open={open}
       >
-        <DialogTrigger asChild>
-          <Tip label={t.starmap.shareTitle}>
+        <Tip label={t.starmap.shareTitle}>
+          <DialogTrigger asChild>
             <Button
               aria-label={t.starmap.shareTitle}
               className="text-muted-foreground hover:text-foreground"
@@ -86,8 +86,8 @@ export function ShareControls({ imported = false, onImport, onResetMap, shareCod
             >
               <Upload className="size-3.5" />
             </Button>
-          </Tip>
-        </DialogTrigger>
+          </DialogTrigger>
+        </Tip>
 
         <DialogContent className="max-w-md">
           <DialogHeader>

--- a/apps/desktop/src/components/ui/dialog.test.tsx
+++ b/apps/desktop/src/components/ui/dialog.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Dialog, DialogContent, DialogTitle } from './dialog'
+
+describe('DialogContent', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('preserves close behavior when the close button has a tooltip', async () => {
+    const onOpenChange = vi.fn()
+
+    render(
+      <Dialog onOpenChange={onOpenChange} open>
+        <DialogContent>
+          <DialogTitle>New profile</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    )
+
+    const closeButton = screen.getByRole('button', { name: 'Close' })
+
+    fireEvent.pointerMove(closeButton, { pointerType: 'mouse' })
+    expect((await screen.findByRole('tooltip')).textContent).toContain('Close')
+
+    fireEvent.click(closeButton)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -73,8 +73,8 @@ function DialogContent({
   const widthClass = fitContent ? 'w-auto max-w-[92vw]' : 'w-full max-w-lg'
 
   const closeButton = showCloseButton ? (
-    <DialogPrimitive.Close asChild data-slot="dialog-close-button">
-      <Tip label={t.common.close}>
+    <Tip label={t.common.close}>
+      <DialogPrimitive.Close asChild data-slot="dialog-close-button">
         <Button
           aria-label={t.common.close}
           className="absolute right-2.5 top-2.5 z-20 text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground"
@@ -84,8 +84,8 @@ function DialogContent({
           <X className="size-4" />
           <span className="sr-only">{t.common.close}</span>
         </Button>
-      </Tip>
-    </DialogPrimitive.Close>
+      </DialogPrimitive.Close>
+    </Tip>
   ) : null
 
   // With a banner, the border can't live on the scroll/clip box (it would draw a


### PR DESCRIPTION
## What does this PR do?

Restores Desktop controls that lost their primary action when native `title` attributes were replaced with themed `Tip` tooltips in `f08b1f3445`.

### User-visible symptoms

- In the **New profile** dialog, the top-right X showed its **Close** tooltip but did not close the dialog. The **Cancel** button still worked.
- In **Profiles**, a non-default profile's **Actions** button showed its tooltip but did not open the Rename/Delete menu.
- The same shared row-menu trigger also left Cron job action menus unresponsive.
- A code audit found the same latent failure on Starmap's **Import / export map** button: its tooltip worked, but its dialog trigger did not.

The controls looked enabled because their hover styles and tooltips still worked; only the Radix-backed action was missing.

## Root cause

Radix `asChild` primitives compose behavior by passing event handlers, state attributes, and refs to their direct child. Before the tooltip migration, each primitive directly wrapped its button:

```tsx
<DialogPrimitive.Close asChild>
  <Button />
</DialogPrimitive.Close>
```

The migration inserted `Tip` between the Radix primitive and the button:

```tsx
<DialogPrimitive.Close asChild>
  <Tip>
    <Button />
  </Tip>
</DialogPrimitive.Close>
```

Radix therefore passed its close or trigger props to `Tip`, not to the visible button. `Tip` forwards its remaining props to the tooltip content rather than the trigger button, so the X, menu trigger, and dialog trigger never received the Radix action handlers.

## Investigation

1. Traced the controlled **New profile** dialog state and ruled out its `busy` guard: the X failed while idle, while **Cancel** still called `onClose` directly.
2. Followed the shared `DialogContent` close button into `Tip` and confirmed that the `asChild` props stopped at the tooltip wrapper.
3. Used `git blame` and `git log -p -S` to identify `f08b1f3445` as the regression that inserted the wrappers.
4. Searched every Desktop TSX file for a direct `asChild -> Tip` composition. The audit found three affected paths: the shared dialog close button, `PanelRowMenu`, and Starmap `ShareControls`.
5. Repeated the scan after the fixes; no direct `asChild -> Tip` composition remains.

## Solution

Reorder each composition so `Tip` is outside the Radix primitive and the Radix primitive directly wraps the button:

```tsx
<Tip>
  <DialogPrimitive.Close asChild>
    <Button />
  </DialogPrimitive.Close>
</Tip>
```

This preserves the themed tooltip while allowing Radix and Tooltip to merge their props onto the same button.

The PR also adds behavior-focused regression tests that verify:

- the shared dialog X keeps its tooltip and emits `onOpenChange(false)` when clicked;
- `PanelRowMenu` keeps its tooltip, opens its menu, and runs the selected action;
- Starmap `ShareControls` keeps its tooltip and opens its dialog.

## Related Issue

No matching issue or PR was found after searching open and closed issues and pull requests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## How to Test

1. Open Desktop's **New profile** dialog, hover the top-right X, and confirm the **Close** tooltip appears.
2. Click the X and confirm the dialog closes.
3. Open **Profiles**, hover a non-default profile, click **Actions**, and confirm the Rename/Delete menu opens.
4. Open **Cron**, click a job's **Actions** button, and confirm its menu opens.
5. Open the Memory Graph, click **Import / export map**, and confirm the dialog opens.
6. Run the automated checks below.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] Python tests are N/A for this Desktop-only TypeScript change; the complete Desktop UI suite passed
- [x] I've added behavior tests for every affected trigger type
- [x] I've tested on my platform: macOS 26.5.2 arm64

### Documentation & Housekeeping

- [x] Documentation changes are N/A; no user-facing API or workflow changed
- [x] `cli-config.yaml.example` changes are N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the change only affects React/Radix component composition
- [x] Tool descriptions and schemas are N/A; no model tools changed

## Verification

```text
npm run test:ui -- src/components/ui/dialog.test.tsx src/app/overlays/panel.test.tsx src/app/starmap/share-controls.test.tsx
Test Files  3 passed (3)
Tests       3 passed (3)

npm run test:ui
Test Files  174 passed (174)
Tests       1346 passed (1346)

npm run typecheck
passed

eslint (modified TSX files)
passed

prettier --check (modified TSX files)
passed
```
