### PR TITLE
fix(approval): detect Windows drive-letter paths in dangerous command patterns

### DIFF
--- a/tests/tools/test_approval_windows.py
+++ b/tests/tools/test_approval_windows.py
@@ -1,0 +1,62 @@
+"""Regression tests for Windows drive-letter path detection in approval.py.
+
+Teknium1 review (#38979): drive-letter rm detection must live in the
+_RM_FLAG_PREFIX / _hardline_rm_path() mechanism, use real single-backslash
+separators (matching what the shell delivers after normalization), and cover
+forward-slash form without gating safe temp writes.
+"""
+import pytest
+
+
+def _detect(cmd):
+    from tools.approval import detect_dangerous_command
+    return detect_dangerous_command(cmd)
+
+
+class TestWindowsDrivePaths:
+    """rm targeting Windows drive roots must be hardline-blocked."""
+
+    def test_rm_rf_windows_forward_slash(self):
+        """rm -rf C:/ must be hardline-blocked (forward-slash form)."""
+        dangerous, key, desc = _detect("rm -rf C:/")
+        assert dangerous is True
+        assert key is not None
+        assert "delete" in (desc or "").lower() or "drive" in (desc or "").lower()
+
+    def test_rm_rf_windows_forward_slash_with_path(self):
+        """rm -rf X:/important must be hardline-blocked."""
+        dangerous, key, desc = _detect("rm -rf X:/important/data")
+        assert dangerous is True
+
+    def test_rm_rf_windows_lowercase_drive(self):
+        """rm -rf c:/ (lowercase) must be hardline-blocked."""
+        dangerous, key, desc = _detect("rm -rf c:/")
+        assert dangerous is True
+
+    def test_rm_rf_windows_single_backslash(self):
+        """rm -rf C:\\ — single backslash as delivered by normalization."""
+        # The shell delivers a single backslash; normalization in approval.py
+        # strips one level of escaping, so we pass the normalized form here.
+        dangerous, key, desc = _detect("rm -rf C:\\")
+        assert dangerous is True
+
+    def test_rm_no_flag_windows_drive_root(self):
+        """rm C:/ (drive root, no flag) must be caught."""
+        dangerous, key, desc = _detect("rm C:/")
+        assert dangerous is True
+
+    def test_safe_write_to_temp_not_blocked(self):
+        """echo data > C:/Temp/scratch.txt must NOT be hardline-blocked.
+        Windows analogue of the safe POSIX /tmp write."""
+        dangerous, key, desc = _detect("echo data > C:/Temp/scratch.txt")
+        # Must not be in HARDLINE_PATTERNS (could be in DANGEROUS_PATTERNS
+        # with a warning, but must not be an unconditional block for temp files)
+        from tools.approval import HARDLINE_PATTERNS
+        import re
+        cmd = "echo data > C:/Temp/scratch.txt"
+        for pattern, _ in HARDLINE_PATTERNS:
+            if re.search(pattern, cmd, re.IGNORECASE):
+                pytest.fail(
+                    f"Safe temp write '{cmd}' matched hardline pattern {pattern!r}. "
+                    "Windows drive-root deletion rule must not catch all drive-path writes."
+                )

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -382,6 +382,11 @@ HARDLINE_PATTERNS = [
     (_RM_FLAG_PREFIX + _hardline_rm_path(r'/(?:(?:\.\.?)?/)*(?:\.\.?)?\**|/ \*'), "recursive delete of root filesystem"),
     (_RM_FLAG_PREFIX + _hardline_rm_path(_HARDLINE_SYSTEM_DIRS), "recursive delete of system directory"),
     (_RM_FLAG_PREFIX + _hardline_rm_path(r'(?:~|\$\{?HOME\}?)(?:/?|/\*)?'), "recursive delete of home directory"),
+    # Windows drive-letter recursive deletes (rm -rf C:\ or rm -rf C:/).
+    # Single backslash in the shell becomes \x5c after normalization;
+    # forward-slash form is accepted directly. Both are hardline because
+    # drive roots have no recovery path, mirroring the POSIX / rule.
+    (_RM_FLAG_PREFIX + _hardline_rm_path(r'[A-Za-z]:[/\\](?:\*)?'), "recursive delete of Windows drive root"),
     # Filesystem format
     (r'\bmkfs(\.[a-z0-9]+)?\b', "format filesystem (mkfs)"),
     # Raw block device overwrites (dd + redirection)
@@ -545,6 +550,9 @@ def _sudo_stdin_block_result(description: str) -> dict:
 
 DANGEROUS_PATTERNS = [
     (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
+    # Windows drive-letter root deletion without flags: rm C:/ rm X:\ etc.
+    # Mirrors the POSIX "delete in root path" rule for Windows paths.
+    (r'\brm\s+(-[^\s]*\s+)*[A-Za-z]:[/\\]', "delete in Windows drive root"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
     (r'\brm\s+--recursive\b', "recursive delete (long flag)"),
     # Windows shell front-ends have destructive built-ins that do not look like


### PR DESCRIPTION
## Problem

rm targeting Windows drive roots had no approval gate. rm -rf C:/ and rm -rf X:\\ could wipe entire drives silently (issue #38964).

## Fix

1. HARDLINE_PATTERNS: _RM_FLAG_PREFIX + _hardline_rm_path() for [A-Za-z]:[/\\] drive roots
2. DANGEROUS_PATTERNS: bare rm [A-Za-z]:[/\\] rule (no flags)

Key improvements over PR #38979: uses existing _hardline_rm_path() mechanism, single-backslash form works correctly, safe writes (echo > C:/Temp/scratch.txt) NOT blocked.

## Verification

6 tests: forward-slash, with-path, lowercase, single-backslash, flagless root, safe temp not blocked. 6/6 pass.

Fixes #38964