### PR TITLE
fix(files): recover glob-shaped content searches

### DIFF
--- a/tests/tools/test_search_glob_pattern_recovery.py
+++ b/tests/tools/test_search_glob_pattern_recovery.py
@@ -3,8 +3,11 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from tools import file_tools
-from tools.file_operations import SearchMatch, SearchResult
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import SearchMatch, SearchResult, ShellFileOperations
 
 
 def _drive_search(monkeypatch, pattern: str, backend_result: SearchResult | None = None):
@@ -88,3 +91,60 @@ def test_translation_rejects_regex_intent_and_plain_text():
     assert file_tools._globish_content_pattern_to_regex(r"\d+") is None
     assert file_tools._globish_content_pattern_to_regex("foo[bar]") is None
     assert file_tools._globish_content_pattern_to_regex("plain text") is None
+
+
+@pytest.fixture
+def real_local_search_backend(monkeypatch, tmp_path):
+    """Run search_tool through ShellFileOperations and the installed ripgrep."""
+    environment = LocalEnvironment(cwd=str(tmp_path), timeout=15)
+    file_ops = ShellFileOperations(environment, cwd=str(tmp_path))
+
+    with file_tools._read_tracker_lock:
+        file_tools._read_tracker.clear()
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda _task_id: file_ops)
+    return tmp_path
+
+
+def test_glob_recovery_reaches_real_ripgrep_through_search_tool(
+    real_local_search_backend,
+):
+    (real_local_search_backend / "sample.txt").write_text(
+        "detector scheduler\n",
+        encoding="utf-8",
+    )
+
+    response = json.loads(
+        file_tools.search_tool(
+            "*detector*scheduler*",
+            target="content",
+            path=".",
+            task_id="glob-recovery-real-rg",
+        )
+    )
+
+    assert "error" not in response
+    assert response["total_count"] == 1
+    assert response["matches"][0]["content"] == "detector scheduler"
+    assert "interpreted as the glob-like pattern" in response["warning"]
+
+
+def test_malformed_non_glob_regex_reaches_real_ripgrep_error(
+    real_local_search_backend,
+):
+    (real_local_search_backend / "sample.txt").write_text(
+        "detector scheduler\n",
+        encoding="utf-8",
+    )
+
+    response = json.loads(
+        file_tools.search_tool(
+            "[",
+            target="content",
+            path=".",
+            task_id="malformed-regex-real-rg",
+        )
+    )
+
+    assert "error" in response
+    assert "regex parse error" in response["error"]
+    assert "Content search expects a regular expression" in response["error"]

--- a/tests/tools/test_search_glob_pattern_recovery.py
+++ b/tests/tools/test_search_glob_pattern_recovery.py
@@ -1,0 +1,90 @@
+"""Regression coverage for glob-shaped content-search patterns (#66129)."""
+
+import json
+from pathlib import Path
+
+from tools import file_tools
+from tools.file_operations import SearchMatch, SearchResult
+
+
+def _drive_search(monkeypatch, pattern: str, backend_result: SearchResult | None = None):
+    seen: list[str] = []
+
+    class FakeFileOps:
+        def search(self, **kwargs):
+            seen.append(kwargs["pattern"])
+            return backend_result or SearchResult(
+                matches=[
+                    SearchMatch(
+                        path="sample.txt",
+                        line_number=1,
+                        content="detector scheduler",
+                    )
+                ],
+                total_count=1,
+            )
+
+    with file_tools._read_tracker_lock:
+        file_tools._read_tracker.clear()
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda _task_id: FakeFileOps())
+    monkeypatch.setattr(
+        file_tools,
+        "_filter_read_blocked_search_results",
+        lambda _result, _task_id: 0,
+    )
+    monkeypatch.setattr(file_tools, "get_read_block_error", lambda _path: None)
+    monkeypatch.setattr(
+        file_tools,
+        "_resolve_path_for_task",
+        lambda path, _task_id: Path(path),
+    )
+
+    response = json.loads(
+        file_tools.search_tool(pattern, target="content", task_id="glob-recovery-test")
+    )
+    return response, seen
+
+
+def test_bare_glob_pattern_is_translated_once(monkeypatch):
+    response, seen = _drive_search(monkeypatch, "*detector*scheduler*")
+
+    assert seen == [r".*detector.*scheduler.*"]
+    assert "error" not in response
+    assert response["total_count"] == 1
+    assert "interpreted as the glob-like pattern" in response["warning"]
+    assert "target='files'" in response["warning"]
+
+
+def test_noncapturing_wrapper_around_glob_is_recovered(monkeypatch):
+    response, seen = _drive_search(monkeypatch, "(?:*detector*scheduler*)")
+
+    assert seen == [r".*detector.*scheduler.*"]
+    assert "error" not in response
+    assert "warning" in response
+
+
+def test_valid_regex_is_never_rewritten(monkeypatch):
+    response, seen = _drive_search(monkeypatch, r"detector.*scheduler")
+
+    assert seen == [r"detector.*scheduler"]
+    assert "error" not in response
+    assert "warning" not in response
+
+
+def test_invalid_non_glob_regex_keeps_error_and_adds_guidance(monkeypatch):
+    backend_error = SearchResult(
+        error="Search failed: rg: regex parse error: unclosed character class",
+        total_count=0,
+    )
+    response, seen = _drive_search(monkeypatch, "[", backend_error)
+
+    assert seen == ["["]
+    assert "Content search expects a regular expression" in response["error"]
+    assert "target='files'" in response["error"]
+    assert "warning" not in response
+
+
+def test_translation_rejects_regex_intent_and_plain_text():
+    assert file_tools._globish_content_pattern_to_regex(r"\d+") is None
+    assert file_tools._globish_content_pattern_to_regex("foo[bar]") is None
+    assert file_tools._globish_content_pattern_to_regex("plain text") is None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import posixpath
+import re
 import sys
 import threading
 from pathlib import Path, PurePosixPath
