### PR TITLE
fix(agent): keep MoA/local calls alive past heartbeat

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -201,6 +201,7 @@ def _codex_wait_notice_recovery(
     call_start: float,
     idle_enabled: bool,
     idle_timeout: float,
+    elapsed: float,
 ) -> str:
     """Describe the earliest enabled Codex watchdog on the call timeline."""
     deadlines: list[float] = []
@@ -211,7 +212,7 @@ def _codex_wait_notice_recovery(
             deadlines.append(ttfb_timeout)
     elif idle_enabled and math.isfinite(idle_timeout):
         deadlines.append(max(0.0, last_event_ts - call_start) + idle_timeout)
-    if not deadlines:
+    if not deadlines or min(deadlines) <= elapsed:
         return ""
     return f"; auto-reconnect at {int(min(deadlines))}s"
 
@@ -636,20 +637,26 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # usually a slow/overloaded provider, but the UI never said so).
         if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
             _elapsed = time.time() - _call_start
-            _recovery = _codex_wait_notice_recovery(
-                stale_timeout=_stale_timeout,
-                ttfb_enabled=_ttfb_enabled,
-                ttfb_timeout=_ttfb_timeout,
-                last_event_ts=getattr(agent, "_codex_stream_last_event_ts", None),
-                call_start=_call_start,
-                idle_enabled=_codex_idle_enabled,
-                idle_timeout=_codex_idle_timeout,
-            )
-            agent._emit_wait_notice(
-                f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
-                f"{int(_elapsed)}s with no response yet (provider may be slow "
-                f"or overloaded{_recovery})"
-            )
+            try:
+                _recovery = _codex_wait_notice_recovery(
+                    stale_timeout=_stale_timeout,
+                    ttfb_enabled=_ttfb_enabled,
+                    ttfb_timeout=_ttfb_timeout,
+                    last_event_ts=getattr(
+                        agent, "_codex_stream_last_event_ts", None
+                    ),
+                    call_start=_call_start,
+                    idle_enabled=_codex_idle_enabled,
+                    idle_timeout=_codex_idle_timeout,
+                    elapsed=_elapsed,
+                )
+                agent._emit_wait_notice(
+                    f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
+                    f"{int(_elapsed)}s with no response yet (provider may be slow "
+                    f"or overloaded{_recovery})"
+                )
+            except Exception:
+                logger.debug("wait-notice construction failed", exc_info=True)
 
         _elapsed = time.time() - _call_start
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -189,6 +190,30 @@ def _env_float(name: str, default: float) -> float:
         return float(os.getenv(name, str(default)))
     except (TypeError, ValueError):
         return default
+
+
+def _codex_wait_notice_recovery(
+    *,
+    stale_timeout: float,
+    ttfb_enabled: bool,
+    ttfb_timeout: float,
+    last_event_ts: Optional[float],
+    call_start: float,
+    idle_enabled: bool,
+    idle_timeout: float,
+) -> str:
+    """Describe the earliest enabled Codex watchdog on the call timeline."""
+    deadlines: list[float] = []
+    if math.isfinite(stale_timeout):
+        deadlines.append(stale_timeout)
+    if last_event_ts is None:
+        if ttfb_enabled and math.isfinite(ttfb_timeout):
+            deadlines.append(ttfb_timeout)
+    elif idle_enabled and math.isfinite(idle_timeout):
+        deadlines.append(max(0.0, last_event_ts - call_start) + idle_timeout)
+    if not deadlines:
+        return ""
+    return f"; auto-reconnect at {int(min(deadlines))}s"
 
 
 # ── Cross-turn stale-call circuit breaker (#58962) ─────────────────────
@@ -611,16 +636,19 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # usually a slow/overloaded provider, but the UI never said so).
         if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
             _elapsed = time.time() - _call_start
-            _deadline = _stale_timeout
-            if (
-                _ttfb_enabled
-                and getattr(agent, "_codex_stream_last_event_ts", None) is None
-            ):
-                _deadline = min(_deadline, _ttfb_timeout)
+            _recovery = _codex_wait_notice_recovery(
+                stale_timeout=_stale_timeout,
+                ttfb_enabled=_ttfb_enabled,
+                ttfb_timeout=_ttfb_timeout,
+                last_event_ts=getattr(agent, "_codex_stream_last_event_ts", None),
+                call_start=_call_start,
+                idle_enabled=_codex_idle_enabled,
+                idle_timeout=_codex_idle_timeout,
+            )
             agent._emit_wait_notice(
                 f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
                 f"{int(_elapsed)}s with no response yet (provider may be slow "
-                f"or overloaded; auto-reconnect at {int(_deadline)}s)"
+                f"or overloaded{_recovery})"
             )
 
         _elapsed = time.time() - _call_start

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "122438640+ragingbulld@users.noreply.github.com": "ragingbulld",  # PR #65606 salvage (non-finite API wait deadlines; #65746)
     "zzpigpinggai@users.noreply.github.com": "zzpigpinggai",  # PR #66017 salvage of #63617 (OpenRouter explicit-provider picker visibility)
     "sam7894604@gmail.com": "sam7894604",  # PR #55803 salvage (discord: /reasoning slash choices)
     "bryan@users.noreply.github.com": "hydraxman",  # PR #62028 salvage (copilot xhigh) — regression-test commit authored under a bare-noreply local git identity; PR author is @hydraxman

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -316,6 +316,24 @@ def test_event_idle_kills_after_first_event_then_silence(tmp_path, monkeypatch):
         stop["flag"] = True
 
 
+def test_wait_notice_handles_infinite_local_stale_timeout():
+    """After the first SSE event, a local endpoint's infinite wall-clock
+    timeout must not reach ``int()``; report the finite idle watchdog instead."""
+    from agent import chat_completion_helpers as h
+
+    recovery = h._codex_wait_notice_recovery(
+        stale_timeout=float("inf"),
+        ttfb_enabled=True,
+        ttfb_timeout=120.0,
+        last_event_ts=130.0,
+        call_start=100.0,
+        idle_enabled=True,
+        idle_timeout=60.0,
+    )
+
+    assert recovery == "; auto-reconnect at 90s"
+
+
 def test_ttfb_disabled_via_env_zero(tmp_path, monkeypatch):
     """Setting HERMES_CODEX_TTFB_TIMEOUT_SECONDS=0 disables the TTFB watchdog;
     a no-event stall then falls through to the (here, 60s) stale timeout, so a

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -329,9 +329,191 @@ def test_wait_notice_handles_infinite_local_stale_timeout():
         call_start=100.0,
         idle_enabled=True,
         idle_timeout=60.0,
+        elapsed=30.0,
     )
 
     assert recovery == "; auto-reconnect at 90s"
+
+
+def test_wait_notice_reports_ttfb_before_first_event():
+    """Before the first SSE event, the finite TTFB cutoff is the recovery."""
+    from agent import chat_completion_helpers as h
+
+    recovery = h._codex_wait_notice_recovery(
+        stale_timeout=float("inf"),
+        ttfb_enabled=True,
+        ttfb_timeout=120.0,
+        last_event_ts=None,
+        call_start=100.0,
+        idle_enabled=True,
+        idle_timeout=60.0,
+        elapsed=30.0,
+    )
+
+    assert recovery == "; auto-reconnect at 120s"
+
+
+@pytest.mark.parametrize(
+    "stale_timeout",
+    [float("inf"), float("-inf"), float("nan")],
+)
+def test_wait_notice_omits_reconnect_when_all_deadlines_are_non_finite(
+    stale_timeout,
+):
+    """A disabled watchdog must not be advertised as a future reconnect."""
+    from agent import chat_completion_helpers as h
+
+    recovery = h._codex_wait_notice_recovery(
+        stale_timeout=stale_timeout,
+        ttfb_enabled=False,
+        ttfb_timeout=float("nan"),
+        last_event_ts=None,
+        call_start=100.0,
+        idle_enabled=False,
+        idle_timeout=float("nan"),
+        elapsed=30.0,
+    )
+
+    assert recovery == ""
+
+
+def test_wait_notice_omits_elapsed_idle_deadline():
+    """An idle watchdog that already expired must not claim future recovery."""
+    from agent import chat_completion_helpers as h
+
+    recovery = h._codex_wait_notice_recovery(
+        stale_timeout=float("inf"),
+        ttfb_enabled=True,
+        ttfb_timeout=120.0,
+        last_event_ts=100.0,
+        call_start=100.0,
+        idle_enabled=True,
+        idle_timeout=30.0,
+        elapsed=60.0,
+    )
+
+    assert recovery == ""
+
+
+def test_wait_notice_does_not_skip_elapsed_stale_deadline_for_later_idle():
+    """An already-due watchdog wins; do not advertise a later deadline."""
+    from agent import chat_completion_helpers as h
+
+    recovery = h._codex_wait_notice_recovery(
+        stale_timeout=30.0,
+        ttfb_enabled=True,
+        ttfb_timeout=120.0,
+        last_event_ts=130.0,
+        call_start=100.0,
+        idle_enabled=True,
+        idle_timeout=60.0,
+        elapsed=60.0,
+    )
+
+    assert recovery == ""
+
+
+def test_moa_heartbeat_survives_infinite_stale_timeout(monkeypatch):
+    """The full 100-poll MoA heartbeat must leave a healthy call running."""
+    from agent import chat_completion_helpers as h
+
+    notices: list[str] = []
+    response = SimpleNamespace(ok=True)
+    agent = SimpleNamespace(
+        platform="desktop",
+        api_mode="chat_completions",
+        provider="moa",
+        _consecutive_stale_streams=0,
+        _interrupt_requested=False,
+        _compute_non_stream_stale_timeout=lambda _kwargs: float("inf"),
+        _touch_activity=lambda _message: None,
+        _emit_wait_notice=notices.append,
+    )
+
+    class HeartbeatThread:
+        """Keep the synthetic worker alive through one heartbeat."""
+
+        def __init__(self, *, target, daemon):
+            self._polls = 0
+            self._target = target
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+        def is_alive(self):
+            self._polls += 1
+            if self._polls == 101:
+                self._target()
+                return False
+            return True
+
+    monkeypatch.setattr(h.threading, "Thread", HeartbeatThread)
+    monkeypatch.setattr(
+        h,
+        "_dispatch_nonstreaming_api_request",
+        lambda *_args, **_kwargs: response,
+    )
+
+    result = h.interruptible_api_call(agent, {"model": "openai-xai-wide"})
+
+    assert result is response
+    assert len(notices) == 1
+    assert "waiting on openai-xai-wide" in notices[0]
+    assert "auto-reconnect" not in notices[0]
+
+
+def test_wait_notice_formatting_error_does_not_abort_request(monkeypatch):
+    """Status construction is fail-open even if its formatter breaks."""
+    from agent import chat_completion_helpers as h
+
+    response = SimpleNamespace(ok=True)
+    agent = SimpleNamespace(
+        platform="desktop",
+        api_mode="chat_completions",
+        provider="moa",
+        _consecutive_stale_streams=0,
+        _interrupt_requested=False,
+        _compute_non_stream_stale_timeout=lambda _kwargs: float("inf"),
+        _touch_activity=lambda _message: None,
+        _emit_wait_notice=lambda _message: None,
+    )
+
+    class HeartbeatThread:
+        def __init__(self, *, target, daemon):
+            self._polls = 0
+            self._target = target
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+        def is_alive(self):
+            self._polls += 1
+            if self._polls == 101:
+                self._target()
+                return False
+            return True
+
+    monkeypatch.setattr(h.threading, "Thread", HeartbeatThread)
+    monkeypatch.setattr(
+        h,
+        "_dispatch_nonstreaming_api_request",
+        lambda *_args, **_kwargs: response,
+    )
+    monkeypatch.setattr(
+        h,
+        "_codex_wait_notice_recovery",
+        lambda **_kwargs: (_ for _ in ()).throw(ValueError("bad display state")),
+    )
+
+    result = h.interruptible_api_call(agent, {"model": "openai-xai-wide"})
+
+    assert result is response
 
 
 def test_ttfb_disabled_via_env_zero(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
MoA and local non-streaming calls can now remain healthy past the 30-second status heartbeat without display formatting aborting the request.

The heartbeat previously converted an intentionally infinite local stale timeout with `int()`, raising `OverflowError` and sending a successful provider call into the retry loop.

## Changes
- Select the earliest applicable finite watchdog deadline on the request timeline.
- Omit the reconnect claim when no finite future recovery deadline exists.
- Keep the entire display-notice construction fail-open so formatter defects cannot trigger provider retries.
- Report the finite TTFB deadline before the first Codex event and the finite event-idle deadline afterward.
- Cover `inf`, `-inf`, `nan`, elapsed deadlines, and the full 100-poll MoA heartbeat path.
- Register @ragingbulld's contributor identity for release attribution.

This salvages #65606 by @ragingbulld. #64924 by @x7peeps identified the bug first; #65594 by @AntonIXO supplied the first full-heartbeat regression shape. Related overlapping fixes: #65759 and #66050.

## Validation
| | Before | After |
|---|---|---|
| MoA/local call after heartbeat | `OverflowError` then provider retries | Status emitted; healthy call completes |
| No finite watchdog | False reconnect deadline or crash | Reconnect suffix omitted |
| Codex watchdog | Generic stale deadline | Earliest applicable finite future cutoff |
| Targeted tests | Regression reproduced | 26 passed |

Real-import E2E constructed `AIAgent(provider="moa", base_url="moa://local")`, confirmed its computed stale timeout is infinite, drove the complete 100-poll heartbeat, and received the synthetic provider response without an exception or reconnect claim.

Fixes #65746.

## Infographic

![Long local calls stay alive](https://v3b.fal.media/files/b/0aa294c9/_2ueK7NMVuXsECCZgifcW_vR5ZoRCw.png)
