### PR TITLE
fix: use OS-aware path for profile folder in system prompt (#66196)

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -381,10 +381,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             pass
 
     # Active-profile hint — names the Hermes profile the agent is running
-    # under so it doesn't conflate ~/.hermes/skills/ (default profile) with
-    # ~/.hermes/profiles/<active>/skills/ (this profile's). Deterministic
-    # for the lifetime of the agent — profile name doesn't change
-    # mid-session, so this doesn't break the prompt cache.
+    # under so it doesn't conflate the default-profile data dir with
+    # the named-profile data dirs. Deterministic for the lifetime of the
+    # agent — profile name doesn't change mid-session, so this doesn't
+    # break the prompt cache.
     # See file_safety._resolve_active_profile_name + classify_cross_profile_target
     # for the matching tool-side guard.
     try:
@@ -392,10 +392,21 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         active_profile = _resolve_active_profile_name()
     except Exception:
         active_profile = "default"
+    # Resolve platform-appropriate display path for the Hermes home root
+    # (e.g. ~/.hermes on POSIX, ~/AppData/Local/.hermes on Windows)
+    # so the agent tells the user the correct location on every OS.
+    from pathlib import Path as _Path
+    from hermes_constants import get_default_hermes_root
+    _homes_root = get_default_hermes_root()
+    try:
+        _root_display = "~/" + str(_homes_root.relative_to(_Path.home()))
+    except ValueError:
+        _root_display = str(_homes_root)
+
     if active_profile == "default":
         stable_parts.append(
-            "Active Hermes profile: default. Other profiles (if any) live "
-            "under ~/.hermes/profiles/<name>/. Each profile has its own "
+            f"Active Hermes profile: default. Other profiles (if any) live "
+            f"under {_root_display}/profiles/<name>/. Each profile has its own "
             "skills/, plugins/, cron/, and memories/ that affect a different "
             "session than this one. Do not modify another profile's "
             "skills/plugins/cron/memories unless the user explicitly directs "
@@ -404,9 +415,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     else:
         stable_parts.append(
             f"Active Hermes profile: {active_profile}. This session reads "
-            f"and writes ~/.hermes/profiles/{active_profile}/. The default "
-            f"profile's data lives at ~/.hermes/skills/, ~/.hermes/plugins/, "
-            f"~/.hermes/cron/, ~/.hermes/memories/ — those belong to a "
+            f"and writes {_root_display}/profiles/{active_profile}/. The default "
+            f"profile's data lives at {_root_display}/skills/, "
+            f"{_root_display}/plugins/, {_root_display}/cron/, "
+            f"{_root_display}/memories/ — those belong to a "
             f"different session run from a different shell. Do NOT modify "
             f"another profile's skills/plugins/cron/memories unless the user "
             f"explicitly directs you to. The cross-profile write guard will "

--- a/tests/tools/test_cross_profile_guard.py
+++ b/tests/tools/test_cross_profile_guard.py
@@ -252,7 +252,7 @@ class TestSystemPromptActiveProfile:
         src = Path("agent/system_prompt.py").read_text()
         assert "Active Hermes profile" in src
         assert "cross_profile=True" in src
-        assert "~/.hermes/profiles/" in src
+        assert "/profiles/<name>/" in src or "/profiles/{active_profile}" in src
         # Both branches present (default and named profile).
         assert "Active Hermes profile: default" in src
         assert "Active Hermes profile: {active_profile}" in src


### PR DESCRIPTION
## Description

The system prompt hardcoded `~/.hermes` when telling the agent where profiles live. On Windows, the Hermes home is at `%LOCALAPPDATA%\\.hermes` or `~/AppData/Local/.hermes`, not `~/.hermes`. This caused the agent to give Windows users incorrect path information.

## Fix

Replace hardcoded `~/.hermes` in the active-profile hint section of `build_system_prompt_parts()` with a dynamically computed display path via `get_default_hermes_root()` from `hermes_constants`. This function already handles OS-specific paths correctly (POSIX: `~/.hermes`, Windows: `~/AppData/Local/.hermes`, custom: full path).

Also updated the corresponding test assertion to no longer depend on the hardcoded `~/.hermes` prefix.

## Related

Fixes #66196