@@ -1846,6 +1847,57 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         return tool_error(str(e))
 
 
+_GLOBISH_CONTENT_REGEX_META_RE = re.compile(r"[\[\]{}()|+^$\\\r\n]")
+_REGEX_SYNTAX_ERROR_MARKERS = (
+    "regex parse error",
+    "invalid regular expression",
+    "repetition operator missing expression",
+    "unclosed character class",
+    "nothing to repeat",
+)
+
+
+def _globish_content_pattern_to_regex(pattern: str) -> str | None:
+    """Translate a clearly glob-shaped invalid content pattern once.
+
+    Content search accepts regular expressions, but smaller/local models
+    sometimes pass filename-glob syntax such as ``*foo*bar*``. Only
+    translate after Python's regex parser rejects the original pattern,
+    and only when the remaining text contains glob wildcards without any
+    other regex-only metacharacters. Valid regex semantics stay unchanged.
+    """
+    candidate = pattern.strip()
+    if candidate.startswith("(?:") and candidate.endswith(")"):
+        candidate = candidate[3:-1]
+    if not candidate or not any(char in candidate for char in "*?"):
+        return None
+    if _GLOBISH_CONTENT_REGEX_META_RE.search(candidate):
+        return None
+    return re.escape(candidate).replace(r"\*", ".*").replace(r"\?", ".")
+
+
+def _normalize_content_search_pattern(pattern: str) -> tuple[str, str | None]:
+    """Return a valid content regex plus an optional recovery warning."""
+    try:
+        re.compile(pattern)
+    except re.error:
+        translated = _globish_content_pattern_to_regex(pattern)
+        if translated is not None:
+            return translated, (
+                "The supplied content-search pattern was not a valid regular "
+                f"expression and was interpreted as the glob-like pattern {pattern!r} "
+                f"(translated regex: {translated!r}). Use target='files' when "
+                "matching file names with globs."
+            )
+    return pattern, None
+
+
+def _looks_like_regex_syntax_error(error: object) -> bool:
+    """Return True when a search failure is specifically regex syntax."""
+    lowered = str(error or "").lower()
+    return any(marker in lowered for marker in _REGEX_SYNTAX_ERROR_MARKERS)
+
+
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
@@ -1853,6 +1905,11 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
     """Search for content or files."""
     try:
         offset, limit = normalize_search_pagination(offset, limit)
+
+        normalized_pattern = pattern
+        pattern_warning = None
+        if target == "content":
+            normalized_pattern, pattern_warning = _normalize_content_search_pattern(pattern)
 
         # Track searches to detect *consecutive* repeated search loops.
         # Include pagination args so users can page through truncated
@@ -1898,7 +1955,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
 
         file_ops = _get_file_ops(task_id)
         result = file_ops.search(
-            pattern=pattern, path=path, target=target, file_glob=file_glob,
+            pattern=normalized_pattern, path=path, target=target, file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
         omitted = _filter_read_blocked_search_results(result, task_id)
@@ -1907,6 +1964,21 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 if hasattr(m, 'content') and m.content:
                     m.content = redact_sensitive_text(m.content, file_read=True)
         result_dict = result.to_dict(densify=True)
+
+        if pattern_warning and not result_dict.get("error"):
+            existing_warning = result_dict.get("warning")
+            result_dict["warning"] = (
+                f"{pattern_warning} {existing_warning}"
+                if existing_warning
+                else pattern_warning
+            )
+        elif target == "content" and result_dict.get("error") and _looks_like_regex_syntax_error(
+            result_dict["error"]
+        ):
+            result_dict["error"] = (
+                f"{result_dict['error']} Content search expects a regular expression. "
+                "Use target='files' when matching file names with globs."
+            )
 
         if omitted:
             result_dict["_omitted"] = (


### PR DESCRIPTION
## Summary

Fixes #66129.

`search_files(target="content")` expects a regular expression, but local/smaller models sometimes supply filename-glob syntax such as `*detector*scheduler*` or `(?:*detector*scheduler*)`. Ripgrep rejects those patterns, and the model can burn several turns repeating the same failed call.

This change adds a deliberately narrow recovery path at the tool-facing boundary:

- first preserve every pattern that compiles as a regular expression;
- for an invalid pattern that is clearly glob-shaped, translate literals plus `*`/`?` once and execute the resulting regex;
- include an explicit warning describing the interpretation and directing filename matching to `target="files"`;
- leave ambiguous/regex-intended malformed patterns untouched, while appending actionable regex-vs-glob guidance to the backend error.

Hermes already blocks a fourth identical consecutive search in `file_tools.py`; this fix works with that existing circuit breaker rather than adding a second competing tracker.

## Validation

- `tests/tools/test_search_glob_pattern_recovery.py` — passed
  - bare glob recovery
  - non-capturing-wrapper recovery
  - valid-regex preservation
  - ambiguous invalid-regex guidance
  - conservative translation boundaries
- `tests/tools/test_read_loop_detection.py` — passed, including the existing repeated-search warning/block contract
- `python -m py_compile tools/file_tools.py` — passed
- `ruff check tools/file_tools.py tests/tools/test_search_glob_pattern_recovery.py` — passed
- `git diff --check` — passed

## Risk

Low and fail-conservative. Valid regexes are byte-for-byte unchanged. Translation only happens after local regex compilation fails and only when the remaining syntax is glob-like without other regex-only metacharacters.