### PR TITLE
feat(mcp): add Comfy Cloud to the MCP catalog with curated 20-tool default (salvage #57308)

### DIFF
--- a/contributors/emails/mattmiller@comfy.org
+++ b/contributors/emails/mattmiller@comfy.org
@@ -1,0 +1,1 @@
+mattmillerai

--- a/optional-mcps/comfy-cloud/manifest.yaml
+++ b/optional-mcps/comfy-cloud/manifest.yaml
@@ -1,0 +1,42 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: comfy-cloud
+description: Generate images, video, audio, and 3D on Comfy Cloud — ComfyUI workflows, templates, and partner models (Flux, Kling, Veo, ...).
+source: https://docs.comfy.org/agent-tools/cloud
+
+# Comfy Cloud ships a hosted remote MCP server (Streamable HTTP) with native
+# MCP OAuth 2.1 + Dynamic Client Registration — same shape as the linear
+# entry. Hermes's MCP client + mcp_oauth_manager handle discovery, PKCE,
+# token exchange, and refresh — nothing to install locally.
+transport:
+  type: http
+  url: https://cloud.comfy.org/mcp
+
+auth:
+  type: oauth
+  # No `provider:` — native MCP OAuth (case 1), not a third-party provider
+  # like Google. The MCP client triggers the browser flow on the first
+  # probe / first connect.
+
+# Tool selection at install time:
+# The server exposes ~30 tools across generation (partner_generate,
+# submit_workflow, run_template), job lifecycle (get_job_status, wait_for_job,
+# get_output), asset handling (upload_file, use_previous_output), and
+# discovery (search_templates / search_models / search_nodes). We leave
+# `default_enabled` unset so the install-time checklist starts with
+# everything pre-checked — users prune what they don't want.
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with your
+  Comfy account. After auth, restart your Hermes session so the Comfy Cloud
+  tools are loaded.
+
+  Discovery tools (search_templates / search_models / search_nodes) work with
+  any Comfy account. Generation tools run on Comfy Cloud and consume credits,
+  so they need a subscription or credit balance — see
+  https://www.comfy.org/cloud for plans.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure comfy-cloud

--- a/optional-mcps/comfy-cloud/manifest.yaml
+++ b/optional-mcps/comfy-cloud/manifest.yaml
@@ -3,7 +3,7 @@
 manifest_version: 1
 
 name: comfy-cloud
-description: Generate images, video, audio, and 3D on Comfy Cloud — ComfyUI workflows, templates, and partner models (Flux, Kling, Veo, ...).
+description: Generate images, video, audio, and 3D on Comfy Cloud.
 source: https://docs.comfy.org/agent-tools/cloud
 
 # Comfy Cloud ships a hosted remote MCP server (Streamable HTTP) with native
@@ -21,12 +21,50 @@ auth:
   # probe / first connect.
 
 # Tool selection at install time:
-# The server exposes ~30 tools across generation (partner_generate,
-# submit_workflow, run_template), job lifecycle (get_job_status, wait_for_job,
-# get_output), asset handling (upload_file, use_previous_output), and
-# discovery (search_templates / search_models / search_nodes). We leave
-# `default_enabled` unset so the install-time checklist starts with
-# everything pre-checked — users prune what they don't want.
+# The server exposes ~37 tools (public beta — surface may grow). At Hermes's
+# measured ~600 tokens/tool schema average, all 37 would add ~16-22k tokens
+# to EVERY API call while enabled — larger than the entire Hermes core
+# toolset. The curated default below (20 tools) keeps the surface to what an
+# agent needs to discover, generate, and fetch results (~9-12k tokens).
+#
+# Deliberately excluded from the default (opt back in any time with
+# `hermes mcp configure comfy-cloud`):
+#   - cql, get_server_info            — power-user / debug probes
+#   - submit_batch, get_batch_status, get_batch_output, wait_for_batch
+#                                     — batch variants of the job lifecycle
+#   - list_saved_workflows, get_saved_workflow, save_workflow,
+#     update_workflow, run_saved_workflow, share_workflow,
+#     import_shared_workflow          — saved/shared workflow management
+#   - create_app, get_app_mode_url    — Comfy App Mode product features
+#   - submit_feedback                 — beta survey link
+#   - report_session_summary         — outbound telemetry; excluded per
+#     Hermes policy (no telemetry without explicit user opt-in)
+tools:
+  default_enabled:
+    # Discovery
+    - search_templates
+    - get_template
+    - get_template_schema
+    - search_models
+    - search_nodes
+    - get_node
+    - get_prompting_guide
+    # Generation
+    - run_template
+    - submit_workflow
+    - partner_generate
+    - upload_file
+    - apply_slots
+    # Job lifecycle
+    - get_job_status
+    - wait_for_job
+    - get_output
+    - use_previous_output
+    - cancel_job
+    - get_queue
+    # Account / handoff
+    - get_billing_status
+    - get_workflow_canvas_url
 
 post_install: |
   On first connection, Hermes will open a browser to authenticate with your
@@ -38,5 +76,7 @@ post_install: |
   so they need a subscription or credit balance — see
   https://www.comfy.org/cloud for plans.
 
-  You can re-run the tool checklist any time with:
+  A curated 20-tool subset is enabled by default (discovery, generation, job
+  lifecycle, billing). Batch jobs, saved/shared workflow management, and App
+  Mode tools are available but unchecked — enable them any time with:
     hermes mcp configure comfy-cloud


### PR DESCRIPTION
## Summary

Adds Comfy Cloud to the Nous MCP catalog with a **curated 20-tool default** — salvage of #57308 by @mattmillerai (Comfy), authorship preserved via cherry-pick.

Comfy Cloud ships a first-party hosted remote MCP server (`https://cloud.comfy.org/mcp`, Streamable HTTP + native OAuth 2.1/DCR/PKCE — same shape as the `linear` entry). `hermes mcp install comfy-cloud` → browser sign-in → generate images/video/audio/3D on Comfy Cloud GPUs.

## Changes

- `optional-mcps/comfy-cloud/manifest.yaml`: catalog entry (contributor commit), then curated on top:
  - `tools.default_enabled`: 20-tool subset — discovery (7), generation (5), job lifecycle (6), billing + canvas handoff (2). The server exposes ~37 tools; at Hermes's measured ~600 tokens/tool schema average, all-enabled adds ~16–22k tokens to **every API call** while enabled — more than the entire Hermes core toolset (12.7k measured). Curated default lands at ~9–12k. Everything else stays opt-in via `hermes mcp configure comfy-cloud`.
  - `report_session_summary` excluded per telemetry policy (no outbound telemetry without explicit opt-in); `submit_feedback`, App Mode tools, `cql`, `get_server_info`, batch variants, saved/shared workflow management unchecked by default.
  - Description trimmed to catalog guideline (≤60 chars).
  - Dropped the PR's `pyproject.toml` data-files line — per-entry packaging enforcement was removed (no-pip policy); `blender`/`unreal-engine` have no such lines.
- `scripts/release.py`: AUTHOR_MAP entry for `mattmiller@comfy.org` → `@mattmillerai`.

## Validation

| Check | Result |
|---|---|
| `_parse_manifest` + `list_catalog` + `get_entry("official/comfy-cloud")` + `_build_server_config` (real imports) | pass — 20 default tools parsed, `{'url': 'https://cloud.comfy.org/mcp', 'auth': 'oauth'}` |
| Live server | `GET /mcp/health` 200; RFC 9728 OAuth metadata served |
| `tests/hermes_cli/test_mcp_catalog.py` + `tests/test_packaging_metadata.py` | pass |

Replaces #57308 (will be closed with credit). Companion skill-routing PR follows separately (#65243 salvage).

## Infographic

![Comfy Cloud MCP catalog entry](https://v3b.fal.media/files/b/0aa2931d/JvzscfLYBicFAiNEsEHfa_nOcigU2f.png)
