### PR TITLE
fix(update): snapshot all profiles before gateway restart

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8979,10 +8979,12 @@ def _run_pre_update_backup(args) -> Optional[str]:
     - ``off``   — nothing runs. Explicit user opt-out is honored fully.
     - ``quick`` (default) — profile-local state snapshots of critical small files
       (pairing JSONs, cron jobs, config, auth; see ``_QUICK_STATE_FILES``) for
-      the invoking profile and every other running profile whose gateway will
-      restart. Files over 1 GiB are skipped with a warning so a bloated state.db
-      can never stall the update (issues #15733, #34600 are the reason this
-      safety net exists).
+      the invoking profile and every registered profile. This intentionally
+      snapshots a superset of the later platform-specific gateway restart scope,
+      covering service-managed, manual, multiplex, and discovery-race cases.
+      Files over 1 GiB are skipped with a warning so a bloated state.db can never
+      stall the update (issues #15733, #34600 are the reason this safety net
+      exists).
     - ``full``  — the quick snapshot PLUS a full zip of HERMES_HOME under
       ``backups/`` (restorable via ``hermes import``; the #48200 wrong-path
       wipe is the reason this level exists).
@@ -9022,21 +9024,28 @@ def _run_pre_update_backup(args) -> Optional[str]:
                 print(f"◆ Pre-update snapshot: {snapshot_id}")
         except Exception as exc:
             # Never let an active-profile snapshot failure block the update or
-            # prevent snapshots for the other running profiles.
+            # prevent snapshots for the other registered profiles, but make the
+            # reduced rollback coverage explicit.
+            print(
+                "⚠ Pre-update snapshot failed [active profile]; "
+                "continuing update"
+            )
             logging.getLogger(__name__).debug("Pre-update snapshot failed: %s", exc)
 
         # The code checkout is shared across profiles and the update path later
-        # restarts every running gateway. Give each other running profile the
-        # same rollback point instead of snapshotting only the invoking profile.
+        # restarts gateways through several platform-specific discovery paths.
+        # Snapshot every registered profile as a safe superset so service-managed,
+        # manual, multiplex, and race-created restart targets are protected without
+        # duplicating that restart topology logic here.
         try:
             from hermes_constants import get_hermes_home
-            from hermes_cli.profiles import list_profiles
+            from hermes_cli.profiles import profiles_to_serve
 
             active_home = get_hermes_home().resolve()
-            for profile in list_profiles():
+            for profile_name, profile_path in profiles_to_serve(multiplex=True):
                 try:
-                    profile_home = profile.path.resolve()
-                    if not profile.gateway_running or profile_home == active_home:
+                    profile_home = profile_path.resolve()
+                    if profile_home == active_home:
                         continue
                     other_snapshot_id = create_quick_snapshot(
                         label="pre-update",
@@ -9046,18 +9055,27 @@ def _run_pre_update_backup(args) -> Optional[str]:
                     )
                     if other_snapshot_id:
                         print(
-                            f"◆ Pre-update snapshot [{profile.name}]: "
+                            f"◆ Pre-update snapshot [{profile_name}]: "
                             f"{other_snapshot_id}"
                         )
                 except Exception as exc:
+                    print(
+                        f"⚠ Pre-update snapshot failed [{profile_name}]; "
+                        "continuing update"
+                    )
                     logging.getLogger(__name__).debug(
                         "Pre-update snapshot failed for profile %s: %s",
-                        getattr(profile, "name", "<unknown>"),
+                        profile_name,
                         exc,
                     )
         except Exception as exc:
             # Preserve the existing best-effort contract: profile discovery
-            # failure must not block the update.
+            # failure must not block the update, but do not imply all profiles
+            # were protected when discovery failed.
+            print(
+                "⚠ Pre-update profile discovery failed; "
+                "other profiles may not have snapshots"
+            )
             logging.getLogger(__name__).debug(
                 "Pre-update snapshot discovery for other profiles failed: %s", exc
             )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8977,11 +8977,12 @@ def _run_pre_update_backup(args) -> Optional[str]:
     Single consolidated mechanism gated on ``updates.pre_update_backup``:
 
     - ``off``   — nothing runs. Explicit user opt-out is honored fully.
