### PR TITLE
fix(feishu): preserve quoted reply ancestry

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -268,6 +268,9 @@ _FEISHU_REACTION_FAILURE = "CrossMark"
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
 _FEISHU_MESSAGE_TEXT_CACHE_SIZE = 512       # LRU cap for reply-context message text lookups
+_FEISHU_REPLY_CHAIN_MAX_DEPTH = 6
+_FEISHU_REPLY_CONTEXT_MAX_CHARS = 500
+_FEISHU_EARLIER_REPLY_SEPARATOR = "\n[Earlier quoted message]\n"
 
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
@@ -3298,14 +3301,26 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        chat_id = getattr(message, "chat_id", "") or ""
+        # root_id can describe quote ancestry as well as a topic. Use only an
+        # explicit thread_id as the ancestry lane guard.
+        explicit_thread_id = getattr(message, "thread_id", None) or None
+        thread_id = explicit_thread_id or getattr(message, "root_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)
             or getattr(message, "root_id", None)
             or None
         )
-        reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
+        reply_to_text = (
+            await self._fetch_message_context_chain(
+                reply_to_message_id,
+                chat_id=chat_id,
+                thread_id=explicit_thread_id,
+            )
+            if reply_to_message_id
+            else None
+        )
 
         sender_primary = (
             getattr(sender_id, "open_id", None)
@@ -3325,7 +3340,6 @@ class FeishuAdapter(BasePlatformAdapter):
             len(media_urls),
         )
 
