### PR TITLE
fix(cron): enforce a single scheduler owner

### DIFF
--- a/agent/secret_sources/base.py
+++ b/agent/secret_sources/base.py
@@ -181,6 +181,14 @@ class SecretSource(ABC):
             return DEFAULT_FETCH_TIMEOUT_SECONDS
         return val if val > 0 else DEFAULT_FETCH_TIMEOUT_SECONDS
 
+    def invalidate_cache(self, home_path: Path) -> None:
+        """Invalidate memory and disk fetch caches for one exact Hermes home.
+
+        Sources without caches may keep this no-op default. Cached sources must
+        override it so long-running schedulers can observe secret rotation
+        without flushing or exposing another profile's values.
+        """
+
     def config_schema(self) -> dict:
         """Optional description of this source's config keys.
 

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -75,8 +75,11 @@ _BWS_DOWNLOAD_TIMEOUT = 60
 _BWS_RUN_TIMEOUT = 30
 
 # In-process cache so repeated load_hermes_dotenv() calls (CLI startup,
-# gateway hot-reload, test suites) don't re-fetch from BSM.
-_CacheKey = Tuple[str, str, str]  # (access_token_fingerprint, project_id, server_url)
+# gateway hot-reload, test suites) don't re-fetch from BSM. The exact canonical
+# home is part of L1 identity so a multiplexed process cannot reuse profile A's
+# values for profile B. L2 is already partitioned by its home-specific path.
+_CacheKey = Tuple[str, str, str, str]
+# (access_token_fingerprint, project_id, server_url, canonical_home)
 _CACHE: Dict[_CacheKey, _CachedFetch] = {}
 
 # Disk-persisted cache so back-to-back CLI invocations (e.g. `hermes chat -q ...`
@@ -94,8 +97,8 @@ _DISK_CACHE_BASENAME = "bws_cache.json"
 
 
 def _cache_key_str(cache_key: _CacheKey) -> str:
-    """Serialize a cache key to a stable string for JSON storage."""
-    token_fp, project_id, server_url = cache_key
+    """Serialize a cache key for L2; its path already supplies home identity."""
+    token_fp, project_id, server_url, _home = cache_key
     return f"{token_fp}|{project_id}|{server_url}"
 
 
@@ -111,6 +114,12 @@ def _disk_cache_path(home_path: Optional[Path] = None) -> Path:
     callers; falls back to `$HERMES_HOME` / `~/.hermes` when home is None.
     """
     return _DISK_CACHE.path(home_path)
+
+
+def _canonical_cache_home(home_path: Optional[Path] = None) -> str:
+    from agent.secret_sources._cache import resolve_cache_home
+
+    return str(resolve_cache_home(home_path).expanduser().resolve())
 
 
 # ---------------------------------------------------------------------------
