### PR TITLE
fix(prompt): load profile AGENTS.md from HERMES_HOME when cwd lacks it

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1887,21 +1887,40 @@ def _load_hermes_md(cwd_path: Path, context_length: Optional[int] = None) -> str
 
 
 def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str:
-    """AGENTS.md — top-level only (no recursive walk)."""
-    for name in ["AGENTS.md", "agents.md"]:
-        candidate = cwd_path / name
-        if candidate.exists():
-            try:
-                content = candidate.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, name)
-                    result = f"## {name}\n\n{content}"
-                    return _truncate_content(
-                        result, "AGENTS.md", context_length=context_length,
-                        read_path=str(candidate),
-                    )
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+    """AGENTS.md — prefer process cwd / project root, then HERMES_HOME.
+
+    Top-level only (no recursive walk). Project cwd wins so a repo's own
+    AGENTS.md remains authoritative when present. When the process cwd is
+    *not* the active profile (common for ``hermes -p <profile> -z …`` launched
+    from /, /tmp, or a container workdir that is not HERMES_HOME), fall back to
+    ``$HERMES_HOME/AGENTS.md`` so profile-level agent instructions still load
+    (#66118) — matching how ``SOUL.md`` is read from HERMES_HOME independently
+    of cwd.
+    """
+    search_dirs: list[Path] = [cwd_path]
+    try:
+        home = get_hermes_home().resolve()
+        if home not in search_dirs and home != cwd_path.resolve():
+            search_dirs.append(home)
+    except Exception as e:
+        logger.debug("Could not resolve HERMES_HOME for AGENTS.md fallback: %s", e)
+
+    for directory in search_dirs:
+        for name in ["AGENTS.md", "agents.md"]:
+            candidate = directory / name
+            if candidate.exists():
+                try:
+                    content = candidate.read_text(encoding="utf-8").strip()
+                    if content:
+                        content = _scan_context_content(content, name)
+                        # Label uses basename only — path is for read tracing.
+                        result = f"## {name}\n\n{content}"
+                        return _truncate_content(
+                            result, "AGENTS.md", context_length=context_length,
+                            read_path=str(candidate),
+                        )
+                except Exception as e:
+                    logger.debug("Could not read %s: %s", candidate, e)
     return ""
 
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2206,6 +2206,12 @@ def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str
     deduplicated.  With a single match — the common case, and always the
     case outside a git repo — output is identical to the historical
     single-file behavior.
