### PR TITLE
fix(memory): keep memory dir/files owner-accessible under restrictive…

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -1,6 +1,8 @@
 """Tests for tools/memory_tool.py — MemoryStore, security scanning, and tool dispatcher."""
 
 import json
+import os
+import stat
 import pytest
 from pathlib import Path
 
@@ -501,6 +503,77 @@ class TestMemoryStorePersistence:
         store = MemoryStore()
         store.load_from_disk()
         assert len(store.memory_entries) == 2
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX directory permissions only")
+class TestMemoryDirPermissions:
+    """Regression tests for issue #66183.
+
+    Under a restrictive umask (some Docker / NAS deployments run with 0o777),
+    a plain ``mkdir`` yields a memories directory with no owner permissions
+    (``d---------``), which makes the memory files unreadable and breaks
+    persistence. The directory must always end up owner-accessible.
+    """
+
+    def test_fresh_dir_owner_accessible_under_restrictive_umask(
+        self, tmp_path, monkeypatch
+    ):
+        # Point at a not-yet-created subdir so mkdir actually runs.
+        mem_dir = tmp_path / "memories"
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: mem_dir)
+
+        old_umask = os.umask(0o777)
+        try:
+            store = MemoryStore()
+            store.load_from_disk()  # must not raise PermissionError
+        finally:
+            os.umask(old_umask)
+
+        mode = stat.S_IMODE(mem_dir.stat().st_mode)
+        # Owner must have read+write+execute so the dir is usable.
+        assert mode & 0o700 == 0o700, oct(mode)
+        # Convention: memories dir is owner-only; do not widen to group/other.
+        assert mode & 0o077 == 0
+
+    def test_add_and_save_roundtrip_under_restrictive_umask(
+        self, tmp_path, monkeypatch
+    ):
+        mem_dir = tmp_path / "memories"
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: mem_dir)
+
+        old_umask = os.umask(0o777)
+        try:
+            store = MemoryStore()
+            store.load_from_disk()
+            store.add("memory", "persists under restrictive umask")  # save + lock
+        finally:
+            os.umask(old_umask)
+
+        # The persisted file and lock file must be owner-accessible, not 000.
+        mem_file = mem_dir / "MEMORY.md"
+        file_mode = stat.S_IMODE(mem_file.stat().st_mode)
+        assert file_mode & 0o600 == 0o600, oct(file_mode)
+        assert file_mode & 0o077 == 0
+
+        reloaded = MemoryStore()
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: mem_dir)
+        reloaded.load_from_disk()
+        assert "persists under restrictive umask" in reloaded.memory_entries
+
+    def test_normal_umask_permissions_unchanged(self, tmp_path, monkeypatch):
+        """The fix must not widen perms under a normal umask (no regression)."""
+        mem_dir = tmp_path / "memories"
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: mem_dir)
+
+        old_umask = os.umask(0o022)
+        try:
+            MemoryStore().load_from_disk()
+        finally:
+            os.umask(old_umask)
+
+        mode = stat.S_IMODE(mem_dir.stat().st_mode)
+        # 0o777 & ~0o022 == 0o755; OR-in 0o700 leaves it unchanged.
+        assert mode == 0o755, oct(mode)
 
 
 class TestMemoryStoreSnapshot:

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -575,6 +575,69 @@ class TestMemoryDirPermissions:
         # 0o777 & ~0o022 == 0o755; OR-in 0o700 leaves it unchanged.
         assert mode == 0o755, oct(mode)
 