@@ -385,7 +394,12 @@ def fetch_bitwarden_secrets(
     if not project_id:
         raise RuntimeError("Bitwarden project_id is empty")
 
-    cache_key = (_token_fingerprint(access_token), project_id, server_url or "")
+    cache_key = (
+        _token_fingerprint(access_token),
+        project_id,
+        server_url or "",
+        _canonical_cache_home(home_path),
+    )
     if use_cache:
         cached = _CACHE.get(cache_key)
         if cached and cached.is_fresh(cache_ttl_seconds):
@@ -599,6 +613,12 @@ class BitwardenSource(SecretSource):
     label = "Bitwarden Secrets Manager"
     shape = "bulk"
     scheme = "bws"
+
+    def invalidate_cache(self, home_path: Path) -> None:
+        canonical_home = _canonical_cache_home(home_path)
+        for key in [key for key in _CACHE if key[3] == canonical_home]:
+            _CACHE.pop(key, None)
+        _DISK_CACHE.clear(home_path)
 
     def override_existing(self, cfg: dict) -> bool:
         # Default True (matches DEFAULT_CONFIG): the point of BSM is

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -525,7 +525,12 @@ class OnePasswordSource(SecretSource):
         token_env = _DEFAULT_TOKEN_ENV
         if isinstance(cfg, dict):
             token_env = str(cfg.get("service_account_token_env") or token_env)
-        return frozenset({token_env})
+        protected = {token_env}
+        # Interactive `op signin` authentication is exported as
+        # OP_SESSION_<account>. These session credentials are as sensitive as
+        # service-account tokens and must never reach no-agent subprocesses.
+        protected.update(name for name in os.environ if name.startswith("OP_SESSION_"))
+        return frozenset(protected)
 
     def config_schema(self) -> dict:
         return {

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -136,6 +136,12 @@ def _disk_cache_path(home_path: Optional[Path] = None) -> Path:
     return _DISK_CACHE.path(home_path)
 
 
+def _canonical_cache_home(home_path: Optional[Path] = None) -> str:
+    from agent.secret_sources._cache import resolve_cache_home
+
+    return str(resolve_cache_home(home_path).expanduser().resolve())
+
+
 # ---------------------------------------------------------------------------
 # Reference validation + fingerprinting
 # ---------------------------------------------------------------------------
@@ -336,7 +342,7 @@ def fetch_onepassword_secrets(
     cache_key: _CacheKey = (
         _auth_fingerprint(token_env),
         account or "",
-        str(home_path) if home_path is not None else "",
+        _canonical_cache_home(home_path),
         _refs_fingerprint(valid),
     )
 
@@ -501,6 +507,12 @@ class OnePasswordSource(SecretSource):
     label = "1Password"
     shape = "mapped"
     scheme = "op"
+
+    def invalidate_cache(self, home_path: Path) -> None:
+        canonical_home = _canonical_cache_home(home_path)
+        for key in [key for key in _CACHE if key[2] == canonical_home]:
+            _CACHE.pop(key, None)
+        _DISK_CACHE.clear(home_path)
 
     def override_existing(self, cfg: dict) -> bool:
         # Default True: an explicit VAR→op:// binding is the strongest

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -182,6 +182,19 @@ def _reset_registry_for_tests() -> None:
     _BUILTINS_LOADED = False
 
 
+def invalidate_caches(home_path: Path) -> None:
+    """Best-effort invalidation of every source cache for one exact home."""
+    _ensure_builtin_sources()
+    for source in _SOURCES.values():
+        try:
+            source.invalidate_cache(home_path)
+        except Exception:  # noqa: BLE001 — refresh must continue source-by-source
+            logger.warning(
+                "Failed to invalidate cache for secret source '%s'", source.name,
+                exc_info=True,
+            )
+
+
 # ---------------------------------------------------------------------------
 # Orchestrated apply
 # ---------------------------------------------------------------------------

--- a/agent/secret_sources/registry.py
+++ b/agent/secret_sources/registry.py
@@ -165,15 +165,13 @@ def _ensure_builtin_sources() -> None:
 
         register_source(BitwardenSource())
     except Exception:  # noqa: BLE001 — never block startup
-        logger.warning("Failed to register bundled Bitwarden secret source",
-                       exc_info=True)
+        logger.warning("Failed to register bundled Bitwarden secret source")
     try:
         from agent.secret_sources.onepassword import OnePasswordSource
 
         register_source(OnePasswordSource())
     except Exception:  # noqa: BLE001 — never block startup
-        logger.warning("Failed to register bundled 1Password secret source",
-                       exc_info=True)
+        logger.warning("Failed to register bundled 1Password secret source")
 
 
 def _reset_registry_for_tests() -> None:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -851,8 +851,9 @@ platform_toolsets:
   google_chat: [hermes-google_chat]
 
 # Exactly one long-running runtime should dispatch due jobs for a HERMES_HOME.
-# auto (default) selects the gateway; desktop is an explicit Desktop-only fallback.
-# Invalid values fail closed so competing runtimes cannot both start a ticker.
+# auto (default) prefers Gateway; Desktop runs the built-in fallback only while
+# no same-HERMES_HOME Gateway is active. Named external providers remain
+# Gateway-only and fail closed if unavailable. Invalid values fail closed.
 cron:
   scheduler_owner: "auto"  # auto | gateway | desktop
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -852,8 +852,9 @@ platform_toolsets:
 
 # Exactly one long-running runtime should dispatch due jobs for a HERMES_HOME.
 # auto (default) prefers Gateway; Desktop runs the built-in fallback only while
-# no same-HERMES_HOME Gateway is active. Named external providers remain
-# Gateway-only and fail closed if unavailable. Invalid values fail closed.
+# no same-HERMES_HOME Gateway is active. Named external providers are always
+# Gateway-only: scheduler_owner: desktop with a named provider is invalid and
+# both runtimes fail closed. Invalid or duplicate policy keys also fail closed.
 cron:
   scheduler_owner: "auto"  # auto | gateway | desktop
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -850,6 +850,12 @@ platform_toolsets:
   teams: [hermes-teams]
   google_chat: [hermes-google_chat]
 
+# Exactly one long-running runtime should dispatch due jobs for a HERMES_HOME.
+# auto (default) selects the gateway; desktop is an explicit Desktop-only fallback.
+# Invalid values fail closed so competing runtimes cannot both start a ticker.
+cron:
+  scheduler_owner: "auto"  # auto | gateway | desktop
+
 # =============================================================================
 # Gateway Platform Settings
 # =============================================================================

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -337,6 +337,9 @@ _parallel_pool: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _parallel_pool_max_workers: Optional[int] = None
 _running_job_ids: set = set()
 _running_lock = threading.Lock()
+# Keep reset + reload atomic when multiple jobs start together. The loader
+# publishes into process-global os.environ before child environments are built.
+_cron_secret_refresh_lock = threading.RLock()
 
 # Job IDs the gateway shutdown path force-killed the tool subprocess of
 # while still in ``_running_job_ids`` (see ``mark_running_jobs_interrupted``
@@ -2587,6 +2590,15 @@ def _guard_job_credential_exfil(job: dict) -> None:
         raise RuntimeError(f"Cron job '{job_id}' blocked for safety: {err}")
 
 
+def _refresh_cron_runtime_secrets() -> None:
+    """Refresh dotenv and configured external secrets for the active home."""
+    from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
+
+    with _cron_secret_refresh_lock:
+        reset_secret_source_cache()
+        load_hermes_dotenv(hermes_home=_get_hermes_home())
+
+
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None
 ) -> tuple[bool, str, str, Optional[str]]:
@@ -2633,6 +2645,10 @@ def run_job(
             err = "no_agent=True but no script is set for this job"
             logger.error("Job '%s': %s", job_id, err)
             return False, "", "", err
+
+        # no_agent returns before the normal agent bootstrap below. Refresh
+        # external sources now, before _run_job_script constructs child env.
+        _refresh_cron_runtime_secrets()
 
         # Apply workdir if configured — lets scripts use predictable relative
         # paths. For no_agent jobs this is just the subprocess cwd (not an
@@ -2948,12 +2964,7 @@ def run_job(
         # is set (mirrors startup), and the Bitwarden value-cache keeps the
         # forced re-pull off the network. load_hermes_dotenv also handles the
         # utf-8/latin-1 encoding fallback internally.
-        from hermes_cli.env_loader import (
-            load_hermes_dotenv,
-            reset_secret_source_cache,
-        )
-        reset_secret_source_cache()
-        load_hermes_dotenv(hermes_home=_get_hermes_home())
+        _refresh_cron_runtime_secrets()
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import threading
 import time
+from types import MappingProxyType
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -32,7 +33,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Mapping, Optional
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -2054,7 +2055,13 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(
+    script_path: str,
+    *,
+    child_env: Optional[Mapping[str, str]] = None,
+    hermes_home: Optional[Path] = None,
+    workdir: Optional[Path] = None,
+) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -2085,7 +2092,15 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         (success, output) — on failure *output* contains the error message so the
         LLM can report the problem to the user.
     """
-    scripts_dir = _get_hermes_home() / "scripts"
+    # no_agent callers provide an atomically prepared environment and home.
+    # Keep the legacy fallback for direct/pre-run-script callers, but never
+    # consult process globals when the prepared values are present.
+    effective_home = (
+        hermes_home.expanduser().resolve()
+        if hermes_home is not None
+        else _get_hermes_home().expanduser().resolve()
+    )
+    scripts_dir = effective_home / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
     scripts_dir_resolved = scripts_dir.resolve()
 
@@ -2123,7 +2138,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         # shutil.which returns None — fall back to a clear error rather
         # than a FileNotFoundError with a confusing "[WinError 2]"
         # traceback.
-        _bash = shutil.which("bash") or (
+        bash_path = child_env.get("PATH", os.defpath) if child_env is not None else None
+        _bash = shutil.which("bash", path=bash_path) or (
             "/bin/bash" if os.path.isfile("/bin/bash") else None
         )
         if _bash is None:
@@ -2139,14 +2155,20 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     try:
         from tools.environments.local import _sanitize_subprocess_env
 
+        effective_env: Mapping[str, str]
+        if child_env is None:
+            effective_env = _sanitize_subprocess_env(os.environ.copy())
+        else:
+            effective_env = child_env
+
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
         result = subprocess.run(
             argv,
             capture_output=True,
             text=True,
             timeout=script_timeout,
-            cwd=str(path.parent),
-            env=_sanitize_subprocess_env(os.environ.copy()),
+            cwd=str(workdir or path.parent),
+            env=effective_env,
             **popen_kwargs,
         )
         stdout = (result.stdout or "").strip()
@@ -2179,7 +2201,12 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
 
 def _run_job_script_with_claim_heartbeat(
-    job: dict, script_path: str
+    job: dict,
+    script_path: str,
+    *,
+    child_env: Optional[Mapping[str, str]] = None,
+    hermes_home: Optional[Path] = None,
+    workdir: Optional[Path] = None,
 ) -> tuple[bool, str]:
     """Run a cron script while keeping its owned one-shot claim fresh.
 
@@ -2193,6 +2220,17 @@ def _run_job_script_with_claim_heartbeat(
     storage.  ``heartbeat_run_claim`` compares that stable owner before every
     refresh, so a stale runner cannot extend a replacement owner's claim.
     """
+
+    def _execute() -> tuple[bool, str]:
+        if child_env is None and hermes_home is None and workdir is None:
+            return _run_job_script(script_path)
+        return _run_job_script(
+            script_path,
+            child_env=child_env,
+            hermes_home=hermes_home,
+            workdir=workdir,
+        )
+
     schedule = job.get("schedule")
     claim = job.get("run_claim")
     owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
@@ -2201,7 +2239,7 @@ def _run_job_script_with_claim_heartbeat(
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path)
+        return _execute()
 
     job_id = str(job.get("id") or "")
     stop = threading.Event()
@@ -2232,10 +2270,10 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path)
+        return _execute()
 
     try:
-        return _run_job_script(script_path)
+        return _execute()
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
@@ -2600,6 +2638,45 @@ def _refresh_cron_runtime_secrets() -> None:
         load_hermes_dotenv(hermes_home=hermes_home)
 
 
+def _prepare_no_agent_child_environment() -> tuple[Path, Mapping[str, str]]:
+    """Atomically refresh and capture one profile's no-agent child environment.
+
+    ``load_hermes_dotenv`` publishes into process-global ``os.environ``. The
+    refresh, copy, sanitization, source-specific bootstrap stripping, and home
+    pin therefore form one critical section. The returned mapping is immutable
+    so later profile refreshes or caller mistakes cannot alter the child view.
+    """
+    from agent.secret_sources.registry import _ordered_enabled_sources
+    from hermes_cli.env_loader import (
+        _load_secrets_config,
+        load_hermes_dotenv,
+        reset_secret_source_cache,
+    )
+    from tools.environments.local import _sanitize_subprocess_env
+
+    with _cron_secret_refresh_lock:
+        pinned_home = _get_hermes_home().expanduser().resolve()
+        reset_secret_source_cache(pinned_home)
+        load_hermes_dotenv(hermes_home=pinned_home)
+
+        child_env = _sanitize_subprocess_env(os.environ.copy())
+        secrets_cfg = _load_secrets_config(pinned_home)
+        for source in _ordered_enabled_sources(secrets_cfg):
+            source_cfg = secrets_cfg.get(source.name)
+            source_cfg = source_cfg if isinstance(source_cfg, dict) else {}
+            # Strip both each source's default bootstrap name and any
+            # configured alias. Sources expose both through the same API.
+            protected_env_vars = set(source.protected_env_vars({}))
+            protected_env_vars.update(source.protected_env_vars(source_cfg))
+            for env_var in protected_env_vars:
+                child_env.pop(env_var, None)
+
+        # The loader and another profile may have changed the process-global
+        # value. Child path resolution always uses this canonical pinned home.
+        child_env["HERMES_HOME"] = str(pinned_home)
+        return pinned_home, MappingProxyType(child_env)
+
+
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None
 ) -> tuple[bool, str, str, Optional[str]]:
@@ -2647,30 +2724,36 @@ def run_job(
             logger.error("Job '%s': %s", job_id, err)
             return False, "", "", err
 
-        # no_agent returns before the normal agent bootstrap below. Refresh
-        # external sources now, before _run_job_script constructs child env.
-        _refresh_cron_runtime_secrets()
+        # Refresh and capture under one lock. After this point the no-agent
+        # child uses only these pinned values, never process-global os.environ.
+        try:
+            pinned_home, child_env = _prepare_no_agent_child_environment()
+        except Exception as exc:
+            logger.error(
+                "Job '%s': no-agent secret refresh failed; child not started",
+                job_id,
+                exc_info=True,
+            )
+            err = f"No-agent secret refresh failed: {type(exc).__name__}: {exc}"
+            return False, "", "", err
 
         # Apply workdir if configured — lets scripts use predictable relative
-        # paths. For no_agent jobs this is just the subprocess cwd (not an
-        # agent TERMINAL_CWD bridge).
+        # paths. For no_agent jobs this is the subprocess cwd (not an agent
+        # TERMINAL_CWD bridge). Script lookup remains rooted at pinned_home.
         _job_workdir = (job.get("workdir") or "").strip() or None
-        _prior_cwd = None
-        if _job_workdir and Path(_job_workdir).is_dir():
-            _prior_cwd = os.getcwd()
-            try:
-                os.chdir(_job_workdir)
-            except OSError:
-                _prior_cwd = None
-
-        try:
-            ok, output = _run_job_script_with_claim_heartbeat(job, script_path)
-        finally:
-            if _prior_cwd is not None:
-                try:
-                    os.chdir(_prior_cwd)
-                except OSError:
-                    pass
+        workdir_candidate = Path(_job_workdir).expanduser() if _job_workdir else None
+        child_workdir = (
+            workdir_candidate.resolve()
+            if workdir_candidate is not None and workdir_candidate.is_dir()
+            else None
+        )
+        ok, output = _run_job_script_with_claim_heartbeat(
+            job,
+            script_path,
+            child_env=child_env,
+            hermes_home=pinned_home,
+            workdir=child_workdir,
+        )
 
         now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3789,8 +3789,11 @@ def _notify_provider_jobs_changed() -> None:
     Never raises into the caller.
     """
     try:
-        from cron.scheduler_provider import resolve_cron_scheduler
-        resolve_cron_scheduler().on_jobs_changed()
+        from cron.scheduler_runtime import get_active_scheduler_provider
+
+        provider = get_active_scheduler_provider()
+        if provider is not None:
+            provider.on_jobs_changed()
     except Exception as e:
         logger.debug("on_jobs_changed notify failed: %s", e)
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2649,15 +2649,13 @@ def _prepare_no_agent_child_environment() -> tuple[Path, Mapping[str, str]]:
     from agent.secret_sources.registry import _ordered_enabled_sources
     from hermes_cli.env_loader import (
         _load_secrets_config,
-        load_hermes_dotenv,
-        reset_secret_source_cache,
+        refresh_hermes_dotenv_strict,
     )
     from tools.environments.local import _sanitize_subprocess_env
 
     with _cron_secret_refresh_lock:
         pinned_home = _get_hermes_home().expanduser().resolve()
-        reset_secret_source_cache(pinned_home)
-        load_hermes_dotenv(hermes_home=pinned_home)
+        refresh_hermes_dotenv_strict(hermes_home=pinned_home)
 
         child_env = _sanitize_subprocess_env(os.environ.copy())
         secrets_cfg = _load_secrets_config(pinned_home)
@@ -2729,12 +2727,18 @@ def run_job(
         try:
             pinned_home, child_env = _prepare_no_agent_child_environment()
         except Exception as exc:
+            from hermes_cli.env_loader import SecretSourceRefreshError
+
+            if isinstance(exc, SecretSourceRefreshError):
+                summary = str(exc)
+            else:
+                summary = f"secret refresh failed (type={type(exc).__name__})"
             logger.error(
-                "Job '%s': no-agent secret refresh failed; child not started",
+                "Job '%s': no-agent %s; child not started",
                 job_id,
-                exc_info=True,
+                summary,
             )
-            err = f"No-agent secret refresh failed: {type(exc).__name__}: {exc}"
+            err = f"No-agent secret refresh failed: {summary}"
             return False, "", "", err
 
         # Apply workdir if configured — lets scripts use predictable relative
@@ -3872,11 +3876,11 @@ def _notify_provider_jobs_changed() -> None:
     Never raises into the caller.
     """
     try:
-        from cron.scheduler_runtime import get_active_scheduler_provider
+        from cron.scheduler_runtime import reserved_active_scheduler_provider
 
-        provider = get_active_scheduler_provider()
-        if provider is not None:
-            provider.on_jobs_changed()
+        with reserved_active_scheduler_provider() as reservation:
+            if reservation is not None:
+                reservation.provider.on_jobs_changed()
     except Exception as e:
         logger.debug("on_jobs_changed notify failed: %s", e)
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2647,18 +2647,15 @@ def _prepare_no_agent_child_environment() -> tuple[Path, Mapping[str, str]]:
     so later profile refreshes or caller mistakes cannot alter the child view.
     """
     from agent.secret_sources.registry import _ordered_enabled_sources
-    from hermes_cli.env_loader import (
-        _load_secrets_config_strict,
-        refresh_hermes_dotenv_strict,
-    )
+    from hermes_cli.env_loader import refresh_hermes_dotenv_strict
     from tools.environments.local import _sanitize_subprocess_env
 
     with _cron_secret_refresh_lock:
         pinned_home = _get_hermes_home().expanduser().resolve()
-        refresh_hermes_dotenv_strict(hermes_home=pinned_home)
+        refresh = refresh_hermes_dotenv_strict(hermes_home=pinned_home)
 
         child_env = _sanitize_subprocess_env(os.environ.copy())
-        secrets_cfg = _load_secrets_config_strict(pinned_home)
+        secrets_cfg = refresh.secrets_config
         for source in _ordered_enabled_sources(secrets_cfg):
             source_cfg = secrets_cfg.get(source.name)
             source_cfg = source_cfg if isinstance(source_cfg, dict) else {}

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2595,8 +2595,9 @@ def _refresh_cron_runtime_secrets() -> None:
     from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
 
     with _cron_secret_refresh_lock:
-        reset_secret_source_cache()
-        load_hermes_dotenv(hermes_home=_get_hermes_home())
+        hermes_home = _get_hermes_home()
+        reset_secret_source_cache(hermes_home)
+        load_hermes_dotenv(hermes_home=hermes_home)
 
 
 def run_job(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2648,7 +2648,7 @@ def _prepare_no_agent_child_environment() -> tuple[Path, Mapping[str, str]]:
     """
     from agent.secret_sources.registry import _ordered_enabled_sources
     from hermes_cli.env_loader import (
-        _load_secrets_config,
+        _load_secrets_config_strict,
         refresh_hermes_dotenv_strict,
     )
     from tools.environments.local import _sanitize_subprocess_env
@@ -2658,7 +2658,7 @@ def _prepare_no_agent_child_environment() -> tuple[Path, Mapping[str, str]]:
         refresh_hermes_dotenv_strict(hermes_home=pinned_home)
 
         child_env = _sanitize_subprocess_env(os.environ.copy())
-        secrets_cfg = _load_secrets_config(pinned_home)
+        secrets_cfg = _load_secrets_config_strict(pinned_home)
         for source in _ordered_enabled_sources(secrets_cfg):
             source_cfg = secrets_cfg.get(source.name)
             source_cfg = source_cfg if isinstance(source_cfg, dict) else {}

--- a/cron/scheduler_lease.py
+++ b/cron/scheduler_lease.py
@@ -1,0 +1,150 @@
+"""Cross-process ownership lease for one cron scheduler per HERMES_HOME."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import IO, Literal
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
+_WINDOWS_LOCK_OFFSET = 1024 * 1024
+_PROCESS_LEASES: set[str] = set()
+_PROCESS_LEASES_LOCK = threading.Lock()
+
+
+def _canonical_lock_path(hermes_home: Path) -> Path:
+    return hermes_home.expanduser().resolve() / "cron" / ".scheduler-owner.lock"
+
+
+def _process_start_time() -> int | None:
+    try:
+        import psutil
+
+        return int(round(psutil.Process(os.getpid()).create_time() * 100))
+    except Exception:
+        return None
+
+
+def _try_lock(handle: IO[str]) -> bool:
+    try:
+        if sys.platform == "win32":
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                handle.write("\n")
+                handle.flush()
+            handle.seek(_WINDOWS_LOCK_OFFSET)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except (BlockingIOError, OSError):
+        return False
+
+
+def _unlock(handle: IO[str]) -> None:
+    try:
+        if sys.platform == "win32":
+            handle.seek(_WINDOWS_LOCK_OFFSET)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except OSError:
+        pass
+
+
+class SchedulerOwnershipLease:
+    """A kernel-authoritative, non-blocking scheduler ownership lease.
+
+    The lock file is deliberately never unlinked. Removing a locked pathname can
+    create a second inode and split ownership between two live processes.
+    """
+
+    def __init__(self, path: Path, handle: IO[str]) -> None:
+        self.path = path
+        self._key = str(path)
+        self._handle: IO[str] | None = handle
+        self._release_lock = threading.Lock()
+
+    @classmethod
+    def try_acquire(
+        cls,
+        *,
+        hermes_home: Path,
+        owner: Literal["gateway", "desktop"],
+        provider: str,
+    ) -> "SchedulerOwnershipLease | None":
+        path = _canonical_lock_path(hermes_home)
+        key = str(path)
+        with _PROCESS_LEASES_LOCK:
+            if key in _PROCESS_LEASES:
+                return None
+            # Reserve before the kernel operation so same-process contenders do
+            # not rely on platform-specific flock semantics.
+            _PROCESS_LEASES.add(key)
+
+        handle: IO[str] | None = None
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            handle = open(path, "a+", encoding="utf-8")
+            if not _try_lock(handle):
+                handle.close()
+                handle = None
+                return None
+
+            metadata = {
+                "version": 1,
+                "pid": os.getpid(),
+                "process_start_time": _process_start_time(),
+                "owner": owner,
+                "provider": provider,
+                "acquired_at": datetime.now(timezone.utc).isoformat(),
+            }
+            handle.seek(0)
+            handle.truncate()
+            json.dump(metadata, handle, sort_keys=True)
+            handle.flush()
+            try:
+                os.fsync(handle.fileno())
+            except OSError:
+                pass
+            return cls(path, handle)
+        except Exception:
+            if handle is not None:
+                try:
+                    handle.close()
+                except OSError:
+                    pass
+                handle = None
+            raise
+        finally:
+            if handle is None:
+                with _PROCESS_LEASES_LOCK:
+                    _PROCESS_LEASES.discard(key)
+
+    def release(self) -> None:
+        with self._release_lock:
+            handle = self._handle
+            if handle is None:
+                return
+            self._handle = None
+            _unlock(handle)
+            try:
+                handle.close()
+            except OSError:
+                pass
+            finally:
+                with _PROCESS_LEASES_LOCK:
+                    _PROCESS_LEASES.discard(self._key)
+
+    def __enter__(self) -> "SchedulerOwnershipLease":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.release()

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -23,7 +23,7 @@ import io
 import logging
 import threading
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, cast
 
 
 logger = logging.getLogger("cron.scheduler_provider")
@@ -34,7 +34,7 @@ _CRON_SCHEDULER_RUNTIME_OWNERS = frozenset({"gateway", "desktop"})
 def _read_scheduler_owner_config_strict() -> dict[str, Any] | None:
     """Read scheduler ownership without the normal tolerant config fallback."""
     from hermes_cli import managed_scope
-    from hermes_cli.config import get_config_path
+    from hermes_cli.config import _expand_env_vars, get_config_path
     from utils import fast_safe_load
 
     def _read_mapping(path) -> dict[str, Any]:
@@ -56,10 +56,15 @@ def _read_scheduler_owner_config_strict() -> dict[str, Any] | None:
         return parsed
 
     try:
-        user_config = _read_mapping(get_config_path())
+        user_config = cast(
+            dict[str, Any], _expand_env_vars(_read_mapping(get_config_path()))
+        )
         managed_dir = managed_scope.get_managed_dir()
         managed_config = (
-            _read_mapping(managed_dir / "config.yaml")
+            cast(
+                dict[str, Any],
+                _expand_env_vars(_read_mapping(managed_dir / "config.yaml")),
+            )
             if managed_dir is not None
             else {}
         )
@@ -81,7 +86,7 @@ def _read_scheduler_owner_config_strict() -> dict[str, Any] | None:
 
 
 def resolve_cron_scheduler_owner(*, config: dict[str, Any] | None = None) -> str | None:
-    """Resolve the single automatic scheduler owner, failing closed on errors."""
+    """Resolve the ownership policy, failing closed on malformed input."""
     if config is None:
         config = _read_scheduler_owner_config_strict()
         if config is None:
@@ -95,9 +100,7 @@ def resolve_cron_scheduler_owner(*, config: dict[str, Any] | None = None) -> str
         return None
     raw_owner = cron_config.get("scheduler_owner", "auto")
     owner = raw_owner.strip().lower() if isinstance(raw_owner, str) else None
-    if owner == "auto":
-        return "gateway"
-    if owner in _CRON_SCHEDULER_RUNTIME_OWNERS:
+    if owner == "auto" or owner in _CRON_SCHEDULER_RUNTIME_OWNERS:
         return owner
     logger.error(
         "Invalid cron.scheduler_owner; scheduler startup disabled. "
@@ -109,19 +112,50 @@ def resolve_cron_scheduler_owner(*, config: dict[str, Any] | None = None) -> str
 def should_start_cron_scheduler(
     runtime_owner: str, *, config: dict[str, Any] | None = None
 ) -> bool:
-    """Return whether this long-running runtime owns automatic dispatch."""
+    """Return whether this runtime participates in the ownership policy.
+
+    Under ``auto`` the gateway is preferred and Desktop may run the built-in
+    ticker as a dynamically yielding standby. Provider-specific fail-closed
+    handling for that standby happens in ``resolve_cron_scheduler_startup``.
+    """
     if runtime_owner not in _CRON_SCHEDULER_RUNTIME_OWNERS:
         raise ValueError("Unknown cron scheduler runtime owner")
-    return resolve_cron_scheduler_owner(config=config) == runtime_owner
+    owner = resolve_cron_scheduler_owner(config=config)
+    return owner == runtime_owner or owner == "auto"
 
 
 def resolve_owned_cron_scheduler(
     runtime_owner: str, *, config: dict[str, Any] | None = None
 ) -> "CronScheduler | None":
     """Resolve the provider only after the shared ownership gate succeeds."""
-    if not should_start_cron_scheduler(runtime_owner, config=config):
-        return None
-    return resolve_cron_scheduler()
+    _owner, provider = resolve_cron_scheduler_startup(runtime_owner, config=config)
+    return provider
+
+
+def resolve_cron_scheduler_startup(
+    runtime_owner: str, *, config: dict[str, Any] | None = None
+) -> "tuple[str | None, CronScheduler | None]":
+    """Resolve one ownership snapshot and its provider for runtime startup."""
+    if runtime_owner not in _CRON_SCHEDULER_RUNTIME_OWNERS:
+        raise ValueError("Unknown cron scheduler runtime owner")
+    if config is None:
+        config = _read_scheduler_owner_config_strict()
+        if config is None:
+            return None, None
+    owner = resolve_cron_scheduler_owner(config=config)
+    if owner is None or (owner != runtime_owner and owner != "auto"):
+        return owner, None
+    provider = resolve_cron_scheduler()
+    if (
+        owner == "auto"
+        and runtime_owner == "desktop"
+        and not isinstance(provider, InProcessCronScheduler)
+    ):
+        logger.info(
+            "Desktop cron standby disabled for external provider under auto ownership"
+        )
+        return owner, None
+    return owner, provider
 
 
 class CronScheduler(ABC):

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -19,9 +19,109 @@ selected via the `cron.provider` config key (empty = built-in).
 """
 from __future__ import annotations
 
+import io
+import logging
 import threading
 from abc import ABC, abstractmethod
 from typing import Any
+
+
+logger = logging.getLogger("cron.scheduler_provider")
+
+_CRON_SCHEDULER_RUNTIME_OWNERS = frozenset({"gateway", "desktop"})
+
+
+def _read_scheduler_owner_config_strict() -> dict[str, Any] | None:
+    """Read scheduler ownership without the normal tolerant config fallback."""
+    from hermes_cli import managed_scope
+    from hermes_cli.config import get_config_path
+    from utils import fast_safe_load
+
+    def _read_mapping(path) -> dict[str, Any]:
+        try:
+            with open(path, encoding="utf-8") as handle:
+                raw = handle.read()
+        except FileNotFoundError:
+            return {}
+        meaningful = [
+            line.split("#", 1)[0].strip()
+            for line in raw.splitlines()
+            if line.split("#", 1)[0].strip() not in {"", "---", "..."}
+        ]
+        if not meaningful:
+            return {}
+        parsed = fast_safe_load(io.StringIO(raw))
+        if not isinstance(parsed, dict):
+            raise ValueError("config root must be a mapping")
+        return parsed
+
+    try:
+        user_config = _read_mapping(get_config_path())
+        managed_dir = managed_scope.get_managed_dir()
+        managed_config = (
+            _read_mapping(managed_dir / "config.yaml")
+            if managed_dir is not None
+            else {}
+        )
+        user_cron = user_config.get("cron", {})
+        managed_cron = managed_config.get("cron", {})
+        if "cron" in user_config and not isinstance(user_cron, dict):
+            raise ValueError("cron section must be a mapping")
+        if "cron" in managed_config and not isinstance(managed_cron, dict):
+            raise ValueError("managed cron section must be a mapping")
+        effective_cron = dict(user_cron)
+        effective_cron.update(managed_cron)
+        return {"cron": effective_cron}
+    except Exception:
+        logger.error(
+            "Unable to read a valid cron.scheduler_owner; scheduler startup disabled. "
+            "Set it to auto, gateway, or desktop in config.yaml."
+        )
+        return None
+
+
+def resolve_cron_scheduler_owner(*, config: dict[str, Any] | None = None) -> str | None:
+    """Resolve the single automatic scheduler owner, failing closed on errors."""
+    if config is None:
+        config = _read_scheduler_owner_config_strict()
+        if config is None:
+            return None
+    if not isinstance(config, dict):
+        logger.error("Invalid configuration root; scheduler startup disabled.")
+        return None
+    cron_config = config.get("cron", {})
+    if "cron" in config and not isinstance(cron_config, dict):
+        logger.error("Invalid cron configuration shape; scheduler startup disabled.")
+        return None
+    raw_owner = cron_config.get("scheduler_owner", "auto")
+    owner = raw_owner.strip().lower() if isinstance(raw_owner, str) else None
+    if owner == "auto":
+        return "gateway"
+    if owner in _CRON_SCHEDULER_RUNTIME_OWNERS:
+        return owner
+    logger.error(
+        "Invalid cron.scheduler_owner; scheduler startup disabled. "
+        "Use auto, gateway, or desktop in config.yaml."
+    )
+    return None
+
+
+def should_start_cron_scheduler(
+    runtime_owner: str, *, config: dict[str, Any] | None = None
+) -> bool:
+    """Return whether this long-running runtime owns automatic dispatch."""
+    if runtime_owner not in _CRON_SCHEDULER_RUNTIME_OWNERS:
+        raise ValueError("Unknown cron scheduler runtime owner")
+    return resolve_cron_scheduler_owner(config=config) == runtime_owner
+
+
+def resolve_owned_cron_scheduler(
+    runtime_owner: str, *, config: dict[str, Any] | None = None
+) -> "CronScheduler | None":
+    """Resolve the provider only after the shared ownership gate succeeds."""
+    if not should_start_cron_scheduler(runtime_owner, config=config):
+        return None
+    return resolve_cron_scheduler()
 
 
 class CronScheduler(ABC):
@@ -119,10 +219,6 @@ def resolve_cron_scheduler() -> "CronScheduler":
     False`` falls back to the built-in with a warning — cron must never be left
     without a trigger.
     """
-    import logging
-
-    logger = logging.getLogger("cron.scheduler_provider")
-
     name = ""
     try:
         from hermes_cli.config import cfg_get, load_config

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -19,105 +19,28 @@ selected via the `cron.provider` config key (empty = built-in).
 """
 from __future__ import annotations
 
-import io
 import logging
 import threading
 from abc import ABC, abstractmethod
-from typing import Any, cast
+from typing import Any
 
 
 logger = logging.getLogger("cron.scheduler_provider")
-
 _CRON_SCHEDULER_RUNTIME_OWNERS = frozenset({"gateway", "desktop"})
 
 
-def _read_scheduler_owner_config_strict() -> dict[str, Any] | None:
-    """Read scheduler ownership without the normal tolerant config fallback."""
-    from hermes_cli import managed_scope
-    from hermes_cli.config import _expand_env_vars, get_config_path
-    from utils import fast_safe_load
-
-    def _read_mapping(path) -> dict[str, Any]:
-        try:
-            with open(path, encoding="utf-8") as handle:
-                raw = handle.read()
-        except FileNotFoundError:
-            return {}
-        meaningful = [
-            line.split("#", 1)[0].strip()
-            for line in raw.splitlines()
-            if line.split("#", 1)[0].strip() not in {"", "---", "..."}
-        ]
-        if not meaningful:
-            return {}
-        parsed = fast_safe_load(io.StringIO(raw))
-        if not isinstance(parsed, dict):
-            raise ValueError("config root must be a mapping")
-        return parsed
-
-    try:
-        user_config = cast(
-            dict[str, Any], _expand_env_vars(_read_mapping(get_config_path()))
-        )
-        managed_dir = managed_scope.get_managed_dir()
-        managed_config = (
-            cast(
-                dict[str, Any],
-                _expand_env_vars(_read_mapping(managed_dir / "config.yaml")),
-            )
-            if managed_dir is not None
-            else {}
-        )
-        user_cron = user_config.get("cron", {})
-        managed_cron = managed_config.get("cron", {})
-        if "cron" in user_config and not isinstance(user_cron, dict):
-            raise ValueError("cron section must be a mapping")
-        if "cron" in managed_config and not isinstance(managed_cron, dict):
-            raise ValueError("managed cron section must be a mapping")
-        effective_cron = dict(user_cron)
-        effective_cron.update(managed_cron)
-        return {"cron": effective_cron}
-    except Exception:
-        logger.error(
-            "Unable to read a valid cron.scheduler_owner; scheduler startup disabled. "
-            "Set it to auto, gateway, or desktop in config.yaml."
-        )
-        return None
-
-
 def resolve_cron_scheduler_owner(*, config: dict[str, Any] | None = None) -> str | None:
-    """Resolve the ownership policy, failing closed on malformed input."""
-    if config is None:
-        config = _read_scheduler_owner_config_strict()
-        if config is None:
-            return None
-    if not isinstance(config, dict):
-        logger.error("Invalid configuration root; scheduler startup disabled.")
-        return None
-    cron_config = config.get("cron", {})
-    if "cron" in config and not isinstance(cron_config, dict):
-        logger.error("Invalid cron configuration shape; scheduler startup disabled.")
-        return None
-    raw_owner = cron_config.get("scheduler_owner", "auto")
-    owner = raw_owner.strip().lower() if isinstance(raw_owner, str) else None
-    if owner == "auto" or owner in _CRON_SCHEDULER_RUNTIME_OWNERS:
-        return owner
-    logger.error(
-        "Invalid cron.scheduler_owner; scheduler startup disabled. "
-        "Use auto, gateway, or desktop in config.yaml."
-    )
-    return None
+    """Compatibility wrapper for the unified strict ownership policy reader."""
+    from cron.scheduler_runtime import read_scheduler_ownership_policy_strict
+
+    policy = read_scheduler_ownership_policy_strict(config)
+    return policy.mode if policy is not None else None
 
 
 def should_start_cron_scheduler(
     runtime_owner: str, *, config: dict[str, Any] | None = None
 ) -> bool:
-    """Return whether this runtime participates in the ownership policy.
-
-    Under ``auto`` the gateway is preferred and Desktop may run the built-in
-    ticker as a dynamically yielding standby. Provider-specific fail-closed
-    handling for that standby happens in ``resolve_cron_scheduler_startup``.
-    """
+    """Compatibility policy probe; it does not itself grant ownership."""
     if runtime_owner not in _CRON_SCHEDULER_RUNTIME_OWNERS:
         raise ValueError("Unknown cron scheduler runtime owner")
     owner = resolve_cron_scheduler_owner(config=config)
@@ -127,7 +50,7 @@ def should_start_cron_scheduler(
 def resolve_owned_cron_scheduler(
     runtime_owner: str, *, config: dict[str, Any] | None = None
 ) -> "CronScheduler | None":
-    """Resolve the provider only after the shared ownership gate succeeds."""
+    """Legacy one-shot resolver. Automatic runtimes use OwnedSchedulerRuntime."""
     _owner, provider = resolve_cron_scheduler_startup(runtime_owner, config=config)
     return provider
 
@@ -135,27 +58,25 @@ def resolve_owned_cron_scheduler(
 def resolve_cron_scheduler_startup(
     runtime_owner: str, *, config: dict[str, Any] | None = None
 ) -> "tuple[str | None, CronScheduler | None]":
-    """Resolve one ownership snapshot and its provider for runtime startup."""
+    """Legacy policy snapshot using strict, no-fallback runtime resolution."""
+    from cron.scheduler_runtime import (
+        read_scheduler_ownership_policy_strict,
+        scheduler_runtime_is_eligible,
+    )
+
     if runtime_owner not in _CRON_SCHEDULER_RUNTIME_OWNERS:
         raise ValueError("Unknown cron scheduler runtime owner")
-    if config is None:
-        config = _read_scheduler_owner_config_strict()
-        if config is None:
-            return None, None
-    owner = resolve_cron_scheduler_owner(config=config)
-    if owner is None or (owner != runtime_owner and owner != "auto"):
-        return owner, None
-    provider = resolve_cron_scheduler()
-    if (
-        owner == "auto"
-        and runtime_owner == "desktop"
-        and not isinstance(provider, InProcessCronScheduler)
-    ):
-        logger.info(
-            "Desktop cron standby disabled for external provider under auto ownership"
-        )
-        return owner, None
-    return owner, provider
+    policy = read_scheduler_ownership_policy_strict(config)
+    if policy is None:
+        return None, None
+    eligible = scheduler_runtime_is_eligible(
+        policy,
+        runtime=runtime_owner,  # type: ignore[arg-type]
+        same_home_gateway_running=False,
+    )
+    if not eligible:
+        return policy.mode, None
+    return policy.mode, resolve_cron_scheduler_runtime_strict(policy.configured_provider)
 
 
 class CronScheduler(ABC):
@@ -200,9 +121,12 @@ class CronScheduler(ABC):
         """
 
     def stop(self) -> None:
-        """Optional eager teardown hook. Default no-op; setting the stop_event
-        is the primary stop signal. Override for providers holding external
-        resources (queue consumers, HTTP servers)."""
+        """Synchronously stop creating dispatches and release owned resources.
+
+        The runtime also sets the provider stop event and drains ``start()`` plus
+        in-flight jobs before releasing ownership. Override for providers holding
+        external resources (queue consumers, callbacks, HTTP servers).
+        """
         return None
 
     # --- Optional hooks for external providers (added Phase 4). --------------
@@ -243,6 +167,36 @@ class CronScheduler(ABC):
         arm missing one-shots, cancel orphaned ones, re-arm changed times.
         Built-in: no-op."""
         return None
+
+
+def resolve_cron_scheduler_runtime_strict(configured_provider: str) -> "CronScheduler | None":
+    """Resolve an automatic-runtime provider without silent fallback."""
+    if configured_provider in _BUILTIN_PROVIDER_NAMES:
+        return InProcessCronScheduler()
+    try:
+        from plugins.cron_providers import load_cron_scheduler
+
+        provider = load_cron_scheduler(configured_provider)
+        if provider is None:
+            logger.error(
+                "Configured cron provider is not installed; automatic scheduler startup disabled."
+            )
+            return None
+        if not provider.is_available():
+            logger.error(
+                "Configured cron provider is unavailable; automatic scheduler startup disabled."
+            )
+            return None
+        logger.info("Using cron scheduler provider: %s", provider.name)
+        return provider
+    except Exception:
+        logger.exception(
+            "Configured cron provider failed to load; automatic scheduler startup disabled."
+        )
+        return None
+
+
+_BUILTIN_PROVIDER_NAMES = frozenset({"", "builtin", "in-process", "inprocess"})
 
 
 def resolve_cron_scheduler() -> "CronScheduler":

--- a/cron/scheduler_runtime.py
+++ b/cron/scheduler_runtime.py
@@ -1,0 +1,358 @@
+"""Unified policy, lease, provider, and drain lifecycle for cron runtimes."""
+from __future__ import annotations
+
+import io
+import logging
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Literal, cast
+
+from cron.scheduler_lease import SchedulerOwnershipLease
+
+logger = logging.getLogger("cron.scheduler_runtime")
+RuntimeOwner = Literal["gateway", "desktop"]
+OwnershipMode = Literal["auto", "gateway", "desktop"]
+_PROVIDER_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_BUILTIN_NAMES = frozenset({"", "builtin", "in-process", "inprocess"})
+_ACTIVE_PROVIDERS: dict[str, Any] = {}
+_ACTIVE_PROVIDERS_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class SchedulerOwnershipPolicy:
+    mode: OwnershipMode
+    configured_provider: str
+
+
+def _read_mapping(path: Path) -> dict[str, Any]:
+    from utils import fast_safe_load
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    meaningful = [
+        line.split("#", 1)[0].strip()
+        for line in raw.splitlines()
+        if line.split("#", 1)[0].strip() not in {"", "---", "..."}
+    ]
+    if not meaningful:
+        return {}
+    parsed = fast_safe_load(io.StringIO(raw))
+    if not isinstance(parsed, dict):
+        raise ValueError("config root must be a mapping")
+    return parsed
+
+
+def _read_effective_cron_config_strict() -> dict[str, Any] | None:
+    from hermes_cli import managed_scope
+    from hermes_cli.config import _expand_env_vars, get_config_path
+
+    try:
+        user_config = cast(dict[str, Any], _expand_env_vars(_read_mapping(get_config_path())))
+        managed_dir = managed_scope.get_managed_dir()
+        managed_config = (
+            cast(
+                dict[str, Any],
+                _expand_env_vars(_read_mapping(managed_dir / "config.yaml")),
+            )
+            if managed_dir is not None
+            else {}
+        )
+        user_cron = user_config.get("cron", {})
+        managed_cron = managed_config.get("cron", {})
+        if "cron" in user_config and not isinstance(user_cron, dict):
+            raise ValueError("cron section must be a mapping")
+        if "cron" in managed_config and not isinstance(managed_cron, dict):
+            raise ValueError("managed cron section must be a mapping")
+        effective = dict(user_cron)
+        effective.update(managed_cron)
+        return {"cron": effective}
+    except Exception:
+        logger.error(
+            "Unable to read valid cron scheduler policy; automatic scheduler startup disabled."
+        )
+        return None
+
+
+def read_scheduler_ownership_policy_strict(
+    config: dict[str, Any] | None = None,
+) -> SchedulerOwnershipPolicy | None:
+    """Read ownership and provider together, failing closed on malformed input."""
+    if config is None:
+        config = _read_effective_cron_config_strict()
+        if config is None:
+            return None
+    if not isinstance(config, dict):
+        logger.error("Invalid configuration root; scheduler startup disabled.")
+        return None
+    cron = config.get("cron", {})
+    if "cron" in config and not isinstance(cron, dict):
+        logger.error("Invalid cron configuration shape; scheduler startup disabled.")
+        return None
+
+    raw_mode = cron.get("scheduler_owner", "auto")
+    mode = raw_mode.strip().lower() if isinstance(raw_mode, str) else ""
+    if mode not in {"auto", "gateway", "desktop"}:
+        logger.error(
+            "Invalid cron.scheduler_owner; scheduler startup disabled. Use auto, gateway, or desktop."
+        )
+        return None
+
+    raw_provider = cron.get("provider", "")
+    if raw_provider is None:
+        raw_provider = ""
+    if not isinstance(raw_provider, str):
+        logger.error("Invalid cron.provider; automatic scheduler startup disabled.")
+        return None
+    provider = raw_provider.strip().lower()
+    if provider in _BUILTIN_NAMES:
+        provider = "builtin"
+    elif not _PROVIDER_NAME_RE.fullmatch(provider):
+        logger.error("Invalid cron.provider; automatic scheduler startup disabled.")
+        return None
+    return SchedulerOwnershipPolicy(cast(OwnershipMode, mode), provider)
+
+
+def scheduler_runtime_is_eligible(
+    policy: SchedulerOwnershipPolicy,
+    *,
+    runtime: RuntimeOwner,
+    same_home_gateway_running: bool,
+) -> bool:
+    if runtime not in {"gateway", "desktop"}:
+        raise ValueError("Unknown cron scheduler runtime owner")
+    if policy.mode == "gateway":
+        return runtime == "gateway"
+    if policy.mode == "desktop":
+        return runtime == "desktop"
+    if runtime == "gateway":
+        return True
+    return policy.configured_provider == "builtin" and not same_home_gateway_running
+
+
+def _home_key(home: Path | None = None) -> str:
+    if home is None:
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home()
+    return str(home.expanduser().resolve())
+
+
+def get_active_scheduler_provider(*, hermes_home: Path | None = None) -> Any | None:
+    """Return only the provider protected by this process's active lease."""
+    with _ACTIVE_PROVIDERS_LOCK:
+        return _ACTIVE_PROVIDERS.get(_home_key(hermes_home))
+
+
+def _set_active_provider(home: Path, provider: Any | None) -> None:
+    key = _home_key(home)
+    with _ACTIVE_PROVIDERS_LOCK:
+        if provider is None:
+            _ACTIVE_PROVIDERS.pop(key, None)
+        else:
+            _ACTIVE_PROVIDERS[key] = provider
+
+
+class OwnedSchedulerRuntime:
+    """Blocking scheduler supervisor intended to run in one daemon thread."""
+
+    def __init__(
+        self,
+        runtime_owner: RuntimeOwner,
+        *,
+        adapters: Any = None,
+        loop: Any = None,
+        can_dispatch: Callable[[], bool] | None = None,
+        gateway_is_running: Callable[[], bool] | None = None,
+        interval: int = 60,
+        poll_interval: float = 0.5,
+        drain_timeout: float = 65.0,
+        hermes_home: Path | None = None,
+    ) -> None:
+        if runtime_owner not in {"gateway", "desktop"}:
+            raise ValueError("Unknown cron scheduler runtime owner")
+        self.runtime_owner: RuntimeOwner = cast(RuntimeOwner, runtime_owner)
+        self.adapters = adapters
+        self.loop = loop
+        self.can_dispatch = can_dispatch
+        self.gateway_is_running = gateway_is_running or (lambda: False)
+        self.interval = interval
+        self.poll_interval = poll_interval
+        self.drain_timeout = drain_timeout
+        self.hermes_home = Path(hermes_home) if hermes_home is not None else None
+        self._active_provider: Any | None = None
+        self._lease: SchedulerOwnershipLease | None = None
+        self._provider_thread: threading.Thread | None = None
+        self._provider_stop: threading.Event | None = None
+        self._provider_failed = threading.Event()
+        self._state_lock = threading.Lock()
+
+    @property
+    def active_provider(self) -> Any | None:
+        with self._state_lock:
+            return self._active_provider
+
+    def _current_home(self) -> Path:
+        if self.hermes_home is not None:
+            return self.hermes_home.expanduser().resolve()
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home().expanduser().resolve()
+
+    def _gateway_running(self) -> bool:
+        if self.runtime_owner != "desktop":
+            return False
+        try:
+            return bool(self.gateway_is_running())
+        except Exception:
+            logger.exception("Unable to inspect gateway runtime lock; Desktop cron yields closed")
+            return True
+
+    def _eligible(self, policy: SchedulerOwnershipPolicy | None) -> bool:
+        return policy is not None and scheduler_runtime_is_eligible(
+            policy,
+            runtime=self.runtime_owner,
+            same_home_gateway_running=self._gateway_running(),
+        )
+
+    def _provider_target(self, provider: Any, stop_event: threading.Event) -> None:
+        from cron.scheduler_provider import InProcessCronScheduler
+
+        kwargs: dict[str, Any] = {
+            "adapters": self.adapters,
+            "loop": self.loop,
+            "interval": self.interval,
+        }
+        if isinstance(provider, InProcessCronScheduler) and self.can_dispatch is not None:
+            kwargs["can_dispatch"] = self.can_dispatch
+        try:
+            provider.start(stop_event, **kwargs)
+        except BaseException:
+            self._provider_failed.set()
+            logger.exception("Cron scheduler provider failed")
+
+    def _start_active(self, policy: SchedulerOwnershipPolicy, home: Path) -> bool:
+        lease = SchedulerOwnershipLease.try_acquire(
+            hermes_home=home,
+            owner=self.runtime_owner,
+            provider=policy.configured_provider,
+        )
+        if lease is None:
+            return False
+
+        # Close policy/gateway-presence check-to-acquire races before provider
+        # construction can produce side effects.
+        fresh = read_scheduler_ownership_policy_strict()
+        if not self._eligible(fresh) or fresh != policy:
+            lease.release()
+            return False
+        assert fresh is not None
+
+        from cron.scheduler_provider import resolve_cron_scheduler_runtime_strict
+
+        provider = resolve_cron_scheduler_runtime_strict(fresh.configured_provider)
+        if provider is None:
+            lease.release()
+            return False
+
+        provider_stop = threading.Event()
+        self._provider_failed.clear()
+        thread = threading.Thread(
+            target=self._provider_target,
+            args=(provider, provider_stop),
+            daemon=True,
+            name=f"{self.runtime_owner}-cron-provider",
+        )
+        with self._state_lock:
+            self._lease = lease
+            self._active_provider = provider
+            self._provider_stop = provider_stop
+            self._provider_thread = thread
+        _set_active_provider(home, provider)
+        try:
+            thread.start()
+        except BaseException:
+            _set_active_provider(home, None)
+            with self._state_lock:
+                self._lease = None
+                self._active_provider = None
+                self._provider_stop = None
+                self._provider_thread = None
+            lease.release()
+            raise
+        logger.info(
+            "%s acquired cron scheduler ownership (provider=%s)",
+            self.runtime_owner.capitalize(),
+            provider.name,
+        )
+        return True
+
+    @staticmethod
+    def _jobs_drained() -> bool:
+        try:
+            from cron.scheduler import get_running_job_ids
+
+            return not get_running_job_ids()
+        except Exception:
+            logger.exception("Unable to inspect in-flight cron jobs; retaining scheduler lease")
+            return False
+
+    def _drain_active(self, stop_event: threading.Event) -> None:
+        with self._state_lock:
+            provider = self._active_provider
+            provider_stop = self._provider_stop
+            thread = self._provider_thread
+            lease = self._lease
+        if provider is None or lease is None:
+            return
+
+        if provider_stop is not None:
+            provider_stop.set()
+        try:
+            provider.stop()
+        except BaseException:
+            logger.exception("Cron scheduler provider stop() failed; retaining lease until drained")
+        _set_active_provider(self._current_home(), None)
+
+        deadline = time.monotonic() + max(0.0, self.drain_timeout)
+        warned = False
+        while (thread is not None and thread.is_alive()) or not self._jobs_drained():
+            if not warned and time.monotonic() >= deadline:
+                warned = True
+                logger.warning(
+                    "Cron scheduler did not drain within %.0fs; retaining ownership until drain or process death",
+                    self.drain_timeout,
+                )
+            # A shutdown request does not weaken the no-overlap invariant.
+            stop_event.wait(min(self.poll_interval, 0.1) if warned else self.poll_interval)
+
+        with self._state_lock:
+            self._active_provider = None
+            self._provider_stop = None
+            self._provider_thread = None
+            self._lease = None
+        lease.release()
+        logger.info("%s released cron scheduler ownership", self.runtime_owner.capitalize())
+
+    def run(self, stop_event: threading.Event) -> None:
+        """Supervise policy and ownership until stopped and fully drained."""
+        home = self._current_home()
+        while not stop_event.is_set():
+            policy = read_scheduler_ownership_policy_strict()
+            active = self.active_provider
+            if active is not None and (not self._eligible(policy) or self._provider_failed.is_set()):
+                self._drain_active(stop_event)
+                if self._provider_failed.is_set():
+                    stop_event.wait(self.poll_interval)
+                continue
+            if active is None and self._eligible(policy):
+                assert policy is not None
+                self._start_active(policy, home)
+            stop_event.wait(self.poll_interval)
+
+        self._drain_active(stop_event)

--- a/cron/scheduler_runtime.py
+++ b/cron/scheduler_runtime.py
@@ -286,6 +286,7 @@ class OwnedSchedulerRuntime:
         self._state_lock = threading.Lock()
         self._active_policy: SchedulerOwnershipPolicy | None = None
         self._active_generation: int | None = None
+        self._active_home: Path | None = None
 
     @property
     def active_provider(self) -> Any | None:
@@ -369,6 +370,7 @@ class OwnedSchedulerRuntime:
             self._provider_stop = provider_stop
             self._provider_thread = thread
             self._active_policy = fresh
+            self._active_home = home
         try:
             thread.start()
         except BaseException:
@@ -379,6 +381,7 @@ class OwnedSchedulerRuntime:
                 self._provider_thread = None
                 self._active_policy = None
                 self._active_generation = None
+                self._active_home = None
             lease.release()
             raise
         generation_state = _publish_active_provider(home, provider)
@@ -408,14 +411,20 @@ class OwnedSchedulerRuntime:
             thread = self._provider_thread
             lease = self._lease
             generation = self._active_generation
+            active_home = self._active_home
         if provider is None or lease is None:
             return
 
         # Fence callbacks first: no new reservations may capture this generation
         # after provider shutdown begins.
+        if generation is not None and active_home is None:
+            logger.error(
+                "Active cron scheduler generation has no pinned home; retaining ownership"
+            )
+            return
         generation_state = (
-            _stop_accepting_provider(self._current_home(), generation)
-            if generation is not None
+            _stop_accepting_provider(active_home, generation)
+            if generation is not None and active_home is not None
             else None
         )
         if provider_stop is not None:
@@ -457,6 +466,7 @@ class OwnedSchedulerRuntime:
             self._lease = None
             self._active_policy = None
             self._active_generation = None
+            self._active_home = None
         lease.release()
         logger.info("%s released cron scheduler ownership", self.runtime_owner.capitalize())
 

--- a/cron/scheduler_runtime.py
+++ b/cron/scheduler_runtime.py
@@ -1,7 +1,7 @@
 """Unified policy, lease, provider, and drain lifecycle for cron runtimes."""
 from __future__ import annotations
 
-import io
+import contextlib
 import logging
 import os
 import re
@@ -9,7 +9,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Literal, cast
+from typing import Any, Callable, Iterator, Literal, cast
 
 from cron.scheduler_lease import SchedulerOwnershipLease
 
@@ -18,8 +18,19 @@ RuntimeOwner = Literal["gateway", "desktop"]
 OwnershipMode = Literal["auto", "gateway", "desktop"]
 _PROVIDER_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 _BUILTIN_NAMES = frozenset({"", "builtin", "in-process", "inprocess"})
-_ACTIVE_PROVIDERS: dict[str, Any] = {}
-_ACTIVE_PROVIDERS_LOCK = threading.Lock()
+_ACTIVE_PROVIDERS_LOCK = threading.Condition()
+_NEXT_GENERATION = 0
+
+
+@dataclass
+class _ActiveProviderGeneration:
+    provider: Any
+    generation: int
+    accepting: bool = True
+    reservations: int = 0
+
+
+_ACTIVE_PROVIDERS: dict[str, _ActiveProviderGeneration] = {}
 
 
 @dataclass(frozen=True)
@@ -29,7 +40,23 @@ class SchedulerOwnershipPolicy:
 
 
 def _read_mapping(path: Path) -> dict[str, Any]:
-    from utils import fast_safe_load
+    import yaml
+
+    class _UniqueKeyLoader(yaml.SafeLoader):
+        pass
+
+    def _construct_unique_mapping(loader: Any, node: Any, deep: bool = False) -> dict:
+        result: dict[Any, Any] = {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            if key in result:
+                raise ValueError("duplicate mapping key")
+            result[key] = loader.construct_object(value_node, deep=deep)
+        return result
+
+    _UniqueKeyLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_unique_mapping
+    )
 
     try:
         raw = path.read_text(encoding="utf-8")
@@ -42,7 +69,7 @@ def _read_mapping(path: Path) -> dict[str, Any]:
     ]
     if not meaningful:
         return {}
-    parsed = fast_safe_load(io.StringIO(raw))
+    parsed = yaml.load(raw, Loader=_UniqueKeyLoader)
     if not isinstance(parsed, dict):
         raise ValueError("config root must be a mapping")
     return parsed
@@ -115,6 +142,11 @@ def read_scheduler_ownership_policy_strict(
     elif not _PROVIDER_NAME_RE.fullmatch(provider):
         logger.error("Invalid cron.provider; automatic scheduler startup disabled.")
         return None
+    if mode == "desktop" and provider != "builtin":
+        logger.error(
+            "Invalid cron scheduler policy: external providers require Gateway ownership; scheduler startup disabled."
+        )
+        return None
     return SchedulerOwnershipPolicy(cast(OwnershipMode, mode), provider)
 
 
@@ -126,6 +158,8 @@ def scheduler_runtime_is_eligible(
 ) -> bool:
     if runtime not in {"gateway", "desktop"}:
         raise ValueError("Unknown cron scheduler runtime owner")
+    if policy.configured_provider != "builtin" and runtime != "gateway":
+        return False
     if policy.mode == "gateway":
         return runtime == "gateway"
     if policy.mode == "desktop":
@@ -143,19 +177,78 @@ def _home_key(home: Path | None = None) -> str:
     return str(home.expanduser().resolve())
 
 
-def get_active_scheduler_provider(*, hermes_home: Path | None = None) -> Any | None:
-    """Return only the provider protected by this process's active lease."""
+class SchedulerProviderReservation:
+    """A callback reservation pinned to one accepting leased generation."""
+
+    def __init__(self, state: _ActiveProviderGeneration) -> None:
+        self._state = state
+        self.provider = state.provider
+        self.generation = state.generation
+        self._released = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+        with _ACTIVE_PROVIDERS_LOCK:
+            if self._released:
+                return
+            self._released = True
+            self._state.reservations -= 1
+            _ACTIVE_PROVIDERS_LOCK.notify_all()
+
+    def __enter__(self) -> "SchedulerProviderReservation":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.release()
+
+
+def reserve_active_scheduler_provider(
+    *, hermes_home: Path | None = None
+) -> SchedulerProviderReservation | None:
+    """Reserve the currently accepting leased generation, or fail closed."""
     with _ACTIVE_PROVIDERS_LOCK:
-        return _ACTIVE_PROVIDERS.get(_home_key(hermes_home))
+        state = _ACTIVE_PROVIDERS.get(_home_key(hermes_home))
+        if state is None or not state.accepting:
+            return None
+        state.reservations += 1
+        return SchedulerProviderReservation(state)
 
 
-def _set_active_provider(home: Path, provider: Any | None) -> None:
+@contextlib.contextmanager
+def reserved_active_scheduler_provider(
+    *, hermes_home: Path | None = None
+) -> Iterator[SchedulerProviderReservation | None]:
+    reservation = reserve_active_scheduler_provider(hermes_home=hermes_home)
+    try:
+        yield reservation
+    finally:
+        if reservation is not None:
+            reservation.release()
+
+
+def _publish_active_provider(home: Path, provider: Any) -> _ActiveProviderGeneration:
+    global _NEXT_GENERATION
     key = _home_key(home)
     with _ACTIVE_PROVIDERS_LOCK:
-        if provider is None:
-            _ACTIVE_PROVIDERS.pop(key, None)
-        else:
-            _ACTIVE_PROVIDERS[key] = provider
+        _NEXT_GENERATION += 1
+        state = _ActiveProviderGeneration(provider=provider, generation=_NEXT_GENERATION)
+        _ACTIVE_PROVIDERS[key] = state
+        return state
+
+
+def _stop_accepting_provider(
+    home: Path, generation: int
+) -> _ActiveProviderGeneration | None:
+    key = _home_key(home)
+    with _ACTIVE_PROVIDERS_LOCK:
+        state = _ACTIVE_PROVIDERS.get(key)
+        if state is None or state.generation != generation:
+            return None
+        state.accepting = False
+        _ACTIVE_PROVIDERS.pop(key, None)
+        _ACTIVE_PROVIDERS_LOCK.notify_all()
+        return state
 
 
 class OwnedSchedulerRuntime:
@@ -191,6 +284,8 @@ class OwnedSchedulerRuntime:
         self._provider_stop: threading.Event | None = None
         self._provider_failed = threading.Event()
         self._state_lock = threading.Lock()
+        self._active_policy: SchedulerOwnershipPolicy | None = None
+        self._active_generation: int | None = None
 
     @property
     def active_provider(self) -> Any | None:
@@ -273,18 +368,22 @@ class OwnedSchedulerRuntime:
             self._active_provider = provider
             self._provider_stop = provider_stop
             self._provider_thread = thread
-        _set_active_provider(home, provider)
+            self._active_policy = fresh
         try:
             thread.start()
         except BaseException:
-            _set_active_provider(home, None)
             with self._state_lock:
                 self._lease = None
                 self._active_provider = None
                 self._provider_stop = None
                 self._provider_thread = None
+                self._active_policy = None
+                self._active_generation = None
             lease.release()
             raise
+        generation_state = _publish_active_provider(home, provider)
+        with self._state_lock:
+            self._active_generation = generation_state.generation
         logger.info(
             "%s acquired cron scheduler ownership (provider=%s)",
             self.runtime_owner.capitalize(),
@@ -308,34 +407,56 @@ class OwnedSchedulerRuntime:
             provider_stop = self._provider_stop
             thread = self._provider_thread
             lease = self._lease
+            generation = self._active_generation
         if provider is None or lease is None:
             return
 
+        # Fence callbacks first: no new reservations may capture this generation
+        # after provider shutdown begins.
+        generation_state = (
+            _stop_accepting_provider(self._current_home(), generation)
+            if generation is not None
+            else None
+        )
         if provider_stop is not None:
             provider_stop.set()
         try:
             provider.stop()
         except BaseException:
             logger.exception("Cron scheduler provider stop() failed; retaining lease until drained")
-        _set_active_provider(self._current_home(), None)
 
         deadline = time.monotonic() + max(0.0, self.drain_timeout)
         warned = False
-        while (thread is not None and thread.is_alive()) or not self._jobs_drained():
+        while True:
+            with _ACTIVE_PROVIDERS_LOCK:
+                reservations_drained = (
+                    generation_state is None or generation_state.reservations == 0
+                )
+            if (
+                (thread is None or not thread.is_alive())
+                and self._jobs_drained()
+                and reservations_drained
+            ):
+                break
             if not warned and time.monotonic() >= deadline:
                 warned = True
                 logger.warning(
                     "Cron scheduler did not drain within %.0fs; retaining ownership until drain or process death",
                     self.drain_timeout,
                 )
-            # A shutdown request does not weaken the no-overlap invariant.
-            stop_event.wait(min(self.poll_interval, 0.1) if warned else self.poll_interval)
+            # stop_event is already set during shutdown, so waiting on it would
+            # busy-spin. The condition paces polling and wakes on reservation release.
+            delay = min(self.poll_interval, 0.1) if warned else self.poll_interval
+            with _ACTIVE_PROVIDERS_LOCK:
+                _ACTIVE_PROVIDERS_LOCK.wait(timeout=delay)
 
         with self._state_lock:
             self._active_provider = None
             self._provider_stop = None
             self._provider_thread = None
             self._lease = None
+            self._active_policy = None
+            self._active_generation = None
         lease.release()
         logger.info("%s released cron scheduler ownership", self.runtime_owner.capitalize())
 
@@ -344,8 +465,14 @@ class OwnedSchedulerRuntime:
         home = self._current_home()
         while not stop_event.is_set():
             policy = read_scheduler_ownership_policy_strict()
-            active = self.active_provider
-            if active is not None and (not self._eligible(policy) or self._provider_failed.is_set()):
+            with self._state_lock:
+                active = self._active_provider
+                active_policy = self._active_policy
+            if active is not None and (
+                not self._eligible(policy)
+                or policy != active_policy
+                or self._provider_failed.is_set()
+            ):
                 self._drain_active(stop_event)
                 if self._provider_failed.is_set():
                     stop_event.wait(self.poll_interval)

--- a/docs/chronos-managed-cron-contract.md
+++ b/docs/chronos-managed-cron-contract.md
@@ -191,6 +191,7 @@ credentials. For hosted agents NAS sets these at provision time:
 | key | meaning |
 |---|---|
 | `cron.provider` | `"chronos"` to activate (empty = built-in ticker) |
+| `cron.scheduler_owner` | Must be `"gateway"` or `"auto"`; external providers are Gateway-only and explicit `"desktop"` fails closed |
 | `cron.chronos.portal_url` | NAS base URL (also the expected JWT `iss`) |
 | `cron.chronos.callback_url` | the agent's own public base URL for NAS→agent fires |
 | `cron.chronos.expected_audience` | this agent's JWT `aud` (`agent:{instance_id}`) |

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4291,15 +4291,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
 
             loop = asyncio.get_running_loop()
-            # Fire in the background (202 immediately). fire_due claims via the
-            # store CAS, so a retry while this is in flight is de-duped. Keep the
-            # scheduler reservation until the actual worker thread exits:
-            # cancelling asyncio.to_thread() does not stop a running worker.
+            # Fire in a dedicated daemon thread (202 immediately). A raw thread
+            # cannot be cancelled by asyncio teardown, so the scheduler
+            # reservation remains tied to the actual callback lifetime rather
+            # than to a cancellable executor wrapper.
             import threading
 
-            worker_started = threading.Event()
             release_lock = threading.Lock()
             released = False
+            completion = loop.create_future()
 
             def _release_fire_reservations() -> None:
                 nonlocal released
@@ -4307,19 +4307,27 @@ class APIServerAdapter(BasePlatformAdapter):
                     if released:
                         return
                     released = True
-                scheduler_reservation.release()
                 try:
-                    loop.call_soon_threadsafe(
-                        _release_pending_api_work, self, reservation
-                    )
-                except RuntimeError:
-                    # The loop can close during process teardown. The scheduler
-                    # reservation has already been released; finish local
-                    # accounting without leaking the detached reservation.
-                    _release_pending_api_work(self, reservation)
+                    scheduler_reservation.release()
+                except BaseException:
+                    # Reservation failures must fail closed without leaking raw
+                    # backend text or preventing pending-work cleanup.
+                    logger.error("cron fire: scheduler reservation release failed")
+                finally:
+                    try:
+                        loop.call_soon_threadsafe(
+                            _release_pending_api_work, self, reservation
+                        )
+                    except RuntimeError:
+                        # The loop can close during process teardown. Finish
+                        # local accounting without leaking the detached work.
+                        _release_pending_api_work(self, reservation)
+
+            def _mark_worker_complete() -> None:
+                if not completion.done():
+                    completion.set_result(None)
 
             def _fire_due_worker() -> None:
-                worker_started.set()
                 try:
                     scheduler_reservation.provider.fire_due(
                         job_id,
@@ -4329,53 +4337,50 @@ class APIServerAdapter(BasePlatformAdapter):
                 except BaseException:
                     # Provider/backend messages can contain credentials. Keep
                     # diagnostics deliberately generic and consume the error in
-                    # the worker so asyncio cannot print an unredacted
-                    # "Task exception was never retrieved" traceback.
+                    # the worker so asyncio cannot print an unredacted traceback.
                     logger.error("cron fire: provider worker failed")
                 finally:
                     _release_fire_reservations()
+                    try:
+                        loop.call_soon_threadsafe(_mark_worker_complete)
+                    except RuntimeError:
+                        pass
 
             async def _wait_for_fire_worker() -> None:
-                worker = asyncio.create_task(
-                    asyncio.to_thread(_fire_due_worker),
-                    name="cron-fire-worker",
-                )
                 cancelled = False
-                while True:
+                while not completion.done():
                     try:
-                        await asyncio.shield(worker)
-                        break
+                        await asyncio.shield(completion)
                     except asyncio.CancelledError:
-                        # Shield the worker from every shutdown cancellation and
-                        # keep this task pending until the worker truly exits.
-                        # Event-loop teardown can also cancel the inner task
-                        # directly; in that case stop awaiting the already
-                        # cancelled wrapper. The real thread still owns release
-                        # through _fire_due_worker()'s finally block (or never
-                        # started, which the outer done callback handles).
                         cancelled = True
-                        if worker.cancelled():
+                        # Loop teardown may cancel the completion future itself.
+                        # The thread still owns release, so stop waiting rather
+                        # than spinning on an already-cancelled Future.
+                        if completion.cancelled():
                             break
                 if cancelled:
                     raise asyncio.CancelledError
 
+            reservation["detached"] = True
+            worker_thread = threading.Thread(
+                target=_fire_due_worker,
+                daemon=True,
+                name="cron-fire-worker",
+            )
+            try:
+                worker_thread.start()
+            except BaseException:
+                _release_fire_reservations()
+                raise
             try:
                 task = asyncio.create_task(
                     _wait_for_fire_worker(),
                     name="cron-fire-supervisor",
                 )
             except BaseException:
-                _release_fire_reservations()
+                # The worker remains authoritative and will release from its
+                # finally block even if no asyncio tracking task can be created.
                 raise
-            reservation["detached"] = True
-
-            def _release_if_never_started(_task: asyncio.Task) -> None:
-                # A task can be cancelled before its coroutine gets its first
-                # turn, in which case no worker exists to run its finally block.
-                if not worker_started.is_set():
-                    _release_fire_reservations()
-
-            task.add_done_callback(_release_if_never_started)
             try:
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4282,8 +4282,13 @@ class APIServerAdapter(BasePlatformAdapter):
             if not job_id:
                 return web.json_response({"error": "missing job_id"}, status=400)
 
-            from cron.scheduler_provider import resolve_cron_scheduler
-            provider = resolve_cron_scheduler()
+            from cron.scheduler_runtime import get_active_scheduler_provider
+
+            provider = get_active_scheduler_provider()
+            if provider is None:
+                return web.json_response(
+                    {"error": "scheduler ownership unavailable"}, status=503
+                )
 
             loop = asyncio.get_running_loop()
             # Fire in the background (202 immediately). fire_due claims via the

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4292,26 +4292,71 @@ class APIServerAdapter(BasePlatformAdapter):
 
             loop = asyncio.get_running_loop()
             # Fire in the background (202 immediately). fire_due claims via the
-            # store CAS, so a retry while this is in flight is de-duped.
-            try:
-                task = asyncio.create_task(
-                    asyncio.to_thread(
-                        scheduler_reservation.provider.fire_due,
+            # store CAS, so a retry while this is in flight is de-duped. Keep the
+            # scheduler reservation until the actual worker thread exits:
+            # cancelling asyncio.to_thread() does not stop a running worker.
+            import threading
+
+            worker_started = threading.Event()
+            release_lock = threading.Lock()
+            released = False
+
+            def _release_fire_reservations() -> None:
+                nonlocal released
+                with release_lock:
+                    if released:
+                        return
+                    released = True
+                scheduler_reservation.release()
+                try:
+                    loop.call_soon_threadsafe(
+                        _release_pending_api_work, self, reservation
+                    )
+                except RuntimeError:
+                    # The loop can close during process teardown. The scheduler
+                    # reservation has already been released; finish local
+                    # accounting without leaking the detached reservation.
+                    _release_pending_api_work(self, reservation)
+
+            def _fire_due_worker() -> None:
+                worker_started.set()
+                try:
+                    scheduler_reservation.provider.fire_due(
                         job_id,
                         adapters=None,
                         loop=loop,
                     )
-                )
+                finally:
+                    _release_fire_reservations()
+
+            async def _wait_for_fire_worker() -> None:
+                worker = asyncio.create_task(asyncio.to_thread(_fire_due_worker))
+                cancelled = False
+                while True:
+                    try:
+                        await asyncio.shield(worker)
+                        break
+                    except asyncio.CancelledError:
+                        # Shield the worker from every shutdown cancellation and
+                        # keep this task pending until the worker truly exits.
+                        cancelled = True
+                if cancelled:
+                    raise asyncio.CancelledError
+
+            try:
+                task = asyncio.create_task(_wait_for_fire_worker())
             except BaseException:
-                scheduler_reservation.release()
+                _release_fire_reservations()
                 raise
             reservation["detached"] = True
 
-            def _release_fire_reservations(_task: asyncio.Task) -> None:
-                scheduler_reservation.release()
-                _release_pending_api_work(self, reservation)
+            def _release_if_never_started(_task: asyncio.Task) -> None:
+                # A task can be cancelled before its coroutine gets its first
+                # turn, in which case no worker exists to run its finally block.
+                if not worker_started.is_set():
+                    _release_fire_reservations()
 
-            task.add_done_callback(_release_fire_reservations)
+            task.add_done_callback(_release_if_never_started)
             try:
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4372,14 +4372,17 @@ class APIServerAdapter(BasePlatformAdapter):
             except BaseException:
                 _release_fire_reservations()
                 raise
+            supervisor = _wait_for_fire_worker()
             try:
                 task = asyncio.create_task(
-                    _wait_for_fire_worker(),
+                    supervisor,
                     name="cron-fire-supervisor",
                 )
             except BaseException:
-                # The worker remains authoritative and will release from its
-                # finally block even if no asyncio tracking task can be created.
+                # Avoid an unawaited-coroutine warning if task construction
+                # itself fails. The worker remains authoritative and will
+                # release from its finally block.
+                supervisor.close()
                 raise
             try:
                 self._background_tasks.add(task)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4282,10 +4282,10 @@ class APIServerAdapter(BasePlatformAdapter):
             if not job_id:
                 return web.json_response({"error": "missing job_id"}, status=400)
 
-            from cron.scheduler_runtime import get_active_scheduler_provider
+            from cron.scheduler_runtime import reserve_active_scheduler_provider
 
-            provider = get_active_scheduler_provider()
-            if provider is None:
+            scheduler_reservation = reserve_active_scheduler_provider()
+            if scheduler_reservation is None:
                 return web.json_response(
                     {"error": "scheduler ownership unavailable"}, status=503
                 )
@@ -4293,13 +4293,25 @@ class APIServerAdapter(BasePlatformAdapter):
             loop = asyncio.get_running_loop()
             # Fire in the background (202 immediately). fire_due claims via the
             # store CAS, so a retry while this is in flight is de-duped.
-            task = asyncio.create_task(
-                asyncio.to_thread(provider.fire_due, job_id, adapters=None, loop=loop)
-            )
+            try:
+                task = asyncio.create_task(
+                    asyncio.to_thread(
+                        scheduler_reservation.provider.fire_due,
+                        job_id,
+                        adapters=None,
+                        loop=loop,
+                    )
+                )
+            except BaseException:
+                scheduler_reservation.release()
+                raise
             reservation["detached"] = True
-            task.add_done_callback(
-                lambda _task: _release_pending_api_work(self, reservation)
-            )
+
+            def _release_fire_reservations(_task: asyncio.Task) -> None:
+                scheduler_reservation.release()
+                _release_pending_api_work(self, reservation)
+
+            task.add_done_callback(_release_fire_reservations)
             try:
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4371,8 +4371,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 worker_thread.start()
             except BaseException:
                 _release_fire_reservations()
-                raise
+                logger.error("cron fire: worker thread start failed")
+                return web.json_response(
+                    {"error": "cron fire dispatch unavailable"}, status=503
+                )
             supervisor = _wait_for_fire_worker()
+            task = None
             try:
                 task = asyncio.create_task(
                     supervisor,
@@ -4380,15 +4384,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
             except BaseException:
                 # Avoid an unawaited-coroutine warning if task construction
-                # itself fails. The worker remains authoritative and will
-                # release from its finally block.
+                # itself fails. The dedicated worker remains authoritative, so
+                # the accepted fire can continue without asyncio task tracking.
                 supervisor.close()
-                raise
-            try:
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
-            except (TypeError, AttributeError):
-                pass
+                logger.error("cron fire: supervisor task start failed")
+            if task is not None:
+                try:
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
+                except (TypeError, AttributeError):
+                    pass
 
             return web.json_response({"status": "accepted", "job_id": job_id}, status=202)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4326,11 +4326,20 @@ class APIServerAdapter(BasePlatformAdapter):
                         adapters=None,
                         loop=loop,
                     )
+                except BaseException:
+                    # Provider/backend messages can contain credentials. Keep
+                    # diagnostics deliberately generic and consume the error in
+                    # the worker so asyncio cannot print an unredacted
+                    # "Task exception was never retrieved" traceback.
+                    logger.error("cron fire: provider worker failed")
                 finally:
                     _release_fire_reservations()
 
             async def _wait_for_fire_worker() -> None:
-                worker = asyncio.create_task(asyncio.to_thread(_fire_due_worker))
+                worker = asyncio.create_task(
+                    asyncio.to_thread(_fire_due_worker),
+                    name="cron-fire-worker",
+                )
                 cancelled = False
                 while True:
                     try:
@@ -4339,12 +4348,22 @@ class APIServerAdapter(BasePlatformAdapter):
                     except asyncio.CancelledError:
                         # Shield the worker from every shutdown cancellation and
                         # keep this task pending until the worker truly exits.
+                        # Event-loop teardown can also cancel the inner task
+                        # directly; in that case stop awaiting the already
+                        # cancelled wrapper. The real thread still owns release
+                        # through _fire_due_worker()'s finally block (or never
+                        # started, which the outer done callback handles).
                         cancelled = True
+                        if worker.cancelled():
+                            break
                 if cancelled:
                     raise asyncio.CancelledError
 
             try:
-                task = asyncio.create_task(_wait_for_fire_worker())
+                task = asyncio.create_task(
+                    _wait_for_fire_worker(),
+                    name="cron-fire-supervisor",
+                )
             except BaseException:
                 _release_fire_reservations()
                 raise

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21092,6 +21092,34 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     InProcessCronScheduler().start(stop_event, adapters=adapters, loop=loop, interval=interval)
 
 
+def _start_gateway_cron_scheduler_if_owned(runner, stop_event, loop):
+    """Start cron only when the shared ownership policy selects this gateway."""
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        resolve_owned_cron_scheduler,
+    )
+
+    provider = resolve_owned_cron_scheduler("gateway")
+    if provider is None:
+        logger.info("Gateway cron scheduler not started by ownership policy")
+        return None, None
+
+    start_kwargs = {"adapters": runner.adapters, "loop": loop}
+    if isinstance(provider, InProcessCronScheduler):
+        start_kwargs["can_dispatch"] = lambda: not (
+            runner._draining or runner._external_drain_active
+        )
+    thread = threading.Thread(
+        target=provider.start,
+        args=(stop_event,),
+        kwargs=start_kwargs,
+        daemon=True,
+        name="cron-scheduler",
+    )
+    thread.start()
+    return provider, thread
+
+
 # Upper bound for cooperatively draining the cron ticker on shutdown. The cron
 # thread delivers via ``safe_schedule_threadsafe`` and blocks on
 # ``future.result(timeout=60)`` (see cron/scheduler.py::_deliver_result), so a
@@ -21584,30 +21612,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             raise SystemExit(runner.exit_code)
         return True
     
-    # Start the background cron scheduler via the resolved provider so
-    # scheduled jobs fire automatically. The built-in provider is the
-    # historical in-process 60s ticker; an external provider (e.g. chronos)
-    # may arm a schedule and return. Pass the event loop so cron delivery can
-    # use live adapters (E2EE support).
-    from cron.scheduler_provider import InProcessCronScheduler, resolve_cron_scheduler
+    # Both gateway and Desktop consult the same ownership helper so only one
+    # long-running runtime dispatches this profile's cron registry.
     cron_stop = threading.Event()
-    cron_provider = resolve_cron_scheduler()
-    cron_start_kwargs = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
-    # External cron providers own their remote scheduling contract. Only the
-    # in-process ticker polls local due jobs, so only it receives the local
-    # external-drain dispatch gate.
-    if isinstance(cron_provider, InProcessCronScheduler):
-        cron_start_kwargs["can_dispatch"] = lambda: not (
-            runner._draining or runner._external_drain_active
-        )
-    cron_thread = threading.Thread(
-        target=cron_provider.start,
-        args=(cron_stop,),
-        kwargs=cron_start_kwargs,
-        daemon=True,
-        name="cron-scheduler",
+    cron_provider, cron_thread = _start_gateway_cron_scheduler_if_owned(
+        runner, cron_stop, asyncio.get_running_loop()
     )
-    cron_thread.start()
 
     # Gateway-only periodic housekeeping (channel dir, cache cleanup, paste
     # sweep, curator) — runs independently of which cron provider is active.
@@ -21646,11 +21656,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # silently dropped (#58818). Awaiting keeps the loop alive so the in-flight
     # delivery finishes before we tear down.
     cron_stop.set()
-    try:
-        cron_provider.stop()
-    except Exception as e:
-        logger.debug("Cron provider stop() error: %s", e)
-    if not await _await_thread_exit(cron_thread, timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT):
+    if cron_provider is not None:
+        try:
+            cron_provider.stop()
+        except Exception as e:
+            logger.debug("Cron provider stop() error: %s", e)
+    if cron_thread is not None and not await _await_thread_exit(
+        cron_thread, timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT
+    ):
         logger.warning(
             "Cron ticker did not exit within %.0fs of shutdown — an in-flight "
             "delivery may have been dropped.", _CRON_SHUTDOWN_DRAIN_TIMEOUT,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21093,31 +21093,26 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
 
 
 def _start_gateway_cron_scheduler_if_owned(runner, stop_event, loop):
-    """Start cron only when the shared ownership policy selects this gateway."""
-    from cron.scheduler_provider import (
-        InProcessCronScheduler,
-        resolve_owned_cron_scheduler,
-    )
+    """Start the unified, dynamically re-evaluating Gateway supervisor."""
+    from cron.scheduler_runtime import OwnedSchedulerRuntime
 
-    provider = resolve_owned_cron_scheduler("gateway")
-    if provider is None:
-        logger.info("Gateway cron scheduler not started by ownership policy")
-        return None, None
-
-    start_kwargs = {"adapters": runner.adapters, "loop": loop}
-    if isinstance(provider, InProcessCronScheduler):
-        start_kwargs["can_dispatch"] = lambda: not (
+    runtime = OwnedSchedulerRuntime(
+        "gateway",
+        adapters=runner.adapters,
+        loop=loop,
+        can_dispatch=lambda: not (
             runner._draining or runner._external_drain_active
-        )
+        ),
+        drain_timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT,
+    )
     thread = threading.Thread(
-        target=provider.start,
+        target=runtime.run,
         args=(stop_event,),
-        kwargs=start_kwargs,
         daemon=True,
-        name="cron-scheduler",
+        name="gateway-cron-supervisor",
     )
     thread.start()
-    return provider, thread
+    return runtime, thread
 
 
 # Upper bound for cooperatively draining the cron ticker on shutdown. The cron
@@ -21615,7 +21610,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Both gateway and Desktop consult the same ownership helper so only one
     # long-running runtime dispatches this profile's cron registry.
     cron_stop = threading.Event()
-    cron_provider, cron_thread = _start_gateway_cron_scheduler_if_owned(
+    _cron_runtime, cron_thread = _start_gateway_cron_scheduler_if_owned(
         runner, cron_stop, asyncio.get_running_loop()
     )
 
@@ -21641,11 +21636,6 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     except Exception:
         pass
 
-    if runner.should_exit_with_failure:
-        if runner.exit_reason:
-            logger.error("Gateway exiting with failure: %s", runner.exit_reason)
-        return False
-    
     # Stop cron scheduler + housekeeping cleanly.
     #
     # These MUST be awaited cooperatively, not join()ed. A cron delivery in
@@ -21656,21 +21646,22 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # silently dropped (#58818). Awaiting keeps the loop alive so the in-flight
     # delivery finishes before we tear down.
     cron_stop.set()
-    if cron_provider is not None:
-        try:
-            cron_provider.stop()
-        except Exception as e:
-            logger.debug("Cron provider stop() error: %s", e)
     if cron_thread is not None and not await _await_thread_exit(
         cron_thread, timeout=_CRON_SHUTDOWN_DRAIN_TIMEOUT
     ):
         logger.warning(
-            "Cron ticker did not exit within %.0fs of shutdown — an in-flight "
-            "delivery may have been dropped.", _CRON_SHUTDOWN_DRAIN_TIMEOUT,
+            "Cron supervisor did not exit within %.0fs of shutdown; ownership "
+            "remains held until provider and in-flight jobs drain or process death.",
+            _CRON_SHUTDOWN_DRAIN_TIMEOUT,
         )
     await _await_thread_exit(
         housekeeping_thread, timeout=_HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT
     )
+
+    if runner.should_exit_with_failure:
+        if runner.exit_reason:
+            logger.error("Gateway exiting with failure: %s", runner.exit_reason)
+        return False
 
     # Stop the planned-stop watcher (daemon=True so this is belt-and-suspenders).
     _planned_stop_watcher_stop.set()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2706,6 +2706,10 @@ DEFAULT_CONFIG = {
     },
 
     "cron": {
+        # Exactly one long-running runtime may dispatch due jobs for a
+        # HERMES_HOME. "auto" deterministically selects the gateway; use
+        # "desktop" only for an intentional Desktop-only installation.
+        "scheduler_owner": "auto",
         # Active cron SCHEDULER provider (Axis B — the trigger that decides
         # WHEN a due job fires). Empty string = the built-in in-process 60s
         # ticker (default). Name an installed provider (plugins/cron_providers/<name>/ or

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2707,8 +2707,9 @@ DEFAULT_CONFIG = {
 
     "cron": {
         # Exactly one long-running runtime may dispatch due jobs for a
-        # HERMES_HOME. "auto" deterministically selects the gateway; use
-        # "desktop" only for an intentional Desktop-only installation.
+        # HERMES_HOME. "auto" is gateway-preferred: Desktop runs the built-in
+        # fallback only while no same-home gateway is active. Named external
+        # providers stay gateway-only and fail closed when unavailable.
         "scheduler_owner": "auto",
         # Active cron SCHEDULER provider (Axis B — the trigger that decides
         # WHEN a due job fires). Empty string = the built-in in-process 60s

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -52,6 +53,14 @@ class SecretSourceRefreshError(RuntimeError):
             f"secret source refresh failed "
             f"(source={source}, type={source_type}, stage={stage})"
         )
+
+
+@dataclass(frozen=True)
+class StrictDotenvRefresh:
+    """One atomic strict-refresh result, including its exact expanded config."""
+
+    loaded_files: tuple[Path, ...]
+    secrets_config: dict[str, Any]
 
 
 def get_secret_source(env_var: str) -> str | None:
@@ -405,7 +414,7 @@ def _apply_external_secret_sources(home_path: Path) -> None:
 
 def refresh_hermes_dotenv_strict(
     *, hermes_home: str | os.PathLike
-) -> list[Path]:
+) -> StrictDotenvRefresh:
     """Refresh no-agent secrets or raise a sanitized fail-closed error.
 
     Ordinary startup remains fail-open through ``load_hermes_dotenv``. This
@@ -471,7 +480,7 @@ def refresh_hermes_dotenv_strict(
         ) from None
 
     if not enabled:
-        return loaded
+        return StrictDotenvRefresh(tuple(loaded), cfg)
 
     for source in enabled:
         try:
@@ -513,7 +522,7 @@ def refresh_hermes_dotenv_strict(
     # must be applied after external sources, even when a source is configured
     # to override existing environment values.
     _apply_managed_env()
-    return loaded
+    return StrictDotenvRefresh(tuple(loaded), cfg)
 
 
 def _load_unique_yaml_mapping(config_path: Path) -> dict:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -566,25 +566,37 @@ def _has_unresolved_env_reference(value: Any) -> bool:
 
 
 def _load_secrets_config_strict(home_path: Path) -> dict:
-    """Parse and expand secrets config, rejecting ambiguity or unresolved refs."""
-    config_path = home_path / "config.yaml"
-    if not config_path.exists():
-        return {}
+    """Load effective secrets config with strict managed-over-user precedence."""
+    from hermes_cli import managed_scope
+    from hermes_cli.config import _deep_merge, _expand_env_vars
 
-    from hermes_cli.config import _expand_env_vars
+    def _secrets_from(path: Path) -> dict:
+        if not path.exists():
+            return {}
+        data = _load_unique_yaml_mapping(path)
+        secrets = data.get("secrets", {})
+        if secrets is None:
+            return {}
+        if not isinstance(secrets, dict):
+            raise ValueError("secrets is not a mapping")
+        expanded = _expand_env_vars(secrets)
+        if not isinstance(expanded, dict):
+            raise ValueError("expanded secrets is not a mapping")
+        return expanded
 
-    data = _load_unique_yaml_mapping(config_path)
-    secrets = data.get("secrets", {})
-    if secrets is None:
-        return {}
-    if not isinstance(secrets, dict):
-        raise ValueError("secrets is not a mapping")
-    expanded = _expand_env_vars(secrets)
-    if not isinstance(expanded, dict):
-        raise ValueError("expanded secrets is not a mapping")
-    if _has_unresolved_env_reference(expanded):
+    user_secrets = _secrets_from(home_path / "config.yaml")
+    managed_dir = managed_scope.get_managed_dir()
+    managed_secrets = (
+        _secrets_from(managed_dir / "config.yaml")
+        if managed_dir is not None
+        else {}
+    )
+    effective = _deep_merge(user_secrets, managed_secrets)
+    if not isinstance(effective, dict):
+        raise ValueError("effective secrets is not a mapping")
+    if _has_unresolved_env_reference(effective):
         raise ValueError("secrets contains an unresolved environment reference")
-    return expanded
+    return effective
 
 
 def _load_secrets_config(home_path: Path) -> dict:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
 from pathlib import Path
+from typing import Any
 
 from dotenv import load_dotenv
 from utils import atomic_replace, fast_safe_load
@@ -509,21 +511,66 @@ def refresh_hermes_dotenv_strict(
     return loaded
 
 
+def _load_unique_yaml_mapping(config_path: Path) -> dict:
+    """Load YAML recursively rejecting duplicate mapping keys."""
+    import yaml
+
+    class _UniqueKeyLoader(yaml.SafeLoader):
+        pass
+
+    def _construct_unique_mapping(
+        loader: Any, node: Any, deep: bool = False
+    ) -> dict[Any, Any]:
+        loader.flatten_mapping(node)
+        result: dict[Any, Any] = {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            if key in result:
+                raise ValueError("duplicate mapping key")
+            result[key] = loader.construct_object(value_node, deep=deep)
+        return result
+
+    _UniqueKeyLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        _construct_unique_mapping,
+    )
+    with open(config_path, "r", encoding="utf-8") as config_file:
+        data = yaml.load(config_file, Loader=_UniqueKeyLoader) or {}
+    if not isinstance(data, dict):
+        raise ValueError("config root is not a mapping")
+    return data
+
+
+def _has_unresolved_env_reference(value: Any) -> bool:
+    if isinstance(value, str):
+        return re.search(r"\${[^}]+}", value) is not None
+    if isinstance(value, dict):
+        return any(_has_unresolved_env_reference(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_has_unresolved_env_reference(item) for item in value)
+    return False
+
+
 def _load_secrets_config_strict(home_path: Path) -> dict:
-    """Parse the secrets section without startup's fail-open swallowing."""
+    """Parse and expand secrets config, rejecting ambiguity or unresolved refs."""
     config_path = home_path / "config.yaml"
     if not config_path.exists():
         return {}
-    with open(config_path, "r", encoding="utf-8") as config_file:
-        data = fast_safe_load(config_file) or {}
-    if not isinstance(data, dict):
-        raise ValueError("config root is not a mapping")
+
+    from hermes_cli.config import _expand_env_vars
+
+    data = _load_unique_yaml_mapping(config_path)
     secrets = data.get("secrets", {})
     if secrets is None:
         return {}
     if not isinstance(secrets, dict):
         raise ValueError("secrets is not a mapping")
-    return secrets
+    expanded = _expand_env_vars(secrets)
+    if not isinstance(expanded, dict):
+        raise ValueError("expanded secrets is not a mapping")
+    if _has_unresolved_env_reference(expanded):
+        raise ValueError("secrets contains an unresolved environment reference")
+    return expanded
 
 
 def _load_secrets_config(home_path: Path) -> dict:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -39,6 +39,19 @@ _SECRET_SOURCES: dict[str, str] = {}
 _APPLIED_HOMES: set[str] = set()
 
 
+class SecretSourceRefreshError(RuntimeError):
+    """Sanitized fail-closed error for no-agent secret refreshes."""
+
+    def __init__(self, *, source: str, source_type: str, stage: str) -> None:
+        self.source = source
+        self.source_type = source_type
+        self.stage = stage
+        super().__init__(
+            f"secret source refresh failed "
+            f"(source={source}, type={source_type}, stage={stage})"
+        )
+
+
 def get_secret_source(env_var: str) -> str | None:
     """Return the label of the secret source that supplied ``env_var``, if any.
 
@@ -232,6 +245,7 @@ def load_hermes_dotenv(
     *,
     hermes_home: str | os.PathLike | None = None,
     project_env: str | os.PathLike | None = None,
+    _apply_external: bool = True,
 ) -> list[Path]:
     """Load Hermes environment files with user config taking precedence.
 
@@ -275,7 +289,8 @@ def load_hermes_dotenv(
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
 
-    _apply_external_secret_sources(home_path)
+    if _apply_external:
+        _apply_external_secret_sources(home_path)
     _apply_managed_env()
 
     return loaded
@@ -384,6 +399,131 @@ def _apply_external_secret_sources(home_path: Path) -> None:
             print(f"  {src.label}: {warn}", file=sys.stderr)
     for conflict in report.conflicts:
         print(f"  Secret sources: {conflict}", file=sys.stderr)
+
+
+def refresh_hermes_dotenv_strict(
+    *, hermes_home: str | os.PathLike
+) -> list[Path]:
+    """Refresh no-agent secrets or raise a sanitized fail-closed error.
+
+    Ordinary startup remains fail-open through ``load_hermes_dotenv``. This
+    path is intentionally stricter because launching a script with a stale
+    externally sourced value is less safe than refusing to launch it.
+    """
+    home_path = Path(hermes_home).expanduser().resolve()
+    _APPLIED_HOMES.discard(str(home_path))
+
+    # Remove every value previously attributed to an external source before
+    # dotenv or vault reload. The caller holds the cron refresh lock across
+    # this removal, reload, and child snapshot.
+    for name in tuple(_SECRET_SOURCES):
+        os.environ.pop(name, None)
+        _SECRET_SOURCES.pop(name, None)
+
+    loaded = load_hermes_dotenv(hermes_home=home_path, _apply_external=False)
+
+    try:
+        cfg = _load_secrets_config_strict(home_path)
+    except Exception as exc:
+        if isinstance(exc, SecretSourceRefreshError):
+            raise
+        raise SecretSourceRefreshError(
+            source="configuration", source_type="mapping", stage="config"
+        ) from None
+
+    try:
+        from agent.secret_sources.registry import apply_all, list_sources
+
+        registered = {source.name: source for source in list_sources()}
+        enabled = []
+        for name, source_cfg in cfg.items():
+            if name == "sources":
+                continue
+            source = registered.get(name)
+            if source is None:
+                if isinstance(source_cfg, dict) and source_cfg.get("enabled") is True:
+                    raise SecretSourceRefreshError(
+                        source="unregistered", source_type="unregistered", stage="config"
+                    )
+                continue
+            if not isinstance(source_cfg, dict):
+                raise SecretSourceRefreshError(
+                    source=source.name,
+                    source_type=type(source).__name__,
+                    stage="config",
+                )
+            try:
+                if source.is_enabled(source_cfg):
+                    enabled.append(source)
+            except Exception:
+                raise SecretSourceRefreshError(
+                    source=source.name,
+                    source_type=type(source).__name__,
+                    stage="config",
+                ) from None
+    except SecretSourceRefreshError:
+        raise
+    except Exception:
+        raise SecretSourceRefreshError(
+            source="registry", source_type="registry", stage="config"
+        ) from None
+
+    if not enabled:
+        return loaded
+
+    for source in enabled:
+        try:
+            source.invalidate_cache(home_path)
+        except Exception:
+            raise SecretSourceRefreshError(
+                source=source.name,
+                source_type=type(source).__name__,
+                stage="invalidate",
+            ) from None
+
+    working_env = os.environ.copy()
+    try:
+        report = apply_all(cfg, home_path, environ=working_env)
+    except Exception:
+        summary = ",".join(source.name for source in enabled)
+        types = ",".join(type(source).__name__ for source in enabled)
+        raise SecretSourceRefreshError(
+            source=summary, source_type=types, stage="apply"
+        ) from None
+
+    source_types = {source.name: type(source).__name__ for source in enabled}
+    for source_report in report.sources:
+        if source_report.result.error or not source_report.result.ok:
+            raise SecretSourceRefreshError(
+                source=source_report.name,
+                source_type=source_types.get(source_report.name, "registered"),
+                stage="fetch",
+            )
+
+    if report.applied_any:
+        for name in report.provenance:
+            os.environ[name] = working_env[name]
+        _sanitize_loaded_credentials()
+        for name, applied in report.provenance.items():
+            _SECRET_SOURCES[name] = applied.source
+    return loaded
+
+
+def _load_secrets_config_strict(home_path: Path) -> dict:
+    """Parse the secrets section without startup's fail-open swallowing."""
+    config_path = home_path / "config.yaml"
+    if not config_path.exists():
+        return {}
+    with open(config_path, "r", encoding="utf-8") as config_file:
+        data = fast_safe_load(config_file) or {}
+    if not isinstance(data, dict):
+        raise ValueError("config root is not a mapping")
+    secrets = data.get("secrets", {})
+    if secrets is None:
+        return {}
+    if not isinstance(secrets, dict):
+        raise ValueError("secrets is not a mapping")
+    return secrets
 
 
 def _load_secrets_config(home_path: Path) -> dict:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -508,6 +508,11 @@ def refresh_hermes_dotenv_strict(
         _sanitize_loaded_credentials()
         for name, applied in report.provenance.items():
             _SECRET_SOURCES[name] = applied.source
+
+    # Preserve normal startup precedence: managed scope is authoritative and
+    # must be applied after external sources, even when a source is configured
+    # to override existing environment values.
+    _apply_managed_env()
     return loaded
 
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -52,7 +52,7 @@ def get_secret_source(env_var: str) -> str | None:
     return _SECRET_SOURCES.get(env_var)
 
 
-def reset_secret_source_cache() -> None:
+def reset_secret_source_cache(hermes_home: Path | None = None) -> None:
     """Forget which HERMES_HOME paths have already had external secrets applied.
 
     The first call to ``_apply_external_secret_sources(home_path)`` in a
@@ -62,7 +62,18 @@ def reset_secret_source_cache() -> None:
     next call to re-pull — useful for tests, and for long-running processes
     that want to refresh after a config change.
     """
-    _APPLIED_HOMES.clear()
+    if hermes_home is None:
+        # Backward-compatible test/startup reset. Callers that need a genuine
+        # backend refresh must provide the exact home so another profile's L1
+        # and L2 entries are not destroyed.
+        _APPLIED_HOMES.clear()
+        return
+
+    canonical_home = hermes_home.expanduser().resolve()
+    _APPLIED_HOMES.discard(str(canonical_home))
+    from agent.secret_sources.registry import invalidate_caches
+
+    invalidate_caches(canonical_home)
 
 
 def format_secret_source_suffix(env_var: str) -> str:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -138,25 +138,42 @@ _log = logging.getLogger(__name__)
 # when the same module is used across TestClient instances or uvicorn reloads.
 # ---------------------------------------------------------------------------
 
-def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60) -> None:
-    """Tick the cron scheduler from inside the desktop dashboard backend.
+def _start_desktop_cron_ticker(
+    stop_event: "threading.Event", interval: int = 60, *, provider: Any = None
+) -> None:
+    """Run the resolved provider for an explicitly owned Desktop ticker."""
+    if provider is None:
+        from cron.scheduler_provider import resolve_cron_scheduler
 
-    The scheduler tick loop normally lives in ``hermes gateway run`` — but the
-    desktop app spawns a ``hermes dashboard`` backend, not a gateway, so a cron
-    a user creates in the app would never fire. We run the resolved cron
-    scheduler provider here (no live adapters; delivery falls back to the
-    per-platform send path).
-
-    Cross-process safe: the built-in provider's ``cron.scheduler.tick`` takes
-    the ``cron/.tick.lock`` file lock, so this never double-fires alongside a
-    real gateway on the same HERMES_HOME — whichever process grabs the lock
-    first wins the tick.
-    """
-    from cron.scheduler_provider import resolve_cron_scheduler
-
-    provider = resolve_cron_scheduler()
+        provider = resolve_cron_scheduler()
     _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
     provider.start(stop_event, interval=interval)
+
+
+def _start_desktop_cron_scheduler_if_owned() -> tuple[
+    "threading.Event | None", "threading.Thread | None"
+]:
+    """Start Desktop's fallback ticker only when it owns automatic dispatch."""
+    if os.getenv("HERMES_DESKTOP") != "1":
+        return None, None
+
+    from cron.scheduler_provider import resolve_owned_cron_scheduler
+
+    provider = resolve_owned_cron_scheduler("desktop")
+    if provider is None:
+        _log.info("Desktop cron scheduler not started by ownership policy")
+        return None, None
+
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_start_desktop_cron_ticker,
+        args=(stop_event,),
+        kwargs={"provider": provider},
+        daemon=True,
+        name="desktop-cron-ticker",
+    )
+    thread.start()
+    return stop_event, thread
 
 
 def _warm_gateway_module() -> None:
@@ -194,20 +211,9 @@ async def _lifespan(app: "FastAPI"):
     # the server socket is already open and accepting probes.
     asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)
 
-    # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
-    # since the app has no gateway running the scheduler. Server `hermes
-    # dashboard` is unaffected — it relies on its own gateway.
-    cron_stop: "threading.Event | None" = None
-    cron_thread: "threading.Thread | None" = None
-    if os.getenv("HERMES_DESKTOP") == "1":
-        cron_stop = threading.Event()
-        cron_thread = threading.Thread(
-            target=_start_desktop_cron_ticker,
-            args=(cron_stop,),
-            daemon=True,
-            name="desktop-cron-ticker",
-        )
-        cron_thread.start()
+    # Desktop remains available when the default gateway owns scheduling; an
+    # explicit desktop owner preserves the Desktop-only fallback.
+    cron_stop, cron_thread = _start_desktop_cron_scheduler_if_owned()
 
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -125,6 +125,7 @@ except ImportError:
 
 WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.environ else Path(__file__).parent / "web_dist"
 _log = logging.getLogger(__name__)
+_DESKTOP_CRON_SHUTDOWN_TIMEOUT = 65.0
 
 # ---------------------------------------------------------------------------
 # Per-channel subscriber registry used by /api/pub (PTY-side gateway → dashboard)
@@ -139,41 +140,88 @@ _log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 def _start_desktop_cron_ticker(
-    stop_event: "threading.Event", interval: int = 60, *, provider: Any = None
+    stop_event: "threading.Event",
+    interval: int = 60,
+    *,
+    provider: Any = None,
+    can_dispatch: Any = None,
 ) -> None:
-    """Run the resolved provider for an explicitly owned Desktop ticker."""
+    """Run Desktop's resolved scheduler, optionally as a yielding standby."""
     if provider is None:
         from cron.scheduler_provider import resolve_cron_scheduler
 
         provider = resolve_cron_scheduler()
     _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
-    provider.start(stop_event, interval=interval)
+    start_kwargs = {"interval": interval}
+    if can_dispatch is not None:
+        start_kwargs["can_dispatch"] = can_dispatch
+    provider.start(stop_event, **start_kwargs)
 
 
 def _start_desktop_cron_scheduler_if_owned() -> tuple[
-    "threading.Event | None", "threading.Thread | None"
+    "Any | None", "threading.Event | None", "threading.Thread | None"
 ]:
     """Start Desktop's fallback ticker only when it owns automatic dispatch."""
     if os.getenv("HERMES_DESKTOP") != "1":
-        return None, None
+        return None, None, None
 
-    from cron.scheduler_provider import resolve_owned_cron_scheduler
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        resolve_cron_scheduler_startup,
+    )
 
-    provider = resolve_owned_cron_scheduler("desktop")
+    owner, provider = resolve_cron_scheduler_startup("desktop")
     if provider is None:
         _log.info("Desktop cron scheduler not started by ownership policy")
-        return None, None
+        return None, None, None
+
+    ticker_kwargs = {"provider": provider}
+    if owner == "auto":
+        # External providers fail closed before this branch because they cannot
+        # promise equivalent per-tick dynamic yielding.
+        assert isinstance(provider, InProcessCronScheduler)
+        from gateway.status import get_running_pid
+
+        ticker_kwargs["can_dispatch"] = (
+            lambda: get_running_pid(cleanup_stale=False) is None
+        )
 
     stop_event = threading.Event()
     thread = threading.Thread(
         target=_start_desktop_cron_ticker,
         args=(stop_event,),
-        kwargs={"provider": provider},
+        kwargs=ticker_kwargs,
         daemon=True,
         name="desktop-cron-ticker",
     )
     thread.start()
-    return stop_event, thread
+    return provider, stop_event, thread
+
+
+async def _stop_desktop_cron_scheduler(
+    provider: Any,
+    stop_event: "threading.Event",
+    thread: "threading.Thread",
+    *,
+    timeout: float = _DESKTOP_CRON_SHUTDOWN_TIMEOUT,
+) -> bool:
+    """Stop Desktop cron and cooperatively await bounded thread teardown."""
+    stop_event.set()
+    try:
+        provider.stop()
+    except Exception as exc:  # noqa: BLE001 — still drain the thread
+        _log.debug("Desktop cron provider stop() error: %s", exc)
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, thread.join, timeout)
+    stopped = not thread.is_alive()
+    if not stopped:
+        _log.warning(
+            "Desktop cron ticker did not exit within %.0fs of shutdown; "
+            "restart remains blocked until the owning Desktop process exits.",
+            timeout,
+        )
+    return stopped
 
 
 def _warm_gateway_module() -> None:
@@ -211,9 +259,9 @@ async def _lifespan(app: "FastAPI"):
     # the server socket is already open and accepting probes.
     asyncio.get_event_loop().run_in_executor(None, _warm_gateway_module)
 
-    # Desktop remains available when the default gateway owns scheduling; an
-    # explicit desktop owner preserves the Desktop-only fallback.
-    cron_stop, cron_thread = _start_desktop_cron_scheduler_if_owned()
+    # Under auto, Desktop runs the built-in ticker as a standby that yields to a
+    # live same-home gateway and resumes if that gateway disappears.
+    cron_provider, cron_stop, cron_thread = _start_desktop_cron_scheduler_if_owned()
 
     # Reap idle/dead keep-alive PTY sessions in the background (30-min TTL).
     pty_reaper_task = asyncio.create_task(run_reaper(PTY_REGISTRY))
@@ -223,8 +271,14 @@ async def _lifespan(app: "FastAPI"):
     finally:
         pty_reaper_task.cancel()
         await PTY_REGISTRY.close_all()
-        if cron_stop is not None:
-            cron_stop.set()
+        if (
+            cron_provider is not None
+            and cron_stop is not None
+            and cron_thread is not None
+        ):
+            await _stop_desktop_cron_scheduler(
+                cron_provider, cron_stop, cron_thread
+            )
 
 
 def _get_event_state(app: "FastAPI"):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -140,85 +140,62 @@ _DESKTOP_CRON_SHUTDOWN_TIMEOUT = 65.0
 # ---------------------------------------------------------------------------
 
 def _start_desktop_cron_ticker(
-    stop_event: "threading.Event",
-    interval: int = 60,
-    *,
-    provider: Any = None,
-    can_dispatch: Any = None,
+    stop_event: "threading.Event", interval: int = 60
 ) -> None:
-    """Run Desktop's resolved scheduler, optionally as a yielding standby."""
-    if provider is None:
-        from cron.scheduler_provider import resolve_cron_scheduler
+    """Deprecated direct built-in ticker shim for compatibility/debug use."""
+    from cron.scheduler_provider import InProcessCronScheduler
 
-        provider = resolve_cron_scheduler()
-    _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
-    start_kwargs = {"interval": interval}
-    if can_dispatch is not None:
-        start_kwargs["can_dispatch"] = can_dispatch
-    provider.start(stop_event, **start_kwargs)
+    InProcessCronScheduler().start(stop_event, interval=interval)
 
 
 def _start_desktop_cron_scheduler_if_owned() -> tuple[
     "Any | None", "threading.Event | None", "threading.Thread | None"
 ]:
-    """Start Desktop's fallback ticker only when it owns automatic dispatch."""
+    """Start Desktop's dynamically yielding scheduler supervisor."""
     if os.getenv("HERMES_DESKTOP") != "1":
         return None, None, None
 
-    from cron.scheduler_provider import (
-        InProcessCronScheduler,
-        resolve_cron_scheduler_startup,
-    )
-
-    owner, provider = resolve_cron_scheduler_startup("desktop")
-    if provider is None:
-        _log.info("Desktop cron scheduler not started by ownership policy")
-        return None, None, None
-
-    ticker_kwargs = {"provider": provider}
-    if owner == "auto":
-        # External providers fail closed before this branch because they cannot
-        # promise equivalent per-tick dynamic yielding.
-        assert isinstance(provider, InProcessCronScheduler)
-        from gateway.status import get_running_pid
-
-        ticker_kwargs["can_dispatch"] = (
-            lambda: get_running_pid(cleanup_stale=False) is None
-        )
+    from cron.scheduler_runtime import OwnedSchedulerRuntime
+    from gateway.status import is_gateway_runtime_lock_active
 
     stop_event = threading.Event()
+    runtime = OwnedSchedulerRuntime(
+        "desktop",
+        gateway_is_running=is_gateway_runtime_lock_active,
+        drain_timeout=_DESKTOP_CRON_SHUTDOWN_TIMEOUT,
+    )
     thread = threading.Thread(
-        target=_start_desktop_cron_ticker,
+        target=runtime.run,
         args=(stop_event,),
-        kwargs=ticker_kwargs,
         daemon=True,
-        name="desktop-cron-ticker",
+        name="desktop-cron-supervisor",
     )
     thread.start()
-    return provider, stop_event, thread
+    return runtime, stop_event, thread
 
 
 async def _stop_desktop_cron_scheduler(
-    provider: Any,
+    _runtime: Any,
     stop_event: "threading.Event",
     thread: "threading.Thread",
     *,
     timeout: float = _DESKTOP_CRON_SHUTDOWN_TIMEOUT,
 ) -> bool:
-    """Stop Desktop cron and cooperatively await bounded thread teardown."""
+    """Stop Desktop cron and await supervisor plus in-flight jobs under one bound."""
     stop_event.set()
-    try:
-        provider.stop()
-    except Exception as exc:  # noqa: BLE001 — still drain the thread
-        _log.debug("Desktop cron provider stop() error: %s", exc)
-
     loop = asyncio.get_running_loop()
-    await loop.run_in_executor(None, thread.join, timeout)
-    stopped = not thread.is_alive()
+    deadline = loop.time() + max(0.0, timeout)
+    from cron.scheduler import get_running_job_ids
+
+    while loop.time() < deadline:
+        if not thread.is_alive() and not get_running_job_ids():
+            return True
+        await asyncio.sleep(0.1)
+    stopped = not thread.is_alive() and not get_running_job_ids()
     if not stopped:
         _log.warning(
-            "Desktop cron ticker did not exit within %.0fs of shutdown; "
-            "restart remains blocked until the owning Desktop process exits.",
+            "Desktop cron supervisor/jobs did not drain within %.0fs; scheduler "
+            "ownership remains held until drain or Desktop process death.",
             timeout,
         )
     return stopped

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10931,18 +10931,10 @@ async def delete_cron_job(job_id: str, profile: Optional[str] = None):
     return await _run_cron_dashboard_io(_delete_cron_job_sync, job_id, profile)
 
 
-def _fire_cron_job_for_profile(profile: str, job_id: str) -> bool:
-    """Run ONE due cron job end-to-end for ``profile`` via the resolved
-    scheduler provider's ``fire_due`` (store CAS claim + ``run_one_job``).
-
-    Scope both cron storage and the runtime Hermes home so the job's store,
-    config, credentials, scripts, skills, and output all belong to the selected
-    profile. Runs with no live adapters; delivery falls back to the per-platform
-    send path.
-    """
+def _fire_cron_job_for_profile(profile: str, job_id: str, reservation) -> bool:
+    """Run one cron job under the already-reserved owner generation."""
     _profile_name, home = _cron_profile_home(profile)
     from cron import jobs as cron_jobs
-    from cron.scheduler_provider import resolve_cron_scheduler
     from hermes_constants import (
         reset_hermes_home_override,
         set_hermes_home_override,
@@ -10951,8 +10943,9 @@ def _fire_cron_job_for_profile(profile: str, job_id: str) -> bool:
     token = set_hermes_home_override(str(home))
     try:
         with cron_jobs.use_cron_store(home):
-            provider = resolve_cron_scheduler()
-            return bool(provider.fire_due(job_id, adapters=None, loop=None))
+            return bool(
+                reservation.provider.fire_due(job_id, adapters=None, loop=None)
+            )
     finally:
         reset_hermes_home_override(token)
 
@@ -11008,24 +11001,50 @@ async def cron_fire_webhook(request: Request):
         # does not retry a fire that is intentionally absent.
         return JSONResponse({"status": "gone", "job_id": job_id}, status_code=200)
 
-    # Run in the background; the store CAS claim inside fire_due de-dupes a
-    # NAS/scheduler retry that arrives while this is in flight. Consume worker
-    # failures inside the coroutine so detached-task diagnostics cannot expose
-    # provider exception text.
-    async def _run_cron_fire() -> None:
+    # Reserve the selected home's active scheduler generation before dispatch.
+    # The authoritative worker thread starts before 202 is returned, so event-
+    # loop task cancellation cannot silently drop an accepted fire.
+    _profile_name, fire_home = _cron_profile_home(profile)
+    from cron.scheduler_runtime import reserve_active_scheduler_provider
+
+    scheduler_reservation = reserve_active_scheduler_provider(hermes_home=fire_home)
+    if scheduler_reservation is None:
+        return JSONResponse(
+            {"error": "scheduler owner unavailable"}, status_code=503
+        )
+
+    release_lock = threading.Lock()
+    released = False
+
+    def _release_reservation() -> None:
+        nonlocal released
+        with release_lock:
+            if released:
+                return
+            released = True
         try:
-            await asyncio.to_thread(_fire_cron_job_for_profile, profile, job_id)
-        except asyncio.CancelledError:
-            raise
+            scheduler_reservation.release()
+        except BaseException:
+            _log.error("Cron dashboard fire reservation cleanup failed")
+
+    def _fire_worker() -> None:
+        try:
+            _fire_cron_job_for_profile(profile, job_id, scheduler_reservation)
         except BaseException:
             _log.error("Cron dashboard fire worker failed")
+        finally:
+            _release_reservation()
 
-    fire_coro = _run_cron_fire()
+    worker_thread = threading.Thread(
+        target=_fire_worker,
+        name="hermes-cron-dashboard-fire",
+        daemon=True,
+    )
     try:
-        asyncio.create_task(fire_coro)
+        worker_thread.start()
     except BaseException:
-        fire_coro.close()
-        _log.error("Cron dashboard fire task startup failed")
+        _release_reservation()
+        _log.error("Cron dashboard fire thread startup failed")
         return JSONResponse(
             {"error": "cron fire dispatch unavailable"}, status_code=503
         )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10931,9 +10931,12 @@ async def delete_cron_job(job_id: str, profile: Optional[str] = None):
     return await _run_cron_dashboard_io(_delete_cron_job_sync, job_id, profile)
 
 
-def _fire_cron_job_for_profile(profile: str, job_id: str, reservation) -> bool:
-    """Run one cron job under the already-reserved owner generation."""
-    _profile_name, home = _cron_profile_home(profile)
+def _fire_cron_job_for_profile(
+    profile: str, job_id: str, reservation, pinned_home: Path
+) -> bool:
+    """Run one cron job under the reserved generation and its pinned home."""
+    del profile  # The caller already resolved and pinned this profile's home.
+    home = pinned_home
     from cron import jobs as cron_jobs
     from hermes_constants import (
         reset_hermes_home_override,
@@ -11005,6 +11008,7 @@ async def cron_fire_webhook(request: Request):
     # The authoritative worker thread starts before 202 is returned, so event-
     # loop task cancellation cannot silently drop an accepted fire.
     _profile_name, fire_home = _cron_profile_home(profile)
+    fire_home = fire_home.expanduser().resolve()
     from cron.scheduler_runtime import reserve_active_scheduler_provider
 
     scheduler_reservation = reserve_active_scheduler_provider(hermes_home=fire_home)
@@ -11029,7 +11033,9 @@ async def cron_fire_webhook(request: Request):
 
     def _fire_worker() -> None:
         try:
-            _fire_cron_job_for_profile(profile, job_id, scheduler_reservation)
+            _fire_cron_job_for_profile(
+                profile, job_id, scheduler_reservation, fire_home
+            )
         except BaseException:
             _log.error("Cron dashboard fire worker failed")
         finally:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11009,10 +11009,26 @@ async def cron_fire_webhook(request: Request):
         return JSONResponse({"status": "gone", "job_id": job_id}, status_code=200)
 
     # Run in the background; the store CAS claim inside fire_due de-dupes a
-    # NAS/scheduler retry that arrives while this is in flight.
-    asyncio.create_task(
-        asyncio.to_thread(_fire_cron_job_for_profile, profile, job_id)
-    )
+    # NAS/scheduler retry that arrives while this is in flight. Consume worker
+    # failures inside the coroutine so detached-task diagnostics cannot expose
+    # provider exception text.
+    async def _run_cron_fire() -> None:
+        try:
+            await asyncio.to_thread(_fire_cron_job_for_profile, profile, job_id)
+        except asyncio.CancelledError:
+            raise
+        except BaseException:
+            _log.error("Cron dashboard fire worker failed")
+
+    fire_coro = _run_cron_fire()
+    try:
+        asyncio.create_task(fire_coro)
+    except BaseException:
+        fire_coro.close()
+        _log.error("Cron dashboard fire task startup failed")
+        return JSONResponse(
+            {"error": "cron fire dispatch unavailable"}, status_code=503
+        )
     return JSONResponse({"status": "accepted", "job_id": job_id}, status_code=202)
 
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -235,8 +235,10 @@ def test_run_job_no_agent_refreshes_external_secrets_before_subprocess(hermes_en
         os.environ["PERSONAL_HUB_CRON_SECRET"] = "fresh-per-run"
 
     try:
-        with patch("hermes_cli.env_loader.reset_secret_source_cache") as reset, \
-             patch("hermes_cli.env_loader.load_hermes_dotenv", side_effect=load_secret) as load:
+        with patch(
+            "hermes_cli.env_loader.refresh_hermes_dotenv_strict",
+            side_effect=load_secret,
+        ) as refresh:
             success, _doc, final_response, error = run_job(job)
     finally:
         os.environ.pop("PERSONAL_HUB_CRON_SECRET", None)
@@ -244,8 +246,7 @@ def test_run_job_no_agent_refreshes_external_secrets_before_subprocess(hermes_en
     assert success is True
     assert error is None
     assert final_response == "secret-loaded"
-    reset.assert_called_once_with(hermes_env)
-    load.assert_called_once_with(hermes_home=hermes_env)
+    refresh.assert_called_once_with(hermes_home=hermes_env)
 
 
 def test_run_job_no_agent_empty_output_is_silent(hermes_env):

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import patch
 
 import pytest
@@ -208,6 +209,43 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert error is None
     assert "RAM 92% on host" in final_response
     assert "RAM 92% on host" in doc
+
+
+def test_run_job_no_agent_refreshes_external_secrets_before_subprocess(hermes_env):
+    """Script-only cron must refresh external secrets before building child env."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "needs-secret.sh"
+    script_path.write_text(
+        '#!/bin/bash\n'
+        'test "$PERSONAL_HUB_CRON_SECRET" = "fresh-per-run"\n'
+        'echo secret-loaded\n'
+    )
+    job = create_job(
+        prompt=None,
+        schedule="every 5m",
+        script="needs-secret.sh",
+        no_agent=True,
+        deliver="local",
+    )
+    os.environ.pop("PERSONAL_HUB_CRON_SECRET", None)
+
+    def load_secret(**_kwargs):
+        os.environ["PERSONAL_HUB_CRON_SECRET"] = "fresh-per-run"
+
+    try:
+        with patch("hermes_cli.env_loader.reset_secret_source_cache") as reset, \
+             patch("hermes_cli.env_loader.load_hermes_dotenv", side_effect=load_secret) as load:
+            success, _doc, final_response, error = run_job(job)
+    finally:
+        os.environ.pop("PERSONAL_HUB_CRON_SECRET", None)
+
+    assert success is True
+    assert error is None
+    assert final_response == "secret-loaded"
+    reset.assert_called_once_with()
+    load.assert_called_once_with(hermes_home=hermes_env)
 
 
 def test_run_job_no_agent_empty_output_is_silent(hermes_env):

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -244,7 +244,7 @@ def test_run_job_no_agent_refreshes_external_secrets_before_subprocess(hermes_en
     assert success is True
     assert error is None
     assert final_response == "secret-loaded"
-    reset.assert_called_once_with()
+    reset.assert_called_once_with(hermes_env)
     load.assert_called_once_with(hermes_home=hermes_env)
 
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -232,7 +232,10 @@ def test_run_job_no_agent_refreshes_external_secrets_before_subprocess(hermes_en
     os.environ.pop("PERSONAL_HUB_CRON_SECRET", None)
 
     def load_secret(**_kwargs):
+        from hermes_cli.env_loader import StrictDotenvRefresh
+
         os.environ["PERSONAL_HUB_CRON_SECRET"] = "fresh-per-run"
+        return StrictDotenvRefresh((), {})
 
     try:
         with patch(

--- a/tests/cron/test_jobs_changed_notify.py
+++ b/tests/cron/test_jobs_changed_notify.py
@@ -35,7 +35,16 @@ def test_notify_helper_calls_provider_on_jobs_changed(monkeypatch):
         def on_jobs_changed(self):
             calls.append(1)
 
-    monkeypatch.setattr(runtime, "get_active_scheduler_provider", lambda: Spy())
+    class Reservation:
+        provider = Spy()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return None
+
+    monkeypatch.setattr(runtime, "reserved_active_scheduler_provider", Reservation)
     sched._notify_provider_jobs_changed()
     assert calls == [1]
 
@@ -58,7 +67,16 @@ def test_notify_helper_swallows_provider_errors(monkeypatch):
         def on_jobs_changed(self):
             raise RuntimeError("kaboom")
 
-    monkeypatch.setattr(runtime, "get_active_scheduler_provider", lambda: Boom())
+    class Reservation:
+        provider = Boom()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return None
+
+    monkeypatch.setattr(runtime, "reserved_active_scheduler_provider", Reservation)
     sched._notify_provider_jobs_changed()  # must not raise
 
 

--- a/tests/cron/test_jobs_changed_notify.py
+++ b/tests/cron/test_jobs_changed_notify.py
@@ -19,6 +19,7 @@ def test_notify_helper_calls_provider_on_jobs_changed(monkeypatch):
     """cron.scheduler._notify_provider_jobs_changed resolves the provider and
     calls on_jobs_changed exactly once."""
     import cron.scheduler_provider as sp
+    import cron.scheduler_runtime as runtime
     import cron.scheduler as sched
 
     calls = []
@@ -34,7 +35,7 @@ def test_notify_helper_calls_provider_on_jobs_changed(monkeypatch):
         def on_jobs_changed(self):
             calls.append(1)
 
-    monkeypatch.setattr(sp, "resolve_cron_scheduler", lambda: Spy())
+    monkeypatch.setattr(runtime, "get_active_scheduler_provider", lambda: Spy())
     sched._notify_provider_jobs_changed()
     assert calls == [1]
 
@@ -43,6 +44,7 @@ def test_notify_helper_swallows_provider_errors(monkeypatch):
     """A provider that raises in on_jobs_changed must not propagate into the
     caller (best-effort notify)."""
     import cron.scheduler_provider as sp
+    import cron.scheduler_runtime as runtime
     import cron.scheduler as sched
 
     class Boom(sp.CronScheduler):
@@ -56,7 +58,7 @@ def test_notify_helper_swallows_provider_errors(monkeypatch):
         def on_jobs_changed(self):
             raise RuntimeError("kaboom")
 
-    monkeypatch.setattr(sp, "resolve_cron_scheduler", lambda: Boom())
+    monkeypatch.setattr(runtime, "get_active_scheduler_provider", lambda: Boom())
     sched._notify_provider_jobs_changed()  # must not raise
 
 

--- a/tests/cron/test_no_agent_child_env.py
+++ b/tests/cron/test_no_agent_child_env.py
@@ -135,6 +135,39 @@ def test_prepare_strips_environment_expanded_bootstrap_alias(tmp_path, monkeypat
     assert "${BOOTSTRAP_ALIAS_NAME}" not in child_env
 
 
+def test_prepare_strips_onepassword_interactive_session_credentials(
+    tmp_path, monkeypatch
+):
+    import agent.secret_sources.registry as registry
+    import cron.scheduler as scheduler
+    import hermes_cli.env_loader as env_loader
+    from agent.secret_sources.onepassword import OnePasswordSource
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setattr(scheduler, "_hermes_home", home)
+    monkeypatch.setenv("OP_SESSION_work", "interactive-session-secret")
+    monkeypatch.setenv("OP_SESSION_personal", "another-session-secret")
+    monkeypatch.setenv("NON_AUTH_VALUE", "keep-me")
+    config = {"onepassword": {"enabled": True}}
+    monkeypatch.setattr(
+        env_loader,
+        "refresh_hermes_dotenv_strict",
+        lambda **_kwargs: env_loader.StrictDotenvRefresh((), config),
+    )
+    monkeypatch.setattr(
+        registry,
+        "_ordered_enabled_sources",
+        lambda _cfg: [OnePasswordSource()],
+    )
+
+    _pinned_home, child_env = scheduler._prepare_no_agent_child_environment()
+
+    assert "OP_SESSION_work" not in child_env
+    assert "OP_SESSION_personal" not in child_env
+    assert child_env["NON_AUTH_VALUE"] == "keep-me"
+
+
 def test_prepare_no_agent_child_env_loads_exact_canonical_home(
     tmp_path, monkeypatch
 ):

--- a/tests/cron/test_no_agent_child_env.py
+++ b/tests/cron/test_no_agent_child_env.py
@@ -26,8 +26,10 @@ class _StrictTestSource(SecretSource):
     def __init__(self, result: FetchResult):
         self.result = result
         self.invalidated: list[Path] = []
+        self.fetch_configs: list[dict] = []
 
     def fetch(self, cfg: dict, home_path: Path) -> FetchResult:
+        self.fetch_configs.append(dict(cfg))
         return self.result
 
     def invalidate_cache(self, home_path: Path) -> None:
@@ -293,6 +295,79 @@ def test_strict_apply_exception_is_sanitized(tmp_path, monkeypatch):
     assert "source=stricttest" in str(raised.value)
     assert "stage=apply" in str(raised.value)
     assert raw_secret not in str(raised.value)
+
+
+def test_strict_refresh_expands_environment_backed_source_config(tmp_path, monkeypatch):
+    import hermes_cli.env_loader as env_loader
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "secrets:\n"
+        "  stricttest:\n"
+        "    enabled: true\n"
+        "    token_alias: ${STRICT_TOKEN_ALIAS}\n"
+    )
+    monkeypatch.setenv("STRICT_TOKEN_ALIAS", "EXPANDED_BOOTSTRAP_NAME")
+    source = _StrictTestSource(FetchResult(secrets={"ROTATING_SECRET": "fresh"}))
+    _install_strict_source(monkeypatch, source)
+
+    env_loader.refresh_hermes_dotenv_strict(hermes_home=home)
+
+    assert source.fetch_configs == [
+        {"enabled": True, "token_alias": "EXPANDED_BOOTSTRAP_NAME"}
+    ]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        (
+            "secrets:\n  stricttest:\n    enabled: false\n"
+            "secrets:\n  stricttest:\n    enabled: true\n"
+        ),
+        (
+            "secrets:\n  stricttest:\n    enabled: false\n"
+            "  stricttest:\n    enabled: true\n"
+        ),
+        (
+            "secrets:\n  stricttest:\n    enabled: true\n"
+            "    enabled: false\n"
+        ),
+    ],
+)
+def test_strict_refresh_rejects_duplicate_yaml_keys(tmp_path, monkeypatch, body):
+    import hermes_cli.env_loader as env_loader
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(body)
+    _install_strict_source(monkeypatch, _StrictTestSource(FetchResult()))
+
+    with pytest.raises(env_loader.SecretSourceRefreshError) as raised:
+        env_loader.refresh_hermes_dotenv_strict(hermes_home=home)
+    assert raised.value.stage == "config"
+    assert "duplicate" not in str(raised.value)
+
+
+def test_strict_refresh_rejects_unresolved_environment_reference(tmp_path, monkeypatch):
+    import hermes_cli.env_loader as env_loader
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "secrets:\n"
+        "  stricttest:\n"
+        "    enabled: true\n"
+        "    token_alias: ${UNSET_STRICT_TOKEN_ALIAS}\n"
+    )
+    monkeypatch.delenv("UNSET_STRICT_TOKEN_ALIAS", raising=False)
+    _install_strict_source(monkeypatch, _StrictTestSource(FetchResult()))
+
+    with pytest.raises(env_loader.SecretSourceRefreshError) as raised:
+        env_loader.refresh_hermes_dotenv_strict(hermes_home=home)
+    assert raised.value.stage == "config"
+    assert "UNSET_STRICT_TOKEN_ALIAS" not in str(raised.value)
 
 
 def test_strict_refresh_success_replaces_stale_value(tmp_path, monkeypatch):

--- a/tests/cron/test_no_agent_child_env.py
+++ b/tests/cron/test_no_agent_child_env.py
@@ -451,6 +451,72 @@ def test_strict_refresh_rejects_unresolved_environment_reference(tmp_path, monke
     assert "UNSET_STRICT_TOKEN_ALIAS" not in str(raised.value)
 
 
+def test_strict_refresh_deep_merges_managed_secret_config_over_user(
+    tmp_path, monkeypatch
+):
+    import hermes_cli.env_loader as env_loader
+
+    home = tmp_path / "profile"
+    managed = tmp_path / "managed"
+    home.mkdir()
+    managed.mkdir()
+    (home / "config.yaml").write_text(
+        "secrets:\n"
+        "  stricttest:\n"
+        "    enabled: true\n"
+        "    token_alias: USER_BOOTSTRAP\n"
+        "    user_setting: keep\n"
+    )
+    (managed / "config.yaml").write_text(
+        "secrets:\n"
+        "  stricttest:\n"
+        "    token_alias: ${MANAGED_ALIAS_NAME}\n"
+        "    managed_setting: authoritative\n"
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    monkeypatch.setenv("MANAGED_ALIAS_NAME", "MANAGED_BOOTSTRAP")
+    source = _StrictTestSource(FetchResult())
+    _install_strict_source(monkeypatch, source)
+
+    result = env_loader.refresh_hermes_dotenv_strict(hermes_home=home)
+
+    expected = {
+        "enabled": True,
+        "token_alias": "MANAGED_BOOTSTRAP",
+        "user_setting": "keep",
+        "managed_setting": "authoritative",
+    }
+    assert source.fetch_configs == [expected]
+    assert result.secrets_config == {"stricttest": expected}
+
+
+def test_strict_refresh_rejects_duplicate_keys_in_managed_config(
+    tmp_path, monkeypatch
+):
+    import hermes_cli.env_loader as env_loader
+
+    home = tmp_path / "profile"
+    managed = tmp_path / "managed"
+    home.mkdir()
+    managed.mkdir()
+    (managed / "config.yaml").write_text(
+        "secrets:\n"
+        "  stricttest:\n"
+        "    enabled: true\n"
+        "    token_alias: FIRST\n"
+        "    token_alias: SECOND\n"
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    _install_strict_source(monkeypatch, _StrictTestSource(FetchResult()))
+
+    with pytest.raises(env_loader.SecretSourceRefreshError) as raised:
+        env_loader.refresh_hermes_dotenv_strict(hermes_home=home)
+
+    assert raised.value.stage == "config"
+    assert "FIRST" not in str(raised.value)
+    assert "SECOND" not in str(raised.value)
+
+
 def test_strict_refresh_reapplies_managed_env_after_external_sources(
     tmp_path, monkeypatch
 ):

--- a/tests/cron/test_no_agent_child_env.py
+++ b/tests/cron/test_no_agent_child_env.py
@@ -47,12 +47,13 @@ def _patch_enabled_source(monkeypatch, *, alias: str = "CUSTOM_BOOTSTRAP") -> No
     import agent.secret_sources.registry as registry
     import hermes_cli.env_loader as env_loader
 
+    config = {
+        "test-source": {"enabled": True, "token_alias": alias},
+    }
     monkeypatch.setattr(
         env_loader,
-        "_load_secrets_config_strict",
-        lambda _home: {
-            "test-source": {"enabled": True, "token_alias": alias},
-        },
+        "refresh_hermes_dotenv_strict",
+        lambda **_kwargs: env_loader.StrictDotenvRefresh((), config),
     )
     monkeypatch.setattr(
         registry,
@@ -75,8 +76,7 @@ def test_prepare_no_agent_child_env_is_immutable_and_strips_bootstrap_vars(
     monkeypatch.setenv("CUSTOM_BOOTSTRAP", "configured-bootstrap")
     _patch_enabled_source(monkeypatch)
 
-    with patch("hermes_cli.env_loader.refresh_hermes_dotenv_strict"):
-        pinned_home, child_env = scheduler._prepare_no_agent_child_environment()
+    pinned_home, child_env = scheduler._prepare_no_agent_child_environment()
 
     assert pinned_home == home.resolve()
     assert isinstance(child_env, MappingProxyType)
@@ -91,10 +91,12 @@ def test_prepare_no_agent_child_env_is_immutable_and_strips_bootstrap_vars(
 def test_prepare_strips_environment_expanded_bootstrap_alias(tmp_path, monkeypatch):
     import agent.secret_sources.registry as registry
     import cron.scheduler as scheduler
+    import hermes_cli.env_loader as env_loader
 
     home = tmp_path / "profile"
     home.mkdir()
-    (home / "config.yaml").write_text(
+    config_path = home / "config.yaml"
+    config_path.write_text(
         "secrets:\n"
         "  test-source:\n"
         "    enabled: true\n"
@@ -107,7 +109,26 @@ def test_prepare_strips_environment_expanded_bootstrap_alias(tmp_path, monkeypat
         registry, "_ordered_enabled_sources", lambda _cfg: [_ProtectedSource()]
     )
 
-    with patch("hermes_cli.env_loader.refresh_hermes_dotenv_strict"):
+    exact_refresh_config = {
+        "test-source": {
+            "enabled": True,
+            "token_alias": "EXPANDED_BOOTSTRAP_TOKEN",
+        }
+    }
+
+    def refresh_then_replace_config(**_kwargs):
+        config_path.write_text(
+            "secrets:\n"
+            "  test-source:\n"
+            "    enabled: true\n"
+            "    token_alias: DIFFERENT_BOOTSTRAP_TOKEN\n"
+        )
+        return env_loader.StrictDotenvRefresh((), exact_refresh_config)
+
+    with patch(
+        "hermes_cli.env_loader.refresh_hermes_dotenv_strict",
+        side_effect=refresh_then_replace_config,
+    ):
         _pinned_home, child_env = scheduler._prepare_no_agent_child_environment()
 
     assert "EXPANDED_BOOTSTRAP_TOKEN" not in child_env
@@ -127,8 +148,9 @@ def test_prepare_no_agent_child_env_loads_exact_canonical_home(
     def reset(path: Path, **_kwargs) -> None:
         calls.append(("reset", path))
 
-    def load(*, hermes_home: Path, **_kwargs) -> None:
+    def load(*, hermes_home: Path, **_kwargs) -> list[Path]:
         calls.append(("load", hermes_home))
+        return []
 
     with patch("hermes_cli.env_loader.reset_secret_source_cache", side_effect=reset), patch(
         "hermes_cli.env_loader.load_hermes_dotenv", side_effect=load
@@ -147,9 +169,10 @@ def test_prepare_no_agent_child_env_rotates_across_consecutive_runs(tmp_path, mo
     monkeypatch.setattr(scheduler, "_hermes_home", home)
     values = iter(("first", "second"))
 
-    def load(*, hermes_home: Path, **_kwargs) -> None:
+    def load(*, hermes_home: Path, **_kwargs) -> list[Path]:
         assert hermes_home == home.resolve()
         os.environ["PERSONAL_HUB_CRON_SECRET"] = next(values)
+        return []
 
     try:
         with patch("hermes_cli.env_loader.reset_secret_source_cache"), patch(
@@ -180,12 +203,13 @@ def test_prepare_no_agent_child_env_two_homes_cannot_interleave(tmp_path, monkey
     beta_loaded = threading.Event()
     original_sanitize = local_env._sanitize_subprocess_env
 
-    def load(*, hermes_home: Path, **_kwargs) -> None:
+    def load(*, hermes_home: Path, **_kwargs) -> list[Path]:
         name = hermes_home.name
         os.environ["PROFILE_SCOPED_SECRET"] = name
         os.environ["HERMES_HOME"] = f"contaminated-by-{name}"
         if name == "beta":
             beta_loaded.set()
+        return []
 
     def sanitize(env: dict[str, str]) -> dict[str, str]:
         if env.get("PROFILE_SCOPED_SECRET") == "alpha":
@@ -447,7 +471,9 @@ def test_strict_refresh_with_no_enabled_sources_is_successful(tmp_path, monkeypa
     home = tmp_path / "profile"
     home.mkdir()
     _install_strict_source(monkeypatch, _StrictTestSource(FetchResult()))
-    assert env_loader.refresh_hermes_dotenv_strict(hermes_home=home) == []
+    result = env_loader.refresh_hermes_dotenv_strict(hermes_home=home)
+    assert result.loaded_files == ()
+    assert result.secrets_config == {}
 
 
 def test_claim_heartbeat_passes_exact_prepared_snapshot_and_home(tmp_path, monkeypatch):

--- a/tests/cron/test_no_agent_child_env.py
+++ b/tests/cron/test_no_agent_child_env.py
@@ -49,7 +49,7 @@ def _patch_enabled_source(monkeypatch, *, alias: str = "CUSTOM_BOOTSTRAP") -> No
 
     monkeypatch.setattr(
         env_loader,
-        "_load_secrets_config",
+        "_load_secrets_config_strict",
         lambda _home: {
             "test-source": {"enabled": True, "token_alias": alias},
         },
@@ -75,9 +75,7 @@ def test_prepare_no_agent_child_env_is_immutable_and_strips_bootstrap_vars(
     monkeypatch.setenv("CUSTOM_BOOTSTRAP", "configured-bootstrap")
     _patch_enabled_source(monkeypatch)
 
-    with patch("hermes_cli.env_loader.reset_secret_source_cache"), patch(
-        "hermes_cli.env_loader.load_hermes_dotenv"
-    ):
+    with patch("hermes_cli.env_loader.refresh_hermes_dotenv_strict"):
         pinned_home, child_env = scheduler._prepare_no_agent_child_environment()
 
     assert pinned_home == home.resolve()
@@ -88,6 +86,32 @@ def test_prepare_no_agent_child_env_is_immutable_and_strips_bootstrap_vars(
     assert "CUSTOM_BOOTSTRAP" not in child_env
     with pytest.raises(TypeError):
         child_env["MUTATION"] = "blocked"
+
+
+def test_prepare_strips_environment_expanded_bootstrap_alias(tmp_path, monkeypatch):
+    import agent.secret_sources.registry as registry
+    import cron.scheduler as scheduler
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "secrets:\n"
+        "  test-source:\n"
+        "    enabled: true\n"
+        "    token_alias: ${BOOTSTRAP_ALIAS_NAME}\n"
+    )
+    monkeypatch.setattr(scheduler, "_hermes_home", home)
+    monkeypatch.setenv("BOOTSTRAP_ALIAS_NAME", "EXPANDED_BOOTSTRAP_TOKEN")
+    monkeypatch.setenv("EXPANDED_BOOTSTRAP_TOKEN", "must-not-reach-child")
+    monkeypatch.setattr(
+        registry, "_ordered_enabled_sources", lambda _cfg: [_ProtectedSource()]
+    )
+
+    with patch("hermes_cli.env_loader.refresh_hermes_dotenv_strict"):
+        _pinned_home, child_env = scheduler._prepare_no_agent_child_environment()
+
+    assert "EXPANDED_BOOTSTRAP_TOKEN" not in child_env
+    assert "${BOOTSTRAP_ALIAS_NAME}" not in child_env
 
 
 def test_prepare_no_agent_child_env_loads_exact_canonical_home(
@@ -368,6 +392,33 @@ def test_strict_refresh_rejects_unresolved_environment_reference(tmp_path, monke
         env_loader.refresh_hermes_dotenv_strict(hermes_home=home)
     assert raised.value.stage == "config"
     assert "UNSET_STRICT_TOKEN_ALIAS" not in str(raised.value)
+
+
+def test_strict_refresh_reapplies_managed_env_after_external_sources(
+    tmp_path, monkeypatch
+):
+    import hermes_cli.env_loader as env_loader
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    (managed / ".env").write_text("LOCKED_API_KEY=managed-value\n")
+    (home / "config.yaml").write_text(
+        "secrets:\n"
+        "  stricttest:\n"
+        "    enabled: true\n"
+        "    override_existing: true\n"
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    source = _StrictTestSource(
+        FetchResult(secrets={"LOCKED_API_KEY": "external-value"})
+    )
+    _install_strict_source(monkeypatch, source)
+
+    env_loader.refresh_hermes_dotenv_strict(hermes_home=home)
+
+    assert os.environ["LOCKED_API_KEY"] == "managed-value"
 
 
 def test_strict_refresh_success_replaces_stale_value(tmp_path, monkeypatch):

--- a/tests/cron/test_no_agent_child_env.py
+++ b/tests/cron/test_no_agent_child_env.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from types import MappingProxyType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _ProtectedSource:
+    name = "test-source"
+
+    def protected_env_vars(self, cfg: dict) -> frozenset[str]:
+        return frozenset({cfg.get("token_alias", "OP_SERVICE_ACCOUNT_TOKEN")})
+
+
+def _patch_enabled_source(monkeypatch, *, alias: str = "CUSTOM_BOOTSTRAP") -> None:
+    import agent.secret_sources.registry as registry
+    import hermes_cli.env_loader as env_loader
+
+    monkeypatch.setattr(
+        env_loader,
+        "_load_secrets_config",
+        lambda _home: {
+            "test-source": {"enabled": True, "token_alias": alias},
+        },
+    )
+    monkeypatch.setattr(
+        registry,
+        "_ordered_enabled_sources",
+        lambda _cfg: [_ProtectedSource()],
+    )
+
+
+def test_prepare_no_agent_child_env_is_immutable_and_strips_bootstrap_vars(
+    tmp_path, monkeypatch
+):
+    import cron.scheduler as scheduler
+
+    canonical_home = tmp_path / "profile"
+    canonical_home.mkdir()
+    home = canonical_home / ".." / "profile"
+    monkeypatch.setattr(scheduler, "_hermes_home", home)
+    monkeypatch.setenv("PERSONAL_HUB_CRON_SECRET", "intended-job-secret")
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "default-bootstrap")
+    monkeypatch.setenv("CUSTOM_BOOTSTRAP", "configured-bootstrap")
+    _patch_enabled_source(monkeypatch)
+
+    with patch("hermes_cli.env_loader.reset_secret_source_cache"), patch(
+        "hermes_cli.env_loader.load_hermes_dotenv"
+    ):
+        pinned_home, child_env = scheduler._prepare_no_agent_child_environment()
+
+    assert pinned_home == home.resolve()
+    assert isinstance(child_env, MappingProxyType)
+    assert child_env["HERMES_HOME"] == str(home.resolve())
+    assert child_env["PERSONAL_HUB_CRON_SECRET"] == "intended-job-secret"
+    assert "OP_SERVICE_ACCOUNT_TOKEN" not in child_env
+    assert "CUSTOM_BOOTSTRAP" not in child_env
+    with pytest.raises(TypeError):
+        child_env["MUTATION"] = "blocked"
+
+
+def test_prepare_no_agent_child_env_resets_before_loading_exact_canonical_home(
+    tmp_path, monkeypatch
+):
+    import cron.scheduler as scheduler
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setattr(scheduler, "_hermes_home", home / ".")
+    calls: list[tuple[str, Path]] = []
+
+    def reset(path: Path) -> None:
+        calls.append(("reset", path))
+
+    def load(*, hermes_home: Path) -> None:
+        calls.append(("load", hermes_home))
+
+    with patch("hermes_cli.env_loader.reset_secret_source_cache", side_effect=reset), patch(
+        "hermes_cli.env_loader.load_hermes_dotenv", side_effect=load
+    ):
+        pinned_home, _child_env = scheduler._prepare_no_agent_child_environment()
+
+    assert pinned_home == home.resolve()
+    assert calls == [("reset", home.resolve()), ("load", home.resolve())]
+
+
+def test_prepare_no_agent_child_env_rotates_across_consecutive_runs(tmp_path, monkeypatch):
+    import cron.scheduler as scheduler
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setattr(scheduler, "_hermes_home", home)
+    values = iter(("first", "second"))
+
+    def load(*, hermes_home: Path) -> None:
+        assert hermes_home == home.resolve()
+        os.environ["PERSONAL_HUB_CRON_SECRET"] = next(values)
+
+    try:
+        with patch("hermes_cli.env_loader.reset_secret_source_cache"), patch(
+            "hermes_cli.env_loader.load_hermes_dotenv", side_effect=load
+        ):
+            _, first = scheduler._prepare_no_agent_child_environment()
+            _, second = scheduler._prepare_no_agent_child_environment()
+    finally:
+        os.environ.pop("PERSONAL_HUB_CRON_SECRET", None)
+
+    assert first["PERSONAL_HUB_CRON_SECRET"] == "first"
+    assert second["PERSONAL_HUB_CRON_SECRET"] == "second"
+
+
+def test_prepare_no_agent_child_env_two_homes_cannot_interleave(tmp_path, monkeypatch):
+    import agent.secret_sources.registry as registry
+    import cron.scheduler as scheduler
+    import hermes_cli.env_loader as env_loader
+    import tools.environments.local as local_env
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    homes = {name: (tmp_path / name).resolve() for name in ("alpha", "beta")}
+    for home in homes.values():
+        home.mkdir()
+
+    entered_snapshot = threading.Event()
+    release_snapshot = threading.Event()
+    beta_loaded = threading.Event()
+    original_sanitize = local_env._sanitize_subprocess_env
+
+    def load(*, hermes_home: Path) -> None:
+        name = hermes_home.name
+        os.environ["PROFILE_SCOPED_SECRET"] = name
+        os.environ["HERMES_HOME"] = f"contaminated-by-{name}"
+        if name == "beta":
+            beta_loaded.set()
+
+    def sanitize(env: dict[str, str]) -> dict[str, str]:
+        if env.get("PROFILE_SCOPED_SECRET") == "alpha":
+            entered_snapshot.set()
+            assert release_snapshot.wait(timeout=5)
+        return original_sanitize(env)
+
+    monkeypatch.setattr(scheduler, "_hermes_home", None)
+    monkeypatch.setattr(env_loader, "reset_secret_source_cache", lambda _home: None)
+    monkeypatch.setattr(env_loader, "load_hermes_dotenv", load)
+    monkeypatch.setattr(env_loader, "_load_secrets_config", lambda _home: {})
+    monkeypatch.setattr(registry, "_ordered_enabled_sources", lambda _cfg: [])
+    monkeypatch.setattr(local_env, "_sanitize_subprocess_env", sanitize)
+
+    snapshots: dict[str, tuple[Path, MappingProxyType]] = {}
+
+    def prepare(name: str) -> None:
+        token = set_hermes_home_override(homes[name])
+        try:
+            snapshots[name] = scheduler._prepare_no_agent_child_environment()
+        finally:
+            reset_hermes_home_override(token)
+
+    alpha = threading.Thread(target=prepare, args=("alpha",))
+    beta = threading.Thread(target=prepare, args=("beta",))
+    try:
+        alpha.start()
+        assert entered_snapshot.wait(timeout=5)
+        beta.start()
+        assert not beta_loaded.wait(timeout=0.1)
+        release_snapshot.set()
+        alpha.join(timeout=5)
+        beta.join(timeout=5)
+    finally:
+        release_snapshot.set()
+        alpha.join(timeout=5)
+        if beta.ident is not None:
+            beta.join(timeout=5)
+        os.environ.pop("PROFILE_SCOPED_SECRET", None)
+
+    assert not alpha.is_alive() and not beta.is_alive()
+    for name, home in homes.items():
+        pinned_home, child_env = snapshots[name]
+        assert pinned_home == home
+        assert child_env["HERMES_HOME"] == str(home)
+        assert child_env["PROFILE_SCOPED_SECRET"] == name
+
+
+def test_refresh_failure_fails_run_safely_without_starting_child(tmp_path, monkeypatch):
+    import cron.scheduler as scheduler
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setattr(scheduler, "_hermes_home", home)
+
+    job = {
+        "id": "refresh-failure",
+        "name": "refresh-failure",
+        "no_agent": True,
+        "script": "never-runs.py",
+    }
+    with patch(
+        "hermes_cli.env_loader.reset_secret_source_cache",
+        side_effect=RuntimeError("refresh failed"),
+    ), patch("cron.scheduler.subprocess.run") as run:
+        success, doc, response, error = scheduler.run_job(job)
+
+    assert success is False
+    assert doc == "" and response == ""
+    assert error == "No-agent secret refresh failed: RuntimeError: refresh failed"
+    run.assert_not_called()
+
+
+def test_claim_heartbeat_passes_exact_prepared_snapshot_and_home(tmp_path, monkeypatch):
+    import cron.scheduler as scheduler
+
+    home = (tmp_path / "profile").resolve()
+    snapshot = MappingProxyType({"HERMES_HOME": str(home), "PATH": "/snapshot/bin"})
+    captured = {}
+
+    def run_script(script_path: str, **kwargs):
+        captured.update(script_path=script_path, **kwargs)
+        return True, "done"
+
+    monkeypatch.setattr(scheduler, "_run_job_script", run_script)
+    result = scheduler._run_job_script_with_claim_heartbeat(
+        {"id": "snapshot"},
+        "script.py",
+        child_env=snapshot,
+        hermes_home=home,
+    )
+
+    assert result == (True, "done")
+    assert captured["child_env"] is snapshot
+    assert captured["hermes_home"] is home
+
+
+def test_prepared_snapshot_path_controls_bash_lookup(tmp_path, monkeypatch):
+    import cron.scheduler as scheduler
+
+    home = (tmp_path / "profile").resolve()
+    scripts = home / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "watch.sh").write_text("echo ignored\n")
+    snapshot = MappingProxyType(
+        {"HERMES_HOME": str(home), "PATH": "/snapshot-only/bin"}
+    )
+    completed = MagicMock(returncode=0, stdout="ok\n", stderr="")
+
+    with patch("cron.scheduler.shutil.which", return_value="/snapshot/bash") as which, patch(
+        "cron.scheduler.subprocess.run", return_value=completed
+    ) as run:
+        result = scheduler._run_job_script(
+            "watch.sh", child_env=snapshot, hermes_home=home
+        )
+
+    assert result == (True, "ok")
+    which.assert_called_once_with("bash", path="/snapshot-only/bin")
+    assert run.call_args.kwargs["env"] is snapshot
+
+
+def test_no_agent_workdir_keeps_relative_script_resolution(tmp_path, monkeypatch):
+    import cron.scheduler as scheduler
+
+    home = tmp_path / "profile"
+    scripts = home / "scripts"
+    workdir = tmp_path / "job-workdir"
+    scripts.mkdir(parents=True)
+    workdir.mkdir()
+    (workdir / "payload.txt").write_text("from-workdir\n")
+    (scripts / "relative.py").write_text(
+        "from pathlib import Path\nprint(Path('payload.txt').read_text().strip())\n"
+    )
+    monkeypatch.setattr(scheduler, "_hermes_home", home)
+
+    job = {
+        "id": "relative-workdir",
+        "name": "relative-workdir",
+        "no_agent": True,
+        "script": "relative.py",
+        "workdir": str(workdir),
+    }
+    with patch("hermes_cli.env_loader.reset_secret_source_cache"), patch(
+        "hermes_cli.env_loader.load_hermes_dotenv"
+    ):
+        success, _doc, response, error = scheduler.run_job(job)
+
+    assert success is True
+    assert error is None
+    assert response == "from-workdir"

--- a/tests/cron/test_no_agent_child_env.py
+++ b/tests/cron/test_no_agent_child_env.py
@@ -8,12 +8,37 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent.secret_sources.base import ErrorKind, FetchResult, SecretSource
+
 
 class _ProtectedSource:
     name = "test-source"
 
     def protected_env_vars(self, cfg: dict) -> frozenset[str]:
         return frozenset({cfg.get("token_alias", "OP_SERVICE_ACCOUNT_TOKEN")})
+
+
+class _StrictTestSource(SecretSource):
+    name = "stricttest"
+    label = "Strict Test"
+    shape = "mapped"
+
+    def __init__(self, result: FetchResult):
+        self.result = result
+        self.invalidated: list[Path] = []
+
+    def fetch(self, cfg: dict, home_path: Path) -> FetchResult:
+        return self.result
+
+    def invalidate_cache(self, home_path: Path) -> None:
+        self.invalidated.append(home_path)
+
+
+def _install_strict_source(monkeypatch, source: SecretSource) -> None:
+    import agent.secret_sources.registry as registry
+
+    monkeypatch.setattr(registry, "_BUILTINS_LOADED", True)
+    monkeypatch.setattr(registry, "_SOURCES", {source.name: source})
 
 
 def _patch_enabled_source(monkeypatch, *, alias: str = "CUSTOM_BOOTSTRAP") -> None:
@@ -63,7 +88,7 @@ def test_prepare_no_agent_child_env_is_immutable_and_strips_bootstrap_vars(
         child_env["MUTATION"] = "blocked"
 
 
-def test_prepare_no_agent_child_env_resets_before_loading_exact_canonical_home(
+def test_prepare_no_agent_child_env_loads_exact_canonical_home(
     tmp_path, monkeypatch
 ):
     import cron.scheduler as scheduler
@@ -73,10 +98,10 @@ def test_prepare_no_agent_child_env_resets_before_loading_exact_canonical_home(
     monkeypatch.setattr(scheduler, "_hermes_home", home / ".")
     calls: list[tuple[str, Path]] = []
 
-    def reset(path: Path) -> None:
+    def reset(path: Path, **_kwargs) -> None:
         calls.append(("reset", path))
 
-    def load(*, hermes_home: Path) -> None:
+    def load(*, hermes_home: Path, **_kwargs) -> None:
         calls.append(("load", hermes_home))
 
     with patch("hermes_cli.env_loader.reset_secret_source_cache", side_effect=reset), patch(
@@ -85,7 +110,7 @@ def test_prepare_no_agent_child_env_resets_before_loading_exact_canonical_home(
         pinned_home, _child_env = scheduler._prepare_no_agent_child_environment()
 
     assert pinned_home == home.resolve()
-    assert calls == [("reset", home.resolve()), ("load", home.resolve())]
+    assert calls == [("load", home.resolve())]
 
 
 def test_prepare_no_agent_child_env_rotates_across_consecutive_runs(tmp_path, monkeypatch):
@@ -96,7 +121,7 @@ def test_prepare_no_agent_child_env_rotates_across_consecutive_runs(tmp_path, mo
     monkeypatch.setattr(scheduler, "_hermes_home", home)
     values = iter(("first", "second"))
 
-    def load(*, hermes_home: Path) -> None:
+    def load(*, hermes_home: Path, **_kwargs) -> None:
         assert hermes_home == home.resolve()
         os.environ["PERSONAL_HUB_CRON_SECRET"] = next(values)
 
@@ -129,7 +154,7 @@ def test_prepare_no_agent_child_env_two_homes_cannot_interleave(tmp_path, monkey
     beta_loaded = threading.Event()
     original_sanitize = local_env._sanitize_subprocess_env
 
-    def load(*, hermes_home: Path) -> None:
+    def load(*, hermes_home: Path, **_kwargs) -> None:
         name = hermes_home.name
         os.environ["PROFILE_SCOPED_SECRET"] = name
         os.environ["HERMES_HOME"] = f"contaminated-by-{name}"
@@ -143,7 +168,9 @@ def test_prepare_no_agent_child_env_two_homes_cannot_interleave(tmp_path, monkey
         return original_sanitize(env)
 
     monkeypatch.setattr(scheduler, "_hermes_home", None)
-    monkeypatch.setattr(env_loader, "reset_secret_source_cache", lambda _home: None)
+    monkeypatch.setattr(
+        env_loader, "reset_secret_source_cache", lambda _home, **_kwargs: None
+    )
     monkeypatch.setattr(env_loader, "load_hermes_dotenv", load)
     monkeypatch.setattr(env_loader, "_load_secrets_config", lambda _home: {})
     monkeypatch.setattr(registry, "_ordered_enabled_sources", lambda _cfg: [])
@@ -197,15 +224,104 @@ def test_refresh_failure_fails_run_safely_without_starting_child(tmp_path, monke
         "script": "never-runs.py",
     }
     with patch(
-        "hermes_cli.env_loader.reset_secret_source_cache",
+        "hermes_cli.env_loader.refresh_hermes_dotenv_strict",
         side_effect=RuntimeError("refresh failed"),
     ), patch("cron.scheduler.subprocess.run") as run:
         success, doc, response, error = scheduler.run_job(job)
 
     assert success is False
     assert doc == "" and response == ""
-    assert error == "No-agent secret refresh failed: RuntimeError: refresh failed"
+    assert error == "No-agent secret refresh failed: secret refresh failed (type=RuntimeError)"
     run.assert_not_called()
+
+
+def test_fetch_result_error_removes_stale_secret_and_never_starts_child(
+    tmp_path, monkeypatch, caplog
+):
+    import cron.scheduler as scheduler
+    import hermes_cli.env_loader as env_loader
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "secrets:\n  stricttest:\n    enabled: true\n    override_existing: true\n"
+    )
+    monkeypatch.setattr(scheduler, "_hermes_home", home)
+    raw_secret = "backend token=do-not-log"
+    _install_strict_source(
+        monkeypatch,
+        _StrictTestSource(
+            FetchResult(error=raw_secret, error_kind=ErrorKind.NETWORK)
+        ),
+    )
+    monkeypatch.setitem(env_loader._SECRET_SOURCES, "ROTATING_SECRET", "stricttest")
+    monkeypatch.setenv("ROTATING_SECRET", "stale-value")
+    job = {
+        "id": "strict-fetch-failure",
+        "name": "strict-fetch-failure",
+        "no_agent": True,
+        "script": "never-runs.py",
+    }
+
+    with caplog.at_level("ERROR"), patch("cron.scheduler.subprocess.run") as run:
+        success, doc, response, error = scheduler.run_job(job)
+
+    assert success is False and doc == "" and response == ""
+    assert error is not None
+    assert "source=stricttest" in error and "stage=fetch" in error
+    assert raw_secret not in error and raw_secret not in caplog.text
+    assert "ROTATING_SECRET" not in os.environ
+    run.assert_not_called()
+
+
+def test_strict_apply_exception_is_sanitized(tmp_path, monkeypatch):
+    import agent.secret_sources.registry as registry
+    import hermes_cli.env_loader as env_loader
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "secrets:\n  stricttest:\n    enabled: true\n"
+    )
+    source = _StrictTestSource(FetchResult(secrets={"VALUE": "unused"}))
+    _install_strict_source(monkeypatch, source)
+    raw_secret = "exception contains SECRET-VALUE"
+    monkeypatch.setattr(registry, "apply_all", lambda *_args: (_ for _ in ()).throw(RuntimeError(raw_secret)))
+
+    with pytest.raises(env_loader.SecretSourceRefreshError) as raised:
+        env_loader.refresh_hermes_dotenv_strict(hermes_home=home)
+    assert "source=stricttest" in str(raised.value)
+    assert "stage=apply" in str(raised.value)
+    assert raw_secret not in str(raised.value)
+
+
+def test_strict_refresh_success_replaces_stale_value(tmp_path, monkeypatch):
+    import hermes_cli.env_loader as env_loader
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "secrets:\n  stricttest:\n    enabled: true\n    override_existing: true\n"
+    )
+    source = _StrictTestSource(FetchResult(secrets={"ROTATING_SECRET": "fresh"}))
+    _install_strict_source(monkeypatch, source)
+    monkeypatch.setitem(env_loader._SECRET_SOURCES, "ROTATING_SECRET", "stricttest")
+    monkeypatch.setenv("ROTATING_SECRET", "stale")
+
+    env_loader.refresh_hermes_dotenv_strict(hermes_home=home)
+
+    assert os.environ["ROTATING_SECRET"] == "fresh"
+    assert env_loader.get_secret_source("ROTATING_SECRET") == "stricttest"
+    assert source.invalidated == [home.resolve()]
+
+
+def test_strict_refresh_with_no_enabled_sources_is_successful(tmp_path, monkeypatch):
+    import hermes_cli.env_loader as env_loader
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    _install_strict_source(monkeypatch, _StrictTestSource(FetchResult()))
+    assert env_loader.refresh_hermes_dotenv_strict(hermes_home=home) == []
 
 
 def test_claim_heartbeat_passes_exact_prepared_snapshot_and_home(tmp_path, monkeypatch):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1715,7 +1715,8 @@ class TestRunJobSessionPersistence:
         fake_db = MagicMock()
         call_order = []
 
-        def _record_reset():
+        def _record_reset(home):
+            assert home == tmp_path
             call_order.append("reset")
 
         def _record_load(*args, **kwargs):

--- a/tests/cron/test_scheduler_lease.py
+++ b/tests/cron/test_scheduler_lease.py
@@ -1,0 +1,144 @@
+"""Real-process contracts for the HERMES_HOME scheduler ownership lease."""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from cron.scheduler_lease import SchedulerOwnershipLease
+
+_ROOT = Path(__file__).resolve().parents[2]
+_PROBE = r"""
+import os, sys, time
+from pathlib import Path
+from cron.scheduler_lease import SchedulerOwnershipLease
+if len(sys.argv) > 3:
+    ready, go = Path(sys.argv[3]), Path(sys.argv[4])
+    ready.touch()
+    while not go.exists():
+        time.sleep(0.005)
+lease = SchedulerOwnershipLease.try_acquire(
+    hermes_home=Path(sys.argv[1]), owner="gateway", provider="builtin"
+)
+print("acquired" if lease else "blocked", flush=True)
+if lease:
+    time.sleep(float(sys.argv[2]))
+    lease.release()
+"""
+
+
+def _spawn(
+    home: Path,
+    hold: float = 0.0,
+    *,
+    ready: Path | None = None,
+    go: Path | None = None,
+) -> subprocess.Popen[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.Popen(
+        [sys.executable, "-c", _PROBE, str(home), str(hold)]
+        + ([str(ready), str(go)] if ready is not None and go is not None else []),
+        cwd=_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _line(proc: subprocess.Popen[str]) -> str:
+    assert proc.stdout is not None
+    return proc.stdout.readline().strip()
+
+
+def test_same_home_cross_process_contention_and_graceful_release(tmp_path):
+    first = _spawn(tmp_path, 1.0)
+    assert _line(first) == "acquired"
+    second = _spawn(tmp_path)
+    assert second.communicate(timeout=5)[0].strip() == "blocked"
+    assert first.wait(timeout=5) == 0
+    third = _spawn(tmp_path)
+    assert third.communicate(timeout=5)[0].strip() == "acquired"
+    assert (tmp_path / "cron" / ".scheduler-owner.lock").exists()
+
+
+def test_different_homes_can_both_acquire(tmp_path):
+    first = _spawn(tmp_path / "a", 0.5)
+    second = _spawn(tmp_path / "b", 0.5)
+    assert _line(first) == "acquired"
+    assert _line(second) == "acquired"
+    assert first.wait(timeout=5) == second.wait(timeout=5) == 0
+
+
+def test_same_process_contention(tmp_path):
+    first = SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path, owner="gateway", provider="builtin"
+    )
+    assert first is not None
+    try:
+        assert SchedulerOwnershipLease.try_acquire(
+            hermes_home=tmp_path, owner="desktop", provider="builtin"
+        ) is None
+    finally:
+        first.release()
+
+
+def test_forced_process_death_recovers_without_unlink(tmp_path):
+    child = _spawn(tmp_path, 30.0)
+    assert _line(child) == "acquired"
+    lock_path = tmp_path / "cron" / ".scheduler-owner.lock"
+    inode = lock_path.stat().st_ino
+    if os.name == "nt":
+        child.kill()
+    else:
+        child.send_signal(signal.SIGKILL)
+    child.wait(timeout=5)
+
+    recovered = SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path, owner="desktop", provider="builtin"
+    )
+    assert recovered is not None
+    try:
+        assert lock_path.stat().st_ino == inode
+    finally:
+        recovered.release()
+
+
+def test_corrupt_stale_metadata_is_diagnostic_only(tmp_path):
+    path = tmp_path / "cron" / ".scheduler-owner.lock"
+    path.parent.mkdir(parents=True)
+    path.write_text("not-json secret-looking-stale-garbage", encoding="utf-8")
+    lease = SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path, owner="gateway", provider="builtin"
+    )
+    assert lease is not None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert payload["pid"] == os.getpid()
+        assert payload["owner"] == "gateway"
+        assert set(payload) == {
+            "version", "pid", "process_start_time", "owner", "provider", "acquired_at"
+        }
+    finally:
+        lease.release()
+
+
+def test_rapid_overlapping_start_has_one_holder(tmp_path):
+    go = tmp_path / "go"
+    ready_paths = [tmp_path / f"ready-{index}" for index in range(8)]
+    children = [
+        _spawn(tmp_path, 0.5, ready=ready, go=go) for ready in ready_paths
+    ]
+    deadline = time.monotonic() + 10
+    while not all(path.exists() for path in ready_paths):
+        assert time.monotonic() < deadline
+        time.sleep(0.01)
+    go.touch()
+    outputs = [child.communicate(timeout=10)[0].strip() for child in children]
+    assert outputs.count("acquired") == 1
+    assert outputs.count("blocked") == 7

--- a/tests/cron/test_scheduler_ownership.py
+++ b/tests/cron/test_scheduler_ownership.py
@@ -1,0 +1,152 @@
+"""Behavior contracts for selecting one cron scheduler owner per Hermes home."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+
+class _RecordingThread:
+    instances = []
+
+    def __init__(self, *, target, args=(), kwargs=None, daemon=None, name=None):
+        self.target = target
+        self.args = args
+        self.kwargs = kwargs or {}
+        self.daemon = daemon
+        self.name = name
+        self.started = False
+        type(self).instances.append(self)
+
+    def start(self):
+        self.started = True
+
+
+def _write_config(home, body: str) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(body, encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({}, "gateway"),
+        ({"cron": {}}, "gateway"),
+        ({"cron": {"scheduler_owner": "auto"}}, "gateway"),
+        ({"cron": {"scheduler_owner": " gateway "}}, "gateway"),
+        ({"cron": {"scheduler_owner": "DESKTOP"}}, "desktop"),
+    ],
+)
+def test_scheduler_owner_selection_contract(config, expected):
+    from cron.scheduler_provider import resolve_cron_scheduler_owner
+
+    assert resolve_cron_scheduler_owner(config=config) == expected
+
+
+@pytest.mark.parametrize("invalid", ["", "both", 42, None])
+def test_invalid_scheduler_owner_fails_closed_without_logging_value(invalid, caplog):
+    from cron.scheduler_provider import resolve_cron_scheduler_owner
+
+    with caplog.at_level("ERROR"):
+        assert resolve_cron_scheduler_owner(
+            config={"cron": {"scheduler_owner": invalid}}
+        ) is None
+    assert "scheduler startup disabled" in caplog.text
+    if isinstance(invalid, str) and invalid:
+        assert invalid not in caplog.text
+
+
+def test_default_config_uses_safe_auto_owner():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["cron"]["scheduler_owner"] == "auto"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        'cron:\n  scheduler_owner: "unterminated\n',
+        "cron: desktop\n",
+        "cron:\n  scheduler_owner: both\n",
+        "null\n",
+    ],
+)
+def test_owner_file_errors_fail_closed(tmp_path, monkeypatch, body):
+    from cron.scheduler_provider import resolve_cron_scheduler_owner
+
+    _write_config(tmp_path, body)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert resolve_cron_scheduler_owner() is None
+
+
+def test_named_profile_reads_its_registry_not_default_registry(tmp_path, monkeypatch):
+    from cron.scheduler_provider import should_start_cron_scheduler
+
+    default_home = tmp_path / ".hermes"
+    profile_home = default_home / "profiles" / "worker"
+    _write_config(default_home, "cron:\n  scheduler_owner: gateway\n")
+    _write_config(profile_home, "cron:\n  scheduler_owner: desktop\n")
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    assert should_start_cron_scheduler("gateway") is False
+    assert should_start_cron_scheduler("desktop") is True
+
+
+def test_gateway_and_desktop_use_same_owner_gate(tmp_path, monkeypatch):
+    from gateway import run as gateway_run
+    from hermes_cli import web_server
+
+    _write_config(tmp_path, "cron:\n  scheduler_owner: desktop\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(gateway_run.threading, "Thread", _RecordingThread)
+    monkeypatch.setattr(web_server.threading, "Thread", _RecordingThread)
+    _RecordingThread.instances.clear()
+    runner = SimpleNamespace(
+        adapters={},
+        _draining=False,
+        _external_drain_active=False,
+    )
+
+    gateway_provider, gateway_thread = gateway_run._start_gateway_cron_scheduler_if_owned(
+        runner, threading.Event(), object()
+    )
+    desktop_stop, desktop_thread = web_server._start_desktop_cron_scheduler_if_owned()
+
+    assert gateway_provider is None
+    assert gateway_thread is None
+    assert isinstance(desktop_stop, threading.Event)
+    assert desktop_thread is _RecordingThread.instances[0]
+    assert desktop_thread.started is True
+    assert desktop_thread.kwargs["provider"].name == "builtin"
+
+
+def test_default_owner_starts_gateway_not_desktop(tmp_path, monkeypatch):
+    from gateway import run as gateway_run
+    from hermes_cli import web_server
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(gateway_run.threading, "Thread", _RecordingThread)
+    monkeypatch.setattr(web_server.threading, "Thread", _RecordingThread)
+    _RecordingThread.instances.clear()
+    runner = SimpleNamespace(
+        adapters={"discord": object()},
+        _draining=False,
+        _external_drain_active=False,
+    )
+
+    gateway_provider, gateway_thread = gateway_run._start_gateway_cron_scheduler_if_owned(
+        runner, threading.Event(), object()
+    )
+    desktop_stop, desktop_thread = web_server._start_desktop_cron_scheduler_if_owned()
+
+    assert gateway_provider.name == "builtin"
+    assert gateway_thread is _RecordingThread.instances[0]
+    assert gateway_thread.started is True
+    assert callable(gateway_thread.kwargs["can_dispatch"])
+    assert desktop_stop is None
+    assert desktop_thread is None

--- a/tests/cron/test_scheduler_ownership.py
+++ b/tests/cron/test_scheduler_ownership.py
@@ -32,9 +32,9 @@ def _write_config(home, body: str) -> None:
 @pytest.mark.parametrize(
     ("config", "expected"),
     [
-        ({}, "gateway"),
-        ({"cron": {}}, "gateway"),
-        ({"cron": {"scheduler_owner": "auto"}}, "gateway"),
+        ({}, "auto"),
+        ({"cron": {}}, "auto"),
+        ({"cron": {"scheduler_owner": "auto"}}, "auto"),
         ({"cron": {"scheduler_owner": " gateway "}}, "gateway"),
         ({"cron": {"scheduler_owner": "DESKTOP"}}, "desktop"),
     ],
@@ -95,6 +95,49 @@ def test_named_profile_reads_its_registry_not_default_registry(tmp_path, monkeyp
     assert should_start_cron_scheduler("desktop") is True
 
 
+def test_owner_env_reference_is_expanded(tmp_path, monkeypatch):
+    from cron.scheduler_provider import resolve_cron_scheduler_owner
+
+    _write_config(tmp_path, "cron:\n  scheduler_owner: ${CRON_OWNER}\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("CRON_OWNER", "desktop")
+
+    assert resolve_cron_scheduler_owner() == "desktop"
+
+
+def test_managed_owner_env_wins_and_uses_selected_profile_scope(
+    tmp_path, monkeypatch
+):
+    from cron.scheduler_provider import resolve_cron_scheduler_owner
+
+    profile_home = tmp_path / ".hermes" / "profiles" / "worker"
+    selected_managed = tmp_path / "managed-worker"
+    other_managed = tmp_path / "managed-default"
+    _write_config(profile_home, "cron:\n  scheduler_owner: desktop\n")
+    _write_config(other_managed, "cron:\n  scheduler_owner: desktop\n")
+    _write_config(selected_managed, "cron:\n  scheduler_owner: ${MANAGED_OWNER}\n")
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(selected_managed))
+    monkeypatch.setenv("MANAGED_OWNER", "gateway")
+
+    assert resolve_cron_scheduler_owner() == "gateway"
+
+
+def test_unresolved_owner_env_reference_fails_closed_without_logging_value(
+    tmp_path, monkeypatch, caplog
+):
+    from cron.scheduler_provider import resolve_cron_scheduler_owner
+
+    ref = "${UNSET_CRON_OWNER_FOR_TEST}"
+    _write_config(tmp_path, f"cron:\n  scheduler_owner: {ref}\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("UNSET_CRON_OWNER_FOR_TEST", raising=False)
+
+    with caplog.at_level("ERROR"):
+        assert resolve_cron_scheduler_owner() is None
+    assert ref not in caplog.text
+
+
 def test_gateway_and_desktop_use_same_owner_gate(tmp_path, monkeypatch):
     from gateway import run as gateway_run
     from hermes_cli import web_server
@@ -114,7 +157,11 @@ def test_gateway_and_desktop_use_same_owner_gate(tmp_path, monkeypatch):
     gateway_provider, gateway_thread = gateway_run._start_gateway_cron_scheduler_if_owned(
         runner, threading.Event(), object()
     )
-    desktop_stop, desktop_thread = web_server._start_desktop_cron_scheduler_if_owned()
+    desktop_provider, desktop_stop, desktop_thread = (
+        web_server._start_desktop_cron_scheduler_if_owned()
+    )
+
+    assert desktop_provider.name == "builtin"
 
     assert gateway_provider is None
     assert gateway_thread is None
@@ -124,7 +171,7 @@ def test_gateway_and_desktop_use_same_owner_gate(tmp_path, monkeypatch):
     assert desktop_thread.kwargs["provider"].name == "builtin"
 
 
-def test_default_owner_starts_gateway_not_desktop(tmp_path, monkeypatch):
+def test_auto_starts_gateway_and_desktop_builtin_standby(tmp_path, monkeypatch):
     from gateway import run as gateway_run
     from hermes_cli import web_server
 
@@ -142,11 +189,82 @@ def test_default_owner_starts_gateway_not_desktop(tmp_path, monkeypatch):
     gateway_provider, gateway_thread = gateway_run._start_gateway_cron_scheduler_if_owned(
         runner, threading.Event(), object()
     )
-    desktop_stop, desktop_thread = web_server._start_desktop_cron_scheduler_if_owned()
+    desktop_provider, desktop_stop, desktop_thread = (
+        web_server._start_desktop_cron_scheduler_if_owned()
+    )
+
+    assert desktop_provider.name == "builtin"
 
     assert gateway_provider.name == "builtin"
     assert gateway_thread is _RecordingThread.instances[0]
     assert gateway_thread.started is True
     assert callable(gateway_thread.kwargs["can_dispatch"])
-    assert desktop_stop is None
-    assert desktop_thread is None
+    assert isinstance(desktop_stop, threading.Event)
+    assert desktop_thread is _RecordingThread.instances[1]
+    assert desktop_thread.started is True
+    assert desktop_thread.kwargs["provider"].name == "builtin"
+    assert callable(desktop_thread.kwargs["can_dispatch"])
+
+
+def test_auto_desktop_standby_tracks_gateway_liveness(tmp_path, monkeypatch):
+    from gateway import status as gateway_status
+    from hermes_cli import web_server
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(web_server.threading, "Thread", _RecordingThread)
+    gateway_pid: dict[str, int | None] = {"value": None}
+    calls = []
+
+    def fake_running_pid(*, cleanup_stale):
+        calls.append(cleanup_stale)
+        return gateway_pid["value"]
+
+    monkeypatch.setattr(gateway_status, "get_running_pid", fake_running_pid)
+    _RecordingThread.instances.clear()
+
+    _, _, thread = web_server._start_desktop_cron_scheduler_if_owned()
+    can_dispatch = thread.kwargs["can_dispatch"]
+    assert can_dispatch() is True
+    gateway_pid["value"] = 1234
+    assert can_dispatch() is False
+    gateway_pid["value"] = None
+    assert can_dispatch() is True
+    assert calls == [False, False, False]
+
+
+def test_auto_desktop_external_provider_fails_closed(tmp_path, monkeypatch):
+    from cron import scheduler_provider
+    from hermes_cli import web_server
+
+    class ExternalProvider:
+        name = "external"
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(scheduler_provider, "resolve_cron_scheduler", ExternalProvider)
+
+    assert web_server._start_desktop_cron_scheduler_if_owned() == (
+        None,
+        None,
+        None,
+    )
+
+
+def test_explicit_desktop_supports_external_provider(tmp_path, monkeypatch):
+    from cron import scheduler_provider
+    from hermes_cli import web_server
+
+    class ExternalProvider:
+        name = "external"
+
+    _write_config(tmp_path, "cron:\n  scheduler_owner: desktop\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(web_server.threading, "Thread", _RecordingThread)
+    monkeypatch.setattr(scheduler_provider, "resolve_cron_scheduler", ExternalProvider)
+    _RecordingThread.instances.clear()
+
+    _, _, thread = web_server._start_desktop_cron_scheduler_if_owned()
+    assert set(thread.kwargs) == {"provider"}
+    assert thread.kwargs["provider"].name == "external"

--- a/tests/cron/test_scheduler_ownership.py
+++ b/tests/cron/test_scheduler_ownership.py
@@ -1,27 +1,7 @@
 """Behavior contracts for selecting one cron scheduler owner per Hermes home."""
-
 from __future__ import annotations
 
-import threading
-from types import SimpleNamespace
-
 import pytest
-
-
-class _RecordingThread:
-    instances = []
-
-    def __init__(self, *, target, args=(), kwargs=None, daemon=None, name=None):
-        self.target = target
-        self.args = args
-        self.kwargs = kwargs or {}
-        self.daemon = daemon
-        self.name = name
-        self.started = False
-        type(self).instances.append(self)
-
-    def start(self):
-        self.started = True
 
 
 def _write_config(home, body: str) -> None:
@@ -78,7 +58,6 @@ def test_owner_file_errors_fail_closed(tmp_path, monkeypatch, body):
 
     _write_config(tmp_path, body)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-
     assert resolve_cron_scheduler_owner() is None
 
 
@@ -90,7 +69,6 @@ def test_named_profile_reads_its_registry_not_default_registry(tmp_path, monkeyp
     _write_config(default_home, "cron:\n  scheduler_owner: gateway\n")
     _write_config(profile_home, "cron:\n  scheduler_owner: desktop\n")
     monkeypatch.setenv("HERMES_HOME", str(profile_home))
-
     assert should_start_cron_scheduler("gateway") is False
     assert should_start_cron_scheduler("desktop") is True
 
@@ -101,13 +79,10 @@ def test_owner_env_reference_is_expanded(tmp_path, monkeypatch):
     _write_config(tmp_path, "cron:\n  scheduler_owner: ${CRON_OWNER}\n")
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("CRON_OWNER", "desktop")
-
     assert resolve_cron_scheduler_owner() == "desktop"
 
 
-def test_managed_owner_env_wins_and_uses_selected_profile_scope(
-    tmp_path, monkeypatch
-):
+def test_managed_owner_env_wins_and_uses_selected_profile_scope(tmp_path, monkeypatch):
     from cron.scheduler_provider import resolve_cron_scheduler_owner
 
     profile_home = tmp_path / ".hermes" / "profiles" / "worker"
@@ -119,7 +94,6 @@ def test_managed_owner_env_wins_and_uses_selected_profile_scope(
     monkeypatch.setenv("HERMES_HOME", str(profile_home))
     monkeypatch.setenv("HERMES_MANAGED_DIR", str(selected_managed))
     monkeypatch.setenv("MANAGED_OWNER", "gateway")
-
     assert resolve_cron_scheduler_owner() == "gateway"
 
 
@@ -132,139 +106,19 @@ def test_unresolved_owner_env_reference_fails_closed_without_logging_value(
     _write_config(tmp_path, f"cron:\n  scheduler_owner: {ref}\n")
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.delenv("UNSET_CRON_OWNER_FOR_TEST", raising=False)
-
     with caplog.at_level("ERROR"):
         assert resolve_cron_scheduler_owner() is None
     assert ref not in caplog.text
 
 
-def test_gateway_and_desktop_use_same_owner_gate(tmp_path, monkeypatch):
-    from gateway import run as gateway_run
-    from hermes_cli import web_server
+def test_managed_provider_precedence_is_read_with_owner(tmp_path, monkeypatch):
+    from cron.scheduler_runtime import read_scheduler_ownership_policy_strict
 
-    _write_config(tmp_path, "cron:\n  scheduler_owner: desktop\n")
+    managed = tmp_path / "managed"
+    _write_config(tmp_path, "cron:\n  scheduler_owner: desktop\n  provider: builtin\n")
+    _write_config(managed, "cron:\n  scheduler_owner: gateway\n  provider: chronos\n")
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("HERMES_DESKTOP", "1")
-    monkeypatch.setattr(gateway_run.threading, "Thread", _RecordingThread)
-    monkeypatch.setattr(web_server.threading, "Thread", _RecordingThread)
-    _RecordingThread.instances.clear()
-    runner = SimpleNamespace(
-        adapters={},
-        _draining=False,
-        _external_drain_active=False,
-    )
-
-    gateway_provider, gateway_thread = gateway_run._start_gateway_cron_scheduler_if_owned(
-        runner, threading.Event(), object()
-    )
-    desktop_provider, desktop_stop, desktop_thread = (
-        web_server._start_desktop_cron_scheduler_if_owned()
-    )
-
-    assert desktop_provider.name == "builtin"
-
-    assert gateway_provider is None
-    assert gateway_thread is None
-    assert isinstance(desktop_stop, threading.Event)
-    assert desktop_thread is _RecordingThread.instances[0]
-    assert desktop_thread.started is True
-    assert desktop_thread.kwargs["provider"].name == "builtin"
-
-
-def test_auto_starts_gateway_and_desktop_builtin_standby(tmp_path, monkeypatch):
-    from gateway import run as gateway_run
-    from hermes_cli import web_server
-
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("HERMES_DESKTOP", "1")
-    monkeypatch.setattr(gateway_run.threading, "Thread", _RecordingThread)
-    monkeypatch.setattr(web_server.threading, "Thread", _RecordingThread)
-    _RecordingThread.instances.clear()
-    runner = SimpleNamespace(
-        adapters={"discord": object()},
-        _draining=False,
-        _external_drain_active=False,
-    )
-
-    gateway_provider, gateway_thread = gateway_run._start_gateway_cron_scheduler_if_owned(
-        runner, threading.Event(), object()
-    )
-    desktop_provider, desktop_stop, desktop_thread = (
-        web_server._start_desktop_cron_scheduler_if_owned()
-    )
-
-    assert desktop_provider.name == "builtin"
-
-    assert gateway_provider.name == "builtin"
-    assert gateway_thread is _RecordingThread.instances[0]
-    assert gateway_thread.started is True
-    assert callable(gateway_thread.kwargs["can_dispatch"])
-    assert isinstance(desktop_stop, threading.Event)
-    assert desktop_thread is _RecordingThread.instances[1]
-    assert desktop_thread.started is True
-    assert desktop_thread.kwargs["provider"].name == "builtin"
-    assert callable(desktop_thread.kwargs["can_dispatch"])
-
-
-def test_auto_desktop_standby_tracks_gateway_liveness(tmp_path, monkeypatch):
-    from gateway import status as gateway_status
-    from hermes_cli import web_server
-
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("HERMES_DESKTOP", "1")
-    monkeypatch.setattr(web_server.threading, "Thread", _RecordingThread)
-    gateway_pid: dict[str, int | None] = {"value": None}
-    calls = []
-
-    def fake_running_pid(*, cleanup_stale):
-        calls.append(cleanup_stale)
-        return gateway_pid["value"]
-
-    monkeypatch.setattr(gateway_status, "get_running_pid", fake_running_pid)
-    _RecordingThread.instances.clear()
-
-    _, _, thread = web_server._start_desktop_cron_scheduler_if_owned()
-    can_dispatch = thread.kwargs["can_dispatch"]
-    assert can_dispatch() is True
-    gateway_pid["value"] = 1234
-    assert can_dispatch() is False
-    gateway_pid["value"] = None
-    assert can_dispatch() is True
-    assert calls == [False, False, False]
-
-
-def test_auto_desktop_external_provider_fails_closed(tmp_path, monkeypatch):
-    from cron import scheduler_provider
-    from hermes_cli import web_server
-
-    class ExternalProvider:
-        name = "external"
-
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("HERMES_DESKTOP", "1")
-    monkeypatch.setattr(scheduler_provider, "resolve_cron_scheduler", ExternalProvider)
-
-    assert web_server._start_desktop_cron_scheduler_if_owned() == (
-        None,
-        None,
-        None,
-    )
-
-
-def test_explicit_desktop_supports_external_provider(tmp_path, monkeypatch):
-    from cron import scheduler_provider
-    from hermes_cli import web_server
-
-    class ExternalProvider:
-        name = "external"
-
-    _write_config(tmp_path, "cron:\n  scheduler_owner: desktop\n")
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("HERMES_DESKTOP", "1")
-    monkeypatch.setattr(web_server.threading, "Thread", _RecordingThread)
-    monkeypatch.setattr(scheduler_provider, "resolve_cron_scheduler", ExternalProvider)
-    _RecordingThread.instances.clear()
-
-    _, _, thread = web_server._start_desktop_cron_scheduler_if_owned()
-    assert set(thread.kwargs) == {"provider"}
-    assert thread.kwargs["provider"].name == "external"
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    policy = read_scheduler_ownership_policy_strict()
+    assert policy is not None
+    assert (policy.mode, policy.configured_provider) == ("gateway", "chronos")

--- a/tests/cron/test_scheduler_ownership.py
+++ b/tests/cron/test_scheduler_ownership.py
@@ -122,3 +122,40 @@ def test_managed_provider_precedence_is_read_with_owner(tmp_path, monkeypatch):
     policy = read_scheduler_ownership_policy_strict()
     assert policy is not None
     assert (policy.mode, policy.configured_provider) == ("gateway", "chronos")
+
+
+def test_explicit_desktop_with_external_provider_fails_closed(caplog):
+    from cron.scheduler_runtime import read_scheduler_ownership_policy_strict
+
+    with caplog.at_level("ERROR"):
+        policy = read_scheduler_ownership_policy_strict(
+            {"cron": {"scheduler_owner": "desktop", "provider": "chronos"}}
+        )
+    assert policy is None
+    assert "external providers require Gateway ownership" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "cron: {}\ncron:\n  scheduler_owner: gateway\n",
+        "cron:\n  scheduler_owner: auto\n  scheduler_owner: gateway\n",
+        "cron:\n  provider: builtin\n  provider: chronos\n",
+    ],
+)
+@pytest.mark.parametrize("managed", [False, True])
+def test_duplicate_scheduler_policy_keys_fail_closed(
+    tmp_path, monkeypatch, body, managed
+):
+    from cron.scheduler_runtime import read_scheduler_ownership_policy_strict
+
+    home = tmp_path / "home"
+    target = tmp_path / "managed" if managed else home
+    _write_config(target, body)
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    if managed:
+        monkeypatch.setenv("HERMES_MANAGED_DIR", str(target))
+    else:
+        monkeypatch.delenv("HERMES_MANAGED_DIR", raising=False)
+    assert read_scheduler_ownership_policy_strict() is None

--- a/tests/cron/test_scheduler_runtime.py
+++ b/tests/cron/test_scheduler_runtime.py
@@ -1,0 +1,317 @@
+"""Policy and full-lifetime scheduler runtime lifecycle tests."""
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from cron.scheduler_lease import SchedulerOwnershipLease
+from cron.scheduler_provider import CronScheduler
+from cron.scheduler_runtime import (
+    OwnedSchedulerRuntime,
+    SchedulerOwnershipPolicy,
+    scheduler_runtime_is_eligible,
+)
+
+
+def _wait_for(predicate, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not reached")
+
+
+class _Provider(CronScheduler):
+    def __init__(self, *, return_immediately=False, ignore_stop=False):
+        self.return_immediately = return_immediately
+        self.ignore_stop = ignore_stop
+        self.started = threading.Event()
+        self.stopped = threading.Event()
+        self.release = threading.Event()
+        self.stop_calls = 0
+
+    @property
+    def name(self):
+        return "external"
+
+    def start(self, stop_event, **_kwargs):
+        self.started.set()
+        if self.return_immediately:
+            return
+        if self.ignore_stop:
+            self.release.wait()
+        else:
+            stop_event.wait()
+        self.stopped.set()
+
+    def stop(self):
+        self.stop_calls += 1
+
+
+@pytest.mark.parametrize(
+    ("mode", "provider", "runtime", "gateway", "expected"),
+    [
+        ("gateway", "builtin", "gateway", False, True),
+        ("gateway", "builtin", "desktop", False, False),
+        ("desktop", "builtin", "gateway", False, False),
+        ("desktop", "builtin", "desktop", True, True),
+        ("auto", "builtin", "gateway", True, True),
+        ("auto", "builtin", "desktop", False, True),
+        ("auto", "builtin", "desktop", True, False),
+        ("auto", "chronos", "gateway", False, True),
+        ("auto", "chronos", "desktop", False, False),
+    ],
+)
+def test_scheduler_runtime_eligibility_matrix(mode, provider, runtime, gateway, expected):
+    policy = SchedulerOwnershipPolicy(mode, provider)
+    assert scheduler_runtime_is_eligible(
+        policy, runtime=runtime, same_home_gateway_running=gateway
+    ) is expected
+
+
+def _run_runtime(runtime):
+    stop = threading.Event()
+    thread = threading.Thread(target=runtime.run, args=(stop,), daemon=True)
+    thread.start()
+    return stop, thread
+
+
+def test_external_start_returning_keeps_lease_until_supervisor_shutdown(
+    tmp_path, monkeypatch
+):
+    provider = _Provider(return_immediately=True)
+    policy = SchedulerOwnershipPolicy("gateway", "external")
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict", lambda: policy
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime(
+        "gateway", hermes_home=tmp_path, poll_interval=0.01, drain_timeout=0.1
+    )
+    stop, thread = _run_runtime(runtime)
+    _wait_for(provider.started.is_set)
+    thread.join(0.05)
+    assert thread.is_alive()
+    assert SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path, owner="desktop", provider="builtin"
+    ) is None
+    stop.set()
+    thread.join(2)
+    assert not thread.is_alive()
+    assert provider.stop_calls == 1
+
+
+def test_desktop_auto_yields_and_gateway_retries_without_overlap(tmp_path, monkeypatch):
+    policy = SchedulerOwnershipPolicy("auto", "builtin")
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict", lambda: policy
+    )
+    desktop_provider = _Provider()
+    gateway_provider = _Provider()
+    providers = iter([desktop_provider, gateway_provider])
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: next(providers),
+    )
+    gateway_present = threading.Event()
+    desktop = OwnedSchedulerRuntime(
+        "desktop",
+        hermes_home=tmp_path,
+        gateway_is_running=gateway_present.is_set,
+        poll_interval=0.01,
+        drain_timeout=0.2,
+    )
+    desktop_stop, desktop_thread = _run_runtime(desktop)
+    _wait_for(desktop_provider.started.is_set)
+
+    gateway = OwnedSchedulerRuntime(
+        "gateway", hermes_home=tmp_path, poll_interval=0.01, drain_timeout=0.2
+    )
+    gateway_stop, gateway_thread = _run_runtime(gateway)
+    time.sleep(0.05)
+    assert not gateway_provider.started.is_set()
+    gateway_present.set()
+    _wait_for(desktop_provider.stopped.is_set)
+    _wait_for(gateway_provider.started.is_set)
+    assert desktop.active_provider is None
+
+    gateway_stop.set()
+    desktop_stop.set()
+    gateway_thread.join(2)
+    desktop_thread.join(2)
+    assert not gateway_thread.is_alive() and not desktop_thread.is_alive()
+
+
+def test_explicit_owner_changes_handoff_both_directions(tmp_path, monkeypatch):
+    state = {"policy": SchedulerOwnershipPolicy("gateway", "builtin")}
+    gateway_first = _Provider()
+    desktop_provider = _Provider()
+    gateway_second = _Provider()
+    providers = iter([gateway_first, desktop_provider, gateway_second])
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda: state["policy"],
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: next(providers),
+    )
+
+    gateway = OwnedSchedulerRuntime(
+        "gateway", hermes_home=tmp_path, poll_interval=0.01, drain_timeout=0.2
+    )
+    gateway_stop, gateway_thread = _run_runtime(gateway)
+    _wait_for(gateway_first.started.is_set)
+    desktop = OwnedSchedulerRuntime(
+        "desktop", hermes_home=tmp_path, poll_interval=0.01, drain_timeout=0.2
+    )
+    desktop_stop, desktop_thread = _run_runtime(desktop)
+
+    state["policy"] = SchedulerOwnershipPolicy("desktop", "builtin")
+    _wait_for(gateway_first.stopped.is_set)
+    _wait_for(desktop_provider.started.is_set)
+    assert gateway.active_provider is None
+
+    state["policy"] = SchedulerOwnershipPolicy("gateway", "builtin")
+    _wait_for(desktop_provider.stopped.is_set)
+    _wait_for(gateway_second.started.is_set)
+    assert desktop.active_provider is None
+
+    gateway_stop.set()
+    desktop_stop.set()
+    gateway_thread.join(2)
+    desktop_thread.join(2)
+    assert not gateway_thread.is_alive() and not desktop_thread.is_alive()
+
+
+def test_malformed_policy_stops_active_provider_before_release(tmp_path, monkeypatch):
+    state: dict[str, SchedulerOwnershipPolicy | None] = {
+        "policy": SchedulerOwnershipPolicy("gateway", "builtin")
+    }
+    provider = _Provider()
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda: state["policy"],
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime(
+        "gateway", hermes_home=tmp_path, poll_interval=0.01, drain_timeout=0.2
+    )
+    stop, thread = _run_runtime(runtime)
+    _wait_for(provider.started.is_set)
+    state["policy"] = None
+    _wait_for(provider.stopped.is_set)
+    lease = SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path, owner="desktop", provider="builtin"
+    )
+    assert lease is not None
+    lease.release()
+    stop.set()
+    thread.join(2)
+
+
+def test_hung_provider_retains_lease_until_it_really_exits(tmp_path, monkeypatch):
+    policy = SchedulerOwnershipPolicy("gateway", "builtin")
+    provider = _Provider(ignore_stop=True)
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict", lambda: policy
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime(
+        "gateway", hermes_home=tmp_path, poll_interval=0.01, drain_timeout=0.05
+    )
+    stop, thread = _run_runtime(runtime)
+    _wait_for(provider.started.is_set)
+    stop.set()
+    time.sleep(0.1)
+    assert thread.is_alive()
+    assert SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path, owner="desktop", provider="builtin"
+    ) is None
+    provider.release.set()
+    thread.join(2)
+    assert not thread.is_alive()
+
+
+def test_inflight_jobs_hold_lease_after_provider_thread_drains(
+    tmp_path, monkeypatch
+):
+    policy = SchedulerOwnershipPolicy("gateway", "builtin")
+    provider = _Provider()
+    running = {"jobs": {"job-1"}}
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict", lambda: policy
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler.get_running_job_ids", lambda: set(running["jobs"])
+    )
+    runtime = OwnedSchedulerRuntime(
+        "gateway", hermes_home=tmp_path, poll_interval=0.01, drain_timeout=0.05
+    )
+    stop, thread = _run_runtime(runtime)
+    _wait_for(provider.started.is_set)
+    stop.set()
+    _wait_for(provider.stopped.is_set)
+    time.sleep(0.08)
+    assert thread.is_alive()
+    assert SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path, owner="desktop", provider="builtin"
+    ) is None
+    running["jobs"].clear()
+    thread.join(2)
+    assert not thread.is_alive()
+
+
+def test_lease_is_held_before_provider_construction(tmp_path, monkeypatch):
+    policy = SchedulerOwnershipPolicy("gateway", "builtin")
+    observed = []
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict", lambda: policy
+    )
+
+    def construct(_name):
+        observed.append(
+            SchedulerOwnershipLease.try_acquire(
+                hermes_home=tmp_path, owner="desktop", provider="builtin"
+            )
+        )
+        return _Provider(return_immediately=True)
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict", construct
+    )
+    runtime = OwnedSchedulerRuntime(
+        "gateway", hermes_home=tmp_path, poll_interval=0.01, drain_timeout=0.1
+    )
+    stop, thread = _run_runtime(runtime)
+    _wait_for(lambda: bool(observed))
+    assert observed == [None]
+    stop.set()
+    thread.join(2)
+
+
+def test_named_provider_resolution_fails_closed(monkeypatch):
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        resolve_cron_scheduler_runtime_strict,
+    )
+
+    monkeypatch.setattr("plugins.cron_providers.load_cron_scheduler", lambda _name: None)
+    assert resolve_cron_scheduler_runtime_strict("missing") is None
+    assert isinstance(resolve_cron_scheduler_runtime_strict("builtin"), InProcessCronScheduler)

--- a/tests/cron/test_scheduler_runtime.py
+++ b/tests/cron/test_scheduler_runtime.py
@@ -11,6 +11,7 @@ from cron.scheduler_provider import CronScheduler
 from cron.scheduler_runtime import (
     OwnedSchedulerRuntime,
     SchedulerOwnershipPolicy,
+    reserve_active_scheduler_provider,
     scheduler_runtime_is_eligible,
 )
 
@@ -63,6 +64,8 @@ class _Provider(CronScheduler):
         ("auto", "builtin", "desktop", True, False),
         ("auto", "chronos", "gateway", False, True),
         ("auto", "chronos", "desktop", False, False),
+        ("desktop", "chronos", "desktop", False, False),
+        ("desktop", "chronos", "gateway", False, False),
     ],
 )
 def test_scheduler_runtime_eligibility_matrix(mode, provider, runtime, gateway, expected):
@@ -210,6 +213,7 @@ def test_malformed_policy_stops_active_provider_before_release(tmp_path, monkeyp
     _wait_for(provider.started.is_set)
     state["policy"] = None
     _wait_for(provider.stopped.is_set)
+    _wait_for(lambda: runtime.active_provider is None)
     lease = SchedulerOwnershipLease.try_acquire(
         hermes_home=tmp_path, owner="desktop", provider="builtin"
     )
@@ -315,3 +319,75 @@ def test_named_provider_resolution_fails_closed(monkeypatch):
     monkeypatch.setattr("plugins.cron_providers.load_cron_scheduler", lambda _name: None)
     assert resolve_cron_scheduler_runtime_strict("missing") is None
     assert isinstance(resolve_cron_scheduler_runtime_strict("builtin"), InProcessCronScheduler)
+
+
+def test_provider_policy_changes_restart_while_gateway_remains_eligible(
+    tmp_path, monkeypatch
+):
+    state = {"policy": SchedulerOwnershipPolicy("gateway", "builtin")}
+    builtin_first = _Provider()
+    external = _Provider()
+    builtin_second = _Provider()
+    providers = iter((builtin_first, external, builtin_second))
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict",
+        lambda: state["policy"],
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: next(providers),
+    )
+    runtime = OwnedSchedulerRuntime(
+        "gateway", hermes_home=tmp_path, poll_interval=0.01, drain_timeout=0.2
+    )
+    stop, thread = _run_runtime(runtime)
+    _wait_for(builtin_first.started.is_set)
+
+    state["policy"] = SchedulerOwnershipPolicy("gateway", "chronos")
+    _wait_for(builtin_first.stopped.is_set)
+    _wait_for(external.started.is_set)
+
+    state["policy"] = SchedulerOwnershipPolicy("gateway", "builtin")
+    _wait_for(external.stopped.is_set)
+    _wait_for(builtin_second.started.is_set)
+
+    stop.set()
+    thread.join(2)
+    assert not thread.is_alive()
+
+
+def test_callback_reservation_fences_drain_and_lease_release(tmp_path, monkeypatch):
+    policy = SchedulerOwnershipPolicy("gateway", "chronos")
+    provider = _Provider()
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict", lambda: policy
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime(
+        "gateway", hermes_home=tmp_path, poll_interval=0.01, drain_timeout=0.05
+    )
+    stop, thread = _run_runtime(runtime)
+    _wait_for(provider.started.is_set)
+    reservation = reserve_active_scheduler_provider(hermes_home=tmp_path)
+    assert reservation is not None and reservation.provider is provider
+
+    stop.set()
+    _wait_for(provider.stopped.is_set)
+    assert reserve_active_scheduler_provider(hermes_home=tmp_path) is None
+    time.sleep(0.08)
+    assert thread.is_alive()
+    assert SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path, owner="desktop", provider="builtin"
+    ) is None
+
+    reservation.release()
+    thread.join(2)
+    assert not thread.is_alive()
+    lease = SchedulerOwnershipLease.try_acquire(
+        hermes_home=tmp_path, owner="desktop", provider="builtin"
+    )
+    assert lease is not None
+    lease.release()

--- a/tests/cron/test_scheduler_runtime.py
+++ b/tests/cron/test_scheduler_runtime.py
@@ -356,6 +356,44 @@ def test_provider_policy_changes_restart_while_gateway_remains_eligible(
     assert not thread.is_alive()
 
 
+def test_callback_generation_uses_pinned_home_during_shutdown(tmp_path, monkeypatch):
+    old_home = tmp_path / "old-home"
+    new_home = tmp_path / "new-home"
+    old_home.mkdir()
+    new_home.mkdir()
+    home_state = {"current": old_home}
+    policy = SchedulerOwnershipPolicy("gateway", "chronos")
+    provider = _Provider()
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.read_scheduler_ownership_policy_strict", lambda: policy
+    )
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler_runtime_strict",
+        lambda _name: provider,
+    )
+    runtime = OwnedSchedulerRuntime(
+        "gateway", poll_interval=0.01, drain_timeout=0.05
+    )
+    monkeypatch.setattr(runtime, "_current_home", lambda: home_state["current"])
+    stop, thread = _run_runtime(runtime)
+    _wait_for(provider.started.is_set)
+    reservation = reserve_active_scheduler_provider(hermes_home=old_home)
+    assert reservation is not None
+    reservation.release()
+
+    home_state["current"] = new_home
+    stop.set()
+    thread.join(2)
+
+    assert not thread.is_alive()
+    assert reserve_active_scheduler_provider(hermes_home=old_home) is None
+    old_home_lease = SchedulerOwnershipLease.try_acquire(
+        hermes_home=old_home, owner="desktop", provider="builtin"
+    )
+    assert old_home_lease is not None
+    old_home_lease.release()
+
+
 def test_callback_reservation_fences_drain_and_lease_release(tmp_path, monkeypatch):
     policy = SchedulerOwnershipPolicy("gateway", "chronos")
     provider = _Provider()

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -84,7 +84,7 @@ def test_long_running_script_refreshes_owned_claim_in_profile_store(
         heartbeat_seen.set()
         return updated
 
-    def _blocking_script(_script_path: str) -> tuple[bool, str]:
+    def _blocking_script(_script_path: str, **_kwargs) -> tuple[bool, str]:
         assert heartbeat_seen.wait(timeout=2), (
             "claim was not refreshed while script blocked"
         )
@@ -146,7 +146,7 @@ def test_script_heartbeat_uses_captured_claim_owner(tmp_path, monkeypatch):
         heartbeat_seen.set()
         return updated
 
-    def _blocking_script(_script_path: str) -> tuple[bool, str]:
+    def _blocking_script(_script_path: str, **_kwargs) -> tuple[bool, str]:
         assert heartbeat_seen.wait(timeout=2)
         return True, "done"
 

--- a/tests/gateway/test_cron_fire_webhook.py
+++ b/tests/gateway/test_cron_fire_webhook.py
@@ -265,7 +265,7 @@ async def test_fire_task_cancellation_holds_reservation_until_worker_exits(
 
 
 @pytest.mark.asyncio
-async def test_fire_inner_task_cancellation_does_not_spin_or_release_early(
+async def test_fire_supervisor_cancellation_does_not_release_worker_early(
     adapter, monkeypatch
 ):
     fired = threading.Event()
@@ -307,23 +307,21 @@ async def test_fire_inner_task_cancellation_does_not_spin_or_release_early(
             for task in asyncio.all_tasks()
             if task.get_name() == "cron-fire-supervisor"
         )
-        inner = next(
-            task
+        assert not any(
+            task.get_name() == "cron-fire-worker"
             for task in asyncio.all_tasks()
-            if task.get_name() == "cron-fire-worker"
         )
 
         outer.cancel()
-        inner.cancel()
-        # This yield would hang if the supervisor busy-spun on the cancelled
-        # inner task.
         await asyncio.wait_for(asyncio.sleep(0.05), timeout=1)
-        assert outer.done()
+        assert not outer.done()
         assert not reservation_released.is_set()
         assert adapter.active_agent_work_count() == 1
 
         release_fire.set()
         assert await asyncio.to_thread(reservation_released.wait, 2)
+        with pytest.raises(asyncio.CancelledError):
+            await outer
         for _ in range(50):
             if adapter.active_agent_work_count() == 0:
                 break
@@ -374,6 +372,52 @@ async def test_fire_provider_exception_is_consumed_and_redacted(
 
     assert raw_secret not in caplog.text
     assert "cron fire: provider worker failed" in caplog.text
+    assert adapter.active_agent_work_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_fire_reservation_release_error_is_contained_and_redacted(
+    adapter, monkeypatch, caplog
+):
+    raw_secret = "reservation-release-secret-must-not-leak"
+    provider_called = threading.Event()
+
+    class Provider:
+        def fire_due(self, job_id, *, adapters=None, loop=None):
+            provider_called.set()
+            return True
+
+    class FailingReservation:
+        provider = Provider()
+
+        def release(self):
+            raise RuntimeError(raw_secret)
+
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.reserve_active_scheduler_provider",
+        lambda: FailingReservation(),
+    )
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer good"},
+            json={"job_id": "abc123"},
+        )
+        assert response.status == 202
+        assert await asyncio.to_thread(provider_called.wait, 2)
+        for _ in range(50):
+            if adapter.active_agent_work_count() == 0:
+                break
+            await asyncio.sleep(0.01)
+
+    assert raw_secret not in caplog.text
+    assert "cron fire: scheduler reservation release failed" in caplog.text
     assert adapter.active_agent_work_count() == 0
 
 

--- a/tests/gateway/test_cron_fire_webhook.py
+++ b/tests/gateway/test_cron_fire_webhook.py
@@ -422,6 +422,111 @@ async def test_fire_reservation_release_error_is_contained_and_redacted(
 
 
 @pytest.mark.asyncio
+async def test_fire_thread_start_failure_returns_sanitized_503(
+    adapter, monkeypatch, caplog
+):
+    raw_secret = "thread-start-secret-must-not-escape"
+    reservation_released = threading.Event()
+
+    class Provider:
+        def fire_due(self, job_id, *, adapters=None, loop=None):
+            raise AssertionError("worker must not run")
+
+    class TrackingReservation:
+        provider = Provider()
+
+        def release(self):
+            reservation_released.set()
+
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.reserve_active_scheduler_provider",
+        lambda: TrackingReservation(),
+    )
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        with patch("threading.Thread.start", side_effect=RuntimeError(raw_secret)):
+            response = await cli.post(
+                "/api/cron/fire",
+                headers={"Authorization": "Bearer good"},
+                json={"job_id": "abc123"},
+            )
+        payload = await response.json()
+        await asyncio.sleep(0)
+
+    assert response.status == 503
+    assert payload == {"error": "cron fire dispatch unavailable"}
+    assert reservation_released.is_set()
+    assert raw_secret not in caplog.text
+    assert "cron fire: worker thread start failed" in caplog.text
+    assert adapter.active_agent_work_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_fire_supervisor_task_failure_is_sanitized_and_worker_continues(
+    adapter, monkeypatch, caplog
+):
+    raw_secret = "create-task-secret-must-not-escape"
+    provider_called = threading.Event()
+    reservation_released = threading.Event()
+
+    class Provider:
+        def fire_due(self, job_id, *, adapters=None, loop=None):
+            provider_called.set()
+            return True
+
+    class TrackingReservation:
+        provider = Provider()
+
+        def release(self):
+            reservation_released.set()
+
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.reserve_active_scheduler_provider",
+        lambda: TrackingReservation(),
+    )
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+    original_create_task = asyncio.create_task
+
+    def create_task(coro, *, name=None, context=None):
+        if name == "cron-fire-supervisor":
+            raise RuntimeError(raw_secret)
+        kwargs = {"name": name}
+        if context is not None:
+            kwargs["context"] = context
+        return original_create_task(coro, **kwargs)
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        with patch(f"{_MOD}.asyncio.create_task", side_effect=create_task):
+            response = await cli.post(
+                "/api/cron/fire",
+                headers={"Authorization": "Bearer good"},
+                json={"job_id": "abc123"},
+            )
+        payload = await response.json()
+        assert await asyncio.to_thread(provider_called.wait, 2)
+        assert await asyncio.to_thread(reservation_released.wait, 2)
+        for _ in range(50):
+            if adapter.active_agent_work_count() == 0:
+                break
+            await asyncio.sleep(0.01)
+
+    assert response.status == 202
+    assert payload == {"status": "accepted", "job_id": "abc123"}
+    assert raw_secret not in caplog.text
+    assert "cron fire: supervisor task start failed" in caplog.text
+    assert adapter.active_agent_work_count() == 0
+
+
+@pytest.mark.asyncio
 async def test_missing_job_id_400(adapter, monkeypatch):
     """Valid token but no job_id → 400, no fire."""
     spy = _SpyProvider()

--- a/tests/gateway/test_cron_fire_webhook.py
+++ b/tests/gateway/test_cron_fire_webhook.py
@@ -265,6 +265,119 @@ async def test_fire_task_cancellation_holds_reservation_until_worker_exits(
 
 
 @pytest.mark.asyncio
+async def test_fire_inner_task_cancellation_does_not_spin_or_release_early(
+    adapter, monkeypatch
+):
+    fired = threading.Event()
+    release_fire = threading.Event()
+    reservation_released = threading.Event()
+
+    class BlockingProvider:
+        def fire_due(self, job_id, *, adapters=None, loop=None):
+            fired.set()
+            release_fire.wait(timeout=2)
+            return True
+
+    class TrackingReservation:
+        provider = BlockingProvider()
+
+        def release(self):
+            reservation_released.set()
+
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.reserve_active_scheduler_provider",
+        lambda: TrackingReservation(),
+    )
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer good"},
+            json={"job_id": "abc123"},
+        )
+        assert response.status == 202
+        assert await asyncio.to_thread(fired.wait, 2)
+        outer = next(
+            task
+            for task in asyncio.all_tasks()
+            if task.get_name() == "cron-fire-supervisor"
+        )
+        inner = next(
+            task
+            for task in asyncio.all_tasks()
+            if task.get_name() == "cron-fire-worker"
+        )
+
+        outer.cancel()
+        inner.cancel()
+        # This yield would hang if the supervisor busy-spun on the cancelled
+        # inner task.
+        await asyncio.wait_for(asyncio.sleep(0.05), timeout=1)
+        assert outer.done()
+        assert not reservation_released.is_set()
+        assert adapter.active_agent_work_count() == 1
+
+        release_fire.set()
+        assert await asyncio.to_thread(reservation_released.wait, 2)
+        for _ in range(50):
+            if adapter.active_agent_work_count() == 0:
+                break
+            await asyncio.sleep(0.01)
+
+    assert adapter.active_agent_work_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_fire_provider_exception_is_consumed_and_redacted(
+    adapter, monkeypatch, caplog
+):
+    raw_secret = "provider-error-secret-must-not-leak"
+    reservation_released = threading.Event()
+
+    class FailingProvider:
+        def fire_due(self, job_id, *, adapters=None, loop=None):
+            raise RuntimeError(raw_secret)
+
+    class TrackingReservation:
+        provider = FailingProvider()
+
+        def release(self):
+            reservation_released.set()
+
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.reserve_active_scheduler_provider",
+        lambda: TrackingReservation(),
+    )
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer good"},
+            json={"job_id": "abc123"},
+        )
+        assert response.status == 202
+        assert await asyncio.to_thread(reservation_released.wait, 2)
+        for _ in range(50):
+            if not adapter._background_tasks:
+                break
+            await asyncio.sleep(0.01)
+
+    assert raw_secret not in caplog.text
+    assert "cron fire: provider worker failed" in caplog.text
+    assert adapter.active_agent_work_count() == 0
+
+
+@pytest.mark.asyncio
 async def test_missing_job_id_400(adapter, monkeypatch):
     """Valid token but no job_id → 400, no fire."""
     spy = _SpyProvider()

--- a/tests/gateway/test_cron_fire_webhook.py
+++ b/tests/gateway/test_cron_fire_webhook.py
@@ -207,6 +207,64 @@ async def test_valid_fire_reservation_blocks_drain_before_body_and_task(adapter,
 
 
 @pytest.mark.asyncio
+async def test_fire_task_cancellation_holds_reservation_until_worker_exits(
+    adapter, monkeypatch
+):
+    fired = threading.Event()
+    release_fire = threading.Event()
+    reservation_released = threading.Event()
+
+    class BlockingProvider:
+        def fire_due(self, job_id, *, adapters=None, loop=None):
+            fired.set()
+            release_fire.wait(timeout=2)
+            return True
+
+    class TrackingReservation:
+        provider = BlockingProvider()
+
+        def release(self):
+            reservation_released.set()
+
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.reserve_active_scheduler_provider",
+        lambda: TrackingReservation(),
+    )
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer good"},
+            json={"job_id": "abc123"},
+        )
+        assert response.status == 202
+        assert await asyncio.to_thread(fired.wait, 2)
+        task = next(iter(adapter._background_tasks))
+
+        task.cancel()
+        await asyncio.sleep(0.05)
+        assert not task.done()
+        assert not reservation_released.is_set()
+        assert adapter.active_agent_work_count() == 1
+
+        release_fire.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        for _ in range(50):
+            if adapter.active_agent_work_count() == 0:
+                break
+            await asyncio.sleep(0.01)
+
+    assert reservation_released.is_set()
+    assert adapter.active_agent_work_count() == 0
+
+
+@pytest.mark.asyncio
 async def test_missing_job_id_400(adapter, monkeypatch):
     """Valid token but no job_id → 400, no fire."""
     spy = _SpyProvider()

--- a/tests/gateway/test_cron_fire_webhook.py
+++ b/tests/gateway/test_cron_fire_webhook.py
@@ -49,11 +49,23 @@ class _SpyProvider:
         return True
 
 
+class _Reservation:
+    def __init__(self, provider):
+        self.provider = provider
+
+    def release(self):
+        return None
+
+
+def _reserve(provider):
+    return lambda: _Reservation(provider)
+
+
 @pytest.mark.asyncio
 async def test_valid_token_accepts_and_fires(adapter, monkeypatch):
     """Valid NAS-JWT + {job_id} → 202 and fire_due invoked with that id."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", lambda: spy)
+    monkeypatch.setattr("cron.scheduler_runtime.reserve_active_scheduler_provider", _reserve(spy))
     # verifier returns claims (valid token)
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
@@ -81,7 +93,7 @@ async def test_valid_token_accepts_and_fires(adapter, monkeypatch):
 async def test_invalid_token_401_and_no_fire(adapter, monkeypatch):
     """Bad/forged token → 401, fire_due NOT invoked."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", lambda: spy)
+    monkeypatch.setattr("cron.scheduler_runtime.reserve_active_scheduler_provider", _reserve(spy))
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: None),  # verification fails
@@ -102,7 +114,7 @@ async def test_invalid_token_401_and_no_fire(adapter, monkeypatch):
 async def test_missing_token_401(adapter, monkeypatch):
     """No Authorization header → verifier gets empty token → 401."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", lambda: spy)
+    monkeypatch.setattr("cron.scheduler_runtime.reserve_active_scheduler_provider", _reserve(spy))
     # Real verifier: empty token returns None.
     app = _create_app(adapter)
     async with TestClient(TestServer(app)) as cli:
@@ -115,7 +127,7 @@ async def test_missing_token_401(adapter, monkeypatch):
 async def test_valid_token_refuses_during_gateway_drain(adapter, monkeypatch):
     spy = _SpyProvider()
     runner = SimpleNamespace(_draining=False, _external_drain_active=True)
-    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", lambda: spy)
+    monkeypatch.setattr("cron.scheduler_runtime.reserve_active_scheduler_provider", _reserve(spy))
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
@@ -157,7 +169,10 @@ async def test_valid_fire_reservation_blocks_drain_before_body_and_task(adapter,
         await release_body.wait()
         return await original_json(request)
 
-    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", BlockingProvider)
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.reserve_active_scheduler_provider",
+        _reserve(BlockingProvider()),
+    )
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
@@ -195,7 +210,7 @@ async def test_valid_fire_reservation_blocks_drain_before_body_and_task(adapter,
 async def test_missing_job_id_400(adapter, monkeypatch):
     """Valid token but no job_id → 400, no fire."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", lambda: spy)
