### PR TITLE
fix(vertex): detect ADC across model pickers

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6438,6 +6438,24 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
             return {"logged_in": has_aws_credentials(), "provider": target}
         except ImportError:
             return {"logged_in": False, "provider": target, "error": "boto3 not installed"}
+    # Plugin-backed providers such as Vertex intentionally live outside the
+    # legacy auth PROVIDER_REGISTRY.  Resolve their auth type from the runtime
+    # provider registry, which is the source of truth for routability.
+    try:
+        from providers import get_provider_profile
+        runtime_profile = get_provider_profile(target)
+    except Exception:
+        runtime_profile = None
+    # Vertex uses Google Application Default Credentials rather than an API
+    # key or Hermes auth-store entry.  Keep this structural and fast: the
+    # adapter checks for an explicit project / credentials path without
+    # importing google-auth or minting a token.
+    if runtime_profile and runtime_profile.auth_type == "vertex":
+        try:
+            from agent.vertex_adapter import has_vertex_credentials
+            return {"logged_in": has_vertex_credentials(), "provider": target}
+        except Exception as exc:
+            return {"logged_in": False, "provider": target, "error": str(exc)}
     return {"logged_in": False}
 
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1975,6 +1975,23 @@ def list_authenticated_providers(
         if not _cp_has_creds and _cp_config and getattr(_cp_config, "auth_type", "") == "aws_sdk":
             _cp_has_creds = _has_aws_sdk_creds_for_listing(_cp.slug)
 
+        # Vertex credentials live in Google's ADC chain, not in an API-key
+        # env var or the Hermes auth store.  Use the adapter's fast structural
+        # detector so Vertex appears in task/model pickers without performing
+        # token acquisition or network I/O while the picker opens.
+        if not _cp_has_creds:
+            try:
+                from providers import get_provider_profile
+                _cp_runtime_profile = get_provider_profile(_cp.slug)
+            except Exception:
+                _cp_runtime_profile = None
+            if _cp_runtime_profile and _cp_runtime_profile.auth_type == "vertex":
+                try:
+                    from agent.vertex_adapter import has_vertex_credentials
+                    _cp_has_creds = bool(has_vertex_credentials())
+                except Exception as exc:
+                    logger.debug("Vertex credential check failed: %s", exc)
+
         if not _cp_has_creds:
             continue
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -544,6 +544,13 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "us.meta.llama4-maverick-17b-instruct-v1:0",
         "us.meta.llama4-scout-17b-instruct-v1:0",
     ],
+    # Vertex exposes Gemini through Google's OpenAI-compatible endpoint and
+    # does not provide a /models listing route. Keep its curated catalog here
+    # so every model picker shares the same source as the setup flow.
+    "vertex": [
+        "google/gemini-3-pro-preview",
+        "google/gemini-3-flash-preview",
+    ],
     # Azure Foundry: user-provided endpoint and model.
     # Empty list because models depend on the endpoint configuration.
     "azure-foundry": [],

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6285,16 +6285,25 @@ def _catalog_provider_env_metadata() -> dict:
 async def get_env_vars(profile: Optional[str] = None):
     with _profile_scope(profile):
         env_on_disk = load_env()
+        try:
+            from agent.vertex_adapter import has_vertex_credentials
+            vertex_credentials_configured = bool(has_vertex_credentials())
+        except Exception:
+            vertex_credentials_configured = False
     channel_keys = _channel_managed_env_keys()
     catalog_meta = _catalog_provider_env_metadata()
 
     def _row(var_name: str, info: dict, *, custom: bool = False) -> dict:
         value = env_on_disk.get(var_name)
         cat_meta = catalog_meta.get(var_name) or {}
