### PR TITLE
fix(simplex): batch multi-attachment sends into one event instead of interrupting the run

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -34,9 +34,17 @@ Optional environment variables:
     SIMPLEX_HOME_CHANNEL_NAME  Human label for the home channel
     HERMES_SIMPLEX_TEXT_BATCH_DELAY
                                Quiet-period seconds (default: 0.8) used to
-                               concatenate rapid-fire inbound text messages
-                               into a single MessageEvent — same pattern as
-                               Telegram's text batching.
+                               combine rapid-fire inbound messages into a
+                               single MessageEvent — same pattern as
+                               Telegram's batching.
+
+Optional ``config.yaml`` settings (``platforms.simplex.extra``):
+    media_batch_delay          Quiet-period seconds for batches containing
+                               media (default: the text batch delay). The
+                               attachments of one send arrive as separate
+                               chat items; widen this if their transfers
+                               routinely finish further apart than the
+                               default window.
 
 The ``websockets`` Python package is imported lazily — the plugin is
 discoverable and ``hermes setup`` can describe it even when websockets is
@@ -77,6 +85,10 @@ WS_RETRY_DELAY_INITIAL = 2.0
 WS_RETRY_DELAY_MAX = 60.0
 HEALTH_CHECK_INTERVAL = 30.0
 HEALTH_CHECK_STALE_THRESHOLD = 300.0
+# Longest a message batch is held open waiting for sibling file transfers
+# to finish downloading, so one stalled XFTP transfer can't hold a chat's
+# messages hostage indefinitely.
+MEDIA_BATCH_MAX_HOLD = 60.0
 
 # Correlation ID prefix for requests we send so we can ignore our own echoes.
 _CORR_PREFIX = "hermes-"
@@ -128,6 +140,17 @@ def _is_image_ext(ext: str) -> bool:
 
 def _is_audio_ext(ext: str) -> bool:
     return ext.lower() in {".mp3", ".wav", ".ogg", ".m4a", ".aac", ".opus"}
+
+
+def _message_type_for_media(media_types: List[str]) -> MessageType:
+    """Classify accumulated media using the same priority as one message."""
+    if any(mt.startswith("audio/") for mt in media_types):
+        return MessageType.VOICE
+    if any(mt.startswith("image/") for mt in media_types):
+        return MessageType.PHOTO
+    if media_types:
+        return MessageType.DOCUMENT
+    return MessageType.TEXT
 
 
 # ---------------------------------------------------------------------------
@@ -182,6 +205,12 @@ class SimplexAdapter(BasePlatformAdapter):
         # when a newChatItems event carries an unfinished rcvFileTransfer,
         # consumed when the file finishes downloading.
         self._pending_file_transfers: Dict[int, dict] = {}
+        # Batch key of the chat each pending transfer belongs to (parallel to
+        # ``_pending_file_transfers``). Multi-attachment sends deliver their
+        # chat items together but the downloads complete serially, often
+        # further apart than the batch quiet period — the batcher uses this
+        # map to hold a flush while siblings are still on the wire.
+        self._pending_transfer_batch_keys: Dict[int, str] = {}
 
         # Correlation tracking for ``_send_command``. Separate from
         # ``_pending_corr_ids`` (which is the upstream cosmetic echo filter)
@@ -189,13 +218,23 @@ class SimplexAdapter(BasePlatformAdapter):
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._corr_counter = 0
 
-        # Text message batching — concatenate rapid-fire messages into one
-        # event before dispatching, mirroring Telegram's batching.
+        # Message batching — combine rapid-fire messages into one event before
+        # dispatching, mirroring Telegram's batching.
         self._text_batch_delay = float(
             os.getenv("HERMES_SIMPLEX_TEXT_BATCH_DELAY", "0.8")
         )
