### PR TITLE
fix: ignore installer-created .install_method runtime stamp (#66189)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,12 @@ docs/superpowers/*
 # treat it as a local edit and autostash it on every run (#38529).
 .hermes-bootstrap-complete
 
+# Installer-created runtime stamp written by scripts/install.sh into the managed
+# checkout root. It is Hermes-managed runtime state, never a code change — ignore
+# so `git status --porcelain` stays clean and `hermes update`'s stash operations
+# skip it (#66189).
+.install_method
+
 # Persistent dev sandbox dir (scripts/dev-sandbox.sh --persistent)
 .hermes-sandbox/
 


### PR DESCRIPTION
## Description

The Git-based installer writes `.install_method` into the Hermes Agent checkout, but the file is not ignored by Git, leaving a managed installation with a dirty working tree.

Since `hermes update` detects changes using `git status --porcelain` and stashes untracked files with `git stash push --include-untracked`, this runtime marker can trigger unnecessary stash and restore operations during updates.

## Fix

Add `.install_method` to `.gitignore` alongside the existing runtime-state markers (`.hermes-bootstrap-complete`, `.update-incomplete`, etc.).

## Related

Fixes #66189