### PR TITLE
fix(tts): fall through to raw import when lazy_deps fails (#53259)

### DIFF
--- a/tests/tools/test_tts_pythonpath_fallback.py
+++ b/tests/tools/test_tts_pythonpath_fallback.py
@@ -1,0 +1,107 @@
+"""Regression tests for #53259.
+
+TTS lazy-import helpers (``_import_edge_tts``, ``_import_elevenlabs``,
+``_import_mistral_client``) must fall through to the raw ``import`` when
+``lazy_deps.ensure()`` fails — e.g. because the venv is read-only but the
+package is importable on ``sys.path`` via ``PYTHONPATH``.
+
+Before the fix, ``except Exception as e: raise ImportError(str(e))`` killed
+execution before the raw import could run.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestLazyDepsFallback:
+    """When ``lazy_deps.ensure()`` raises any exception (typically
+    ``FeatureUnavailable``), the import helpers must NOT re-raise.
+    They should fall through to the raw ``import`` below.
+    """
+
+    def test_edge_tts_falls_through_on_lazy_deps_failure(self):
+        from tools.lazy_deps import FeatureUnavailable
+        from tools import tts_tool
+
+        with patch(
+            "tools.lazy_deps.ensure",
+            side_effect=FeatureUnavailable("tts.edge", ("edge-tts",), "lazy install disabled"),
+        ), patch.dict("sys.modules", {"edge_tts": MagicMock()}):
+            result = tts_tool._import_edge_tts()
+
+        assert result is not None
+
+    def test_elevenlabs_falls_through_on_lazy_deps_failure(self):
+        from tools.lazy_deps import FeatureUnavailable
+        from tools import tts_tool
+
+        mock_client = MagicMock()
+        with patch(
+            "tools.lazy_deps.ensure",
+            side_effect=FeatureUnavailable("tts.elevenlabs", ("elevenlabs",), "lazy install disabled"),
+        ), patch.dict(
+            "sys.modules",
+            {"elevenlabs": MagicMock(), "elevenlabs.client": MagicMock()},
+        ):
+            with patch("builtins.__import__") as mock_import:
+                def _side_effect(name, *args, **kwargs):
+                    if name == "elevenlabs.client":
+                        mod = MagicMock()
+                        mod.ElevenLabs = mock_client
+                        return mod
+                    return MagicMock()
+
+                mock_import.side_effect = _side_effect
+                result = tts_tool._import_elevenlabs()
+
+        assert result is not None
+
+    def test_mistral_falls_through_on_lazy_deps_failure(self):
+        from tools.lazy_deps import FeatureUnavailable
+        from tools import tts_tool
+
+        mock_mistral = MagicMock()
+        with patch(
+            "tools.lazy_deps.ensure",
+            side_effect=FeatureUnavailable("tts.mistral", ("mistralai",), "lazy install disabled"),
+        ), patch.dict(
+            "sys.modules",
+            {"mistralai": MagicMock(), "mistralai.client": MagicMock()},
+        ):
+            with patch("builtins.__import__") as mock_import:
+                def _side_effect(name, *args, **kwargs):
+                    if name == "mistralai.client":
+                        mod = MagicMock()
+                        mod.Mistral = mock_mistral
+                        return mod
+                    return MagicMock()
+
+                mock_import.side_effect = _side_effect
+                result = tts_tool._import_mistral_client()
+
+        assert result is not None
+
+    def test_edge_tts_raises_when_package_truly_missing(self):
+        """When the package is NOT on sys.path, the raw import must still
+        raise ImportError — we should not swallow real import failures.
+        """
+        from tools import tts_tool
+
+        with patch.dict("sys.modules", {"edge_tts": None}):
+            with pytest.raises(ImportError):
+                tts_tool._import_edge_tts()
+
+    def test_elevenlabs_raises_when_package_truly_missing(self):
+        from tools import tts_tool
+
+        with patch.dict("sys.modules", {"elevenlabs": None}):
+            with pytest.raises(ImportError):
+                tts_tool._import_elevenlabs()
+
+    def test_mistral_raises_when_package_truly_missing(self):
+        from tools import tts_tool
+
+        with patch.dict("sys.modules", {"mistralai": None}):
+            with pytest.raises(ImportError):
+                tts_tool._import_mistral_client()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -90,8 +90,11 @@ def _import_edge_tts():
         _lazy_ensure("tts.edge", prompt=False)
     except ImportError:
         pass
-    except Exception as e:
-        raise ImportError(str(e))
+    except Exception:
+        # FeatureUnavailable or other error — package may still be
+        # importable on sys.path (e.g. PYTHONPATH installs, Docker
+        # layered filesystems).  Fall through to the raw import.
+        pass
     import edge_tts
     return edge_tts
 
@@ -111,8 +114,11 @@ def _import_elevenlabs():
         # lazy_deps module itself missing — fall through to the raw import
         # so older code paths still get a clean ImportError.
         pass
-    except Exception as e:  # FeatureUnavailable or any unexpected error
-        raise ImportError(str(e))
+    except Exception:
+        # FeatureUnavailable or other error — package may still be
+        # importable on sys.path (e.g. PYTHONPATH installs, Docker
+        # layered filesystems).  Fall through to the raw import.
+        pass
     from elevenlabs.client import ElevenLabs
     return ElevenLabs
 
@@ -134,8 +140,11 @@ def _import_mistral_client():
         ensure("tts.mistral", prompt=False)
     except ImportError:
         pass
-    except Exception as e:  # FeatureUnavailable or any unexpected error
-        raise ImportError(str(e))
+    except Exception:
+        # FeatureUnavailable or other error — package may still be
+        # importable on sys.path (e.g. PYTHONPATH installs, Docker
+        # layered filesystems).  Fall through to the raw import.
+        pass
     from mistralai.client import Mistral
     return Mistral
 


### PR DESCRIPTION
## Summary

Fix TTS lazy-import helpers to fall through to raw `import` when `lazy_deps.ensure()` fails, allowing packages installed via `PYTHONPATH` to work.

## Problem

When TTS packages (edge-tts, elevenlabs, mistralai) are installed outside the venv but remain importable on `sys.path` (e.g. via `PYTHONPATH`, Docker layered filesystems, shared `/opt/data/pypackages` locations), the TTS tool fails with:

Error: "ElevenLabs provider selected but 'elevenlabs' package not installed.
Run: pip install elevenlabs"

This happens because `_import_edge_tts()`, `_import_elevenlabs()`, and `_import_mistral_client()` catch `lazy_deps.ensure()` failures and **re-raise** as `ImportError`, killing execution before the raw `import` line below ever runs.

## Fix

Replace `raise ImportError(str(e))` with `pass` in the `except Exception` handler of all three functions. Execution now falls through to the raw `import`, which:
- **Succeeds** if the package is importable on `sys.path`
- **Raises clean `ImportError`** if truly missing

### Files changed

- `tools/tts_tool.py` — 3 one-line changes (lines 93, 115, 138)
- `tests/tools/test_tts_pythonpath_fallback.py` — new test file (6 tests)

### Test coverage

| Test | Verifies |
|---|---|
| `test_edge_tts_falls_through_on_lazy_deps_failure` | `FeatureUnavailable` → still returns module |
| `test_elevenlabs_falls_through_on_lazy_deps_failure` | `FeatureUnavailable` → still returns class |
| `test_mistral_falls_through_on_lazy_deps_failure` | `FeatureUnavailable` → still returns class |
| `test_edge_tts_raises_when_package_truly_missing` | Truly missing → clean `ImportError` |
| `test_elevenlabs_raises_when_package_truly_missing` | Truly missing → clean `ImportError` |
| `test_mistral_raises_when_package_truly_missing` | Truly missing → clean `ImportError` |

## Related

Fixes #53259
<img width="1341" height="247" alt="Screenshot 2026-07-17 155345" src="https://github.com/user-attachments/assets/91f724df-7981-4309-bfce-be1a82bbd411" />
