### PR TITLE
test(cli): add command-registry dispatch coverage gate

### DIFF
--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -164,24 +164,50 @@ class TestDerivedDicts:
             assert isinstance(desc, str) and len(desc) > 0, f"{cmd} has empty description"
 
     def test_every_cli_command_has_dispatch_handler(self):
-        """Every non-gateway_only CommandDef must have a handler branch in
+        """Every non-gateway_only CommandDef must reach a handler in
         process_command().  When this fails, a command is showing up in help
         and autocomplete but returning "Unknown command" at runtime.
 
         See #22960, #27603, #50618 for prior instances of this bug class.
-        """
-        import inspect
-        import re
 
+        Each command is dispatched for real against a ``MagicMock(spec=HermesCLI)``
+        bound as ``self``, so the actual alias resolution and dispatch chain in
+        process_command() execute while the handler bodies collapse to mock
+        no-ops.  The unbound-with-mock-self form is deliberate here and differs
+        from the ``HermesCLI.__new__`` helper used elsewhere (see
+        tests/cli/test_cli_prefix_matching.py): a real instance runs the handler
+        bodies, and sweeping all ~74 commands would block on the ``Choice
+        [1/2/3]:`` stdin prompts in /undo and /update and hit the network in
+        /voice.  Single-command behavior tests should still use a real instance.
+
+        A handler that raises is still a handler — the assertion is on the
+        observable "Unknown command" fallback (cli.py:9064,9074), which is the
+        exact symptom users report.  The fallback's prefix-matching path is made
+        deterministic by emptying the skill/plugin/quick-command sources, so it
+        cannot raise before reaching that print.
+        """
+        from unittest.mock import MagicMock, patch
+
+        import cli as cli_mod
         from cli import HermesCLI
 
-        src = inspect.getsource(HermesCLI.process_command)
-        # Canonical forms:  elif canonical == "foo":  /  if canonical in {"foo", "bar"}:
-        dispatched = set(re.findall(r'canonical\s*(?:==|in\s+\{)\s*"([^"]+)"', src))
-        dispatched.update(re.findall(r"canonical\s*(?:==|in\s+\{)\s*'([^']+)'", src))
-
         registry_cli = {cmd.name for cmd in COMMAND_REGISTRY if not cmd.gateway_only}