-        chat_id = getattr(message, "chat_id", "") or ""
         chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id, is_bot=is_bot)
         source = self.build_source(
@@ -4259,6 +4273,105 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception:
             logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
             return None
+
+    async def _fetch_message_context_chain(
+        self,
+        message_id: str,
+        *,
+        chat_id: str,
+        thread_id: Optional[str],
+        max_depth: int = _FEISHU_REPLY_CHAIN_MAX_DEPTH,
+        max_chars: int = _FEISHU_REPLY_CONTEXT_MAX_CHARS,
+    ) -> Optional[str]:
+        """Fetch bounded quoted-message ancestry with the direct parent first."""
+        if not message_id or max_depth <= 0 or max_chars <= 0:
+            return None
+        if not self._client:
+            return await self._fetch_message_text(message_id)
+
+        current_id: Optional[str] = message_id
+        seen: set[str] = set()
+        rendered = ""
+
+        for _ in range(max_depth):
+            if not current_id or current_id in seen:
+                break
+            seen.add(current_id)
+
+            try:
+                request = self._build_get_message_request(current_id)
+                response = await self._run_blocking(
+                    self._client.im.v1.message.get,
+                    request,
+                )
+            except Exception:
+                logger.warning(
+                    "[Feishu] Failed to fetch reply ancestry from %s",
+                    message_id,
+                    exc_info=True,
+                )
+                break
+
+            if not response or getattr(response, "success", lambda: False)() is False:
+                logger.warning(
+                    "[Feishu] Failed to fetch reply ancestor %s: [%s] %s",
+                    current_id,
+                    getattr(response, "code", "unknown"),
+                    getattr(response, "msg", "message lookup failed"),
+                )
+                break
+
+            items = getattr(getattr(response, "data", None), "items", None) or []
+            item = items[0] if items else None
+            if item is None:
+                break
+
+            item_chat_id = str(getattr(item, "chat_id", "") or "")
+            if chat_id and item_chat_id and item_chat_id != chat_id:
+                logger.warning(
+                    "[Feishu] Stopped reply ancestry at %s: chat mismatch",
+                    current_id,
+                )
+                break
+
+            item_thread_id = str(getattr(item, "thread_id", "") or "")
+            if thread_id and item_thread_id and item_thread_id != thread_id:
+                logger.warning(
+                    "[Feishu] Stopped reply ancestry at %s: thread mismatch",
+                    current_id,
+                )
+                break
+
+            body = getattr(item, "body", None)
+            text = self._extract_text_from_raw_content(
+                msg_type=getattr(item, "msg_type", "") or "",
+                raw_content=getattr(body, "content", "") or "",
+                mentions=getattr(item, "mentions", None),
+            )
+            if text:
+                self._message_text_cache[current_id] = text
+                while len(self._message_text_cache) > _FEISHU_MESSAGE_TEXT_CACHE_SIZE:
+                    self._message_text_cache.popitem(last=False)
+
+                if not rendered:
+                    rendered = text[:max_chars]
+                else:
+                    remaining = max_chars - len(rendered)
+                    if remaining <= len(_FEISHU_EARLIER_REPLY_SEPARATOR):
+                        break
+                    rendered += _FEISHU_EARLIER_REPLY_SEPARATOR
+                    remaining = max_chars - len(rendered)
+                    rendered += text[:remaining]
+                if len(rendered) >= max_chars:
+                    break
+
+            current_id = (
+                getattr(item, "parent_id", None)
+                or getattr(item, "upper_message_id", None)
+                or None
+            )
+
+        return rendered or None
 
     def _extract_text_from_raw_content(
         self,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -267,7 +267,8 @@ _FEISHU_REACTION_FAILURE = "CrossMark"
 # drain on completion; the cap is a safeguard against unbounded growth from
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
-_FEISHU_MESSAGE_TEXT_CACHE_SIZE = 512       # LRU cap for reply-context message text lookups
+_FEISHU_MESSAGE_TEXT_CACHE_SIZE = 512  # LRU cap for reply-context message text lookups
+_FEISHU_MESSAGE_ITEM_CACHE_SIZE = 128
 _FEISHU_REPLY_CHAIN_MAX_DEPTH = 6
 _FEISHU_REPLY_CONTEXT_MAX_CHARS = 500
 _FEISHU_EARLIER_REPLY_SEPARATOR = "\n[Earlier quoted message]\n"
@@ -1497,6 +1498,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: "OrderedDict[str, Optional[str]]" = OrderedDict()
+        self._message_item_cache: "OrderedDict[str, Any]" = OrderedDict()
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -3302,10 +3304,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 text = f"{hint}\n\n{text}" if text else hint
 
         chat_id = getattr(message, "chat_id", "") or ""
-        # root_id can describe quote ancestry as well as a topic. Use only an
-        # explicit thread_id as the ancestry lane guard.
+        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        # Keep the existing session route above unchanged. root_id is also
+        # quote metadata, so only an explicit topic ID is safe as a lane guard.
         explicit_thread_id = getattr(message, "thread_id", None) or None
-        thread_id = explicit_thread_id or getattr(message, "root_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)
@@ -4248,15 +4250,9 @@ class FeishuAdapter(BasePlatformAdapter):
             self._message_text_cache.move_to_end(message_id)
             return self._message_text_cache[message_id]
         try:
-            request = self._build_get_message_request(message_id)
-            response = await self._run_blocking(self._client.im.v1.message.get, request)
-            if not response or getattr(response, "success", lambda: False)() is False:
-                code = getattr(response, "code", "unknown")
-                msg = getattr(response, "msg", "message lookup failed")
-                logger.warning("[Feishu] Failed to fetch parent message %s: [%s] %s", message_id, code, msg)
+            parent = await self._fetch_message_item(message_id)
+            if parent is None:
                 return None
-            items = getattr(getattr(response, "data", None), "items", None) or []
-            parent = items[0] if items else None
             body = getattr(parent, "body", None)
             msg_type = getattr(parent, "msg_type", "") or ""
             raw_content = getattr(body, "content", "") or ""
@@ -4270,6 +4266,32 @@ class FeishuAdapter(BasePlatformAdapter):
             while len(self._message_text_cache) > _FEISHU_MESSAGE_TEXT_CACHE_SIZE:
                 self._message_text_cache.popitem(last=False)
             return text
+        except Exception:
+            logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
+            return None
+
+    async def _fetch_message_item(self, message_id: str) -> Optional[Any]:
+        """Fetch one message through a shared LRU for text/media reply context."""
+        if not self._client or not message_id:
+            return None
+        if message_id in self._message_item_cache:
+            self._message_item_cache.move_to_end(message_id)
+            return self._message_item_cache[message_id]
+        try:
+            request = self._build_get_message_request(message_id)
+            response = await self._run_blocking(self._client.im.v1.message.get, request)
+            if not response or getattr(response, "success", lambda: False)() is False:
+                code = getattr(response, "code", "unknown")
+                msg = getattr(response, "msg", "message lookup failed")
+                logger.warning("[Feishu] Failed to fetch parent message %s: [%s] %s", message_id, code, msg)
+                return None
+            items = getattr(getattr(response, "data", None), "items", None) or []
+            item = items[0] if items else None
+            if item is not None:
+                self._message_item_cache[message_id] = item
+                while len(self._message_item_cache) > _FEISHU_MESSAGE_ITEM_CACHE_SIZE:
+                    self._message_item_cache.popitem(last=False)
+            return item
         except Exception:
             logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
             return None
@@ -4298,32 +4320,11 @@ class FeishuAdapter(BasePlatformAdapter):
                 break
             seen.add(current_id)
 
-            try:
-                request = self._build_get_message_request(current_id)
-                response = await self._run_blocking(
-                    self._client.im.v1.message.get,
-                    request,
-                )
-            except Exception:
-                logger.warning(
-                    "[Feishu] Failed to fetch reply ancestry from %s",
-                    message_id,
-                    exc_info=True,
-                )
-                break
-
-            if not response or getattr(response, "success", lambda: False)() is False:
-                logger.warning(
-                    "[Feishu] Failed to fetch reply ancestor %s: [%s] %s",
-                    current_id,
-                    getattr(response, "code", "unknown"),
-                    getattr(response, "msg", "message lookup failed"),
-                )
-                break
-
-            items = getattr(getattr(response, "data", None), "items", None) or []
-            item = items[0] if items else None
+            item = await self._fetch_message_item(current_id)
             if item is None:
+                cached_text = self._message_text_cache.get(current_id)
+                if cached_text and not rendered:
+                    rendered = cached_text[:max_chars]
                 break
 
             item_chat_id = str(getattr(item, "chat_id", "") or "")
@@ -4350,6 +4351,7 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             if text:
                 self._message_text_cache[current_id] = text
+                self._message_text_cache.move_to_end(current_id)
                 while len(self._message_text_cache) > _FEISHU_MESSAGE_TEXT_CACHE_SIZE:
                     self._message_text_cache.popitem(last=False)
 
@@ -4365,9 +4367,15 @@ class FeishuAdapter(BasePlatformAdapter):
                 if len(rendered) >= max_chars:
                     break
 
+            if rendered and (
+                max_chars - len(rendered) <= len(_FEISHU_EARLIER_REPLY_SEPARATOR)
+            ):
+                break
+
             current_id = (
                 getattr(item, "parent_id", None)
                 or getattr(item, "upper_message_id", None)
+                or getattr(item, "root_id", None)
                 or None
             )
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2311,6 +2311,7 @@ class TestFeishuFetchMessageText(unittest.TestCase):
         adapter._bot_user_id = ""
         adapter._bot_name = "Hermes"
         adapter._message_text_cache = OrderedDict()
+        adapter._message_item_cache = OrderedDict()
         adapter._client = Mock()
         adapter._build_get_message_request = Mock(return_value=object())
         return adapter
@@ -2320,6 +2321,7 @@ class TestFeishuFetchMessageText(unittest.TestCase):
         text,
         *,
         parent_id=None,
+        root_id=None,
         chat_id="oc_chat",
         thread_id=None,
     ):
@@ -2329,6 +2331,7 @@ class TestFeishuFetchMessageText(unittest.TestCase):
             mentions=[],
             parent_id=parent_id,
             upper_message_id=None,
+            root_id=root_id,
             chat_id=chat_id,
             thread_id=thread_id,
         )
@@ -2367,6 +2370,44 @@ class TestFeishuFetchMessageText(unittest.TestCase):
             result,
             "直接父消息\n[Earlier quoted message]\n更早的原始问题",
         )