+        # XFTP completion timing varies and SimpleX exposes no album boundary,
+        # so a universally longer media delay would still be a guess while
+        # slowing every lone attachment. Preserve the existing default, but
+        # let platform config widen the media quiet period when transfers need it.
+        self._media_batch_delay = float(
+            extra.get("media_batch_delay", self._text_batch_delay)
+        )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        # When each held batch started waiting on pending transfers, for the
+        # MEDIA_BATCH_MAX_HOLD cutoff.
+        self._batch_hold_started: Dict[str, float] = {}
 
         logger.info(
             "SimpleX adapter initialized: url=%s auto_accept=%s groups=%s",
@@ -446,6 +485,7 @@ class SimplexAdapter(BasePlatformAdapter):
             file_id = file_info.get("fileId") if isinstance(file_info, dict) else None
             if file_id is not None and file_id in self._pending_file_transfers:
                 pending = self._pending_file_transfers.pop(file_id)
+                self._pending_transfer_batch_keys.pop(file_id, None)
                 file_source = file_info.get("fileSource", {}) or {}
                 file_path = (
                     file_source.get("filePath")
@@ -583,6 +623,9 @@ class SimplexAdapter(BasePlatformAdapter):
                     file_id,
                 )
                 self._pending_file_transfers[file_id] = chat_item
+                self._pending_transfer_batch_keys[file_id] = (
+                    f"{self.platform.value}:{chat_id}"
+                )
                 # Fire-and-forget: simplex-chat does not return a corrId reply
                 # for /freceive, so awaiting one would block the event loop.
                 await self._send_fire_and_forget(f"/freceive {file_id}")
@@ -618,18 +661,9 @@ class SimplexAdapter(BasePlatformAdapter):
             user_name=sender_name or sender_id,
         )
 
-        # Message type
-        msg_type = MessageType.TEXT
-        if media_types:
-            if any(mt.startswith("audio/") for mt in media_types):
-                msg_type = MessageType.VOICE
-            elif any(mt.startswith("image/") for mt in media_types):
-                msg_type = MessageType.PHOTO
-            else:
-                # Catch-all: non-image/non-audio files (tagged
-                # application/octet-stream above) are documents so run.py's
-                # document-context injection surfaces the file to the agent.
-                msg_type = MessageType.DOCUMENT
+        # Catch-all media types are documents so run.py's document-context
+        # injection surfaces non-image/non-audio files to the agent.
+        msg_type = _message_type_for_media(media_types)
 
         # Timestamp
         ts_str = meta.get("itemTs") or meta.get("createdAt", "")
@@ -658,28 +692,32 @@ class SimplexAdapter(BasePlatformAdapter):
             (text or "")[:50],
         )
 
-        # Batch consecutive text messages so the agent sees one combined
-        # message instead of dropping earlier ones when the user pastes
-        # several lines in quick succession.
-        if msg_type == MessageType.TEXT and text:
+        # Batch consecutive messages so rapid text sends and SimpleX's
+        # separately delivered media items reach the agent as one event.
+        if (msg_type == MessageType.TEXT and text) or msg_type in {
+            MessageType.PHOTO,
+            MessageType.DOCUMENT,
+            MessageType.VOICE,
+        }:
             self._enqueue_text_event(msg_event)
         else:
             await self.handle_message(msg_event)
 
     # ------------------------------------------------------------------
-    # Text message batching
+    # Message batching
     # ------------------------------------------------------------------
 
     def _text_batch_key(self, event: MessageEvent) -> str:
-        """Session-scoped key for text message batching."""
+        """Session-scoped key for inbound message batching."""
         return f"{event.source.platform.value}:{event.source.chat_id}"
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
-        """Buffer a text event and reset the flush timer."""
+        """Buffer an inbound event and reset the appropriate flush timer."""
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
         if existing is None:
             self._pending_text_batches[key] = event