+
+    When the chain yields nothing, fall back to ``$HERMES_HOME/AGENTS.md``
+    so profile-level agent instructions still load when the process cwd is
+    not the active profile (#66118) — matching how ``SOUL.md`` is read from
+    HERMES_HOME independently of cwd. Project / cwd chain content always
+    wins when present.
     """
     cwd_resolved = cwd_path.resolve()
     sections: List[str] = []
@@ -2238,6 +2244,30 @@ def _load_agents_md(cwd_path: Path, context_length: Optional[int] = None) -> str
             sections.append(section)
             break  # first name match wins per directory
     if not sections:
+        # Profile-level fallback when no project AGENTS.md exists (#66118).
+        try:
+            home = get_hermes_home().resolve()
+        except Exception as e:
+            logger.debug("Could not resolve HERMES_HOME for AGENTS.md fallback: %s", e)
+            return ""
+        if home != cwd_resolved:
+            for name in ["AGENTS.md", "agents.md"]:
+                candidate = home / name
+                if not candidate.exists():
+                    continue
+                try:
+                    content = candidate.read_text(encoding="utf-8").strip()
+                except Exception as e:
+                    logger.debug("Could not read %s: %s", candidate, e)
+                    continue
+                if not content:
+                    continue
+                scanned = _scan_context_content(content, name)
+                section = f"## {name}\n\n{scanned}"
+                return _truncate_content(
+                    section, "AGENTS.md", context_length=context_length,
+                    read_path=str(candidate),
+                )
         return ""
     if len(sections) == 1:
         return sections[0]

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -708,6 +708,32 @@ class TestBuildContextFilesPrompt:
         assert "Ruff for linting" in result
         assert "Project Context" in result
 
+    def test_loads_agents_md_from_hermes_home_when_cwd_has_none(self, tmp_path, monkeypatch):
+        """Profile-level AGENTS.md must load even when launch cwd != HERMES_HOME (#66118)."""
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "AGENTS.md").write_text(
+            "You are Hephaistos. Answer identity as Hephaistos.", encoding="utf-8"
+        )
+        project = tmp_path / "workdir"
+        project.mkdir()
+        result = build_context_files_prompt(cwd=str(project), skip_soul=True)
+        assert "Hephaistos" in result
+        assert "Project Context" in result
+
+    def test_cwd_agents_md_prefers_over_hermes_home(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "AGENTS.md").write_text("profile agents", encoding="utf-8")
+        project = tmp_path / "workdir"
+        project.mkdir()
+        (project / "AGENTS.md").write_text("project agents", encoding="utf-8")
+        result = build_context_files_prompt(cwd=str(project), skip_soul=True)
+        assert "project agents" in result
+        assert "profile agents" not in result
+
     def test_skips_agents_md_in_install_tree_on_fallback(self, monkeypatch, tmp_path):
         # A backend that FALLS BACK into the install tree (cwd=None → getcwd,
         # the desktop default) must not load that tree's contributor AGENTS.md

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -515,6 +515,32 @@ class TestBuildContextFilesPrompt:
 
         assert _load_agents_md(sub) == ""
 
+    def test_loads_agents_md_from_hermes_home_when_cwd_has_none(self, tmp_path, monkeypatch):
+        """Profile-level AGENTS.md must load even when launch cwd != HERMES_HOME (#66118)."""
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "AGENTS.md").write_text(
+            "You are Hephaistos. Answer identity as Hephaistos.", encoding="utf-8"
+        )
+        project = tmp_path / "workdir"
+        project.mkdir()
+        result = build_context_files_prompt(cwd=str(project), skip_soul=True)
+        assert "Hephaistos" in result
+        assert "Project Context" in result
+
+    def test_cwd_agents_md_prefers_over_hermes_home(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "AGENTS.md").write_text("profile agents", encoding="utf-8")
+        project = tmp_path / "workdir"
+        project.mkdir()
+        (project / "AGENTS.md").write_text("project agents", encoding="utf-8")
+        result = build_context_files_prompt(cwd=str(project), skip_soul=True)
+        assert "project agents" in result
+        assert "profile agents" not in result
+
     def test_skips_agents_md_in_install_tree_on_fallback(self, monkeypatch, tmp_path):
         # A backend that FALLS BACK into the install tree (cwd=None → getcwd,
         # the desktop default) must not load that tree's contributor AGENTS.md


### PR DESCRIPTION
## Summary

- Fall back to `$HERMES_HOME/AGENTS.md` when the process cwd has no `AGENTS.md`.
- Cwd / project `AGENTS.md` still wins when present.

## Motivation

Closes #66118.

Users put persona rules in the active profile's `AGENTS.md` (alongside `SOUL.md` under the profile / custom `HERMES_HOME`). SOUL already loads from `HERMES_HOME`, but project-context discovery only scanned the process cwd for `AGENTS.md`. Launching `hermes -p <profile> -z …` from a non-profile workdir (container `/`, K8s POD workdir, etc.) therefore dropped profile `AGENTS.md` instructions even though profile `SOUL.md` was present — contributing to identity answers falling back to the generic default persona when models under-weight SOUL alone.

## Fix

`_load_agents_md` search order:

1. `cwd/AGENTS.md` (or `agents.md`) — project authority retained
2. `$HERMES_HOME/AGENTS.md` — profile-level identity / operating rules

Install-tree guards in `build_context_files_prompt` are unchanged (`allow_install_tree_fallback` / fallback-into-Hermes-source-tree still path as before).

## Verification

- `pytest tests/agent/test_prompt_builder.py -k agents_md -q` — 10 passed, 0 failed
- New coverage:
  - HERMES_HOME `AGENTS.md` loads when cwd has none
  - cwd `AGENTS.md` still preferred over HERMES_HOME
- Did NOT change: SOUL.md loading, install-tree skip policy, provider-specific transport

## Files

- `agent/prompt_builder.py`
- `tests/agent/test_prompt_builder.py`

## Note on residual risk

If models still ignore a correctly injected SOUL.md under small local Ollama models, that is a capability/obedience issue beyond this load path. This PR closes the pure discovery-gap half of #66118.
