### PR TITLE
Fix MCP toolsets for explicit platform sessions

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -276,6 +276,21 @@ def _clear_tool_defs_cache() -> None:
     _tool_defs_cache.clear()
 
 
+def _registered_mcp_toolsets() -> List[str]:
+    """Return dynamically registered MCP toolset names.
+
+    MCP servers register tools at runtime into ``mcp-<server>`` toolsets.
+    Those toolsets are not in the static platform toolset definitions, so
+    platform sessions with an explicit enabled list need a small bridge to see
+    them.
+    """
+    return [
+        ts_name
+        for ts_name in registry.get_registered_toolset_names()
+        if ts_name.startswith("mcp-")
+    ]
+
+
 def get_tool_definitions(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
@@ -386,6 +401,19 @@ def _compute_tool_definitions(
                     print(f"✅ Enabled legacy toolset '{toolset_name}': {', '.join(legacy_tools)}")
             elif not quiet_mode:
                 print(f"⚠️  Unknown toolset: {toolset_name}")
+
+        # MCP toolsets are discovered dynamically at runtime, so they do not
+        # appear in the static per-platform toolsets (hermes-telegram,
+        # hermes-discord, QQ, etc.).  Auto-include all configured MCP servers
+        # for those platform sessions, while preserving explicit MCP scoping:
+        # if the caller already named an MCP toolset, treat that as a deliberate
+        # subset and do not widen it to every MCP server.
+        if not any(ts.startswith("mcp-") for ts in effective_enabled_toolsets):
+            for toolset_name in _registered_mcp_toolsets():
+                resolved = resolve_toolset(toolset_name)
+                tools_to_include.update(resolved)
+                if resolved and not quiet_mode:
+                    print(f"✅ Auto-enabled MCP toolset '{toolset_name}': {', '.join(resolved)}")
     else:
         # Default: start with everything
         from toolsets import get_all_toolsets

--- a/tests/test_model_tools_mcp_toolsets.py
+++ b/tests/test_model_tools_mcp_toolsets.py
@@ -1,0 +1,85 @@
+"""Regression coverage for MCP toolsets in explicit platform toolsets."""
+
+import json
+
+import model_tools
+from tools.registry import registry
+
+
+def _schema(name: str) -> dict:
+    return {
+        "name": name,
+        "description": f"Test schema for {name}",
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
+def _register_tool(name: str, toolset: str) -> None:
+    registry.register(
+        name=name,
+        toolset=toolset,
+        schema=_schema(name),
+        handler=lambda args, **kw: json.dumps({"ok": True}),
+    )
+    model_tools._clear_tool_defs_cache()
+
+
+def _deregister_tools(*names: str) -> None:
+    for name in names:
+        registry.deregister(name)
+    model_tools._clear_tool_defs_cache()
+
+
+def _tool_names(defs: list[dict]) -> set[str]:
+    return {td["function"]["name"] for td in defs}
+
+
+def test_explicit_platform_toolsets_auto_include_registered_mcp_toolsets():
+    tool_name = "mcp_gateway_auto_test_query"
+    _register_tool(tool_name, "mcp-gateway-auto-test")
+    try:
+        defs = model_tools.get_tool_definitions(
+            enabled_toolsets=["terminal"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        names = _tool_names(defs)
+        assert "terminal" in names
+        assert tool_name in names
+    finally:
+        _deregister_tools(tool_name)
+
+
+def test_disabled_toolsets_still_remove_auto_included_mcp_toolsets():
+    tool_name = "mcp_gateway_disabled_test_query"
+    _register_tool(tool_name, "mcp-gateway-disabled-test")
+    try:
+        defs = model_tools.get_tool_definitions(
+            enabled_toolsets=["terminal"],
+            disabled_toolsets=["mcp-gateway-disabled-test"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        names = _tool_names(defs)
+        assert "terminal" in names
+        assert tool_name not in names
+    finally:
+        _deregister_tools(tool_name)
+
+
+def test_explicit_mcp_enabled_toolset_does_not_widen_to_every_mcp_server():
+    in_scope = "mcp_gateway_scoped_test_query"
+    out_of_scope = "mcp_gateway_scoped_other_query"
+    _register_tool(in_scope, "mcp-gateway-scoped-test")
+    _register_tool(out_of_scope, "mcp-gateway-scoped-other")
+    try:
+        defs = model_tools.get_tool_definitions(
+            enabled_toolsets=["mcp-gateway-scoped-test"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        names = _tool_names(defs)
+        assert in_scope in names
+        assert out_of_scope not in names
+    finally:
+        _deregister_tools(in_scope, out_of_scope)


### PR DESCRIPTION
## Summary
- auto-include registered MCP toolsets when a platform/gateway session uses an explicit non-MCP toolset list
- preserve explicit MCP scoping when a caller already names an MCP toolset
- preserve disabled_toolsets as the final subtractive filter

## Tests
- scripts/run_tests.sh tests/test_model_tools_mcp_toolsets.py -- -q
- env UV_CACHE_DIR=.uv-cache uv run --extra dev ruff check model_tools.py tests/test_model_tools_mcp_toolsets.py

Split out from the previous broader PR per maintainer request. The filename-glob content-search change was dropped because it is a duplicate of #66176; streaming and TUI npm changes will be proposed separately.