### PR TITLE
fix(cli): show Codex OAuth quota in status bar

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -507,6 +507,14 @@ def _resolve_codex_usage_credentials(
     return entry.runtime_api_key, str(entry.runtime_base_url or base_url or "").strip(), None
 
 
+def _codex_window_label(key: str, window: dict[str, Any]) -> str:
+    """Name Codex quota windows by duration when the API exposes it."""
+    duration = window.get("limit_window_seconds")
+    if _is_finite_num(duration) and duration >= 6 * 24 * 60 * 60:
+        return "Weekly"
+    return "Weekly" if key == "secondary_window" else "Session"
+
+
 def _fetch_codex_account_usage(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
@@ -525,14 +533,14 @@ def _fetch_codex_account_usage(
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
-    for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
+    for key in ("primary_window", "secondary_window"):
         window = rate_limit.get(key) or {}
         used = window.get("used_percent")
         if used is None:
             continue
         windows.append(
             AccountUsageWindow(
-                label=label,
+                label=_codex_window_label(key, window),
                 used_percent=float(used),
                 reset_at=_parse_dt(window.get("reset_at")),
             )

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -510,7 +510,10 @@ def _resolve_codex_usage_credentials(
 def _codex_window_label(key: str, window: dict[str, Any]) -> str:
     """Name Codex quota windows by duration when the API exposes it."""
     duration = window.get("limit_window_seconds")
-    if _is_finite_num(duration) and duration >= 6 * 24 * 60 * 60:
+    if (
+        _is_finite_num(duration)
+        and 6 * 24 * 60 * 60 <= duration <= 8 * 24 * 60 * 60
+    ):
         return "Weekly"
     return "Weekly" if key == "secondary_window" else "Session"
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1294,6 +1294,13 @@ display:
   #     prompt_symbol: "⚔"                  # Prompt symbol (bare token; renderers add trailing space)
   #   tool_prefix: "╎"                       # Tool output line prefix (default: ┊)
   #
+  # Show OpenAI Codex OAuth quota remaining in the classic CLI status bar.
+  # The refresh is non-blocking; unavailable 5-hour or weekly windows are
+  # omitted instead of rendered as placeholders.
+  account_usage_footer:
+    enabled: false
+    refresh_seconds: 300
+
   skin: default
 
 # =============================================================================

--- a/cli.py
+++ b/cli.py
@@ -31,6 +31,7 @@ import json
 import re
 import concurrent.futures
 import base64
+import hashlib
 import atexit
 import errno
 import tempfile
@@ -4115,6 +4116,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._status_bar_usage_inflight = False
         self._status_bar_usage_last_attempt = 0.0
         self._status_bar_usage_provider = None
+        self._status_bar_usage_identity = None
+        self._status_bar_usage_generation = 0
         self._status_bar_usage_session = None
         self._status_bar_usage_weekly = None
         # When True, the input separator rules and the dynamic status bar are
@@ -4539,6 +4542,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         idle = max(0.0, time.time() - last_finished_at)
         return f"✓ {format_duration_compact(idle)}"
 
+    @staticmethod
+    def _status_bar_account_usage_identity(provider, base_url, api_key) -> bytes:
+        """Return a non-reversible cache key without retaining OAuth secrets."""
+        material = "\0".join(
+            (str(provider or ""), str(base_url or ""), str(api_key or ""))
+        ).encode("utf-8", errors="replace")
+        return hashlib.sha256(material).digest()
+
     def _get_status_bar_account_usage(self, agent):
         """Return cached OAuth quota windows and schedule a non-blocking refresh."""
         display_cfg = getattr(self, "config", {}).get("display") or {}
@@ -4546,6 +4557,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         provider = str(getattr(agent, "provider", "") or "").strip().lower()
         if not usage_cfg.get("enabled") or provider != "openai-codex":
             return None, None
+
+        base_url = getattr(agent, "base_url", None)
+        api_key = getattr(agent, "api_key", None)
+        identity = self._status_bar_account_usage_identity(provider, base_url, api_key)
 
         try:
             refresh_seconds = max(60.0, float(usage_cfg.get("refresh_seconds", 300)))
@@ -4559,11 +4574,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         now = time.monotonic()
         with lock:
-            if getattr(self, "_status_bar_usage_provider", None) != provider:
+            if getattr(self, "_status_bar_usage_identity", None) != identity:
                 self._status_bar_usage_provider = provider
+                self._status_bar_usage_identity = identity
+                self._status_bar_usage_generation = (
+                    int(getattr(self, "_status_bar_usage_generation", 0) or 0) + 1
+                )
                 self._status_bar_usage_last_attempt = 0.0
+                # A worker for the previous credential may still be running.
+                # It is now stale; the generation check below prevents it from
+                # committing or clearing the new credential's cache state.
+                self._status_bar_usage_inflight = False
                 self._status_bar_usage_session = None
                 self._status_bar_usage_weekly = None
+            generation = int(getattr(self, "_status_bar_usage_generation", 0) or 0)
             session_window = getattr(self, "_status_bar_usage_session", None)
             weekly_window = getattr(self, "_status_bar_usage_weekly", None)
             inflight = bool(getattr(self, "_status_bar_usage_inflight", False))
@@ -4574,10 +4598,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 self._status_bar_usage_last_attempt = now
 
         if should_refresh:
-            base_url = getattr(agent, "base_url", None)
-            api_key = getattr(agent, "api_key", None)
-
             def _refresh() -> None:
+                success = False
+                session = None
+                weekly = None
                 try:
                     from agent.account_usage import fetch_account_usage
 
@@ -4586,16 +4610,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         base_url=base_url,
                         api_key=api_key,
                     )
-                    session = None
-                    weekly = None
-                    for window in getattr(snapshot, "windows", ()) if snapshot else ():
-                        if window.label == "Session":
-                            session = window
-                        elif window.label == "Weekly":
-                            weekly = window
-                    with lock:
-                        self._status_bar_usage_session = session
-                        self._status_bar_usage_weekly = weekly
+                    if snapshot is not None:
+                        success = True
+                        for window in getattr(snapshot, "windows", ()):
+                            if window.label == "Session":
+                                session = window
+                            elif window.label == "Weekly":
+                                weekly = window
                 except Exception:
                     # Footer diagnostics are optional UI. Provider/auth/network
                     # failures must never escape the refresh thread or disrupt
@@ -4603,7 +4624,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     pass
                 finally:
                     with lock:
-                        self._status_bar_usage_inflight = False
+                        current_generation = int(
+                            getattr(self, "_status_bar_usage_generation", 0) or 0
+                        )
+                        current_identity = getattr(self, "_status_bar_usage_identity", None)
+                        if current_generation == generation and current_identity == identity:
+                            # A failed refresh hides the old value rather than
+                            # presenting an indefinitely stale quota.
+                            self._status_bar_usage_session = session if success else None
+                            self._status_bar_usage_weekly = weekly if success else None
+                            self._status_bar_usage_inflight = False
                     app = getattr(self, "_app", None)
                     if app is not None:
                         try:
@@ -4615,7 +4645,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 threading.Thread(target=_refresh, daemon=True).start()
             except Exception:
                 with lock:
-                    self._status_bar_usage_inflight = False
+                    current_generation = int(
+                        getattr(self, "_status_bar_usage_generation", 0) or 0
+                    )
+                    if current_generation == generation:
+                        self._status_bar_usage_session = None
+                        self._status_bar_usage_weekly = None
+                        self._status_bar_usage_inflight = False
 
         return session_window, weekly_window
 

--- a/cli.py
+++ b/cli.py
@@ -466,7 +466,10 @@ def load_cli_config() -> Dict[str, Any]:
             # Print a one-line summary of resolved modal prompts (approval /
             # clarify) into scrollback so the decision survives the repaint.
             "persist_prompts": True,
-
+            "account_usage_footer": {
+                "enabled": False,
+                "refresh_seconds": 300,
+            },
             "skin": "default",
         },
         "clarify": {
@@ -4105,6 +4108,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
+        # OAuth account usage is fetched off the prompt-toolkit render path.
+        # The status bar reads these cached windows; a render may only schedule
+        # a refresh, never block on provider network I/O.
+        self._status_bar_usage_lock = threading.Lock()
+        self._status_bar_usage_inflight = False
+        self._status_bar_usage_last_attempt = 0.0
+        self._status_bar_usage_provider = None
+        self._status_bar_usage_session = None
+        self._status_bar_usage_weekly = None
         # When True, the input separator rules and the dynamic status bar are
         # hidden until the next user input. Set by _recover_after_resize() so a
         # SIGWINCH cannot stamp a freshly-drawn status bar on top of one that
@@ -4527,6 +4539,86 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         idle = max(0.0, time.time() - last_finished_at)
         return f"✓ {format_duration_compact(idle)}"
 
+    def _get_status_bar_account_usage(self, agent):
+        """Return cached OAuth quota windows and schedule a non-blocking refresh."""
+        display_cfg = getattr(self, "config", {}).get("display") or {}
+        usage_cfg = display_cfg.get("account_usage_footer") or {}
+        provider = str(getattr(agent, "provider", "") or "").strip().lower()
+        if not usage_cfg.get("enabled") or provider != "openai-codex":
+            return None, None
+
+        try:
+            refresh_seconds = max(60.0, float(usage_cfg.get("refresh_seconds", 300)))
+        except (TypeError, ValueError):
+            refresh_seconds = 300.0
+
+        lock = getattr(self, "_status_bar_usage_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._status_bar_usage_lock = lock
+
+        now = time.monotonic()
+        with lock:
+            if getattr(self, "_status_bar_usage_provider", None) != provider:
+                self._status_bar_usage_provider = provider
+                self._status_bar_usage_last_attempt = 0.0
+                self._status_bar_usage_session = None
+                self._status_bar_usage_weekly = None
+            session_window = getattr(self, "_status_bar_usage_session", None)
+            weekly_window = getattr(self, "_status_bar_usage_weekly", None)
+            inflight = bool(getattr(self, "_status_bar_usage_inflight", False))
+            last_attempt = float(getattr(self, "_status_bar_usage_last_attempt", 0.0) or 0.0)
+            should_refresh = not inflight and now - last_attempt >= refresh_seconds
+            if should_refresh:
+                self._status_bar_usage_inflight = True
+                self._status_bar_usage_last_attempt = now
+
+        if should_refresh:
+            base_url = getattr(agent, "base_url", None)
+            api_key = getattr(agent, "api_key", None)
+
+            def _refresh() -> None:
+                try:
+                    from agent.account_usage import fetch_account_usage
+
+                    snapshot = fetch_account_usage(
+                        provider,
+                        base_url=base_url,
+                        api_key=api_key,
+                    )
+                    session = None
+                    weekly = None
+                    for window in getattr(snapshot, "windows", ()) if snapshot else ():
+                        if window.label == "Session":
+                            session = window
+                        elif window.label == "Weekly":
+                            weekly = window
+                    with lock:
+                        self._status_bar_usage_session = session
+                        self._status_bar_usage_weekly = weekly
+                except Exception:
+                    # Footer diagnostics are optional UI. Provider/auth/network
+                    # failures must never escape the refresh thread or disrupt
+                    # the active conversation.
+                    pass
+                finally:
+                    with lock:
+                        self._status_bar_usage_inflight = False
+                    app = getattr(self, "_app", None)
+                    if app is not None:
+                        try:
+                            app.invalidate()
+                        except Exception:
+                            pass
+
+            try:
+                threading.Thread(target=_refresh, daemon=True).start()
+            except Exception:
+                with lock:
+                    self._status_bar_usage_inflight = False
+
+        return session_window, weekly_window
+
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.
         # self.model reflects the originally configured model and never
@@ -4566,6 +4658,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             "session_total_tokens": 0,
             "session_api_calls": 0,
             "compressions": 0,
+            "session_quota_used": None,
+            "session_quota_remaining": None,
+            "weekly_quota_used": None,
+            "weekly_quota_remaining": None,
             "active_background_tasks": 0,
             "active_background_processes": 0,
             "active_background_subagents": 0,
@@ -4602,6 +4698,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         if not agent:
             return snapshot
+
+        session_window, weekly_window = self._get_status_bar_account_usage(agent)
+        for prefix, window in (("session", session_window), ("weekly", weekly_window)):
+            if window is None or window.used_percent is None:
+                continue
+            used = max(0, min(100, round(float(window.used_percent))))
+            snapshot[f"{prefix}_quota_used"] = used
+            snapshot[f"{prefix}_quota_remaining"] = 100 - used
 
         snapshot["session_input_tokens"] = getattr(agent, "session_input_tokens", 0) or 0
         snapshot["session_output_tokens"] = getattr(agent, "session_output_tokens", 0) or 0
@@ -5059,6 +5163,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 return self._trim_status_bar_text(text, width)
             if width < 76:
                 parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                session_remaining = snapshot.get("session_quota_remaining")
+                weekly_remaining = snapshot.get("weekly_quota_remaining")
+                if session_remaining is not None:
+                    parts.append(f"5h {session_remaining}%")
+                if weekly_remaining is not None:
+                    parts.append(f"week {weekly_remaining}%")
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -5085,6 +5195,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             compressions = snapshot.get("compressions", 0)
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            session_remaining = snapshot.get("session_quota_remaining")
+            weekly_remaining = snapshot.get("weekly_quota_remaining")
+            if session_remaining is not None:
+                parts.append(f"5h {session_remaining}%")
+            if weekly_remaining is not None:
+                parts.append(f"week {weekly_remaining}%")
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -5138,6 +5254,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 percent = snapshot["context_percent"]
                 percent_label = f"{percent}%" if percent is not None else "--"
                 if width < 76:
+                    session_used = snapshot.get("session_quota_used")
+                    session_remaining = snapshot.get("session_quota_remaining")
+                    weekly_used = snapshot.get("weekly_quota_used")
+                    weekly_remaining = snapshot.get("weekly_quota_remaining")
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
@@ -5148,6 +5268,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
+                    if session_remaining is not None:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(
+                            (
+                                self._status_bar_context_style(session_used),
+                                f"5h {session_remaining}%",
+                            )
+                        )
+                    if weekly_remaining is not None:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(
+                            (
+                                self._status_bar_context_style(weekly_used),
+                                f"week {weekly_remaining}%",
+                            )
+                        )
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -5177,6 +5313,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         context_label = "ctx --"
 
                     bar_style = self._status_bar_context_style(percent)
+                    session_used = snapshot.get("session_quota_used")
+                    session_remaining = snapshot.get("session_quota_remaining")
+                    weekly_used = snapshot.get("weekly_quota_used")
+                    weekly_remaining = snapshot.get("weekly_quota_remaining")
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
@@ -5191,6 +5331,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                     ]
+                    if session_remaining is not None:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(
+                            (
+                                self._status_bar_context_style(session_used),
+                                f"5h {session_remaining}%",
+                            )
+                        )
+                    if weekly_remaining is not None:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(
+                            (
+                                self._status_bar_context_style(weekly_used),
+                                f"week {weekly_remaining}%",
+                            )
+                        )
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1885,6 +1885,13 @@ DEFAULT_CONFIG = {
         # failure isn't silent from the UI's perspective.  Set false to suppress.
         "turn_completion_explainer": True,
         "show_cost": False,       # Show $ cost in the status bar (off by default)
+        # Optional OpenAI Codex OAuth quota readout in the classic CLI status
+        # bar. Refreshes in the background and only renders windows returned by
+        # the API ("5h" and/or "week").
+        "account_usage_footer": {
+            "enabled": False,
+            "refresh_seconds": 300,
+        },
         "skin": "default",
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -237,6 +237,38 @@ def test_codex_usage_treats_wham_used_percent_as_used_not_remaining(monkeypatch)
     assert "86% used" not in rendered
 
 
+def test_codex_usage_labels_single_seven_day_primary_window_as_weekly(monkeypatch):
+    """Some Codex plans expose only one 7-day primary window."""
+    payload = {
+        "plan_type": "pro",
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 27,
+                "limit_window_seconds": 604800,
+                "reset_at": 1784784391,
+            },
+            "secondary_window": None,
+        },
+        "credits": {"has_credits": False},
+    }
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="live-agent-token",
+    )
+
+    assert snapshot is not None
+    assert [window.label for window in snapshot.windows] == ["Weekly"]
+    assert snapshot.windows[0].used_percent == 27
+
+
 # ── Banked rate-limit reset credits (`/usage reset`) ─────────────────────────
 
 

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -108,6 +108,12 @@ class TestCLIStatusBar:
         cli_obj._status_bar_usage_inflight = False
         cli_obj._status_bar_usage_last_attempt = time.monotonic()
         cli_obj._status_bar_usage_provider = "openai-codex"
+        cli_obj._status_bar_usage_identity = cli_obj._status_bar_account_usage_identity(
+            "openai-codex",
+            getattr(cli_obj.agent, "base_url", None),
+            getattr(cli_obj.agent, "api_key", None),
+        )
+        cli_obj._status_bar_usage_generation = 1
         cli_obj._status_bar_usage_session = None
         cli_obj._status_bar_usage_weekly = AccountUsageWindow(
             label="Weekly",
@@ -149,6 +155,12 @@ class TestCLIStatusBar:
         cli_obj._status_bar_usage_inflight = False
         cli_obj._status_bar_usage_last_attempt = time.monotonic()
         cli_obj._status_bar_usage_provider = "openai-codex"
+        cli_obj._status_bar_usage_identity = cli_obj._status_bar_account_usage_identity(
+            "openai-codex",
+            getattr(cli_obj.agent, "base_url", None),
+            getattr(cli_obj.agent, "api_key", None),
+        )
+        cli_obj._status_bar_usage_generation = 1
         cli_obj._status_bar_usage_session = AccountUsageWindow(
             label="Session",
             used_percent=18,
@@ -287,6 +299,131 @@ class TestCLIStatusBar:
         assert snapshot["session_quota_remaining"] is None
         assert snapshot["weekly_quota_remaining"] is None
         assert uncaught == []
+
+    def test_openai_quota_credential_rotation_rejects_stale_worker_result(self, monkeypatch):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.6-luna"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.agent.provider = "openai-codex"
+        cli_obj.agent.base_url = "https://chatgpt.com/backend-api/codex"
+        cli_obj.agent.api_key = "oauth-account-a"
+        cli_obj.config = {
+            "display": {
+                "account_usage_footer": {
+                    "enabled": True,
+                    "refresh_seconds": 300,
+                }
+            }
+        }
+        cli_obj._status_bar_usage_lock = threading.Lock()
+        cli_obj._status_bar_usage_inflight = False
+        cli_obj._status_bar_usage_last_attempt = 0.0
+        cli_obj._status_bar_usage_provider = None
+        cli_obj._status_bar_usage_identity = None
+        cli_obj._status_bar_usage_generation = 0
+        cli_obj._status_bar_usage_session = None
+        cli_obj._status_bar_usage_weekly = None
+
+        account_a_started = threading.Event()
+        release_account_a = threading.Event()
+        account_b_started = threading.Event()
+        both_workers_finished = threading.Event()
+        invalidations = []
+
+        def _fetch(provider, *, base_url=None, api_key=None):
+            if api_key == "oauth-account-a":
+                account_a_started.set()
+                assert release_account_a.wait(timeout=2)
+                used = 90
+            else:
+                account_b_started.set()
+                used = 20
+            return AccountUsageSnapshot(
+                provider=provider,
+                source="usage_api",
+                fetched_at=datetime.now().astimezone(),
+                windows=(AccountUsageWindow(label="Weekly", used_percent=used),),
+            )
+
+        def _invalidate():
+            invalidations.append(None)
+            if len(invalidations) == 2:
+                both_workers_finished.set()
+
+        cli_obj._app = SimpleNamespace(invalidate=_invalidate)
+        monkeypatch.setattr(account_usage, "fetch_account_usage", _fetch)
+
+        cli_obj._get_status_bar_snapshot()
+        assert account_a_started.wait(timeout=1)
+
+        cli_obj.agent.api_key = "oauth-account-b"
+        cli_obj._get_status_bar_snapshot()
+        assert account_b_started.wait(timeout=1)
+
+        release_account_a.set()
+        assert both_workers_finished.wait(timeout=2)
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        assert snapshot["weekly_quota_remaining"] == 80
+
+    def test_openai_quota_refresh_failure_hides_cached_value(self, monkeypatch):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.6-luna"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.agent.provider = "openai-codex"
+        cli_obj.agent.api_key = "oauth-token"
+        cli_obj.config = {
+            "display": {
+                "account_usage_footer": {
+                    "enabled": True,
+                    "refresh_seconds": 300,
+                }
+            }
+        }
+        cli_obj._status_bar_usage_lock = threading.Lock()
+        cli_obj._status_bar_usage_inflight = False
+        cli_obj._status_bar_usage_last_attempt = 0.0
+        cli_obj._status_bar_usage_provider = "openai-codex"
+        cli_obj._status_bar_usage_identity = cli_obj._status_bar_account_usage_identity(
+            "openai-codex",
+            getattr(cli_obj.agent, "base_url", None),
+            getattr(cli_obj.agent, "api_key", None),
+        )
+        cli_obj._status_bar_usage_generation = 0
+        cli_obj._status_bar_usage_session = None
+        cli_obj._status_bar_usage_weekly = AccountUsageWindow(
+            label="Weekly",
+            used_percent=27,
+        )
+
+        finished = threading.Event()
+
+        def _fetch(*args, **kwargs):
+            finished.set()
+            raise RuntimeError("usage endpoint unavailable")
+
+        monkeypatch.setattr(account_usage, "fetch_account_usage", _fetch)
+
+        cli_obj._get_status_bar_snapshot()
+        assert finished.wait(timeout=1)
+        deadline = time.monotonic() + 2
+        while cli_obj._status_bar_usage_inflight and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        assert snapshot["weekly_quota_remaining"] is None
 
     def test_post_compression_sentinel_does_not_render_negative(self):
         """Right after a compression, last_prompt_tokens is parked at the -1

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -1,9 +1,12 @@
+import threading
 import time
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import cli as cli_mod
+from agent import account_usage
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
 from cli import HermesCLI
 
 
@@ -81,6 +84,209 @@ class TestCLIStatusBar:
         assert "6%" in text
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
+
+    def test_openai_weekly_quota_appears_in_wide_status_bar(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.6-luna"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.agent.provider = "openai-codex"
+        cli_obj.config = {
+            "display": {
+                "account_usage_footer": {
+                    "enabled": True,
+                    "refresh_seconds": 300,
+                }
+            }
+        }
+        cli_obj._status_bar_usage_lock = threading.Lock()
+        cli_obj._status_bar_usage_inflight = False
+        cli_obj._status_bar_usage_last_attempt = time.monotonic()
+        cli_obj._status_bar_usage_provider = "openai-codex"
+        cli_obj._status_bar_usage_session = None
+        cli_obj._status_bar_usage_weekly = AccountUsageWindow(
+            label="Weekly",
+            used_percent=27,
+        )
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        text = cli_obj._build_status_bar_text(width=140)
+        cli_obj._status_bar_visible = True
+        cli_obj._get_tui_terminal_width = lambda: 140
+        fragment_text = "".join(text for _, text in cli_obj._get_status_bar_fragments())
+
+        assert snapshot["weekly_quota_remaining"] == 73
+        assert "week 73%" in text
+        assert "week 73%" in fragment_text
+        assert "5h" not in text
+        assert "5h" not in fragment_text
+
+    def test_openai_five_hour_and_weekly_quotas_both_appear_when_available(self):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.6-luna"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.agent.provider = "openai-codex"
+        cli_obj.config = {
+            "display": {
+                "account_usage_footer": {
+                    "enabled": True,
+                    "refresh_seconds": 300,
+                }
+            }
+        }
+        cli_obj._status_bar_usage_lock = threading.Lock()
+        cli_obj._status_bar_usage_inflight = False
+        cli_obj._status_bar_usage_last_attempt = time.monotonic()
+        cli_obj._status_bar_usage_provider = "openai-codex"
+        cli_obj._status_bar_usage_session = AccountUsageWindow(
+            label="Session",
+            used_percent=18,
+        )
+        cli_obj._status_bar_usage_weekly = AccountUsageWindow(
+            label="Weekly",
+            used_percent=27,
+        )
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        text = cli_obj._build_status_bar_text(width=160)
+        cli_obj._status_bar_visible = True
+        cli_obj._get_tui_terminal_width = lambda: 160
+        fragment_text = "".join(text for _, text in cli_obj._get_status_bar_fragments())
+
+        assert snapshot["session_quota_remaining"] == 82
+        assert snapshot["weekly_quota_remaining"] == 73
+        assert "5h 82%" in text
+        assert "week 73%" in text
+        assert "5h 82%" in fragment_text
+        assert "week 73%" in fragment_text
+
+    def test_openai_weekly_quota_refresh_is_nonblocking_and_cached(self, monkeypatch):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.6-luna"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.agent.provider = "openai-codex"
+        cli_obj.agent.base_url = "https://chatgpt.com/backend-api/codex"
+        cli_obj.agent.api_key = "oauth-token"
+        cli_obj.config = {
+            "display": {
+                "account_usage_footer": {
+                    "enabled": True,
+                    "refresh_seconds": 300,
+                }
+            }
+        }
+        cli_obj._status_bar_usage_lock = threading.Lock()
+        cli_obj._status_bar_usage_inflight = False
+        cli_obj._status_bar_usage_last_attempt = 0.0
+        cli_obj._status_bar_usage_provider = None
+        cli_obj._status_bar_usage_session = None
+        cli_obj._status_bar_usage_weekly = None
+
+        started = threading.Event()
+        release = threading.Event()
+        calls = []
+
+        def _fetch(provider, *, base_url=None, api_key=None):
+            calls.append((provider, base_url, api_key))
+            started.set()
+            assert release.wait(timeout=2)
+            return AccountUsageSnapshot(
+                provider="openai-codex",
+                source="usage_api",
+                fetched_at=datetime.now().astimezone(),
+                windows=(AccountUsageWindow(label="Weekly", used_percent=27),),
+            )
+
+        monkeypatch.setattr(account_usage, "fetch_account_usage", _fetch)
+
+        before = time.monotonic()
+        first = cli_obj._get_status_bar_snapshot()
+        elapsed = time.monotonic() - before
+
+        assert elapsed < 0.2
+        assert first["weekly_quota_remaining"] is None
+        assert started.wait(timeout=1)
+
+        release.set()
+        deadline = time.monotonic() + 2
+        while cli_obj._status_bar_usage_inflight and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        second = cli_obj._get_status_bar_snapshot()
+        third = cli_obj._get_status_bar_snapshot()
+
+        assert second["weekly_quota_remaining"] == 73
+        assert third["weekly_quota_remaining"] == 73
+        assert calls == [
+            (
+                "openai-codex",
+                "https://chatgpt.com/backend-api/codex",
+                "oauth-token",
+            )
+        ]
+
+    def test_openai_quota_refresh_failure_is_fail_open(self, monkeypatch):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.6-luna"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.agent.provider = "openai-codex"
+        cli_obj.config = {
+            "display": {
+                "account_usage_footer": {
+                    "enabled": True,
+                    "refresh_seconds": 300,
+                }
+            }
+        }
+        cli_obj._status_bar_usage_lock = threading.Lock()
+        cli_obj._status_bar_usage_inflight = False
+        cli_obj._status_bar_usage_last_attempt = 0.0
+        cli_obj._status_bar_usage_provider = None
+        cli_obj._status_bar_usage_session = None
+        cli_obj._status_bar_usage_weekly = None
+
+        finished = threading.Event()
+        uncaught = []
+
+        def _fetch(*args, **kwargs):
+            finished.set()
+            raise RuntimeError("usage endpoint unavailable")
+
+        monkeypatch.setattr(account_usage, "fetch_account_usage", _fetch)
+        monkeypatch.setattr(threading, "excepthook", lambda args: uncaught.append(args))
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        assert finished.wait(timeout=1)
+        deadline = time.monotonic() + 2
+        while cli_obj._status_bar_usage_inflight and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        assert snapshot["session_quota_remaining"] is None
+        assert snapshot["weekly_quota_remaining"] is None
+        assert uncaught == []
 
     def test_post_compression_sentinel_does_not_render_negative(self):
         """Right after a compression, last_prompt_tokens is parked at the -1

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -72,6 +72,7 @@ A persistent status bar sits above the input area, updating in real time:
 | Token count | Context tokens used / max context window |
 | Context bar | Visual fill indicator with color-coded thresholds |
 | Cost | Estimated session cost (or `n/a` for unknown/zero-priced models) |
+| `5h N%` / `week N%` | OpenAI Codex OAuth quota remaining. Enable with `display.account_usage_footer.enabled`; unavailable windows are omitted. |
 | 🗜️ N | **Context compression count** — how many times the running session has been auto-compressed. Appears once the first compression fires. |
 | ▶ N | **Active background tasks** — how many `/background` prompts are still running in the current session. Appears whenever at least one task is in flight. |
 | Duration | Elapsed session time |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1483,6 +1483,9 @@ display:
   show_reasoning: false   # Show model reasoning/thinking above each response (toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar
+  account_usage_footer:   # OpenAI Codex OAuth quota remaining in the CLI status bar
+    enabled: false
+    refresh_seconds: 300
   timestamps: false       # When true, prefixes user and assistant labels with [HH:MM] timestamps in the CLI / TUI transcript
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
   runtime_footer:         # Gateway: append a runtime-context footer to final replies

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/cli.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/cli.md
@@ -68,6 +68,7 @@ hermes -w -z "Fix issue #123"     # 在 worktree 中以单次查询模式运行
 | Token 计数 | 已使用的上下文 token 数 / 最大上下文窗口 |
 | 上下文进度条 | 带颜色阈值编码的可视填充指示器 |
 | 费用 | 预估会话费用（未知或零价格模型显示 `n/a`） |
+| `5h N%` / `week N%` | OpenAI Codex OAuth 剩余额度。通过 `display.account_usage_footer.enabled` 启用；API 未返回的窗口不显示。 |
 | 🗜️ N | **上下文压缩次数**——当前运行会话被自动压缩的次数。首次压缩触发后显示。 |
 | ▶ N | **活跃后台任务数**——当前会话中仍在运行的 `/background` prompt（提示词）数量。至少有一个任务进行中时显示。 |
 | 时长 | 会话已用时间 |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1156,6 +1156,9 @@ display:
   show_reasoning: false   # 在每次响应上方显示模型推理/思考（用 /reasoning show|hide 切换）
   streaming: false        # 将 token 实时流式传输到终端
   show_cost: false        # 在 CLI 状态栏中显示估计 $ 成本
+  account_usage_footer:   # CLI 状态栏显示 OpenAI Codex OAuth 剩余额度
+    enabled: false
+    refresh_seconds: 300
   timestamps: false       # 为 true 时，在 CLI/TUI 记录中为用户和 assistant 标签添加 [HH:MM] 时间戳前缀
   tool_preview_length: 0  # 工具调用预览的最大字符数（0 = 无限制，显示完整路径/命令）
   runtime_footer:         # Gateway：在最终回复中附加运行时上下文页脚


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in OpenAI Codex OAuth quota readout to the classic CLI status bar. It shows only the windows returned by the usage API, as remaining percentages:

```text
week 69%
5h 82% | week 69%
```

The usage request runs in a daemon worker and never blocks prompt-toolkit rendering. Results are cached for five minutes, refresh failures fail open and hide stale values, and the cache is isolated by a non-reversible credential identity plus generation guard so an old account request cannot overwrite a newly rotated credential.

The fix also recognizes the current API shape where a single seven-day window is returned as `primary_window`; that window is labeled Weekly rather than Session.

## Related Issue

No existing issue found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Classify 6–8 day Codex quota windows as Weekly even when returned as `primary_window`.
- Add a non-blocking, credential-scoped account-usage cache to the classic CLI status bar.
- Render `5h N%` and/or `week N%`; omit unavailable windows.
- Add `display.account_usage_footer.enabled` and `refresh_seconds` defaults and examples.
- Document the setting in English and Simplified Chinese.
- Cover weekly-only responses, both windows, caching, fail-open behavior, credential rotation races, and stale-value removal.

## How to Test

1. Authenticate with `hermes auth` using OpenAI Codex OAuth.
2. Add this to `~/.hermes/config.yaml`:

   ```yaml
   display:
     account_usage_footer:
       enabled: true
       refresh_seconds: 300
   ```

3. Start classic CLI with an OpenAI Codex model. The status bar should show `week N%`; when the API also returns the five-hour window it should show `5h N% | week N%`.
4. Run:

   ```bash
   scripts/run_tests.sh tests/agent/test_account_usage.py tests/test_account_usage.py tests/cli/test_cli_status_bar.py tests/hermes_cli/test_config.py tests/test_lint_config.py -q
   ```

Verification on macOS 26.5.1:

- Focused suite: **229 passed, 0 failed**.
- Real OAuth E2E: `week 69%`, `5h None`; rendered `week 69%` only.
- Windows footgun scan: passed.
- Full repository suite: 41,958 passed; 29 failures in 17 unrelated files and 3 unrelated browser/provider files timed out. No changed-file test failed; representative Anthropic failures reproduce alone on current main code.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the full test suite and all tests pass (see unrelated current-main failures above)
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example`
- [x] Architecture/workflow docs: N/A
- [x] I've considered cross-platform impact; the worker uses existing Python threading and no platform-specific APIs
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

```text
⚕ gpt-5.6-luna │ 0/272K │ 0% │ week 69% │ 15m │ ⏲ 0s
```
