### PR TITLE
fix(cron): resolve jobs.json path lazily so tests can't write the user's real jobs file

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -115,26 +115,40 @@ _cron_store_override: ContextVar[Optional[_CronStorePaths]] = ContextVar(
 )
 
 
+# Import-time snapshot of the compatibility constants, so deliberate
+# re-pointing of the module surface (monkeypatched CRON_DIR/JOBS_FILE/
+# OUTPUT_DIR — the documented escape hatch existing tests/embedders use)
+# is distinguishable from the constants merely being stale.
+_IMPORT_STORE = _CronStorePaths(CRON_DIR, JOBS_FILE, OUTPUT_DIR)
+
+
 def _current_cron_store() -> _CronStorePaths:
     """Return paths pinned to this execution context's profile.
 
-    With no use_cron_store() override active, the active profile home is
-    resolved FRESH via get_hermes_home() (context-local override, then the
-    HERMES_HOME env var) instead of trusting the import-time capture. A test
-    or embedder that re-points HERMES_HOME after this module was imported
-    therefore reads/writes ITS OWN store — not whatever jobs.json the import
-    happened to freeze (the filed incident: fixtures that patched the env too
-    late silently rewrote the user's real jobs file). The module-level
-    constants keep their import-time values as the documented compatibility
-    surface, and the common path (home unchanged since import) still returns
-    them unchanged.
+    Precedence, most explicit first:
+
+    1. an active use_cron_store() override (ContextVar);
+    2. deliberately re-pointed module constants — if CRON_DIR/JOBS_FILE/
+       OUTPUT_DIR no longer match their import-time values, someone chose
+       the documented process-wide compatibility surface; honor it;
+    3. the ACTIVE profile home, resolved fresh via get_hermes_home()
+       (context-local override, then the HERMES_HOME env var) — so a test
+       or embedder that re-points HERMES_HOME after this module was
+       imported reads/writes ITS OWN store, not whatever jobs.json the
+       import happened to freeze (the filed incident: fixtures that patched
+       the env too late silently rewrote the user's real jobs file);
+    4. the import-time constants (home unchanged since import — the common
+       path, returned unchanged).
     """
     override = _cron_store_override.get()
     if override is not None:
         return override
+    live_constants = _CronStorePaths(CRON_DIR, JOBS_FILE, OUTPUT_DIR)
+    if live_constants != _IMPORT_STORE:
+        return live_constants
     home = get_hermes_home().resolve()
     if home == HERMES_DIR:
-        return _CronStorePaths(CRON_DIR, JOBS_FILE, OUTPUT_DIR)
+        return live_constants
     cron_dir = home / "cron"
     return _CronStorePaths(cron_dir, cron_dir / "jobs.json", cron_dir / "output")
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -116,11 +116,27 @@ _cron_store_override: ContextVar[Optional[_CronStorePaths]] = ContextVar(
 
 
 def _current_cron_store() -> _CronStorePaths:
-    """Return paths pinned to this execution context's profile."""
+    """Return paths pinned to this execution context's profile.
+
+    With no use_cron_store() override active, the active profile home is
+    resolved FRESH via get_hermes_home() (context-local override, then the
+    HERMES_HOME env var) instead of trusting the import-time capture. A test
+    or embedder that re-points HERMES_HOME after this module was imported
+    therefore reads/writes ITS OWN store — not whatever jobs.json the import
+    happened to freeze (the filed incident: fixtures that patched the env too
+    late silently rewrote the user's real jobs file). The module-level
+    constants keep their import-time values as the documented compatibility
+    surface, and the common path (home unchanged since import) still returns
+    them unchanged.
+    """
     override = _cron_store_override.get()
     if override is not None:
         return override
-    return _CronStorePaths(CRON_DIR, JOBS_FILE, OUTPUT_DIR)
+    home = get_hermes_home().resolve()
+    if home == HERMES_DIR:
+        return _CronStorePaths(CRON_DIR, JOBS_FILE, OUTPUT_DIR)
+    cron_dir = home / "cron"
+    return _CronStorePaths(cron_dir, cron_dir / "jobs.json", cron_dir / "output")
 
 
 @contextlib.contextmanager

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1945,3 +1945,36 @@ class TestClaimDispatch:
         # At minimum, the good job's record is still intact (no corruption from the bad neighbor)
         loaded = {j["id"]: j for j in load_jobs()}
         assert "good" in loaded
+
+
+class TestLateEnvRepointScopesStore:
+    """A HERMES_HOME set AFTER cron.jobs import must scope the store even
+    without use_cron_store(): fixtures that patch the environment too late
+    previously read/wrote the import-time jobs.json — the user's real file."""
+
+    def test_late_env_repoint_scopes_store(self, tmp_path, monkeypatch):
+        import cron.jobs as jobs
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        store = jobs._current_cron_store()
+        expected = tmp_path.resolve() / "cron"
+        assert store.cron_dir == expected
+        assert store.jobs_file == expected / "jobs.json"
+        assert store.output_dir == expected / "output"
+        # the import-time compatibility constants are untouched
+        assert jobs.JOBS_FILE != store.jobs_file
+
+    def test_unchanged_home_returns_import_time_constants(self, monkeypatch):
+        import cron.jobs as jobs
+
+        monkeypatch.setenv("HERMES_HOME", str(jobs.HERMES_DIR))
+        store = jobs._current_cron_store()
+        assert store.jobs_file is jobs.JOBS_FILE
+
+    def test_use_cron_store_override_still_wins(self, tmp_path, monkeypatch):
+        import cron.jobs as jobs
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "env-home"))
+        with jobs.use_cron_store(tmp_path / "override-home"):
+            store = jobs._current_cron_store()
+            assert store.jobs_file == (tmp_path / "override-home").resolve() / "cron" / "jobs.json"

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1978,3 +1978,16 @@ class TestLateEnvRepointScopesStore:
         with jobs.use_cron_store(tmp_path / "override-home"):
             store = jobs._current_cron_store()
             assert store.jobs_file == (tmp_path / "override-home").resolve() / "cron" / "jobs.json"
