### PR TITLE
fix(agent): drive model-identity workaround from provider profile

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -439,12 +439,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     else:
         skills_prompt = ""
 
-    # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
-    # of the requested model. Inject explicit model identity into the system prompt
-    # so the agent can correctly report which model it is (workaround for API bug).
-    # Stable for the lifetime of an agent instance — model and provider are fixed
-    # at construction time.
-    if agent.provider == "alibaba":
+    # Some gateways report a wrong model name in API responses (Alibaba's
+    # coding/token-plan gateways return a fixed name regardless of the
+    # requested model). Inject explicit model identity into the system prompt
+    # so the agent can correctly report which model it is (workaround for API
+    # bug). Driven by the provider profile's misreports_model_identity flag so
+    # provider plugins can opt in without a core edit. Stable for the lifetime
+    # of an agent instance — model and provider are fixed at construction time.
+    _misreports_identity = False
+    try:
+        from providers import get_provider_profile
+
+        _profile = get_provider_profile(agent.provider) if agent.provider else None
+        _misreports_identity = bool(_profile and _profile.misreports_model_identity)
+    except Exception:
+        pass
+    if _misreports_identity:
         _model_short = agent.model.split("/")[-1] if "/" in agent.model else agent.model
         stable_parts.append(
             f"You are powered by the model named {_model_short}. "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -326,12 +326,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     else:
         skills_prompt = ""
 
-    # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
-    # of the requested model. Inject explicit model identity into the system prompt
-    # so the agent can correctly report which model it is (workaround for API bug).
-    # Stable for the lifetime of an agent instance — model and provider are fixed
-    # at construction time.
-    if agent.provider == "alibaba":
+    # Some gateways report a wrong model name in API responses (Alibaba's
+    # coding/token-plan gateways return a fixed name regardless of the
+    # requested model). Inject explicit model identity into the system prompt
+    # so the agent can correctly report which model it is (workaround for API
+    # bug). Driven by the provider profile's misreports_model_identity flag so
+    # provider plugins can opt in without a core edit. Stable for the lifetime
+    # of an agent instance — model and provider are fixed at construction time.
+    _misreports_identity = False
+    try:
+        from providers import get_provider_profile
+
+        _profile = get_provider_profile(agent.provider) if agent.provider else None
+        _misreports_identity = bool(_profile and _profile.misreports_model_identity)
+    except Exception:
+        pass
+    if _misreports_identity:
         _model_short = agent.model.split("/")[-1] if "/" in agent.model else agent.model
         stable_parts.append(
             f"You are powered by the model named {_model_short}. "

--- a/plugins/model-providers/alibaba-coding-plan/__init__.py
+++ b/plugins/model-providers/alibaba-coding-plan/__init__.py
@@ -16,6 +16,9 @@ alibaba_coding_plan = ProviderProfile(
     env_vars=("ALIBABA_CODING_PLAN_API_KEY", "DASHSCOPE_API_KEY", "ALIBABA_CODING_PLAN_BASE_URL"),
     base_url="https://coding-intl.dashscope.aliyuncs.com/v1",
     auth_type="api_key",
+    # The Coding Plan gateway reports a fixed model name in responses
+    # regardless of the requested model.
+    misreports_model_identity=True,
 )
 
 register_provider(alibaba_coding_plan)

--- a/plugins/model-providers/alibaba/__init__.py
+++ b/plugins/model-providers/alibaba/__init__.py
@@ -8,6 +8,7 @@ alibaba = ProviderProfile(
     aliases=("dashscope", "alibaba-cloud", "qwen-dashscope"),
     env_vars=("DASHSCOPE_API_KEY",),
     base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    misreports_model_identity=True,
 )
 
 register_provider(alibaba)

--- a/providers/base.py
+++ b/providers/base.py
@@ -87,6 +87,13 @@ class ProviderProfile:
     # e.g. "api.gmi-serving.com". Derived from base_url when empty.
     hostname: str = ""
 
+    # True when the provider's API reports a wrong model name in responses
+    # (e.g. Alibaba's coding/token-plan gateways return a fixed name
+    # regardless of the requested model). system_prompt.py injects an
+    # explicit model-identity line for these providers so the agent can
+    # answer "what model are you" correctly.
+    misreports_model_identity: bool = False
+
     # ── Client-level quirks (set once at client construction) ─
     default_headers: dict[str, str] = field(default_factory=dict)
 

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -185,6 +185,35 @@ def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
     assert agent._cached_system_prompt_static == "\n\n".join(expected.split("\n\n")[:4])
 
 
+class TestModelIdentityWorkaround:
+    """The identity line is driven by the profile's misreports_model_identity
+    flag, not a hard-coded provider name (#2314 originally targeted the
+    coding plan; the name check went stale when alibaba-coding-plan became a
+    first-class provider)."""
+
+    IDENTITY_MARKER = "You are powered by the model named"
+
+    def test_injected_for_alibaba(self):
+        agent = _make_agent(provider="alibaba", model="qwen3.7-max")
+        stable = _stable_prompt(agent)
+        assert self.IDENTITY_MARKER in stable
+        assert "qwen3.7-max" in stable
+
+    def test_injected_for_alibaba_coding_plan(self):
+        # The regression case: coding-plan sessions lost the workaround when
+        # the provider split off from "alibaba".
+        agent = _make_agent(provider="alibaba-coding-plan", model="qwen3.7-max")
+        assert self.IDENTITY_MARKER in _stable_prompt(agent)
+
+    def test_absent_for_provider_without_flag(self):
+        agent = _make_agent(provider="deepseek", model="deepseek-v3.2")
+        assert self.IDENTITY_MARKER not in _stable_prompt(agent)
+
+    def test_absent_for_unknown_provider(self):
+        agent = _make_agent(provider="no-such-provider", model="some-model")
+        assert self.IDENTITY_MARKER not in _stable_prompt(agent)
+
+
 class TestTelegramRichMessagesHint:
     """Verify that TELEGRAM_RICH_MESSAGES_HINT is conditionally included."""
 


### PR DESCRIPTION
## What does this PR do?

Restores the model-identity workaround for Alibaba Coding Plan sessions and makes it profile-driven.

`agent/system_prompt.py` injects a "You are powered by the model named ..." line for gateways that misreport the model name in API responses. The guard reads `agent.provider == "alibaba"`, which was correct when 2c06ec5f5 wrote it (the coding endpoint was reached through the `alibaba` provider with a base URL override), but went stale when `alibaba-coding-plan` became a first-class provider in 727d1088c. Since then, the very sessions the workaround was written for (see 2ea805430 / PR #2314) no longer match the check, while plain DashScope sessions, whose responses are fine, do.

This PR adds a `misreports_model_identity: bool = False` field to `ProviderProfile`, sets it on the bundled `alibaba` and `alibaba-coding-plan` profiles, and has `system_prompt.py` consult the profile instead of a hard-coded name. Behaviour for `alibaba` is unchanged; `alibaba-coding-plan` regains the injection; provider plugins whose gateways have the same behaviour (Alibaba's Token Plan gateways do) can opt in without a core edit, in line with the "widen the generic plugin surface, don't special-case it in core" guidance in AGENTS.md.

## Related Issue

Fixes #66134

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `providers/base.py`: new `misreports_model_identity: bool = False` field on `ProviderProfile`, documented beside the other identity fields
- `plugins/model-providers/alibaba/__init__.py`: set the flag (preserves current behaviour for `provider == "alibaba"`)
- `plugins/model-providers/alibaba-coding-plan/__init__.py`: set the flag (restores the workaround for Coding Plan sessions)
- `agent/system_prompt.py`: replace the `== "alibaba"` name check with a profile lookup via `get_provider_profile()`, guarded by try/except so an unknown or unset provider stays a no-op
- `tests/agent/test_system_prompt.py`: new `TestModelIdentityWorkaround` covering injected-for-`alibaba`, injected-for-`alibaba-coding-plan` (the regression case), absent-for-unflagged-provider, absent-for-unknown-provider

## How to Test

1. `scripts/run_tests.sh tests/agent/test_system_prompt.py tests/providers/` (133 tests, all passing, includes the four new tests)
2. `ruff check` on the five changed files passes
3. Manual: build the stable prompt parts for an agent with `provider="alibaba-coding-plan"` and check the identity line is present (absent on main)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the affected areas via the canonical runner (`scripts/run_tests.sh tests/agent/test_system_prompt.py tests/providers/`, 133 passed) plus `ruff`, rather than the entire tree, since the change is one guard in system_prompt.py plus a declarative profile field
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — the new field is documented inline in `providers/base.py` alongside the other profile fields, which is where the model-provider plugin guide points authors
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — N/A, no architecture change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — N/A, no tool behaviour change

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/agent/test_system_prompt.py tests/providers/
=== Summary: 7 files, 133 tests passed, 0 failed (100% complete) in 4.8s (8 workers) ===

$ ruff check providers/base.py agent/system_prompt.py plugins/model-providers/alibaba/__init__.py plugins/model-providers/alibaba-coding-plan/__init__.py tests/agent/test_system_prompt.py
All checks passed!
```

---

🤖 Generated with Claude Code (Claude Fable 5)
🧑‍💻 Ideated, directed and reviewed by a human, @oliver-mee
