### PR TITLE
fix(mattermost): filter bot messages in free-response channels

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -466,6 +466,7 @@ class GatewayAuthorizationMixin:
             Platform.FEISHU: "FEISHU_ALLOW_BOTS",
             Platform.TELEGRAM: "TELEGRAM_ALLOW_BOTS",
             Platform.SLACK: "SLACK_ALLOW_BOTS",
+            Platform.MATTERMOST: "MATTERMOST_ALLOW_BOTS",
         }
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1931,6 +1931,7 @@ DEFAULT_CONFIG = {
         "require_mention": True,       # Require @mention to respond in channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
+        "allow_bots": "all",           # Bot senders: none | mentions | all (compatibility default)
         "channel_prompts": {},         # Per-channel ephemeral system prompts
     },
 

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -119,6 +119,11 @@ class MattermostAdapter(BasePlatformAdapter):
         self._last_post_status: Optional[int] = None
         self._last_post_error: str = ""
 
+        # Mattermost websocket posts do not include the sender's is_bot flag.
+        # Cache /users/{id} lookups so filtering does not add one REST request
+        # per message from an already-seen sender.
+        self._user_is_bot_cache: Dict[str, bool] = {}
+
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
 
@@ -149,6 +154,63 @@ class MattermostAdapter(BasePlatformAdapter):
         except aiohttp.ClientError as exc:
             logger.error("MM API GET %s network error: %s", path, exc)
             return {}
+
+    def _message_mentions_self(self, text: str) -> bool:
+        text_lower = text.lower()
+        return any(
+            pattern and pattern.lower() in text_lower
+            for pattern in (f"@{self._bot_username}", f"@{self._bot_user_id}")
+        )
+
+    def _mattermost_allow_bots_policy(self) -> str:
+        """Return the configured bot policy: ``none``, ``mentions``, or ``all``."""
+        raw = self.config.extra.get("allow_bots") if self.config.extra else None
+        if raw is None:
+            raw = os.getenv("MATTERMOST_ALLOW_BOTS", "all")
+        value = str(raw).strip().lower()
+        if value in {"none", "mentions", "all"}:
+            return value
+        logger.warning(
+            "Mattermost: invalid allow_bots policy %r; using 'all' for compatibility",
+            raw,
+        )
+        return "all"
+
+    async def _sender_is_bot(self, user_id: str) -> bool:
+        """Resolve Mattermost's user-level ``is_bot`` flag, failing open."""
+        if not user_id:
+            return False
+        if user_id in self._user_is_bot_cache:
+            return self._user_is_bot_cache[user_id]
+        if not self._session:
+            return False
+        user = await self._api_get(f"users/{user_id}")
+        # Do not negatively cache a failed or malformed lookup: a transient API
+        # failure must not permanently disable filtering for this process.
+        if not isinstance(user, dict) or "is_bot" not in user:
+            return False
+        is_bot = bool(user["is_bot"])
+        self._user_is_bot_cache[user_id] = is_bot
+        return is_bot
+
+    async def _should_ignore_bot_sender(
+        self,
+        user_id: str,
+        message_text: str,
+    ) -> tuple[bool, bool]:
+        """Return ``(ignore_message, sender_is_bot)`` for an inbound sender."""
+        sender_is_bot = await self._sender_is_bot(user_id)
+        if not sender_is_bot:
+            return False, False
+
+        policy = self._mattermost_allow_bots_policy()
+        if policy == "none":
+            logger.debug("Mattermost: ignoring bot sender %s (allow_bots=none)", user_id)
+            return True, True
+        if policy == "mentions" and not self._message_mentions_self(message_text):
+            logger.debug("Mattermost: ignoring unmentioned bot sender %s", user_id)
+            return True, True
+        return False, True
 
     async def _api_post(
         self, path: str, payload: Dict[str, Any]
@@ -821,6 +883,12 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
+        sender_id = post.get("user_id", "")
+        ignore_bot_sender, sender_is_bot = await self._should_ignore_bot_sender(
+            sender_id, message_text
+        )
+        if ignore_bot_sender:
+            return
 
         # Mention-gating for non-DM channels.
         # Config (config.yaml `mattermost.*` with env-var fallback):
@@ -879,7 +947,6 @@ class MattermostAdapter(BasePlatformAdapter):
                     ).strip()
 
         # Resolve sender info.
