### PR TITLE
fix(tools): recover terminal cwd that exists but the user can't enter

### DIFF
--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -6,6 +6,11 @@ otherwise raise ``FileNotFoundError`` before bash starts, wedging every
 subsequent terminal/file-tool call until the gateway restarts.
 
 Regression coverage for https://github.com/NousResearch/hermes-agent/issues/17558.
+
+Also covers #65583: a working directory that *exists* but the runtime user
+cannot enter (e.g. a ``/root`` cwd captured while running as root and replayed
+under a non-root gateway) makes ``Popen(cwd=...)`` raise ``PermissionError``
+just as fatally, so ``_resolve_safe_cwd`` must reject it too.
 """
 
 import os
@@ -14,9 +19,21 @@ import tempfile
 import threading
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from tools.environments.local import (
     LocalEnvironment,
     _resolve_safe_cwd,
+)
+
+_skip_as_root = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="root bypasses directory permission checks, so os.access can't "
+    "simulate an unenterable dir",
+)
+_posix_only = pytest.mark.skipif(
+    os.name != "posix",
+    reason="chmod-based unenterable-dir simulation is POSIX-only",
 )
 
 
@@ -50,6 +67,82 @@ class TestResolveSafeCwd:
         sep = os.path.sep
         monkeypatch.setattr(os.path, "isdir", lambda p: p == sep)
         assert _resolve_safe_cwd("/no/such/deep/dir") == sep
+
+
+class TestResolveSafeCwdUnenterable:
+    """#65583: a cwd that exists but the user can't enter must be rejected.
+
+    ``Popen(cwd=path)`` chdir()s into *path* in the child, which needs
+    execute/search permission on the directory. A ``/root`` working dir
+    captured while running as root and replayed under a non-root gateway
+    ``exists`` (so ``os.path.isdir`` is True) but is unenterable, and Popen
+    raises ``PermissionError`` before bash starts — wedging every terminal and
+    file-tool call. ``_resolve_safe_cwd`` must treat it like a missing cwd.
+    """
+
+    @_posix_only
+    @_skip_as_root
+    def test_unenterable_dir_falls_back_to_home(self, tmp_path, monkeypatch):
+        locked = tmp_path / "root-like"
+        locked.mkdir(mode=0o000)
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        try:
+            assert os.path.isdir(str(locked))  # it exists…
+            assert not os.access(str(locked), os.X_OK)  # …but is unenterable
+            assert _resolve_safe_cwd(str(locked)) == str(home)
+        finally:
+            os.chmod(str(locked), 0o700)  # let tmp_path cleanup remove it
+
+    @_posix_only
+    @_skip_as_root
+    def test_unenterable_dir_falls_back_to_tempdir_when_home_unusable(
+        self, tmp_path, monkeypatch
+    ):
+        locked = tmp_path / "root-like"
+        locked.mkdir(mode=0o000)
+        # HOME points at another unenterable dir → must reach the tempdir floor.
+        bad_home = tmp_path / "bad-home"
+        bad_home.mkdir(mode=0o000)
+        monkeypatch.setenv("HOME", str(bad_home))
+        try:
+            assert _resolve_safe_cwd(str(locked)) == tempfile.gettempdir()
+        finally:
+            os.chmod(str(locked), 0o700)
+            os.chmod(str(bad_home), 0o700)
+
+    @_posix_only
+    @_skip_as_root
+    def test_run_bash_recovers_from_unenterable_cwd(self, tmp_path, monkeypatch, caplog):
+        locked = tmp_path / "root-like"
+        locked.mkdir(mode=0o000)
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(cwd=str(locked), timeout=10)
+
+        captured: dict = {}
+        fds: list = []
+        try:
+            with patch("tools.environments.local._find_bash", return_value="/bin/bash"), \
+                 patch("subprocess.Popen", side_effect=_make_fake_popen(captured, fds)), \
+                 patch("tools.terminal_tool._interrupt_event", _fake_interrupt()), \
+                 caplog.at_level("WARNING", logger="tools.environments.local"):
+                env.execute("echo hello")
+        finally:
+            _close_fds(fds)
+            os.chmod(str(locked), 0o700)
+
+        # Popen must have been handed an enterable directory, NOT the locked one.
+        assert captured["cwd"] == str(home)
+        assert os.access(captured["cwd"], os.X_OK)
+        assert env.cwd == str(home)
+        # The warning must name the real reason (accessibility), not "missing".
+        assert any("not accessible" in rec.message for rec in caplog.records)
+        assert not any("missing on disk" in rec.message for rec in caplog.records)
 
 
 def _fake_interrupt():

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -95,29 +95,67 @@ def _quote_bash_path(path: str) -> str:
     return shlex.quote(_bash_safe_path(path))
 
 
+def _cwd_is_usable(cwd: str) -> bool:
+    """True when ``cwd`` is a directory the current process can enter.
+
+    ``subprocess.Popen(cwd=...)`` chdir()s into the directory in the child,
+    which needs execute/search permission on it. A path that merely *exists*
+    isn't enough: a ``/root`` working directory captured while running as root
+    and later replayed under a non-root gateway exists (``os.path.isdir`` is
+    True) but is unenterable, and Popen raises ``PermissionError`` before bash
+    starts (#65583). ``os.access(cwd, os.X_OK)`` is the exact capability Popen
+    needs, so we gate on it — on POSIX only, since ``os.access`` execute bits
+    are not meaningful on Windows (the EACCES-on-cwd failure is POSIX-specific).
+    """
+    if not cwd or not os.path.isdir(cwd):
+        return False
+    if _IS_WINDOWS:
+        return True
+    return os.access(cwd, os.X_OK)
+
+
 def _resolve_safe_cwd(cwd: str) -> str:
-    """Return ``cwd`` if it exists as a directory, else the nearest existing
-    ancestor.  Falls back to ``tempfile.gettempdir()`` only if walking up the
-    path can't find any existing directory (effectively never on a healthy
-    filesystem, but cheap belt-and-braces).
+    """Return ``cwd`` if the current process can use it as a working directory,
+    else a safe fallback.
+
+    Two failure modes are handled:
+
+    * **Missing** cwd — most commonly a previous tool call ``rm -rf``'d its own
+      working directory (issue #17558). Recover to the nearest *existing,
+      enterable* ancestor so we stay close to where we were.
+    * **Unenterable** cwd — the directory exists but the runtime user has no
+      search permission on it, e.g. a ``/root`` cwd captured while running as
+      root and replayed under a non-root gateway (#65583). Climbing to the
+      nearest enterable ancestor would land on ``/`` (a useless working dir),
+      so prefer the user's home — where a fresh session starts and which is
+      writable by the runtime user.
+
+    In both cases ``subprocess.Popen(..., cwd=...)`` would otherwise raise
+    (``FileNotFoundError`` / ``PermissionError``) before bash starts, wedging
+    every subsequent terminal and file-tool call until the gateway restarts.
+    Falls back to ``tempfile.gettempdir()`` when nothing else is usable.
 
     On Windows, also normalizes Git Bash / MSYS-style POSIX paths
-    (``/c/Users/x``) to native Windows form before the isdir check so a
-    perfectly valid ``pwd -P`` result from bash doesn't get rejected as
-    "missing" (see ``_msys_to_windows_path``).
-
-    Used by ``_run_bash`` to recover when the configured cwd is gone — most
-    commonly because a previous tool call deleted its own working directory
-    (issue #17558).  Without this guard, ``subprocess.Popen(..., cwd=...)``
-    raises ``FileNotFoundError`` before bash starts, wedging every subsequent
-    terminal call until the gateway restarts.
+    (``/c/Users/x``) to native Windows form before the check so a perfectly
+    valid ``pwd -P`` result from bash doesn't get rejected (see
+    ``_msys_to_windows_path``).
     """
     cwd = _msys_to_windows_path(cwd) if _IS_WINDOWS else cwd
