### PR TITLE
fix(gateway): _platform_status feeds is_connected the real PlatformConfig

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5152,10 +5152,23 @@ def _platform_status(platform: dict) -> str:
         # check_fn (typically just dependency / env presence).
         if entry.is_connected is not None:
             try:
-                from gateway.config import PlatformConfig
+                from gateway.config import Platform, PlatformConfig, load_gateway_config
 
-                synthetic = PlatformConfig(enabled=True)
-                configured = bool(entry.is_connected(synthetic))
+                # Resolve the real PlatformConfig from ~/.hermes/config.yaml so
+                # ``is_connected`` sees credentials the user has already saved
+                # (e.g. Feishu's ``extra.app_id``). Previously this passed an
+                # empty ``PlatformConfig(enabled=True)`` and every plugin
+                # platform rendered as "not configured" even when the gateway
+                # was actively connected.
+                platform_cfg: PlatformConfig | None = None
+                try:
+                    gw_cfg = load_gateway_config()
+                    platform_cfg = gw_cfg.platforms.get(Platform(entry.name))
+                except Exception:
+                    platform_cfg = None
+                if platform_cfg is None:
+                    platform_cfg = PlatformConfig(enabled=True)
+                configured = bool(entry.is_connected(platform_cfg))
             except Exception:
                 configured = False
         else:

--- a/tests/hermes_cli/test_setup_irc.py
+++ b/tests/hermes_cli/test_setup_irc.py
@@ -123,6 +123,72 @@ class TestIRCFreshInstallDiscovery:
             _unregister_irc_platform()
 
 
+class TestPluginIsConnectedUsesRealPlatformConfig:
+    """Regression: _platform_status must feed the plugin's is_connected hook
+    with the *real* PlatformConfig loaded from config.yaml, not an empty one.
+
+    Prior behaviour handed ``PlatformConfig(enabled=True)`` (no ``extra``,
+    no ``token``) to ``is_connected``. Plugins like Feishu whose
+    ``is_connected`` reads ``config.extra["app_id"]`` always returned False,
+    so the setup menu rendered "not configured" even when the gateway was
+    actively connected to the platform.
+    """
+
+    def test_uses_real_platform_config_when_is_connected_defined(self, monkeypatch):
+        """is_connected receives the PlatformConfig from load_gateway_config()."""
+        import hermes_cli.gateway as gateway_mod
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        captured: list[PlatformConfig] = []
+
+        def _fake_is_connected(cfg):
+            captured.append(cfg)
+            return bool(cfg.extra.get("app_id"))
+
+        plat = _register_irc_platform(
+            is_connected=_fake_is_connected,
+            validate_config=_fake_is_connected,
+        )
+        try:
+            fake_cfg = GatewayConfig()
+            fake_cfg.platforms[Platform("irc")] = PlatformConfig(
+                enabled=True, extra={"app_id": "cli_test123"}
+            )
+            monkeypatch.setattr(
+                "gateway.config.load_gateway_config", lambda: fake_cfg
+            )
+
+            status = gateway_mod._platform_status(plat)
+
+            assert status == "configured"
+            assert len(captured) == 1
+            assert captured[0].extra.get("app_id") == "cli_test123"
+        finally:
+            _unregister_irc_platform()
+
+    def test_falls_back_to_empty_config_when_yaml_missing(self, monkeypatch):
+        """If load_gateway_config() raises, _platform_status still returns
+        a status string (falling back to an empty PlatformConfig)."""
+        import hermes_cli.gateway as gateway_mod
+
+        plat = _register_irc_platform(
+            is_connected=lambda cfg: False,
+            validate_config=lambda cfg: False,
+        )
+        try:
+            def _boom():
+                raise RuntimeError("no config.yaml")
+
+            monkeypatch.setattr(
+                "gateway.config.load_gateway_config", _boom
+            )
+
+            status = gateway_mod._platform_status(plat)
+            assert status == "not configured"
+        finally:
+            _unregister_irc_platform()
+
+
 # ── Interactive setup dispatch ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- The gateway setup menu (`hermes gateway setup`) rendered plugin-registered platforms as `(not configured)` even when the user had saved credentials in `~/.hermes/config.yaml` and the gateway was actively connected to the platform.
- Root cause: [`hermes_cli/gateway.py::_platform_status`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/gateway.py) fabricated an empty `PlatformConfig(enabled=True)` and handed it to the plugin's `is_connected` hook, so any hook that reads `config.extra[...]` (Feishu / DingTalk / WeCom / Google Chat / Home Assistant / ntfy / Photon / Raft / SimpleX / …) always returned `False`.
- Fix loads the real `PlatformConfig` via `load_gateway_config()` and falls back to the empty synthetic only when YAML loading fails.

## Reproduction (before fix)

1. Install Hermes, run `hermes gateway setup`, pick 🪽 Feishu / Lark, complete the QR-pair flow.
2. Verify credentials landed in both `~/.hermes/.env` (`FEISHU_APP_ID` / `FEISHU_APP_SECRET`) and `~/.hermes/config.yaml` (`gateway.platforms.feishu.extra.app_id`).
3. Start the gateway — logs show `✓ feishu connected` and a live WebSocket to `msg-frontier.feishu.cn`.
4. Re-open `hermes gateway setup` → Feishu still reads `(not configured)`. Selecting it re-enters the pairing wizard.

After this patch step 4 correctly reads `configured`.

## Why the empty synthetic slipped through

Built-in platforms take the token-var / env-var branch further down in `_platform_status`, which reads `~/.hermes/.env` directly, so `.env`-only credentials (Telegram, Discord, WhatsApp, …) already worked. Only plugin-registered adapters with an `is_connected` hook that consults `config.extra[...]` hit the empty-config bug. That's why Telegram/Discord look fine in the same menu but Feishu doesn't.

## Test plan

- [x] `pytest tests/hermes_cli/test_setup_irc.py -v` — 10/10 pass, including two new regression cases in `TestPluginIsConnectedUsesRealPlatformConfig`:
  - `test_uses_real_platform_config_when_is_connected_defined` — asserts the hook receives the `PlatformConfig` from `load_gateway_config()` (with `extra["app_id"]` populated) and returns `configured`.
  - `test_falls_back_to_empty_config_when_yaml_missing` — asserts a raised `load_gateway_config()` still yields `not configured` (fresh-install path).
- [x] Manual: `hermes gateway setup` now shows Feishu as `configured` after saving credentials, without re-entering the pairing flow.
- [x] Manual: All other plugin platforms with no credentials remain `not configured`.

## Notes for reviewer

- The change is a strict superset of the previous behaviour — the fallback branch preserves the old empty-config path if `load_gateway_config()` raises.
- No public API changes; only the internal status-string renderer is affected.