### PR TITLE
fix(kanban): preserve inherited project bindings

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2408,6 +2408,7 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    _trusted_project_id: bool = False,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2462,7 +2463,7 @@ def create_task(
     project_repo: Optional[str] = None
     if project_id is not None:
         project_id = str(project_id).strip() or None
-    if project_id:
+    if project_id and not _trusted_project_id:
         try:
             from hermes_cli import projects_db as _pdb
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1036,6 +1036,46 @@ def test_create_inherits_worker_dir_workspace(monkeypatch, worker_env):
         conn.close()
 
 
+def test_create_inherits_worker_project_and_branch_without_local_registry(monkeypatch, worker_env):
+    """An inherited opaque project id is already trusted by the parent task.
+
+    Worker profiles do not own the operator profile's per-profile projects.db,
+    so resolving the id again would silently drop a valid shared binding.
+    """
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        self_tid = kb.create_task(
+            conn,
+            title="project worker",
+            assignee="test-worker",
+            workspace_kind="worktree",
+            workspace_path="/home/teknium/proj/.worktrees/delivery",
+            branch_name="delivery/spec-42",
+            project_id="p_existing",
+            _trusted_project_id=True,
+        )
+        kb.claim_task(conn, self_tid)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", self_tid)
+
+    d = json.loads(kt._handle_create({"title": "follow-up", "assignee": "peer"}))
+    assert d["ok"] is True
+    conn = kb.connect()
+    try:
+        child = kb.get_task(conn, d["task_id"])
+        assert child is not None
+        assert child.workspace_kind == "worktree"
+        assert child.workspace_path == "/home/teknium/proj/.worktrees/delivery"
+        assert child.branch_name == "delivery/spec-42"
+        assert child.project_id == "p_existing"
+    finally:
+        conn.close()
+
+
 def test_create_explicit_workspace_beats_inheritance(monkeypatch, worker_env):
     """An explicit workspace arg overrides worker-task inheritance."""
     from tools import kanban_tools as kt

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1090,6 +1090,8 @@ def _handle_create(args: dict, **kw) -> str:
     workspace_kind = args.get("workspace_kind")
     workspace_path = args.get("workspace_path")
     project_id = args.get("project") or args.get("project_id")
+    branch_name = None
+    trusted_project_id = False
     _inherit_workspace = workspace_kind is None and workspace_path is None
     if workspace_kind is None:
         workspace_kind = "scratch"
@@ -1130,10 +1132,15 @@ def _handle_create(args: dict, **kw) -> str:
                     if _self_task is not None and _self_task.workspace_kind:
                         workspace_kind = _self_task.workspace_kind
                         workspace_path = _self_task.workspace_path
+                        branch_name = _self_task.branch_name
                         # Keep follow-up children inside the same project so the
                         # whole subtree shares one repo + branch convention.
                         if project_id is None and _self_task.project_id:
                             project_id = _self_task.project_id
+                            # The parent task is the authority for this opaque
+                            # binding. Worker profiles intentionally do not own
+                            # the operator profile's per-profile projects.db.
+                            trusted_project_id = True
             new_tid = kb.create_task(
                 conn,
                 title=str(title).strip(),
@@ -1144,7 +1151,9 @@ def _handle_create(args: dict, **kw) -> str:
                 priority=int(priority) if priority is not None else 0,
                 workspace_kind=str(workspace_kind),
                 workspace_path=workspace_path,
+                branch_name=branch_name,
                 project_id=project_id,
+                _trusted_project_id=trusted_project_id,
                 triage=triage,
                 idempotency_key=idempotency_key,
                 max_runtime_seconds=(


### PR DESCRIPTION
## Summary

- preserve an existing task-scoped `project_id` when `kanban_create` inherits a worker workspace
- inherit the parent worktree branch alongside its workspace path
- keep explicit project ids on the existing per-profile registry validation path

Worker profiles intentionally do not own the operator profile’s per-profile `projects.db`. Re-resolving an already validated parent binding therefore dropped `project_id` from child tasks, even though their workspace was inherited.

## Verification

- `pytest tests/tools/test_kanban_tools.py -q` — 114 passed
- regression covers a project-linked worktree parent without a local project registry