### PR TITLE
feat(kanban): add fail-closed task cancellation

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -164,7 +164,10 @@ class GatewayKanbanWatchersMixin:
 
         # "status" covers dashboard drag-drop and `_set_status_direct()`
         # writes — surface those transitions to subscribers too.
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked")
+        TERMINAL_KINDS = (
+            "completed", "blocked", "gave_up", "crashed", "timed_out",
+            "cancelled", "status", "archived", "unblocked",
+        )
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -390,6 +393,14 @@ class GatewayKanbanWatchersMixin:
                             msg = (
                                 f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
                                 f"(max_runtime={limit}s); will retry"
+                            )
+                        elif kind == "cancelled":
+                            reason = ""
+                            if ev.payload and ev.payload.get("reason"):
+                                reason = f": {str(ev.payload['reason'])[:160]}"
+                            msg = (
+                                f"⛔ {board_tag}{tag}Kanban {sub['task_id']} "
+                                f"cancelled{reason}"
                             )
                         elif kind == "status":
                             new_status = ""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -205,7 +205,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("kanban", "Multi-profile collaboration board (tasks, links, comments)",
                "Tools & Skills", args_hint="[subcommand]",
                subcommands=("init", "boards", "create", "list", "ls", "show", "assign",
-                            "reclaim", "reassign", "diagnostics", "diag", "link", "unlink",
+                            "reclaim", "cancel", "reassign", "diagnostics", "diag", "link", "unlink",
                             "claim", "comment", "complete", "edit", "block", "unblock",
                             "archive", "tail", "dispatch", "stats", "notify-subscribe",
                             "notify-list", "notify-unsubscribe", "log", "runs",

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -456,6 +456,20 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Human-readable reason (recorded on the reclaimed event)",
     )
 
+    p_cancel = sub.add_parser(
+        "cancel",
+        help="Terminate active work and archive the task atomically",
+    )
+    p_cancel.add_argument("task_id")
+    p_cancel.add_argument(
+        "--reason", default=None,
+        help="Human-readable reason (recorded on the cancelled event)",
+    )
+    p_cancel.add_argument(
+        "--json", action="store_true",
+        help="Emit the explicit cancellation outcome as JSON",
+    )
+
     p_reassign = sub.add_parser(
         "reassign",
         help="Reassign a task to a different profile, optionally reclaiming first",
@@ -962,6 +976,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "show":     _cmd_show,
             "assign":   _cmd_assign,
             "reclaim":  _cmd_reclaim,
+            "cancel":   _cmd_cancel,
             "reassign": _cmd_reassign,
             "diagnostics": _cmd_diagnostics,
             "diag":     _cmd_diagnostics,
@@ -1661,6 +1676,32 @@ def _cmd_reclaim(args: argparse.Namespace) -> int:
         return 1
     print(f"Reclaimed {args.task_id}")
     return 0
+
+
+def _cmd_cancel(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        result = kb.cancel_task(
+            conn, args.task_id,
+            reason=getattr(args, "reason", None),
+        )
+    payload = {
+        "ok": result.ok,
+        "task_id": result.task_id,
+        "outcome": result.outcome,
+        "idempotent": result.idempotent,
+        "termination": result.termination,
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    elif result.ok:
+        suffix = " (already cancelled)" if result.idempotent else ""
+        print(f"Cancelled {result.task_id}{suffix}")
+    else:
+        print(
+            f"cannot cancel {result.task_id}: {result.outcome}",
+            file=sys.stderr,
+        )
+    return 0 if result.ok else 1
 
 
 def _cmd_reassign(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1089,6 +1089,17 @@ class Event:
     run_id: Optional[int] = None
 
 
+@dataclass(frozen=True)
+class CancelResult:
+    """Explicit outcome of an operator cancellation request."""
+
+    ok: bool
+    task_id: str
+    outcome: str
+    idempotent: bool = False
+    termination: dict[str, Any] = field(default_factory=dict)
+
+
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
@@ -1225,7 +1236,7 @@ CREATE TABLE IF NOT EXISTS task_runs (
     ended_at            INTEGER,
     outcome             TEXT,
     -- outcome: completed | blocked | crashed | timed_out | spawn_failed |
-    --          gave_up | reclaimed | (null while still running)
+    --          gave_up | reclaimed | cancelled | (null while still running)
     summary             TEXT,
     metadata            TEXT,
     error               TEXT
@@ -3246,7 +3257,7 @@ def _end_run(
     """Close the currently-active run for ``task_id`` and clear the pointer.
 
     ``outcome`` is the semantic result (completed / blocked / crashed /
-    timed_out / spawn_failed / gave_up / reclaimed). ``status`` is the
+    timed_out / spawn_failed / gave_up / reclaimed / cancelled). ``status`` is the
     run-row status (usually just ``outcome``, but callers can pass it
     explicitly). Returns the closed run_id or ``None`` if no active run
     existed (e.g. a CLI user calling ``hermes kanban complete`` on a
@@ -5540,29 +5551,173 @@ def decompose_triage_task(
 
 
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Archive an inactive task.
+
+    Archival is a data-lifecycle operation, not worker control.  Any active
+    claim, PID, or run pointer makes this fail closed; callers that intend to
+    stop work must use :func:`cancel_task`.
+    """
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
             "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
-            "WHERE id = ? AND status != 'archived'",
+            "WHERE id = ? AND status NOT IN ('archived', 'running') "
+            "  AND claim_lock IS NULL AND worker_pid IS NULL "
+            "  AND current_run_id IS NULL",
             (task_id,),
         )
         if cur.rowcount != 1:
             return False
-        # If archive happened while a run was still in flight (e.g. user
-        # archived a running task from the dashboard), close that run with
-        # outcome='reclaimed' so attempt history isn't orphaned.
-        run_id = _end_run(
-            conn, task_id,
-            outcome="reclaimed", status="reclaimed",
-            summary="task archived with run still active",
-        )
-        _append_event(conn, task_id, "archived", None, run_id=run_id)
+        _append_event(conn, task_id, "archived")
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.
     recompute_ready(conn)
     return True
+
+
+def cancel_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+    signal_fn=None,
+) -> CancelResult:
+    """Terminate any active local worker and atomically archive its task.
+
+    The task transition is intentionally conditional on positive termination
+    proof.  If a claimed worker is remote, has no usable PID, survives the
+    signal sequence, or the task changes during termination, its claim and run
+    remain intact so the dispatcher cannot create a duplicate worker.
+    """
+    row = conn.execute(
+        "SELECT status, claim_lock, worker_pid, current_run_id "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if not row:
+        return CancelResult(False, task_id, "not_found")
+
+    prior_cancel = conn.execute(
+        "SELECT 1 FROM task_events WHERE task_id = ? AND kind = 'cancelled' "
+        "LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row["status"] == "archived":
+        if prior_cancel:
+            return CancelResult(True, task_id, "cancelled", idempotent=True)
+        return CancelResult(False, task_id, "already_archived")
+    if row["status"] == "done":
+        return CancelResult(False, task_id, "already_completed")
+
+    snapshot = {
+        "status": row["status"],
+        "claim_lock": row["claim_lock"],
+        "worker_pid": row["worker_pid"],
+        "current_run_id": row["current_run_id"],
+    }
+    active = bool(
+        row["status"] == "running"
+        or row["claim_lock"] is not None
+        or row["worker_pid"] is not None
+        or row["current_run_id"] is not None
+    )
+    termination = _terminate_reclaimed_worker(
+        row["worker_pid"] if active else None,
+        row["claim_lock"] if active else None,
+        signal_fn=signal_fn,
+    )
+
+    if active and not termination.get("terminated"):
+        cancelled_elsewhere = False
+        with write_txn(conn):
+            current = conn.execute(
+                "SELECT status, claim_lock, worker_pid, current_run_id "
+                "FROM tasks WHERE id = ?",
+                (task_id,),
+            ).fetchone()
+            unchanged = bool(current) and all(
+                current[key] == value for key, value in snapshot.items()
+            )
+            cancelled_elsewhere = bool(
+                current
+                and current["status"] == "archived"
+                and conn.execute(
+                    "SELECT 1 FROM task_events "
+                    "WHERE task_id = ? AND kind = 'cancelled' LIMIT 1",
+                    (task_id,),
+                ).fetchone()
+            )
+            if unchanged:
+                payload = {
+                    "reason": reason,
+                    "outcome": "termination_failed",
+                    **termination,
+                }
+                _append_event(
+                    conn, task_id, "cancel_failed", payload,
+                    run_id=row["current_run_id"],
+                )
+        if cancelled_elsewhere:
+            return CancelResult(
+                True, task_id, "cancelled", idempotent=True,
+                termination=termination,
+            )
+        return CancelResult(
+            False, task_id,
+            "termination_failed" if unchanged else "race_lost",
+            termination=termination,
+        )
+
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE tasks SET status = 'archived', claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL "
+            "WHERE id = ? AND status = ? AND claim_lock IS ? "
+            "AND worker_pid IS ? AND current_run_id IS ?",
+            (
+                task_id, snapshot["status"], snapshot["claim_lock"],
+                snapshot["worker_pid"], snapshot["current_run_id"],
+            ),
+        )
+        if cur.rowcount != 1:
+            current = conn.execute(
+                "SELECT status FROM tasks WHERE id = ?", (task_id,),
+            ).fetchone()
+            if (
+                current
+                and current["status"] == "archived"
+                and conn.execute(
+                    "SELECT 1 FROM task_events "
+                    "WHERE task_id = ? AND kind = 'cancelled' LIMIT 1",
+                    (task_id,),
+                ).fetchone()
+            ):
+                return CancelResult(
+                    True, task_id, "cancelled", idempotent=True,
+                    termination=termination,
+                )
+            return CancelResult(
+                False, task_id, "race_lost", termination=termination,
+            )
+        run_id = _end_run(
+            conn, task_id,
+            outcome="cancelled", status="cancelled",
+            summary=reason or "cancelled by operator",
+            metadata=termination,
+        )
+        payload = {
+            "reason": reason,
+            "previous_status": snapshot["status"],
+            "previous_claim": snapshot["claim_lock"],
+            **termination,
+        }
+        _append_event(conn, task_id, "cancelled", payload, run_id=run_id)
+
+    recompute_ready(conn)
+    return CancelResult(
+        True, task_id, "cancelled", termination=termination,
+    )
 
 
 def delete_archived_task(conn: sqlite3.Connection, task_id: str) -> bool:

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3069,10 +3069,17 @@
       const finalPatch = withCompletionSummary(patch, 1);
       if (!finalPatch) return Promise.resolve();
       setPatchErr(null);
-      return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}`, boardSlug), {
-        method: "PATCH",
+      const isCancellation = finalPatch.status === "archived"
+        && data && data.task && data.task.status === "running";
+      const path = isCancellation
+        ? `${API}/tasks/${encodeURIComponent(props.taskId)}/cancel`
+        : `${API}/tasks/${encodeURIComponent(props.taskId)}`;
+      return SDK.fetchJSON(withBoard(path, boardSlug), {
+        method: isCancellation ? "POST" : "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(finalPatch),
+        body: JSON.stringify(isCancellation
+          ? { reason: "cancelled from dashboard" }
+          : finalPatch),
       }).then(function () { load(); props.onRefresh(); })
         .catch(function (e) { setPatchErr(parseApiErrorMessage(e)); });
     };
@@ -4043,8 +4050,12 @@
         b(tx(t, "complete", "Complete"),  { status: "done" },
           task.status === "running" || task.status === "ready" || task.status === "blocked",
           getDestructiveConfirm(t, "done")),
-        b(tx(t, "archive", "Archive"),   { status: "archived" }, task.status !== "archived",
-          getDestructiveConfirm(t, "archived")),
+        task.status === "running"
+          ? b(tx(t, "cancelTask", "Cancel task"), { status: "archived" }, true,
+              tx(t, "confirmCancelTask",
+                "Cancel this task? Its worker must terminate before the task is archived."))
+          : b(tx(t, "archive", "Archive"), { status: "archived" }, task.status !== "archived",
+              getDestructiveConfirm(t, "archived")),
       ),
       specifyMsg ? h("div", {
         className: specifyMsg.ok

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1559,6 +1559,30 @@ class ReclaimBody(BaseModel):
     reason: Optional[str] = None
 
 
+class CancelBody(BaseModel):
+    reason: Optional[str] = None
+
+
+@router.post("/tasks/{task_id}/cancel")
+def cancel_task_endpoint(
+    task_id: str,
+    payload: CancelBody,
+    board: Optional[str] = Query(None),
+):
+    """Terminate active work and archive the task as one guarded action."""
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        result = kanban_db.cancel_task(conn, task_id, reason=payload.reason)
+        response = asdict(result)
+        if result.ok:
+            return response
+        status_code = 404 if result.outcome == "not_found" else 409
+        raise HTTPException(status_code=status_code, detail=response)
+    finally:
+        conn.close()
+
+
 @router.post("/tasks/{task_id}/reclaim")
 def reclaim_task_endpoint(
     task_id: str,

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -54,6 +54,33 @@ def _create_completed_subscription(summary="done once"):
         conn.close()
 
 
+def test_kanban_notifier_delivers_cancelled_outcome_and_unsubscribes(
+    tmp_path, monkeypatch,
+):
+    db_path = tmp_path / "cancelled.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="cancel me", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        assert kb.cancel_task(conn, tid, reason="owner cancelled").ok
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    assert tid in adapter.sent[0]["text"]
+    assert "cancelled" in adapter.sent[0]["text"].lower()
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, task_id=tid) == []
+    finally:
+        conn.close()
+
+
 def _unseen_terminal_events(tid):
     conn = kb.connect()
     try:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -354,6 +354,11 @@ def test_kanban_autocomplete_includes_live_subcommands():
     assert "reclaim" in texts
     assert "reassign" in texts
 
+    doc = Document("/kanban ca", cursor_position=len("/kanban ca"))
+    texts = {c.text for c in completer.get_completions(doc, None)}
+
+    assert "cancel" in texts
+
 
 def test_kanban_not_gateway_only():
     # kanban is available in BOTH CLI and gateway surfaces.
@@ -365,8 +370,30 @@ def test_kanban_not_gateway_only():
 
 
 # ---------------------------------------------------------------------------
-# reclaim + reassign CLI smoke tests
+# reclaim + cancel + reassign CLI smoke tests
 # ---------------------------------------------------------------------------
+
+def test_run_slash_cancel_reports_explicit_idempotent_outcome(kanban_home):
+    import re
+
+    out = kc.run_slash("create 'cancel before dispatch' --assignee worker")
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+
+    first = json.loads(kc.run_slash(
+        f"cancel {tid} --reason 'no longer needed' --json"
+    ))
+    assert first["ok"] is True
+    assert first["outcome"] == "cancelled"
+    assert first["idempotent"] is False
+
+    repeated = json.loads(kc.run_slash(f"cancel {tid} --json"))
+    assert repeated["ok"] is True
+    assert repeated["outcome"] == "cancelled"
+    assert repeated["idempotent"] is True
+
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, tid).status == "archived"
+
 
 def test_run_slash_reclaim_running_task(kanban_home):
     import re

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1943,9 +1943,8 @@ def test_cli_complete_bad_metadata_exits_nonzero(kanban_home):
 # Integration hardening (Apr 2026 audit fixes)
 # -------------------------------------------------------------------------
 
-def test_archive_of_running_task_closes_run(kanban_home):
-    """Archiving a claimed task must close the in-flight run with
-    outcome='reclaimed', not orphan it."""
+def test_archive_of_running_task_refuses_without_terminating_worker(kanban_home):
+    """Archive is data lifecycle, not cancellation; live claims fail closed."""
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="x", assignee="worker")
@@ -1954,15 +1953,158 @@ def test_archive_of_running_task_closes_run(kanban_home):
         assert run.ended_at is None
         open_run_id = run.id
 
-        assert kb.archive_task(conn, tid) is True
+        assert kb.archive_task(conn, tid) is False
 
         task = kb.get_task(conn, tid)
+        assert task.status == "running"
+        assert task.current_run_id == open_run_id
+        assert task.claim_lock is not None
+        assert kb.get_run(conn, open_run_id).ended_at is None
+    finally:
+        conn.close()
+
+
+def test_cancel_running_task_terminates_then_archives_with_explicit_outcome(
+    kanban_home, monkeypatch,
+):
+    import signal
+
+    conn = kb.connect()
+    alive = {"value": True}
+    signals = []
+
+    def fake_signal(pid, sig):
+        signals.append((pid, sig))
+        if sig == signal.SIGTERM:
+            alive["value"] = False
+
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: alive["value"])
+    try:
+        tid = kb.create_task(conn, title="cancel me", assignee="worker")
+        assert kb.claim_task(conn, tid)
+        kb._set_worker_pid(conn, tid, 4242)
+        run_id = kb.latest_run(conn, tid).id
+
+        result = kb.cancel_task(
+            conn, tid, reason="owner cancelled", signal_fn=fake_signal,
+        )
+
+        assert result.ok is True
+        assert result.outcome == "cancelled"
+        assert result.task_id == tid
+        assert result.idempotent is False
+        assert result.termination["terminated"] is True
+        assert signals == [(4242, signal.SIGTERM)]
+        task = kb.get_task(conn, tid)
         assert task.status == "archived"
-        assert task.current_run_id is None
-        # The previously-active run must now be closed.
-        closed = kb.get_run(conn, open_run_id)
-        assert closed.ended_at is not None
-        assert closed.outcome == "reclaimed"
+        assert task.claim_lock is None
+        assert task.worker_pid is None
+        run = kb.get_run(conn, run_id)
+        assert run.ended_at is not None
+        assert run.outcome == "cancelled"
+        events = kb.list_events(conn, tid)
+        cancelled = [event for event in events if event.kind == "cancelled"]
+        assert len(cancelled) == 1
+        assert cancelled[0].payload["reason"] == "owner cancelled"
+
+        repeated = kb.cancel_task(conn, tid, reason="repeat", signal_fn=fake_signal)
+        assert repeated.ok is True
+        assert repeated.outcome == "cancelled"
+        assert repeated.idempotent is True
+        events = kb.list_events(conn, tid)
+        assert len([event for event in events if event.kind == "cancelled"]) == 1
+    finally:
+        conn.close()
+
+
+def test_cancel_live_worker_failure_keeps_claim_and_prevents_redispatch(
+    kanban_home, monkeypatch,
+):
+    conn = kb.connect()
+    signals = []
+
+    def surviving_signal(pid, sig):
+        signals.append((pid, sig))
+
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(kb.time, "sleep", lambda _seconds: None)
+    try:
+        tid = kb.create_task(conn, title="still alive", assignee="worker")
+        assert kb.claim_task(conn, tid)
+        kb._set_worker_pid(conn, tid, 4343)
+        before = kb.get_task(conn, tid)
+        run_id = kb.latest_run(conn, tid).id
+
+        result = kb.cancel_task(
+            conn, tid, reason="owner cancelled", signal_fn=surviving_signal,
+        )
+
+        assert result.ok is False
+        assert result.outcome == "termination_failed"
+        assert result.termination["termination_attempted"] is True
+        assert result.termination["terminated"] is False
+        after = kb.get_task(conn, tid)
+        assert after.status == "running"
+        assert after.claim_lock == before.claim_lock
+        assert after.worker_pid == 4343
+        assert after.current_run_id == run_id
+        assert kb.get_run(conn, run_id).ended_at is None
+        assert any(event.kind == "cancel_failed" for event in kb.list_events(conn, tid))
+    finally:
+        conn.close()
+
+
+def test_cancel_unclaimed_task_archives_without_signalling(kanban_home):
+    conn = kb.connect()
+    signalled = []
+    try:
+        tid = kb.create_task(conn, title="not started", assignee="worker")
+        result = kb.cancel_task(
+            conn, tid, reason="no longer needed",
+            signal_fn=lambda pid, sig: signalled.append((pid, sig)),
+        )
+        assert result.ok is True
+        assert result.outcome == "cancelled"
+        assert result.termination["termination_attempted"] is False
+        assert signalled == []
+        assert kb.get_task(conn, tid).status == "archived"
+    finally:
+        conn.close()
+
+
+def test_cancel_compare_and_swap_does_not_clobber_new_claim(
+    kanban_home, monkeypatch,
+):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="claim changes", assignee="worker")
+        assert kb.claim_task(conn, tid)
+        kb._set_worker_pid(conn, tid, 4444)
+
+        def terminate_then_reclaim(_pid, _lock, signal_fn=None):
+            conn.execute(
+                "UPDATE tasks SET claim_lock = ?, worker_pid = ? WHERE id = ?",
+                ("new-owner:claim", 5555, tid),
+            )
+            conn.commit()
+            return {
+                "prev_pid": 4444,
+                "host_local": True,
+                "termination_attempted": True,
+                "terminated": True,
+                "sigkill": False,
+            }
+
+        monkeypatch.setattr(kb, "_terminate_reclaimed_worker", terminate_then_reclaim)
+        result = kb.cancel_task(conn, tid, reason="owner cancelled")
+
+        assert result.ok is False
+        assert result.outcome == "race_lost"
+        task = kb.get_task(conn, tid)
+        assert task.status == "running"
+        assert task.claim_lock == "new-owner:claim"
+        assert task.worker_pid == 5555
+        assert task.current_run_id is not None
     finally:
         conn.close()
 
@@ -2522,7 +2664,7 @@ def test_pid_alive_detects_zombie(kanban_home):
         time.sleep(0.3)
         # Verify /proc reports zombie state so the test is actually
         # exercising the zombie path and not some other liveness failure
-        with open(f"/proc/{pid}/status") as f:
+        with open(f"/proc/{pid}/status", encoding="utf-8") as f:
             state_line = next(
                 (l for l in f if l.startswith("State:")), ""
             )

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1143,7 +1143,19 @@ def test_dashboard_done_actions_prompt_for_completion_summary():
     assert "Completion summary" in bundle
     assert "result: summary" in bundle
     assert "body: JSON.stringify(patch)" in bundle
-    assert "body: JSON.stringify(finalPatch)" in bundle
+    assert ": finalPatch" in bundle
+
+
+def test_dashboard_running_archive_action_routes_through_cancel_endpoint():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = (
+        repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    ).read_text()
+
+    assert 'data.task.status === "running"' in bundle
+    assert '/cancel`' in bundle
+    assert 'method: isCancellation ? "POST" : "PATCH"' in bundle
+    assert 'tx(t, "cancelTask", "Cancel task")' in bundle
 
 
 def test_dashboard_surfaces_ready_blocked_error_inline():
@@ -1400,8 +1412,8 @@ def test_patch_status_done_without_summary_still_works(client):
         conn.close()
 
 
-def test_patch_status_archive_closes_running_run(client):
-    """PATCH to archived while running must close the in-flight run."""
+def test_patch_status_archive_refuses_running_task(client):
+    """Archival is not cancellation and must leave active work intact."""
     r = client.post("/api/plugins/kanban/tasks", json={"title": "z", "assignee": "worker"})
     tid = r.json()["task"]["id"]
     from hermes_cli import kanban_db as kb
@@ -1416,13 +1428,14 @@ def test_patch_status_archive_closes_running_run(client):
         f"/api/plugins/kanban/tasks/{tid}",
         json={"status": "archived"},
     )
-    assert r.status_code == 200, r.text
+    assert r.status_code == 409, r.text
     conn = kb.connect()
     try:
         task = kb.get_task(conn, tid)
-        assert task.status == "archived"
-        assert task.current_run_id is None
-        assert kb.latest_run(conn, tid).outcome == "reclaimed"
+        assert task.status == "running"
+        assert task.current_run_id == open_run.id
+        assert task.claim_lock is not None
+        assert kb.latest_run(conn, tid).ended_at is None
     finally:
         conn.close()
 
@@ -1963,6 +1976,56 @@ def test_reclaim_endpoint_releases_running_claim(client):
         assert row["claim_lock"] is None
     finally:
         conn2.close()
+
+
+def test_cancel_endpoint_returns_explicit_idempotent_outcome(client):
+    conn = kb.connect()
+    try:
+        t = kb.create_task(conn, title="cancel before dispatch", assignee="x")
+    finally:
+        conn.close()
+
+    first = client.post(
+        f"/api/plugins/kanban/tasks/{t}/cancel",
+        json={"reason": "owner cancelled"},
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["outcome"] == "cancelled"
+    assert first.json()["idempotent"] is False
+
+    repeated = client.post(
+        f"/api/plugins/kanban/tasks/{t}/cancel",
+        json={},
+    )
+    assert repeated.status_code == 200, repeated.text
+    assert repeated.json()["outcome"] == "cancelled"
+    assert repeated.json()["idempotent"] is True
+
+
+def test_cancel_endpoint_fails_closed_without_termination_proof(client):
+    conn = kb.connect()
+    try:
+        t = kb.create_task(conn, title="claimed without pid", assignee="x")
+        assert kb.claim_task(conn, t)
+        before = kb.get_task(conn, t)
+    finally:
+        conn.close()
+
+    r = client.post(
+        f"/api/plugins/kanban/tasks/{t}/cancel",
+        json={"reason": "owner cancelled"},
+    )
+    assert r.status_code == 409, r.text
+    assert r.json()["detail"]["outcome"] == "termination_failed"
+
+    conn = kb.connect()
+    try:
+        after = kb.get_task(conn, t)
+        assert after.status == "running"
+        assert after.claim_lock == before.claim_lock
+        assert after.current_run_id == before.current_run_id
+    finally:
+        conn.close()
 
 
 def test_reclaim_endpoint_409_for_non_running_task(client):

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -734,6 +734,7 @@ The dashboard plugin API now exposes these read-only endpoints (plus a run-contr
 | `GET /api/plugins/kanban/workers/active` | Currently spawned workers with PID, profile, task id, started-at, last heartbeat |
 | `GET /api/plugins/kanban/runs/{id}` | Single-run detail — task id, status, started/ended, exit code, log path |
 | `POST /api/plugins/kanban/runs/{run_id}/terminate` | Terminate a reclaimable run — stops the worker and frees the task for re-dispatch |
+| `POST /api/plugins/kanban/tasks/{task_id}/cancel` | Terminate active work, verify the worker is gone, and archive the task with an explicit `cancelled` outcome |
 | `GET /api/plugins/kanban/inspect` | Combined dispatcher snapshot — backlog, in-progress count vs. `max_in_progress`, recent events |
 
 All of these are gated by the same dashboard plugin auth as the rest of the kanban plugin API.
@@ -851,7 +852,7 @@ A subscription removes itself automatically once the task reaches `done` or `arc
 
 ## Runs — one row per attempt
 
-A task is a logical unit of work; a **run** is one attempt to execute it. When the dispatcher claims a ready task it creates a row in `task_runs` and points `tasks.current_run_id` at it. When that attempt ends — completed, blocked, crashed, timed out, spawn-failed, reclaimed — the run row closes with an `outcome` and the task's pointer clears. A task that's been attempted three times has three `task_runs` rows.
+A task is a logical unit of work; a **run** is one attempt to execute it. When the dispatcher claims a ready task it creates a row in `task_runs` and points `tasks.current_run_id` at it. When that attempt ends — completed, blocked, crashed, timed out, spawn-failed, reclaimed, or cancelled — the run row closes with an `outcome` and the task's pointer clears. A task that's been attempted three times has three `task_runs` rows.
 
 Why two tables instead of just mutating the task: you need **full attempt history** for real-world postmortems ("the second reviewer attempt got to approve, the third merged"), and you need a clean place to hang per-attempt metadata — which files changed, which tests ran, which findings a reviewer noted. Those are run facts, not task facts.
 
@@ -893,7 +894,7 @@ Runs are exposed on the dashboard (Run History section in the drawer, one colour
 
 **Bulk close caveat.** `hermes kanban complete a b c --summary X` is refused — structured handoff is per-run, so copy-pasting the same summary to N tasks is almost always wrong. Bulk close *without* `--summary` / `--metadata` still works for the common "I finished a pile of admin tasks" case.
 
-**Reclaimed runs from status changes.** If you drag a running task off `running` in the dashboard (back to `ready`, or straight to `todo`), or archive a task that was still running, the in-flight run closes with `outcome='reclaimed'` rather than being orphaned. The `task_runs` row is always in a terminal state when `tasks.current_run_id` is `NULL`, and vice versa — that invariant holds across CLI, dashboard, dispatcher, and notifier.
+**Cancellation versus archival.** Archival is a data-lifecycle operation and refuses a running task. Use `hermes kanban cancel <task_id> --reason "…"` (or the dashboard's **Cancel task** action) to stop active work. Cancellation signals a host-local worker, verifies the PID has disappeared, and only then closes the run with `outcome='cancelled'` and archives the task. If termination cannot be proven, the task stays running and claimed so the dispatcher cannot start a duplicate worker.
 
 **Synthetic runs for never-claimed completions.** Completing or blocking a task that was never claimed (e.g. a human closes a `ready` task from the dashboard with a summary, or a CLI user runs `hermes kanban complete <ready-task> --summary X`) would otherwise drop the handoff. Instead the kernel inserts a zero-duration run row (`started_at == ended_at`) carrying the summary / metadata / reason so attempt history stays complete. The `completed` / `blocked` event's `run_id` points at that row.
 
@@ -919,7 +920,9 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 | `dependency_wait` | `{reason, kind}` | Worker blocked with `kind=dependency` — the task is only waiting on another task, so it routes to `todo` (parent-gated, auto-promoted) instead of `blocked`. No human needed. |
 | `block_loop_detected` | `{reason, kind, recurrences, limit}` | A task was unblocked and re-blocked for the same reason `BLOCK_RECURRENCE_LIMIT` times (default 2). Instead of landing in `blocked` again — where a cron would keep unblocking it — it routes to `triage` for a human decision, breaking the unblock↔re-block loop. |
 | `unblocked` | — | `blocked → ready` (or `todo` if parents are still open), either manually or via `/unblock`. Resets the dispatcher's `consecutive_failures` but deliberately preserves `block_recurrences` so the loop breaker keeps its memory. `run_id` is `NULL`. |
-| `archived` | — | Hidden from the default board. If the task was still running, carries the `run_id` of the run that was reclaimed as a side effect. |
+| `cancelled` | `{reason, previous_status, previous_claim, terminated, ...}` | Operator cancellation terminated active work (if any), closed the run with `outcome='cancelled'`, and archived the task. Repeating the operation is idempotent. |
+| `cancel_failed` | `{reason, outcome, termination_attempted, terminated, ...}` | Cancellation could not prove worker termination. Task, claim, PID, and active run remain unchanged. |
+| `archived` | — | Inactive task hidden from the default board. Archival refuses active claims; it never terminates a worker. |
 
 **Edits** (human-driven changes that aren't transitions):
 


### PR DESCRIPTION
## What does this PR do?

Adds a first-class, fail-closed `hermes kanban cancel` operation for safely cancelling dispatched Kanban work.

Archiving a live task does not terminate its worker, while reclaiming without an immediate terminal transition can permit redispatch. The new operation coordinates termination, state verification, claim release, a single explicit `cancelled` outcome, and archival. If worker termination cannot be verified, it preserves the task's claim/run/PID state and refuses to archive it.

Cancellation is idempotent, supports unclaimed tasks without signalling, is available through the CLI and dashboard API/UI, and prevents the worker watcher from later overwriting an already-cancelled outcome.

## Related Issue

None. Reproduced on v2026.7.7.2 and current `main`; no matching issue or PR was found.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

- Add database-level atomic cancellation and an explicit `cancelled` task outcome.
- Add bounded, cross-platform worker termination through `psutil`, with fail-closed verification.
- Expose cancellation through `hermes kanban cancel`, the dashboard API, and the dashboard task action.
- Make watcher/notifier handling cancellation-aware and preserve idempotence.
- Document cancellation semantics and the distinction from archive.
- Add regressions for running, unclaimed, repeated, and failed-termination paths plus CLI/API/notifier coverage.

## How to Test

1. Run `bash scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_cli.py tests/plugins/test_kanban_dashboard_plugin.py tests/gateway/test_kanban_notifier.py` (346 passed).
2. Run `bash scripts/run_tests.sh tests/hermes_cli/test_commands.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py` (407 passed).
3. Run `python scripts/check-windows-footguns.py --diff origin/main` and `node --check plugins/kanban/dashboard/dist/index.js`.

Also exercised on Ubuntu under WSL2 against a real dispatched Codex worker: cancellation terminated the worker, verified PID disappearance, emitted one `cancelled` event, archived the task, and remained idempotent on repeat.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (two focused mandatory-wrapper suites: 753 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 host, Ubuntu under WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation in `website/docs/user-guide/features/kanban.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys (N/A; no config key added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows (N/A)
- [x] I've considered cross-platform impact and passed `scripts/check-windows-footguns.py --diff origin/main`
- [x] I've updated tool descriptions/schemas if I changed tool behavior (N/A; CLI/API operation, not an MCP tool schema change)

## Screenshots / Logs

Focused validation: 753 passed, 0 failed; Windows footgun scan clean; dashboard JavaScript syntax check passed.