-        sender_id = post.get("user_id", "")
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
 
         # Thread support: if the post is in a thread, use root_id. In
@@ -956,6 +1023,7 @@ class MattermostAdapter(BasePlatformAdapter):
             user_name=sender_name,
             thread_id=thread_id,
             message_id=post_id,
+            is_bot=sender_is_bot,
         )
 
         # Per-channel ephemeral prompt
@@ -1204,8 +1272,8 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
 
     The MattermostAdapter reads its runtime configuration via
     ``os.getenv()`` for ``MATTERMOST_REQUIRE_MENTION``,
-    ``MATTERMOST_FREE_RESPONSE_CHANNELS``, and
-    ``MATTERMOST_ALLOWED_CHANNELS``.  Rather than rewrite those call sites
+    ``MATTERMOST_FREE_RESPONSE_CHANNELS``, ``MATTERMOST_ALLOWED_CHANNELS``,
+    and ``MATTERMOST_ALLOW_BOTS``. Rather than rewrite those call sites
     to read from ``PlatformConfig.extra``, this hook keeps the env-driven
     model and merely owns the YAML→env translation here, next to the
     adapter that consumes it.
@@ -1228,6 +1296,9 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
+    allow_bots = mattermost_cfg.get("allow_bots")
+    if allow_bots is not None and not os.getenv("MATTERMOST_ALLOW_BOTS"):
+        os.environ["MATTERMOST_ALLOW_BOTS"] = str(allow_bots).lower()
     return None  # all settings flow through env; nothing to merge into extras
 
 
@@ -1278,9 +1349,9 @@ def register(ctx) -> None:
         setup_fn=interactive_setup,
         # YAML→env config bridge — owns the translation of
         # ``config.yaml`` ``mattermost:`` keys (require_mention,
-        # free_response_channels, allowed_channels) into ``MATTERMOST_*``
-        # env vars that the adapter reads via ``os.getenv()``.  Replaces
-        # the hardcoded block that used to live in ``gateway/config.py``.
+        # free_response_channels, allowed_channels, allow_bots) into
+        # ``MATTERMOST_*`` env vars that the adapter reads via ``os.getenv()``.
+        # Replaces the hardcoded block that used to live in ``gateway/config.py``.
         # Hook contract: #24836 / #25443.
         apply_yaml_config_fn=_apply_yaml_config,
         # Auth env vars for _is_user_authorized() integration.

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -2,7 +2,6 @@
 import json
 import os
 import time
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, AsyncMock
 
 import pytest
@@ -497,43 +496,68 @@ class TestMattermostBotIdentity:
         assert adapter._api_get.await_count == 2
 
 
+def _make_mattermost_auth_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner.pairing_stores = {}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    return runner
+
+
+def _make_mattermost_bot_source():
+    from gateway.session import Platform, SessionSource
+
+    return SessionSource(
+        platform=Platform.MATTERMOST,
+        chat_id="chan_456",
+        chat_type="channel",
+        user_id="moviepilot_bot",
+        user_name="moviepilot",
+        is_bot=True,
+    )
+
+
 class TestMattermostBotYamlConfig:
-    def test_yaml_allow_bots_bridges_to_runtime_env(self, monkeypatch):
-        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+    def test_default_config_preserves_historical_all_policy(self):
+        from hermes_cli.config import DEFAULT_CONFIG
 
