### PR TITLE
fix(search): recover from glob-style content patterns instead of looping

### DIFF
--- a/tests/tools/test_search_budget_truncation.py
+++ b/tests/tools/test_search_budget_truncation.py
@@ -129,5 +129,8 @@ def test_real_rg_error_still_hard_fails(ops, monkeypatch):
 
     result = ops.search("[", path="/big", target="content")
 
-    assert result.error == "Search failed: rg: regex parse error:"
+    # A genuinely invalid regex (no glob '*' to reinterpret) must still hard
+    # fail, now with an actionable recovery hint appended (issue #66129).
+    assert result.error.startswith("Search failed: rg: regex parse error:")
+    assert "target='files'" in result.error
     assert result.limit_reason is None

--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -28,6 +28,7 @@ import pytest
 
 from tools.file_operations import (
     ShellFileOperations,
+    _glob_like_to_regex,
     _pattern_has_regex_newline,
     _split_tool_diagnostics,
 )
@@ -179,6 +180,82 @@ class TestSearchContentNewlineWarning:
 
         assert res.error is None
         assert res.total_count == 0
+        assert res.warning is None
+
+
+class TestGlobLikeToRegex:
+    """Unit coverage for the glob->regex recovery translator (issue #66129)."""
+
+    def test_bare_glob_maps_wildcards(self):
+        assert _glob_like_to_regex("*detector*scheduler*") == ".*detector.*scheduler.*"
+
+    def test_group_wrapped_glob_is_unwrapped(self):
+        assert _glob_like_to_regex("(?:*detector*scheduler*)") == ".*detector.*scheduler.*"
+        assert _glob_like_to_regex("(*foo*)") == ".*foo.*"
+
+    def test_question_mark_maps_to_dot(self):
+        assert _glob_like_to_regex("a?b*c") == "a.b.*c"
+
+    def test_regex_specials_are_escaped(self):
+        # A '.' in the pattern must stay literal in the recovered regex.
+        assert _glob_like_to_regex("*a.b*") == ".*a\\.b.*"
+
+    def test_no_star_returns_none(self):
+        # Without a glob '*' there is nothing glob-like to recover; don't
+        # second-guess a genuinely broken regex.
+        assert _glob_like_to_regex("needle") is None
+        assert _glob_like_to_regex("[") is None
+
+
+@pytest.mark.skipif(not shutil.which("rg"), reason="ripgrep required")
+class TestGlobAsRegexRecovery:
+    """Issue #66129: a glob passed into the content-regex field must recover
+    with a warning instead of erroring and looping."""
+
+    @pytest.fixture
+    def code_tree(self, tmp_path):
+        (tmp_path / "a.py").write_text(
+            "class DetectorScheduler:\n    detector_scheduler = 1\n"
+        )
+        (tmp_path / "b.py").write_text("unrelated line\n")
+        return tmp_path
+
+    def test_bare_glob_recovers_with_warning(self, code_tree):
+        res = _search(_ops(code_tree), "_search_with_rg", "*detector*scheduler*", code_tree)
+        assert res.error is None
+        assert res.total_count == 1
+        assert res.matches[0].line_number == 2
+        assert res.warning is not None
+        assert "glob" in res.warning.lower()
+
+    def test_group_wrapped_glob_recovers(self, code_tree):
+        res = _search(_ops(code_tree), "_search_with_rg",
+                      "(?:*detector*scheduler*)", code_tree)
+        assert res.error is None
+        assert res.total_count == 1
+
+    def test_recovery_through_high_level_search(self, code_tree):
+        res = _ops(code_tree).search(
+            "*detector*scheduler*", path=str(code_tree), target="content"
+        )
+        assert res.error is None
+        assert res.total_count == 1
+        assert res.warning is not None
+
+    def test_invalid_regex_without_glob_still_errors_actionably(self, code_tree):
+        # No '*' to reinterpret — surface an error, but one the model can act on.
+        res = _search(_ops(code_tree), "_search_with_rg", "[", code_tree)
+        assert res.error is not None
+        assert "Search failed" in res.error
+        assert "target='files'" in res.error
+        assert not res.matches
+
+    def test_valid_regex_with_star_is_unaffected(self, code_tree):
+        # A legitimate regex containing '*' succeeds on the first pass, so no
+        # recovery warning should be attached (no regression / false positive).
+        res = _search(_ops(code_tree), "_search_with_rg", "detector.*scheduler", code_tree)
+        assert res.error is None
+        assert res.total_count == 1
         assert res.warning is None
 
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -345,6 +345,35 @@ def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]
     return result.stdout, None
 
 
