### PR TITLE
fix(gateway): prune stored /v1/responses history images and stop post-compression history duplication

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -409,7 +409,16 @@ def conversation_history_after_compression(agent: Any, messages: list) -> Option
 
     A shallow copy is intentional: it captures the current compacted dict
     identities as history while allowing later same-turn appends to remain new.
+
+    Every ``_compress_context()`` call site in the codebase calls this
+    function right after, so it is also the single chokepoint for flagging
+    "this turn's in-memory history was rewritten by compression" — consumed
+    by ``agent/turn_finalizer.py`` (result dict) and, from there, by API
+    server callers (``gateway/platforms/api_server.py``) that must not
+    exact-prefix-match a pre-compression history against the post-compression
+    transcript. Reset at turn start in ``agent/turn_context.py``.
     """
+    agent._history_compressed_this_turn = True
     if bool(getattr(agent, "_last_compaction_in_place", False)):
         return list(messages)
     return None

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -212,6 +212,9 @@ def build_turn_context(
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
+    # Reset per-turn compression signal (set by
+    # conversation_history_after_compression() if this turn compresses).
+    agent._history_compressed_this_turn = False
     # Generate unique task_id if not provided to isolate VMs between tasks.
     effective_task_id = task_id or str(uuid.uuid4())
     agent._current_task_id = effective_task_id

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -435,6 +435,11 @@ def finalize_turn(
         "final_response": final_response,
         "last_reasoning": last_reasoning,
         "messages": messages,
+        # Signals to API server callers (gateway/platforms/api_server.py)
+        # that context compression rewrote the in-memory history mid-turn,
+        # so ``messages`` is not an extension of the pre-turn conversation
+        # history — see conversation_history_after_compression().
+        "history_compressed": bool(getattr(agent, "_history_compressed_this_turn", False)),
         "api_calls": api_call_count,
         "completed": completed,
         "turn_exit_reason": _turn_exit_reason,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -657,6 +657,28 @@ group_sessions_per_user: true
 # key (``extra.key`` / API_SERVER_KEY).
 
 # ─────────────────────────────────────────────────────────────────────────────
+# API Server — operational tuning
+# ─────────────────────────────────────────────────────────────────────────────
+# Bounds and cadence for the OpenAI-compatible API server
+# (gateway/platforms/api_server.py). Values shown are the built-in defaults.
+gateway:
+  api_server:
+    # Maximum number of agent runs the API server will service concurrently.
+    # Requests to /v1/chat/completions, /v1/responses, and /v1/runs that
+    # arrive while this many runs are already in flight are rejected with
+    # HTTP 429 + a Retry-After header, bounding CPU / memory /
+    # upstream-LLM-quota exhaustion from a request flood. Set to 0 to
+    # disable the cap entirely.
+    max_concurrent_runs: 10
+
+    # Number of newest image parts kept verbatim in stored /v1/responses
+    # conversation_history; older ones are replaced with a text placeholder
+    # before storage/re-send. Base64 images otherwise accumulate across a
+    # previous_response_id chain and get re-sent to the provider on every
+    # turn. -1 disables pruning, 0 strips every image.
+    max_history_images: 3
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Gateway Streaming
 # ─────────────────────────────────────────────────────────────────────────────
 # Stream tokens to messaging platforms in real-time. The bot sends a message

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -236,6 +236,71 @@ _TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
 _IMAGE_PART_TYPES = frozenset({"image_url", "input_image"})
 _FILE_PART_TYPES = frozenset({"file", "input_file"})
 
+# Superset of _IMAGE_PART_TYPES used for history pruning: stored conversation
+# history can also carry Anthropic-shape ``{"type": "image", ...}`` blocks
+# (see agent/message_sanitization.py's identical set), not just the
+# Chat-Completions/Responses spellings accepted on input.
+_HISTORY_IMAGE_PART_TYPES = _IMAGE_PART_TYPES | {"image"}
+
+_OLDER_IMAGE_PLACEHOLDER = {"type": "text", "text": "[older image omitted from context]"}
+
+
+def _prune_history_images(history: List[Dict[str, Any]], keep_last: int) -> List[Dict[str, Any]]:
+    """Replace all but the newest ``keep_last`` image parts in ``history`` with a text placeholder.
+
+    Images are counted across the whole history, oldest first, so the
+    ``keep_last`` most recent image parts (by position, not by message) survive
+    verbatim and everything older is replaced with a placeholder. Text parts
+    and plain-string message contents are untouched, and no message is ever
+    removed.
+
+    ``history`` and its message dicts are shared, live objects (loaded from
+    the response store / session state and reused across requests) — this
+    never mutates them. Only messages that actually lose an image part are
+    shallow-copied into the returned list; everything else is passed through
+    by reference.
+
+    ``keep_last == -1`` disables pruning (returns ``history`` unchanged).
+    ``keep_last == 0`` replaces every image part.
+    """
+    if keep_last == -1:
+        return history
+
+    total_images = 0
+    for msg in history:
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and str(part.get("type") or "").strip().lower() in _HISTORY_IMAGE_PART_TYPES:
+                    total_images += 1
+
+    to_drop = total_images - keep_last
+    if to_drop <= 0:
+        return history
+
+    dropped = 0
+    pruned_history: List[Dict[str, Any]] = []
+    for msg in history:
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if not isinstance(content, list) or dropped >= to_drop:
+            pruned_history.append(msg)
+            continue
+        new_parts = []
+        msg_changed = False
+        for part in content:
+            if (
+                dropped < to_drop
+                and isinstance(part, dict)
+                and str(part.get("type") or "").strip().lower() in _HISTORY_IMAGE_PART_TYPES
+            ):
+                dropped += 1
+                msg_changed = True
+                new_parts.append(dict(_OLDER_IMAGE_PLACEHOLDER))
+            else:
+                new_parts.append(part)
+        pruned_history.append({**msg, "content": new_parts} if msg_changed else msg)
+    return pruned_history
+
 
 def _normalize_multimodal_content(content: Any) -> Any:
     """Validate and normalize multimodal content for the API server.
