### PR TITLE
fix(terminal): reject unquoted backslash Windows paths before Git Bash mangles them

### DIFF
--- a/tests/tools/test_terminal_windows_path_lint.py
+++ b/tests/tools/test_terminal_windows_path_lint.py
@@ -1,0 +1,127 @@
+"""Tests for the Windows Git Bash unquoted-backslash-path lint.
+
+On Windows the local terminal backend runs commands through Git Bash,
+which strips single backslashes from unquoted words — ``C:\\Users\\x``
+reaches the command as ``C:Usersx``. The lint rejects such commands
+loudly before execution instead of letting the path mangle silently
+(this broke stored cron-job prompts for days before being noticed).
+"""
+
+import json
+import platform
+
+import pytest
+
+from tools.terminal_tool import (
+    _find_unquoted_backslash_win_path,
+    cleanup_all_environments,
+    terminal_tool,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the detector (platform-independent)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("command,expected", [
+    # The original bug: unquoted backslash path in a python invocation.
+    (
+        r"python C:\Users\Paul\.hermes\scripts\x.py",
+        r"C:\Users\Paul\.hermes\scripts\x.py",
+    ),
+    # Bare drive-letter path as the command itself.
+    (r"C:\tools\run.exe --flag", r"C:\tools\run.exe"),
+    # After a shell operator.
+    (r"cd /tmp && cat C:\logs\out.txt", r"C:\logs\out.txt"),
+    # First path quoted, second unquoted — the unquoted one is flagged.
+    (r"cp 'C:\a\b' C:\c\d", r"C:\c\d"),
+])
+def test_flags_unquoted_backslash_paths(command, expected):
+    assert _find_unquoted_backslash_win_path(command) == expected
+
+
+@pytest.mark.parametrize("command", [
+    # Forward slashes — the recommended form.
+    "python C:/Users/Paul/.hermes/scripts/x.py",
+    # Single-quoted — bash preserves the backslashes literally.
+    r"python 'C:\Users\Paul\x.py'",
+    # Double-quoted — bash keeps backslashes before ordinary characters.
+    r'python "C:\Users\Paul\x.py"',
+    # Doubled backslashes — bash collapses them back to single ones.
+    r"python C:\\Users\\Paul\\x.py",
+    # Inside a here-doc body backslashes before ordinary chars survive.
+    "cat <<EOF\n" + r"path is C:\Users\Paul" + "\nEOF",
+    # No Windows path at all.
+    "ls -la /tmp && echo done",
+    # Drive-letter-like text without a backslash (URL-ish, scp-ish).
+    "scp host:/tmp/f . && echo C:/ok",
+])
+def test_passes_safe_commands(command):
+    assert _find_unquoted_backslash_win_path(command) is None
+
+
+def test_unterminated_single_quote_does_not_crash():
+    assert _find_unquoted_backslash_win_path(r"echo 'C:\Users\Paul") is None
+
+
+# ---------------------------------------------------------------------------
+# terminal_tool gate (platform monkeypatched so it runs everywhere)
+# ---------------------------------------------------------------------------
+
+def test_terminal_tool_rejects_backslash_path_loudly(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.delenv("HERMES_TERMINAL_SKIP_WIN_PATH_LINT", raising=False)
+    monkeypatch.setattr(
+        "tools.terminal_tool.platform.system", lambda: "Windows"
+    )
+
+    result = json.loads(
+        terminal_tool(r"python C:\Users\Paul\.hermes\scripts\x.py")
+    )
+
+    assert result["exit_code"] == -1
+    assert result["status"] == "error"
+    assert "Git Bash" in result["error"]
+    assert r"C:\Users\Paul\.hermes\scripts\x.py" in result["error"]
+    # The error must teach the fix, not just reject.
+    assert "forward slashes" in result["error"]
+
+
+def test_terminal_tool_lint_skipped_on_non_windows(monkeypatch):
+    """The lint is Windows-only: on POSIX hosts backslash commands are
+    legitimate shell escapes and must not be intercepted."""
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setattr(
+        "tools.terminal_tool.platform.system", lambda: "Linux"
+    )
+    monkeypatch.setattr(
+        "tools.terminal_tool._find_unquoted_backslash_win_path",
+        lambda _c: pytest.fail("lint must not run on non-Windows hosts"),
+    )
+    # Force the command down an early error path *after* the lint gate so
+    # no real environment is created: foreground timeout above the cap.
+    result = json.loads(terminal_tool(r"echo C:\x", timeout=100000))
+    assert "exceeds the maximum" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Real execution on a Windows host (integration; skipped elsewhere)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows-only")
+def test_windows_real_run_backslash_errors_and_forward_slash_works(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.delenv("HERMES_TERMINAL_SKIP_WIN_PATH_LINT", raising=False)
+
+    # Backslash path: rejected loudly before any bash process runs.
+    rejected = json.loads(terminal_tool(r"echo C:\Users\nobody\x.txt"))
+    assert rejected["status"] == "error"
+    assert "Git Bash" in rejected["error"]
+
+    # Forward-slash form of the same command: executes and survives intact.
+    try:
+        ran = json.loads(terminal_tool("echo C:/Users/nobody/x.txt"))
+        assert ran.get("exit_code") == 0
+        assert "C:/Users/nobody/x.txt" in ran.get("output", "")
+    finally:
+        cleanup_all_environments()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -315,6 +315,59 @@ def _validate_workdir(workdir: str) -> str | None:
     return None
 
 
+# Matches a drive-letter path token starting at a known position, for the
+# error message shown when the Windows path lint fires.
+_WIN_PATH_TOKEN_RE = re.compile(r'[A-Za-z]:\\[^\s;|&<>()\'"`]*')
+
+
+def _find_unquoted_backslash_win_path(command: str) -> str | None:
+    """Return the first drive-letter path whose backslashes bash would eat.
+
+    On Windows the local backend runs commands through Git Bash, which
+    strips single backslashes from unquoted words — ``C:\\Users\\x``
+    reaches the command as ``C:Usersx``, so it fails with a mangled path
+    (or worse, silently operates on the wrong one). Paths inside single
+    quotes, inside double quotes, or written with doubled backslashes all
+    survive intact, so only unquoted single-backslash paths are flagged.
+
+    Scanning stops at the first here-doc operator: unquoted here-doc
+    bodies keep backslashes before ordinary characters, so paths there
+    are safe and would be false positives.
+    """
+    heredoc = command.find("<<")
+    if heredoc != -1:
+        command = command[:heredoc]
+    i, n = 0, len(command)
+    while i < n:
+        ch = command[i]
+        if ch == "'":
+            end = command.find("'", i + 1)
+            if end == -1:
+                break
+            i = end + 1
+            continue
+        if ch == '"':
+            i += 1
+            while i < n:
+                if command[i] == "\\":
+                    i += 2
+                    continue
+                if command[i] == '"':
+                    i += 1
+                    break
+                i += 1
+            continue
+        if ch == "\\":
+            i += 2
+            continue
+        if ch.isalpha() and command[i + 1:i + 3] == ":\\" and command[i + 3:i + 4] != "\\":
+            m = _WIN_PATH_TOKEN_RE.match(command, i)
+            if m:
+                return m.group(0)
+        i += 1
+    return None
+
+
 def _handle_sudo_failure(output: str, env_type: str) -> str:
     """
     Check for sudo failure and add helpful message for messaging contexts.
@@ -977,6 +1030,17 @@ PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REP
 
 Do NOT use vim/nano/interactive tools without pty=true — they hang without a pseudo-terminal. Pipe git output to cat if it might page.
 """
+
+# On a Windows host the local backend drives Git Bash, and unquoted
+# backslash paths get mangled by bash word-splitting (C:\Users\x ->
+# C:Usersx). Tell the model up front; a pre-execution lint in
+# terminal_tool() rejects such commands loudly as the backstop.
+if platform.system() == "Windows" and os.getenv("TERMINAL_ENV", "local").strip().lower() in ("", "local"):
+    TERMINAL_TOOL_DESCRIPTION += (
+        "\nWindows host: commands run in Git Bash. Write Windows paths with forward "
+        "slashes (C:/Users/x) or single-quote them ('C:\\Users\\x') — unquoted "
+        "backslash paths get mangled by bash and are rejected before execution.\n"
+    )
 
 # Global state for environment lifecycle management
 _active_environments: Dict[str, Any] = {}
@@ -2226,6 +2290,32 @@ def terminal_tool(
                     "output": "",
                     "exit_code": -1,
                     "error": guidance,
+                    "status": "error",
+                }, ensure_ascii=False)
+
+        # Windows + local backend: Git Bash strips single backslashes from
+        # unquoted words, silently mangling drive-letter paths
+        # (C:\Users\x -> C:Usersx). Fail loudly with a fix instead of
+        # executing a corrupted command. Quoted or doubled-backslash paths
+        # pass through untouched (see _find_unquoted_backslash_win_path).
+        if (
+            env_type == "local"
+            and platform.system() == "Windows"
+            and not env_var_enabled("HERMES_TERMINAL_SKIP_WIN_PATH_LINT")
+        ):
+            bad_path = _find_unquoted_backslash_win_path(command)
+            if bad_path:
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": (
+                        f"Unquoted Windows path detected: {bad_path} — this shell is "
+                        "Git Bash, which strips single backslashes from unquoted text, "
+                        "so the command would run with a mangled path "
+                        "(C:\\Users\\x becomes C:Usersx). Rewrite the path with forward "
+                        "slashes (C:/Users/x) or wrap it in single quotes "
+                        "('C:\\Users\\x'), then retry."
+                    ),
                     "status": "error",
                 }, ensure_ascii=False)
 