+
+    def test_fetch_message_context_chain_follows_root_only_ancestry(self):
+        adapter = self._build_adapter()
+        messages = {
+            "m_parent": self._reply_item("直接父消息", root_id="m_root"),
+            "m_root": self._reply_item("根消息"),
+        }
+        self._install_reply_messages(adapter, messages)
+
+        result = asyncio.run(
+            adapter._fetch_message_context_chain(
+                "m_parent", chat_id="oc_chat", thread_id=None
+            )
+        )
+
+        self.assertEqual(result, "直接父消息\n[Earlier quoted message]\n根消息")
+
+    def test_fetch_message_context_chain_reuses_cached_message_items(self):
+        adapter = self._build_adapter()
+        messages = {
+            "m_parent": self._reply_item("直接父消息", parent_id="m_root"),
+            "m_root": self._reply_item("根消息"),
+        }
+        self._install_reply_messages(adapter, messages)
+
+        first = asyncio.run(
+            adapter._fetch_message_context_chain(
+                "m_parent", chat_id="oc_chat", thread_id=None
+            )
+        )
+        second = asyncio.run(
+            adapter._fetch_message_context_chain(
+                "m_parent", chat_id="oc_chat", thread_id=None
+            )
+        )
+
+        self.assertEqual(first, second)
+        self.assertEqual(adapter._client.im.v1.message.get.call_count, 2)
 
     def test_fetch_message_context_chain_stops_before_cross_chat_ancestor(self):
         adapter = self._build_adapter()
