### PR TITLE
fix(dep_ensure): add timeout and stdin=DEVNULL to install subprocess.run

### DIFF
--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -154,6 +154,8 @@ def ensure_dependency(
     result = subprocess.run(
         cmd,
         env=run_env,
+        timeout=300,
+        stdin=subprocess.DEVNULL,
     )
     if result.returncode != 0:
         return False


### PR DESCRIPTION
## Summary

Add `timeout=300` and `stdin=subprocess.DEVNULL` to the `subprocess.run()` call in `ensure_dependency()` that invokes the install script.

## Problem

`hermes_cli/dep_ensure.py:154` runs `subprocess.run(cmd, env=run_env)` with no timeout. If the install script hangs (e.g. waiting for a network operation, interactive prompt despite `IS_INTERACTIVE=false`, or a stuck package manager), the call blocks indefinitely, freezing the entire agent turn. Additionally, missing `stdin=subprocess.DEVNULL` means the child process can accidentally inherit stdin and deadlock or read from the agent's stdin stream.

## Fix

Minimal 2-line addition: `timeout=300` (5 minutes is ample for a dep install script) and `stdin=subprocess.DEVNULL` to prevent stdin inheritance.

## Testing
- Syntax check passed (py_compile)
- Behavior verified