### PR TITLE
fix(desktop): resolve plugin directory locally in remote mode

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8473,6 +8473,11 @@ function disposeTerminalSession(id) {
   return true
 }
 
+// Desktop plugins are renderer code loaded from this machine. Their directory
+// is therefore an Electron-owned runtime fact, independent of whichever local,
+// remote, or cloud backend the renderer is currently connected to.
+ipcMain.handle('hermes:plugins:dir', async () => path.join(HERMES_HOME, 'desktop-plugins'))
+
 ipcMain.handle('hermes:fs:readDir', async (_event, dirPath) => readDirForIpc(dirPath))
 
 ipcMain.handle('hermes:fs:gitRoot', async (_event, startPath) => gitRootForIpc(startPath))

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -104,6 +104,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   },
   revealLogs: () => ipcRenderer.invoke('hermes:logs:reveal'),
   getRecentLogs: () => ipcRenderer.invoke('hermes:logs:recent'),
+  getDesktopPluginsDir: () => ipcRenderer.invoke('hermes:plugins:dir'),
   readDir: dirPath => ipcRenderer.invoke('hermes:fs:readDir', dirPath),
   gitRoot: startPath => ipcRenderer.invoke('hermes:fs:gitRoot', startPath),
   revealPath: targetPath => ipcRenderer.invoke('hermes:fs:reveal', targetPath),

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -6,7 +6,6 @@ import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
 import { $pluginRecords, type PluginRecord, setPluginEnabled } from '@/contrib/plugins-store'
 import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
-import { getStatus } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Package } from '@/lib/icons'
@@ -22,10 +21,10 @@ function reveal(file: string) {
 
 async function revealPluginsDir() {
   try {
-    const { hermes_home } = await getStatus()
+    const pluginsDir = await window.hermesDesktop.getDesktopPluginsDir()
     // openDir (not reveal): the door often doesn't exist on first use, and
     // showItemInFolder on a missing path silently no-ops (esp. Windows).
-    const result = await window.hermesDesktop?.openDir?.(`${hermes_home}/desktop-plugins`)
+    const result = await window.hermesDesktop.openDir?.(pluginsDir)
 
     if (result && !result.ok) {
       notifyError(result.error ?? 'unknown error', 'Could not open the plugins folder')

--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { discoverRuntimePlugins } from './runtime-loader'
+
+describe('desktop runtime plugin discovery', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('scans the Electron-owned local plugin directory', async () => {
+    const getDesktopPluginsDir = vi.fn(async () => '/Users/test/.hermes/desktop-plugins')
+    const readDir = vi.fn(async () => ({ entries: [] }))
+
+    vi.stubGlobal('window', {
+      hermesDesktop: {
+        getDesktopPluginsDir,
+        readDir
+      }
+    })
+
+    await discoverRuntimePlugins()
+
+    expect(getDesktopPluginsDir).toHaveBeenCalledOnce()
+    expect(readDir).toHaveBeenCalledWith('/Users/test/.hermes/desktop-plugins')
+  })
+})

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -27,7 +27,6 @@
  * trust seam.
  */
 
-import { getStatus } from '@/hermes'
 import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
 import { notifyError } from '@/store/notifications'
 
@@ -246,8 +245,8 @@ async function scanDiskPlugins(): Promise<void> {
   scanning = true
 
   try {
-    const { hermes_home } = await getStatus()
-    const { entries } = await desktop.readDir(`${hermes_home}/desktop-plugins`)
+    const pluginsDir = await desktop.getDesktopPluginsDir()
+    const { entries } = await desktop.readDir(pluginsDir)
     const seen = new Set<string>()
 
     for (const dir of entries.filter(e => e.isDirectory)) {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -105,6 +105,7 @@ declare global {
       }
       revealLogs: () => Promise<{ ok: boolean; path: string; error?: string }>
       getRecentLogs: () => Promise<{ path: string; lines: string[] }>
+      getDesktopPluginsDir: () => Promise<string>
       readDir: (path: string) => Promise<HermesReadDirResult>
       gitRoot?: (path: string) => Promise<string | null>
       // Reveal a path in the OS file manager (Finder / Explorer).


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop runtime plugin discovery and the "Open plugins folder" action when Desktop is connected to an authenticated remote or cloud gateway.

`/api/status` intentionally withholds absolute host paths when `auth_required` is enabled because the endpoint is publicly reachable for liveness checks. The Desktop plugin loader nevertheless used `status.hermes_home` to construct a path for Electron's local filesystem bridge. In remote mode that field is absent, producing `undefined/desktop-plugins`; even if present, it would describe the backend host rather than the Desktop machine.

This change makes Electron authoritative for the local Desktop plugin directory. The renderer obtains `<local HERMES_HOME>/desktop-plugins` through a narrow typed IPC capability, independently of the active local, remote, or cloud backend.

## Related Issue

N/A — no matching open issue or PR was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `hermes:plugins:dir`, backed by Electron's process-local `HERMES_HOME`.
- Exposed the capability as typed `window.hermesDesktop.getDesktopPluginsDir()`.
- Updated disk plugin discovery and the plugins settings action to use the local Electron path.
- Added a behavior test proving discovery scans the Electron-owned directory.

## How to Test

1. Connect Hermes Desktop to a remote gateway whose public `/api/status` response omits `hermes_home`.
2. Open Settings → Plugins and click "Open plugins folder"; verify the local `<HERMES_HOME>/desktop-plugins` directory opens instead of reporting `mkdir 'undefined'`.
3. Put a valid `plugin.js` under that local directory and rescan; verify the plugin is discovered while the remote connection remains active.

Automated checks run:

- `npm run fix`
- `npm run typecheck`
- `npm run test:ui` — 172 files, 1344 tests passed
- `npm run test:desktop:platforms` — 42 files, 432 passed, 1 skipped
- `npm run build`

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] Python tests are N/A for this Desktop-only TypeScript/Electron change; the relevant Desktop suites pass.
- [x] I've added tests for my changes.
- [x] I've tested on macOS 26.5.2 (Apple silicon).

### Documentation & Housekeeping

- [x] Documentation update is N/A; this restores the existing documented Desktop plugin behavior.
- [x] `cli-config.yaml.example` update is N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered: the path is joined by Electron's platform-native `path.join` from the already resolved `HERMES_HOME`.
- [x] Tool description/schema updates are N/A.

## Screenshots / Logs

Before the fix, "Open plugins folder" in remote mode reports:

```text
Could not open the plugins folder
ENOENT: no such file or directory, mkdir 'undefined'
```