@@ -991,6 +1056,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # the cap. Bounds CPU / memory / upstream-LLM-quota exhaustion
         # from a request flood (#7483).
         self._max_concurrent_runs: int = self._resolve_max_concurrent_runs()
+        # Newest image parts kept in stored /v1/responses conversation
+        # history; older ones are replaced with a text placeholder (#see
+        # gateway.api_server.max_history_images). Read once at construction —
+        # matches _max_concurrent_runs (a live server restart already picks
+        # up config changes on the next adapter init).
+        self._max_history_images: int = self._resolve_max_history_images()
         # Number of in-flight runs on the non-streaming chat/responses paths
         # (the /v1/runs path tracks its own in-flight set via
         # _active_run_tasks).
@@ -1119,6 +1190,28 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return default
         return max(0, value)
+
+    @staticmethod
+    def _resolve_max_history_images() -> int:
+        """Read the stored-history image cap from config.yaml.
+
+        gateway.api_server.max_history_images. Falls back to the default of 3
+        when unset or malformed. -1 disables pruning; 0 strips every image.
+        """
+        default = 3
+        try:
+            from hermes_cli.config import cfg_get, load_config
+
+            raw = cfg_get(
+                load_config(),
+                "gateway",
+                "api_server",
+                "max_history_images",
+                default=default,
+            )
+            return int(raw)
+        except Exception:
+            return default
 
     @staticmethod
     def _resolve_model_name(explicit: str) -> str:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3292,6 +3292,9 @@ class APIServerAdapter(BasePlatformAdapter):
             if conversation_history_snapshot is None:
                 conversation_history_snapshot = list(conversation_history)
                 conversation_history_snapshot.append({"role": "user", "content": user_message})