+def _glob_like_to_regex(pattern: str) -> Optional[str]:
+    """Convert a glob-style content pattern to a substring regex, or ``None``.
+
+    Local / smaller models sometimes pass a glob into the content *regex* field
+    — e.g. ``*foo*bar*`` or the group-wrapped ``(?:*foo*bar*)`` — which ripgrep
+    rejects with a "regex parse error" ("repetition operator missing
+    expression"). Given only that raw diagnostic the model re-emits the same bad
+    pattern and the session loops (issue #66129).
+
+    This maps glob wildcards to regex (``*`` -> ``.*``, ``?`` -> ``.``) and
+    regex-escapes everything else, after stripping one optional wrapping
+    ``(?:...)`` / ``(...)`` group. Returns ``None`` when the pattern carries no
+    ``*`` wildcard, so callers only retry on the shape this targets and never
+    second-guess an intentional (but genuinely broken) regex.
+    """
+    if "*" not in pattern:
+        return None
+    inner = pattern.strip()
+    for prefix in ("(?:", "("):
+        if inner.startswith(prefix) and inner.endswith(")"):
+            inner = inner[len(prefix):-1]
+            break
+    translated = "".join(
+        ".*" if ch == "*" else "." if ch == "?" else re.escape(ch)
+        for ch in inner
+    )
+    return translated or None
+
+
 def _split_tool_diagnostics(output: str) -> tuple[str, str]:
     """Separate rg/grep diagnostic lines from real match output.
 
@@ -2267,53 +2296,92 @@ class ShellFileOperations(FileOperations):
     def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],
                         limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Search using ripgrep."""
-        cmd_parts = ["rg", "--line-number", "--no-heading", "--with-filename"]
-        
-        # Add context if requested
-        if context > 0:
-            cmd_parts.extend(["-C", str(context)])
-        
-        # Add file glob filter (must be quoted to prevent shell expansion)
-        if file_glob:
-            cmd_parts.extend(["--glob", self._escape_shell_arg(file_glob)])
-        
-        # Output mode handling
-        if output_mode == "files_only":
-            cmd_parts.append("-l")  # Files only
-        elif output_mode == "count":
-            cmd_parts.append("-c")  # Count per file
-        
-        # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
-        
-        # Fetch extra rows so we can report the true total before slicing.
-        # For context mode, rg emits separator lines ("--") between groups,
-        # so we grab generously and filter in Python.
-        fetch_limit = limit + offset + 200 if context > 0 else limit + offset
-        cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
-        
-        # `set -o pipefail` so rg's exit status propagates through `| head`.
-        # Without it the pipeline reports head's status (0), masking rg's
-        # error code (2) and making the guard below unreachable. rg handles a
-        # truncating head cleanly (exit 0 on SIGPIPE), so pipefail does not
-        # introduce false errors on a successful-but-truncated search.
-        cmd = "set -o pipefail; " + " ".join(cmd_parts)
-        result = self._exec(cmd, timeout=60)
-        stdout, limit_reason = _search_stdout_and_limit(result)
 
-        # _exec merges stderr into stdout (stderr=subprocess.STDOUT), so rg's
-        # diagnostic lines ("rg: <file>: <error>", "rg: regex parse error:")
-        # are interleaved with match output. Split them out: diagnostics must
-        # not be parsed as matches, and on a hard error they ARE the message.
-        diagnostics, payload = _split_tool_diagnostics(stdout)
+        def _run_rg(pat: str):
+            """Run rg for ``pat`` and return (result, stdout, limit_reason,
+            diagnostics, payload). Only the pattern varies across retries."""
+            cmd_parts = ["rg", "--line-number", "--no-heading", "--with-filename"]
 
