### PR TITLE
fix(approval): detect MongoDB destructive operations in terminal commands

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -620,6 +620,15 @@ DANGEROUS_PATTERNS = [
     # *next* line to satisfy the negative lookahead, silently allowing DELETE without WHERE.
     (r'\bDELETE\s+FROM\b(?![^\n]*\bWHERE\b)', "SQL DELETE without WHERE"),
     (r'\bTRUNCATE\s+(TABLE)?\s*\w', "SQL TRUNCATE"),
+    # MongoDB destructive operations — .drop() deletes an entire collection
+    # and .drop_database() deletes all collections.  .delete_many({}) without
+    # a filter removes every document.  These are the NoSQL equivalent of
+    # DROP TABLE / TRUNCATE and should always require explicit user approval.
+    # Inspired by #66032: 1.17B documents lost when LLM-generated inline
+    # python3 -c script included collection.drop() alongside a read query.
+    (r'\.drop\s*\(\s*\)', "MongoDB collection drop"),
+    (r'\.drop_database\s*\(', "MongoDB database drop"),
+    (r'\.delete_many\s*\(\s*\{\s*\}\s*\)', "MongoDB delete_many with empty filter (drops all documents)"),
     (rf'>\s*{_SYSTEM_CONFIG_PATH}', "overwrite system config"),
     (r'\bsystemctl\s+(-[^\s]+\s+)*(stop|restart|disable|mask)\b', "stop/restart system service"),
     (r'\bkill\s+-9\s+-1\b', "kill all processes"),


### PR DESCRIPTION
## Summary

Add MongoDB-specific destructive operation patterns to `DANGEROUS_PATTERNS` in `tools/approval.py` so that inline `python3 -c` scripts containing `collection.drop()`, `drop_database()`, or `delete_many({})` trigger the approval gate with a specific warning before execution.

## Problem (Closes #66032)

An LLM-generated inline Python script included `collection.drop()` alongside a read-only `estimated_document_count()` call. The existing `python3 -c` pattern flags script execution generically, but does not inspect the script body for database-destructive operations. The user approved the generic "script execution" warning without realizing it contained a collection drop, resulting in 1.17B documents permanently lost.

## Fix

Three new patterns added to `DANGEROUS_PATTERNS` after the SQL patterns:

| Pattern | Matches | Description |
|---------|---------|-------------|
| `\.drop\s*\(\s*\)` | `collection.drop()`, `db[x].drop()` | MongoDB collection drop |
| `\.drop_database\s*\(` | `client.drop_database("db")` | MongoDB database drop |
| `\.delete_many\s*\(\s*\{\s*\}\s*\)` | `col.delete_many({})` | Bulk delete with empty filter |

These patterns fire even when embedded inside `python3 -c "..."` because the full command string is scanned. The user now sees a specific warning ("MongoDB collection drop") instead of the generic "script execution via -e/-c flag".

## Why `.delete_many({})` only

`delete_many({"status": "old"})` with a specific filter is a legitimate targeted operation. Only the empty-filter variant `delete_many({})` — which deletes every document in the collection — is flagged as dangerous.

## Testing

- `python3 -m py_compile tools/approval.py` passes
- Patterns verified against: `db[s].drop()`, `db.drop_database()`, `col.delete_many({})`, `db[s].estimated_document_count()` (not matched)