### PR TITLE
Fix: Auto-compression never fires in pure chat (no tool calls) path [#65959]

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5012,14 +5012,37 @@ def run_conversation(
             else:
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""
-                
+
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery
                 # status messages.  _mute_post_response was set during a
                 # prior housekeeping tool turn and should not silence the
                 # final response path.
                 agent._mute_post_response = False
-                
+
+                # Post-response compression check (mirrors tool-call branch at ~line 4956).
+                # A long pure-chat session can cross the compression threshold without
+                # ever hitting the tool-call compression site — guard against that.
+                _compressor = agent.context_compressor
+                if _compressor.last_prompt_tokens > 0:
+                    _real_tokens = _compressor.last_prompt_tokens
+                elif _compressor.last_prompt_tokens == -1:
+                    _real_tokens = 0
+                else:
+                    _real_tokens = estimate_request_tokens_rough(
+                        messages, tools=agent.tools or None
+                    )
+                if agent.compression_enabled and _compressor.should_compress(_real_tokens):
+                    agent._safe_print("  ⟳ compacting context…")
+                    messages, active_system_prompt = agent._compress_context(
+                        messages, system_message,
+                        approx_tokens=agent.context_compressor.last_prompt_tokens,
+                        task_id=effective_task_id,
+                    )
+                    conversation_history = conversation_history_after_compression(
+                        agent, messages
+                    )
+
                 # Check if response only has think block with no actual content after it
                 if not agent._has_content_after_think_block(final_response):
                     # ── Partial stream recovery ─────────────────────


### PR DESCRIPTION
## Summary
Fixes #65959 — Auto-compression did not fire after long TUI session crossed threshold.

## Root Cause
In `agent/conversation_loop.py`, the post-response `should_compress()` check (lines ~4956-4965) only existed in the **tool-call branch** (`if assistant_message.tool_calls:`). When the model returned a final text response with **no tool calls**, execution jumped to the `else` branch and **skipped the compression check entirely**, breaking out of the loop.

A pure-chat TUI session (user text → assistant text, no `read_file`, `search_files`, etc.) could grow past the ~200k token threshold with **zero** `conversation_compression` records persisted — exactly as reported for session `20260716_112216_60220c`.

## Fix
Added the identical compression logic to the **no-tool-calls branch** (after line 4982), mirroring the tool-call path:
- Uses real `last_prompt_tokens` when available
- Falls back to rough estimate including tool schemas
- Respects `compression_enabled` flag and cooldown guards via `should_compress()`

## Testing
- Syntax clean (`python3 -m py_compile`)
- All 32 core compression tests pass (`test_compress_focus.py`, `test_compressed_summary_metadata.py`, `test_compression_concurrent_fork.py`)
- Logic is a verbatim mirror of the existing proven tool-call compression site

## Notes
- Minimal, targeted change (23 lines added)
- No behavior change for tool-call turns
- Closes the gap that let pure-chat sessions bypass auto-compression indefinitely