-        # rg exit codes: 0=matches found, 1=no matches, 2=error. rg returns 2
-        # even on partial errors (e.g. one unreadable file in a tree that
-        # otherwise matched), so only surface an error when exit==2 AND no
-        # usable match payload remains. Otherwise we keep the real matches.
-        if result.exit_code == 2 and not payload.strip():
+            # Add context if requested
+            if context > 0:
+                cmd_parts.extend(["-C", str(context)])
+
+            # Add file glob filter (must be quoted to prevent shell expansion)
+            if file_glob:
+                cmd_parts.extend(["--glob", self._escape_shell_arg(file_glob)])
+
+            # Output mode handling
+            if output_mode == "files_only":
+                cmd_parts.append("-l")  # Files only
+            elif output_mode == "count":
+                cmd_parts.append("-c")  # Count per file
+
+            # Add pattern and path
+            cmd_parts.append(self._escape_shell_arg(pat))
+            cmd_parts.append(self._escape_shell_arg(path))
+
+            # Fetch extra rows so we can report the true total before slicing.
+            # For context mode, rg emits separator lines ("--") between groups,
+            # so we grab generously and filter in Python.
+            fetch_limit = limit + offset + 200 if context > 0 else limit + offset
+            cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
+
+            # `set -o pipefail` so rg's exit status propagates through `| head`.
+            # Without it the pipeline reports head's status (0), masking rg's
+            # error code (2) and making the guard below unreachable. rg handles a
+            # truncating head cleanly (exit 0 on SIGPIPE), so pipefail does not
+            # introduce false errors on a successful-but-truncated search.
+            cmd = "set -o pipefail; " + " ".join(cmd_parts)
+            res = self._exec(cmd, timeout=60)
+            out, lim = _search_stdout_and_limit(res)
+            # _exec merges stderr into stdout (stderr=subprocess.STDOUT), so rg's
+            # diagnostic lines ("rg: <file>: <error>", "rg: regex parse error:")
+            # are interleaved with match output. Split them out: diagnostics must
+            # not be parsed as matches, and on a hard error they ARE the message.
+            diag, pay = _split_tool_diagnostics(out)
+            return res, out, lim, diag, pay
+
+        result, stdout, limit_reason, diagnostics, payload = _run_rg(pattern)
+
+        # rg exit codes: 0=matches found, 1=no matches, 2=error.
+        def _is_hard_error(res, pay) -> bool:
+            # rg returns 2 even on partial errors (e.g. one unreadable file in a
+            # tree that otherwise matched), so only treat exit==2 AND no usable
+            # match payload as a hard error. Otherwise we keep the real matches.
+            return res.exit_code == 2 and not pay.strip()
+
+        # Glob-as-regex recovery (issue #66129): local/small models sometimes
+        # pass a glob into the content-regex field ("*foo*bar*", or wrapped as
+        # "(?:*foo*bar*)"). rg rejects it with a regex parse error and, given
+        # only the raw diagnostic, the model retries the same bad pattern and
+        # the session loops. Retry ONCE interpreting the pattern as a glob; if
+        # that resolves, return the matches with a warning so the model learns
+        # the correct shape instead of spinning.
+        recovery_warning = None
+        if _is_hard_error(result, payload) and "regex parse error" in diagnostics.lower():
+            translated = _glob_like_to_regex(pattern)
+            if translated:
+                retried = _run_rg(translated)
+                if not _is_hard_error(retried[0], retried[4]):
+                    result, stdout, limit_reason, diagnostics, payload = retried
+                    recovery_warning = (
+                        f"'{pattern}' is not a valid regex; interpreted it as a glob "
+                        f"and searched for the regex '{translated}' instead. The "
+                        f"'pattern' field takes a REGEX for content search — use '.*' "
+                        f"for '*' and '.' for '?'. To match file NAMES by glob, call "
+                        f"search_files with target='files'."
+                    )
+
+        if _is_hard_error(result, payload):
             error_msg = diagnostics.strip() or result.stdout.strip() or "Search error"