+    def test_recovers_pre_existing_000_tree(self, tmp_path, monkeypatch):
+        """A memories dir + files + lock left at 000 by an earlier
+        restrictive-umask run must be repaired, not silently read as empty
+        (the maintainer-flagged gap on #66183)."""
+        mem_dir = tmp_path / "memories"
+        mem_dir.mkdir()
+        (mem_dir / "MEMORY.md").write_text(
+            "pre-existing fact\n\u00a7\nsecond fact\n", encoding="utf-8"
+        )
+        (mem_dir / "MEMORY.md.lock").write_text("", encoding="utf-8")
+        # Clamp the whole tree to 000, as a prior umask-0777 run would leave it.
+        os.chmod(mem_dir / "MEMORY.md", 0o000)
+        os.chmod(mem_dir / "MEMORY.md.lock", 0o000)
+        os.chmod(mem_dir, 0o000)
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: mem_dir)
+
+        try:
+            store = MemoryStore()
+            store.load_from_disk()  # must recover, not return []
+            # A mutation must succeed despite the pre-existing 000 lock file.
+            result = store.add("memory", "added after recovery")
+        finally:
+            # Ensure cleanup can remove the tree even if an assert fails.
+            for p in (mem_dir / "MEMORY.md", mem_dir / "MEMORY.md.lock", mem_dir):
+                try:
+                    os.chmod(p, 0o700)
+                except OSError:
+                    pass
+
+        assert "pre-existing fact" in store.memory_entries
+        assert "second fact" in store.memory_entries
+        assert result["success"] is True
+
+    def test_creates_nested_missing_parents_owner_accessible(
+        self, tmp_path, monkeypatch
+    ):
+        """Every missing parent component must be created owner-accessible, so
+        descent doesn't stall on a 000 intermediate dir under umask 0777."""
+        deep = tmp_path / "a" / "b" / "c" / "memories"  # 3 missing parents
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: deep)
+
+        old_umask = os.umask(0o777)
+        try:
+            store = MemoryStore()
+            store.load_from_disk()
+            store.add("memory", "nested works")
+        finally:
+            os.umask(old_umask)
+
+        for component in (
+            tmp_path / "a",
+            tmp_path / "a" / "b",
+            tmp_path / "a" / "b" / "c",
+            deep,
+        ):
+            mode = stat.S_IMODE(component.stat().st_mode)
+            assert mode & 0o700 == 0o700, f"{component}: {oct(mode)}"
+
+        reloaded = MemoryStore()
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: deep)
+        reloaded.load_from_disk()
+        assert "nested works" in reloaded.memory_entries
+
 
 class TestMemoryStoreSnapshot:
     def test_snapshot_frozen_at_load(self, store):

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -26,6 +26,7 @@ Design:
 import json
 import logging
 import os
+import stat
 import tempfile
 import time
 from contextlib import contextmanager
@@ -55,6 +56,38 @@ logger = logging.getLogger(__name__)
 def get_memory_dir() -> Path:
     """Return the profile-scoped memories directory."""
     return get_hermes_home() / "memories"
+
+
+def _ensure_owner_access(path: Path, mask: int) -> None:
+    """OR ``mask`` into ``path``'s mode so the owner can always use it.
+
+    Directories created with ``mkdir`` and files created via ``mkstemp`` /
+    ``open`` all honor the process umask, so under a restrictive umask
+    (e.g. ``0o077`` or ``0o777`` — seen in some Docker / NAS deployments) they
+    can land with no owner permissions (``d---------`` / ``----------``). That
+    makes memory directories, files (MEMORY.md, USER.md) and lock files
+    unreadable and silently breaks persistence across sessions (issue #66183).
+
+    OR-ing the owner bits in never widens group/other access beyond what the
+    umask already allowed — the memories tree stays owner-only by convention
+    (see ``_secure_dir`` in ``hermes_cli/config``). No-op on non-POSIX and
+    best-effort otherwise: a perms tweak must never break memory persistence.
+    """
+    if os.name != "posix":
+        return
+    try:
+        current = stat.S_IMODE(os.stat(path).st_mode)
+        if current | mask != current:
+            os.chmod(path, current | mask)
+    except OSError:
+        pass
+
+
+def _ensure_memory_dir(path: Path) -> None:
+    """Create ``path`` (and parents) and guarantee owner ``rwx`` on it (#66183)."""
+    path.mkdir(parents=True, exist_ok=True)
+    _ensure_owner_access(path, 0o700)
+
 
 ENTRY_DELIMITER = "\n§\n"
 
@@ -183,7 +216,7 @@ class MemoryStore:
         stable for the entire session (prefix-cache invariant holds).
         """
         mem_dir = get_memory_dir()
-        mem_dir.mkdir(parents=True, exist_ok=True)
+        _ensure_memory_dir(mem_dir)
 
         self.memory_entries = self._read_file(mem_dir / "MEMORY.md")
         self.user_entries = self._read_file(mem_dir / "USER.md")
@@ -249,13 +282,16 @@ class MemoryStore:
         atomically replaced via os.replace().
         """
         lock_path = path.with_suffix(path.suffix + ".lock")
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        _ensure_memory_dir(lock_path.parent)
 
         if fcntl is None and msvcrt is None:
             yield
             return
 
         fd = open(lock_path, "a+", encoding="utf-8")
