### PR TITLE
feat(matrix): add m.location event support

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2695,7 +2695,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
             # Parse coordinates from geo:lat,lon[;crs=...][;u=...]
             lat = lon = None
-            if geo_uri.startswith("geo:"):
+            if isinstance(geo_uri, str) and geo_uri.startswith("geo:"):
                 coords_part = geo_uri[4:].split(";")[0]
                 parts = coords_part.split(",")
                 if len(parts) >= 2:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2680,6 +2680,43 @@ class MatrixAdapter(BasePlatformAdapter):
             await self._handle_text_message(
                 room_id, sender, event_id, event_ts, source_content, relates_to
             )
+        elif msgtype == "m.location":
+            # Forward Matrix location as a text message with coordinates.
+            geo_uri = source_content.get("geo_uri", "")
+            body = source_content.get("body", "")
+
+            # Also check MSC3488 location (newer standard)
+            msc_location = source_content.get("org.matrix.msc3488.location", {})
+            description = (
+                msc_location.get("description", "")
+                if isinstance(msc_location, dict)
+                else ""
+            )
+
+            # Parse coordinates from geo:lat,lon[;crs=...][;u=...]
+            lat = lon = None
+            if geo_uri.startswith("geo:"):
+                coords_part = geo_uri[4:].split(";")[0]
+                parts = coords_part.split(",")
+                if len(parts) >= 2:
+                    try:
+                        lat = float(parts[0].strip())
+                        lon = float(parts[1].strip())
+                    except (ValueError, TypeError):
+                        pass
+
+            if lat is not None and lon is not None:
+                text = f"📍 Location: {lat}, {lon}"
+                if description:
+                    text += f" ({description})"
+                elif body and body not in ("Location", "Posizione", ""):
+                    text += f" — {body}"
+
+                loc_content = dict(source_content)
+                loc_content["body"] = text
+                await self._handle_text_message(
+                    room_id, sender, event_id, event_ts, loc_content, relates_to
+                )
 
     async def _resolve_message_context(
         self,

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -4097,6 +4097,45 @@ class TestMatrixOnRoomMessageFilter:
         self.adapter._handle_text_message.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_location_with_valid_geo_uri_reaches_text_handler(self):
+        ev = self._mk_event(
+            sender="@alice:example.org", body="Location", msgtype="m.location"
+        )
+        ev.content.update({"geo_uri": "geo:40.5694,9.7845"})
+
+        await self.adapter._on_room_message(ev)
+
+        self.adapter._handle_text_message.assert_awaited_once()
+        forwarded_content = self.adapter._handle_text_message.await_args.args[4]
+        assert forwarded_content["body"] == "📍 Location: 40.5694, 9.7845"
+
+    @pytest.mark.asyncio
+    async def test_location_uses_msc3488_description_in_forwarded_text(self):
+        ev = self._mk_event(sender="@alice:example.org", msgtype="m.location")
+        ev.content.update(
+            {
+                "geo_uri": "geo:40.5694,9.7845",
+                "org.matrix.msc3488.location": {"description": "Current position"},
+            }
+        )
+
+        await self.adapter._on_room_message(ev)
+
+        self.adapter._handle_text_message.assert_awaited_once()
+        forwarded_content = self.adapter._handle_text_message.await_args.args[4]
+        assert forwarded_content["body"] == "📍 Location: 40.5694, 9.7845 (Current position)"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("geo_uri", [None, 42, "not-a-geo-uri", "geo:bad,coords"])
+    async def test_location_with_malformed_geo_uri_is_dropped(self, geo_uri):
+        ev = self._mk_event(sender="@alice:example.org", msgtype="m.location")
+        ev.content.update({"geo_uri": geo_uri})
+
+        await self.adapter._on_room_message(ev)
+
+        self.adapter._handle_text_message.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_unauthorized_user_reaches_text_handler(self):
         """MATRIX_ALLOWED_USERS is enforced by gateway authz, not adapter intake."""
         self.adapter._allowed_user_ids = {"@alice:example.org"}


### PR DESCRIPTION
## Summary

Matrix clients (Element, Element Android, FluffyChat, etc.) can share locations via the `m.location` msgtype with a `geo_uri` (e.g. `geo:40.5694,9.7845`). Previously these events were **silently dropped** because the Matrix adapter only dispatched `m.text`, `m.notice`, and media msgtypes (`m.image`, `m.audio`, `m.video`, `m.file`).

## What this PR does

Adds an `elif msgtype == "m.location"` branch in the message dispatch that:

1. Parses the `geo_uri` field to extract latitude/longitude
2. Supports **MSC3488** location descriptions when present
3. Falls back to the `body` field for custom location labels
4. Forwards coordinates as a formatted text message via `_handle_text_message`

The agent then receives the location as a normal text message (`📍 Location: 40.5694, 9.7845`) and can use it for distance calculations, maps lookups, or any geo-aware tools.

## Tested

- Self-hosted Matrix Synapse homeserver on Raspberry Pi 5 (ARM64)
- Element Android client sharing location
- Coordinates correctly routed to the agent
- Used for OSRM-based distance calculations (maps_client.py)

## Checklist

- [x] Works on self-hosted Matrix (Synapse)
- [x] Handles both legacy `geo_uri` and MSC3488 `org.matrix.msc3488.location`
- [x] Gracefully handles malformed coordinates (falls through silently)
- [x] No new dependencies
- [x] Follows existing code patterns (`_handle_text_message` reuse)