+            if "regex parse error" in error_msg.lower():
+                # Turn the raw rg diagnostic into an actionable recovery hint so
+                # the model changes shape instead of re-emitting the same regex.
+                error_msg += (
+                    " — the 'pattern' field is a REGEX, not a glob: use '.*' instead "
+                    "of '*' and '.' instead of '?', or call search_files with "
+                    "target='files' to match file names by glob."
+                )
             return SearchResult(error=f"Search failed: {error_msg}", total_count=0)
 
         # Parse the diagnostic-free payload so error text never becomes a match.
@@ -2328,6 +2396,7 @@ class ShellFileOperations(FileOperations):
                 total_count=total,
                 truncated=bool(limit_reason),
                 limit_reason=limit_reason,
+                warning=recovery_warning,
             )
         
         elif output_mode == "count":
@@ -2345,6 +2414,7 @@ class ShellFileOperations(FileOperations):
                 total_count=sum(counts.values()),
                 truncated=bool(limit_reason),
                 limit_reason=limit_reason,
+                warning=recovery_warning,
             )
         
         else:
@@ -2388,6 +2458,7 @@ class ShellFileOperations(FileOperations):
                 total_count=total,
                 truncated=total > offset + limit or bool(limit_reason),
                 limit_reason=limit_reason,
+                warning=recovery_warning,
             )
     
     def _search_with_grep(self, pattern: str, path: str, file_glob: Optional[str],


### PR DESCRIPTION
## What does this PR do?

Local / smaller models (seen with Qwen3.6 on llama.cpp) sometimes call `search_files` with `target="content"` and a **glob** where a regex is expected (`*detector*scheduler*`, sometimes wrapped as `(?:*detector*scheduler*)`). ripgrep rejects it with a `regex parse error`; the tool returned the raw diagnostic with no recovery path, so the model re-emitted the same pattern and the session got stuck in a tool loop (wasting turn budget, filling context).

This makes `search_files` tolerant of that wrong-shape input: on a ripgrep regex parse error it retries once interpreting the pattern as a glob, and either returns the real matches (with a warning teaching the correct shape) or, when there's nothing glob-like to reinterpret, surfaces an actionable hint instead of a bare parse error. This is the content (regex) direction of the mismatch #5873 described for the files (glob) direction.

## Related Issue

Fixes #66129

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py`: add `_glob_like_to_regex()` — converts a glob-style pattern to a substring regex (`*`→`.*`, `?`→`.`, everything else escaped) after stripping one optional wrapping `(?:...)` / `(...)` group; returns `None` when there's no `*` wildcard so a genuinely broken regex is never second-guessed.
- `tools/file_operations.py`: `_search_with_rg` retries **once** with the glob→regex translation only when `rg` reports a `regex parse error` and a glob is present; on success returns matches with a `warning`. When there's no glob to reinterpret, the hard error is kept but augmented with an actionable hint (use a regex, or `target='files'` for glob file-name matching). Scoped to ripgrep — `grep` (BRE) doesn't raise this parse error on a leading `*`.
- `tests/tools/test_search_error_guard.py`: new `TestGlobLikeToRegex` (unit) + `TestGlobAsRegexRecovery` (end-to-end) coverage.
- `tests/tools/test_search_budget_truncation.py`: updated `test_real_rg_error_still_hard_fails` from an exact-string equality to a behavior contract (still hard-fails + now actionable).

## How to Test

1. Point Hermes at a local model and let it call `search_files` with `target="content"` and a glob like `*detector*scheduler*` — previously it errored and looped; now it returns matches with a warning.
2. `scripts/run_tests.sh tests/tools/test_search_error_guard.py -q` — 35 passed (incl. the new tests).
3. `scripts/run_tests.sh tests/tools/test_search_budget_truncation.py tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py tests/tools/test_x_search_tool.py -q` — all pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite (`scripts/run_tests.sh`, the repo's sanctioned wrapper) and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — recovery is pure-Python string logic; ripgrep-only path unchanged elsewhere
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (behavior is recovery-only; existing schema still accurate)

## Screenshots / Logs

Before (loop): `rg` returns `regex parse error: (?:*detector*scheduler*) ^ repetition operator missing expression`, model retries the same pattern.
After (recovered):