+        # Under a restrictive umask the lock file can land at 000, blocking the
+        # next process from opening it — keep it owner-accessible (#66183).
+        _ensure_owner_access(lock_path, 0o600)
         try:
             if fcntl:
                 fcntl.flock(fd, fcntl.LOCK_EX)
@@ -308,7 +344,7 @@ class MemoryStore:
 
     def save_to_disk(self, target: str):
         """Persist entries to the appropriate file. Called after every mutation."""
-        get_memory_dir().mkdir(parents=True, exist_ok=True)
+        _ensure_memory_dir(get_memory_dir())
         self._write_file(self._path_for(target), self._entries_for(target))
 
     def _entries_for(self, target: str) -> List[str]:
@@ -777,6 +813,10 @@ class MemoryStore:
                     f.flush()
                     os.fsync(f.fileno())
                 atomic_replace(tmp_path, path)
+                # mkstemp honors the umask, so under a restrictive umask the
+                # persisted file can be 000 (unreadable even by its owner) —
+                # keep memory files owner-accessible (#66183).
+                _ensure_owner_access(path, 0o600)
             except BaseException:
                 # Clean up temp file on any failure
                 try:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -84,8 +84,28 @@ def _ensure_owner_access(path: Path, mask: int) -> None:
 
 
 def _ensure_memory_dir(path: Path) -> None:
-    """Create ``path`` (and parents) and guarantee owner ``rwx`` on it (#66183)."""
-    path.mkdir(parents=True, exist_ok=True)
+    """Create ``path`` (and any missing parents) with guaranteed owner ``rwx``.
+
+    A plain ``mkdir(parents=True)`` followed by a single chmod is not enough
+    under a restrictive umask (e.g. ``0o777``): each intermediate parent is
+    created ``000`` first, and descent into it fails before the chmod on the
+    leaf is ever reached. So we create each missing component individually and
+    OR-in owner ``rwx`` on it before descending further (#66183). The final
+    call also repairs a pre-existing ``000`` target directory.
+    """
+    missing: list[Path] = []
+    probe = path
+    while not probe.exists():
+        missing.append(probe)
+        if probe.parent == probe:  # reached filesystem root
+            break
+        probe = probe.parent
+    for component in reversed(missing):
+        try:
+            component.mkdir(exist_ok=True)
+        except FileExistsError:
+            pass
+        _ensure_owner_access(component, 0o700)
     _ensure_owner_access(path, 0o700)
 
 
@@ -288,9 +308,13 @@ class MemoryStore:
             yield
             return
 
+        # Repair a pre-existing 000 lock file BEFORE opening it: an unreadable
+        # lock left by an earlier restrictive-umask run would otherwise fail to
+        # open here and wedge every mutation path (#66183). No-op if absent.
+        _ensure_owner_access(lock_path, 0o600)
         fd = open(lock_path, "a+", encoding="utf-8")
-        # Under a restrictive umask the lock file can land at 000, blocking the
-        # next process from opening it — keep it owner-accessible (#66183).
+        # And repair the freshly-created case: open() under a restrictive umask
+        # creates the lock file at 000, blocking the NEXT process from opening it.
         _ensure_owner_access(lock_path, 0o600)
         try:
             if fcntl:
@@ -724,6 +748,11 @@ class MemoryStore:
         """
         if not path.exists():
             return []
+        # Repair a pre-existing 000 memory file left by an earlier
+        # restrictive-umask run before reading it. Without this the read below
+        # fails with PermissionError, the except returns [], and the entries
+        # silently vanish from the session (#66183).
+        _ensure_owner_access(path, 0o600)
         try:
             raw = path.read_text(encoding="utf-8")
         except (OSError, IOError):


### PR DESCRIPTION
… umask

memory_tool.py created the memories directory, memory files (MEMORY.md, USER.md) and lock files with plain mkdir/mkstemp/open, all of which honor the process umask. Under a restrictive umask (e.g. 0o777, seen in some Docker/NAS deployments) they land at 000 (d---------/----------), making memory unreadable even by its owner and silently breaking persistence across sessions.

Add _ensure_owner_access() and route the directory (0o700), written files (0o600) and lock files (0o600) through it. Owner bits are OR-ed in, so group/other access is never widened beyond what the umask allowed and the memories tree stays owner-only per _secure_dir convention.

Fixes #66183

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

