### PR TITLE
fix(agent): break self-reinforcing trailing-artifact loop in assistant history

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1549,6 +1549,22 @@ def init_agent(
     # single turn; the runtime already executes such batches concurrently.
     agent._parallel_tool_call_guidance = bool(_agent_section.get("parallel_tool_call_guidance", True))
 
+    # Trailing-artifact scrub (self-reinforcing stray-token loop breaker).
+    # Read into plain attrs consumed by chat_completion_helpers._strip_trailing_artifact.
+    agent._strip_trailing_artifacts = bool(_agent_section.get("strip_trailing_artifacts", True))
+    try:
+        agent._trailing_artifact_max_len = int(_agent_section.get("trailing_artifact_max_len", 12))
+    except (TypeError, ValueError):
+        agent._trailing_artifact_max_len = 12
+    try:
+        agent._trailing_artifact_min_repeats = int(_agent_section.get("trailing_artifact_min_repeats", 2))
+    except (TypeError, ValueError):
+        agent._trailing_artifact_min_repeats = 2
+    try:
+        agent._trailing_artifact_window = int(_agent_section.get("trailing_artifact_window", 8))
+    except (TypeError, ValueError):
+        agent._trailing_artifact_window = 8
+
     # Local Python toolchain probe toggle.  Default True.  When False,
     # the probe is skipped entirely (no subprocess calls, no system-prompt
     # line).  Useful for users on exotic setups where the probe heuristics

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1238,6 +1238,113 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
 
 
 
+# Matches a trailing "isolated stray token" artifact: an optional run of
+# whitespace, then a short ASCII word, at the very end of the content. The
+# word must be bounded on the left by a newline or the start of the string —
+# a stray token the upstream appended as its own line/fragment, NOT a word
+# that ends a real sentence (those are preceded by a letter/space on the same
+# line, and usually terminated by punctuation).
+_TRAILING_ARTIFACT_RE = re.compile(r"(?:\n\s*|\A)\s*([A-Za-z][A-Za-z'-]*)\s*\Z")
+
+
+def _strip_trailing_artifact(agent, content: str) -> str:
+    """Remove a self-reinforcing trailing stray token from assistant content.
+
+    Upstream models occasionally emit a spurious isolated token at the very
+    end of a turn (observed: a bare ``course`` appended as ``…sentence.\\n\\ncourse``
+    or as the entire content of a tool-only turn). Because Hermes stores the
+    assistant output verbatim into conversation history, the model then sees
+    that token ending prior assistant turns and imitates itself, appending it
+    to every subsequent turn — a self-reinforcement loop (the effect is
+    documented in the repetition literature: the more times a fragment repeats
+    in context, the higher the probability of continuing it). Once the loop
+    locks in, it recurs deterministically on every turn and worsens as the
+    contaminated history grows; clearing the token from history breaks it.
+
+    We break the loop at the storage boundary (the same place ``_strip_think_blocks``
+    and secret redaction run) so a scrub here cleans every downstream consumer:
+    API replay, state.db, gateway delivery, compression, title generation.
+
+    Conservative by design — ALL of these must hold before we strip:
+      * The content ends with an isolated short ASCII word (``<= max_len``),
+        sitting on its own after a newline or being the entire content.
+      * That same word already ends at least ``min_repeats`` recent assistant
+        turns in the running history. A first, one-off occurrence is left
+        untouched (it might be a legitimate one-word reply); only a token that
+        has demonstrably begun repeating across turns — the signature of the
+        self-reinforcement loop — is removed. This history check is what keeps
+        the heuristic from eating real content.
+
+    Returns the content unchanged when the feature is disabled, the content
+    doesn't match, or the history check fails.
+    """
+    if not getattr(agent, "_strip_trailing_artifacts", True):
+        return content
+    if not isinstance(content, str) or not content:
+        return content
+
+    max_len = getattr(agent, "_trailing_artifact_max_len", 12)
+    min_repeats = getattr(agent, "_trailing_artifact_min_repeats", 2)
+    # Bounded window of recent assistant turns to inspect for the contiguous
+    # run. Must be >= min_repeats or the loop could never be confirmed.
+    window = max(getattr(agent, "_trailing_artifact_window", 8), min_repeats)
+
+    m = _TRAILING_ARTIFACT_RE.search(content)
+    if not m:
+        return content
+    token = m.group(1)
+    if len(token) > max_len:
+        return content
+    # The whole content being exactly the token is the strongest signal, but
+    # still require the history repetition check below to avoid eating a
+    # legitimate one-word answer ("Yes", "Done").
+
+    # Count how many of the MOST RECENT, CONTIGUOUS assistant turns already end
+    # with this same isolated token. Contiguity is the loop signature: a
+    # self-reinforcing artifact contaminates every turn from some point onward,
+    # so the recent assistant turns form an unbroken run of "…\n<token>". We
+    # walk assistant turns newest-first and STOP at the first one that does not
+    # end with this token — a break in the run means these are unrelated older
+    # occurrences (e.g. a legitimate one-word "Done" ten turns ago), not an
+    # active loop, and must not license stripping. We also cap the walk at a
+    # bounded window of recent assistant turns so a huge history can't be
+    # scanned in full and so detection stays local to the current run.
+    recent = getattr(agent, "_session_messages", None)
+    if not isinstance(recent, list):
+        return content
+    repeats = 0
+    assistant_turns_seen = 0
+    for prior in reversed(recent):
+        if not isinstance(prior, dict) or prior.get("role") != "assistant":
+            continue
+        prior_content = prior.get("content")
+        # A synthetic/scaffolding turn with no string content doesn't break the
+        # contiguous run (it isn't a real assistant reply) — skip it.
+        if not isinstance(prior_content, str) or not prior_content:
+            continue
+        assistant_turns_seen += 1
+        pm = _TRAILING_ARTIFACT_RE.search(prior_content)
+        if pm and pm.group(1) == token:
+            repeats += 1
+            if repeats >= min_repeats:
+                break
+        else:
+            # First recent assistant turn that does NOT end with this token —
+            # the contiguous run is broken, so there is no active loop.
+            break
+        # Bounded window: stop after inspecting at most window recent assistant
+        # turns even if every one matched (defensive cap; the break above
+        # normally ends the walk far sooner).
+        if assistant_turns_seen >= window:
+            break
+    if repeats < min_repeats:
+        return content
+
+    # Strip the matched trailing artifact (and any whitespace it sat on).
+    cleaned = content[: m.start()].rstrip()
+    return cleaned
+
+
 def build_assistant_message(agent, assistant_message, finish_reason: str) -> dict:
     """Build a normalized assistant message dict from an API response message.
 
@@ -1296,6 +1403,16 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # compression, title generation.
     if isinstance(_san_content, str) and _san_content:
         _san_content = agent._strip_think_blocks(_san_content).strip()
+
+    # Break the self-reinforcing trailing-artifact loop (e.g. a bare "course"
+    # the upstream appended, which the model then imitates from its own prior
+    # turns every subsequent turn). Only strips a short isolated trailing token
+    # that has already begun repeating across recent assistant turns; a one-off
+    # is left intact. Runs at the storage boundary so it also cleans the
+    # verbatim anthropic_content_blocks replay path below. See
+    # _strip_trailing_artifact.
+    if isinstance(_san_content, str) and _san_content:
+        _san_content = _strip_trailing_artifact(agent, _san_content)
 
     # Defence-in-depth: redact credentials (PATs, API keys, Bearer tokens)
     # from assistant content BEFORE the message enters conversation history.
@@ -1388,6 +1505,32 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # agent/transports/anthropic.py and agent/anthropic_adapter.py.
     ordered_blocks = getattr(assistant_message, "anthropic_content_blocks", None)
     if ordered_blocks:
+        # Keep the verbatim replay list in sync with the trailing-artifact
+        # scrub applied to _san_content above: if the last block is a plain
+        # text block, scrub the same self-reinforcing token from its text so
+        # the interleaved-thinking replay path can't resurrect it. Only text
+        # blocks are touched — thinking/signature/tool_use blocks are left
+        # byte-identical so signed-block replay stays valid.
+        try:
+            if isinstance(ordered_blocks, list) and ordered_blocks:
+                _last = ordered_blocks[-1]
+                if (
+                    isinstance(_last, dict)
+                    and _last.get("type") == "text"
+                    and isinstance(_last.get("text"), str)
+                    and _last["text"]
+                ):
+                    _scrubbed = _strip_trailing_artifact(agent, _last["text"])
+                    if _scrubbed != _last["text"]:
+                        # Copy-on-write: don't mutate the block dict shared with
+                        # the raw API response object.
+                        ordered_blocks = list(ordered_blocks)
+                        _new_last = dict(_last)
+                        _new_last["text"] = _scrubbed
+                        ordered_blocks[-1] = _new_last
+        except Exception:
+            # Never let scrubbing break message construction.
+            ordered_blocks = getattr(assistant_message, "anthropic_content_blocks", None)
         msg["anthropic_content_blocks"] = ordered_blocks
 
     # Codex Responses API: preserve encrypted reasoning items for

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1345,6 +1345,171 @@ def _strip_trailing_artifact(agent, content: str) -> str:
     return cleaned
 
 
+# Matches a "scratchpad marker" leading a line: a short word (ASCII or CJK)
+# immediately followed by a colon (ASCII ':' or fullwidth '：'). This is the
+# structural signature of a leaked internal-reasoning line — e.g. a model that
+# emits "count: <thought>" / "plan: <thought>" / "思考：<thought>" scratch lines
+# it was meant to keep private. The marker WORD is discovered dynamically from
+# the content; we never hard-code which word leaked, because a hallucinated
+# scratch marker can be ANY short word (see _strip_trailing_scratch_block).
+_SCRATCH_MARKER_RE = re.compile(
+    r"^\s*([A-Za-z][A-Za-z]{0,11}|[\u4e00-\u9fff]{1,6})[:：]"
+)
+
+
+def _scratch_block_marker(content: str):
+    """If ``content`` ENDS with a run of one or more non-blank lines that all
+    begin with the SAME scratch marker word, return that marker word (else None).
+
+    A "trailing scratch block" is the tail of the content where every non-blank
+    line starts with ``<marker>:`` for one fixed ``<marker>`` (blank lines inside
+    the run are tolerated and skipped). This is the sibling of the bare-token
+    artifact handled by :func:`_strip_trailing_artifact`: instead of a single
+    stray word, the upstream leaked a multi-line block of private reasoning at
+    the very end of the turn.
+
+    Returns ``(marker, block_start_index)`` where ``block_start_index`` is the
+    character offset of the first line of the block, so
+    ``content[:block_start_index].rstrip()`` removes the whole trailing block.
+    Returns ``None`` when the content does not end with such a block.
+    """
+    if not isinstance(content, str) or not content:
+        return None
+    lines = content.split("\n")
+    # Locate the last non-blank line — the block, if any, ends here.
+    last = None
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip():
+            last = i
+            break
+    if last is None:
+        return None
+    m = _SCRATCH_MARKER_RE.match(lines[last])
+    if not m:
+        return None
+    marker = m.group(1)
+    # Walk upward while each non-blank line carries the SAME marker; blank lines
+    # between marker lines are part of the block and skipped. Stop at the first
+    # non-blank line that is NOT a "<marker>:" line for this same marker — that
+    # is real content, and the block starts below it.
+    block_top = last
+    k = last
+    while k >= 0:
+        if not lines[k].strip():
+            k -= 1
+            continue
+        mm = _SCRATCH_MARKER_RE.match(lines[k])
+        if mm and mm.group(1) == marker:
+            block_top = k
+            k -= 1
+        else:
+            break
+    block_start_index = sum(len(l) + 1 for l in lines[:block_top])
+    return marker, block_start_index
+
+
+def _content_has_scratch_marker(content: str, marker: str) -> bool:
+    """True if ANY line of ``content`` begins with ``<marker>:`` (the given
+    scratch marker word).
+
+    Used only for the loop-detection gate. It counts marker occurrences
+    ANYWHERE in a prior turn — including turns where the scratch block sits mid
+    content followed by a normal closing sentence ("mixed" leaks) — because
+    those are equally evidence that the model is in a scratchpad-leaking state,
+    even though we only ever STRIP a trailing block (never mid-content text).
+    """
+    if not isinstance(content, str) or not content or not marker:
+        return False
+    for ln in content.split("\n"):
+        mm = _SCRATCH_MARKER_RE.match(ln)
+        if mm and mm.group(1) == marker:
+            return True
+    return False
+
+
+def _strip_trailing_scratch_block(agent, content: str) -> str:
+    """Remove a self-reinforcing trailing *scratch block* from assistant content.
+
+    Sibling of :func:`_strip_trailing_artifact`. Where that function handles a
+    single stray trailing word (``…sentence.\\n\\ncourse``), this one handles the
+    richer case observed in production: a model leaks a multi-line block of its
+    private reasoning at the very end of a turn — consecutive lines each led by a
+    short "scratch marker" and a colon, e.g.::
+
+        …real answer text.
+
+        count: I should check X before Y.
+        count: actually Z is simpler.
+        count 完.
+
+    Stored verbatim into history, the model then sees prior turns ending in
+    these ``count:`` lines and imitates itself, so the block recurs and the loop
+    locks in — the identical self-reinforcement dynamic documented on
+    :func:`_strip_trailing_artifact`, just with a block instead of a token.
+
+    The leaked marker word is NOT hard-coded: a hallucinated scratch marker can
+    be any short word (``count`` today, ``plan``/``note``/``思考`` tomorrow), so
+    the marker is discovered from the current content and then confirmed against
+    recent history. Conservative by design — ALL must hold before we strip:
+
+      * The content ENDS with a scratch block (a run of trailing lines all led
+        by one fixed ``<marker>:``). Mid-content marker lines are never removed,
+        so a legitimate closing sentence after the block is always preserved.
+      * That SAME marker already appears in at least ``min_repeats`` recent
+        assistant turns within a bounded window. A one-off block is left intact.
+        The gate counts a prior turn as evidence if the marker appears anywhere
+        in it (trailing OR mixed), because both signal the leaking state; but the
+        strip itself only ever touches the trailing block of the current turn.
+
+    Runs at the same storage boundary as ``_strip_trailing_artifact`` so one
+    scrub cleans every downstream consumer (API replay, state.db, gateway
+    delivery, compression, title generation). Returns the content unchanged when
+    the feature is disabled, there is no trailing block, or the gate fails.
+    """
+    if not getattr(agent, "_strip_trailing_artifacts", True):
+        return content
+    if not isinstance(content, str) or not content:
+        return content
+
+    min_repeats = getattr(agent, "_trailing_artifact_min_repeats", 2)
+    window = max(getattr(agent, "_trailing_artifact_window", 8), min_repeats)
+
+    found = _scratch_block_marker(content)
+    if not found:
+        return content
+    marker, block_start_index = found
+
+    # Loop gate: count recent assistant turns (newest-first, bounded window)
+    # that also carry this marker. Unlike the bare-token walk, we do NOT require
+    # strict contiguity — the leak is intermittent early on (it appears, then
+    # several clean turns, then returns), so a contiguity break would miss the
+    # loop before it locks in. A bounded windowed count keeps detection local
+    # while tolerating the gaps. A single occurrence (no priors) is left intact.
+    recent = getattr(agent, "_session_messages", None)
+    if not isinstance(recent, list):
+        return content
+    repeats = 0
+    assistant_turns_seen = 0
+    for prior in reversed(recent):
+        if not isinstance(prior, dict) or prior.get("role") != "assistant":
+            continue
+        prior_content = prior.get("content")
+        if not isinstance(prior_content, str) or not prior_content:
+            continue
+        assistant_turns_seen += 1
+        if assistant_turns_seen > window:
+            break
+        if _content_has_scratch_marker(prior_content, marker):
+            repeats += 1
+            if repeats >= min_repeats:
+                break
+    if repeats < min_repeats:
+        return content
+
+    # Strip the trailing scratch block (and any whitespace it sat on).
+    return content[:block_start_index].rstrip()
+
+
 def build_assistant_message(agent, assistant_message, finish_reason: str) -> dict:
     """Build a normalized assistant message dict from an API response message.
 
@@ -1413,6 +1578,13 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # _strip_trailing_artifact.
     if isinstance(_san_content, str) and _san_content:
         _san_content = _strip_trailing_artifact(agent, _san_content)
+
+    # Sibling scrub for the multi-line variant: a trailing block of leaked
+    # scratchpad lines (each led by the same "<marker>:") rather than a single
+    # stray word. Same self-reinforcement dynamic, same storage-boundary fix.
+    # See _strip_trailing_scratch_block.
+    if isinstance(_san_content, str) and _san_content:
+        _san_content = _strip_trailing_scratch_block(agent, _san_content)
 
     # Defence-in-depth: redact credentials (PATs, API keys, Bearer tokens)
     # from assistant content BEFORE the message enters conversation history.
@@ -1521,6 +1693,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
                     and _last["text"]
                 ):
                     _scrubbed = _strip_trailing_artifact(agent, _last["text"])
