### PR TITLE
fix(cli): scope TUI npm install check to ui-tui lockfile graph

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1462,6 +1462,99 @@ def _termux_workspace_install_context(
     return ws_root, tuple(workspace_args)
 
 
+def _lockfile_dep_names(entry: dict) -> set[str]:
+    """Package names declared as deps on a lockfile ``packages`` entry."""
+    names: set[str] = set()
+    for field in (
+        "dependencies",
+        "optionalDependencies",
+        "devDependencies",
+        "peerDependencies",
+    ):
+        block = entry.get(field)
+        if isinstance(block, dict):
+            names.update(str(k) for k in block.keys())
+    return names
+
+
+def _resolve_lockfile_package_key(
+    packages: dict, name: str, from_key: str = ""
+) -> str | None:
+    """Resolve *name* to a ``packages`` map key using npm-style node_modules walk.
+
+    Walks outward from *from_key* looking for nested
+    ``.../node_modules/<name>`` entries, then falls back to the workspace-root
+    ``node_modules/<name>``.
+    """
+    candidates: list[str] = []
+    if from_key:
+        base = from_key
+        while True:
+            candidates.append(f"{base}/node_modules/{name}")
+            if "/node_modules/" in base:
+                base = base.rsplit("/node_modules/", 1)[0]
+                continue
+            if "/" in base and not base.startswith("node_modules"):
+                parent = base.rsplit("/", 1)[0]
+                if parent and parent != base:
+                    base = parent
+                    continue
+            break
+    candidates.append(f"node_modules/{name}")
+    for candidate in candidates:
+        if candidate in packages:
+            return candidate
+    return None
+
+
+def _workspace_lockfile_package_closure(
+    packages: dict, root: Path, ws_root: Path
+) -> set[str] | None:
+    """Return lockfile package keys reachable from the *root* workspace only.
+
+    The TUI launch path runs ``npm install --workspace ui-tui`` (see
+    ``_make_tui_argv``) and never materialises other monorepo workspaces
+    (``web``, ``apps/desktop``, …) in ``node_modules/.package-lock.json``.
+    Comparing the entire root lockfile ``packages`` map against that marker
+    therefore treats hundreds of intentionally-uninstalled packages as
+    "missing" and forces a reinstall on every dashboard start (#66084).
+
+    Returns:
+      * a set of package keys to compare against the install marker, or
+      * ``None`` to fall back to full-lockfile comparison (standalone /
+        non-workspace layouts where *root* IS the workspace root).
+    """
+    if ws_root == root:
+        return None
+    try:
+        rel = root.resolve().relative_to(ws_root.resolve()).as_posix()
+    except ValueError:
+        return None
+    if not rel or rel == ".":
+        return None
+
+    seeds: list[str] = []
+    for key in packages:
+        if key == rel or key.startswith(f"{rel}/"):
+            seeds.append(key)
+    if not seeds:
+        return None
+
+    needed: set[str] = set(seeds)
+    queue = list(seeds)
+    while queue:
+        key = queue.pop()
+        entry = packages.get(key)
+        if not isinstance(entry, dict):
+            continue
+        for dep_name in _lockfile_dep_names(entry):
+            resolved = _resolve_lockfile_package_key(packages, dep_name, key)
+            if resolved and resolved not in needed:
+                needed.add(resolved)
+                queue.append(resolved)
+    return needed
+
+
 def _tui_need_npm_install(root: Path) -> bool:
     """True when @hermes/ink is missing or node_modules is behind package-lock.json.
 
@@ -1482,7 +1575,13 @@ def _tui_need_npm_install(root: Path) -> bool:
     already match, which used to trigger a spurious "Installing TUI
     dependencies" on every launch.
 
-    For each entry in the root lock's ``packages`` map:
+    When *root* is a workspace member (``ui-tui`` under a monorepo lockfile),
+    only packages reachable from that workspace's dependency graph are
+    compared.  Other monorepo workspaces (``web``, ``apps/desktop``, …) are
+    not installed by the TUI's ``--workspace ui-tui`` install and must not
+    force a reinstall (#66084).
+
+    For each compared entry in the root lock's ``packages`` map:
       - missing from hidden lock → reinstall (unless the entry is marked
         ``optional`` or ``peer``, which npm may intentionally skip per platform)
       - present but with differing fields (excluding npm-written runtime
@@ -1523,10 +1622,18 @@ def _tui_need_npm_install(root: Path) -> bool:
     def comparable(pkg: dict) -> dict:
         return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
 
-    for name, pkg in wanted.items():
+    scope = _workspace_lockfile_package_closure(wanted, root, ws_root)
+    names_to_check = (
+        (name for name in wanted if name in scope)
+        if scope is not None
+        else (name for name in wanted if name)
+    )
+
+    for name in names_to_check:
         if not name:
             continue
 
+        pkg = wanted.get(name)
         if not isinstance(pkg, dict):
             continue
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -604,3 +604,75 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     assert install_cmd[:2] == ["/bin/npm", "install"]
     # cwd must be tui_dir (standalone), not parent
     assert calls[0][1]["cwd"] == str(tui_dir)
+
+
+def test_workspace_scoped_lock_ignores_sibling_workspace_packages(
+    tmp_path: Path, main_mod
+) -> None:
+    """Monorepo root lock includes web/apps packages that --workspace ui-tui
+    never installs. Those missing entries must NOT force reinstall (#66084).
+    """
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text(
+        '{"name":"@hermes/tui","dependencies":{"ink":"1.0.0"}}'
+    )
+    (tmp_path / "package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"name":"@hermes/tui","dependencies":{"ink":"1.0.0"}},'
+        '"node_modules/ink":{"version":"1.0.0"},'
+        '"web":{"name":"web","dependencies":{"@codemirror/view":"1.0.0"}},'
+        '"node_modules/@codemirror/view":{"version":"1.0.0"},'
+        '"apps/desktop":{"name":"desktop","dependencies":{"electron":"1.0.0"}},'
+        '"node_modules/electron":{"version":"1.0.0"}'
+        "}}"
+    )
+    # Hidden lock only has what a workspace-scoped install would materialize.
+    _touch_ink(tmp_path)
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"name":"@hermes/tui","dependencies":{"ink":"1.0.0"}},'
+        '"node_modules/ink":{"version":"1.0.0"}'
+        "}}"
+    )
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_workspace_scoped_lock_still_detects_missing_tui_dep(
+    tmp_path: Path, main_mod
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    (tmp_path / "package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"name":"@hermes/tui","dependencies":{"ink":"1.0.0","react":"1.0.0"}},'
+        '"node_modules/ink":{"version":"1.0.0"},'
+        '"node_modules/react":{"version":"1.0.0"},'
+        '"web":{"name":"web","dependencies":{"@codemirror/view":"1.0.0"}},'
+        '"node_modules/@codemirror/view":{"version":"1.0.0"}'
+        "}}"
+    )
+    _touch_ink(tmp_path)
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{'
+        '"ui-tui":{"name":"@hermes/tui","dependencies":{"ink":"1.0.0","react":"1.0.0"}},'
+        '"node_modules/ink":{"version":"1.0.0"}'
+        "}}"
+    )
+    # react is in the TUI graph and missing from the marker → reinstall.
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
+def test_standalone_lock_compare_unchanged_without_workspace_member(
+    tmp_path: Path, main_mod
+) -> None:
+    """When root IS the workspace root, keep full lockfile comparison."""
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        '{"packages":{"node_modules/foo":{"version":"1.0.0"},"node_modules/bar":{"version":"1.0.0"}}}'
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        '{"packages":{"node_modules/foo":{"version":"1.0.0"}}}'
+    )
+    assert main_mod._tui_need_npm_install(tmp_path) is True


### PR DESCRIPTION
## Summary

- Scope `_tui_need_npm_install` lockfile comparison to the `ui-tui` workspace dependency closure instead of the full monorepo lockfile.
- Avoids forcing a redundant TUI `npm install` on essentially every dashboard/TUI start when sibling workspaces (`web`, `apps/desktop`, …) are present in the root lock but never installed by `--workspace ui-tui`.

## Motivation

Closes #66084.

Root cause: the TUI launch path intentionally runs a workspace-scoped install (`npm install --workspace ui-tui --include=dev`), but the "do we need npm install?" helper still compared **every** entry in the root `package-lock.json` `packages` map against `node_modules/.package-lock.json`. Packages that belong only to other workspaces never appear in the marker, so the check returned `True` even when the ui-tui graph was fully up to date (hundreds of false "missing" packages on a real monorepo install).

## Fix

- Resolve the dependency closure reachable from the `ui-tui` (and nested `ui-tui/packages/*`) lockfile package keys.
- Compare only those keys against the install marker.
- Standalone layouts (`_workspace_root(root) == root`) keep the previous full-lock comparison.

## Verification

- `pytest tests/hermes_cli/test_tui_npm_install.py -q` — 33 passed, 0 failed
- New regression tests for:
  - sibling workspace packages ignored when ui-tui graph is complete
  - missing dep **in** the ui-tui graph still forces reinstall
  - standalone full-lock behavior unchanged
- Did NOT change: the npm install command itself, workspace install cwd selection, or rebuild heuristics.

## Files

- `hermes_cli/main.py`
- `tests/hermes_cli/test_tui_npm_install.py`