+
+    def test_patched_compatibility_constants_beat_env(self, tmp_path, monkeypatch):
+        """Deliberately re-pointed module constants are the documented
+        process-wide escape hatch — they win over a repointed HERMES_HOME."""
+        import cron.jobs as jobs
+
+        patched_dir = tmp_path / "patched-cron"
+        monkeypatch.setattr(jobs, "CRON_DIR", patched_dir)
+        monkeypatch.setattr(jobs, "JOBS_FILE", patched_dir / "jobs.json")
+        monkeypatch.setattr(jobs, "OUTPUT_DIR", patched_dir / "output")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "env-home"))
+        store = jobs._current_cron_store()
+        assert store.jobs_file == patched_dir / "jobs.json"

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1991,3 +1991,58 @@ class TestLateEnvRepointScopesStore:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "env-home"))
         store = jobs._current_cron_store()
         assert store.jobs_file == patched_dir / "jobs.json"
+
+    def test_public_io_after_late_env_repoint_leaves_old_file_untouched(
+        self, tmp_path, monkeypatch
+    ):
+        """The public API, not the store internals: save_jobs()/load_jobs()
+        called after a post-import HERMES_HOME repoint must operate on the NEW
+        home's jobs.json and leave the import-time file byte-identical.
+
+        The "import-time home" is SIMULATED at a tmp location by patching the
+        module constants and the import-time snapshot together (so they still
+        compare equal and the deliberate-repoint branch does not fire). The
+        test must never touch the real import-time jobs.json: if this module
+        was first imported before the suite's env isolation applied, that
+        path IS the developer's live file — writing a sentinel there is
+        exactly the incident this PR exists to prevent."""
+        import cron.jobs as jobs
+
+        sim_old_home = tmp_path / "import-time-home"
+        sim_cron = sim_old_home / "cron"
+        monkeypatch.setattr(jobs, "HERMES_DIR", sim_old_home)
+        monkeypatch.setattr(jobs, "CRON_DIR", sim_cron)
+        monkeypatch.setattr(jobs, "JOBS_FILE", sim_cron / "jobs.json")
+        monkeypatch.setattr(jobs, "OUTPUT_DIR", sim_cron / "output")
+        monkeypatch.setattr(
+            jobs, "_IMPORT_STORE",
+            jobs._CronStorePaths(jobs.CRON_DIR, jobs.JOBS_FILE, jobs.OUTPUT_DIR),
+        )
+
+        # Plant a sentinel at the (simulated) import-time location — the file
+        # a late-patching fixture used to clobber.
+        old_file = jobs.JOBS_FILE
+        old_file.parent.mkdir(parents=True, exist_ok=True)
+        sentinel = '[{"id": "sentinel-do-not-touch"}]'
+        old_file.write_text(sentinel, encoding="utf-8")
+
+        new_home = tmp_path / "late-home"
+        monkeypatch.setenv("HERMES_HOME", str(new_home))
+
+        job = {
+            "id": "lateenvjob01",
+            "name": "late-env",
+            "prompt": None,
+            "schedule_display": None,
+            "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+            "enabled": True,
+        }
+        save_jobs([job])
+
+        # public read round-trips from the NEW home...
+        loaded = load_jobs()
+        assert [j["id"] for j in loaded] == ["lateenvjob01"]
+        new_file = new_home.resolve() / "cron" / "jobs.json"
+        assert new_file.is_file()
+        # ...and the import-time file is byte-identical to the sentinel.
+        assert old_file.read_text(encoding="utf-8") == sentinel


### PR DESCRIPTION
## Summary
Cherry-picks @slow4cyl's 3 commits from #61674 onto current main — `_current_cron_store()` now resolves `get_hermes_home()` lazily so a `HERMES_HOME` set after `cron.jobs` import scopes the cron store instead of writing the user's real `jobs.json`.

## Changes
- `cron/jobs.py`: `_current_cron_store()` gains a 4-tier fallback — (1) `use_cron_store()` override, (2) deliberately patched module constants (detected via `_IMPORT_STORE` snapshot comparison), (3) fresh `get_hermes_home()` if different from import-time `HERMES_DIR`, (4) import-time constants if home unchanged.
- `tests/cron/test_jobs.py`: 5 new tests covering all 4 precedence tiers + a public `save_jobs()`/`load_jobs()` regression that verifies the import-time file is left byte-identical.

## Validation
| | Before | After |
|---|---|---|
| Late HERMES_HOME repoint | writes real `~/.hermes/cron/jobs.json` | writes to the repointed home |
| Monkeypatched constants | honored | honored (unchanged) |
| `use_cron_store()` override | wins | wins (unchanged) |
| Home unchanged since import | import-time constants | import-time constants (unchanged) |
| E2E (real imports, temp HERMES_HOME) | — | 7/7 pass |
| Ruff | — | clean |
| New tests | — | 5/5 pass |
| Cron suite (system Python) | 79 fail (missing httpx/croniter) | same 79 fail, +10 new passes, 0 new failures |

Closes #61674
