### PR TITLE
fix(desktop): body-drop opens split + preserve Desktop session token

### DIFF
--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -30,13 +30,13 @@ import type { PointerEvent as ReactPointerEvent } from 'react'
 import { findGroup } from '@/components/pane-shell/tree/model'
 import {
   type DoubleTapContext,
+  radialPosition,
   rectContains,
   slotBefore,
   snapshotStrips,
   snapshotZones,
   startDragSession,
-  type StripSnapshot,
-  subZonePosition
+  type StripSnapshot
 } from '@/components/pane-shell/tree/renderer/drag-session'
 import {
   $layoutTree,
@@ -161,18 +161,33 @@ export function startSessionDrag(
         return { kind: 'group', groupId: zone.id, groupIds: [zone.id], pos: 'center', stack }
       }
 
-      // The composer (and everything in it) is always the link/attach drop;
-      // elsewhere the shared radial targeting decides center vs edge.
-      const pos = composers.some(rect => rectContains(rect, x, y)) ? 'center' : subZonePosition(zones, zone.id, x, y)
+      // Composer only = @session link. Elsewhere: edge = split, body = split
+      // right (video-style "add a chat" — center-as-link was invisible to users
+      // who dropped on the chat and got an @chip or a silent no-op).
+      const overComposer = composers.some(rect => rectContains(rect, x, y))
       const surface = surfaces.find(s => rectContains(s.rect, x, y))
 
-      if (pos === 'center') {
+      if (overComposer) {
         split = null
         link = surface?.composerTarget ?? 'main'
-      } else {
-        split = { anchor: surface?.anchor ?? 'workspace', pos }
-        link = null
+
+        return { kind: 'group', groupId: zone.id, groupIds: [zone.id], pos: 'center' }
       }
+
+      // Slightly smaller center ellipse than pane drags so edge splits are
+      // easier to hit without hunting a thin band.
+      const pos = radialPosition(zone.rect, x, y, 0.48)
+
+      if (pos === 'center') {
+        // Default body drop: open as a right-hand tile (matches "Open in split → Right").
+        split = { anchor: surface?.anchor ?? 'workspace', pos: 'right' }
+        link = null
+
+        return { kind: 'group', groupId: zone.id, groupIds: [zone.id], pos: 'right' }
+      }
+
+      split = { anchor: surface?.anchor ?? 'workspace', pos }
+      link = null
 
       return { kind: 'group', groupId: zone.id, groupIds: [zone.id], pos }
     },

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -41,10 +41,12 @@ import { exportSession } from '@/lib/session-export'
 import { activeGateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeSessionId, $selectedStoredSessionId, setSessions } from '@/store/session'
+import { revealTreePane } from '@/components/pane-shell/tree/store'
 import { $sessionTiles, openSessionTile } from '@/store/session-states'
 import { canOpenSessionWindow, openSessionInNewWindow } from '@/store/windows'
 
 import type { SessionTitleResponse } from '../../types'
+import { CONTEXT_SPLIT_KIT, DROPDOWN_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 
 // Rename a session, preferring the gateway's session.title RPC over REST.
 //
@@ -321,10 +323,21 @@ function useSessionActions({
     </Item>
   )
 
-  const renderItems = (kit: MenuKit) => (
+  const renderItems = (kit: MenuKit, splitKit: typeof DROPDOWN_SPLIT_KIT) => (
     <>
       {openItems.map(item => renderMenuItem(kit.Item, item))}
-      {openItems.length > 0 && <kit.Separator />}
+      {surface === 'row' && sessionId && !alreadyTabbed && (
+        <SplitSubmenu
+          kit={splitKit}
+          label={r.openInSplit}
+          onSplit={dir => {
+            triggerHaptic('selection')
+            openSessionTile(sessionId, dir)
+            revealTreePane(`session-tile:${sessionId}`)
+          }}
+        />
+      )}
+      {(openItems.length > 0 || (surface === 'row' && sessionId && !alreadyTabbed)) && <kit.Separator />}
       {identityItems.map(item => renderMenuItem(kit.Item, item))}
       <CopyButton
         appearance={kit.Item === DropdownMenuItem ? 'menu-item' : 'context-menu-item'}
@@ -393,10 +406,10 @@ export function SessionActionsMenu({ children, align = 'end', sideOffset = 6, ..
         <DropdownMenuContent
           align={align}
           aria-label={t.sidebar.row.actionsFor(actions.title)}
-          className="w-40"
+          className="w-44"
           sideOffset={sideOffset}
         >
-          {renderItems(DROPDOWN_KIT)}
+          {renderItems(DROPDOWN_KIT, DROPDOWN_SPLIT_KIT)}
         </DropdownMenuContent>
       </DropdownMenu>
       {renameDialog}
@@ -416,8 +429,8 @@ export function SessionContextMenu({ children, ...actions }: SessionContextMenuP
     <>
       <ContextMenu>
         <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-        <ContextMenuContent aria-label={t.sidebar.row.actionsFor(actions.title)} className="w-40">
-          {renderItems(CONTEXT_KIT)}
+        <ContextMenuContent aria-label={t.sidebar.row.actionsFor(actions.title)} className="w-44">
+          {renderItems(CONTEXT_KIT, CONTEXT_SPLIT_KIT)}
         </ContextMenuContent>
       </ContextMenu>
       {renameDialog}

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -236,6 +236,16 @@ def load_hermes_dotenv(
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 
+    # Desktop-spawned backends (HERMES_DESKTOP=1) mint HERMES_DASHBOARD_SESSION_TOKEN
+    # and pass it in the child env. User .env is loaded with override=True below, which
+    # would clobber that mint and leave Electron main 401'ing against its own backend
+    # ("Could not connect to Hermes gateway" boot overlay). Preserve the spawn mint.
+    _desktop_preserve: dict[str, str] = {}
+    if os.environ.get("HERMES_DESKTOP") == "1":
+        for _k in ("HERMES_DASHBOARD_SESSION_TOKEN",):
+            if _k in os.environ and os.environ[_k]:
+                _desktop_preserve[_k] = os.environ[_k]
+
     # Fix corrupted .env files before python-dotenv parses them (#8908).
     if user_env.exists():
         _sanitize_env_file_if_needed(user_env)
@@ -245,6 +255,9 @@ def load_hermes_dotenv(
     if user_env.exists():
         _load_dotenv_with_fallback(user_env, override=True)
         loaded.append(user_env)
+
+    for _k, _v in _desktop_preserve.items():
+        os.environ[_k] = _v
 
     # Load .op.env AFTER .env so that .env values win, but the bootstrap
     # token (OP_SERVICE_ACCOUNT_TOKEN) becomes available for
@@ -266,6 +279,10 @@ def load_hermes_dotenv(
 
     _apply_external_secret_sources(home_path)
     _apply_managed_env()
+
+    # Re-apply after managed/external loads (same desktop mint reason as above).
+    for _k, _v in _desktop_preserve.items():
+        os.environ[_k] = _v
 
     return loaded
 


### PR DESCRIPTION
## Summary
Fixes two issues that break everyday Hermes Desktop multi-session UX and headless boot:

1. **Token clobber** — `load_hermes_dotenv(override=True)` replaces the Desktop-minted `HERMES_DASHBOARD_SESSION_TOKEN` with `~/.hermes/.env`, causing pool backend **401** / gateway boot failures. When `HERMES_DESKTOP=1`, preserve mint keys after dotenv/managed env load.

2. **Session drag** — dropping a session on the chat **body** previously inserted an `@session` chip (link). Users following multi-session demos expect a **split pane**. Body drop now opens a **right tile**; composer still links; edges still split. Session row context menu gains **Open in split**.

## Test plan
- [x] Patches apply cleanly on current `main`
- [x] Desktop unit tests for session-actions-menu still pass (local)
- [ ] Open Desktop, drag non-active session onto chat body → right split appears
- [ ] Right-click session → Open in split → Right
- [ ] With `HERMES_DASHBOARD_SESSION_TOKEN` in `.env`, Desktop-spawned backend still accepts mint token (no 401)

## Notes
Local workaround previously: remove token from `.env` or re-apply patches after every `hermes update` reset.