### PR TITLE
fix(agent): honour disabled reasoning on the profile-less chat_completions path

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -474,6 +474,15 @@ class ChatCompletionsTransport(ProviderTransport):
                 gh_reasoning = params.get("github_reasoning_extra")
                 if gh_reasoning is not None:
                     extra_body["reasoning"] = gh_reasoning
+            elif (
+                isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            ):
+                # Honor an explicit disable instead of forcing enabled=True.
+                # Nous rejects enabled=false, so omit the field there, as the
+                # nous profile does.
+                if not is_nous:
+                    extra_body["reasoning"] = {"enabled": False}
             else:
                 _effort = "medium"
                 if reasoning_config and isinstance(reasoning_config, dict):

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -410,6 +410,36 @@ class TestChatCompletionsBuildKwargs:
         # Nous rejects enabled=false; reasoning omitted entirely
         assert "reasoning" not in kw.get("extra_body", {})
 
+    def test_disabled_reasoning_honored_without_profile(self, transport):
+        """A profile-less route must not re-enable reasoning the caller disabled."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            supports_reasoning=True,
+            reasoning_config={"enabled": False},
+        )
+        assert kw["extra_body"]["reasoning"]["enabled"] is False
+
+    def test_disabled_reasoning_omitted_for_nous_without_profile(self, transport):
+        """Nous rejects enabled=false, so the field is omitted, as the profile does."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            supports_reasoning=True,
+            reasoning_config={"enabled": False},
+            is_nous=True,
+        )
+        assert "reasoning" not in kw.get("extra_body", {})
+
+    def test_requested_effort_preserved_without_profile(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            supports_reasoning=True,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "high"}
+
     def test_ollama_num_ctx(self, transport):
         from providers import get_provider_profile
         profile = get_provider_profile("custom")


### PR DESCRIPTION
## What

`ChatCompletionsTransport.build_kwargs` hardcodes `reasoning: {"enabled": True, "effort": ...}` for
reasoning-capable routes that resolve no provider profile, so a caller passing `{"enabled": False}` gets
reasoning back on at medium effort.

## Why

`5a6720b88` fixed thinking-off at the reporting site and in the zai profile. The transport branch at
`agent/transports/chat_completions.py:481` was not part of that change and still overrides an explicit
disable.

The branch is reached when a reasoning-capable base_url resolves no profile. `_supports_reasoning_extra_body`
(`run_agent.py:5425`) admits Nous Portal, GitHub Models, LM Studio, Ollama and OpenRouter; profile lookup is
keyed on the provider string, which is optional (`agent.provider = provider_name or ""`,
`agent/agent_init.py:436`), and `get_provider_profile("")` returns None. So an OpenRouter or Nous Portal
base_url configured without a provider name lands here. `AIAgent`'s own docstring (`agent/agent_init.py:382`)
documents `reasoning_config` as an OpenRouter override that can be set to disable, which is the case that
breaks.

Reproduced on `7cb2d2cd4`:

```python
t.build_kwargs(model="gpt-4o", messages=[...], supports_reasoning=True,
               reasoning_config={"enabled": False})
# extra_body["reasoning"] -> {'enabled': True, 'effort': 'medium'}
```

Every profiled sibling already honours the disable: nous omits the field
(`plugins/model-providers/nous/__init__.py:35`), openrouter forwards the config
(`plugins/model-providers/openrouter/__init__.py:158`), and the Kimi branch twenty lines up maps disabled to
`thinking: {"type": "disabled"}` (`chat_completions.py:462`). Each defaults to medium only in the absence of
an explicit config. The legacy branch applies that default to explicit configs too, including an explicit off.

For the wire value I followed `agent/auxiliary_client.py:6632`, which emits `{"enabled": False}` for the same
disabled-and-no-profile-reasoning case. Nous is the exception: it rejects `enabled: false`, so the field is
omitted there, which is what the nous profile does.

The origin looks like an oversight rather than intent. `f69a33794` ("fix: forward reasoning_effort for custom
providers (GLM-5.2 on ARK)") rewrote this branch to stop hardcoding medium effort and honour the caller's
effort; it did not carry the enabled flag through.

I did not find an open issue for this, so the reproduction above stands in for one.

## Testing

Three contracts in `tests/agent/transports/test_chat_completions.py`, alongside the existing
`test_nous_omits_disabled_reasoning`:

- `test_disabled_reasoning_honored_without_profile`: disabled stays disabled.
- `test_disabled_reasoning_omitted_for_nous_without_profile`: Nous omits the field.
- `test_requested_effort_preserved_without_profile`: an explicit effort survives the new branch.

The first two fail on stock `main` and pass with the fix. The third passes either way and pins the
else-branch this change restructures.

`tests/agent/transports/test_chat_completions.py`: 93 passed. The wider `tests/agent/transports` run has the
same 52 pre-existing failures before and after (unrelated codex and bedrock suites, missing deps in my env),
plus the 3 new tests.

Assertions are on the request kwargs. I have not driven a live profile-less endpoint.