@@ -2433,6 +2474,35 @@ class TestFeishuFetchMessageText(unittest.TestCase):
 
         self.assertEqual(result, "直接父消息")
 
+    def test_fetch_message_context_chain_falls_back_to_cached_direct_text(self):
+        adapter = self._build_adapter()
+        adapter._message_text_cache["m_parent"] = "缓存的直接父消息"
+        adapter._client.im.v1.message.get = Mock(side_effect=OSError("offline"))
+
+        result = asyncio.run(
+            adapter._fetch_message_context_chain(
+                "m_parent", chat_id="oc_chat", thread_id=None
+            )
+        )
+
+        self.assertEqual(result, "缓存的直接父消息")
+
+    def test_fetch_message_context_chain_stops_before_unneeded_ancestor_call(self):
+        adapter = self._build_adapter()
+        messages = {
+            "m_parent": self._reply_item("p" * 500, parent_id="m_unneeded"),
+        }
+        self._install_reply_messages(adapter, messages)
+
+        result = asyncio.run(
+            adapter._fetch_message_context_chain(
+                "m_parent", chat_id="oc_chat", thread_id=None
+            )
+        )
+
+        self.assertEqual(result, "p" * 500)
+        self.assertEqual(adapter._client.im.v1.message.get.call_count, 1)
+
     def test_fetch_message_context_chain_honors_total_character_budget(self):
         adapter = self._build_adapter()
         messages = {
@@ -2484,6 +2554,25 @@ class TestFeishuFetchMessageText(unittest.TestCase):
             "直接父消息\n[Earlier quoted message]\n祖先消息",
         )
         self.assertEqual(adapter._client.im.v1.message.get.call_count, 2)
+
+    def test_fetch_message_context_chain_caps_api_calls_at_max_depth(self):
+        adapter = self._build_adapter()
+        messages = {
+            f"m{index}": self._reply_item(
+                str(index), parent_id=f"m{index + 1}" if index < 7 else None
+            )
+            for index in range(8)
+        }
+        self._install_reply_messages(adapter, messages)
+
+        result = asyncio.run(
+            adapter._fetch_message_context_chain(
+                "m0", chat_id="oc_chat", thread_id=None
+            )
+        )
+
+        self.assertNotIn("6", result or "")
+        self.assertEqual(adapter._client.im.v1.message.get.call_count, 6)
 
     def test_fetch_message_text_marks_is_self_via_string_id_shape(self):
         """History-path Mention objects carry id as str + id_type; is_self must still work."""

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2315,6 +2315,175 @@ class TestFeishuFetchMessageText(unittest.TestCase):
         adapter._build_get_message_request = Mock(return_value=object())
         return adapter
 