+            conversation_history_snapshot = _prune_history_images(
+                conversation_history_snapshot, self._max_history_images
+            )
             self._response_store.put(response_id, {
                 "response": response_env,
                 "conversation_history": conversation_history_snapshot,
@@ -3859,6 +3862,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if stored is None:
                 return web.json_response(_openai_error(f"Previous response not found: {previous_response_id}"), status=404)
             conversation_history = list(stored.get("conversation_history", []))
+            conversation_history = _prune_history_images(conversation_history, self._max_history_images)
             stored_session_id = stored.get("session_id")
             # If no instructions provided, carry forward from previous
             if instructions is None:
@@ -4040,6 +4044,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Store the complete response object for future chaining / GET retrieval
         if store:
+            full_history = _prune_history_images(full_history, self._max_history_images)
             self._response_store.put(response_id, {
                 "response": response_data,
                 "conversation_history": full_history,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4418,6 +4418,18 @@ class APIServerAdapter(BasePlatformAdapter):
         current_user = {"role": "user", "content": user_message}
         agent_messages = result.get("messages") if isinstance(result, dict) else None
 
+        # Mid-turn context compression rewrites the agent's in-memory history,
+        # so ``agent_messages`` is no longer an extension of ``prior`` — the
+        # exact-prefix match below fails and falls through to the append
+        # branch, duplicating the (uncompressed, full-size) prior history
+        # behind the already-compacted transcript. ``history_compressed`` is
+        # an explicit signal (set in agent/conversation_compression.py) that
+        # this happened: the agent transcript alone is the canonical
+        # post-compression history, so return it verbatim instead of guessing
+        # from a prefix comparison.
+        if result.get("history_compressed") and isinstance(agent_messages, list) and agent_messages:
+            return list(agent_messages)
+
         if isinstance(agent_messages, list) and agent_messages:
             turn_start = APIServerAdapter._response_messages_turn_start_index(
                 conversation_history,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3030,6 +3030,12 @@ DEFAULT_CONFIG = {
             # bounding CPU / memory / upstream-LLM-quota exhaustion from a
             # request flood. Set to 0 to disable the cap entirely.
             "max_concurrent_runs": 10,
+            # Number of newest image parts kept verbatim in stored
+            # /v1/responses conversation history; older ones are replaced with
+            # a text placeholder before storage/re-send. Base64 images
+            # otherwise accumulate across a chain and get re-sent every turn.
+            # -1 disables pruning, 0 strips every image.
+            "max_history_images": 3,
         },
     },
 

--- a/tests/gateway/test_api_server_history_pruning.py
+++ b/tests/gateway/test_api_server_history_pruning.py
@@ -1,0 +1,345 @@
+"""Tests for /v1/responses history image pruning and the compression-duplication fix.
+
+Covers:
+- ``_prune_history_images`` (pure function) — keeps the newest N image parts,
+  replaces older ones with a text placeholder, never mutates its input.
+- ``APIServerAdapter._resolve_max_history_images`` — config default/override/
+  garbage-fallback for ``gateway.api_server.max_history_images``.
+- Integration: pruning applied on the chain-load and store paths of
+  /v1/responses.
+- ``_build_response_conversation_history`` honoring ``result["history_compressed"]``
+  to avoid duplicating history when agent-side context compression rewrote the
+  in-memory transcript mid-turn.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _prune_history_images,
+    cors_middleware,
+    security_headers_middleware,
+)
+
+
+def _img(name: str) -> dict:
+    # A real-looking https URL: fixtures that flow through the HTTP endpoint
+    # hit ``_normalize_multimodal_content``'s URL-scheme validation, while
+    # fixtures injected straight into the response store don't care either
+    # way — so use one shape everywhere.
+    return {"type": "image_url", "image_url": {"url": f"https://example.com/{name}.png"}}
+
+
+def _text(text: str) -> dict:
+    return {"type": "text", "text": text}
+
+
+# ---------------------------------------------------------------------------
+# _prune_history_images
+# ---------------------------------------------------------------------------
+
+
+class TestPruneHistoryImages:
+    def _sample_history(self):
+        # 4 image parts total, oldest-to-newest: img1, img2, img3, img4.
+        return [
+            {"role": "user", "content": [_text("look"), _img("img1")]},
+            {"role": "assistant", "content": "ok, describing"},
+            {"role": "user", "content": [_img("img2"), _text("and this one")]},
+            {"role": "user", "content": [_img("img3")]},
+            {"role": "user", "content": [_img("img4"), _text("last one")]},
+        ]
+
+    def test_keeps_newest_n_replaces_older(self):
+        history = self._sample_history()
+        pruned = _prune_history_images(history, keep_last=3)
+
+        # img1 (oldest) is replaced; img2/img3/img4 survive verbatim.
+        assert pruned[0]["content"] == [_text("look"), {"type": "text", "text": "[older image omitted from context]"}]
+        assert pruned[2]["content"] == [_img("img2"), _text("and this one")]
+        assert pruned[3]["content"] == [_img("img3")]
+        assert pruned[4]["content"] == [_img("img4"), _text("last one")]
+
+    def test_text_and_string_content_preserved(self):
+        history = self._sample_history()
+        pruned = _prune_history_images(history, keep_last=3)
+
+        # Plain-string content untouched, and unmodified messages pass
+        # through by reference (not deep-copied).
+        assert pruned[1]["content"] == "ok, describing"
+        assert pruned[1] is history[1]
+
+    def test_no_messages_deleted(self):
+        history = self._sample_history()
+        pruned = _prune_history_images(history, keep_last=0)
+        assert len(pruned) == len(history)
+        assert [m["role"] for m in pruned] == [m["role"] for m in history]
+
+    def test_does_not_mutate_input_list_or_dicts(self):
+        history = self._sample_history()
+        original_first_content = list(history[0]["content"])
+        _prune_history_images(history, keep_last=0)
+        assert history[0]["content"] == original_first_content
+        assert history[0]["content"][1] == _img("img1")
+
+    def test_keep_last_negative_one_is_noop(self):
+        history = self._sample_history()
+        pruned = _prune_history_images(history, keep_last=-1)
+        assert pruned is history
+
+    def test_keep_last_zero_replaces_all_images(self):
+        history = self._sample_history()
+        pruned = _prune_history_images(history, keep_last=0)
+        placeholder = {"type": "text", "text": "[older image omitted from context]"}
+        assert pruned[0]["content"] == [_text("look"), placeholder]
+        assert pruned[2]["content"] == [placeholder, _text("and this one")]
+        assert pruned[3]["content"] == [placeholder]
+        assert pruned[4]["content"] == [placeholder, _text("last one")]
+
+    def test_history_with_no_images_returned_equivalent(self):
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": [_text("hi there")]},
+        ]
+        pruned = _prune_history_images(history, keep_last=3)
+        assert pruned == history
+
+    def test_keep_last_at_or_above_total_is_noop(self):
+        history = self._sample_history()
+        pruned = _prune_history_images(history, keep_last=4)
+        assert pruned == history
+
+    def test_anthropic_style_image_type_pruned(self):
+        # Stored history can carry Anthropic-shape "image" blocks, not just
+        # "image_url"/"input_image".
+        history = [
+            {"role": "user", "content": [{"type": "image", "source": {"type": "base64", "data": "AAAA"}}]},
+            {"role": "user", "content": [_img("img2")]},
+        ]
+        pruned = _prune_history_images(history, keep_last=1)
+        assert pruned[0]["content"] == [{"type": "text", "text": "[older image omitted from context]"}]
+        assert pruned[1]["content"] == [_img("img2")]
+
+
+# ---------------------------------------------------------------------------
+# gateway.api_server.max_history_images config resolution
+# ---------------------------------------------------------------------------
+
+
+class TestMaxHistoryImagesConfig:
+    def test_resolve_defaults_to_3_when_unset(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert APIServerAdapter._resolve_max_history_images() == 3
+
+    def test_resolve_reads_config_value(self):
+        cfg = {"gateway": {"api_server": {"max_history_images": 7}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert APIServerAdapter._resolve_max_history_images() == 7
+
+    def test_resolve_honors_disable_sentinel(self):
+        cfg = {"gateway": {"api_server": {"max_history_images": -1}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert APIServerAdapter._resolve_max_history_images() == -1
+
+    def test_resolve_garbage_falls_back_to_default(self):
+        cfg = {"gateway": {"api_server": {"max_history_images": "not-an-int"}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert APIServerAdapter._resolve_max_history_images() == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration: pruning applied on the /v1/responses chain-load/store paths
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/responses", adapter._handle_responses)
+    return app
+
+
+@pytest.fixture
+def adapter():
+    a = _make_adapter()
+    a._max_history_images = 3
+    return a
+
+
+class TestHistoryPruningIntegration:
+    @pytest.mark.asyncio
+    async def test_loaded_chain_history_passed_to_agent_is_pruned(self, adapter):
+        """Loading a previous_response_id chain prunes before it reaches _run_agent."""
+        stored_history = [
+            {"role": "user", "content": [_img("img1"), _text("first")]},
+            {"role": "user", "content": [_img("img2")]},
+            {"role": "user", "content": [_img("img3")]},
+            {"role": "user", "content": [_img("img4")]},
+        ]
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": stored_history,
+                "session_id": "s1",
+            },
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "one more",
+                        "previous_response_id": "resp_prev",
+                    },
+                )
+
+            assert resp.status == 200
+            passed_history = mock_run.call_args.kwargs["conversation_history"]
+            assert passed_history[0]["content"] == [
+                {"type": "text", "text": "[older image omitted from context]"},
+                _text("first"),
+            ]
+            assert passed_history[1]["content"] == [_img("img2")]
+            assert passed_history[2]["content"] == [_img("img3")]
+            assert passed_history[3]["content"] == [_img("img4")]
+            # Original stored row untouched.
+            assert adapter._response_store.get("resp_prev")["conversation_history"] == stored_history
+
+    @pytest.mark.asyncio
+    async def test_stored_history_after_call_is_pruned(self, adapter):
+        """The conversation_history written to the response store is pruned."""
+        agent_transcript = [
+            {"role": "user", "content": [_img("img1")]},
+            {"role": "assistant", "content": [_img("img2"), _text("described")]},
+            {"role": "user", "content": [_img("img3")]},
+            {"role": "assistant", "content": [_img("img4"), _text("described again")]},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "described again", "messages": agent_transcript, "api_calls": 1},
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": [{"role": "user", "content": [_img("img1")]}]},
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            stored = adapter._response_store.get(data["id"])
+            image_parts = [
+                part
+                for msg in stored["conversation_history"]
+                if isinstance(msg.get("content"), list)
+                for part in msg["content"]
+                if part.get("type") == "image_url"
+            ]
+            assert len(image_parts) == 3
+            assert stored["conversation_history"][0]["content"] == [
+                {"type": "text", "text": "[older image omitted from context]"}
+            ]
+
+
+# ---------------------------------------------------------------------------
+# Compression-duplication fix — _build_response_conversation_history
+# ---------------------------------------------------------------------------
+
+
+class TestBuildResponseConversationHistoryCompressionFlag:
+    def test_history_compressed_flag_returns_agent_transcript_verbatim(self):
+        """When compression rewrote history mid-turn, the agent transcript is
+        the canonical post-compression history — no prior-prefix duplication."""
+        prior = [
+            {"role": "user", "content": "turn1"},
+            {"role": "assistant", "content": "resp1"},
+        ]
+        # Compaction dropped the old turn entirely — no prefix relationship
+        # to `prior` at all.
+        agent_messages = [
+            {"role": "system", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "user", "content": "turn2"},
+            {"role": "assistant", "content": "resp2"},
+        ]
+        result = {"messages": agent_messages, "history_compressed": True}
+
+        out = APIServerAdapter._build_response_conversation_history(
+            prior, "turn2", result, "resp2"
+        )
+        assert out == agent_messages
+        assert out[: len(prior)] != prior
+
+    def test_no_flag_exact_prefix_uses_old_path(self):
+        """Regression: without the flag, exact-prefix match still short-circuits."""
+        prior = [{"role": "user", "content": "turn1"}]
+        agent_messages = prior + [
+            {"role": "user", "content": "turn2"},
+            {"role": "assistant", "content": "resp2"},
+        ]
+        result = {"messages": agent_messages}
+
+        out = APIServerAdapter._build_response_conversation_history(
+            prior, "turn2", result, "resp2"
+        )
+        assert out == agent_messages
+
+    def test_no_flag_suffix_shaped_result_uses_old_append_path(self):
+        """Regression: without the flag, a turn-suffix-only messages list still
+        gets appended behind prior + current_user (byte-identical to today)."""
+        prior = [{"role": "user", "content": "turn1"}]
+        agent_messages = [{"role": "assistant", "content": "resp2"}]
+        result = {"messages": agent_messages}
+
+        out = APIServerAdapter._build_response_conversation_history(
+            prior, "turn2", result, "resp2"
+        )
+        assert out == [
+            {"role": "user", "content": "turn1"},
+            {"role": "user", "content": "turn2"},
+            {"role": "assistant", "content": "resp2"},
+        ]
+
+    def test_flag_set_but_no_messages_falls_back_to_final_response_path(self):
+        """history_compressed=True with no agent transcript still falls back
+        to the final_response append path (flag alone isn't enough)."""
+        prior = [{"role": "user", "content": "turn1"}]
+        result = {"messages": [], "history_compressed": True}
+
+        out = APIServerAdapter._build_response_conversation_history(
+            prior, "turn2", result, "resp2"
+        )
+        assert out == [
+            {"role": "user", "content": "turn1"},
+            {"role": "user", "content": "turn2"},
+            {"role": "assistant", "content": "resp2"},
+        ]
+
+
+class TestConversationHistoryAfterCompressionSetsFlag:
+    def test_sets_history_compressed_this_turn(self):
+        from agent.conversation_compression import conversation_history_after_compression
+
+        agent = SimpleNamespace(_history_compressed_this_turn=False)
+        conversation_history_after_compression(agent, [{"role": "user", "content": "x"}])
+        assert agent._history_compressed_this_turn is True


### PR DESCRIPTION
## What does this PR do?

Fixes two compounding problems in `/v1/responses` `previous_response_id` chaining that make `response_store.db` and the per-turn provider payload grow without bound:

1. **Stored-history image pruning.** Every response row snapshots the full `conversation_history`; inline base64 images accumulate across a chain and are re-sent to the provider on every turn (measured on a real deployment: avg 1.6MB, max 3.9MB per row; a 100-row store at 1.1GB). `truncation: "auto"` is message-count-based and not image-aware. This PR replaces all but the newest N image parts with a text placeholder (`[older image omitted from context]`) at the four points where history is loaded/persisted, preserving text parts and never deleting messages. N is configurable via `gateway.api_server.max_history_images` (default 3; `-1` disables, `0` strips all).

2. **Post-compression history duplication.** When mid-turn context compression rewrites the in-memory history, `_response_messages_turn_start_index`'s exact-prefix match fails, so `_build_response_conversation_history` falls through to the append branch and stores the ORIGINAL uncompressed history with the compacted transcript appended after it. The stored chain therefore never advances to the compacted baseline — the next turn reloads the oversized history and compresses again, every turn. This PR adds an explicit `history_compressed` signal (set at the single chokepoint `conversation_history_after_compression()`, reset each turn in `build_turn_context()`, surfaced on the result dict in `finalize_turn()`); when set, the agent transcript is stored verbatim instead of prefix-guessing.

## Related Issue

Fixes #56895

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/api_server.py` — `_prune_history_images()` helper + `_HISTORY_IMAGE_PART_TYPES`; pruning applied at chain load (`_handle_responses` `previous_response_id` branch), non-stream store, and `_persist_response_snapshot` (single chokepoint covering all streaming snapshots); `history_compressed` consumption in `_build_response_conversation_history`
- `agent/conversation_compression.py` — set `_history_compressed_this_turn` in `conversation_history_after_compression()` (called by every `_compress_context()` site)
- `agent/turn_context.py` — per-turn flag reset
- `agent/turn_finalizer.py` — surface `history_compressed` on the result dict
- `hermes_cli/config.py` — `gateway.api_server.max_history_images` default (3)
- `cli-config.yaml.example` — document the `gateway.api_server` block (`max_concurrent_runs`, `max_history_images`)
- `tests/gateway/test_api_server_history_pruning.py` — 20 tests: helper semantics (keep-newest-N, placeholder, non-mutation, `-1`/`0` sentinels, Anthropic-shape `image` blocks), config resolution, load/store integration, compression-flag behavior and both legacy paths unchanged without the flag

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_api_server_history_pruning.py` — 20 passed
2. `scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_api_server_multimodal.py` — green except one pre-existing failure (`TestHealthDetailedEndpoint::test_health_detailed_returns_ok`), which fails identically on unmodified `upstream/main`
3. Reproduce #56895: chain `/v1/responses` turns past the compression threshold; before this PR the stored history re-grows and compresses every turn, after it the chain advances to the compacted baseline
4. Full suite via `scripts/run_tests.sh -j 4`: failure set is byte-identical between this branch and clean `upstream/main` (46 pre-existing failures in 17 files — voice_mode/lsp/verification/web_server/etc., none touching this change; verified by running the same file set on a clean `upstream/main` worktree)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the test suite — all tests pass except failures already present on unmodified `upstream/main` (details above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04 (Linux 5.15), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`cli-config.yaml.example`, config default comments)
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact — pure-Python list/dict handling, no platform-specific code
- [x] I've updated tool descriptions/schemas — N/A (no tool behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhkDXHyxb1cQodR83Z2uiq