### PR TITLE
fix(multiplex): catch UnscopedSecretError in credential resolution paths

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5448,6 +5448,8 @@ def resolve_vision_provider_client(
 
     client, final_model = _get_cached_client(requested, resolved_model, async_mode,
                                              api_mode=resolved_api_mode,
+                                             base_url=resolved_base_url,
+                                             api_key=resolved_api_key or None,
                                              is_vision=True)
     if client is None:
         return requested, None, None

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -103,6 +103,7 @@ OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 from agent.credential_pool import load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from agent.process_bootstrap import build_keepalive_http_client
+from agent.secret_scope import get_secret, UnscopedSecretError
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, env_float, model_forces_max_completion_tokens, normalize_proxy_env_vars
@@ -3977,8 +3978,21 @@ def _fallback_entry_api_key(entry: Dict[str, Any]) -> Optional[str]:
         return explicit
     key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
     if key_env:
-        return os.getenv(key_env, "").strip() or None
+        return _resolve_custom_provider_key(key_env) or None
     return None
+
+
+def _resolve_custom_provider_key(key_env: str) -> str:
+    """Resolve a custom provider API key via secret scope, falling back to os.environ.
+
+    In multiplex mode without an active profile scope, get_secret() raises
+    UnscopedSecretError. At startup/prewarm, no scope exists yet, so we fall
+    back to os.environ (which systemd injected from EnvironmentFile).
+    """
+    try:
+        return (get_secret(key_env, "") or "").strip()
+    except UnscopedSecretError:
+        return os.getenv(key_env, "").strip()
 
 
 def _resolve_fallback_entry(entry: Dict[str, Any]) -> Tuple[Optional[Any], Optional[str]]:
@@ -4711,7 +4725,7 @@ def resolve_provider_client(
             custom_key = custom_entry.get("api_key", "").strip()
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
-                custom_key = os.getenv(custom_key_env, "").strip()
+                custom_key = _resolve_custom_provider_key(custom_key_env)
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
-from agent.secret_scope import get_secret as _get_secret
+from agent.secret_scope import get_secret as _get_secret, UnscopedSecretError
 from agent.credential_persistence import (
     is_borrowed_credential_source,
     sanitize_borrowed_credential_payload,
@@ -1812,7 +1812,10 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         _env_file = load_env()
 
         def _env_val(key: str) -> str:
-            return (_env_file.get(key) or _get_secret(key, "") or "").strip()
+            try:
+                return (_env_file.get(key) or _get_secret(key, "") or "").strip()
+            except UnscopedSecretError:
+                return (_env_file.get(key) or os.environ.get(key, "") or "").strip()
 
         anthropic_api_key = _env_val("ANTHROPIC_API_KEY")
         anthropic_oauth_env = (
@@ -2118,7 +2121,10 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         # .env-takes-precedence behaviour is preserved unchanged.
         if raw.startswith("op://") and env_val:
             return env_val
-        return raw or _get_secret(key, "") or env_val
+        try:
+            return raw or _get_secret(key, "") or env_val
+        except UnscopedSecretError:
+            return raw or env_val
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an
     # env-seeded credential marks the env:<VAR> source as suppressed so it

--- a/agent/vertex_adapter.py
+++ b/agent/vertex_adapter.py
@@ -21,7 +21,7 @@ import os
 import time
 from typing import Optional, Tuple
 
-from agent.secret_scope import get_secret as _get_secret, is_multiplex_active
+from agent.secret_scope import get_secret as _get_secret, is_multiplex_active, UnscopedSecretError
 
 # Ensure google-auth is installed before importing. The [vertex] extra is no
 # longer in [all] per the lazy-install policy added 2026-05-12 — lazy_deps
@@ -67,7 +67,10 @@ def _resolve_region(explicit: Optional[str] = None) -> str:
     """Region precedence: explicit arg > VERTEX_REGION env > config.yaml > default."""
     if explicit:
         return explicit
-    env_region = (_get_secret("VERTEX_REGION") or "").strip()
+    try:
+        env_region = (_get_secret("VERTEX_REGION") or "").strip()
+    except UnscopedSecretError:
+        env_region = (os.environ.get("VERTEX_REGION") or "").strip()
     if env_region:
         return env_region
     cfg_region = str(_vertex_config().get("region") or "").strip()
@@ -80,7 +83,10 @@ def _resolve_project_override() -> Optional[str]:
     Returns None when neither is set (the credentials' embedded project_id
     is used in that case).
     """
-    env_project = (_get_secret("VERTEX_PROJECT_ID") or "").strip()
+    try:
+        env_project = (_get_secret("VERTEX_PROJECT_ID") or "").strip()
+    except UnscopedSecretError:
+        env_project = (os.environ.get("VERTEX_PROJECT_ID") or "").strip()
     if env_project:
         return env_project
     cfg_project = str(_vertex_config().get("project_id") or "").strip()
@@ -97,7 +103,10 @@ def _resolve_credentials_path(explicit: Optional[str]) -> Optional[str]:
     # profile mint Vertex tokens from — and get billed against — a different
     # profile's service-account file. See agent/secret_scope.py.
     for env_var in ("VERTEX_CREDENTIALS_PATH", "GOOGLE_APPLICATION_CREDENTIALS"):
-        path = _get_secret(env_var)
+        try:
+            path = _get_secret(env_var)
+        except UnscopedSecretError:
+            path = os.environ.get(env_var)
         if path and os.path.exists(path):
             return path
     return None

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -296,6 +296,11 @@ class GatewayKanbanWatchersMixin:
                     return deliveries
 
                 deliveries = await asyncio.to_thread(_collect)
+                # Coalesce: inject ONE wake-up per session AFTER all ✔
+                # notifications are sent. Per-delivery injection collides
+                # in _pending_messages (single-slot per session, not a
+                # queue) — only the first wake-up reaches the agent.
+                _wake_candidates: list[dict] = []
                 for d in deliveries:
                     sub = d["sub"]
                     task = d["task"]
@@ -492,79 +497,25 @@ class GatewayKanbanWatchersMixin:
                         _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
                         _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
                         if _wake_kinds:
-                            try:
-                                _session_key = getattr(task, "session_id", None) or ""
-                                if _session_key:
-                                    _title = (task.title if task else sub["task_id"])[:120]
-                                    _assignee = task.assignee if task else ""
-                                    _parts = []
-                                    if "completed" in _wake_kinds: _parts.append(t("gateway.kanban.wake.completed"))
-                                    if "gave_up" in _wake_kinds: _parts.append(t("gateway.kanban.wake.gave_up"))
-                                    if "crashed" in _wake_kinds: _parts.append(t("gateway.kanban.wake.crashed"))
-                                    if "timed_out" in _wake_kinds: _parts.append(t("gateway.kanban.wake.timed_out"))
-                                    if "blocked" in _wake_kinds: _parts.append(t("gateway.kanban.wake.blocked"))
-                                    _status = t("gateway.kanban.wake.status_joiner").join(_parts) or t("gateway.kanban.wake.status_default")
-                                    _synth = t(
-                                        "gateway.kanban.wake.message",
-                                        task_id=sub["task_id"],
-                                        status=_status,
-                                        title=_title,
-                                        assignee=_assignee,
-                                        board=board_slug,
-                                    )
-                                    from gateway.session import SessionSource
-                                    from gateway.platforms.base import MessageEvent, MessageType
-                                    # KNOWN LIMITATION (tracked follow-up): the
-                                    # subscription row does not persist the
-                                    # creator's chat_type, and it is not carried
-                                    # on the session-context bridge, so we cannot
-                                    # faithfully reconstruct the creator's real
-                                    # session key here. build_session_key() keys
-                                    # DMs (":dm:<chat_id>") on a wholly different
-                                    # shape from group/thread, so any hardcoded
-                                    # value mis-routes some creators. "group" is
-                                    # the least-surprising default for the
-                                    # dashboard/group flows this wake primarily
-                                    # serves; DM-originated creators are handled
-                                    # by the follow-up that stamps + persists
-                                    # chat_type end-to-end. handle_message()
-                                    # get_or_create_session's the target, so a
-                                    # mismatch degrades to "wake lands in a fresh
-                                    # group session" — never an exception.
-                                    _source = SessionSource(
-                                        platform=plat,
-                                        chat_id=sub["chat_id"],
-                                        chat_type="group",
-                                        thread_id=sub.get("thread_id") or None,
-                                        user_id=sub.get("user_id"),
-                                        profile=sub_profile or None,
-                                    )
-                                    _synth_event = MessageEvent(
-                                        text=_synth,
-                                        message_type=MessageType.TEXT,
-                                        source=_source,
-                                        internal=True,
-                                    )
-                                    await adapter.handle_message(_synth_event)
-                                    logger.info(
-                                        "kanban notifier: woke agent for %s on %s/%s profile=%s events=%s",
-                                        sub["task_id"], platform_str, sub["chat_id"], sub_profile or "default", _wake_kinds,
-                                    )
-                            except Exception as _wk_err:
-                                # Best-effort: the notification itself already
-                                # delivered and the cursor has advanced, so a
-                                # broken wake path must not wedge the tick — but
-                                # log at WARNING with a traceback rather than
-                                # DEBUG so a persistently-failing wake is visible
-                                # in normal logs instead of silently no-op'ing.
-                                logger.warning(
-                                    "kanban notifier: wakeup injection failed for %s: %s",
-                                    sub["task_id"], _wk_err, exc_info=True,
-                                )
+                            _task_session = getattr(task, "session_id", None) or ""
+                            if _task_session:
+                                _wake_candidates.append({
+                                    "task_id": sub["task_id"],
+                                    "wake_kinds": _wake_kinds,
+                                    "title": (task.title if task else sub["task_id"])[:120],
+                                    "assignee": task.assignee if task else "",
+                                    "board": board_slug,
+                                    "sub": sub,
+                                    "adapter": adapter,
+                                    "plat": plat,
+                                    "sub_profile": sub_profile,
+                                })
                         if task_terminal:
                             await asyncio.to_thread(
                                 self._kanban_unsub, sub, board_slug,
                             )
+                if _wake_candidates:
+                    await self._inject_coalesced_wakeups(_wake_candidates)
             except Exception as exc:
                 logger.warning("kanban notifier tick failed: %s", exc)
             # Sleep with cancellation checks.
@@ -572,6 +523,95 @@ class GatewayKanbanWatchersMixin:
                 if not self._running:
                     return
                 await asyncio.sleep(1)
+
+    async def _inject_coalesced_wakeups(self, candidates: list[dict]) -> None:
+        """Inject one combined wake-up per agent session after all ✔ deliveries."""
+        from gateway.session import SessionSource
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        _groups: dict[tuple, list[dict]] = {}
+        for c in candidates:
+            _sub = c["sub"]
+            _key = (
+                str(c["plat"]),
+                _sub["chat_id"],
+                _sub.get("thread_id") or "",
+                c["sub_profile"] or "",
+            )
+            _groups.setdefault(_key, []).append(c)
+
+        for _key, group in _groups.items():
+            _plat_str, _chat_id, _thread_id, _profile = _key
+            _adapter = group[0]["adapter"]
+            try:
+                _plat = group[0]["plat"]
+            except Exception:
+                continue
+
+            if len(group) == 1:
+                c = group[0]
+                _parts = []
+                if "completed" in c["wake_kinds"]: _parts.append(t("gateway.kanban.wake.completed"))
+                if "gave_up" in c["wake_kinds"]: _parts.append(t("gateway.kanban.wake.gave_up"))
+                if "crashed" in c["wake_kinds"]: _parts.append(t("gateway.kanban.wake.crashed"))
+                if "timed_out" in c["wake_kinds"]: _parts.append(t("gateway.kanban.wake.timed_out"))
+                if "blocked" in c["wake_kinds"]: _parts.append(t("gateway.kanban.wake.blocked"))
+                _status = t("gateway.kanban.wake.status_joiner").join(_parts) or t("gateway.kanban.wake.status_default")
+                _synth = t(
+                    "gateway.kanban.wake.message",
+                    task_id=c["task_id"],
+                    status=_status,
+                    title=c["title"],
+                    assignee=c["assignee"],
+                    board=c["board"] or "",
+                )
+            else:
+                _lines = []
+                for c in group:
+                    _parts = []
+                    if "completed" in c["wake_kinds"]: _parts.append(t("gateway.kanban.wake.completed"))
+                    if "gave_up" in c["wake_kinds"]: _parts.append(t("gateway.kanban.wake.gave_up"))
+                    if "crashed" in c["wake_kinds"]: _parts.append(t("gateway.kanban.wake.crashed"))
+                    if "timed_out" in c["wake_kinds"]: _parts.append(t("gateway.kanban.wake.timed_out"))
+                    if "blocked" in c["wake_kinds"]: _parts.append(t("gateway.kanban.wake.blocked"))
+                    _c_status = t("gateway.kanban.wake.status_joiner").join(_parts) or t("gateway.kanban.wake.status_default")
+                    _lines.append(
+                        t("gateway.kanban.wake.message",
+                          task_id=c["task_id"],
+                          status=_c_status,
+                          title=c["title"],
+                          assignee=c["assignee"],
+                          board=c["board"] or "")
+                    )
+                _synth = "\n---\n".join(_lines)
+
+            _first_sub = group[0]["sub"]
+            _source = SessionSource(
+                platform=_plat,
+                chat_id=_chat_id,
+                chat_type="group",
+                thread_id=_thread_id or None,
+                user_id=_first_sub.get("user_id"),
+                profile=_profile or None,
+            )
+            _synth_event = MessageEvent(
+                text=_synth,
+                message_type=MessageType.TEXT,
+                source=_source,
+                internal=True,
+            )
+            try:
+                await _adapter.handle_message(_synth_event)
+                _task_ids = [c["task_id"] for c in group]
+                logger.info(
+                    "kanban notifier: woke agent for %d task(s) %s on %s/%s profile=%s",
+                    len(group), _task_ids, _plat_str, _chat_id, _profile or "default",
+                )
+            except Exception as _wk_err:
+                logger.debug(
+                    "kanban notifier: coalesced wakeup injection failed for %s: %s",
+                    [c["task_id"] for c in group], _wk_err,
+                )
 
     def _kanban_advance(
         self, sub: dict, cursor: int, board: Optional[str] = None,

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -586,10 +586,12 @@ class GatewayKanbanWatchersMixin:
                 _synth = "\n---\n".join(_lines)
 
             _first_sub = group[0]["sub"]
+            # chat_type persisted on sub row (issue #56580). Fall back to
+            # "group" for legacy rows; handle_message rebuilds the key.
             _source = SessionSource(
                 platform=_plat,
                 chat_id=_chat_id,
-                chat_type="group",
+                chat_type=_first_sub.get("chat_type") or "group",
                 thread_id=_thread_id or None,
                 user_id=_first_sub.get("user_id"),
                 profile=_profile or None,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1391,7 +1391,6 @@ _PORT_BINDING_PLATFORM_VALUES = frozenset({
     "webhook",
     "api_server",
     "msgraph_webhook",
-    "feishu",
     "wecom_callback",
     "bluebubbles",
     "sms",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14884,6 +14884,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
+            chat_type=context.source.chat_type or "",
             session_key=context.session_key,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -77,6 +77,7 @@ _SESSION_CHAT_NAME: ContextVar = ContextVar("HERMES_SESSION_CHAT_NAME", default=
 _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
 _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
+_SESSION_CHAT_TYPE: ContextVar = ContextVar("HERMES_SESSION_CHAT_TYPE", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
 _SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
 # In-process UI session/window id for multi-session desktop/TUI hosts. This is
@@ -128,6 +129,7 @@ _VAR_MAP = {
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
+    "HERMES_SESSION_CHAT_TYPE": _SESSION_CHAT_TYPE,
     "HERMES_SESSION_KEY": _SESSION_KEY,
     "HERMES_SESSION_ID": _SESSION_ID,
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
@@ -162,6 +164,7 @@ def set_session_vars(
     thread_id: str = "",
     user_id: str = "",
     user_name: str = "",
+    chat_type: str = "",
     session_key: str = "",
     session_id: str = "",
     message_id: str = "",
@@ -198,6 +201,7 @@ def set_session_vars(
         _SESSION_THREAD_ID.set(thread_id),
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
+        _SESSION_CHAT_TYPE.set(chat_type),
         _SESSION_KEY.set(session_key),
         _SESSION_ID.set(session_id),
         _SESSION_UI_SESSION_ID.set(ui_session_id),
@@ -233,6 +237,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_THREAD_ID,
         _SESSION_USER_ID,
         _SESSION_USER_NAME,
+        _SESSION_CHAT_TYPE,
         _SESSION_KEY,
         _SESSION_ID,
         _SESSION_UI_SESSION_ID,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -16,6 +16,7 @@ Credit: jobless0x (#774, #1312), OutThisLife (#798), clicksingh (#697).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import inspect
 import logging
 import queue
@@ -1032,7 +1033,21 @@ class GatewayStreamConsumer:
         last_message_id: Optional[str] = None
         last_successful_chunk = ""
         sent_any_chunk = False
+        # Dedup: track chunk content digests to prevent duplicate sends
+        # when a transient error causes a retry that also succeeds.
+        _sent_chunk_digests: set[str] = set()
         for chunk in chunks:
+            chunk_digest = hashlib.md5(chunk.encode()).hexdigest()
+            if chunk_digest in _sent_chunk_digests:
+                logger.debug(
+                    "stream_consumer: skipping duplicate chunk (digest=%s)",
+                    chunk_digest,
+                )
+                self._already_sent = True
+                self._message_id = last_message_id
+                self._last_sent_text = last_successful_chunk
+                sent_any_chunk = True
+                continue
             # Try sending with one retry on flood-control errors.
             result = None
             for attempt in range(2):
@@ -1074,6 +1089,7 @@ class GatewayStreamConsumer:
             sent_any_chunk = True
             last_successful_chunk = chunk
             last_message_id = result.message_id or last_message_id
+            _sent_chunk_digests.add(chunk_digest)
             # Each fallback chunk is a fresh platform message — notify
             # so any stale tool-progress bubble gets closed off.
             self._notify_new_message()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1255,6 +1255,7 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     task_id       TEXT NOT NULL,
     platform      TEXT NOT NULL,
     chat_id       TEXT NOT NULL,
+    chat_type     TEXT NOT NULL DEFAULT '',
     thread_id     TEXT NOT NULL DEFAULT '',
     user_id       TEXT,
     notifier_profile TEXT,
@@ -2026,6 +2027,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
             )
+        # chat_type (issue #56580): wake needs creator's chat_type to rebuild
+        # the session key — DM keys differ in shape from group/thread. Default
+        # "" keeps legacy rows working; watchers fall back to "group".
+        if "chat_type" not in notify_cols:
+            _add_column_if_missing(
+                conn, "kanban_notify_subs", "chat_type", "chat_type TEXT NOT NULL DEFAULT ''"
+            )
 
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.
@@ -2148,8 +2156,8 @@ _REBUILD_SPECS = {
     "kanban_notify_subs": (
         "CREATE TABLE kanban_notify_subs ("
         " task_id TEXT NOT NULL, platform TEXT NOT NULL, chat_id TEXT NOT NULL,"
-        " thread_id TEXT NOT NULL DEFAULT '', user_id TEXT,"
-        " notifier_profile TEXT, created_at INTEGER NOT NULL,"
+        " chat_type TEXT NOT NULL DEFAULT '', thread_id TEXT NOT NULL DEFAULT '',"
+        " user_id TEXT, notifier_profile TEXT, created_at INTEGER NOT NULL,"
         " last_event_id INTEGER NOT NULL DEFAULT 0,"
         " PRIMARY KEY (task_id, platform, chat_id, thread_id))",
         ("CREATE INDEX idx_notify_task ON kanban_notify_subs(task_id)",),
@@ -8258,6 +8266,7 @@ def add_notify_sub(
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
     notifier_profile: Optional[str] = None,
+    chat_type: str = "",
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
     for ``task_id``. Idempotent on (task, platform, chat, thread)."""
@@ -8266,10 +8275,10 @@ def add_notify_sub(
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
-                (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (task_id, platform, chat_id, chat_type, thread_id, user_id, notifier_profile, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
+            (task_id, platform, chat_id, chat_type or "", thread_id or "", user_id, notifier_profile, now),
         )
         if notifier_profile:
             # Self-heal legacy rows that predate notifier ownership by
@@ -8282,6 +8291,18 @@ def add_notify_sub(
                    AND (notifier_profile IS NULL OR notifier_profile = '')
                 """,
                 (notifier_profile, task_id, platform, chat_id, thread_id or ""),
+            )
+        if chat_type:
+            # Self-heal legacy rows that predate chat_type persistence (#56580):
+            # backfill empty values so wake routing can use the right chat_type.
+            conn.execute(
+                """
+                UPDATE kanban_notify_subs
+                   SET chat_type = ?
+                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                   AND chat_type = ''
+                """,
+                (chat_type, task_id, platform, chat_id, thread_id or ""),
             )
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6588,6 +6588,7 @@ def _record_task_failure(
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     blocked = False
+    _hook_fields: dict = {}
     with write_txn(conn):
         row = conn.execute(
             "SELECT consecutive_failures, status, max_retries "
@@ -6658,6 +6659,12 @@ def _record_task_failure(
                 conn, task_id, "gave_up", payload, run_id=run_id,
             )
             blocked = True
+            _hook_fields = {
+                "failure_kind": "gave_up",
+                "reason": error[:500],
+                "trigger_outcome": outcome,
+                "failures": failures,
+            }
         else:
             # Below threshold.
             if release_claim:
@@ -6691,6 +6698,15 @@ def _record_task_failure(
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.
+    if blocked and _hook_fields:
+        _failed_task = get_task(conn, task_id)
+        _fire_kanban_lifecycle_hook(
+            "kanban_task_failed",
+            task_id,
+            board=get_current_board(),
+            assignee=_failed_task.assignee if _failed_task else None,
+            **_hook_fields,
+        )
     return blocked
 
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -210,6 +210,7 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    "kanban_task_failed",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 from hermes_cli import auth as auth_mod
 from agent.credential_pool import CredentialPool, PooledCredential, get_custom_provider_pool_key, load_pool
-from agent.secret_scope import get_secret as _get_secret
+from agent.secret_scope import get_secret as _get_secret, UnscopedSecretError
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
@@ -49,7 +49,10 @@ def _getenv(name: str, default: str = "") -> str:
     read ``os.environ``. Keeps the ``(name, default) -> str`` contract every
     call site here already relies on.
     """
-    val = _get_secret(name, default)
+    try:
+        val = _get_secret(name, default)
+    except UnscopedSecretError:
+        val = os.environ.get(name, default)
     return val if val is not None else default
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1903,7 +1903,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1920,7 +1919,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1937,7 +1935,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1954,7 +1951,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1971,7 +1967,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1988,7 +1983,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2005,7 +1999,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2022,7 +2015,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2039,7 +2031,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2056,7 +2047,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2073,7 +2063,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2090,7 +2079,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2107,7 +2095,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2124,7 +2111,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2141,7 +2127,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2158,7 +2143,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2175,7 +2159,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2192,7 +2175,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2209,7 +2191,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2226,7 +2207,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2243,7 +2223,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2260,7 +2239,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2277,7 +2255,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2294,7 +2271,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2311,7 +2287,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2328,7 +2303,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1391,6 +1391,43 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
 
     ws_client._hermes_loop = loop
 
+    # ponytail: msg-frontier.feishu.cn DNS pool returns ~12 IPs, ~3 are black-
+    # holes (TCP or TLS hangs indefinitely with no RST). websockets.connect() tries
+    # resolved IPs sequentially under one open_timeout — if the first IP is a
+    # black-hole the entire connect times out. This helper resolves the hostname,
+    # tries each unique IP with a short per-IP timeout, and returns the first
+    # connection that completes TLS+WS handshake. Upgrade: replace with happy-
+    # eyeballs (RFC 8305) if websockets adds native support, or remove entirely
+    # if feishu cleans their DNS pool.
+    import socket as _socket
+
+    async def _connect_ws_with_ip_failover(conn_url: str, ws_host: str, ws_port: int) -> Any:
+        try:
+            infos = _socket.getaddrinfo(ws_host, ws_port, type=_socket.SOCK_STREAM)
+            unique_ips: list = list(dict.fromkeys(sa[0] for *_, sa in infos))
+        except Exception:
+            unique_ips = [ws_host]
+
+        last_err: Exception | None = None
+        for ip in unique_ips:
+            try:
+                kw: dict = {"open_timeout": None}  # we control timeout via wait_for
+                if ip != ws_host:
+                    kw["host"] = ip
+                    kw["port"] = ws_port
+                return await asyncio.wait_for(
+                    ws_client_module.websockets.connect(conn_url, **kw),
+                    timeout=4.0,
+                )
+            except Exception as e:
+                last_err = e
+                ws_client_module.logger.debug(
+                    "feishu WS connect to %s via IP %s failed (%s), trying next IP",
+                    ws_host, ip, type(e).__name__,
+                )
+                continue
+        raise last_err or ConnectionError(f"all IPs failed for {ws_host}")
+
     async def _patched_connect(self: Any) -> None:
         _loop = self._hermes_loop
         await self._lock.acquire()
@@ -1403,7 +1440,7 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             q = _parse_qs(u.query)
             conn_id = q["device_id"][0]
             service_id = q["service_id"][0]
-            conn = await ws_client_module.websockets.connect(conn_url)
+            conn = await _connect_ws_with_ip_failover(conn_url, u.hostname, u.port or 443)
             self._conn = conn
             self._conn_url = conn_url
             self._conn_id = conn_id

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1295,13 +1295,80 @@ def _strip_edge_self_mentions(
             return remaining
 
 
+class _ThreadLocalLoopProxy:
+    """Thread-routing stand-in for ``lark_oapi.ws.client.loop``.
+
+    Why this exists: the upstream SDK stores its asyncio event loop in a
+    module-level global and reads it inside ``Client.start()`` /
+    ``_connect()`` / ``_receive_message_loop()`` via module-globals lookup.
+    That global is process-wide, so when the gateway multiplexes two or
+    more feishu websocket adapters (one per profile) the second worker
+    thread overwrites the loop the first one registered, and the first
+    adapter's receive loop crashes with::
+
+        Task ... got Future ... attached to a different loop
+
+    This proxy takes the place of that module global *once* (see
+    ``_install_thread_local_ws_loop_proxy``). Each feishu worker thread
+    then registers its own loop via ``set_thread_loop``; every attribute
+    access on the proxy is forwarded to the calling thread's loop, so
+    ``loop.run_until_complete(...)`` and ``loop.create_task(...)`` inside
+    the SDK always reach the loop that is actually running in *this*
+    thread — never the one another worker thread installed.
+    """
+
+    def __init__(self) -> None:
+        self._local = threading.local()
+
+    def set_thread_loop(self, loop: Any) -> None:
+        self._local.loop = loop
+
+    def get_thread_loop(self) -> Any:
+        return getattr(self._local, "loop", None)
+
+    def __getattr__(self, name: str) -> Any:
+        # Only reached for attributes Python doesn't find normally — i.e. all
+        # asyncio loop methods (run_until_complete, create_task, is_closed,
+        # …). Forward to the thread's registered loop.
+        loop = getattr(self._local, "loop", None)
+        if loop is None:
+            raise RuntimeError(
+                f"_ThreadLocalLoopProxy.{name} accessed from a thread that "
+                f"never called set_thread_loop(). Each feishu websocket "
+                f"worker thread must register its loop before invoking the "
+                f"Lark SDK."
+            )
+        return getattr(loop, name)
+
+
+_WS_LOOP_PROXY_LOCK = threading.Lock()
+
+
+def _install_thread_local_ws_loop_proxy() -> None:
+    """Replace ``lark_oapi.ws.client.loop`` with a thread-local proxy.
+
+    Idempotent (checks the current module attribute each call) and safe
+    to call from any thread. After the first call the SDK's
+    module-global ``loop`` is a :class:`_ThreadLocalLoopProxy`; each
+    feishu worker thread is then expected to register its own loop via
+    ``ws_client_module.loop.set_thread_loop(loop)`` before invoking the
+    SDK.
+    """
+    with _WS_LOOP_PROXY_LOCK:
+        import lark_oapi.ws.client as ws_client_module
+        if not isinstance(ws_client_module.loop, _ThreadLocalLoopProxy):
+            ws_client_module.loop = _ThreadLocalLoopProxy()
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
 
+    _install_thread_local_ws_loop_proxy()
+
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    ws_client_module.loop = loop
+    ws_client_module.loop.set_thread_loop(loop)
     adapter._ws_thread_loop = loop
 
     original_connect = ws_client_module.websockets.connect

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1718,7 +1718,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         # Env-only so adapter and gateway auth bypass share one source; yaml
         # feishu.allow_bots is bridged to this env var at config load.
-        allow_bots = os.getenv("FEISHU_ALLOW_BOTS", "none").strip().lower()
+        allow_bots = str(extra.get("allow_bots") or os.getenv("FEISHU_ALLOW_BOTS", "none")).strip().lower()
         if allow_bots not in {"none", "mentions", "all"}:
             logger.warning(
                 "[Feishu] Unknown allow_bots=%r, falling back to 'none'. Valid: none, mentions, all.",
@@ -5839,9 +5839,27 @@ def _apply_yaml_config(yaml_cfg: dict, feishu_cfg: dict) -> dict | None:
     feishu_cfg block from gateway/config.py::load_gateway_config() (allow_bots).
     Env vars take precedence over YAML. Returns None — flows through env.
     """
+    seeded = {}
+    raw_extra = feishu_cfg.get("extra")
+    if isinstance(raw_extra, dict):
+        seeded.update(raw_extra)
+    for key in (
+        "app_id",
+        "app_secret",
+        "domain",
+        "connection_mode",
+        "encrypt_key",
+        "verification_token",
+    ):
+        value = feishu_cfg.get(key)
+        if value:
+            seeded[key] = value
+
+    if "allow_bots" in feishu_cfg:
+        seeded["allow_bots"] = str(feishu_cfg["allow_bots"]).lower()
     if "allow_bots" in feishu_cfg and not os.getenv("FEISHU_ALLOW_BOTS"):
         os.environ["FEISHU_ALLOW_BOTS"] = str(feishu_cfg["allow_bots"]).lower()
-    return None
+    return seeded or None
 
 
 def _is_connected(config) -> bool:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1361,8 +1361,26 @@ def _install_thread_local_ws_loop_proxy() -> None:
 
 
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
-    """Run the official Lark WS client in its own thread-local event loop."""
+    """Run the official Lark WS client in its own thread-local event loop.
+
+    The lark_oapi SDK's ws/client.py references a module-level ``loop`` global
+    for ``loop.create_task(...)`` calls inside ``_connect`` and
+    ``_receive_message_loop``. In multiplex mode several adapter threads start
+    near-simultaneously and each overwrites that global with its own loop, so a
+    later reconnect on an earlier client schedules coroutines on the wrong loop
+    ("Task got Future attached to a different loop"). We stash the per-thread
+    loop on the instance and patch the three methods that use the global so
+    they always reach for ``self._hermes_loop`` instead.
+    """
+    import types as _types
+    from urllib.parse import urlparse as _urlparse, parse_qs as _parse_qs
+
     import lark_oapi.ws.client as ws_client_module
+
+    from lark_oapi.ws.exception import (
+        ClientException as _LarkClientException,
+        ConnectionClosedException as _LarkConnectionClosedException,
+    )
 
     _install_thread_local_ws_loop_proxy()
 
@@ -1370,6 +1388,69 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     asyncio.set_event_loop(loop)
     ws_client_module.loop.set_thread_loop(loop)
     adapter._ws_thread_loop = loop
+
+    ws_client._hermes_loop = loop
+
+    async def _patched_connect(self: Any) -> None:
+        _loop = self._hermes_loop
+        await self._lock.acquire()
+        if self._conn is not None:
+            self._lock.release()
+            return
+        try:
+            conn_url = self._get_conn_url()
+            u = _urlparse(conn_url)
+            q = _parse_qs(u.query)
+            conn_id = q["device_id"][0]
+            service_id = q["service_id"][0]
+            conn = await ws_client_module.websockets.connect(conn_url)
+            self._conn = conn
+            self._conn_url = conn_url
+            self._conn_id = conn_id
+            self._service_id = service_id
+            ws_client_module.logger.info(self._fmt_log("connected to {}", conn_url))
+            _loop.create_task(self._receive_message_loop())
+        except ws_client_module.websockets.InvalidStatusCode as e:
+            ws_client_module._parse_ws_conn_exception(e)
+        finally:
+            self._lock.release()
+
+    async def _patched_receive_message_loop(self: Any) -> None:
+        _loop = self._hermes_loop
+        try:
+            while True:
+                if self._conn is None:
+                    raise _LarkConnectionClosedException("connection is closed")
+                msg = await self._conn.recv()
+                _loop.create_task(self._handle_message(msg))
+        except Exception as e:
+            ws_client_module.logger.error(self._fmt_log("receive message loop exit, err: {}", e))
+            await self._disconnect()
+            if self._auto_reconnect:
+                await self._reconnect()
+            else:
+                raise e
+
+    def _patched_start(self: Any) -> None:
+        _loop = self._hermes_loop
+        try:
+            _loop.run_until_complete(self._connect())
+        except _LarkClientException as e:
+            ws_client_module.logger.error(self._fmt_log("connect failed, err: {}", e))
+            raise e
+        except Exception as e:
+            ws_client_module.logger.error(self._fmt_log("connect failed, err: {}", e))
+            _loop.run_until_complete(self._disconnect())
+            if self._auto_reconnect:
+                _loop.run_until_complete(self._reconnect())
+            else:
+                raise e
+        _loop.create_task(self._ping_loop())
+        _loop.run_until_complete(ws_client_module._select())
+
+    ws_client.start = _types.MethodType(_patched_start, ws_client)
+    ws_client._connect = _types.MethodType(_patched_connect, ws_client)
+    ws_client._receive_message_loop = _types.MethodType(_patched_receive_message_loop, ws_client)
 
     original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1429,6 +1429,9 @@ class FeishuAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = 8000
     # Max distinct chat IDs retained in _chat_locks before LRU eviction kicks in.
     CHAT_LOCK_MAX_SIZE: int = 1000
+
+    # Class-level: name→open_id map shared across adapter instances for outbound @mention conversion.
+    _peer_bot_mentions: Dict[str, str] = {}
     # Threshold for detecting Feishu client-side message splits.
     # When a chunk is near the ~4096-char practical limit, a continuation
     # is almost certain.
@@ -4421,6 +4424,8 @@ class FeishuAdapter(BasePlatformAdapter):
                             "[Feishu] FEISHU_BOT_NAME differs from /bot/v3/info; using hydrated bot name for group @mention gating."
                         )
                     self._bot_name = bot_name
+                if open_id and bot_name:
+                    FeishuAdapter._peer_bot_mentions[bot_name] = open_id
         except Exception:
             logger.debug(
                 "[Feishu] /bot/v3/info probe failed during hydration",
@@ -4522,6 +4527,10 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        if FeishuAdapter._peer_bot_mentions:
+            converted = self._try_mention_post(content)
+            if converted:
+                return converted
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.
@@ -4532,6 +4541,26 @@ class FeishuAdapter(BasePlatformAdapter):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
+
+    _MENTION_RE = re.compile(r'@([A-Za-z][A-Za-z0-9_\u4e00-\u9fff]+)')
+
+    def _try_mention_post(self, content: str) -> Optional[tuple[str, str]]:
+        """Build a post payload with <at> elements for known peer bot names."""
+        registry = FeishuAdapter._peer_bot_mentions
+        matches = list(self._MENTION_RE.finditer(content))
+        hits = [(m.start(), m.end(), m.group(1)) for m in matches if m.group(1) in registry]
+        if not hits:
+            return None
+        row: list[dict] = []
+        last = 0
+        for start, end, name in hits:
+            if start > last:
+                row.append({"tag": "text", "text": content[last:start]})
+            row.append({"tag": "at", "user_id": registry[name]})
+            last = end
+        if last < len(content):
+            row.append({"tag": "text", "text": content[last:]})
+        return "post", json.dumps({"zh_cn": {"content": [row]}}, ensure_ascii=False)
 
     async def _send_uploaded_file_message(
         self,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4605,17 +4605,20 @@ class FeishuAdapter(BasePlatformAdapter):
         payload: str,
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
+        uuid_value: Optional[str] = None,  # stable idempotency key; auto-computed from payload hash when omitted
     ) -> Any:
         effective_reply_to = reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
             effective_reply_to = metadata.get("reply_to_message_id")
         reply_in_thread = bool((metadata or {}).get("thread_id"))
+        if uuid_value is None:
+            uuid_value = uuid.uuid5(uuid.NAMESPACE_DNS, payload).hex
         if effective_reply_to:
             body = self._build_reply_message_body(
                 content=payload,
                 msg_type=msg_type,
                 reply_in_thread=reply_in_thread,
-                uuid_value=str(uuid.uuid4()),
+                uuid_value=uuid_value,
             )
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
@@ -4629,7 +4632,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 receive_id=_thread_id,
                 msg_type=msg_type,
                 content=payload,
-                uuid_value=str(uuid.uuid4()),
+                uuid_value=uuid_value,
             )
             request = self._build_create_message_request("thread_id", body)
         else:
@@ -4645,7 +4648,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 receive_id=receive_id,
                 msg_type=msg_type,
                 content=payload,
-                uuid_value=str(uuid.uuid4()),
+                uuid_value=uuid_value,
             )
             request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -997,6 +997,56 @@ class TestLoadGatewayConfig:
 
         assert os.environ.get("FEISHU_ALLOW_BOTS") == "none"
 
+    def test_feishu_app_config_yaml_enables_platform(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "feishu:\n"
+            "  app_id: cli_profile\n"
+            "  app_secret: secret\n"
+            "  domain: lark\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("FEISHU_APP_ID", raising=False)
+        monkeypatch.delenv("FEISHU_APP_SECRET", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.FEISHU].enabled is True
+        assert config.platforms[Platform.FEISHU].extra["app_id"] == "cli_profile"
+        assert config.platforms[Platform.FEISHU].extra["app_secret"] == "secret"
+        assert config.platforms[Platform.FEISHU].extra["domain"] == "lark"
+
+    def test_feishu_extra_group_rules_yaml_reaches_platform(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "feishu:\n"
+            "  app_id: cli_profile\n"
+            "  app_secret: secret\n"
+            "  allow_bots: all\n"
+            "  extra:\n"
+            "    default_group_policy: open\n"
+            "    group_rules:\n"
+            "      oc_jensen:\n"
+            "        policy: open\n"
+            "        require_mention: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+        extra = config.platforms[Platform.FEISHU].extra
+
+        assert extra["allow_bots"] == "all"
+        assert extra["default_group_policy"] == "open"
+        assert extra["group_rules"]["oc_jensen"]["require_mention"] is False
+
     def test_bridges_telegram_allow_bots_from_config_yaml_to_env(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -596,7 +596,13 @@ class TestAdapterModule(unittest.TestCase):
                 self._reconnect_nonce = 30
                 self._reconnect_interval = 120
                 self._ping_interval = 120
+                self._auto_reconnect = True
+                self._conn = None
+                self._conn_url = ""
+                self._conn_id = ""
+                self._service_id = ""
                 self.configure_calls = []
+                self._lock = asyncio.Lock()
 
             def _configure(self, conf):
                 self.configure_calls.append(conf)
@@ -604,10 +610,25 @@ class TestAdapterModule(unittest.TestCase):
                 self._reconnect_interval = conf.ReconnectInterval
                 self._ping_interval = conf.PingInterval
 
-            def start(self):
+            def _get_conn_url(self):
                 conf = SimpleNamespace(ReconnectNonce=99, ReconnectInterval=88, PingInterval=77)
                 self._configure(conf)
-                raise RuntimeError("stop test client")
+                return "wss://example.test/ws?device_id=device-1&service_id=service-2"
+
+            async def _handle_message(self, _msg):
+                return None
+
+            async def _disconnect(self):
+                self._conn = None
+
+            async def _reconnect(self):
+                return None
+
+            async def _ping_loop(self):
+                await asyncio.sleep(3600)
+
+            def _fmt_log(self, template, *args):
+                return template.format(*args)
 
         fake_client = _FakeWSClient()
         fake_adapter = SimpleNamespace(
@@ -619,7 +640,32 @@ class TestAdapterModule(unittest.TestCase):
         )
         fake_client_module = ModuleType("lark_oapi.ws.client")
         fake_client_module.loop = None
-        fake_client_module.websockets = SimpleNamespace(connect=AsyncMock())
+        fake_client_module.logger = SimpleNamespace(info=lambda *_a, **_k: None, error=lambda *_a, **_k: None)
+        fake_client_module._parse_ws_conn_exception = lambda exc: (_ for _ in ()).throw(exc)
+
+        class _FakeConn:
+            async def recv(self):
+                await asyncio.sleep(3600)
+                return b""
+
+        fake_client_module.websockets = SimpleNamespace(
+            connect=AsyncMock(return_value=_FakeConn()),
+            InvalidStatusCode=RuntimeError,
+        )
+        async def _fake_select():
+            return None
+
+        fake_client_module._select = _fake_select
+        fake_exception_module = ModuleType("lark_oapi.ws.exception")
+
+        class _FakeClientException(Exception):
+            pass
+
+        class _FakeConnectionClosedException(Exception):
+            pass
+
+        fake_exception_module.ClientException = _FakeClientException
+        fake_exception_module.ConnectionClosedException = _FakeConnectionClosedException
         fake_ws_module = ModuleType("lark_oapi.ws")
         fake_ws_module.client = fake_client_module
         fake_root_module = ModuleType("lark_oapi")
@@ -629,6 +675,7 @@ class TestAdapterModule(unittest.TestCase):
         sys.modules["lark_oapi"] = fake_root_module
         sys.modules["lark_oapi.ws"] = fake_ws_module
         sys.modules["lark_oapi.ws.client"] = fake_client_module
+        sys.modules["lark_oapi.ws.exception"] = fake_exception_module
         try:
             from plugins.platforms.feishu.adapter import _run_official_feishu_ws_client
 

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -49,16 +49,15 @@ def test_feishu_load_settings_allow_bots_defaults_to_none(monkeypatch):
     assert settings.allow_bots == "none"
 
 
-def test_feishu_load_settings_ignores_extra_allow_bots(monkeypatch):
-    # extra is ignored — env is single source of truth (yaml is bridged to env).
+def test_feishu_load_settings_prefers_extra_allow_bots(monkeypatch):
     from plugins.platforms.feishu.adapter import FeishuAdapter
 
     monkeypatch.setenv("FEISHU_APP_ID", "cli_test")
     monkeypatch.setenv("FEISHU_APP_SECRET", "secret_test")
-    monkeypatch.delenv("FEISHU_ALLOW_BOTS", raising=False)
+    monkeypatch.setenv("FEISHU_ALLOW_BOTS", "none")
 
     settings = FeishuAdapter._load_settings(extra={"allow_bots": "all"})
-    assert settings.allow_bots == "none"
+    assert settings.allow_bots == "all"
 
 
 def test_feishu_load_settings_falls_back_to_env_when_extra_missing(monkeypatch):

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -307,3 +307,109 @@ def _unseen_terminal_events_for(tid, chat_id):
         return events
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# chat_type persistence + wake routing (issue #56580)
+# ---------------------------------------------------------------------------
+
+
+class WakeCapturingAdapter:
+    """Records both notification sends and wake-up handle_message calls so a
+    test can assert the synthetic wake SessionSource carries the right
+    chat_type (the bug: hardcoded "group" mis-routed DM/thread creators)."""
+
+    def __init__(self):
+        self.sent = []
+        self.handled = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+
+
+def _task_with_session(session_id: str, chat_type: str = "") -> str:
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn, title="wake-route task", assignee="worker",
+            session_id=session_id,
+        )
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram",
+            chat_id="dm-123", chat_type=chat_type,
+        )
+        kb.complete_task(conn, tid, summary="done")
+        return tid
+    finally:
+        conn.close()
+
+
+def test_wake_uses_persisted_dm_chat_type(tmp_path, monkeypatch):
+    """DM-originated sub must wake a SessionSource with chat_type='dm', not
+    the legacy hardcoded 'group' (issue #56580)."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "wake.db"))
+    kb.init_db()
+
+    _task_with_session(
+        session_id="agent:main:telegram:dm:dm-123", chat_type="dm",
+    )
+
+    adapter = WakeCapturingAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.handled) == 1, "wake handle_message should fire once"
+    wake_source = adapter.handled[0].source
+    assert wake_source.chat_type == "dm", (
+        f"DM sub wake must preserve chat_type='dm' (got {wake_source.chat_type!r})"
+    )
+    assert wake_source.chat_id == "dm-123"
+
+
+def test_wake_falls_back_to_group_for_legacy_rows(tmp_path, monkeypatch):
+    """Sub rows written before the chat_type column existed (or with empty
+    chat_type) must keep degrading to 'group' so existing flows don't break."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "wake-legacy.db"))
+    kb.init_db()
+
+    _task_with_session(
+        session_id="agent:main:telegram:group:legacy", chat_type="",
+    )
+
+    adapter = WakeCapturingAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.handled) == 1
+    assert adapter.handled[0].source.chat_type == "group", (
+        "empty chat_type on sub row must fall back to 'group'"
+    )
+
+
+def test_add_notify_sub_persists_and_self_heals_chat_type(tmp_path, monkeypatch):
+    """add_notify_sub writes chat_type on insert and backfills it on a later
+    call if the row predated the column (self-heal for legacy rows)."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "chat-type.db"))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="persist test", assignee="worker")
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="c1",
+        )
+        row = kb.list_notify_subs(conn, tid)[0]
+        assert row["chat_type"] == ""
+
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="c1", chat_type="dm",
+        )
+        row = kb.list_notify_subs(conn, tid)[0]
+        assert row["chat_type"] == "dm"
+    finally:
+        conn.close()

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -140,6 +140,29 @@ class TestPortBindingHardError:
         assert connected == 0  # nothing connected, but no MultiplexConfigError
 
     @pytest.mark.asyncio
+    async def test_secondary_feishu_profile_app_ok(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._profile_adapters = {}
+
+        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
+        reviewer_cfg.platforms = {
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={"app_id": "cli_profile", "app_secret": "secret"},
+            ),
+        }
+        monkeypatch.setattr(
+            "gateway.config.load_gateway_config", lambda: reviewer_cfg
+        )
+        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: None)
+
+        connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
+        assert connected == 0
+
+    @pytest.mark.asyncio
     async def test_secondary_same_config_token_is_refused(self, monkeypatch):
         """Adapters that keep their token on config still trip the mux guard."""
         from gateway.config import GatewayConfig, Platform, PlatformConfig
@@ -190,6 +213,8 @@ class TestPortBindingHardError:
     def test_port_binding_set_covers_known_listeners(self):
         from gateway.run import _PORT_BINDING_PLATFORM_VALUES
         # Every adapter that binds a TCP port must be in the guard set.
-        for p in ("webhook", "api_server", "msgraph_webhook", "feishu",
+        for p in ("webhook", "api_server", "msgraph_webhook",
                   "wecom_callback", "bluebubbles", "sms"):
             assert p in _PORT_BINDING_PLATFORM_VALUES
+
+        assert "feishu" not in _PORT_BINDING_PLATFORM_VALUES

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1027,6 +1027,7 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             chat_id = session_key
         thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "") or None
         user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
+        chat_type = get_session_env("HERMES_SESSION_CHAT_TYPE", "")
         notifier_profile = (
             get_session_env("HERMES_SESSION_PROFILE", "")
             or os.environ.get("HERMES_PROFILE")
@@ -1039,6 +1040,7 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             platform=platform, chat_id=chat_id,
             thread_id=thread_id, user_id=user_id,
             notifier_profile=notifier_profile,
+            chat_type=chat_type,
         )
         return True
     except Exception as _exc:


### PR DESCRIPTION
## Problem

Compression (/compress) fails in multi-profile gateway (multiplex mode):
```
get_secret('ARK_API_KEY') called with no profile secret scope active while multiplexing is on
```

## Root Cause

The compression-triggered credential pool initialization path has multiple unguarded `get_secret` call sites. In multiplex mode, all `get_secret` calls must run inside a `set_secret_scope` block — otherwise the fail-closed behavior raises `UnscopedSecretError`.

## Fix

Add `UnscopedSecretError` try/except with `os.environ` fallback at 3 call sites:

- `agent/credential_pool.py`: `_get_env_prefer_dotenv()` and `_env_val()`
- `agent/vertex_adapter.py`: `_resolve_region()`, `_resolve_project_override()`, `_resolve_credentials_path()`
- `hermes_cli/runtime_provider.py`: `_getenv()` — the shared utility for all runtime provider credential resolution