+    @staticmethod
+    def _reply_item(
+        text,
+        *,
+        parent_id=None,
+        chat_id="oc_chat",
+        thread_id=None,
+    ):
+        return SimpleNamespace(
+            body=SimpleNamespace(content=json.dumps({"text": text})),
+            msg_type="text",
+            mentions=[],
+            parent_id=parent_id,
+            upper_message_id=None,
+            chat_id=chat_id,
+            thread_id=thread_id,
+        )
+
+    @staticmethod
+    def _install_reply_messages(adapter, messages):
+        adapter._build_get_message_request = lambda message_id: SimpleNamespace(
+            message_id=message_id
+        )
+
+        def get_message(request):
+            response = Mock()
+            response.success = Mock(return_value=True)
+            response.data = SimpleNamespace(items=[messages[request.message_id]])
+            return response
+
+        adapter._client.im.v1.message.get = Mock(side_effect=get_message)
+
+    def test_fetch_message_context_chain_keeps_direct_parent_first(self):
+        adapter = self._build_adapter()
+        messages = {
+            "m_parent": self._reply_item("直接父消息", parent_id="m_grandparent"),
+            "m_grandparent": self._reply_item("更早的原始问题"),
+        }
+        self._install_reply_messages(adapter, messages)
+
+        result = asyncio.run(
+            adapter._fetch_message_context_chain(
+                "m_parent",
+                chat_id="oc_chat",
+                thread_id=None,
+            )
+        )
+
+        self.assertEqual(
+            result,
+            "直接父消息\n[Earlier quoted message]\n更早的原始问题",
+        )
+
+    def test_fetch_message_context_chain_stops_before_cross_chat_ancestor(self):
+        adapter = self._build_adapter()
+        messages = {
+            "m_parent": self._reply_item(
+                "直接父消息",
+                parent_id="m_foreign",
+            ),
+            "m_foreign": self._reply_item(
+                "其他群消息",
+                chat_id="oc_other",
+            ),
+        }
+        self._install_reply_messages(adapter, messages)
+
+        result = asyncio.run(
+            adapter._fetch_message_context_chain(
+                "m_parent",
+                chat_id="oc_chat",
+                thread_id=None,
+            )
+        )
+
+        self.assertEqual(result, "直接父消息")
+
+    def test_fetch_message_context_chain_rejects_explicit_thread_mismatch(self):
+        adapter = self._build_adapter()
+        messages = {
+            "m_parent": self._reply_item("其他话题消息", thread_id="omt_other"),
+        }
+        self._install_reply_messages(adapter, messages)
+
+        result = asyncio.run(
+            adapter._fetch_message_context_chain(
+                "m_parent",
+                chat_id="oc_chat",
+                thread_id="omt_current",
+            )
+        )
+
+        self.assertIsNone(result)
+
+    def test_fetch_message_context_chain_keeps_direct_parent_on_ancestor_error(self):
+        adapter = self._build_adapter()
+        direct = Mock()
+        direct.success = Mock(return_value=True)
+        direct.data = SimpleNamespace(
+            items=[self._reply_item("直接父消息", parent_id="m_unavailable")]
+        )
+        adapter._build_get_message_request = lambda message_id: SimpleNamespace(
+            message_id=message_id
+        )
+        adapter._client.im.v1.message.get = Mock(
+            side_effect=[direct, OSError("offline")]
+        )
+
+        result = asyncio.run(
+            adapter._fetch_message_context_chain(
+                "m_parent",
+                chat_id="oc_chat",
+                thread_id=None,
+            )
+        )
+
+        self.assertEqual(result, "直接父消息")
+
+    def test_fetch_message_context_chain_honors_total_character_budget(self):
+        adapter = self._build_adapter()
+        messages = {
+            "m_parent": self._reply_item(
+                "p" * 450,
+                parent_id="m_grandparent",
+            ),
+            "m_grandparent": self._reply_item("g" * 200),
+        }
+        self._install_reply_messages(adapter, messages)
+
+        result = asyncio.run(
+            adapter._fetch_message_context_chain(
+                "m_parent",
+                chat_id="oc_chat",
+                thread_id=None,
+                max_chars=500,
+            )
+        )
+
+        self.assertEqual(len(result), 500)
+        self.assertTrue(result.startswith("p" * 450))
+        self.assertIn("[Earlier quoted message]", result)
+
+    def test_fetch_message_context_chain_breaks_parent_cycles(self):
+        adapter = self._build_adapter()
+        messages = {
+            "m_parent": self._reply_item(
+                "直接父消息",
+                parent_id="m_grandparent",
+            ),
+            "m_grandparent": self._reply_item(
+                "祖先消息",
+                parent_id="m_parent",
+            ),
+        }
+        self._install_reply_messages(adapter, messages)
+
+        result = asyncio.run(
+            adapter._fetch_message_context_chain(
+                "m_parent",
+                chat_id="oc_chat",
+                thread_id=None,
+            )
+        )
+
+        self.assertEqual(
+            result,
+            "直接父消息\n[Earlier quoted message]\n祖先消息",
+        )
+        self.assertEqual(adapter._client.im.v1.message.get.call_count, 2)
 
     def test_fetch_message_text_marks_is_self_via_string_id_shape(self):
         """History-path Mention objects carry id as str + id_type; is_self must still work."""