+        assert DEFAULT_CONFIG["mattermost"]["allow_bots"] == "all"
+
+    def test_gateway_loader_bridges_yaml_policy_into_authorization(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "mattermost:\n  allow_bots: none\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.delenv("MATTERMOST_ALLOW_BOTS", raising=False)
+        monkeypatch.setenv("MATTERMOST_ALLOWED_USERS", "human_user")
+        monkeypatch.setenv("MATTERMOST_ALLOW_ALL_USERS", "false")
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "false")
 
-        _apply_yaml_config({}, {"allow_bots": "none"})
+        from gateway.config import load_gateway_config
+
+        load_gateway_config()
 
         assert os.environ["MATTERMOST_ALLOW_BOTS"] == "none"
+        assert _make_mattermost_auth_runner()._is_user_authorized(
+            _make_mattermost_bot_source()
+        ) is False
 
 
 class TestMattermostBotAuthorization:
-    @staticmethod
-    def _runner():
-        from gateway.run import GatewayRunner
-
-        runner = object.__new__(GatewayRunner)
-        runner.pairing_store = SimpleNamespace(is_approved=lambda *_args, **_kwargs: False)
-        return runner
-
-    @staticmethod
-    def _source():
-        from gateway.session import Platform, SessionSource
-
-        return SessionSource(
-            platform=Platform.MATTERMOST,
-            chat_id="chan_456",
-            chat_type="channel",
-            user_id="moviepilot_bot",
-            user_name="moviepilot",
-            is_bot=True,
-        )
-
     def test_allow_bots_all_bypasses_human_allowlist(self, monkeypatch):
         monkeypatch.setenv("MATTERMOST_ALLOW_BOTS", "all")
         monkeypatch.setenv("MATTERMOST_ALLOWED_USERS", "human_user")
-        assert self._runner()._is_user_authorized(self._source()) is True
+        assert _make_mattermost_auth_runner()._is_user_authorized(
+            _make_mattermost_bot_source()
+        ) is True
 
 # ---------------------------------------------------------------------------
 # File upload (send_image)

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -2,8 +2,10 @@
 import json
 import os
 import time
-import pytest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageType
@@ -359,10 +361,17 @@ class TestMattermostMentionBehavior:
         self.adapter._bot_username = "hermes-bot"
         self.adapter.handle_message = AsyncMock()
 
-    def _make_event(self, message, channel_type="O", channel_id="chan_456"):
+    def _make_event(
+        self,
+        message,
+        channel_type="O",
+        channel_id="chan_456",
+        user_id="user_123",
+        post_id="post_mention",
+    ):
         post_data = {
-            "id": "post_mention",
-            "user_id": "user_123",
+            "id": post_id,
+            "user_id": user_id,
             "channel_id": channel_id,
             "message": message,
         }
@@ -393,6 +402,138 @@ class TestMattermostMentionBehavior:
             await self.adapter._handle_ws_event(self._make_event("hello", channel_id="chan_456"))
             assert self.adapter.handle_message.called
 
