### PR TITLE
fix(model-picker): keep custom provider routes selectable

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -25,7 +25,7 @@ const startManualProviderOAuth = vi.fn()
 
 vi.mock('@/hermes', () => ({
   getGlobalModelInfo: () => getGlobalModelInfo(),
-  getGlobalModelOptions: () => getGlobalModelOptions(),
+  getGlobalModelOptions: (options?: unknown) => getGlobalModelOptions(options),
   getAuxiliaryModels: () => getAuxiliaryModels(),
   getMoaModels: () => getMoaModels(),
   setModelAssignment: (body: unknown) => setModelAssignment(body),
@@ -96,6 +96,94 @@ describe('ModelSettings', () => {
     // "Nous" shows in both the trigger and the open list.
     expect((await screen.findAllByText('Nous')).length).toBeGreaterThan(0)
     expect(screen.queryByText(/DeepSeek/)).toBeNull()
+  })
+
+  it('retains the current model during initial provider hydration', async () => {
+    await renderModelSettings()
+
+    const triggers = await screen.findAllByRole('combobox')
+
+    expect(triggers[1].textContent).toContain('hermes-4')
+    expect(getGlobalModelOptions).toHaveBeenCalledTimes(1)
+    expect(getGlobalModelOptions).not.toHaveBeenCalledWith({ refresh: true })
+  })
+
+  it('clears a stale model and probes an empty user-defined provider after a user switch', async () => {
+    getGlobalModelOptions
+      .mockResolvedValueOnce({
+        providers: [
+          {
+            name: 'Nous',
+            slug: 'nous',
+            models: ['hermes-4'],
+            authenticated: true
+          },
+          {
+            name: 'Local Gateway',
+            slug: 'local-gateway',
+            models: [],
+            authenticated: true,
+            is_user_defined: true
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        providers: [
+          {
+            name: 'Nous',
+            slug: 'nous',
+            models: ['hermes-4'],
+            authenticated: true
+          },
+          {
+            name: 'Local Gateway',
+            slug: 'local-gateway',
+            models: ['local-model-a', 'local-model-b'],
+            authenticated: true,
+            is_user_defined: true
+          }
+        ]
+      })
+
+    await renderModelSettings()
+
+    const triggers = await screen.findAllByRole('combobox')
+    fireEvent.click(triggers[0])
+    fireEvent.click(await screen.findByRole('option', { name: 'Local Gateway' }))
+
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalledWith({ refresh: true }))
+    await waitFor(() => expect(screen.getAllByRole('combobox')[1].textContent).toContain('local-model-a'))
+    expect(screen.getAllByRole('combobox')[1].textContent).not.toContain('hermes-4')
+  })
+
+  it('does not live-probe an empty built-in provider after a user switch', async () => {
+    getGlobalModelOptions.mockResolvedValueOnce({
+      providers: [
+        {
+          name: 'Nous',
+          slug: 'nous',
+          models: ['hermes-4'],
+          authenticated: true
+        },
+        {
+          name: 'Built-in Empty',
+          slug: 'built-in-empty',
+          models: [],
+          authenticated: true,
+          is_user_defined: false
+        }
+      ]
+    })
+
+    await renderModelSettings()
+
+    const triggers = await screen.findAllByRole('combobox')
+    fireEvent.click(triggers[0])
+    fireEvent.click(await screen.findByRole('option', { name: 'Built-in Empty' }))
+
+    await waitFor(() => expect(screen.getAllByRole('combobox')[1].textContent).not.toContain('hermes-4'))
+    expect(getGlobalModelOptions).toHaveBeenCalledTimes(1)
+    expect(getGlobalModelOptions).not.toHaveBeenCalledWith({ refresh: true })
   })
 
   it('writes the profile default speed (service_tier) when the fast switch is toggled', async () => {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -293,9 +293,30 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   const needsSetup = !!selectedProvider && !isProviderReady(selectedProviderRow)
   const setupIsApiKey = needsSetup && selectedProviderRow?.auth_type === 'api_key' && !!selectedProviderRow?.key_env
 
-  // Clear any half-typed key when switching provider so it can't leak across.
+  // Clear any half-typed key and stale model when switching provider.
+  // Without this, switching to a custom provider whose models haven't been
+  // probed yet (empty models list) leaves the previous provider's model
+  // visible in the Select via withActive(), making it look like the model
+  // list didn't refresh.  For empty-but-authenticated providers, call
+  // with refresh=true so the backend probes the live /models endpoint.
   useEffect(() => {
     setApiKeyDraft('')
+    setSelectedModel('')
+
+    const row = providers.find(p => p.slug === selectedProvider)
+    if (row && row.authenticated !== false && (row.models?.length ?? 0) === 0) {
+      const epoch = profileEpoch.current
+      getGlobalModelOptions({ refresh: true })
+        .then(opts => {
+          if (profileEpoch.current !== epoch) return
+          setProviders(opts.providers || [])
+          const refreshed = opts.providers?.find(p => p.slug === selectedProvider)
+          if (refreshed?.models?.length) {
+            setSelectedModel(refreshed.models[0])
+          }
+        })
+        .catch(() => {})
+    }
   }, [selectedProvider])
 
   const auxDraftProviderModels = useMemo(

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -219,6 +219,9 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   // so a request in flight when the user switches profiles can't paint profile
   // A's models/providers into profile B (or fire onMainModelChanged for A).
   const profileEpoch = useRef(0)
+  // Keep user-driven provider probes ordered independently of profile loads.
+  // A slower reply for an earlier selection must not repaint a later one.
+  const providerSelectionEpoch = useRef(0)
 
   const refresh = useCallback(async () => {
     const epoch = profileEpoch.current
@@ -293,31 +296,45 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
   const needsSetup = !!selectedProvider && !isProviderReady(selectedProviderRow)
   const setupIsApiKey = needsSetup && selectedProviderRow?.auth_type === 'api_key' && !!selectedProviderRow?.key_env
 
-  // Clear any half-typed key and stale model when switching provider.
-  // Without this, switching to a custom provider whose models haven't been
-  // probed yet (empty models list) leaves the previous provider's model
-  // visible in the Select via withActive(), making it look like the model
-  // list didn't refresh.  For empty-but-authenticated providers, call
-  // with refresh=true so the backend probes the live /models endpoint.
-  useEffect(() => {
-    setApiKeyDraft('')
-    setSelectedModel('')
+  // This must be an event handler, not a selectedProvider effect: refresh()
+  // hydrates the provider and model together, and an effect would erase that
+  // valid initial model. Only an actual user provider change invalidates it.
+  const selectMainProvider = useCallback(
+    (provider: string) => {
+      const selectionEpoch = providerSelectionEpoch.current + 1
+      providerSelectionEpoch.current = selectionEpoch
 
-    const row = providers.find(p => p.slug === selectedProvider)
-    if (row && row.authenticated !== false && (row.models?.length ?? 0) === 0) {
+      setSelectedProvider(provider)
+      setSelectedModel('')
+      setApiKeyDraft('')
+
+      const row = providers.find(candidate => candidate.slug === provider)
+
+      // Built-ins use their curated/cached catalogs. Live probing is only the
+      // fallback for user-defined endpoints that arrived empty because they
+      // were not the active custom provider during the initial inventory.
+      if (!row?.is_user_defined || row.authenticated === false || (row.models?.length ?? 0) > 0) {
+        return
+      }
+
       const epoch = profileEpoch.current
-      getGlobalModelOptions({ refresh: true })
+      void getGlobalModelOptions({ refresh: true })
         .then(opts => {
-          if (profileEpoch.current !== epoch) return
+          if (profileEpoch.current !== epoch || providerSelectionEpoch.current !== selectionEpoch) {
+            return
+          }
+
           setProviders(opts.providers || [])
-          const refreshed = opts.providers?.find(p => p.slug === selectedProvider)
+          const refreshed = opts.providers?.find(candidate => candidate.slug === provider)
+
           if (refreshed?.models?.length) {
             setSelectedModel(refreshed.models[0])
           }
         })
         .catch(() => {})
-    }
-  }, [selectedProvider])
+    },
+    [providers]
+  )
 
   const auxDraftProviderModels = useMemo(
     () => providers.find(provider => provider.slug === auxDraft.provider)?.models ?? [],
@@ -716,7 +733,7 @@ export function ModelSettings({ onMainModelChanged }: ModelSettingsProps) {
       <section>
         <p className="mb-3 text-xs text-muted-foreground">{m.appliesDesc}</p>
         <div className="flex flex-wrap items-center gap-2">
-          <Select onValueChange={setSelectedProvider} value={selectedProvider}>
+          <Select onValueChange={selectMainProvider} value={selectedProvider}>
             <SelectTrigger className={cn('min-w-40', CONTROL_TEXT)}>
               <SelectValue placeholder={m.provider} />
             </SelectTrigger>

--- a/apps/desktop/src/app/shell/model-menu-panel.custom-providers.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.custom-providers.test.tsx
@@ -1,0 +1,152 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, findByText, render } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DropdownMenu, DropdownMenuContent } from '@/components/ui/dropdown-menu'
+import { $activeSessionId, $currentModel, $currentProvider } from '@/store/session'
+
+import { ModelMenuPanel } from './model-menu-panel'
+
+// Radix calls these on open; jsdom doesn't implement them.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+const getGlobalModelOptions = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  getGlobalModelOptions: (...args: unknown[]) => getGlobalModelOptions(...args)
+}))
+
+// The exact payload shape observed live from /api/model/options for a config
+// with one bare `model.provider: custom` main model plus two named
+// `custom_providers` entries. Reproduces issue #59702: the Desktop picker
+// shows only one of these three rows even though the backend/network payload
+// is always complete (verified independently 3 ways: REST with refresh, REST
+// without refresh, and the live gateway WebSocket JSON-RPC call).
+const MAIN_CUSTOM_PROVIDER = {
+  api_url: 'http://10.0.0.1:8090/v1',
+  is_current: true,
+  is_user_defined: true,
+  models: ['Qwen3.6-27B-NVFP4-MTP-GGUF.gguf'],
+  name: 'Custom endpoint',
+  slug: 'custom',
+  source: 'model-config',
+  total_models: 1
+}
+
+const NAMED_CUSTOM_PROVIDER_A = {
+  api_url: 'http://10.0.0.2:8080/v1',
+  is_current: false,
+  is_user_defined: true,
+  models: ['gemma-4-12b-omni'],
+  name: '3090-gemma4-12b',
+  slug: 'custom:3090-gemma4-12b',
+  source: 'user-config',
+  total_models: 1
+}
+
+const NAMED_CUSTOM_PROVIDER_B = {
+  api_url: 'http://10.0.0.3:8000/v1',
+  is_current: false,
+  is_user_defined: true,
+  models: ['gemma-4-26b-a4b-nvfp4'],
+  name: 'spark-gemma4-26b-a4b',
+  slug: 'custom:spark-gemma4-26b-a4b',
+  source: 'user-config',
+  total_models: 1
+}
+
+beforeEach(() => {
+  $activeSessionId.set('runtime-1')
+  $currentModel.set('Qwen3.6-27B-NVFP4-MTP-GGUF.gguf')
+  $currentProvider.set('custom')
+  getGlobalModelOptions.mockResolvedValue({
+    providers: [MAIN_CUSTOM_PROVIDER, NAMED_CUSTOM_PROVIDER_A, NAMED_CUSTOM_PROVIDER_B]
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function renderPanel(onSelectModel = vi.fn()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={client}>
+      <DropdownMenu open>
+        <DropdownMenuContent>
+          <ModelMenuPanel onSelectModel={onSelectModel} requestGateway={vi.fn() as never} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </QueryClientProvider>
+  )
+
+  return onSelectModel
+}
+
+describe('ModelMenuPanel multiple custom_providers entries (#59702)', () => {
+  it('renders all three custom provider groups when three are configured', async () => {
+    renderPanel()
+
+    // Wait for the async useQuery to resolve and the panel to re-render.
+    await findByText(document.body, 'Custom endpoint')
+
+    expect(document.body.textContent).toContain('Custom endpoint')
+    expect(document.body.textContent).toContain('3090-gemma4-12b')
+    expect(document.body.textContent).toContain('spark-gemma4-26b-a4b')
+  })
+
+  it('renders each provider group model row, not just the first', async () => {
+    renderPanel()
+
+    await findByText(document.body, 'Custom endpoint')
+
+    expect(
+      document.body.textContent?.includes('Qwen3.6-27B-NVFP4-MTP-GGUF.gguf') ||
+        document.body.textContent?.includes('Qwen3.6 27B NVFP4 MTP GGUF.Gguf')
+    ).toBe(true)
+    expect(document.body.textContent).toContain('Gemma 4 12b Omni')
+    // spark's model id renders as its family display name, accept either the
+    // raw id or the humanized form. We only care whether the ROW exists at all.
+    expect(
+      document.body.textContent?.includes('gemma-4-26b-a4b-nvfp4') ||
+        document.body.textContent?.includes('Gemma 4 26b A4b Nvfp4')
+    ).toBe(true)
+  })
+
+  it('renders all three groups via the real gateway.request path (not the REST fallback)', async () => {
+    // Prod always goes through gateway.request once connected. model-options.ts
+    // only falls back to REST getGlobalModelOptions when `gateway` is undefined.
+    // Earlier tests only exercised the REST fallback and passed; this exercises
+    // the actual code path a connected Desktop app uses.
+    const gatewayRequest = vi.fn().mockResolvedValue({
+      providers: [MAIN_CUSTOM_PROVIDER, NAMED_CUSTOM_PROVIDER_A, NAMED_CUSTOM_PROVIDER_B]
+    })
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    render(
+      <QueryClientProvider client={client}>
+        <DropdownMenu open>
+          <DropdownMenuContent>
+            <ModelMenuPanel
+              gateway={{ request: gatewayRequest } as never}
+              onSelectModel={vi.fn()}
+              requestGateway={vi.fn() as never}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </QueryClientProvider>
+    )
+
+    await findByText(document.body, 'Custom endpoint')
+
+    expect(gatewayRequest).toHaveBeenCalledWith('model.options', expect.objectContaining({ session_id: 'runtime-1' }))
+    expect(document.body.textContent).toContain('Custom endpoint')
+    expect(document.body.textContent).toContain('3090-gemma4-12b')
+    expect(document.body.textContent).toContain('spark-gemma4-26b-a4b')
+  })
+})

--- a/apps/desktop/src/app/shell/model-menu-panel.custom-providers.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.custom-providers.test.tsx
@@ -22,10 +22,10 @@ vi.mock('@/hermes', () => ({
 
 // The exact payload shape observed live from /api/model/options for a config
 // with one bare `model.provider: custom` main model plus two named
-// `custom_providers` entries. Reproduces issue #59702: the Desktop picker
-// shows only one of these three rows even though the backend/network payload
-// is always complete (verified independently 3 ways: REST with refresh, REST
-// without refresh, and the live gateway WebSocket JSON-RPC call).
+// `custom_providers` entries (issue #59702). These tests pin down that when
+// the payload carries all three rows, the panel renders all three: the #59702
+// bug lives in the backend payload (the bare custom row arriving with an
+// empty model list), not in this component's grouping or render logic.
 const MAIN_CUSTOM_PROVIDER = {
   api_url: 'http://10.0.0.1:8090/v1',
   is_current: true,
@@ -105,17 +105,10 @@ describe('ModelMenuPanel multiple custom_providers entries (#59702)', () => {
 
     await findByText(document.body, 'Custom endpoint')
 
-    expect(
-      document.body.textContent?.includes('Qwen3.6-27B-NVFP4-MTP-GGUF.gguf') ||
-        document.body.textContent?.includes('Qwen3.6 27B NVFP4 MTP GGUF.Gguf')
-    ).toBe(true)
+    // Model ids render as their humanized family display names.
+    expect(document.body.textContent).toContain('Qwen3.6 27B NVFP4 MTP GGUF.Gguf')
     expect(document.body.textContent).toContain('Gemma 4 12b Omni')
-    // spark's model id renders as its family display name, accept either the
-    // raw id or the humanized form. We only care whether the ROW exists at all.
-    expect(
-      document.body.textContent?.includes('gemma-4-26b-a4b-nvfp4') ||
-        document.body.textContent?.includes('Gemma 4 26b A4b Nvfp4')
-    ).toBe(true)
+    expect(document.body.textContent).toContain('Gemma 4 26b A4b Nvfp4')
   })
 
   it('renders all three groups via the real gateway.request path (not the REST fallback)', async () => {
@@ -126,6 +119,7 @@ describe('ModelMenuPanel multiple custom_providers entries (#59702)', () => {
     const gatewayRequest = vi.fn().mockResolvedValue({
       providers: [MAIN_CUSTOM_PROVIDER, NAMED_CUSTOM_PROVIDER_A, NAMED_CUSTOM_PROVIDER_B]
     })
+
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
     render(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2120,17 +2120,55 @@ def list_authenticated_providers(
             if _pair[0] and _pair[1]:
                 _section3_emitted_pairs.add(_pair)
 
-    # --- 3b. Active bare custom endpoint from model config ---
+    # --- 3b. Bare custom endpoint declared in model config ---
     # A config can still use the direct one-off form:
     #   model.provider: custom
     #   model.base_url: https://some-openai-compatible/v1
     # In that shape there is no named providers:/custom_providers row for the
-    # picker to render, but the gateway only passes this current model slice to
-    # list_authenticated_providers(). Surface the active endpoint explicitly so
-    # /model does not look like it ignored config.yaml.
+    # picker to render.
+    #
+    # Two sources can identify this endpoint:
+    #   1. The caller-supplied current_provider/current_base_url/current_model
+    #      (what existing callers pass to describe "the active endpoint" for
+    #      the current request).
+    #   2. The static config.yaml `model:` block, read directly here, for when
+    #      the caller's current_provider reflects a *different*, currently
+    #      active provider (e.g. the live session switched to another model).
+    #      Without this fallback, the row only appeared while it happened to
+    #      be the session's active provider. Switching to any other model made
+    #      it vanish from the picker entirely, and since it never re-populated
+    #      `seen_slugs`, the unconfigured-canonical-provider fallback then
+    #      inserted a misleading 0-model "run `hermes model` to configure"
+    #      skeleton in its place (#59702).
+    _base_url = ""
+    _default_model = ""
+    _api_key = ""
+    _is_current = False
+
+    if _current_provider_norm == "custom" and current_base_url:
+        _base_url = str(current_base_url).strip()
+        _default_model = current_model or ""
+        _is_current = True
+    else:
+        try:
+            from hermes_cli.config import load_config as _load_config_3b
+            _model_cfg = _load_config_3b().get("model") or {}
+        except Exception:
+            _model_cfg = {}
+
+        _configured_provider = str(_model_cfg.get("provider", "") or "").strip().lower()
+        _configured_base_url = str(_model_cfg.get("base_url", "") or "").strip()
+
+        if _configured_provider == "custom" and _configured_base_url:
+            _base_url = _configured_base_url
+            _default_model = str(_model_cfg.get("default", "") or "").strip()
+            _api_key = str(_model_cfg.get("api_key", "") or "").strip()
+            _is_current = bool(current_base_url) and str(current_base_url).strip().rstrip("/").lower() == (
+                _base_url.rstrip("/").lower()
+            )
+
     if (
-        _current_provider_norm == "custom"
-        and current_base_url
+        _base_url
         and "custom" not in seen_slugs
         and not any(
             isinstance(_cp, dict)
@@ -2139,29 +2177,40 @@ def list_authenticated_providers(
                 or _cp.get("url", "")
                 or _cp.get("api", "")
             ).strip().rstrip("/").lower()
-            == str(current_base_url).strip().rstrip("/").lower()
+            == _base_url.strip().rstrip("/").lower()
             for _cp in (custom_providers or [])
         )
     ):
-        _models = [current_model] if current_model else []
-        if refresh or probe_current_custom_provider:
+        _models = [_default_model] if _default_model else []
+
+        # Caller-supplied branch keeps the existing refresh/probe-current
+        # timing (an explicit refresh, or probe_current_custom_provider's
+        # "probe only the active endpoint" middle ground). The config-sourced
+        # fallback branch has no caller-supplied current_model to fall back
+        # to, so it always defers to the shared probing policy instead.
+        _should_probe_3b = (
+            (refresh or probe_current_custom_provider)
+            if _is_current and _current_provider_norm == "custom"
+            else _can_probe_custom_provider(row_is_current=_is_current)
+        )
+        if _should_probe_3b:
             try:
                 from hermes_cli.models import fetch_api_models
-
-                _live_models = fetch_api_models("", str(current_base_url).strip().rstrip("/"))
-                if _live_models:
-                    _models = _live_models
+                live_models = fetch_api_models(_api_key, _base_url, headers=None)
+                if live_models:
+                    _models = live_models
             except Exception:
                 pass
+
         results.append({
             "slug": "custom",
             "name": "Custom endpoint",
-            "is_current": True,
+            "is_current": _is_current,
             "is_user_defined": True,
             "models": _models[:max_models] if max_models is not None else _models,
             "total_models": len(_models),
             "source": "model-config",
-            "api_url": str(current_base_url).strip().rstrip("/"),
+            "api_url": _base_url.strip().rstrip("/"),
         })
         seen_slugs.add("custom")
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2151,8 +2151,8 @@ def list_authenticated_providers(
         _is_current = True
     else:
         try:
-            from hermes_cli.config import load_config as _load_config_3b
-            _model_cfg_raw = _load_config_3b().get("model")
+            from hermes_cli.config import load_config
+            _model_cfg_raw = load_config().get("model")
         except Exception:
             _model_cfg_raw = None
         # config.model can be a bare string in older configs (see

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2152,9 +2152,13 @@ def list_authenticated_providers(
     else:
         try:
             from hermes_cli.config import load_config as _load_config_3b
-            _model_cfg = _load_config_3b().get("model") or {}
+            _model_cfg_raw = _load_config_3b().get("model")
         except Exception:
-            _model_cfg = {}
+            _model_cfg_raw = None
+        # config.model can be a bare string in older configs (see
+        # hermes_cli/inventory.py's ConfigContext loader) — only a mapping
+        # carries a provider/base_url to recover here.
+        _model_cfg = _model_cfg_raw if isinstance(_model_cfg_raw, dict) else {}
 
         _configured_provider = str(_model_cfg.get("provider", "") or "").strip().lower()
         _configured_base_url = str(_model_cfg.get("base_url", "") or "").strip()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -90,6 +90,7 @@ AUTHOR_MAP = {
     "drexux0@gmail.com": "Drexuxux",  # PR #36042 salvage (gateway: /footer reachable mid-run via safe-toggle set)
     "iganapolsky@gmail.com": "IgorGanapolsky",  # PR #62125 salvage (compaction anti-thrash threshold verification)
     "275853971+aeyeopsdev@users.noreply.github.com": "aeyeopsdev",  # PRs #36035/#36068 salvage (google-chat: http inbound without pubsub; clarify cards)
+    "matthijs@vandenbos.org": "mvdbos",  # PR #66124 salvage of #59069 (desktop: refresh custom-provider models on user switch)
     "tturney1@gmail.com": "TheTom",  # PR #62696 salvage (gateway: expand @ context references under runtime/session model resolution)
     "1822947159@qq.com": "ljy-2000",  # PR #62204 adopted in #62290
     "xwolf.live@gmail.com": "vizi0uz",  # PR #59795 adopted in #62290

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -266,6 +266,32 @@ def test_list_authenticated_providers_bare_custom_endpoint_defers_to_matching_na
     assert any(p["slug"] == "custom:my-endpoint" for p in providers)
 
 
+def test_list_authenticated_providers_tolerates_legacy_scalar_model_config(monkeypatch):
+    """A legacy bare-string `model:` config value must not crash the picker.
+
+    hermes_cli/inventory.py's ConfigContext loader already treats config.model
+    as a bare string in older configs. The config-sourced 3b fallback must
+    tolerate the same shape instead of calling ``.get()`` on a str.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": "gpt-4o"},
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="xai-oauth",
+        current_base_url="",
+        current_model="grok-4",
+        user_providers={},
+        custom_providers=[],
+        max_models=50,
+    )
+
+    assert not any(p["slug"] == "custom" for p in providers)
+
+
 def test_switch_model_accepts_explicit_bare_custom_current_endpoint(monkeypatch):
     """Picker selections for bare custom endpoints should route to current base_url."""
     monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -186,6 +186,86 @@ def test_list_authenticated_providers_can_probe_active_bare_custom_endpoint(monk
     assert bare_custom["models"] == ["gpt-4o", "gpt-4o-mini"]
 
 
+def test_list_authenticated_providers_bare_custom_endpoint_survives_provider_switch(monkeypatch):
+    """Regression for #59702: the bare model.provider=custom row must not
+    vanish from the picker when the live session is on a different provider.
+
+    The caller only passes the session's current provider slice, so when the
+    session has switched away from the bare custom endpoint, the row has to be
+    recovered from the static config.yaml ``model:`` block instead. Before the
+    fix, the row silently disappeared and the unconfigured-canonical-provider
+    fallback replaced it with a misleading 0-model setup skeleton.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {
+                "default": "gpt-4o",
+                "provider": "custom",
+                "base_url": "https://www.ccsub.net/v1",
+            }
+        },
+    )
+    # The config-sourced fallback live-probes the endpoint; keep the test
+    # hermetic and prove the config default model is used when the probe
+    # returns nothing.
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **k: [])
+
+    providers = list_authenticated_providers(
+        current_provider="xai-oauth",
+        current_base_url="",
+        current_model="grok-4",
+        user_providers={},
+        custom_providers=[],
+        max_models=50,
+    )
+
+    bare_custom = next((p for p in providers if p["slug"] == "custom"), None)
+    assert bare_custom is not None
+    assert bare_custom["name"] == "Custom endpoint"
+    assert bare_custom["is_current"] is False
+    assert bare_custom["is_user_defined"] is True
+    assert bare_custom["models"] == ["gpt-4o"]
+    assert bare_custom["api_url"] == "https://www.ccsub.net/v1"
+
+
+def test_list_authenticated_providers_bare_custom_endpoint_defers_to_matching_named_entry(monkeypatch):
+    """The config-sourced bare row must not duplicate a named custom_providers
+    entry that already covers the same base_url."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {
+                "default": "gpt-4o",
+                "provider": "custom",
+                "base_url": "https://www.ccsub.net/v1",
+            }
+        },
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="xai-oauth",
+        current_base_url="",
+        current_model="grok-4",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "my-endpoint",
+                "base_url": "https://www.ccsub.net/v1",
+                "model": "gpt-4o",
+            }
+        ],
+        max_models=50,
+    )
+
+    assert not any(p["slug"] == "custom" for p in providers)
+    assert any(p["slug"] == "custom:my-endpoint" for p in providers)
+
+
 def test_switch_model_accepts_explicit_bare_custom_current_endpoint(monkeypatch):
     """Picker selections for bare custom endpoints should route to current base_url."""
     monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)


### PR DESCRIPTION
## What does this PR do?

Fixes two custom-provider picker paths that remain broken after configured providers became visible in the Desktop inventory:

- In Settings -> Model, an actual provider selection now clears the previous provider's model without clearing the valid model loaded during initial hydration. If the selected user-defined provider arrived with an empty catalog, Desktop performs a user-driven refresh and ignores stale replies from earlier selections or profiles.
- A bare `model.provider: custom` endpoint now remains in the shared provider inventory after the live session switches to another provider. The fallback reads the static `model:` configuration, avoids duplicating a matching named custom provider, and tolerates legacy scalar `model:` values.

This salvages #59069 by Matthijs van den Bos and #59808 by Tom Turney with their original commit authorship preserved, then addresses the outstanding review findings on top.

## Related Issue

Fixes #59063
Fixes #59702

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/settings/model-settings.tsx`: move provider-change invalidation into the user event handler, limit automatic discovery to empty user-defined providers, and order asynchronous refresh results.
- `apps/desktop/src/app/settings/model-settings.test.tsx`: cover initial model retention, stale-model clearing plus discovery, and the built-in-provider no-probe case.
- `hermes_cli/model_switch.py`: recover a configured bare custom endpoint when it is not active, without duplicating named endpoints or crashing on legacy scalar config.
- `tests/hermes_cli/test_model_switch_custom_providers.py`: cover switched-away, matching-named-provider, and legacy-scalar configurations.
- `apps/desktop/src/app/shell/model-menu-panel.custom-providers.test.tsx`: verify complete custom-provider payloads render through both REST and live gateway request paths.

## How to Test

1. Configure a user-defined provider with `discover_models: true` and no explicit model catalog. In Settings -> Model, switch from a populated provider to it and verify the previous model disappears and discovered models populate.
2. Reload Settings and verify initial provider/model hydration retains the current model rather than clearing it.
3. Configure a bare `model.provider: custom` endpoint, switch the live session to a different provider, and verify the bare custom row remains available in the picker.
4. Run `npm run test:ui -- src/app/settings/model-settings.test.tsx src/app/shell/model-menu-panel.custom-providers.test.tsx` from `apps/desktop` (16 tests passed).
5. Run the focused Python regressions in GitHub CI. They were not rerun locally under this workstation's test-safety policy.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (focused Desktop regression suite)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Focused Desktop regression suite:

`Test Files 2 passed (2)`

`Tests 16 passed (16)`
