### PR TITLE
fix(agent): stop strip_think_blocks from crashing on multimodal content

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -672,6 +672,27 @@ def strip_think_blocks(agent, content: str) -> str:
     """
     if not content:
         return ""
+    # Content may arrive as a multimodal list (e.g. after a vision/image turn:
+    # [{"type": "text", "text": ...}, {"type": "image", ...}]) rather than a
+    # plain string. The regex passes below require a str, so coerce first:
+    # concatenate any text blocks and drop non-text parts. Without this, a
+    # follow-up turn after an image is loaded into context crashes with
+    # ``TypeError: expected string or bytes-like object, got 'list'``.
+    if not isinstance(content, str):
+        if isinstance(content, list):
+            parts = []
+            for block in content:
+                if isinstance(block, str):
+                    parts.append(block)
+                elif isinstance(block, dict):
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+            content = "".join(parts)
+        else:
+            content = str(content)
+        if not content:
+            return ""
     # 1. Closed tag pairs — case-insensitive for all variants so
     #    mixed-case tags (<THINK>, <Thinking>) don't slip through to
     #    the unterminated-tag pass and take trailing content with them.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5515,11 +5515,11 @@ def run_conversation(
                 
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:
-                    agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
+                    agent._safe_print(f"🎉 Conversation completed after {api_call_count} API call(s) (provider={getattr(agent, 'provider', '') or 'unknown'})")
                 break
             
         except Exception as e:
-            error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
+            error_msg = f"Error during API call #{api_call_count} (provider={getattr(agent, 'provider', '') or 'unknown'}): {str(e)}"
             try:
                 print(f"❌ {error_msg}")
             except (OSError, ValueError):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -491,6 +491,32 @@ class TestStripThinkBlocks:
         result = agent._strip_think_blocks("<thought>orphaned reasoning without close")
         assert "<thought>" not in result
 
+    # ─── Multimodal content coverage ─────────────────────────────────────
+    # After a vision/image turn, an assistant message's ``content`` can be a
+    # multimodal list of blocks instead of a plain string. strip_think_blocks
+    # must coerce it (concatenate text blocks, drop non-text) rather than pass
+    # a list to re.sub — which raised
+    # ``TypeError: expected string or bytes-like object, got 'list'`` and
+    # crashed the next turn's interim-visible-text extraction.
+    def test_multimodal_list_extracts_text_blocks(self, agent):
+        content = [
+            {"type": "text", "text": "<think>hidden</think>visible answer"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]
+        result = agent._strip_think_blocks(content)
+        assert "hidden" not in result
+        assert "visible answer" in result
+
+    def test_multimodal_list_no_text_blocks_returns_empty(self, agent):
+        content = [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}]
+        assert agent._strip_think_blocks(content) == ""
+
+    def test_multimodal_list_of_plain_strings(self, agent):
+        assert agent._strip_think_blocks(["hello ", "world"]) == "hello world"
+
+    def test_empty_list_returns_empty(self, agent):
+        assert agent._strip_think_blocks([]) == ""
+
     # ─── Unterminated-block coverage (#8878, #9568, #10408) ──────────────
     # Reasoning models served via NIM / MiniMax M2.7 frequently drop the
     # closing tag, leaking raw reasoning into assistant content. The open


### PR DESCRIPTION
## Summary

After a vision/image turn, an assistant message's `content` can be a **multimodal list** of blocks (`[{"type":"text",...}, {"type":"image",...}]`) instead of a plain string. `strip_think_blocks` only guarded `if not content` and then passed `content` straight to `re.sub`, so the next turn's interim-visible-text extraction (`_interim_assistant_visible_text` → `_strip_think_blocks`) crashes with:

```
TypeError: expected string or bytes-like object, got 'list'
```

Because it fires inside the conversation loop's outer `try`, it retries and re-crashes on every attempt — the turn is stuck until the multimodal message ages out of context. Repro: load an image into context (any vision path), then send a follow-up message.

## Fix

Coerce non-string content before the regex passes: concatenate text blocks, drop non-text parts (images etc.). Plain-string input is unchanged; sibling shapes (list of strings, list with no text, empty list) are covered too.

## Drive-by: misleading "OpenAI-compatible" wording

The same loop's completion/error prints hardcode `"OpenAI-compatible API call"` regardless of the active provider. On an anthropic-only deployment the crash surfaces as `❌ Error during OpenAI-compatible API call #N: ...`, which reads like a protocol/config problem and sends you down the wrong path (it did for us). Changed to print the actual provider: `API call #N (provider=anthropic)`.

## Test plan

- [x] New `TestStripThinkBlocks` cases reproduce the crash — they **fail on pre-fix code** with the exact `TypeError: ... got 'list'`, pass with the fix.
- [x] Full `TestStripThinkBlocks` suite green (29 passed), no regression to existing string-path behavior.
- [x] Coerce contract covered: text-block extraction strips `<think>`, image-only list → `""`, list-of-strings joins, empty list → `""`.