### PR TITLE
fix(agent): tolerate content-parts lists in interim visible text

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4821,6 +4821,14 @@ class AIAgent:
         if visible:
             return visible
         content = assistant_msg.get("content")
+        if isinstance(content, list):
+            # Compaction and multimodal providers leave content as a parts
+            # list; only the textual parts are interim-deliverable.
+            content = "".join(
+                part["text"]
+                for part in content
+                if isinstance(part, dict) and isinstance(part.get("text"), str)
+            )
         return self._strip_think_blocks(content or "").strip()
 
     def _interim_text_was_delivered(self, text: str) -> bool:

--- a/tests/run_agent/test_interim_visible_list_content.py
+++ b/tests/run_agent/test_interim_visible_list_content.py
@@ -1,0 +1,45 @@
+"""Interim visible text must survive content-parts lists.
+
+After context compaction (and with multimodal providers) an assistant
+message's ``content`` can be a list of parts instead of a string.
+``_interim_assistant_visible_text`` passed the list straight into the
+think-block regexes, and every later API call in the conversation died
+with ``TypeError: expected string or bytes-like object, got 'list'``.
+"""
+
+from run_agent import AIAgent
+
+
+def _bare_agent() -> AIAgent:
+    return object.__new__(AIAgent)
+
+
+def test_interim_visible_text_handles_content_parts_list():
+    agent = _bare_agent()
+    msg = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "<think>hidden</think>Risposta visibile."},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,xx"}},
+            {"type": "text", "text": " Continua."},
+        ],
+    }
+
+    assert agent._interim_assistant_visible_text(msg) == "Risposta visibile. Continua."
+
+
+def test_interim_visible_text_ignores_non_text_only_parts_list():
+    agent = _bare_agent()
+    msg = {
+        "role": "assistant",
+        "content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,xx"}}],
+    }
+
+    assert agent._interim_assistant_visible_text(msg) == ""
+
+
+def test_interim_visible_text_still_handles_plain_string():
+    agent = _bare_agent()
+    msg = {"role": "assistant", "content": "<think>x</think>ciao"}
+
+    assert agent._interim_assistant_visible_text(msg) == "ciao"


### PR DESCRIPTION
## Bug

`AIAgent._interim_assistant_visible_text` (`run_agent.py:4823-4824`) reads the assistant message content and passes it straight into the think-block stripper:

```python
content = assistant_msg.get("content")
return self._strip_think_blocks(content or "").strip()
```

`_strip_think_blocks` (`run_agent.py:1513`) forwards to `strip_think_blocks` in `agent/agent_runtime_helpers.py`, which runs `re.sub(...)` on that value (`agent_runtime_helpers.py:678`). When `content` is a **list of parts** rather than a string, `re.sub` raises:

```
TypeError: expected string or bytes-like object, got 'list'
```

The exception propagates out of `_interim_assistant_visible_text` and then out of every subsequent API call in the turn, so the conversation appears frozen to the user (observed in practice with several back-to-back API calls in one turn all dying the same way).

## When is `content` a list?

An assistant message's `content` is a parts list (not a string) after **context compaction**, and with **multimodal** providers, e.g.:

```python
[{"type": "text", "text": "..."}, {"type": "image_url", "image_url": {...}}]
```

The helper only ever handled string content, so this path was unguarded.

## Fix

Join the textual parts before stripping think-blocks; non-text parts (images) are ignored, and plain-string content is unchanged. 8 lines in `run_agent.py`.

## Tests

New `tests/run_agent/test_interim_visible_list_content.py` — 3 cases: a mixed text/image parts list, an image-only list, and a plain string.

- **Failing-first verified**: against the unfixed `run_agent.py`, `test_interim_visible_text_handles_content_parts_list` fails with `TypeError: expected string or bytes-like object, got 'list'`.
- **With the fix**: `tests/run_agent/test_interim_visible_list_content.py` 3/3 pass; `tests/run_agent/test_run_agent_codex_responses.py` 104/104 pass (107 total).