+            existing = event
         else:
             if event.text:
                 existing.text = (
@@ -688,26 +726,47 @@ class SimplexAdapter(BasePlatformAdapter):
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
+            existing.message_type = _message_type_for_media(existing.media_types)
 
         prior_task = self._pending_text_batch_tasks.get(key)
         if prior_task and not prior_task.done():
             prior_task.cancel()
+        delay = (
+            self._media_batch_delay if existing.media_urls else self._text_batch_delay
+        )
         self._pending_text_batch_tasks[key] = asyncio.create_task(
-            self._flush_text_batch(key)
+            self._flush_text_batch(key, delay)
         )
 
-    async def _flush_text_batch(self, key: str) -> None:
-        """Wait for the quiet period then dispatch the aggregated text."""
+    async def _flush_text_batch(self, key: str, delay: float) -> None:
+        """Wait for the quiet period then dispatch the aggregated event."""
         current_task = asyncio.current_task()
         try:
-            await asyncio.sleep(self._text_batch_delay)
+            await asyncio.sleep(delay)
+            # A sibling attachment from the same send may still be
+            # downloading — the chat items arrive together, but XFTP
+            # completions land serially and regularly straddle the quiet
+            # period. Keep the batch open until the transfer finishes
+            # (its completion re-enters the batcher and resets the timer),
+            # bounded by MEDIA_BATCH_MAX_HOLD.
+            if key in self._pending_transfer_batch_keys.values():
+                started = self._batch_hold_started.setdefault(
+                    key, time.monotonic()
+                )
+                if time.monotonic() - started < MEDIA_BATCH_MAX_HOLD:
+                    self._pending_text_batch_tasks[key] = asyncio.create_task(
+                        self._flush_text_batch(key, delay)
+                    )
+                    return
             event = self._pending_text_batches.pop(key, None)
+            self._batch_hold_started.pop(key, None)
             if not event:
                 return
             logger.info(
-                "[SimpleX] Flushing text batch %s (%d chars)",
+                "[SimpleX] Flushing message batch %s (%d chars, %d media items)",
                 key,
                 len(event.text or ""),
+                len(event.media_urls),
             )
             await self.handle_message(event)
         finally:

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -402,7 +402,9 @@ def test_register_calls_register_platform():
 # Inbound attachment message type classification
 # ---------------------------------------------------------------------------
 
-def _make_file_chat_item(file_path: str, file_name: str) -> dict:
+def _make_file_chat_item(
+    file_path: str, file_name: str, *, file_id: int = 7, text: str = "here you go"
+) -> dict:
     """Minimal direct-chat rcvMsgContent item carrying a completed file."""
     return {
         "chatInfo": {
@@ -414,12 +416,30 @@ def _make_file_chat_item(file_path: str, file_name: str) -> dict:
             "meta": {"itemTs": "2026-01-01T00:00:00Z"},
             "content": {
                 "type": "rcvMsgContent",
-                "msgContent": {"type": "file", "text": "here you go"},
+                "msgContent": {"type": "file", "text": text},
             },
             "file": {
-                "fileId": 7,
+                "fileId": file_id,
                 "fileName": file_name,
                 "fileSource": {"filePath": file_path},
+            },
+        },
+    }
+
+
+def _make_text_chat_item(text: str) -> dict:
+    """Minimal direct-chat rcvMsgContent item carrying plain text."""
+    return {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 42, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemTs": "2026-01-01T00:00:00Z"},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "text", "text": text},
             },
         },
     }
@@ -432,7 +452,10 @@ async def test_document_file_sets_document_type():
     from gateway.config import PlatformConfig
     from gateway.platforms.base import MessageType
 
-    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"ws_url": "ws://localhost:5225", "media_batch_delay": 0.05},
+    )
     adapter = SimplexAdapter(cfg)
     dispatched = []
 
@@ -441,6 +464,7 @@ async def test_document_file_sets_document_type():
 
     adapter.handle_message = _capture
     await adapter._handle_chat_item(_make_file_chat_item("/tmp/report.pdf", "report.pdf"))
+    await asyncio.sleep(0.1)
 
     assert dispatched, "_handle_chat_item did not dispatch any event"
     assert dispatched[0].message_type == MessageType.DOCUMENT
@@ -455,7 +479,10 @@ async def test_image_file_still_sets_photo_type():
     from gateway.config import PlatformConfig
     from gateway.platforms.base import MessageType
 
-    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"ws_url": "ws://localhost:5225", "media_batch_delay": 0.05},
+    )
     adapter = SimplexAdapter(cfg)
     dispatched = []
 
@@ -464,6 +491,231 @@ async def test_image_file_still_sets_photo_type():
 
     adapter.handle_message = _capture
     await adapter._handle_chat_item(_make_file_chat_item("/tmp/pic.jpg", "pic.jpg"))
+    await asyncio.sleep(0.1)
 
     assert dispatched, "_handle_chat_item did not dispatch any event"
     assert dispatched[0].message_type == MessageType.PHOTO