+                    _scrubbed = _strip_trailing_scratch_block(agent, _scrubbed)
                     if _scrubbed != _last["text"]:
                         # Copy-on-write: don't mutate the block dict shared with
                         # the raw API response object.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -660,6 +660,12 @@ def run_conversation(
     user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message
     messages = _ctx.messages
+    # Expose the running messages list to helpers that need recent history
+    # (e.g. build_assistant_message's trailing-artifact scrub reads recent
+    # assistant turn endings). The list is mutated in place throughout the
+    # loop, so this reference stays live; rollback/compression paths that
+    # rebind `messages` re-set this attr at their own sites.
+    agent._session_messages = messages
     conversation_history = _ctx.conversation_history
     active_system_prompt = _ctx.active_system_prompt
     effective_task_id = _ctx.effective_task_id
@@ -5480,7 +5486,20 @@ def run_conversation(
                     length_continue_retries = 0
                 
                 final_response = agent._strip_think_blocks(final_response).strip()
-                
+
+                # Break the self-reinforcing trailing-artifact loop on the
+                # USER-FACING response too, not just the persisted message. The
+                # scrub below runs inside _build_assistant_message (final_msg),
+                # but final_response is derived separately from raw provider
+                # content (plus any truncated-continuation prefix) and only had
+                # think blocks stripped — so without this the stray token would
+                # still be delivered/returned even while it's scrubbed from
+                # history. Running the identical scrub here keeps delivered and
+                # persisted text in agreement. Ordering: final_msg is not yet
+                # appended to `messages`, so the history window this reads is the
+                # same one _build_assistant_message sees just below.
+                final_response = agent._strip_trailing_artifact(final_response)
+
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
 
                 # Pop thinking-only prefill and empty-response retry

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5499,6 +5499,7 @@ def run_conversation(
                 # appended to `messages`, so the history window this reads is the
                 # same one _build_assistant_message sees just below.
                 final_response = agent._strip_trailing_artifact(final_response)
+                final_response = agent._strip_trailing_scratch_block(final_response)
 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1072,6 +1072,29 @@ DEFAULT_CONFIG = {
         # compounds over a long conversation.  Costs ~70 tokens in the cached
         # system prompt.  Set False to disable globally.
         "parallel_tool_call_guidance": True,
+        # Trailing-artifact scrub — breaks a self-reinforcing loop where an
+        # upstream model emits a spurious isolated token at the end of a turn
+        # (observed: a bare "course"), Hermes stores it verbatim in history,
+        # and the model then imitates its own prior turns and appends that
+        # token every subsequent turn. When enabled, a short isolated trailing
+        # token is stripped at the storage boundary ONLY once it has begun
+        # repeating across recent assistant turns (a one-off is left intact).
+        # Default True. Set False to disable.
+        "strip_trailing_artifacts": True,
+        # Max length (chars) of a trailing token eligible for the artifact
+        # scrub above. Longer trailing words are never touched.
+        "trailing_artifact_max_len": 12,
+        # How many recent assistant turns must already END with the same token
+        # before it is treated as a self-reinforcing artifact and stripped.
+        # Raising this makes the scrub more conservative (require more evidence
+        # of a loop before acting).
+        "trailing_artifact_min_repeats": 2,
+        # Bounded window of recent assistant turns inspected for the contiguous
+        # run of the trailing token. Detection walks assistant turns newest-first
+        # and stops at the first that does NOT end with the token (a break in the
+        # run = no active loop), so this is a defensive cap on how far back a
+        # huge history is scanned. Coerced up to at least min_repeats.
+        "trailing_artifact_window": 8,
         # Local-environment toolchain probe — surfaces Python/pip/uv/PEP-668
         # state in the system prompt when something non-default is detected
         # (e.g. python3 has no pip module, pip→python version mismatch, PEP

--- a/run_agent.py
+++ b/run_agent.py
@@ -5971,6 +5971,19 @@ class AIAgent:
         from agent.chat_completion_helpers import _strip_trailing_artifact
         return _strip_trailing_artifact(self, content)
 
+    def _strip_trailing_scratch_block(self, content: str) -> str:
+        """Forwarder — see ``agent.chat_completion_helpers._strip_trailing_scratch_block``.
+
+        Sibling of ``_strip_trailing_artifact`` for the multi-line variant: a
+        trailing block of leaked scratchpad lines (each led by the same
+        ``<marker>:``) rather than a single stray word. Exposed on the agent so
+        the conversation loop can run the identical scrub on the user-facing
+        ``final_response`` that ``build_assistant_message`` runs on the persisted
+        message, keeping delivered and stored text in agreement.
+        """
+        from agent.chat_completion_helpers import _strip_trailing_scratch_block
+        return _strip_trailing_scratch_block(self, content)
+
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5960,6 +5960,17 @@ class AIAgent:
         from agent.chat_completion_helpers import build_assistant_message
         return build_assistant_message(self, assistant_message, finish_reason)
 
+    def _strip_trailing_artifact(self, content: str) -> str:
+        """Forwarder — see ``agent.chat_completion_helpers._strip_trailing_artifact``.
+
+        Exposed on the agent so the conversation loop can run the same
+        self-reinforcing trailing-artifact scrub on the user-facing
+        ``final_response`` that ``build_assistant_message`` runs on the persisted
+        message, keeping delivered and stored text in agreement.
+        """
+        from agent.chat_completion_helpers import _strip_trailing_artifact
+        return _strip_trailing_artifact(self, content)
+
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2348,6 +2348,166 @@ class TestBuildAssistantMessage:
         assert result["content"] == ""
 
 
+class TestStripTrailingArtifact:
+    """Self-reinforcing trailing stray-token loop breaker (the "course" bug).
+
+    Ground truth: an upstream model appended a bare "course" at the end of a
+    turn, Hermes stored it verbatim, and the model then copied it from its own
+    prior turns every subsequent turn. The scrub removes such a token ONLY once
+    it has begun repeating across recent assistant turns.
+    """
+
+    def _contaminated_history(self, token="course", n=2):
+        return [
+            {"role": "user", "content": "do a thing"},
+            *[
+                {"role": "assistant", "content": f"Sure, doing thing {i}.\n\n{token}"}
+                for i in range(n)
+            ],
+        ]
+
+    def test_one_off_not_stripped(self, agent):
+        """A first, one-off trailing token (no repeats in history) is kept —
+        it might be a legitimate one-word reply, so require evidence of a loop."""
+        agent._session_messages = [{"role": "user", "content": "hi"}]
+        msg = _mock_assistant_msg(content="Here is the answer.\n\ncourse")
+        result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] == "Here is the answer.\n\ncourse"
+
+    def test_repeating_token_stripped(self, agent):
+        """Once the token already ends >= min_repeats recent assistant turns,
+        the new occurrence is stripped."""
+        agent._session_messages = self._contaminated_history(n=2)
+        msg = _mock_assistant_msg(content="I'll run the command.\n\ncourse")
+        result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] == "I'll run the command."
+
+    def test_bare_token_only_content_stripped(self, agent):
+        """A tool-only turn whose entire text content is the artifact token is
+        stripped to empty once the loop is established."""
+        agent._session_messages = self._contaminated_history(n=2)
+        msg = _mock_assistant_msg(content="course")
+        result = agent._build_assistant_message(msg, "tool_calls")
+        assert result["content"] == ""
+
+    def test_legitimate_trailing_word_not_stripped(self, agent):
+        """A normal sentence that happens to end in a real word (with the same
+        word NOT repeating as an isolated trailing token in history) is kept."""
+        agent._session_messages = [
+            {"role": "assistant", "content": "Let me explain the course."},
+            {"role": "assistant", "content": "This is the second course."},
+        ]
+        msg = _mock_assistant_msg(content="The main course is ready.")
+        result = agent._build_assistant_message(msg, "stop")
+        # "course." ends with punctuation on the same line as other words, so
+        # it is not an isolated trailing token and never matches.
+        assert result["content"] == "The main course is ready."
+
+    def test_long_trailing_word_not_stripped(self, agent):
+        """A trailing token longer than max_len is never stripped even if it
+        somehow repeats."""
+        long_tok = "x" * (agent._trailing_artifact_max_len + 5)
+        agent._session_messages = [
+            {"role": "assistant", "content": f"one\n\n{long_tok}"},
+            {"role": "assistant", "content": f"two\n\n{long_tok}"},
+        ]
+        msg = _mock_assistant_msg(content=f"three\n\n{long_tok}")
+        result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] == f"three\n\n{long_tok}"
+
+    def test_disabled_flag_is_noop(self, agent):
+        """With the feature disabled, even a clearly contaminated turn is kept."""
+        agent._strip_trailing_artifacts = False
+        agent._session_messages = self._contaminated_history(n=3)
+        msg = _mock_assistant_msg(content="Doing it.\n\ncourse")
+        result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] == "Doing it.\n\ncourse"
+
+    def test_different_trailing_token_not_stripped(self, agent):
+        """History repeats 'course' but the new turn ends in a different token —
+        no strip (the loop is token-specific)."""
+        agent._session_messages = self._contaminated_history(token="course", n=3)
+        msg = _mock_assistant_msg(content="All set.\n\nokay")
+        result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] == "All set.\n\nokay"
+
+    def test_anthropic_content_blocks_trailing_text_scrubbed(self, agent):
+        """When the interleaved-thinking verbatim replay path is active, the
+        trailing text block is scrubbed too so it can't resurrect the token —
+        but thinking/tool_use blocks are left untouched."""
+        agent._session_messages = self._contaminated_history(n=2)
+        blocks = [
+            {"type": "thinking", "thinking": "reason", "signature": "sig"},
+            {"type": "tool_use", "id": "t1", "name": "terminal", "input": {}},
+            {"type": "text", "text": "Running it.\n\ncourse"},
+        ]
+        msg = _mock_assistant_msg(content="Running it.\n\ncourse")
+        msg.anthropic_content_blocks = blocks
+        result = agent._build_assistant_message(msg, "tool_calls")
+        out_blocks = result["anthropic_content_blocks"]
+        # thinking + tool_use blocks byte-identical
+        assert out_blocks[0] == {"type": "thinking", "thinking": "reason", "signature": "sig"}
+        assert out_blocks[1] == {"type": "tool_use", "id": "t1", "name": "terminal", "input": {}}
+        # trailing text block scrubbed
+        assert out_blocks[2]["text"] == "Running it."
+        # original block dict not mutated (copy-on-write)
+        assert blocks[2]["text"] == "Running it.\n\ncourse"
+
+    def test_noncontiguous_historical_match_not_stripped(self, agent):
+        """Unrelated older occurrences that do NOT form a contiguous recent run
+        must not license a strip. Here two old turns ended with 'course', but a
+        normal reply since then broke the run — there is no active loop, so a
+        new turn ending in 'course' is left intact (guards teknium's concern
+        that scanning all earlier turns could delete legitimate content)."""
+        agent._session_messages = [
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "content": "First answer.\n\ncourse"},
+            {"role": "assistant", "content": "Second answer.\n\ncourse"},
+            # A normal reply since then breaks the contiguous run:
+            {"role": "assistant", "content": "A perfectly normal reply."},
+        ]
+        msg = _mock_assistant_msg(content="Latest answer.\n\ncourse")
+        result = agent._build_assistant_message(msg, "stop")
+        # The most recent assistant turn ends normally, so the run is broken and
+        # the two old matches must not count.
+        assert result["content"] == "Latest answer.\n\ncourse"
+
+    def test_bounded_window_does_not_scan_whole_history(self, agent):
+        """Only a bounded window of recent assistant turns is inspected. With a
+        small window and a fresh normal turn at the head, an old contiguous run
+        of the token deeper in history stays out of reach and is not counted."""
+        agent._trailing_artifact_window = 2
+        agent._session_messages = [
+            {"role": "assistant", "content": f"old {i}\n\ncourse"} for i in range(10)
+        ]
+        # Head (most recent) assistant turn is normal — breaks the run within
+        # the window immediately.
+        agent._session_messages.append({"role": "assistant", "content": "normal recent reply."})
+        msg = _mock_assistant_msg(content="new one\n\ncourse")
+        result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] == "new one\n\ncourse"
+
+    def test_delivered_final_response_matches_persisted(self, agent):
+        """End-to-end agreement: the user-facing final_response scrub and the
+        persisted-message scrub must produce the same text for the same history,
+        so the delivered response can't retain a token that was cleared from the
+        stored transcript (teknium's second concern). Models the conversation
+        loop: final_response is scrubbed via agent._strip_trailing_artifact and
+        the persisted message via _build_assistant_message on the same content
+        and history window."""
+        agent._session_messages = self._contaminated_history(n=2)
+        raw = "I'll run the command.\n\ncourse"
+
+        # Persisted path (build_assistant_message runs the scrub internally).
+        persisted = agent._build_assistant_message(_mock_assistant_msg(content=raw), "stop")["content"]
+        # Delivered path (conversation loop applies the identical scrub to the
+        # separately-derived final_response before returning/delivering it).
+        delivered = agent._strip_trailing_artifact(raw)
+
+        assert delivered == "I'll run the command."
+        assert delivered == persisted
+
+
 class TestFormatToolsForSystemMessage:
     def test_no_tools_returns_empty_array(self, agent):
         agent.tools = []

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2508,6 +2508,157 @@ class TestStripTrailingArtifact:
         assert delivered == persisted
 
 