### PR DESCRIPTION
## What does this PR do?

Feishu quote replies currently fetch only the direct parent text. When that parent is itself a reply, short follow-ups such as “this one” or “agree” lose the original question that gives the parent its meaning.

This change follows the explicit `parent_id` / `upper_message_id` ancestry for quoted messages and supplies a bounded text chain through the existing `reply_to_text` field.

## Related Issue

Fixes #67184.

This is intentionally separate from quote/topic routing in #36233 and replied-attachment handling in #54570.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/feishu/adapter.py`
  - Follow bounded quoted-message ancestry with the direct parent first.
  - Reuse a shared LRU message-item fetch path so text and future media context do not duplicate API calls.
  - Follow `parent_id`, `upper_message_id`, and root-only ancestry while retaining cycle protection.
  - Keep the complete reply context within the existing 500-character gateway budget.
  - Stop after six messages, on cycles, API errors, cross-chat ancestors, or explicit thread mismatches.
  - Use the adapter-owned blocking-call executor for Feishu SDK requests.
- `tests/gateway/test_feishu.py`
  - Cover nested quotes, direct-parent priority, total budget, cycles, API degradation, chat boundaries, thread boundaries, and inbound propagation.

## How to Test

Rebased onto `a51143fbbe6ddbc0c7f403d0579c4d75504c6793`, preserving the native-thread-only routing from #115344. Ordinary quoted replies keep their main-chat route; explicit topic IDs remain intact.

- `scripts/run_tests.sh tests/gateway/test_feishu*.py tests/gateway/test_reply_to_injection.py -j 1` — 196 passed across 17 files on macOS/Python 3.12.13, with the canonical hermetic runner.
- `ruff check plugins/platforms/feishu/adapter.py tests/gateway/test_feishu.py` — passed.
- `git diff --check` — passed.

The rebase initially exposed two route-test fixtures still mocking the old text lookup. Both now mock the ancestry lookup and assert its exact chat/thread arguments. No routing assertion was removed. The full repository suite and a live Feishu API end-to-end test were not run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete `pytest tests/ -q` suite
- [x] I've added tests for my changes
- [x] I've tested on macOS with Python 3.12 and `lark-oapi==1.6.8`

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing configuration or API changes
- [x] `cli-config.yaml.example` update — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A
- [x] Cross-platform impact considered; the change is platform-independent Python and Feishu API handling
- [x] Tool descriptions/schemas update — N/A

## Screenshots / Logs

Not applicable. The behavior is covered by deterministic adapter and gateway regression tests.