+    monkeypatch.setattr("cron.scheduler_runtime.reserve_active_scheduler_provider", _reserve(spy))
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
@@ -215,7 +230,7 @@ async def test_valid_fire_fails_closed_without_active_leased_provider(
     adapter, monkeypatch
 ):
     monkeypatch.setattr(
-        "cron.scheduler_runtime.get_active_scheduler_provider", lambda: None
+        "cron.scheduler_runtime.reserve_active_scheduler_provider", lambda: None
     )
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
@@ -238,7 +253,7 @@ async def test_fire_does_not_require_api_server_key(adapter, monkeypatch):
     """The fire endpoint must NOT gate on API_SERVER_KEY — auth is the NAS-JWT.
     A request with NO API key header but a valid fire token still succeeds."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", lambda: spy)
+    monkeypatch.setattr("cron.scheduler_runtime.reserve_active_scheduler_provider", _reserve(spy))
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),

--- a/tests/gateway/test_cron_fire_webhook.py
+++ b/tests/gateway/test_cron_fire_webhook.py
@@ -53,7 +53,7 @@ class _SpyProvider:
 async def test_valid_token_accepts_and_fires(adapter, monkeypatch):
     """Valid NAS-JWT + {job_id} → 202 and fire_due invoked with that id."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", lambda: spy)
     # verifier returns claims (valid token)
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
@@ -81,7 +81,7 @@ async def test_valid_token_accepts_and_fires(adapter, monkeypatch):
 async def test_invalid_token_401_and_no_fire(adapter, monkeypatch):
     """Bad/forged token → 401, fire_due NOT invoked."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", lambda: spy)
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: None),  # verification fails
@@ -102,7 +102,7 @@ async def test_invalid_token_401_and_no_fire(adapter, monkeypatch):
 async def test_missing_token_401(adapter, monkeypatch):
     """No Authorization header → verifier gets empty token → 401."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", lambda: spy)
     # Real verifier: empty token returns None.
     app = _create_app(adapter)
     async with TestClient(TestServer(app)) as cli:
