### PR TITLE
fix(slack): avoid duplicating rich-text link messages

### DIFF
--- a/contributors/emails/mehrzad.karami@gmail.com
+++ b/contributors/emails/mehrzad.karami@gmail.com
@@ -1,0 +1,2 @@
+mzkarami
+# PR #66204 contributor identity

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -139,8 +139,8 @@ def _extract_text_from_slack_blocks(blocks: list) -> str:
                 pieces.append(el.get("text", ""))
             elif el_type == "link":
                 url = el.get("url", "")
-                text = el.get("text", "") or url
-                pieces.append(f"{text} ({url})")
+                text = el.get("text", "")
+                pieces.append(f"{text} ({url})" if text and text != url else url)
             elif el_type == "channel":
                 pieces.append(f"<#{el.get('channel_id', '')}>")
             elif el_type == "user":
@@ -206,6 +206,28 @@ def _extract_text_from_slack_blocks(blocks: list) -> str:
             _walk_elements(block.get("elements", []))
 
     return "\n".join(parts)
+
+
+_SLACK_MRKDWN_LINK_RE = re.compile(
+    r"<((?:https?|mailto):[^>|]+)(?:\|([^>]+))?>"
+)
+
+
+def _normalize_slack_text_for_dedupe(text: str) -> str:
+    """Canonicalize equivalent Slack plain-text and rich-block link forms.
+
+    Slack serializes the same authored link as ``<url|label>`` in the event's
+    plain ``text`` field and as a structured ``link`` element in ``blocks``.
+    Comparing those raw strings makes a normal rich-text message look like
+    additional quoted content and appends the whole message a second time.
+    """
+
+    def _link(match: re.Match) -> str:
+        url, label = match.group(1), match.group(2)
+        return f"{label} ({url})" if label and label != url else url
+
+    canonical = _SLACK_MRKDWN_LINK_RE.sub(_link, text or "")
+    return re.sub(r"\s+", " ", canonical).strip()
 
 
 def _serialize_slack_blocks_for_agent(blocks: list, max_chars: int = 6000) -> str:
@@ -3181,7 +3203,12 @@ class SlackAdapter(BasePlatformAdapter):
                 # Only append if the blocks contain text not already present
                 # in the plain text field (avoids duplication).
                 stripped_blocks = blocks_text.strip()
-                if stripped_blocks and stripped_blocks not in text.strip():
+                block_text_is_duplicate = (
+                    stripped_blocks in text.strip()
+                    or _normalize_slack_text_for_dedupe(stripped_blocks)
+                    == _normalize_slack_text_for_dedupe(text)
+                )
+                if stripped_blocks and not block_text_is_duplicate:
                     logger.debug(
                         "Slack: extracted additional text from blocks "
                         "(likely quoted/forwarded content): %s",

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1748,6 +1748,49 @@ class TestIncomingDocumentHandling:
         assert msg_event.text == "hello world"
 
     @pytest.mark.asyncio
+    async def test_rich_text_blocks_do_not_duplicate_semantically_equal_slack_links(
+        self, adapter
+    ):
+        """Slack's plain ``text`` uses mrkdwn links while rich_text blocks use
+        structured links. They are the same authored message and must not be
+        appended as a second copy merely because their serializations differ."""
+        event = self._make_event(
+            text=(
+                "Review <https://github.com/acme/design/pull/7|PR #7> and "
+                "<http://preview.example.com>."
+            ),
+            blocks=[
+                {
+                    "type": "rich_text",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {"type": "text", "text": "Review "},
+                                {
+                                    "type": "link",
+                                    "url": "https://github.com/acme/design/pull/7",
+                                    "text": "PR #7",
+                                },
+                                {"type": "text", "text": " and "},
+                                {
+                                    "type": "link",
+                                    "url": "http://preview.example.com",
+                                },
+                                {"type": "text", "text": "."},
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == event["text"]
+
+    @pytest.mark.asyncio
     async def test_rich_text_quotes_and_lists_are_extracted(self, adapter):
         """Nested quote and list content should be surfaced from rich_text blocks."""
         event = self._make_event(


### PR DESCRIPTION
## What does this PR do?

Prevents Slack messages with links from being duplicated when the same authored content arrives in both Slack's plain `text` field and structured `rich_text` blocks.

Slack serializes a labeled link as `<url|label>` in the plain field and as a structured link element in blocks. The adapter rendered the block form as `label (url)`, so the existing raw substring check treated it as additional quoted content and appended the entire message again.

This change canonicalizes equivalent Slack link representations for deduplication while preserving extraction of genuinely additional quoted, forwarded, list, and preformatted block content.

## Related Issue

No exact issue found. Related but distinct: https://github.com/NousResearch/hermes-agent/pull/43533 addresses duplication caused by bang-command rewriting; this PR addresses semantically identical normal messages whose link serializations differ.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/slack/adapter.py`
  - Render unlabelled structured Slack links without repeating the URL.
  - Canonicalize Slack mrkdwn and structured link forms before deciding whether block text is additional content.
- `tests/gateway/test_slack.py`
  - Add regression coverage for labeled and unlabelled links represented in both event forms.
- `contributors/emails/mehrzad.karami@gmail.com`
  - Add the contributor mapping required by the repository attribution check using the current one-file-per-email format.

## How to Test

1. Run the Slack gateway test file:

```bash
./venv/bin/python -m pytest tests/gateway/test_slack.py -q
```

2. Run the contributor/release tests:

```bash
./venv/bin/python -m pytest tests/scripts/test_contributor_map.py tests/scripts/test_release_acp_registry.py -q
```

3. Confirm the synthetic message containing both `<url|label>` / `<url>` plain forms and structured links reaches the agent exactly once.
4. Confirm existing quote/list extraction and command-routing tests continue to pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is documented in the helper docstring and regression test
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-independent Slack payload parsing
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
248 passed in tests/gateway/test_slack.py
15 passed in tests/scripts/test_contributor_map.py and tests/scripts/test_release_acp_registry.py
Contributor mapping runtime probe: passed
Git diff check: passed
```
