### PR TITLE
fix(model_switch): dedupe self-duplicate provider views in typed-model routing

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -811,6 +811,61 @@ def _configured_provider_matches(
                     matches[slug] = hit
                     break
 
+    def _user_provider_alias(entry: dict, name: str) -> Optional[str]:
+        """Return the ``providers.<slug>`` key when ``entry`` is a legacy view
+        of that same user-provider config entry, else None.
+
+        ``get_compatible_custom_providers()`` re-exposes every ``providers``
+        dict entry as a legacy custom-provider row (dual exposure kept for
+        legacy ``custom_providers`` consumers).  Callers such as the gateway
+        /model path pass BOTH views here, so without canonicalization one
+        physical endpoint counts as two matches and the #45006 multi-provider
+        guard rejects an unambiguous bare model name.
+
+        Identity checks, strongest first:
+        1. ``provider_key`` — stamped by ``_normalize_custom_provider_entry``
+           with the originating ``providers`` dict key.
+        2. Display name + base_url — a view whose ``name`` equals a
+           ``providers`` entry's display name AND targets the same endpoint IS
+           that entry (covers views built without ``provider_key``).  Both
+           URLs must be nonempty and normalized-equal; if either side lacks
+           an endpoint URL the entries are NOT collapsed, so same-name
+           entries with incomplete endpoint identity stay distinct and the
+           multi-provider guard still applies.
+        """
+        if not isinstance(user_providers, dict):
+            return None
+        provider_key = entry.get("provider_key")
+        if (
+            isinstance(provider_key, str)
+            and provider_key.strip()
+            and provider_key.strip() in user_providers
+        ):
+            return provider_key.strip()
+        entry_url = str(entry.get("base_url", "") or "").strip().rstrip("/").lower()
+        name_lower = name.strip().lower()
+        for slug, cfg in user_providers.items():
+            if not isinstance(slug, str) or not isinstance(cfg, dict):
+                continue
+            display = cfg.get("name")
+            display_lower = (
+                display.strip().lower()
+                if isinstance(display, str) and display.strip()
+                else slug.strip().lower()
+            )
+            if display_lower != name_lower:
+                continue
+            cfg_url = ""
+            for url_key in ("base_url", "url", "api"):
+                raw_url = cfg.get(url_key)
+                if isinstance(raw_url, str) and raw_url.strip():
+                    cfg_url = raw_url.strip().rstrip("/").lower()
+                    break
+            if not entry_url or not cfg_url or entry_url != cfg_url:
+                continue
+            return slug
+        return None
+
     if isinstance(custom_providers, list):
         for entry in custom_providers:
             if not isinstance(entry, dict):
@@ -824,7 +879,14 @@ def _configured_provider_matches(
             for key in ("models", "model", "default_model"):
                 hit = _match(entry.get(key))
                 if hit:
-                    matches[slug] = hit
+                    # Same physical entry as a ``providers.<slug>`` block?
+                    # Attribute the match to the user-provider slug so one
+                    # endpoint never counts as two providers (#45006 D1).
+                    alias = _user_provider_alias(entry, name)
+                    if alias is not None:
+                        matches.setdefault(alias, hit)
+                    else:
+                        matches[slug] = hit
                     break
 
     return matches

--- a/tests/hermes_cli/test_model_switch_configured_provider_routing.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider_routing.py
@@ -308,3 +308,184 @@ def test_xai_oauth_soft_accept_preserved_when_no_match():
     )
     assert result.success is True, result.error_message
     assert result.target_provider == "xai-oauth"
+
+
+# ---------------------------------------------------------------------------
+# Self-duplicate provider view dedupe (#45006)
+#
+# Callers like the gateway /model path pass BOTH ``cfg["providers"]`` (as
+# user_providers) AND ``get_compatible_custom_providers(cfg)`` (as
+# custom_providers).  The latter re-exposes every ``providers`` dict entry as a
+# legacy custom-provider row, so ONE physical endpoint used to count as TWO
+# matches ("relay-lb" + "custom:Relay LB East") and the ambiguity guard
+# rejected an unambiguous bare model name.
+# ---------------------------------------------------------------------------
+
+_LB_PROVIDERS = {
+    "relay-lb": {
+        "name": "Relay LB East",
+        "base_url": "http://relay-east.internal:8080",
+        "api_key": "lb-key",
+        "api_mode": "anthropic_messages",
+        "default_model": "claude-opus-4-8",
+        "models": {"claude-fable-5": {}, "claude-opus-4-8": {}},
+    }
+}
+
+
+def _gateway_shaped_views(cfg_providers):
+    """Build (user_providers, custom_providers) exactly as the gateway /model
+    path does: providers dict + its get_compatible_custom_providers() view."""
+    from hermes_cli.config import get_compatible_custom_providers
+
+    return cfg_providers, get_compatible_custom_providers(
+        {"providers": cfg_providers}
+    )
+
+
+def test_dual_exposed_user_provider_counts_as_one():
+    """The D1 repro: a bare model name declared by exactly one ``providers``
+    entry that is ALSO re-exposed via get_compatible_custom_providers() must
+    switch successfully — not trip the multi-provider guard."""
+    user_providers, custom_providers = _gateway_shaped_views(dict(_LB_PROVIDERS))
+    # Sanity: the legacy view really is present (dual exposure is load-bearing
+    # for legacy custom_providers consumers and must not be silently dropped).
+    assert any(
+        e.get("name") == "Relay LB East" for e in custom_providers
+    ), custom_providers
+
+    result = _run_switch(
+        raw_input="claude-fable-5",
+        current_provider="openai-codex",
+        current_model="gpt-5.4",
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "relay-lb"
+    assert result.new_model == "claude-fable-5"
+
+
+def test_dual_exposed_match_resolves_user_provider_endpoint_and_key():
+    """After deduping to the ``providers.<slug>`` entry, credentials must come
+    from THAT entry (base_url + api_key), i.e. the reroute takes the
+    explicit-provider user-config credential path."""
+    user_providers, custom_providers = _gateway_shaped_views(dict(_LB_PROVIDERS))
+
+    with patch("hermes_cli.model_switch.resolve_alias", return_value=None), \
+         patch("hermes_cli.model_switch.list_provider_models", return_value=[]), \
+         patch("hermes_cli.model_switch.normalize_model_for_provider", side_effect=lambda model, provider: model), \
+         patch("hermes_cli.models.validate_requested_model", return_value=_ACCEPTED), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             # Empty runtime answer -> switch_model must fall back to the
+             # user-provider entry's own base_url and api_key.
+             return_value={"api_key": "", "base_url": "", "api_mode": ""},
+         ):
+        result = switch_model(
+            raw_input="claude-fable-5",
+            current_provider="openai-codex",
+            current_model="gpt-5.4",
+            current_base_url="",
+            user_providers=user_providers,
+            custom_providers=custom_providers,
+        )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "relay-lb"
+    assert result.base_url == "http://relay-east.internal:8080"
+    assert result.api_key == "lb-key"
+
+
+def test_legacy_view_without_provider_key_dedupes_by_name_and_url():
+    """A legacy custom row lacking ``provider_key`` but whose display name AND
+    endpoint equal a ``providers`` entry IS that entry — still one match."""
+    custom_providers = [
+        {
+            # Hand-rolled legacy view: no provider_key stamp.
+            "name": "Relay LB East",
+            "base_url": "http://relay-east.internal:8080/",  # trailing slash on purpose
+            "models": {"claude-fable-5": {}},
+        }
+    ]
+    result = _run_switch(
+        raw_input="claude-fable-5",
+        current_provider="openai-codex",
+        current_model="gpt-5.4",
+        user_providers=dict(_LB_PROVIDERS),
+        custom_providers=custom_providers,
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "relay-lb"
+
+
+def test_genuine_ambiguity_across_user_and_custom_still_errors():
+    """Two DIFFERENT endpoints declaring the same model must still trip the
+    guard: dedupe only collapses views of the SAME physical entry."""
+    custom_providers = [
+        {
+            "name": "Other LB",
+            "base_url": "http://relay-west.internal:8080",
+            "models": {"claude-fable-5": {}},
+        }
+    ]
+    result = _run_switch(
+        raw_input="claude-fable-5",
+        current_provider="openai-codex",
+        current_model="gpt-5.4",
+        user_providers=dict(_LB_PROVIDERS),
+        custom_providers=custom_providers,
+    )
+    assert result.success is False
+    assert "--provider" in result.error_message
+    assert "relay-lb" in result.error_message
+    assert "custom:Other LB" in result.error_message
+
+
+def test_same_display_name_different_endpoint_is_still_ambiguous():
+    """A custom entry that merely SHARES a display name with a ``providers``
+    entry but points at a different endpoint is NOT the same provider — the
+    guard must still fire rather than silently picking one."""
+    custom_providers = [
+        {
+            "name": "Relay LB East",  # name collision, different box
+            "base_url": "http://relay-other.internal:8080",
+            "models": {"claude-fable-5": {}},
+        }
+    ]
+    result = _run_switch(
+        raw_input="claude-fable-5",
+        current_provider="openai-codex",
+        current_model="gpt-5.4",
+        user_providers=dict(_LB_PROVIDERS),
+        custom_providers=custom_providers,
+    )
+    assert result.success is False
+    assert "--provider" in result.error_message
+    assert "relay-lb" in result.error_message
+    assert "custom:Relay LB East" in result.error_message
+
+
+def test_same_display_name_with_missing_endpoint_url_is_not_collapsed():
+    """A custom entry that shares a display name with a ``providers`` entry but
+    declares NO endpoint URL has incomplete identity — name equality alone must
+    NOT collapse it onto the ``providers`` entry, so the guard still fires."""
+    custom_providers = [
+        {
+            "name": "Relay LB East",  # name collision, endpoint unknown
+            "models": {"claude-fable-5": {}},
+        }
+    ]
+    result = _run_switch(
+        raw_input="claude-fable-5",
+        current_provider="openai-codex",
+        current_model="gpt-5.4",
+        user_providers=dict(_LB_PROVIDERS),
+        custom_providers=custom_providers,
+    )
+    assert result.success is False
+    assert "--provider" in result.error_message
+    assert "relay-lb" in result.error_message
+    assert "custom:Relay LB East" in result.error_message


### PR DESCRIPTION
## Problem

Bare `/model <name>` hard-fails for a model that is declared by exactly **one** configured endpoint:

```
Model 'my-model' is declared by multiple configured providers (relay-lb, custom:Relay LB East).
Pass --provider to disambiguate.
```

Callers such as the gateway `/model` path (`gateway/slash_commands.py`) pass both `cfg["providers"]` (as `user_providers`) **and** `get_compatible_custom_providers(cfg)` (as `custom_providers`) into typed-model resolution. `get_compatible_custom_providers()` re-exposes every `providers`-dict entry as a legacy custom-provider row, so `_configured_provider_matches()` counts the **same physical endpoint twice** — once as `providers.<slug>`, once as `custom:<display name>` — and the #45006 multi-provider ambiguity guard rejects a perfectly unambiguous name. The only workaround is to always type `--provider`, which defeats the point of the guard.

## Change

Dedupe at the match-collection altitude: before recording a `custom:<name>` match, recognize when the entry is merely a legacy *view* of a `providers.<slug>` block and attribute the match to that slug instead. Identity checks, strongest first:

1. **`provider_key`** — stamped by `_normalize_custom_provider_entry()` with the originating `providers`-dict key when the view is built by `providers_dict_to_custom_providers()`.
2. **Display name + base_url** — a view whose `name` equals a `providers` entry's display name AND targets the same endpoint (trailing-slash/case-insensitive URL compare) *is* that entry; this covers hand-rolled views that lack the `provider_key` stamp.

## Correctness notes

- The dual exposure in `get_compatible_custom_providers()` is deliberately left intact — it is load-bearing for the legacy `custom_providers` consumers (runtime provider resolution, credential pool, pickers). Only the match *accounting* changes.
- Genuine ambiguity still errors: two **different** endpoints declaring the same model — including a display-name collision on different `base_url`s — keep tripping the `--provider` guard. Both cases are pinned by new tests.
- A match attributed to the slug resolves the entry's `base_url`/key via the explicit-provider user-config credential path, identical to `/model <name> --provider <slug>`.

## Tests

`tests/hermes_cli/test_model_switch_configured_provider_routing.py` gains 5 dedupe cases:

- dual-exposed user provider counts as one match (bare `/model` routes, no ambiguity error) — **fails before the fix**
- the dedup'd match resolves the provider's endpoint and key — **fails before the fix**
- a legacy view without `provider_key` dedupes by display name + base_url (trailing slash tolerated) — **fails before the fix**
- two different endpoints with the same model still error (guard intact)
- display-name collision on different base_urls still errors (guard intact)

Full file (15 tests) plus the adjacent model-switch suites pass with the fix.