+
+
+@pytest.mark.asyncio
+async def test_two_photos_within_batch_window_dispatch_as_one_event():
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"ws_url": "ws://localhost:5225", "media_batch_delay": 0.05},
+    )
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = _capture
+    await adapter._handle_chat_item(
+        _make_file_chat_item("/tmp/first.jpg", "first.jpg", file_id=7, text="")
+    )
+    await adapter._handle_chat_item(
+        _make_file_chat_item("/tmp/second.jpg", "second.jpg", file_id=8, text="")
+    )
+
+    assert dispatched == []
+    await asyncio.sleep(0.1)
+
+    assert len(dispatched) == 1
+    assert dispatched[0].message_type == MessageType.PHOTO
+    assert dispatched[0].media_urls == ["/tmp/first.jpg", "/tmp/second.jpg"]
+
+
+@pytest.mark.asyncio
+async def test_text_then_photo_batch_upgrades_message_type():
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"ws_url": "ws://localhost:5225", "media_batch_delay": 0.05},
+    )
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = _capture
+    await adapter._handle_chat_item(_make_text_chat_item("look at this"))
+    await adapter._handle_chat_item(
+        _make_file_chat_item("/tmp/photo.jpg", "photo.jpg", text="")
+    )
+    await asyncio.sleep(0.1)
+
+    assert len(dispatched) == 1
+    assert dispatched[0].text == "look at this"
+    assert dispatched[0].message_type == MessageType.PHOTO
+    assert dispatched[0].media_urls == ["/tmp/photo.jpg"]
+
+
+@pytest.mark.asyncio
+async def test_mixed_media_batch_uses_voice_photo_document_precedence():
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"ws_url": "ws://localhost:5225", "media_batch_delay": 0.05},
+    )
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = _capture
+    await adapter._handle_chat_item(
+        _make_file_chat_item("/tmp/report.pdf", "report.pdf", file_id=7, text="")
+    )
+    await adapter._handle_chat_item(
+        _make_file_chat_item("/tmp/photo.jpg", "photo.jpg", file_id=8, text="")
+    )
+    await adapter._handle_chat_item(
+        _make_file_chat_item("/tmp/note.ogg", "note.ogg", file_id=9, text="")
+    )
+    await asyncio.sleep(0.1)
+
+    assert len(dispatched) == 1
+    assert dispatched[0].message_type == MessageType.VOICE
+    assert dispatched[0].media_urls == [
+        "/tmp/report.pdf",
+        "/tmp/photo.jpg",
+        "/tmp/note.ogg",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_single_photo_dispatches_only_after_batch_window():
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"ws_url": "ws://localhost:5225", "media_batch_delay": 0.05},
+    )
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = _capture
+    await adapter._handle_chat_item(
+        _make_file_chat_item("/tmp/only.jpg", "only.jpg", text="")
+    )
+
+    assert dispatched == []
+    await asyncio.sleep(0.1)
+
+    assert len(dispatched) == 1
+    assert dispatched[0].message_type == MessageType.PHOTO
+    assert dispatched[0].media_urls == ["/tmp/only.jpg"]
+
+
+def _rcv_file_complete_event(file_path: str, file_name: str, file_id: int) -> dict:
+    """Daemon rcvFileComplete event for a previously deferred transfer."""
+    return {
+        "resp": {
+            "type": "rcvFileComplete",
+            "chatItem": _make_file_chat_item(
+                file_path, file_name, file_id=file_id, text=""
+            ),
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_batch_held_while_sibling_transfer_downloading():
+    """Multi-attachment sends deliver chat items together but downloads
+    complete serially, often further apart than the quiet period. The flush
+    must hold while a sibling transfer for the same chat is pending."""
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"ws_url": "ws://localhost:5225", "media_batch_delay": 0.05},
+    )
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    async def _no_send(command):
+        pass
+
+    adapter.handle_message = _capture
+    adapter._send_fire_and_forget = _no_send
+
+    # Two voice notes from one send arrive together, neither downloaded yet.
+    await adapter._handle_chat_item(
+        _make_file_chat_item("", "note1.ogg", file_id=31, text="")
+    )
+    await adapter._handle_chat_item(
+        _make_file_chat_item("", "note2.ogg", file_id=32, text="")
+    )
+
+    # First transfer completes; the second is still on the wire, so the
+    # batch must stay open well past the quiet period.
+    await adapter._handle_event(
+        _rcv_file_complete_event("/tmp/note1.ogg", "note1.ogg", 31)
+    )
+    await asyncio.sleep(0.12)
+    assert dispatched == []
+
+    await adapter._handle_event(
+        _rcv_file_complete_event("/tmp/note2.ogg", "note2.ogg", 32)
+    )
+    await asyncio.sleep(0.12)
+
+    assert len(dispatched) == 1
+    assert dispatched[0].message_type == MessageType.VOICE
+    assert dispatched[0].media_urls == ["/tmp/note1.ogg", "/tmp/note2.ogg"]
+
+
+@pytest.mark.asyncio
+async def test_batch_hold_capped_by_max_hold(monkeypatch):
+    """A transfer that never completes must not hold the batch hostage —
+    after MEDIA_BATCH_MAX_HOLD the batch flushes with what it has."""
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    monkeypatch.setattr(_simplex, "MEDIA_BATCH_MAX_HOLD", 0.0)
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"ws_url": "ws://localhost:5225", "media_batch_delay": 0.05},
+    )
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    async def _no_send(command):
+        pass
+
+    adapter.handle_message = _capture
+    adapter._send_fire_and_forget = _no_send
+
+    # A voice note that never finishes downloading...
+    await adapter._handle_chat_item(
+        _make_file_chat_item("", "stuck.ogg", file_id=41, text="")
+    )
+    # ...must not block an already-complete photo in the same chat.
+    await adapter._handle_chat_item(
+        _make_file_chat_item("/tmp/pic.jpg", "pic.jpg", file_id=42, text="")
+    )
+    await asyncio.sleep(0.12)
+
+    assert len(dispatched) == 1
+    assert dispatched[0].message_type == MessageType.PHOTO
+    assert dispatched[0].media_urls == ["/tmp/pic.jpg"]

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -60,6 +60,19 @@ SIMPLEX_HOME_CHANNEL=<contact-id>
 | `SIMPLEX_HOME_CHANNEL_NAME` | Optional | Human label for the home channel |
 | `HERMES_SIMPLEX_TEXT_BATCH_DELAY` | Optional | Quiet-period seconds (default: `0.8`) used to concatenate rapid-fire inbound text messages into one event |
 