+    @pytest.mark.asyncio
+    async def test_allow_bots_none_ignores_bot_in_free_response_channel(self):
+        self.adapter._user_is_bot_cache["moviepilot_bot"] = True
+        with patch.dict(
+            os.environ,
+            {
+                "MATTERMOST_ALLOW_BOTS": "none",
+                "MATTERMOST_FREE_RESPONSE_CHANNELS": "chan_456",
+            },
+        ):
+            await self.adapter._handle_ws_event(
+                self._make_event("", user_id="moviepilot_bot")
+            )
+        assert not self.adapter.handle_message.called
+
+    @pytest.mark.asyncio
+    async def test_allow_bots_none_still_accepts_human(self):
+        self.adapter._user_is_bot_cache["user_123"] = False
+        with patch.dict(
+            os.environ,
+            {
+                "MATTERMOST_ALLOW_BOTS": "none",
+                "MATTERMOST_FREE_RESPONSE_CHANNELS": "chan_456",
+            },
+        ):
+            await self.adapter._handle_ws_event(self._make_event("hello"))
+        assert self.adapter.handle_message.called
+        assert self.adapter.handle_message.call_args[0][0].source.is_bot is False
+
+    @pytest.mark.asyncio
+    async def test_allow_bots_mentions_requires_explicit_mention(self):
+        self.adapter._user_is_bot_cache["moviepilot_bot"] = True
+        with patch.dict(
+            os.environ,
+            {
+                "MATTERMOST_ALLOW_BOTS": "mentions",
+                "MATTERMOST_FREE_RESPONSE_CHANNELS": "chan_456",
+            },
+        ):
+            await self.adapter._handle_ws_event(
+                self._make_event("status", user_id="moviepilot_bot", post_id="bot_1")
+            )
+            assert not self.adapter.handle_message.called
+
+            await self.adapter._handle_ws_event(
+                self._make_event(
+                    "@hermes-bot status",
+                    user_id="moviepilot_bot",
+                    post_id="bot_2",
+                )
+            )
+            assert self.adapter.handle_message.called
+            message = self.adapter.handle_message.call_args[0][0]
+            assert message.text == "status"
+            assert message.source.is_bot is True
+
+    @pytest.mark.asyncio
+    async def test_allow_bots_all_accepts_bot_message(self):
+        self.adapter._user_is_bot_cache["moviepilot_bot"] = True
+        with patch.dict(
+            os.environ,
+            {
+                "MATTERMOST_ALLOW_BOTS": "all",
+                "MATTERMOST_FREE_RESPONSE_CHANNELS": "chan_456",
+            },
+        ):
+            await self.adapter._handle_ws_event(
+                self._make_event("status", user_id="moviepilot_bot")
+            )
+        assert self.adapter.handle_message.called
+        assert self.adapter.handle_message.call_args[0][0].source.is_bot is True
+
+
+class TestMattermostBotIdentity:
+    @pytest.mark.asyncio
+    async def test_sender_bot_flag_is_cached_after_user_api_lookup(self):
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._api_get = AsyncMock(return_value={"id": "bot_1", "is_bot": True})
+
+        assert await adapter._sender_is_bot("bot_1") is True
+        assert await adapter._sender_is_bot("bot_1") is True
+        adapter._api_get.assert_awaited_once_with("users/bot_1")
+
+    @pytest.mark.asyncio
+    async def test_failed_user_lookup_is_not_negatively_cached(self):
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._api_get = AsyncMock(return_value={})
+
+        assert await adapter._sender_is_bot("bot_1") is False
+        assert await adapter._sender_is_bot("bot_1") is False
+        assert adapter._api_get.await_count == 2
+
+
+class TestMattermostBotYamlConfig:
+    def test_yaml_allow_bots_bridges_to_runtime_env(self, monkeypatch):
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+
+        monkeypatch.delenv("MATTERMOST_ALLOW_BOTS", raising=False)
+
+        _apply_yaml_config({}, {"allow_bots": "none"})
+
+        assert os.environ["MATTERMOST_ALLOW_BOTS"] == "none"
+
+
+class TestMattermostBotAuthorization:
+    @staticmethod
+    def _runner():
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.pairing_store = SimpleNamespace(is_approved=lambda *_args, **_kwargs: False)
+        return runner
+
+    @staticmethod
+    def _source():
+        from gateway.session import Platform, SessionSource
+
+        return SessionSource(
+            platform=Platform.MATTERMOST,
+            chat_id="chan_456",
+            chat_type="channel",
+            user_id="moviepilot_bot",
+            user_name="moviepilot",
+            is_bot=True,
+        )
+
+    def test_allow_bots_all_bypasses_human_allowlist(self, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_ALLOW_BOTS", "all")
+        monkeypatch.setenv("MATTERMOST_ALLOWED_USERS", "human_user")
+        assert self._runner()._is_user_authorized(self._source()) is True
 
 # ---------------------------------------------------------------------------
 # File upload (send_image)

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -225,6 +225,20 @@ To find a channel ID in Mattermost: open the channel, click the channel name hea
 
 When the bot is `@mentioned`, the mention is automatically stripped from the message before processing.
 
+### Bot messages
+
+Mattermost bot accounts can post into free-response channels and accidentally
+trigger bot-to-bot loops. Configure how Hermes handles those senders:
+
+```yaml
+mattermost:
+  allow_bots: none  # none | mentions | all
+```
+
+- `none` ignores every other Mattermost bot account.
+- `mentions` accepts a bot message only when it explicitly mentions Hermes.
+- `all` is the default and preserves the historical Mattermost behavior.
+
 ## Channel allowlist (`allowed_channels`)
 
 Restrict the bot to a fixed set of Mattermost channels. When set, the bot **only** responds in channels whose ID appears in the list — messages from any other channel are silently ignored, even if the bot is `@mentioned`.


### PR DESCRIPTION
## Bug Description

Mattermost bot accounts can post into free-response channels and be dispatched to the agent as if they were human senders. This can cause bot-to-bot reply loops, channel spam, and unnecessary model usage.

Unlike the Discord, Slack, Feishu, and Telegram adapters, Mattermost had no `allow_bots` policy and did not propagate bot identity into `SessionSource`.

## Root Cause

Mattermost websocket `posted` events include the sender `user_id`, but not the user's `is_bot` flag. The adapter only ignored its own user ID and system posts; it never resolved the sender through `/api/v4/users/{id}` before dispatch.

## Fix

- Resolve and cache Mattermost sender `is_bot` flags through the users API.
- Add `mattermost.allow_bots` with the same three modes used by sibling adapters:
  - `none` — ignore other bot accounts;
  - `mentions` — accept bot messages only when they explicitly mention Hermes;
  - `all` — preserve historical Mattermost intake behavior.
- Keep `all` as the adapter default for backward compatibility. The gateway bot allowlist bypass is activated only when `allow_bots` is explicitly configured and bridged to `MATTERMOST_ALLOW_BOTS`.
- Propagate accepted bot identity into `SessionSource.is_bot` so gateway authorization behaves consistently with other adapters.
- Do not negatively cache failed user lookups, so a transient Mattermost API failure cannot permanently misclassify a sender.
- Document the YAML setting and bot-loop use case.

## How to Verify

1. Configure a Mattermost free-response channel and set:
   ```yaml
   mattermost:
     allow_bots: none
   ```
2. Post from a Mattermost bot account in that channel; Hermes should not dispatch or reply.
3. Post from a human account; Hermes should still respond normally.
4. Set `allow_bots: mentions`; an unmentioned bot post should be ignored, while an explicit `@Hermes` bot post should be accepted.

## Test Plan

- [x] Added regression coverage for `none`, `mentions`, and `all`.
- [x] Added coverage that human free-response messages remain accepted.
- [x] Added coverage for user-API bot lookup caching and transient lookup failures.
- [x] Added YAML-to-runtime bridge coverage.
- [x] Added gateway authorization coverage for explicitly allowed bot traffic.
- [x] `tests/gateway/test_mattermost.py`: 70 passed.
- [x] Discord/Feishu/Slack/Telegram bot-auth regression suites: 27 passed.
- [x] Ruff, `py_compile`, and `git diff --check` passed.
- [x] Verified against a real Mattermost bot account (`is_bot: true`) and the resulting `allow_bots: none` decision locally.

## Risk Assessment

**Low to medium.** The default preserves historical Mattermost intake behavior. The first message from each previously unseen sender adds one cached `/users/{id}` lookup. Failed or malformed lookups fail open at adapter filtering and are not cached, preserving existing message handling while allowing a later lookup to recover.
