### PR TITLE
fix(credential-pool): stop cross-profile env leak in multiplex mode (#65940)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2169,7 +2169,6 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
     def _get_env_prefer_dotenv(key: str) -> str:
         env_file = load_env()
         raw = env_file.get(key, "").strip()
-        env_val = os.environ.get(key, "").strip()
         # If .env contains an unresolved op:// reference, prefer the
         # already-resolved value from os.environ (set by
         # load_hermes_dotenv() -> apply_onepassword_secrets()).  The raw
@@ -2177,11 +2176,16 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         # provider auth attempt would receive a URL instead of a key.  This
         # happens during a partial migration, or when the user wrote op://
         # references straight into .env rather than the secrets.onepassword
-        # config block.  For every non-op:// value the original
-        # .env-takes-precedence behaviour is preserved unchanged.
-        if raw.startswith("op://") and env_val:
-            return env_val
-        return raw or _get_secret(key, "") or env_val
+        # config block.
+        if raw.startswith("op://"):
+            env_val = os.environ.get(key, "").strip()
+            if env_val:
+                return env_val
+        # _get_secret is profile-scope-aware: in multiplex mode it reads the
+        # active profile's secret scope (not os.environ); when multiplex is
+        # off it falls back to os.environ — so this single call preserves the
+        # legacy behaviour without cross-profile leakage (issue #65940).
+        return raw or _get_secret(key, "")
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an
     # env-seeded credential marks the env:<VAR> source as suppressed so it

--- a/tests/tools/test_credential_pool_cross_profile_leak.py
+++ b/tests/tools/test_credential_pool_cross_profile_leak.py
@@ -1,0 +1,114 @@
+"""Tests for credential-pool cross-profile env leakage (#65940).
+
+In multiplex mode, ``_seed_from_env`` must NOT fall through to
+``os.environ.get()`` when the active profile's scope has no matching
+key — that would leak another profile's credential into the pool.
+
+Fixtures and helpers are duplicated inline (no dependency on the base
+``isolated_hermes_home`` fixture from conftest) to keep this test
+self-contained and easy to reason about.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+import pytest
+
+from agent.credential_pool import PooledCredential, _seed_from_env
+from agent.secret_scope import (
+    get_secret,
+    set_multiplex_active,
+    set_secret_scope,
+)
+
+
+def _empty_pool() -> list[PooledCredential]:
+    return []
+
+
+class TestCredentialPoolCrossProfile:
+    """Regression tests for #65940."""
+
+    def test_single_profile_fallthrough_to_os_environ(self, monkeypatch):
+        """When multiplex is OFF (default), an env var set in os.environ IS
+        picked up — single-profile behaviour is unchanged."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-single-profile-key")
+        entries = _empty_pool()
+        changed, _sources = _seed_from_env("openrouter", entries)
+        assert changed is True, "should seed from os.environ when multiplex off"
+        assert any(
+            e.access_token == "sk-single-profile-key" for e in entries
+        ), "single-profile fallthrough broken"
+
+    def test_multiplex_active_no_scope_raises(self):
+        """When multiplex is ACTIVE but no secret scope is installed,
+        ``get_secret`` raises ``UnscopedSecretError`` — fail-closed."""
+        set_multiplex_active(True)
+        try:
+            with pytest.raises(RuntimeError, match="no profile secret scope"):
+                get_secret("OPENROUTER_API_KEY")
+        finally:
+            set_multiplex_active(False)
+
+    def test_cross_profile_leak_not_reproduced(self, monkeypatch):
+        """When multiplex is ACTIVE and profile B's scope (no OPENROUTER key)
+        is installed, _seed_from_env must NOT see profile A's key in
+        os.environ."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-leaked-from-A")
+        set_multiplex_active(True)
+        token = set_secret_scope({"ANTHROPIC_API_KEY": "profile-B-key"})
+        try:
+            entries = _empty_pool()
+            changed, _sources = _seed_from_env("openrouter", entries)
+            # Expected: profile B has no OPENROUTER key, so nothing seeds
+            assert changed is False, "should NOT seed cross-profile leaked key"
+            assert not any(
+                e.access_token == "sk-leaked-from-A" for e in entries
+            ), "profile A's key leaked into profile B's pool"
+        finally:
+            set_secret_scope(None)
+            set_multiplex_active(False)
+
+    def test_dotenv_still_wins_in_single_profile(self, monkeypatch, tmp_path):
+        """When multiplex is off, ~/.hermes/.env takes priority over
+        os.environ — the old contract is preserved."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-from-os-environ")
+        # Point at a tmp .env
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        dotenv = hermes_home / ".env"
+        dotenv.write_text("OPENROUTER_API_KEY=sk-from-dotenv\n")
+        monkeypatch.setattr("hermes_cli.config.get_env_path", lambda: dotenv)
+        # Force reload
+        from hermes_cli.config import _env_cache
+        _env_cache = None  # type: ignore[attr-defined]
+
+        entries = _empty_pool()
+        changed, _sources = _seed_from_env("openrouter", entries)
+        assert changed is True
+        # The .env value should win
+        seeded = [e for e in entries if e.access_token == "sk-from-dotenv"]
+        assert len(seeded) == 1, ".env value should be seeded, not os.environ"
+
+    def test_multiplex_scope_takes_priority(self, monkeypatch):
+        """When multiplex is ACTIVE and scope IS installed, the scope's
+        value seeds the pool — not os.environ."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-leaked")
+        set_multiplex_active(True)
+        token = set_secret_scope({"OPENROUTER_API_KEY": "sk-from-scope"})
+        try:
+            entries = _empty_pool()
+            changed, _sources = _seed_from_env("openrouter", entries)
+            assert changed is True
+            # Must seed from scope, not os.environ
+            assert any(
+                e.access_token == "sk-from-scope" for e in entries
+            ), "scope value should seed the pool"
+            assert not any(
+                e.access_token == "sk-leaked" for e in entries
+            ), "os.environ leaked despite scope being installed"
+        finally:
+            set_secret_scope(None)
+            set_multiplex_active(False)


### PR DESCRIPTION
## Problem

In multiplex mode, credential pool seeding can fall back to a process-wide environment variable when the active profile has no key. That value may belong to another profile.

## Root cause

`_seed_from_env` → `_get_env_prefer_dotenv` fell through to `os.environ.get(key, '')` when the active profile's `.env` had no entry. In a multiplexed gateway process, `os.environ` may hold another profile's key (set by that profile's startup), so the missing key silently became —present—, leaking profile A's credential into profile B's pool.

`_get_secret` (`agent.secret_scope.get_secret`) already implements profile-aware secret scope resolution, but the fallthrough `or env_val` sidestepped it entirely.

## Fix

Drop the unconditional `os.environ` read from `_get_env_prefer_dotenv`; route through `_get_secret` alone, which handles both single-profile (os.environ fallback) and multiplex (scope-aware) modes correctly.

The `op://` 1Password resolution path is preserved — a resolved value legitimately sits in os.environ regardless of profile.

## Tests

`tests/tools/test_credential_pool_cross_profile_leak.py` (5 tests):
- Single-profile fallthrough to os.environ (unchanged contract)
- Multiplex ACTIVE + no scope → `UnscopedSecretError` (fail-closed)
- Cross-profile `os.environ` value does NOT leak when scope lacks the key
- `.env` still wins over `os.environ` in single-profile mode
- Scope value wins over `os.environ` leak in multiplex mode

191/191 existing credential-pool tests pass.