-    - ``quick`` (default) — a state snapshot of critical small files
-      (pairing JSONs, cron jobs, config, auth; see ``_QUICK_STATE_FILES``)
-      under ``state-snapshots/``. Files over 1 GiB are skipped with a
-      warning so a bloated state.db can never stall the update
-      (issues #15733, #34600 are the reason this safety net exists).
+    - ``quick`` (default) — profile-local state snapshots of critical small files
+      (pairing JSONs, cron jobs, config, auth; see ``_QUICK_STATE_FILES``) for
+      the invoking profile and every other running profile whose gateway will
+      restart. Files over 1 GiB are skipped with a warning so a bloated state.db
+      can never stall the update (issues #15733, #34600 are the reason this
+      safety net exists).
     - ``full``  — the quick snapshot PLUS a full zip of HERMES_HOME under
       ``backups/`` (restorable via ``hermes import``; the #48200 wrong-path
       wipe is the reason this level exists).
@@ -9006,17 +9007,60 @@ def _run_pre_update_backup(args) -> Optional[str]:
     snapshot_id = None
     try:
         from hermes_cli.backup import create_quick_snapshot
-
-        snapshot_id = create_quick_snapshot(
-            label="pre-update",
-            keep=_PRE_UPDATE_SNAPSHOT_KEEP,
-            max_file_size=_PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
-        )
-        if snapshot_id:
-            print(f"◆ Pre-update snapshot: {snapshot_id}")
     except Exception as exc:
-        # Never let a snapshot failure block an update.
-        logging.getLogger(__name__).debug("Pre-update snapshot failed: %s", exc)
+        logging.getLogger(__name__).debug(
+            "Could not load pre-update snapshot support: %s", exc
+        )
+    else:
+        try:
+            snapshot_id = create_quick_snapshot(
+                label="pre-update",
+                keep=_PRE_UPDATE_SNAPSHOT_KEEP,
+                max_file_size=_PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
+            )
+            if snapshot_id:
+                print(f"◆ Pre-update snapshot: {snapshot_id}")
+        except Exception as exc:
+            # Never let an active-profile snapshot failure block the update or
+            # prevent snapshots for the other running profiles.
+            logging.getLogger(__name__).debug("Pre-update snapshot failed: %s", exc)
+
+        # The code checkout is shared across profiles and the update path later
+        # restarts every running gateway. Give each other running profile the
+        # same rollback point instead of snapshotting only the invoking profile.
+        try:
+            from hermes_constants import get_hermes_home
+            from hermes_cli.profiles import list_profiles
+
+            active_home = get_hermes_home().resolve()
+            for profile in list_profiles():
+                try:
+                    profile_home = profile.path.resolve()
+                    if not profile.gateway_running or profile_home == active_home:
+                        continue
+                    other_snapshot_id = create_quick_snapshot(
+                        label="pre-update",
+                        hermes_home=profile_home,
+                        keep=_PRE_UPDATE_SNAPSHOT_KEEP,
+                        max_file_size=_PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
+                    )
+                    if other_snapshot_id:
+                        print(
+                            f"◆ Pre-update snapshot [{profile.name}]: "
+                            f"{other_snapshot_id}"
+                        )
+                except Exception as exc:
+                    logging.getLogger(__name__).debug(
+                        "Pre-update snapshot failed for profile %s: %s",
+                        getattr(profile, "name", "<unknown>"),
+                        exc,
+                    )
+        except Exception as exc:
+            # Preserve the existing best-effort contract: profile discovery
+            # failure must not block the update.
+            logging.getLogger(__name__).debug(
+                "Pre-update snapshot discovery for other profiles failed: %s", exc
+            )
 
     if mode != "full":
         if snapshot_id:

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -2114,26 +2114,23 @@ class TestRunPreUpdateBackup:
         assert "Pre-update snapshot" in out
         assert "Creating pre-update backup" not in out
         assert self._snaps(hermes_home)
+        assert self._snaps(hermes_home / "profiles" / "coder")
         assert not self._zips(hermes_home)
 
-    def test_snapshots_other_running_profiles_before_shared_update(
+    def test_snapshots_every_known_profile_before_shared_update(
         self, hermes_home, monkeypatch, capsys
     ):
-        """Every running profile restarted by an update gets its own snapshot."""
+        """Every registered profile gets a rollback point before shared update."""
         other_home = hermes_home / "profiles" / "coder"
-        other_profile = Namespace(
-            name="coder",
-            path=other_home,
-            gateway_running=True,
-        )
-        stopped_profile = Namespace(
-            name="stopped",
-            path=hermes_home / "profiles" / "stopped",
-            gateway_running=False,
-        )
+        stopped_home = hermes_home / "profiles" / "stopped"
+        stopped_home.mkdir()
+        (stopped_home / "config.yaml").write_text("model:\n  provider: stopped\n")
         monkeypatch.setattr(
-            "hermes_cli.profiles.list_profiles",
-            lambda: [other_profile, stopped_profile],
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex: [
+                ("coder", other_home),
+                ("stopped", stopped_home),
+            ],
         )
 
         from hermes_cli.main import _run_pre_update_backup
@@ -2144,11 +2141,12 @@ class TestRunPreUpdateBackup:
         assert snap_id is not None
         assert self._snaps(hermes_home)
         assert self._snaps(other_home)
-        assert not self._snaps(stopped_profile.path)
+        assert self._snaps(stopped_home)
         assert "coder" in out
+        assert "stopped" in out
 
     def test_secondary_snapshot_failure_does_not_skip_later_profiles(
-        self, hermes_home, monkeypatch
+        self, hermes_home, monkeypatch, capsys
     ):
         """A broken profile must not prevent snapshots for remaining gateways."""
         from hermes_cli import backup as backup_mod
@@ -2158,10 +2156,13 @@ class TestRunPreUpdateBackup:
         (bad_home / "config.yaml").write_text("model:\n  provider: broken\n")
         good_home = hermes_home / "profiles" / "coder"
         profiles = [
-            Namespace(name="broken", path=bad_home, gateway_running=True),
-            Namespace(name="coder", path=good_home, gateway_running=True),
+            ("broken", bad_home),
+            ("coder", good_home),
         ]
-        monkeypatch.setattr("hermes_cli.profiles.list_profiles", lambda: profiles)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex: profiles,
+        )
 
         real_create = backup_mod.create_quick_snapshot
 
@@ -2175,20 +2176,23 @@ class TestRunPreUpdateBackup:
         from hermes_cli.main import _run_pre_update_backup
 
         snap_id = _run_pre_update_backup(Namespace(no_backup=False, backup=False))
+        out = capsys.readouterr().out
 
         assert snap_id is not None
         assert self._snaps(good_home)
+        assert "broken" in out
+        assert "snapshot failed" in out.lower()
 
-    def test_active_snapshot_failure_does_not_skip_running_profiles(
-        self, hermes_home, monkeypatch
+    def test_active_snapshot_failure_does_not_skip_registered_profiles(
+        self, hermes_home, monkeypatch, capsys
     ):
-        """The active backup is isolated from backups for other gateways."""
+        """The active backup is isolated from backups for registered profiles."""
         from hermes_cli import backup as backup_mod
 
         other_home = hermes_home / "profiles" / "coder"
         monkeypatch.setattr(
-            "hermes_cli.profiles.list_profiles",
-            lambda: [Namespace(name="coder", path=other_home, gateway_running=True)],
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex: [("coder", other_home)],
         )
         real_create = backup_mod.create_quick_snapshot
 
@@ -2202,9 +2206,12 @@ class TestRunPreUpdateBackup:
         from hermes_cli.main import _run_pre_update_backup
 
         snap_id = _run_pre_update_backup(Namespace(no_backup=False, backup=False))
+        out = capsys.readouterr().out
 
         assert snap_id is None
         assert self._snaps(other_home)
+        assert "active profile" in out.lower()
+        assert "snapshot failed" in out.lower()
 
     def test_backup_flag_forces_full(self, hermes_home, capsys):
         """--backup forces the full zip (plus quick snapshot) for one run."""

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -2116,6 +2116,96 @@ class TestRunPreUpdateBackup:
         assert self._snaps(hermes_home)
         assert not self._zips(hermes_home)
 
+    def test_snapshots_other_running_profiles_before_shared_update(
+        self, hermes_home, monkeypatch, capsys
+    ):
+        """Every running profile restarted by an update gets its own snapshot."""
+        other_home = hermes_home / "profiles" / "coder"
+        other_profile = Namespace(
+            name="coder",
+            path=other_home,
+            gateway_running=True,
+        )
+        stopped_profile = Namespace(
+            name="stopped",
+            path=hermes_home / "profiles" / "stopped",
+            gateway_running=False,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [other_profile, stopped_profile],
+        )
+
+        from hermes_cli.main import _run_pre_update_backup
+
+        snap_id = _run_pre_update_backup(Namespace(no_backup=False, backup=False))
+        out = capsys.readouterr().out
+
+        assert snap_id is not None
+        assert self._snaps(hermes_home)
+        assert self._snaps(other_home)
+        assert not self._snaps(stopped_profile.path)
+        assert "coder" in out
+
+    def test_secondary_snapshot_failure_does_not_skip_later_profiles(
+        self, hermes_home, monkeypatch
+    ):
+        """A broken profile must not prevent snapshots for remaining gateways."""
+        from hermes_cli import backup as backup_mod
+
+        bad_home = hermes_home / "profiles" / "broken"
+        bad_home.mkdir()
+        (bad_home / "config.yaml").write_text("model:\n  provider: broken\n")
+        good_home = hermes_home / "profiles" / "coder"
+        profiles = [
+            Namespace(name="broken", path=bad_home, gateway_running=True),
+            Namespace(name="coder", path=good_home, gateway_running=True),
+        ]
+        monkeypatch.setattr("hermes_cli.profiles.list_profiles", lambda: profiles)
+
+        real_create = backup_mod.create_quick_snapshot
+
+        def flaky_create(*args, hermes_home=None, **kwargs):
+            if hermes_home == bad_home.resolve():
+                raise OSError("simulated snapshot failure")
+            return real_create(*args, hermes_home=hermes_home, **kwargs)
+
+        monkeypatch.setattr(backup_mod, "create_quick_snapshot", flaky_create)
+
+        from hermes_cli.main import _run_pre_update_backup
+
+        snap_id = _run_pre_update_backup(Namespace(no_backup=False, backup=False))
+
+        assert snap_id is not None
+        assert self._snaps(good_home)
+
+    def test_active_snapshot_failure_does_not_skip_running_profiles(
+        self, hermes_home, monkeypatch
+    ):
+        """The active backup is isolated from backups for other gateways."""
+        from hermes_cli import backup as backup_mod
+
+        other_home = hermes_home / "profiles" / "coder"
+        monkeypatch.setattr(
+            "hermes_cli.profiles.list_profiles",
+            lambda: [Namespace(name="coder", path=other_home, gateway_running=True)],
+        )
+        real_create = backup_mod.create_quick_snapshot
+
+        def active_fails(*args, hermes_home=None, **kwargs):
+            if hermes_home is None:
+                raise OSError("simulated active snapshot failure")
+            return real_create(*args, hermes_home=hermes_home, **kwargs)
+
+        monkeypatch.setattr(backup_mod, "create_quick_snapshot", active_fails)
+
+        from hermes_cli.main import _run_pre_update_backup
+
+        snap_id = _run_pre_update_backup(Namespace(no_backup=False, backup=False))
+
+        assert snap_id is None
+        assert self._snaps(other_home)
+
     def test_backup_flag_forces_full(self, hermes_home, capsys):
         """--backup forces the full zip (plus quick snapshot) for one run."""
         from hermes_cli.main import _run_pre_update_backup


### PR DESCRIPTION
## What does this PR do?

Makes the pre-update quick-snapshot scope safely cover the update restart scope in multi-profile installations.

`hermes update` previously snapshotted only the invoking profile because `_run_pre_update_backup()` called `create_quick_snapshot()` without an explicit profile home. The same update later restarts gateways through several platform-specific paths. Non-invoking profiles therefore had no contemporaneous rollback point.

This change keeps the invoking profile's existing snapshot/return behavior and snapshots every registered profile as a deliberate superset of the later restart scope. That avoids duplicating platform-specific systemd, launchd, manual, Windows, and multiplex discovery logic and closes discovery-race gaps. Snapshot failures remain best-effort and isolated, but are now surfaced to the operator so reduced rollback coverage is not silent.

## Related Issue

Fixes #66140

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`
  - Snapshot every registered profile before shared-code update/restart as a safe superset of restart targets.
  - Deduplicate the invoking profile by resolved profile path.
  - Isolate active and per-profile snapshot failures while preserving existing best-effort update semantics.
  - Surface snapshot/discovery failures to the operator and report each successful profile snapshot ID.
- `tests/hermes_cli/test_backup.py`
  - Reproduce the missing secondary-profile snapshot against real temporary profile files.
  - Verify registered profiles are protected regardless of their point-in-time `gateway_running` state.
  - Verify active or secondary snapshot failures do not skip remaining profiles and produce visible warnings.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_backup.py::TestRunPreUpdateBackup -q`.
2. Run `python -m pytest tests/hermes_cli/test_backup.py -q`.
3. Run `python -m pytest tests/hermes_cli/test_update_venv_health.py -q`.
4. In a multi-profile installation, run `hermes --profile <one-profile> update`; confirm every registered profile home receives a new `state-snapshots/*-pre-update/` directory before any gateway restart.

## Test Results

- `TestRunPreUpdateBackup`: 14 passed
- `tests/hermes_cli/test_backup.py`: 156 passed
- `tests/hermes_cli/test_update_venv_health.py`: 18 passed
- `tests/hermes_cli/test_profiles.py`: 155 passed
- Broad `scripts/run_tests.sh` smoke run: reached 6,414 passes before being stopped; the checkout/environment also reported 119 unrelated failures outside the changed backup/update modules, so the full-suite checkbox remains intentionally unchecked.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing issues and PRs for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for the bug fix
- [x] I've tested on Linux with profile-local temporary files and the project test suite

### Documentation & Housekeeping

- [x] Relevant function documentation was updated
- [x] `cli-config.yaml.example`: N/A, no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no architecture or workflow contract changed
- [x] Cross-platform impact considered: uses existing `pathlib`, profile discovery, and backup APIs
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Before the fix, the regression test failed because the secondary running profile had no snapshot:

```text
AssertionError: assert []
... self._snaps(other_home)
```

After the fix:

```text
14 passed in 0.32s
156 passed in 24.52s
18 passed in 0.22s
```