### PR DESCRIPTION
## Problem

On Windows the local terminal backend runs commands through Git Bash, which strips single backslashes from unquoted words: `python C:\Users\Paul\scripts\x.py` reaches the command as `python C:UsersPaulscriptsx.py`. The command fails with a mangled path — or worse, silently operates on the wrong one. In our deployment this silently broke stored cron-job prompts for days before anyone noticed, because the failure mode (mangled path, exit 1) looks like a missing file rather than a shell-quoting issue.

Verified against real Git Bash: only **unquoted single-backslash** paths are mangled. Single-quoted, double-quoted, and doubled-backslash forms all survive intact.

## Fix (two layers)

1. **Pre-execution lint** (`_find_unquoted_backslash_win_path`, local backend on Windows only): a quote-aware scan that detects drive-letter paths with unquoted single backslashes and returns a loud, actionable error naming the offending path and the fix (forward slashes or single quotes), instead of executing a corrupted command. The safe forms bash preserves — single-quoted, double-quoted, doubled-backslash, here-doc bodies — pass through untouched. Runs before environment creation, so rejected commands never spawn a bash process. Escape hatch: `HERMES_TERMINAL_SKIP_WIN_PATH_LINT=1`.

2. **Model-facing prevention**: a Windows-only note appended to the terminal tool description telling the model the shell is Git Bash and Windows paths need forward slashes or single quotes, so it writes safe paths in the first place.

## Tests

`tests/tools/test_terminal_windows_path_lint.py` — 15 tests:
- detector unit tests (flags the bug cases, passes all bash-safe quoting forms, here-docs, unterminated quotes)
- `terminal_tool()` gate test (platform monkeypatched, runs on any CI OS): backslash command → loud error teaching the fix
- non-Windows guard: the lint never runs on POSIX hosts, where backslash escapes are legitimate
- Windows-only integration test: real backslash command rejected before any bash spawns; the forward-slash form of the same command executes successfully

All 15 pass on a Windows 11 host; the wider terminal/local-env test selection shows no regressions vs a clean checkout of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)