### PR TITLE
Fix TUI npm freshness check for workspace installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1427,9 +1427,34 @@ def _npm_lock_dep_names(pkg: dict) -> set[str]:
     return names
 
 
-def _npm_lock_node_modules_path(package_name: str) -> str:
-    """Return package-lock ``packages`` key for an installed dependency name."""
-    return f"node_modules/{package_name}"
+def _npm_lock_resolve_dep_path(
+    packages: dict,
+    *,
+    declaring_path: str,
+    package_name: str,
+) -> str | None:
+    """Resolve a dependency using npm's local-to-ancestor lookup order."""
+    current = declaring_path.rstrip("/")
+    while True:
+        # Node skips an ancestor that is itself named node_modules; appending
+        # another node_modules there would produce an invalid lookup path.
+        if current != "node_modules" and not current.endswith("/node_modules"):
+            candidate = (
+                f"{current}/node_modules/{package_name}"
+                if current
+                else f"node_modules/{package_name}"
+            )
+            if candidate in packages:
+                return candidate
+
+        if not current:
+            return None
+        current = current.rsplit("/", 1)[0] if "/" in current else ""
+
+
+def _npm_lock_is_installed_package(package_path: str) -> bool:
+    """Return whether a lockfile key represents an installed package."""
+    return package_path.startswith("node_modules/") or "/node_modules/" in package_path
 
 
 def _npm_lock_workspace_subset(
@@ -1469,7 +1494,7 @@ def _npm_lock_workspace_subset(
         if not isinstance(pkg, dict):
             continue
         traversed.add(name)
-        if name.startswith("node_modules/"):
+        if _npm_lock_is_installed_package(name):
             selected.add(name)
 
         resolved = pkg.get("resolved")
@@ -1477,8 +1502,12 @@ def _npm_lock_workspace_subset(
             queue.append(resolved)
 
         for dep_name in _npm_lock_dep_names(pkg):
-            dep_path = _npm_lock_node_modules_path(dep_name)
-            if dep_path in packages and dep_path not in selected:
+            dep_path = _npm_lock_resolve_dep_path(
+                packages,
+                declaring_path=name,
+                package_name=dep_name,
+            )
+            if dep_path is not None and dep_path not in selected:
                 queue.append(dep_path)
 
     return {name: packages[name] for name in selected}

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1409,6 +1409,81 @@ to avoid false-positive reinstalls on every launch.
 """
 
 
+_NPM_LOCK_DEP_KEYS = (
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+)
+
+
+def _npm_lock_dep_names(pkg: dict) -> set[str]:
+    """Return dependency package names declared by one package-lock entry."""
+    names: set[str] = set()
+    for key in _NPM_LOCK_DEP_KEYS:
+        deps = pkg.get(key)
+        if isinstance(deps, dict):
+            names.update(str(name) for name in deps if name)
+    return names
+
+
+def _npm_lock_node_modules_path(package_name: str) -> str:
+    """Return package-lock ``packages`` key for an installed dependency name."""
+    return f"node_modules/{package_name}"
+
+
+def _npm_lock_workspace_subset(
+    packages: dict,
+    *,
+    workspace_path: str | None,
+) -> dict:
+    """Return package-lock entries reachable from one workspace package.
+
+    ``npm install --workspace ui-tui`` actualizes only the selected workspace
+    graph, while the repo root lockfile records every workspace.  Comparing
+    against the whole root lockfile therefore reports sibling workspaces as
+    missing even when the TUI install is fresh.
+    """
+    if not workspace_path:
+        return packages
+    workspace_pkg = packages.get(workspace_path)
+    if not isinstance(workspace_pkg, dict):
+        return packages
+
+    selected: set[str] = set()
+    traversed: set[str] = set()
+    queue: list[str] = [workspace_path]
+    for name, pkg in packages.items():
+        if (
+            isinstance(pkg, dict)
+            and pkg.get("link")
+            and pkg.get("resolved") == workspace_path
+        ):
+            queue.append(name)
+
+    while queue:
+        name = queue.pop()
+        if name in traversed:
+            continue
+        pkg = packages.get(name)
+        if not isinstance(pkg, dict):
+            continue
+        traversed.add(name)
+        if name.startswith("node_modules/"):
+            selected.add(name)
+
+        resolved = pkg.get("resolved")
+        if pkg.get("link") and isinstance(resolved, str) and resolved in packages:
+            queue.append(resolved)
+
+        for dep_name in _npm_lock_dep_names(pkg):
+            dep_path = _npm_lock_node_modules_path(dep_name)
+            if dep_path in packages and dep_path not in selected:
+                queue.append(dep_path)
+
+    return {name: packages[name] for name in selected}
+
+
 def _workspace_root(dir: Path) -> Path:
     """Return the npm workspace root for *dir*.
 
@@ -1515,10 +1590,19 @@ def _tui_need_npm_install(root: Path) -> bool:
     # can bump the root lockfile timestamp even when installed deps already
     # match. Fall back to mtime when either file is unparseable.
     try:
-        wanted = json.loads(lock.read_text(encoding="utf-8")).get("packages") or {}
+        wanted_lock = json.loads(lock.read_text(encoding="utf-8"))
+        wanted = wanted_lock.get("packages") or {}
         installed = json.loads(marker.read_text(encoding="utf-8")).get("packages") or {}
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return lock.stat().st_mtime > marker.stat().st_mtime
+
+    workspace_path: str | None = None
+    if ws_root != root:
+        try:
+            workspace_path = root.relative_to(ws_root).as_posix()
+        except ValueError:
+            workspace_path = None
+    wanted = _npm_lock_workspace_subset(wanted, workspace_path=workspace_path)
 
     def comparable(pkg: dict) -> dict:
         return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -155,6 +155,92 @@ def test_workspace_install_detects_missing_tui_dependency(
     assert main_mod._tui_need_npm_install(tui_dir) is True
 
 
+def _write_duplicate_root_and_workspace_dependencies(
+    root: Path,
+    *,
+    hidden_packages: dict,
+) -> Path:
+    """Write a workspace lock with distinct root and TUI-local dependency trees."""
+    tui_dir = root / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(root)
+    (root / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "ui-tui": {
+                        "name": "hermes-tui",
+                        "devDependencies": {"@types/node": "^22.20.0"},
+                    },
+                    "node_modules/hermes-tui": {
+                        "resolved": "ui-tui",
+                        "link": True,
+                    },
+                    "node_modules/@types/node": {
+                        "version": "24.13.2",
+                        "dependencies": {"undici-types": "~7.18.0"},
+                    },
+                    "node_modules/undici-types": {"version": "7.18.0"},
+                    "ui-tui/node_modules/@types/node": {
+                        "version": "22.20.0",
+                        "dependencies": {"undici-types": "~6.21.0"},
+                    },
+                    "ui-tui/node_modules/undici-types": {"version": "6.21.0"},
+                }
+            }
+        )
+    )
+    (root / "node_modules" / ".package-lock.json").write_text(
+        json.dumps({"packages": hidden_packages})
+    )
+    return tui_dir
+
+
+def test_workspace_install_prefers_local_dependency_over_root_duplicate(
+    tmp_path: Path, main_mod
+) -> None:
+    """A fresh workspace-local dependency must not be replaced by the root copy."""
+    tui_dir = _write_duplicate_root_and_workspace_dependencies(
+        tmp_path,
+        hidden_packages={
+            "node_modules/hermes-tui": {
+                "resolved": "ui-tui",
+                "link": True,
+            },
+            "ui-tui/node_modules/@types/node": {
+                "version": "22.20.0",
+                "dependencies": {"undici-types": "~6.21.0"},
+            },
+            "ui-tui/node_modules/undici-types": {"version": "6.21.0"},
+        },
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_workspace_install_detects_missing_local_dependency_despite_root_copy(
+    tmp_path: Path, main_mod
+) -> None:
+    """A root duplicate must not hide a missing workspace-local dependency."""
+    tui_dir = _write_duplicate_root_and_workspace_dependencies(
+        tmp_path,
+        hidden_packages={
+            "node_modules/hermes-tui": {
+                "resolved": "ui-tui",
+                "link": True,
+            },
+            "node_modules/@types/node": {
+                "version": "24.13.2",
+                "dependencies": {"undici-types": "~7.18.0"},
+            },
+            "node_modules/undici-types": {"version": "7.18.0"},
+        },
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
 def test_no_install_when_only_optional_peer_package_missing_from_hidden_lock(tmp_path: Path, main_mod) -> None:
     _touch_ink(tmp_path)
     (tmp_path / "package-lock.json").write_text(

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -1,5 +1,6 @@
 """_tui_need_npm_install: auto npm when node_modules is behind the lockfile."""
 
+import json
 import os
 import types
 from pathlib import Path
@@ -57,6 +58,101 @@ def test_need_install_when_required_package_missing_from_hidden_lock(tmp_path: P
         '{"packages":{"node_modules/foo":{"version":"1.0.0"}}}'
     )
     assert main_mod._tui_need_npm_install(tmp_path) is True
+
+
+def test_workspace_install_ignores_sibling_workspace_packages(
+    tmp_path: Path, main_mod
+) -> None:
+    """A fresh ui-tui install must not be invalidated by web/desktop packages."""
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "": {"workspaces": ["ui-tui", "web"]},
+                    "ui-tui": {
+                        "name": "hermes-tui",
+                        "dependencies": {"foo": "^1.0.0"},
+                    },
+                    "web": {
+                        "name": "hermes-web",
+                        "dependencies": {"web-only": "^1.0.0"},
+                    },
+                    "node_modules/hermes-tui": {
+                        "resolved": "ui-tui",
+                        "link": True,
+                    },
+                    "node_modules/foo": {"version": "1.0.0"},
+                    "node_modules/web-only": {"version": "1.0.0"},
+                }
+            }
+        )
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/hermes-tui": {
+                        "resolved": "ui-tui",
+                        "link": True,
+                    },
+                    "node_modules/foo": {"version": "1.0.0"},
+                }
+            }
+        )
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_workspace_install_detects_missing_tui_dependency(
+    tmp_path: Path, main_mod
+) -> None:
+    """The workspace scope must still catch dependencies ui-tui actually needs."""
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "ui-tui": {
+                        "name": "hermes-tui",
+                        "dependencies": {
+                            "foo": "^1.0.0",
+                            "missing-tui-dep": "^1.0.0",
+                        },
+                    },
+                    "node_modules/hermes-tui": {
+                        "resolved": "ui-tui",
+                        "link": True,
+                    },
+                    "node_modules/foo": {"version": "1.0.0"},
+                    "node_modules/missing-tui-dep": {"version": "1.0.0"},
+                    "node_modules/web-only": {"version": "1.0.0"},
+                }
+            }
+        )
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "node_modules/hermes-tui": {
+                        "resolved": "ui-tui",
+                        "link": True,
+                    },
+                    "node_modules/foo": {"version": "1.0.0"},
+                }
+            }
+        )
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is True
 
 
 def test_no_install_when_only_optional_peer_package_missing_from_hidden_lock(tmp_path: Path, main_mod) -> None:


### PR DESCRIPTION
## Summary
- scope _tui_need_npm_install() to the ui-tui workspace dependency graph when running from a monorepo workspace
- ignore sibling workspace packages that are not expected from npm install --workspace ui-tui
- still detect missing dependencies that ui-tui actually needs, including workspace link entries

## Tests
- scripts/run_tests.sh tests/hermes_cli/test_tui_npm_install.py -- -q
- env UV_CACHE_DIR=.uv-cache uv run --extra dev ruff check hermes_cli/main.py tests/hermes_cli/test_tui_npm_install.py

Split out from #66195 per maintainer request.