### PR TITLE
fix(desktop): prevent false runtime-not-ready under gateway load

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-status-snapshot.test.ts
+++ b/apps/desktop/src/app/shell/hooks/use-status-snapshot.test.ts
@@ -31,7 +31,9 @@ async function flushAsync() {
 
 beforeEach(() => {
   vi.useFakeTimers()
-  vi.mocked(getStatus).mockReset().mockResolvedValue({} as never)
+  vi.mocked(getStatus)
+    .mockReset()
+    .mockResolvedValue({} as never)
 })
 
 afterEach(() => {
@@ -83,10 +85,11 @@ describe('useStatusSnapshot', () => {
   })
 
   it('still publishes an authoritative runtime failure', async () => {
-    const requestGatewayMock = vi.fn(async (method: string) =>
-      (method === 'setup.runtime_check'
-        ? { error: 'No usable credentials found for nous.', ok: false }
-        : { provider_configured: true }) as never
+    const requestGatewayMock = vi.fn(
+      async (method: string) =>
+        (method === 'setup.runtime_check'
+          ? { error: 'No usable credentials found for nous.', ok: false }
+          : { provider_configured: true }) as never
     )
 
     const requestGateway = requestGatewayMock as unknown as GatewayRequester
@@ -102,12 +105,37 @@ describe('useStatusSnapshot', () => {
     })
   })
 
+  it('clears readiness immediately when the gateway disconnects', async () => {
+    const pendingStatus = deferred<never>()
+
+    vi.mocked(getStatus)
+      .mockResolvedValueOnce({} as never)
+      .mockReturnValueOnce(pendingStatus.promise)
+
+    const requestGateway = vi.fn(
+      async (method: string) =>
+        (method === 'setup.runtime_check' ? { ok: true } : { provider_configured: true }) as never
+    ) as unknown as GatewayRequester
+
+    const { rerender, result } = renderHook(({ gatewayState }) => useStatusSnapshot(gatewayState, requestGateway), {
+      initialProps: { gatewayState: 'open' }
+    })
+
+    await flushAsync()
+    expect(result.current.inferenceStatus).toMatchObject({ ready: true, source: 'runtime_check' })
+
+    rerender({ gatewayState: 'connecting' })
+
+    expect(getStatus).toHaveBeenCalledTimes(2)
+    expect(result.current.inferenceStatus).toBeNull()
+  })
+
   it('waits for a slow refresh to settle before scheduling another one', async () => {
     const setup = deferred<unknown>()
     const runtime = deferred<unknown>()
 
-    const requestGatewayMock = vi.fn((method: string) =>
-      (method === 'setup.runtime_check' ? runtime.promise : setup.promise) as never
+    const requestGatewayMock = vi.fn(
+      (method: string) => (method === 'setup.runtime_check' ? runtime.promise : setup.promise) as never
     )
 
     const requestGateway = requestGatewayMock as unknown as GatewayRequester

--- a/apps/desktop/src/app/shell/hooks/use-status-snapshot.test.ts
+++ b/apps/desktop/src/app/shell/hooks/use-status-snapshot.test.ts
@@ -1,0 +1,142 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getStatus } from '@/hermes'
+
+import { useStatusSnapshot } from './use-status-snapshot'
+
+vi.mock('@/hermes', () => ({
+  getStatus: vi.fn()
+}))
+
+type GatewayRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined
+  let reject: (reason?: unknown) => void = () => undefined
+
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+
+  return { promise, reject, resolve }
+}
+
+async function flushAsync() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.mocked(getStatus).mockReset().mockResolvedValue({} as never)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('useStatusSnapshot', () => {
+  it('keeps the last authoritative readiness through a transient RPC failure', async () => {
+    let refresh = 0
+
+    const requestGatewayMock = vi.fn(async (method: string) => {
+      const cycle = Math.floor(refresh / 2)
+      refresh += 1
+
+      if (cycle > 0) {
+        throw new Error(`${method} timed out`)
+      }
+
+      return (method === 'setup.runtime_check' ? { ok: true } : { provider_configured: true }) as never
+    })
+
+    const requestGateway = requestGatewayMock as unknown as GatewayRequester
+
+    const { result } = renderHook(() => useStatusSnapshot('open', requestGateway))
+
+    await flushAsync()
+    expect(result.current.inferenceStatus).toMatchObject({ ready: true, source: 'runtime_check' })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000)
+    })
+
+    expect(result.current.inferenceStatus).toMatchObject({ ready: true, source: 'runtime_check' })
+  })
+
+  it('does not present an initial transport failure as inference not ready', async () => {
+    const requestGatewayMock = vi.fn(async (method: string) => {
+      throw new Error(`${method} connection closed`)
+    })
+
+    const requestGateway = requestGatewayMock as unknown as GatewayRequester
+
+    const { result } = renderHook(() => useStatusSnapshot('open', requestGateway))
+
+    await flushAsync()
+
+    expect(result.current.inferenceStatus).toBeNull()
+  })
+
+  it('still publishes an authoritative runtime failure', async () => {
+    const requestGatewayMock = vi.fn(async (method: string) =>
+      (method === 'setup.runtime_check'
+        ? { error: 'No usable credentials found for nous.', ok: false }
+        : { provider_configured: true }) as never
+    )
+
+    const requestGateway = requestGatewayMock as unknown as GatewayRequester
+
+    const { result } = renderHook(() => useStatusSnapshot('open', requestGateway))
+
+    await flushAsync()
+
+    expect(result.current.inferenceStatus).toMatchObject({
+      ready: false,
+      reason: expect.stringContaining('No usable credentials found for nous.'),
+      source: 'runtime_check'
+    })
+  })
+
+  it('waits for a slow refresh to settle before scheduling another one', async () => {
+    const setup = deferred<unknown>()
+    const runtime = deferred<unknown>()
+
+    const requestGatewayMock = vi.fn((method: string) =>
+      (method === 'setup.runtime_check' ? runtime.promise : setup.promise) as never
+    )
+
+    const requestGateway = requestGatewayMock as unknown as GatewayRequester
+
+    renderHook(() => useStatusSnapshot('open', requestGateway))
+    await flushAsync()
+
+    expect(requestGatewayMock).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+
+    expect(requestGatewayMock).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      setup.resolve({ provider_configured: true })
+      runtime.resolve({ ok: true })
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(14_999)
+    })
+    expect(requestGatewayMock).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(requestGatewayMock).toHaveBeenCalledTimes(4)
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-status-snapshot.ts
+++ b/apps/desktop/src/app/shell/hooks/use-status-snapshot.ts
@@ -16,6 +16,13 @@ export function useStatusSnapshot(gatewayState: string | undefined, requestGatew
     let cancelled = false
     let timer: number | undefined
 
+    // A closed/connecting gateway cannot have an authoritative live-runtime
+    // result. Clear readiness before starting the REST status leg so a hung
+    // getStatus() cannot leave a stale "ready" state visible after disconnect.
+    if (gatewayState !== 'open') {
+      setInferenceStatus(null)
+    }
+
     const scheduleRefresh = () => {
       if (!cancelled) {
         timer = window.setTimeout(() => void refresh(), REFRESH_MS)
@@ -30,9 +37,7 @@ export function useStatusSnapshot(gatewayState: string | undefined, requestGatew
         // race newer healthy results.
         const [statusResult, inferenceResult] = await Promise.allSettled([
           getStatus(),
-          gatewayState === 'open'
-            ? evaluateRuntimeReadiness(requestGateway)
-            : Promise.resolve(null)
+          gatewayState === 'open' ? evaluateRuntimeReadiness(requestGateway) : Promise.resolve(null)
         ])
 
         if (cancelled) {

--- a/apps/desktop/src/app/shell/hooks/use-status-snapshot.ts
+++ b/apps/desktop/src/app/shell/hooks/use-status-snapshot.ts
@@ -14,18 +14,24 @@ export function useStatusSnapshot(gatewayState: string | undefined, requestGatew
 
   useEffect(() => {
     let cancelled = false
+    let timer: number | undefined
+
+    const scheduleRefresh = () => {
+      if (!cancelled) {
+        timer = window.setTimeout(() => void refresh(), REFRESH_MS)
+      }
+    }
 
     const refresh = async () => {
       try {
-        const [next, inference] = await Promise.all([
+        // Wait for both legs before scheduling the next refresh. setInterval
+        // allowed a slow runtime check to overlap with later polls, which
+        // multiplied load on an already-busy gateway and let stale failures
+        // race newer healthy results.
+        const [statusResult, inferenceResult] = await Promise.allSettled([
           getStatus(),
           gatewayState === 'open'
-            ? evaluateRuntimeReadiness(requestGateway).catch(error => ({
-                checksDisagree: false,
-                ready: false,
-                reason: error instanceof Error ? error.message : String(error),
-                source: 'fallback' as const
-              }))
+            ? evaluateRuntimeReadiness(requestGateway)
             : Promise.resolve(null)
         ])
 
@@ -33,19 +39,37 @@ export function useStatusSnapshot(gatewayState: string | undefined, requestGatew
           return
         }
 
-        setStatusSnapshot(next)
-        setInferenceStatus(inference)
-      } catch {
-        // Keep last snapshot through transient gateway flaps.
+        if (statusResult.status === 'fulfilled') {
+          setStatusSnapshot(statusResult.value)
+        }
+
+        if (inferenceResult.status === 'fulfilled') {
+          const inference = inferenceResult.value
+
+          if (inference === null) {
+            setInferenceStatus(null)
+          } else if (inference.source !== 'fallback') {
+            // runtime_check/setup_status returned an authoritative boolean.
+            // A fallback means both RPCs failed or returned no boolean, so it
+            // is a transient/unknown transport state, not proof that inference
+            // became unconfigured. Keep the last authoritative result instead
+            // of flashing "Inference not ready" during a gateway flap.
+            setInferenceStatus(inference)
+          }
+        }
+      } finally {
+        scheduleRefresh()
       }
     }
 
     void refresh()
-    const timer = window.setInterval(() => void refresh(), REFRESH_MS)
 
     return () => {
       cancelled = true
-      window.clearInterval(timer)
+
+      if (timer !== undefined) {
+        window.clearTimeout(timer)
+      }
     }
   }, [gatewayState, requestGateway])
 

--- a/tests/tui_gateway/test_inline_rpc_gil_starvation.py
+++ b/tests/tui_gateway/test_inline_rpc_gil_starvation.py
@@ -64,6 +64,7 @@ def capture(server):
 # seconds when the GIL is contended by concurrent agent turns.
 
 FRONTEND_POLLED_RPCS = [
+    "session.active_list",   # live-session rehydrate — in-memory registry
     "session.list",          # loads session list — SQLite query
     "pet.info",              # petdex poll — file/network read
     "process.list",          # background process status — process registry scan

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -242,6 +242,12 @@ _LONG_HANDLERS = frozenset(
         # the WS read loop and causing false "needs setup" (#50005 family).
         "setup.runtime_check",
         "setup.status",
+        # Desktop also polls the in-memory live-session registry every 15s.
+        # The handler is normally cheap, but under heavy agent GIL pressure it
+        # can still stall for tens of seconds. Keep it off the WS reader thread
+        # so a delayed status rehydrate cannot block runtime readiness, prompt
+        # submission, or interrupts queued behind it on the same socket.
+        "session.active_list",
         "session.branch",
         "session.compress",
         "session.list",


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop polls REST status and gateway runtime readiness every 15 seconds. Under heavy concurrent agent load, `session.active_list` could occupy the shared WebSocket reader for tens of seconds. Readiness requests queued behind it could then time out, and the Desktop hook published the transport fallback (`ready: false`) as if it were an authoritative credential failure. The interval could also start overlapping refreshes, allowing a stale failure to race a newer healthy result.

This PR fixes both sides of that failure mode:

- Desktop status refreshes are single-flight and schedule the next poll only after the current refresh settles.
- REST and readiness results settle independently.
- Transient readiness fallbacks preserve the last authoritative result; a real authoritative `ok: false` is still surfaced immediately.
- `session.active_list` runs through the gateway worker pool so a slow live-session rehydrate cannot block readiness, prompts, or interrupts on the same socket.

## Related Issue

No linked issue. Reproduced against a live remote Desktop/backend connection under concurrent agent load.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `apps/desktop/src/app/shell/hooks/use-status-snapshot.ts` to use non-overlapping, independently settled polling.
- Added `apps/desktop/src/app/shell/hooks/use-status-snapshot.test.ts` covering transient failures, real credential failures, initial unknown state, and overlapping polls.
- Added `session.active_list` to `tui_gateway.server._LONG_HANDLERS`.
- Extended the gateway GIL-starvation regression matrix.

## How to Test

1. Connect Desktop to a remote Hermes dashboard and start several concurrent agent turns.
2. Keep the connection under enough load that live-session polling is delayed.
3. Verify Desktop retains the last authoritative readiness during the transient delay, still reports genuine credential failures, and continues polling without overlapping refreshes.

Automated checks run:

- `npm test -- src/app/shell/hooks/use-status-snapshot.test.ts src/lib/runtime-readiness.test.ts` — 10 passed
- `npm run typecheck` — passed
- targeted ESLint — passed
- `scripts/run_tests.sh tests/tui_gateway/test_inline_rpc_gil_starvation.py` — 9 passed on Ubuntu

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete Python test suite
- [x] I've added tests for my changes
- [x] I've tested on Windows 11 Desktop and an Ubuntu remote backend

### Documentation & Housekeeping

- [x] Documentation changes are N/A
- [x] Config example changes are N/A
- [x] Contributor/agent guide changes are N/A
- [x] I've considered cross-platform impact
- [x] Tool description/schema changes are N/A

## Screenshots / Logs

During the live failure, `setup.runtime_check` still returned `ok: true` for the configured provider while `session.active_list` took 23.2 seconds on the same connection. After applying both fixes, live-session polling completed in 209 ms and authoritative readiness returned `ok: true` in 337 ms.