### PR TITLE
fix(memory): ensure memory directories have 0o755 permissions on Docker

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -184,6 +184,7 @@ class MemoryStore:
         """
         mem_dir = get_memory_dir()
         mem_dir.mkdir(parents=True, exist_ok=True)
+        mem_dir.chmod(mem_dir.stat().st_mode | 0o755)
 
         self.memory_entries = self._read_file(mem_dir / "MEMORY.md")
         self.user_entries = self._read_file(mem_dir / "USER.md")
@@ -250,6 +251,7 @@ class MemoryStore:
         """
         lock_path = path.with_suffix(path.suffix + ".lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.parent.chmod(lock_path.parent.stat().st_mode | 0o755)
 
         if fcntl is None and msvcrt is None:
             yield
@@ -309,6 +311,7 @@ class MemoryStore:
     def save_to_disk(self, target: str):
         """Persist entries to the appropriate file. Called after every mutation."""
         get_memory_dir().mkdir(parents=True, exist_ok=True)
+        get_memory_dir().chmod(get_memory_dir().stat().st_mode | 0o755)
         self._write_file(self._path_for(target), self._entries_for(target))
 
     def _entries_for(self, target: str) -> List[str]:


### PR DESCRIPTION
## Problem

When running Hermes Agent in Docker containers (especially on NAS devices like UGREEN), `memory_tool.py` creates directories with `000` permissions (`d---------`). This happens when the container's umask is `0777`, causing `mkdir(parents=True, exist_ok=True)` to create directories with no permissions at all.

Impact:
- MEMORY.md and USER.md become unreadable
- Lock files get `000` permissions
- Agent loses persistent memory across sessions

## Fix

Add `chmod(0o755)` OR'd with existing mode after each `mkdir` call at the three affected locations:

- Line 186: `mem_dir.mkdir()` in `_load_from_disk`
- Line 252: `lock_path.parent.mkdir()` in `_file_lock`
- Line 311: `get_memory_dir().mkdir()` in `save_to_disk`

Using `| 0o755` (bitwise OR) ensures we only ADD permissions, never remove existing ones.

Closes #66183