-    if cwd and os.path.isdir(cwd):
+    if _cwd_is_usable(cwd):
         return cwd
+
+    # Unenterable-but-present (#65583): the nearest enterable ancestor is
+    # typically ``/``, a useless working dir, so prefer the user's home.
+    if cwd and os.path.isdir(cwd):
+        home = os.path.expanduser("~")
+        if home != cwd and _cwd_is_usable(home):
+            return home
+        return tempfile.gettempdir()
+
+    # Missing (#17558): walk up to the nearest existing, enterable ancestor.
     parent = os.path.dirname(cwd) if cwd else ""
     while parent:
-        if os.path.isdir(parent):
+        if _cwd_is_usable(parent):
             return parent
         next_parent = os.path.dirname(parent)
         if next_parent == parent:
@@ -1194,14 +1232,22 @@ class LocalEnvironment(BaseEnvironment):
         safe_cwd = _resolve_safe_cwd(self.cwd)
         if safe_cwd != self.cwd:
             # MSYS → Windows translation alone shouldn't surface as a warning
-            # (it's a benign normalization, not a recovery). Only warn when
-            # the directory really doesn't exist on disk.
+            # (it's a benign normalization, not a recovery). Only warn when the
+            # directory is genuinely unusable — missing (#17558) or present but
+            # unenterable by the runtime user (#65583) — and name the reason so
+            # the log points at the real cause.
             normalized = _msys_to_windows_path(self.cwd) if _IS_WINDOWS else self.cwd
             if safe_cwd != normalized:
+                reason = (
+                    "not accessible to the current user"
+                    if os.path.isdir(normalized)
+                    else "missing on disk"
+                )
                 logger.warning(
-                    "LocalEnvironment cwd %r is missing on disk; "
+                    "LocalEnvironment cwd %r is %s; "
                     "falling back to %r so terminal commands keep working.",
                     self.cwd,
+                    reason,
                     safe_cwd,
                 )
             self.cwd = safe_cwd


### PR DESCRIPTION
## What

Makes the terminal environment recover from a working directory that **exists but the runtime user can't enter**, fixing #65583 (all terminal/file tools failing with `PermissionError: [Errno 13] Permission denied: '/root'`).

- **`tools/environments/local.py`** — `_resolve_safe_cwd` previously rescued only a *missing* cwd (`os.path.isdir` passes for `/root`, so it sailed through to `Popen`). New `_cwd_is_usable()` helper gates on `os.access(cwd, os.X_OK)` (POSIX) — exactly the search permission `Popen(cwd=...)`'s child `chdir` needs. An unenterable cwd now falls back to the user's **home** (where a fresh session starts, and writable) instead of climbing to a useless `/`; the `_run_bash` recovery warning names the real reason (*missing* vs *not accessible*).
- **`tests/tools/test_local_env_cwd_recovery.py`** — new `TestResolveSafeCwdUnenterable` class (unit + real-`_run_bash`); existing #17558 deleted-cwd tests unchanged.

## Why — root cause

`hermes-gateway` runs as non-root `hermes`. A `/root` working directory gets captured and replayed into the terminal session, then `subprocess.Popen(cwd="/root")` (`tools/environments/local.py`) raises `PermissionError` **before bash starts** — because the child's `chdir("/root")` is denied. `init_session`'s login snapshot and non-login probe both hit it, producing the reporter's exact log:

```
init_session failed (session=...): [Errno 13] Permission denied: '/root';
non-login probe: [Errno 13] Permission denied: '/root' — falling back to bash -l per command
```

Every subsequent `terminal` / `read_file` / `write_file` / `search_files` call re-enters the same `Popen(cwd="/root")` and fails identically. The old guard couldn't help: `/root` *exists*, so `os.path.isdir` returned True and it was handed straight to `Popen`.

Where `/root` comes from (any of these; the guard fixes them all at the single point of use):
- **`hermes_cli/setup.py`** defaults `terminal.cwd` to `str(Path.home())` → `/root` when setup runs as root; persisted in `config.yaml` and bridged to `TERMINAL_CWD` on every gateway/cron start (survives restart and chowning — matching the report).
- A cron job `workdir` or the process `os.getcwd()` (e.g. `hermes cron ...` run as root from `/root`).

The fix lives in `_resolve_safe_cwd` — the existing safety net (`_run_bash`) that already recovers a deleted cwd (#17558) — so it self-heals an already-poisoned deployment at runtime, regardless of which path injected the bad cwd, with no config surgery required.

## How to test

Automated:

```bash
scripts/run_tests.sh tests/tools/test_local_env_cwd_recovery.py
```

End-to-end (performed, no mocks): built a real `LocalEnvironment(cwd=<chmod 000 dir>)` (simulating `/root` under a non-root user) and ran actual bash through it.

- **Before the fix**: `init_session failed … [Errno 13] Permission denied … — falling back to bash -l per command`, then a `PermissionError` traceback on `execute()` — the reporter's signature, reproduced verbatim.
- **After the fix**: warning `LocalEnvironment cwd '…/root-like' is not accessible to the current user; falling back to '…/home'`, then `echo`/`pwd`/`whoami` run cleanly with `env.cwd` self-healed to `$HOME`.

Full `tests/tools/` hermetic run: 7984 passed (2 pre-existing `test_voice_mode` audio-env failures, unrelated — they pass in isolation and only fail under the parallel runner; confirmed identical on clean `main`).

## Platforms tested

Linux (x86_64), non-root euid. The accessibility gate is POSIX-only (`os.access` execute bits aren't meaningful on Windows, where this EACCES-on-cwd failure doesn't occur); Windows keeps the existing isdir-only behavior.

## Related (not in this PR)

The most common `/root` capture is `hermes_cli/setup.py` writing a concrete `str(Path.home())` into `terminal.cwd`. Storing the runtime placeholder (`.`/`auto`) there instead would prevent *new* root-run installs from persisting `/root` — a natural prevention follow-up, but out of scope here since this guard already cures existing deployments at the point of use.

Fixes #65583