+        is_set = bool(value) or (
+            var_name == "VERTEX_CREDENTIALS_PATH"
+            and vertex_credentials_configured
+        )
         # Hand OPTIONAL_ENV_VARS prose wins where present; the catalog fills any
         # gaps (description/url) and always supplies provider grouping hints.
         return {
-            "is_set": bool(value),
+            "is_set": is_set,
             "redacted_value": redact_key(value) if value else None,
             "description": info.get("description") or cat_meta.get("description", ""),
             "url": info.get("url") if info.get("url") is not None else cat_meta.get("url"),

--- a/tests/hermes_cli/test_provider_parity.py
+++ b/tests/hermes_cli/test_provider_parity.py
@@ -11,6 +11,7 @@ an invariant against the real FastAPI endpoints (not a snapshot / count), so it
 can never silently drift again when a provider plugin is added.
 """
 
+import pytest
 from fastapi.testclient import TestClient
 
 from hermes_cli.models import CANONICAL_PROVIDERS
@@ -95,3 +96,17 @@ def test_no_provider_appears_on_both_tabs():
     """
     overlap = (_keys_tab_providers() & _accounts_tab_providers()) - _EXEMPT - _DUAL_TAB
     assert not overlap, f"providers appearing on BOTH desktop tabs: {sorted(overlap)}"
+
+
+@pytest.mark.asyncio
+async def test_vertex_adc_marks_desktop_provider_connected(monkeypatch):
+    import agent.vertex_adapter as vertex_adapter
+    import hermes_cli.web_server as web_server
+
+    monkeypatch.setattr(web_server, "load_env", lambda: {})
+    monkeypatch.setattr(vertex_adapter, "has_vertex_credentials", lambda: True)
+
+    result = await web_server.get_env_vars()
+
+    assert result["VERTEX_CREDENTIALS_PATH"]["is_set"] is True
+    assert result["VERTEX_CREDENTIALS_PATH"]["redacted_value"] is None

--- a/tests/hermes_cli/test_vertex_provider.py
+++ b/tests/hermes_cli/test_vertex_provider.py
@@ -80,6 +80,55 @@ def test_resolve_runtime_provider_raises_autherror_when_unresolved(monkeypatch):
     assert "not a static API key" in msg
 
 
+def test_vertex_auth_status_uses_adc_credential_detector(monkeypatch):
+    import agent.vertex_adapter as va
+    from hermes_cli.auth import get_auth_status
+
+    monkeypatch.setattr(va, "has_vertex_credentials", lambda: True)
+
+    assert get_auth_status("vertex") == {
+        "logged_in": True,
+        "provider": "vertex",
+    }
+
+
+def test_vertex_adc_surfaces_in_task_model_options(monkeypatch):
+    import agent.models_dev as models_dev
+    import agent.vertex_adapter as va
+    import hermes_cli.model_switch as model_switch
+    import hermes_cli.models as models
+    from hermes_cli.inventory import ConfigContext, build_models_payload
+
+    monkeypatch.setattr(models_dev, "fetch_models_dev", lambda: {})
+    monkeypatch.setattr(va, "has_vertex_credentials", lambda: True)
+    monkeypatch.setattr(
+        model_switch,
+        "_credential_pool_is_usable",
+        lambda *args, **kwargs: False,
+    )
+    monkeypatch.setattr(models, "cached_provider_model_ids", lambda provider: [])
+
+    payload = build_models_payload(
+        ConfigContext(
+            current_provider="openai-codex",
+            current_model="gpt-test",
+            current_base_url="",
+            user_providers={},
+            custom_providers=[],
+        ),
+        include_unconfigured=True,
+        picker_hints=True,
+    )
+    vertex = next(row for row in payload["providers"] if row["slug"] == "vertex")
+
+    assert vertex["authenticated"] is True
+    assert vertex["source"] == "canonical"
+    assert vertex["models"] == [
+        "google/gemini-3-pro-preview",
+        "google/gemini-3-flash-preview",
+    ]
+
+
 def test_vertex_extra_body_thinking_config():
     from providers import get_provider_profile
 


### PR DESCRIPTION
## What does this PR do?

Makes Google Vertex AI configured through Application Default Credentials (ADC) consistently visible across Hermes' generic auth status, task/model pickers, and the Desktop Providers UI.

The Vertex runtime already worked because `agent.vertex_adapter` resolves ADC and project configuration. Discovery paths did not share that logic: they only checked the legacy API-key/OAuth registries, so a working Vertex setup could still appear unauthenticated and be omitted from cron/auxiliary model selectors.

This fix uses the runtime provider registry as the auth-type source of truth and the existing fast `has_vertex_credentials()` structural detector. It does not mint a token or perform network I/O when a picker opens.

Related: #56687. This overlaps with #57399 and #61933, but also covers the generic `get_auth_status()` path and the Desktop `/api/env` Connected badge. Unlike #57399, picker discovery remains structural-only rather than calling `get_vertex_config()` and minting an OAuth token.

## Related Issue

Related to #56687.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/auth.py`
  - Resolve plugin-backed auth types through `providers.get_provider_profile()`.
  - Report Vertex as authenticated when its existing ADC/project detector succeeds.
- `hermes_cli/model_switch.py`
  - Surface Vertex in authenticated provider lists used by cron and auxiliary task model selectors.
  - Keep discovery fast and offline by using `has_vertex_credentials()`.
- `hermes_cli/models.py`
  - Put Vertex's curated Gemini models in the shared provider catalog so setup and task pickers use one source.
- `hermes_cli/web_server.py`
  - Mark the Desktop Vertex provider card Connected when ADC/project configuration is available, even without `VERTEX_CREDENTIALS_PATH`.
  - Run the detector inside the requested profile scope.
- Tests
  - Cover generic auth status, authenticated picker payload, shared model catalog, and the Desktop ADC Connected badge.

## How to Test

1. Configure a `vertex:` project/region and working ADC without setting `VERTEX_CREDENTIALS_PATH`.
2. Open a model selector for a cron or auxiliary task; Vertex should be authenticated and list:
   - `google/gemini-3-pro-preview`
   - `google/gemini-3-flash-preview`
3. Open Desktop Providers; Vertex should show Connected without exposing a credential path.
4. Run:
   - Focused suite: `174 passed`
   - Full suite: GitHub CI matrix requested. The local installed pytest has no
     `pytest-xdist`; a serial full-suite run was stopped at 18% after 13 minutes
     rather than modifying the production Hermes venv to add test-only packages.
   - Ruff, `py_compile`, and `git diff --check`: passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and documented the overlap above
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — full matrix delegated to
  GitHub CI; the local focused suite passed 174 tests
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04 with real Google ADC and a live Vertex request

### Documentation & Housekeeping

- [x] Documentation update — N/A; behavior and inline comments updated
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no workflow or architecture change
- [x] Cross-platform impact considered; discovery is profile-scoped and filesystem/config-only
- [x] Tool descriptions/schemas update — N/A