+### Optional `config.yaml` settings (`platforms.simplex.extra`)
+
+| Setting | Description |
+|---|---|
+| `media_batch_delay` | Quiet-period seconds for batches containing media (default: the text batch delay). SimpleX has no album concept — the attachments of one send arrive as separate chat items, and the adapter batches them into a single message, holding the batch while sibling file transfers are still downloading. Widen this only if transfers routinely finish further apart than the default window. |
+
+```yaml
+platforms:
+  simplex:
+    extra:
+      media_batch_delay: 2.0
+```
+
 ## Find your contact ID or display name
 
 After starting the daemon, open a conversation with your agent contact. The numeric `contactId` appears in session logs. If you'd rather use the display name shown in the SimpleX UI, that works too — `SIMPLEX_ALLOWED_USERS` accepts either form.


### PR DESCRIPTION
## What does this PR do?

Stops a multi-attachment send from interrupting the agent's in-flight run. SimpleX has no album concept: sending 2+ images as one message from a phone client delivers each image as its own chat item with its own XFTP transfer. The adapter dispatched every non-text item immediately, so image 1 started an agent run and image 2 arrived seconds later into the busy session, with the default `busy_input_mode: interrupt`, the user gets "⚡ Interrupting current task. I'll respond to your message shortly." instead of one reply that saw both images.

The adapter already batches rapid-fire **text** through a quiet-period batcher (mirroring Telegram), and the batcher's merge path already merges `media_urls`/`media_types`; that branch was just unreachable, because the dispatch gate only routed `TEXT` events into it. 

This PR:

- **Widens the gate** so `PHOTO`/`DOCUMENT`/`VOICE` events flow through the same quiet-period batcher (a voice-note burst is the same shape as an image pair).
- **Fixes the merge path** to recompute `message_type` on every merge (`VOICE > PHOTO > DOCUMENT > TEXT`, the same priority used to classify a single message); previously a batch stayed stuck at the first event's type, so text-then-image would dispatch as `TEXT` and the gateway's media handling would never see the attachment.
- **Holds the flush while sibling transfers are downloading.** A quiet period alone is not enough: the chat items of one send arrive together (sub-second), but their XFTP downloads complete serially and regularly finish further apart than any sane quiet window. Since the adapter already tracks pending transfers, the flush now re-arms while a transfer for the same chat is still on the wire, bounded by a 60s cap so one stalled download can't hold the chat's messages hostage.
- Adds an optional `platforms.simplex.extra.media_batch_delay` (defaults to the existing text batch delay; no new env var, per `AGENTS.md`; behavioral settings live in `config.yaml`).

