### PR TITLE
fix(model-metadata): auto-extend provider prefixes from registered profiles

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -712,6 +712,20 @@ try:
 except Exception:
     pass
 
+# Auto-extend _PROVIDER_PREFIXES the same way, so "provider:model" strings
+# strip correctly for plugin providers (user plugins under
+# $HERMES_HOME/plugins/model-providers/ included) without editing this file.
+# The _OLLAMA_TAG_PATTERN guard in _strip_provider_prefix still protects
+# Ollama-style "model:tag" strings from over-stripping.
+try:
+    _plugin_prefixes: set[str] = set()
+    for _pp in _list_providers():
+        _plugin_prefixes.add(_pp.name.lower())
+        _plugin_prefixes.update(str(_a).lower() for _a in _pp.aliases)
+    _PROVIDER_PREFIXES = frozenset(_PROVIDER_PREFIXES | _plugin_prefixes)
+except Exception:
+    pass
+
 
 def _infer_provider_from_url(base_url: str) -> Optional[str]:
     """Infer the models.dev provider name from a base URL.

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -894,6 +894,28 @@ class TestStripProviderPrefix:
         assert _strip_provider_prefix("http://example.com") == "http://example.com"
         assert _strip_provider_prefix("https://example.com") == "https://example.com"
 
+    def test_registered_provider_names_and_aliases_are_prefixes(self):
+        """Prefixes auto-extend from registered profiles, like _URL_TO_PROVIDER.
+
+        Bundled plugin providers (and user plugins under
+        $HERMES_HOME/plugins/model-providers/) must strip without a manual
+        entry in the static frozenset.
+        """
+        from providers import list_providers
+
+        from agent.model_metadata import _PROVIDER_PREFIXES
+
+        for profile in list_providers():
+            assert profile.name.lower() in _PROVIDER_PREFIXES, (
+                f"registered provider {profile.name!r} missing from prefixes"
+            )
+            for alias in profile.aliases:
+                assert str(alias).lower() in _PROVIDER_PREFIXES, (
+                    f"alias {alias!r} of {profile.name!r} missing from prefixes"
+                )
+        # And a concrete strip using a bundled provider absent from the
+        # static set (fireworks ships as a plugin only).
+        assert _strip_provider_prefix("fireworks:some/model-v1") == "some/model-v1"
 
     @patch("agent.model_metadata.fetch_model_metadata")
     def test_ollama_model_tag_not_mangled_in_context_lookup(self, mock_fetch):


### PR DESCRIPTION
## What does this PR do?

`_PROVIDER_PREFIXES` in `agent/model_metadata.py` is a hand-maintained frozenset, so providers that ship as plugins are never recognised as `provider:` prefixes in model strings. `fireworks:accounts/fireworks/models/foo` does not strip today, and no user plugin under `$HERMES_HOME/plugins/model-providers/` ever can, so those strings miss cache and models.dev lookups and fall back to default context lengths. #7575 was this same gap for xAI, fixed at the time by hand-adding names.

This PR auto-extends the set from registered provider profiles (name plus aliases, lowercased), mirroring the `_URL_TO_PROVIDER` auto-extend block that already sits directly below it in the same file. The existing `_OLLAMA_TAG_PATTERN` guard is untouched, so Ollama `model:tag` strings still do not strip. Nothing changes for names already in the static set; the change is purely additive.

## Related Issue

Fixes #66106

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`: after the existing `_URL_TO_PROVIDER` auto-extend, rebuild `_PROVIDER_PREFIXES` as the union of the static set and every registered profile's `name` and `aliases`, inside the same `try/except` idiom
- `tests/agent/test_model_metadata.py`: new test asserting every registered profile's name and aliases are recognised as prefixes, plus a concrete strip using `fireworks` (a bundled plugin absent from the static set)

## How to Test

1. `scripts/run_tests.sh tests/agent/test_model_metadata.py` (123 tests, all passing, includes the new test)
2. `ruff check agent/model_metadata.py tests/agent/test_model_metadata.py` passes
3. Manual: `python -c "from agent.model_metadata import _strip_provider_prefix; print(_strip_provider_prefix('fireworks:some/model-v1'))"` prints `some/model-v1` (prints the unstripped string on main)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the affected file via the canonical runner (`scripts/run_tests.sh tests/agent/test_model_metadata.py`, 123 passed) plus `ruff`, rather than the entire tree, since the change is one module-level block in one file
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — N/A, behaviour is documented in the code comment beside the block, matching how the `_URL_TO_PROVIDER` auto-extend is documented
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — N/A, no architecture change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — pure Python set arithmetic, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — N/A, no tool behaviour change

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/agent/test_model_metadata.py
=== Summary: 1 files, 123 tests passed, 0 failed (100% complete) in 8.8s (8 workers) ===

$ ruff check agent/model_metadata.py tests/agent/test_model_metadata.py
All checks passed!
```

---

🤖 Generated with Claude Code (Claude Fable 5)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