@@ -115,7 +115,7 @@ async def test_missing_token_401(adapter, monkeypatch):
 async def test_valid_token_refuses_during_gateway_drain(adapter, monkeypatch):
     spy = _SpyProvider()
     runner = SimpleNamespace(_draining=False, _external_drain_active=True)
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", lambda: spy)
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
@@ -157,7 +157,7 @@ async def test_valid_fire_reservation_blocks_drain_before_body_and_task(adapter,
         await release_body.wait()
         return await original_json(request)
 
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", BlockingProvider)
+    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", BlockingProvider)
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
@@ -195,7 +195,7 @@ async def test_valid_fire_reservation_blocks_drain_before_body_and_task(adapter,
 async def test_missing_job_id_400(adapter, monkeypatch):
     """Valid token but no job_id → 400, no fire."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", lambda: spy)
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
@@ -211,11 +211,34 @@ async def test_missing_job_id_400(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_valid_fire_fails_closed_without_active_leased_provider(
+    adapter, monkeypatch
+):
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.get_active_scheduler_provider", lambda: None
+    )
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        response = await cli.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer good"},
+            json={"job_id": "abc123"},
+        )
+        payload = await response.json()
+    assert response.status == 503
+    assert payload == {"error": "scheduler ownership unavailable"}
+
+
+@pytest.mark.asyncio
 async def test_fire_does_not_require_api_server_key(adapter, monkeypatch):
     """The fire endpoint must NOT gate on API_SERVER_KEY — auth is the NAS-JWT.
     A request with NO API key header but a valid fire token still succeeds."""
     spy = _SpyProvider()
-    monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: spy)
+    monkeypatch.setattr("cron.scheduler_runtime.get_active_scheduler_provider", lambda: spy)
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -279,7 +279,10 @@ async def test_start_gateway_does_not_start_cron_after_aborted_startup(tmp_path,
     monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
     monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: None)
     monkeypatch.setattr("gateway.run.GatewayRunner", AbortedStartupRunner)
-    monkeypatch.setattr("gateway.run._start_cron_ticker", fail_if_cron_starts)
+    monkeypatch.setattr(
+        "gateway.run._start_gateway_cron_scheduler_if_owned",
+        fail_if_cron_starts,
+    )
     monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
 
     with pytest.raises(SystemExit) as exc:

--- a/tests/hermes_cli/test_cron_fire_dashboard.py
+++ b/tests/hermes_cli/test_cron_fire_dashboard.py
@@ -13,6 +13,9 @@ hosted agents don't expose). It must:
     background, returning 202.
 """
 
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 from starlette.testclient import TestClient
 
@@ -140,3 +143,68 @@ def test_valid_token_accepts_and_fires(monkeypatch):
         client.close()
     # background task ran the fire for the resolved profile
     assert fired == [("default", "j1")]
+
+
+@pytest.mark.asyncio
+async def test_worker_exception_is_consumed_and_redacted(monkeypatch, caplog):
+    raw_secret = "RAW_SECRET_SENTINEL"
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+
+    async def dashboard_io(_callback, *_args):
+        return "default"
+
+    monkeypatch.setattr(web_server, "_run_cron_dashboard_io", dashboard_io)
+    monkeypatch.setattr(
+        web_server,
+        "_fire_cron_job_for_profile",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError(raw_secret)),
+    )
+    request = SimpleNamespace(
+        headers={"Authorization": "Bearer good"},
+        json=lambda: asyncio.sleep(0, result={"job_id": "failing"}),
+    )
+    created = []
+    original_create_task = asyncio.create_task
+
+    def capture_task(coro):
+        task = original_create_task(coro)
+        created.append(task)
+        return task
+
+    monkeypatch.setattr(web_server.asyncio, "create_task", capture_task)
+    response = await web_server.cron_fire_webhook(request)
+    assert response.status_code == 202
+    await created[0]
+    assert created[0].exception() is None
+    assert raw_secret not in caplog.text
+    assert "Cron dashboard fire worker failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_task_start_failure_is_sanitized(monkeypatch, caplog):
+    raw_secret = "TASK_START_SECRET_SENTINEL"
+    monkeypatch.setattr(
+        "plugins.cron_providers.chronos.verify.get_fire_verifier",
+        lambda: (lambda **kw: {"purpose": "cron_fire"}),
+    )
+
+    async def dashboard_io(_callback, *_args):
+        return "default"
+
+    monkeypatch.setattr(web_server, "_run_cron_dashboard_io", dashboard_io)
+    monkeypatch.setattr(
+        web_server.asyncio,
+        "create_task",
+        lambda _coro: (_ for _ in ()).throw(RuntimeError(raw_secret)),
+    )
+    request = SimpleNamespace(
+        headers={"Authorization": "Bearer good"},
+        json=lambda: asyncio.sleep(0, result={"job_id": "startup-failure"}),
+    )
+    response = await web_server.cron_fire_webhook(request)
+    assert response.status_code == 503
+    assert raw_secret not in caplog.text
+    assert raw_secret not in bytes(response.body).decode()

--- a/tests/hermes_cli/test_cron_fire_dashboard.py
+++ b/tests/hermes_cli/test_cron_fire_dashboard.py
@@ -14,6 +14,7 @@ hosted agents don't expose). It must:
 """
 
 import asyncio
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -120,34 +121,58 @@ def test_unknown_job_200_gone(monkeypatch):
 
 
 def test_valid_token_accepts_and_fires(monkeypatch):
-    """Valid token + known job -> 202 and fire_due invoked for the resolved
-    profile."""
+    """Valid token + known job -> 202 after the worker thread starts."""
     fired = []
+    released = threading.Event()
+
+    class Reservation:
+        provider = object()
+
+        def release(self):
+            released.set()
+
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire", "aud": "agent:x"}),
     )
     monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda jid: "default")
-    monkeypatch.setattr(web_server, "_fire_cron_job_for_profile",
-                        lambda p, j: fired.append((p, j)) or True)
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.reserve_active_scheduler_provider",
+        lambda **_kw: Reservation(),
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_fire_cron_job_for_profile",
+        lambda p, j, r: fired.append((p, j)) or True,
+    )
 
     client, pa, ph = _client(auth_required=False)
     try:
-        resp = client.post("/api/cron/fire",
-                           headers={"Authorization": "Bearer good"},
-                           json={"job_id": "j1"})
+        resp = client.post(
+            "/api/cron/fire",
+            headers={"Authorization": "Bearer good"},
+            json={"job_id": "j1"},
+        )
         assert resp.status_code == 202
         assert resp.json()["job_id"] == "j1"
     finally:
         _restore(pa, ph)
         client.close()
-    # background task ran the fire for the resolved profile
+    assert released.wait(timeout=2)
     assert fired == [("default", "j1")]
 
 
 @pytest.mark.asyncio
 async def test_worker_exception_is_consumed_and_redacted(monkeypatch, caplog):
     raw_secret = "RAW_SECRET_SENTINEL"
+    released = threading.Event()
+
+    class Reservation:
+        provider = object()
+
+        def release(self):
+            released.set()
+
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
@@ -157,6 +182,10 @@ async def test_worker_exception_is_consumed_and_redacted(monkeypatch, caplog):
         return "default"
 
     monkeypatch.setattr(web_server, "_run_cron_dashboard_io", dashboard_io)
+    monkeypatch.setattr(
+        "cron.scheduler_runtime.reserve_active_scheduler_provider",
+        lambda **_kw: Reservation(),
+    )
     monkeypatch.setattr(
         web_server,
         "_fire_cron_job_for_profile",
@@ -166,26 +195,24 @@ async def test_worker_exception_is_consumed_and_redacted(monkeypatch, caplog):
         headers={"Authorization": "Bearer good"},
         json=lambda: asyncio.sleep(0, result={"job_id": "failing"}),
     )
-    created = []
-    original_create_task = asyncio.create_task
-
-    def capture_task(coro):
-        task = original_create_task(coro)
-        created.append(task)
-        return task
-
-    monkeypatch.setattr(web_server.asyncio, "create_task", capture_task)
     response = await web_server.cron_fire_webhook(request)
     assert response.status_code == 202
-    await created[0]
-    assert created[0].exception() is None
+    assert released.wait(timeout=2)
     assert raw_secret not in caplog.text
     assert "Cron dashboard fire worker failed" in caplog.text
 
 
 @pytest.mark.asyncio
-async def test_task_start_failure_is_sanitized(monkeypatch, caplog):
-    raw_secret = "TASK_START_SECRET_SENTINEL"
+async def test_thread_start_failure_is_sanitized(monkeypatch, caplog):
+    raw_secret = "THREAD_START_SECRET_SENTINEL"
+    released = threading.Event()
+
+    class Reservation:
+        provider = object()
+
+        def release(self):
+            released.set()
+
     monkeypatch.setattr(
         "plugins.cron_providers.chronos.verify.get_fire_verifier",
         lambda: (lambda **kw: {"purpose": "cron_fire"}),
@@ -196,9 +223,13 @@ async def test_task_start_failure_is_sanitized(monkeypatch, caplog):
 
     monkeypatch.setattr(web_server, "_run_cron_dashboard_io", dashboard_io)
     monkeypatch.setattr(
-        web_server.asyncio,
-        "create_task",
-        lambda _coro: (_ for _ in ()).throw(RuntimeError(raw_secret)),
+        "cron.scheduler_runtime.reserve_active_scheduler_provider",
+        lambda **_kw: Reservation(),
+    )
+    monkeypatch.setattr(
+        web_server.threading.Thread,
+        "start",
+        lambda _thread: (_ for _ in ()).throw(RuntimeError(raw_secret)),
     )
     request = SimpleNamespace(
         headers={"Authorization": "Bearer good"},
@@ -206,5 +237,6 @@ async def test_task_start_failure_is_sanitized(monkeypatch, caplog):
     )
     response = await web_server.cron_fire_webhook(request)
     assert response.status_code == 503
+    assert released.is_set()
     assert raw_secret not in caplog.text
     assert raw_secret not in bytes(response.body).decode()

--- a/tests/hermes_cli/test_cron_fire_dashboard.py
+++ b/tests/hermes_cli/test_cron_fire_dashboard.py
@@ -143,7 +143,7 @@ def test_valid_token_accepts_and_fires(monkeypatch):
     monkeypatch.setattr(
         web_server,
         "_fire_cron_job_for_profile",
-        lambda p, j, r: fired.append((p, j)) or True,
+        lambda p, j, r, home: fired.append((p, j)) or True,
     )
 
     client, pa, ph = _client(auth_required=False)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -7794,18 +7794,24 @@ class TestDesktopCronTicker:
         with self._client():
             assert called.wait(3.0), "expected cron tick for explicit desktop owner"
 
-    def test_ticker_skipped_for_default_gateway_owner(
+    def test_auto_ticker_yields_to_live_gateway(
         self, monkeypatch, _isolate_hermes_home
     ):
         import threading
         import cron.scheduler as sched
+        import gateway.status as gateway_status
 
         called = threading.Event()
         monkeypatch.setattr(sched, "tick", lambda *a, **k: called.set())
+        monkeypatch.setattr(
+            gateway_status,
+            "get_running_pid",
+            lambda *, cleanup_stale: 1234,
+        )
         monkeypatch.setenv("HERMES_DESKTOP", "1")
 
         with self._client():
-            assert not called.wait(0.5), "gateway owner must suppress Desktop ticker"
+            assert not called.wait(0.5), "live gateway must suppress Desktop ticker"
 
     def test_ticker_skipped_without_desktop(self, monkeypatch, _isolate_hermes_home):
         import threading

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -7805,8 +7805,8 @@ class TestDesktopCronTicker:
         monkeypatch.setattr(sched, "tick", lambda *a, **k: called.set())
         monkeypatch.setattr(
             gateway_status,
-            "get_running_pid",
-            lambda *, cleanup_stale: 1234,
+            "is_gateway_runtime_lock_active",
+            lambda: True,
         )
         monkeypatch.setenv("HERMES_DESKTOP", "1")
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -7766,7 +7766,7 @@ class TestValidateProviderCredential:
 
 
 class TestDesktopCronTicker:
-    """The dashboard backend fires cron jobs itself only when desktop-spawned."""
+    """Desktop cron fallback runs only when config assigns Desktop ownership."""
 
     def _client(self):
         try:
@@ -7777,7 +7777,26 @@ class TestDesktopCronTicker:
 
         return TestClient(app)
 
-    def test_ticker_runs_when_desktop(self, monkeypatch, _isolate_hermes_home):
+    def test_ticker_runs_for_explicit_desktop_owner(
+        self, monkeypatch, _isolate_hermes_home
+    ):
+        import threading
+        import cron.scheduler as sched
+
+        called = threading.Event()
+        monkeypatch.setattr(sched, "tick", lambda *a, **k: called.set())
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        (Path(os.environ["HERMES_HOME"]) / "config.yaml").write_text(
+            "cron:\n  scheduler_owner: desktop\n",
+            encoding="utf-8",
+        )
+
+        with self._client():
+            assert called.wait(3.0), "expected cron tick for explicit desktop owner"
+
+    def test_ticker_skipped_for_default_gateway_owner(
+        self, monkeypatch, _isolate_hermes_home
+    ):
         import threading
         import cron.scheduler as sched
 
@@ -7786,7 +7805,7 @@ class TestDesktopCronTicker:
         monkeypatch.setenv("HERMES_DESKTOP", "1")
 
         with self._client():
-            assert called.wait(3.0), "expected cron tick under HERMES_DESKTOP=1"
+            assert not called.wait(0.5), "gateway owner must suppress Desktop ticker"
 
     def test_ticker_skipped_without_desktop(self, monkeypatch, _isolate_hermes_home):
         import threading

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -91,12 +91,17 @@ def test_fire_cron_job_scopes_store_and_runtime_home_together(
             return True
 
     reservation = type("Reservation", (), {"provider": RecordingProvider()})()
+    monkeypatch.setattr(
+        web_server,
+        "_cron_profile_home",
+        lambda _profile: (_ for _ in ()).throw(AssertionError("home re-resolved")),
+    )
 
     outer_token = set_hermes_home_override(default_home)
     try:
         assert (
             web_server._fire_cron_job_for_profile(
-                "worker_alpha", "worker-job", reservation
+                "worker_alpha", "worker-job", reservation, worker_home
             )
             is True
         )

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -90,14 +90,16 @@ def test_fire_cron_job_scopes_store_and_runtime_home_together(
             captured["jobs_file"] = cron_jobs._current_cron_store().jobs_file
             return True
 
-    monkeypatch.setattr(
-        "cron.scheduler_provider.resolve_cron_scheduler",
-        lambda: RecordingProvider(),
-    )
+    reservation = type("Reservation", (), {"provider": RecordingProvider()})()
 
     outer_token = set_hermes_home_override(default_home)
     try:
-        assert web_server._fire_cron_job_for_profile("worker_alpha", "worker-job") is True
+        assert (
+            web_server._fire_cron_job_for_profile(
+                "worker_alpha", "worker-job", reservation
+            )
+            is True
+        )
         assert captured == {
             "job_id": "worker-job",
             "runtime_home": worker_home,

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -52,6 +52,23 @@ def _err(code: int, stderr: str):
     return mock.Mock(returncode=code, stdout="", stderr=stderr)
 
 
+def test_protected_env_vars_include_interactive_sessions_and_configured_token(
+    monkeypatch,
+):
+    monkeypatch.setenv("OP_SESSION_work", "session")
+    monkeypatch.setenv("OP_SESSION_personal", "session")
+    monkeypatch.setenv("UNRELATED", "value")
+
+    protected = op.OnePasswordSource().protected_env_vars(
+        {"service_account_token_env": "CUSTOM_OP_TOKEN"}
+    )
+
+    assert "CUSTOM_OP_TOKEN" in protected
+    assert "OP_SESSION_work" in protected
+    assert "OP_SESSION_personal" in protected
+    assert "UNRELATED" not in protected
+
+
 # ---------------------------------------------------------------------------
 # Reference validation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- enforce one scheduler owner per canonical `HERMES_HOME` with a full-lifetime kernel lease and dynamic gateway/Desktop handoff
- fence callbacks to the active generation and retain ownership until providers, jobs, callback reservations, and actual worker threads drain
- refresh external secrets atomically before relevant `no_agent` subprocesses and capture an immutable sanitized child environment
- strictly parse, expand, and deep-merge user/managed secret configuration; fail closed on malformed, unresolved, duplicate, or failed refresh state
- keep external scheduling providers gateway-only while preserving automatic Desktop-only scheduling
- sanitize lifecycle failures so backend or secret-bearing exception text cannot escape
- pin dashboard and gateway fires to the reserved canonical home and synchronously start authoritative worker threads before returning `202`

## Problem

Gateway and Desktop could both dispatch one shared cron registry. The file lock serialized individual ticks but allowed either process to win, so jobs alternated between processes with different managed-secret bootstrap contexts. `no_agent` execution also constructed subprocess environments before managed-secret refresh.

## Safety properties

- gateway credentials remain isolated from Desktop
- ownership handoff never unlinks the kernel lock file
- stale callback generations fail closed
- cancellation cannot release a reservation while synchronous work is still running
- environment precedence remains `dotenv → external sources → managed .env`
- configured bootstrap aliases and active `OP_SESSION_*` credentials are stripped from children
- raw provider, reservation, thread/task-start, backend, and secret-source exception text is not returned or logged

## Validation

Exact reviewed head: `eda3bc24502cbdf6a106cd824607fb91cf0d8a53`

- `843 passed` in the final affected upstream matrix
- independent final specification review: PASS
- independent adversarial security/concurrency review: APPROVED
- additional reviewer matrices: 815, 232, 120, 112, 91, and 65 tests passed
- Ruff, Python compilation, and `git diff --check` passed
- exact worktree clean

No secret values are included in this change.