Verified end-to-end on a live deployment (Fedora, Hermes v0.18.0, simplex-chat v6.5.5, iOS client). 

Before (two images sent as one message split into two events and the second interrupted the run):

```
18:25:45,554 SimpleX: file 23 (IMG_....jpg) not yet received, accepting transfer
18:25:46,141 SimpleX: file 24 (IMG_..._1.jpg) not yet received, accepting transfer
18:25:48,812 [SimpleX] Flushing message batch simplex:4 (0 chars, 1 media items)
18:25:50,238 [SimpleX] Flushing message batch simplex:4 (0 chars, 1 media items)
```

(the two completions landed ~1.4s apart, outside any reasonable quiet window, which is why the pending-transfer hold exists rather than a bigger delay). 

After (one event carrying both images plus the caption, one agent reply, no interrupt):

```
08:23:40,760 SimpleX: file 25 (IMG_....jpg) not yet received, accepting transfer
08:23:41,459 SimpleX: file 26 (IMG_..._1.jpg) not yet received, accepting transfer
08:23:44,133 [SimpleX] Flushing message batch simplex:4 (31 chars, 2 media items)
08:23:44,245 inbound message: platform=simplex user=... chat=4 msg='...'
```

Note: on current `main`, inbound *images* reach the deferral path (and therefore the pending-transfer hold) only once the audio-only `/freceive` guard is generalized; #55180 / PR #55185, same dependency #59974 has. This fix stands alone for voice-note bursts and captioned sends, and composes with #55185 for the full multi-image flow. Telegram has the same class of bug on file (#53198, #31541); this is the SimpleX sibling. Also adjacent but orthogonal: #63163 changes the batch *key* (per-sender authorship in groups); this PR changes what the batch *accepts* (they compose).

## Related Issue

None found: I searched open/closed issues and PRs for `simplex image batch`, `simplex multiple images`, `simplex interrupt`, `album`, `simplex batching`; nearest matches are the Telegram analogs (#53198/#31541) and the complementary #55185. Root-cause analysis included above in lieu of a pre-filed issue; I am happy to split one out if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/simplex/adapter.py`: route `PHOTO`/`DOCUMENT`/`VOICE` through `_enqueue_text_event`; extract `_message_type_for_media()` and recompute the merged event's type on every merge; track the batch key of each pending transfer and hold `_flush_text_batch` while siblings are downloading (`MEDIA_BATCH_MAX_HOLD = 60s` cap); read `extra.media_batch_delay` (defaults to the text delay); generalize the flush log line; document the setting in a module-docstring `config.yaml` section.
- `tests/gateway/test_simplex_plugin.py`: six new tests: two photos in one window become one `PHOTO` event with both `media_urls`; text-then-image upgrades the merged type; mixed media resolves by `VOICE > PHOTO > DOCUMENT` precedence; a single image still dispatches after the window; the flush holds while a sibling transfer is pending (driven through the real `rcvFileComplete` path) and flushes both once it lands; the hold gives up at the cap. Config goes through `PlatformConfig(extra={"media_batch_delay": ...})`.
- `website/docs/user-guide/messaging/simplex.md`: document `platforms.simplex.extra.media_batch_delay` with a config example.

## How to Test

1. Pair a phone client with the bot, start an agent conversation.
2. Send 2+ images as a single message (optionally with a caption).
3. Without this patch: gateway logs two separate one-item flushes and the user gets "⚡ Interrupting current task…" and the run restarts against the second image alone. With this patch: one `Flushing message batch … (N chars, 2 media items)` line, one agent reply that references both images.
4. `scripts/run_tests.sh tests/gateway/test_simplex_plugin.py` (36 pass).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(simplex): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (open + closed; nearest are #55185  (the deferral guard this composes with) and the Telegram album fixes #53198/#31541)

## Infographic

<img width="1536" height="1024" alt="hermes-simplex-media-batching-pr-66141-v2" src="https://github.com/user-attachments/assets/62a00c89-ed90-46ad-8a98-3d430c964802" />