-        missing = registry_cli - dispatched
+        missing = set()
+
+        for name in sorted(registry_cli):
+            fake = MagicMock(spec=HermesCLI)
+            fake.config = {}  # no quick_commands shadowing the registry
+            with patch("cli._cprint") as mock_cprint, \
+                    patch.object(cli_mod, "_ensure_skill_commands", return_value={}), \
+                    patch.object(cli_mod, "get_skill_bundles", return_value={}), \
+                    patch.object(cli_mod, "_get_plugin_cmd_handler_names", return_value=set()):
+                try:
+                    HermesCLI.process_command(fake, f"/{name}")
+                except Exception:
+                    continue  # reached a handler; it just cannot run on a mock
+                printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+            if "Unknown command" in printed:
+                missing.add(name)
 
         assert not missing, (
             f"commands in COMMAND_REGISTRY with no dispatch handler: {sorted(missing)}. "

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -163,6 +163,32 @@ class TestDerivedDicts:
         for cmd, desc in COMMANDS.items():
             assert isinstance(desc, str) and len(desc) > 0, f"{cmd} has empty description"
 
+    def test_every_cli_command_has_dispatch_handler(self):
+        """Every non-gateway_only CommandDef must have a handler branch in
+        process_command().  When this fails, a command is showing up in help
+        and autocomplete but returning "Unknown command" at runtime.
+
+        See #22960, #27603, #50618 for prior instances of this bug class.
+        """
+        import inspect
+        import re
+
+        from cli import HermesCLI
+
+        src = inspect.getsource(HermesCLI.process_command)
+        # Canonical forms:  elif canonical == "foo":  /  if canonical in {"foo", "bar"}:
+        dispatched = set(re.findall(r'canonical\s*(?:==|in\s+\{)\s*"([^"]+)"', src))
+        dispatched.update(re.findall(r"canonical\s*(?:==|in\s+\{)\s*'([^']+)'", src))
+
+        registry_cli = {cmd.name for cmd in COMMAND_REGISTRY if not cmd.gateway_only}
+        missing = registry_cli - dispatched
+
+        assert not missing, (
+            f"commands in COMMAND_REGISTRY with no dispatch handler: {sorted(missing)}. "
+            "Add an `elif canonical == \"<name>\":` branch to HermesCLI.process_command() "
+            "in cli.py, or mark the command gateway_only=True if it is not meant for CLI."
+        )
+
 
 # ---------------------------------------------------------------------------
 # Gateway helpers


### PR DESCRIPTION
## Summary

Adds `test_every_cli_command_has_dispatch_handler`, an enumeration gate that prevents the recurring bug class where commands are added to `COMMAND_REGISTRY` but never wired into `HermesCLI.process_command()`.

## The Bug Class

`COMMAND_REGISTRY` (source of truth for what commands *exist*) and the `elif` chain in `process_command()` (source of truth for what commands *work*) are maintained independently with no automated reconciliation. When they drift, the command breaks silently — appearing in `/help`, autocomplete, and all derived surfaces (Telegram/Slack) as functional, but returning "Unknown command" at runtime.

This has occurred at least five times:

| Command | First reported | Status |
|---|---|---|
| `/model` | #3821 (~3mo) | Fixed |
| `/resume` | #2591 (~2mo) | Fixed |
| `/sessions` | #22960 (~2mo) | Fixed May 2026 |
| `/indicator` | #22960 (~2mo) | Open (5 competing PRs) |
| `/whoami` | #35892 (~1mo) | Open |

The documented cost of not having this gate is not only recurrences of this bug class, but ballooning PRs from users converging on the same bug from everyday use. #51009 by @GitWhoIsThis (24d ago) is a superset issue that enumerated the full set of missing handlers. It remains open.

## This PR

A single test in `TestDerivedDicts` that uses `inspect.getsource` to extract every dispatched canonical name from `process_command()` and asserts coverage over every `gateway_only=False` entry in `COMMAND_REGISTRY`. The test currently fails honestly, and that's the point.

Currently FAILS on main: `['indicator', 'whoami']`. This PR is blocked until those handlers are merged (see #41869 / #40047 / #51178 and #35996). Once they land, the gate self-resolves and any future handler-less `CommandDef` fails CI immediately.

## Prior Art in This Codebase

The enumeration-gate pattern is well-established here:
- `test_commands_dict_includes_all_cli_commands` — asserts `COMMAND_REGISTRY` ⊆ `COMMANDS`
- `test_commands_by_category_covers_all_categories` — asserts category completeness
- `tests/providers/test_provider_profiles.py` — asserts provider registry invariants
- `tests/hermes_cli/test_auth_commands.py` — asserts auth-step registry invariants

All follow `for <item> in <REGISTRY>: assert <invariant>`. This PR extends that pattern to the dispatch gap.

## Test Plan

```bash
$ scripts/run_tests.sh tests/hermes_cli/test_commands.py -q
# (...snip...)
E       AssertionError: commands in COMMAND_REGISTRY with no dispatch handler: ['indicator', 'whoami']. Add an `elif canonical == "<name>":` branch to HermesCLI.process_command() in cli.py, or mark the command gateway_only=True if it is not meant for CLI.
E       assert not {'indicator', 'whoami'}

tests/hermes_cli/test_commands.py:186: AssertionError
=========================== short test summary info ============================
FAILED tests/hermes_cli/test_commands.py::TestDerivedDicts::test_every_cli_command_has_dispatch_handler
1 failed, 173 passed in 3.05s

=== 1 file with test failures (1 test failed) ===
  tests/hermes_cli/test_commands.py  (1 test failed)
```