+class TestStripTrailingScratchBlock:
+    """Sibling of the bare-token loop breaker for the multi-line variant: a
+    trailing block of leaked scratchpad lines (each led by the same
+    ``<marker>:``) rather than a single stray word.
+
+    Ground truth (production, session 20260720_221918_7f069b, claude-opus-4-8):
+    the model leaked its private ``count: …`` reasoning as trailing lines, stored
+    verbatim, then imitated itself so the block recurred and the loop locked in.
+    The leaked marker is discovered dynamically — it is NOT hard-coded to
+    ``count`` — because a hallucinated scratch marker can be any short word.
+    """
+
+    def _history(self, marker="count", n=2):
+        """A recent history where n assistant turns carry the given marker."""
+        return [
+            {"role": "user", "content": "do a thing"},
+            *[
+                {"role": "assistant", "content": f"Prior answer {i}.\n\n{marker}: private thought {i}."}
+                for i in range(n)
+            ],
+        ]
+
+    def test_trailing_block_stripped_once_loop_established(self, agent):
+        """A trailing scratch block is removed once the marker has begun
+        repeating across recent turns; the real answer text is preserved."""
+        agent._session_messages = self._history(n=2)
+        raw = "Here is the real answer.\n\ncount: I should double-check X.\ncount: actually Y is simpler."
+        result = agent._build_assistant_message(_mock_assistant_msg(content=raw), "stop")
+        assert result["content"] == "Here is the real answer."
+
+    def test_single_trailing_line_block_stripped(self, agent):
+        """The block can be a single trailing marker line (not only multi-line)."""
+        agent._session_messages = self._history(n=2)
+        raw = "Answer body.\n\ncount: one stray reasoning line."
+        result = agent._build_assistant_message(_mock_assistant_msg(content=raw), "stop")
+        assert result["content"] == "Answer body."
+
+    def test_one_off_block_not_stripped(self, agent):
+        """A first, one-off scratch block (no repetition in history) is left
+        intact — it might be legitimate content, and there is no active loop."""
+        agent._session_messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "A perfectly normal earlier reply."},
+        ]
+        raw = "The answer.\n\nnote: remember to test."
+        result = agent._build_assistant_message(_mock_assistant_msg(content=raw), "stop")
+        assert result["content"] == raw
+
+    def test_marker_is_dynamic_not_hardcoded(self, agent):
+        """The marker is discovered from the content — a hallucinated marker
+        other than 'count' (here 'plan') is handled identically."""
+        agent._session_messages = self._history(marker="plan", n=2)
+        raw = "Shipping it.\n\nplan: step one.\nplan: step two."
+        result = agent._build_assistant_message(_mock_assistant_msg(content=raw), "stop")
+        assert result["content"] == "Shipping it."
+
+    def test_cjk_marker_stripped(self, agent):
+        """A CJK scratch marker with a fullwidth colon is handled too."""
+        agent._session_messages = self._history(marker="思考", n=2)
+        raw = "结论在此。\n\n思考：先查 A。\n思考：再查 B。"
+        result = agent._build_assistant_message(_mock_assistant_msg(content=raw), "stop")
+        assert result["content"] == "结论在此。"
+
+    def test_mid_content_marker_line_kept(self, agent):
+        """CRITICAL C1 safety guarantee: a marker block that is NOT at the very
+        end (a normal sentence closes the turn after it) is left completely
+        untouched — we only ever strip a TRAILING block, never mid-content."""
+        agent._session_messages = self._history(n=3)
+        raw = "Analysis done.\n\ncount: check the suffix lineage.\n\n先并行查这三项。"
+        result = agent._build_assistant_message(_mock_assistant_msg(content=raw), "stop")
+        assert result["content"] == raw
+
+    def test_different_marker_not_counted(self, agent):
+        """History repeats 'count' but the new turn's trailing block uses a
+        different marker with no history of its own — the gate is marker-specific
+        (mirrors the bare-token behaviour), so it is left intact."""
+        agent._session_messages = self._history(marker="count", n=3)
+        raw = "All set.\n\nokay: this is different."
+        result = agent._build_assistant_message(_mock_assistant_msg(content=raw), "stop")
+        assert result["content"] == raw
+
+    def test_disabled_flag_is_noop(self, agent):
+        """With the shared feature flag disabled, even a contaminated turn is kept."""
+        agent._strip_trailing_artifacts = False
+        agent._session_messages = self._history(n=3)
+        raw = "Doing it.\n\ncount: leaked reasoning."
+        result = agent._build_assistant_message(_mock_assistant_msg(content=raw), "stop")
+        assert result["content"] == raw
+
+    def test_intermittent_history_still_detected(self, agent):
+        """Unlike the bare-token contiguous walk, the scratch gate tolerates gaps:
+        the leak is intermittent early on (block, then a few clean turns, then the
+        block returns). A clean turn between marker turns must NOT reset the gate,
+        as long as min_repeats marker turns fall within the bounded window."""
+        agent._session_messages = [
+            {"role": "assistant", "content": "one\n\ncount: a"},
+            {"role": "assistant", "content": "a perfectly clean intervening reply."},
+            {"role": "assistant", "content": "two\n\ncount: b"},
+        ]
+        raw = "three\n\ncount: c"
+        result = agent._build_assistant_message(_mock_assistant_msg(content=raw), "stop")
+        # Two 'count' turns within the window (gap tolerated) → loop confirmed.
+        assert result["content"] == "three"
+
+    def test_bounded_window_does_not_scan_whole_history(self, agent):
+        """Only a bounded window of recent assistant turns is inspected. With a
+        small window and clean recent turns at the head, an old run of the marker
+        deeper in history stays out of reach and must not license a strip."""
+        agent._trailing_artifact_window = 2
+        agent._session_messages = [
+            {"role": "assistant", "content": f"old {i}\n\ncount: x"} for i in range(10)
+        ]
+        agent._session_messages += [
+            {"role": "assistant", "content": "recent clean reply one."},
+            {"role": "assistant", "content": "recent clean reply two."},
+        ]
+        raw = "new\n\ncount: y"
+        result = agent._build_assistant_message(_mock_assistant_msg(content=raw), "stop")
+        assert result["content"] == raw
+
+    def test_anthropic_content_blocks_trailing_text_scrubbed(self, agent):
+        """The interleaved-thinking verbatim replay path scrubs the trailing text
+        block's scratch block too, leaving thinking/tool_use blocks byte-identical."""
+        agent._session_messages = self._history(n=2)
+        blocks = [
+            {"type": "thinking", "thinking": "reason", "signature": "sig"},
+            {"type": "tool_use", "id": "t1", "name": "terminal", "input": {}},
+            {"type": "text", "text": "Running it.\n\ncount: leaked."},
+        ]
+        msg = _mock_assistant_msg(content="Running it.\n\ncount: leaked.")
+        msg.anthropic_content_blocks = blocks
+        result = agent._build_assistant_message(msg, "tool_calls")
+        out_blocks = result["anthropic_content_blocks"]
+        assert out_blocks[0] == {"type": "thinking", "thinking": "reason", "signature": "sig"}
+        assert out_blocks[1] == {"type": "tool_use", "id": "t1", "name": "terminal", "input": {}}
+        assert out_blocks[2]["text"] == "Running it."
+        # original block dict not mutated (copy-on-write)
+        assert blocks[2]["text"] == "Running it.\n\ncount: leaked."
+
+    def test_delivered_final_response_matches_persisted(self, agent):
+        """The user-facing final_response scrub and the persisted-message scrub
+        produce the same text for the same history, so the delivered response
+        can't retain a scratch block that was cleared from the stored transcript."""
+        agent._session_messages = self._history(n=2)
+        raw = "The real answer.\n\ncount: leaked reasoning line."
+        persisted = agent._build_assistant_message(_mock_assistant_msg(content=raw), "stop")["content"]
+        delivered = agent._strip_trailing_scratch_block(raw)
+        assert delivered == "The real answer."
+        assert delivered == persisted
+
+
 class TestFormatToolsForSystemMessage:
     def test_no_tools_returns_empty_array(self, agent):
         agent.tools = []

--- a/tests/run_agent/test_trailing_artifact_e2e.py
+++ b/tests/run_agent/test_trailing_artifact_e2e.py
@@ -185,3 +185,124 @@ def test_e2e_disabled_flag_ships_artifact():
     persisted = _last_assistant(result["messages"])
     assert persisted is not None
     assert persisted["content"] == "Doing it.\n\ncourse"
+
+
+# ---------------------------------------------------------------------------
+# Scratch-block variant: a trailing block of leaked "<marker>:" reasoning lines
+# (rather than a single stray word). Same self-reinforcement loop, driven
+# through the real conversation loop. Ground truth: production session
+# 20260720_221918_7f069b (claude-opus-4-8) leaked repeating "count:" blocks.
+# ---------------------------------------------------------------------------
+
+
+def _scratch_contaminated_history(marker="count", n=2):
+    """n assistant turns each ending in a leaked scratch block, alternating with
+    user turns — the loop is already established when the current turn runs."""
+    msgs = []
+    for i in range(n):
+        msgs.append({"role": "user", "content": f"request {i}"})
+        msgs.append(
+            {"role": "assistant", "content": f"Handling step {i}.\n\n{marker}: private note {i}."}
+        )
+    return msgs
+
+
+def test_e2e_scratch_block_delivered_and_persisted_both_scrubbed_and_agree():
+    """Once the scratch-block loop is established, a new turn ending in a
+    trailing 'count:' block must ship clean to the user AND land clean in
+    history, and the two must be identical. Real conversation loop."""
+    agent = _make_agent(max_iterations=10)
+    raw = "Here is the real answer.\n\ncount: double-check X.\ncount: actually Y."
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content=raw, finish_reason="stop"),
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(
+            "do the thing",
+            conversation_history=_scratch_contaminated_history(n=2),
+        )
+
+    assert result["final_response"] == "Here is the real answer."
+    persisted = _last_assistant(result["messages"])
+    assert persisted is not None
+    assert persisted["content"] == "Here is the real answer."
+    assert result["final_response"] == persisted["content"]
+
+
+def test_e2e_scratch_block_one_off_delivered_intact():
+    """A one-off trailing scratch block with NO established loop is left intact
+    end-to-end (might be legitimate content)."""
+    agent = _make_agent(max_iterations=10)
+    raw = "Here is the answer.\n\nnote: remember to test."
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content=raw, finish_reason="stop"),
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("do the thing")  # no prior history
+
+    assert result["final_response"] == raw
+    persisted = _last_assistant(result["messages"])
+    assert persisted is not None
+    assert persisted["content"] == raw
+
+
+def test_e2e_scratch_block_mixed_closing_sentence_preserved():
+    """C1 safety guarantee end-to-end: when a normal sentence closes the turn
+    AFTER the scratch block (a 'mixed' leak), nothing is stripped — the block is
+    not trailing, so the closing sentence is never lost."""
+    agent = _make_agent(max_iterations=10)
+    raw = "Analysis done.\n\ncount: check the suffix.\n\n先并行查这三项。"
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content=raw, finish_reason="stop"),
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(
+            "do the thing",
+            conversation_history=_scratch_contaminated_history(n=3),
+        )
+
+    assert result["final_response"] == raw
+    persisted = _last_assistant(result["messages"])
+    assert persisted is not None
+    assert persisted["content"] == raw
+
+
+def test_e2e_scratch_block_disabled_flag_ships_block():
+    """With the feature disabled, an established scratch-block loop still ships
+    the block both delivered and persisted — proves the scrub is what removes it."""
+    agent = _make_agent(max_iterations=10)
+    agent._strip_trailing_artifacts = False
+    raw = "Doing it.\n\ncount: leaked reasoning."
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content=raw, finish_reason="stop"),
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(
+            "do the thing",
+            conversation_history=_scratch_contaminated_history(n=3),
+        )
+
+    assert result["final_response"] == raw
+    persisted = _last_assistant(result["messages"])
+    assert persisted is not None
+    assert persisted["content"] == raw

--- a/tests/run_agent/test_trailing_artifact_e2e.py
+++ b/tests/run_agent/test_trailing_artifact_e2e.py
@@ -1,0 +1,187 @@
+"""End-to-end tests for the self-reinforcing trailing-artifact scrub (#66150).
+
+These drive the real ``run_conversation`` loop (not just the pure
+``_strip_trailing_artifact`` helper), with a mocked OpenAI SDK returning a
+response that ends in the stray "course" token. They assert the invariant that
+matters in production: the token is gone from BOTH the user-facing
+``final_response`` (what the gateway/CLI delivers) AND the persisted assistant
+message in ``messages`` (what enters history and gets replayed), and that the
+two agree — which is exactly the second review point (delivered text was
+derived separately and previously kept the artifact even when history was
+cleaned).
+
+Mirrors the harness in tests/run_agent/test_turn_completion_explainer.py: we
+patch ``run_agent.OpenAI`` and drive ``agent.client``, so these pass
+identically in CI and locally.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent(max_iterations: int = 10, config: dict | None = None) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config or {}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=max_iterations,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent._fallback_chain = []
+    # Trailing-artifact scrub attrs (init reads these from config; the mocked
+    # load_config returns {} so set the shipped defaults explicitly).
+    agent._strip_trailing_artifacts = True
+    agent._trailing_artifact_max_len = 12
+    agent._trailing_artifact_min_repeats = 2
+    agent._trailing_artifact_window = 8
+    return agent
+
+
+def _contaminated_history(token="course", n=2):
+    """n assistant turns that each already end with the stray token, separated
+    by user turns — i.e. the self-reinforcement loop is already established when
+    the current turn runs. Uses realistic user/assistant alternation (real
+    conversations never place two assistant turns back-to-back; the loop's
+    'contiguous assistant turns' are adjacent in assistant-order but separated
+    by user turns in the raw list, which is exactly what the scrub walks)."""
+    msgs = []
+    for i in range(n):
+        msgs.append({"role": "user", "content": f"request {i}"})
+        msgs.append({"role": "assistant", "content": f"Handling step {i}.\n\n{token}"})
+    return msgs
+
+
+def _last_assistant(messages):
+    for m in reversed(messages):
+        if isinstance(m, dict) and m.get("role") == "assistant" and isinstance(m.get("content"), str):
+            return m
+    return None
+
+
+def test_e2e_delivered_and_persisted_both_scrubbed_and_agree():
+    """The whole point: once the loop is established, a new turn ending in the
+    stray token must ship clean to the user AND land clean in history, and the
+    two must be identical. Runs the real conversation loop."""
+    agent = _make_agent(max_iterations=10)
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="I'll run the command now.\n\ncourse", finish_reason="stop"),
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(
+            "do the thing",
+            conversation_history=_contaminated_history(n=2),
+        )
+
+    # Delivered (user-facing) text is scrubbed.
+    assert result["final_response"] == "I'll run the command now."
+    # Persisted assistant message (enters history / replay) is scrubbed too.
+    persisted = _last_assistant(result["messages"])
+    assert persisted is not None
+    assert persisted["content"] == "I'll run the command now."
+    # Delivered and persisted agree — no drift between what the user sees and
+    # what gets replayed on the next turn.
+    assert result["final_response"] == persisted["content"]
+
+
+def test_e2e_one_off_token_delivered_intact():
+    """A one-off trailing token with NO established loop in history is a
+    legitimate reply and must NOT be stripped — end-to-end, delivered intact."""
+    agent = _make_agent(max_iterations=10)
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="Here is the answer.\n\ncourse", finish_reason="stop"),
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("do the thing")  # no prior history
+
+    assert result["final_response"] == "Here is the answer.\n\ncourse"
+    persisted = _last_assistant(result["messages"])
+    assert persisted is not None
+    assert persisted["content"] == "Here is the answer.\n\ncourse"
+
+
+def test_e2e_noncontiguous_history_delivered_intact():
+    """Two old matching turns broken by a normal reply do NOT form an active
+    loop, so a new turn ending in the token ships intact — end-to-end guard for
+    the contiguity fix (unrelated historical matches must not delete content)."""
+    agent = _make_agent(max_iterations=10)
+    history = [
+        {"role": "user", "content": "start"},
+        {"role": "assistant", "content": "First.\n\ncourse"},
+        {"role": "user", "content": "next"},
+        {"role": "assistant", "content": "Second.\n\ncourse"},
+        {"role": "user", "content": "again"},
+        {"role": "assistant", "content": "A perfectly normal reply."},
+        {"role": "user", "content": "keep going"},
+    ]
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="Latest answer.\n\ncourse", finish_reason="stop"),
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("do the thing", conversation_history=history)
+
+    assert result["final_response"] == "Latest answer.\n\ncourse"
+    persisted = _last_assistant(result["messages"])
+    assert persisted is not None
+    assert persisted["content"] == "Latest answer.\n\ncourse"
+
+
+def test_e2e_disabled_flag_ships_artifact():
+    """With the feature disabled, an established loop still ships the token both
+    delivered and persisted — proves the scrub (not something else) is what
+    removes it in the enabled cases."""
+    agent = _make_agent(max_iterations=10)
+    agent._strip_trailing_artifacts = False
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="Doing it.\n\ncourse", finish_reason="stop"),
+    ]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(
+            "do the thing",
+            conversation_history=_contaminated_history(n=3),
+        )
+
+    assert result["final_response"] == "Doing it.\n\ncourse"
+    persisted = _last_assistant(result["messages"])
+    assert persisted is not None
+    assert persisted["content"] == "Doing it.\n\ncourse"


### PR DESCRIPTION
## Problem

An upstream model occasionally emits a spurious isolated token at the very end of a turn. Observed in production against a Claude model served through a gateway: a bare `course` appended as `…sentence.\n\ncourse`, or as the *entire* content of a tool-only turn.

Because Hermes stores assistant output verbatim into conversation history, the model then sees that token ending prior assistant turns and **imitates itself**, appending it to every subsequent turn. This is a self-reinforcement loop: once it locks in, it recurs deterministically on every turn and gets worse as the contaminated history grows.

The mechanism is documented in the repetition literature — Apple ML ["Learning to Break the Loop"](https://machinelearning.apple.com/research/analyzing-mitigating-repetitions) and [arXiv:2512.04419](https://arxiv.org/abs/2512.04419): *the more times a fragment repeats in context, the higher the probability of continuing to generate it.*

Decode-side mitigations (repetition penalty, DRY sampler) aren't available when the model is served through a gateway/provider you don't control. The one lever the agent framework does have is **not feeding the artifact back into context** — break the loop at the point where assistant output enters history.

### How it was root-caused

Captured the raw upstream SSE bytes before any client-side conversion: the stray `\n\ncourse` was present in the provider's own `text_delta` — so the framework was faithfully storing what the model produced. Walking the conversation history showed a first spontaneous occurrence, then every subsequent assistant turn ending in the same token. A control experiment (scrubbing the token from prior turns' history, everything else identical) dropped the recurrence rate from ~100% toward ~50% and produced fully clean turns — confirming the history contamination, not a conversion bug, drives it.

## Fix

At the storage boundary in `build_assistant_message()` — the same place `_strip_think_blocks` and secret redaction already run, so one scrub cleans every downstream consumer (API replay, `state.db`, gateway delivery, compression, title generation).

New `_strip_trailing_artifact()` is deliberately conservative. **All** must hold before it strips:

- content ends with an isolated short ASCII word (`<= max_len`), sitting on its own after a newline or being the entire content;
- that same word already ends `>= min_repeats` recent assistant turns in the running history. A one-off occurrence is left intact (it may be a legitimate one-word reply) — only a token that has **demonstrably begun repeating across turns** (the signature of the loop) is removed.

The history check is what keeps the heuristic from eating real content: a normal sentence that ends in a word (e.g. `The main course is ready.`) never matches, because the word is not isolated on its own line.

The scrub is also applied to the trailing `text` block of the interleaved-thinking verbatim replay path (`anthropic_content_blocks`), copy-on-write, leaving `thinking`/`signature`/`tool_use` blocks byte-identical so signed-block replay stays valid.

## Config (`agent.*`, default on)

| key | default | meaning |
|---|---|---|
| `strip_trailing_artifacts` | `true` | enable the scrub |
| `trailing_artifact_max_len` | `12` | max length of a trailing token eligible to strip |
| `trailing_artifact_min_repeats` | `2` | how many recent assistant turns must already end with the token before it's treated as a loop |

## Tests

`TestStripTrailingArtifact` (8 cases): one-off-kept, repeat-stripped, bare-token-stripped, legitimate-trailing-word-kept, long-word-kept, disabled-noop, different-token-kept, and the `anthropic_content_blocks` path (trailing text scrubbed, thinking/tool_use untouched, original block dict not mutated). Existing `TestBuildAssistantMessage` suite still green.
