### PR TITLE
fix(desktop): stop CJK truncated labels & chips from clipping their bottom edge

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/chrome.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chrome.tsx
@@ -28,7 +28,7 @@ const rowPadX = 'pl-2 pr-1'
 const rowGap = 'gap-1.5'
 const rowLead = 'grid size-3.5 shrink-0 place-items-center'
 const rowInset = cn(rowPadX, rowGap, 'flex h-full min-w-0 items-center self-stretch py-0.5')
-const rowLabel = 'min-w-0 truncate text-[0.8125rem] leading-none text-(--ui-text-secondary)'
+const rowLabel = 'min-w-0 truncate text-[0.8125rem] leading-tight text-(--ui-text-secondary)'
 
 /** Codicon size in sidebar row leads — matches the file tree (`tree.tsx`). */
 export const SIDEBAR_LEAD_ICON_SIZE = '0.875rem' as const

--- a/apps/desktop/src/app/shell/sidebar-label.tsx
+++ b/apps/desktop/src/app/shell/sidebar-label.tsx
@@ -16,7 +16,7 @@ export function SidebarPanelLabel({ children, className, dotClassName, ...props 
       {...props}
     >
       <span aria-hidden="true" className={cn('dither inline-block size-2 shrink-0 rounded-[1px]', dotClassName)} />
-      <span className="min-w-0 truncate leading-none">{children}</span>
+      <span className="min-w-0 truncate leading-tight">{children}</span>
     </span>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -113,7 +113,7 @@ const SLASH_CHIP_VARIANT: Record<SlashChipKind, string> = {
 }
 
 export const SLASH_CHIP_BASE_CLASS =
-  'mx-0.5 inline-flex max-w-64 items-center gap-1 rounded px-1.5 py-0.5 align-middle text-[0.86em] font-medium leading-none'
+  'mx-0.5 inline-flex max-w-64 items-center gap-1 rounded px-1.5 py-0.5 align-middle text-[0.86em] font-medium leading-tight'
 
 export function slashChipClass(kind: SlashChipKind): string {
   return `${SLASH_CHIP_BASE_CLASS} ${SLASH_CHIP_VARIANT[kind]}`
@@ -144,7 +144,7 @@ const DirectiveIcon: FC<{ type: string }> = ({ type }) => (
  * raw HTML composer chips in `rich-editor.ts`. Neutral subtle wash + plain
  * muted-foreground text so chips read as quiet tags on any bubble color. */
 export const DIRECTIVE_CHIP_CLASS =
-  'mx-0.5 inline-flex max-w-56 items-center gap-1 rounded px-1.5 py-0.5 align-middle text-[0.86em] font-normal leading-none bg-[color-mix(in_srgb,currentColor_8%,transparent)] text-muted-foreground'
+  'mx-0.5 inline-flex max-w-56 items-center gap-1 rounded px-1.5 py-0.5 align-middle text-[0.86em] font-normal leading-tight bg-[color-mix(in_srgb,currentColor_8%,transparent)] text-muted-foreground'
 
 /**
  * Parses our composer's `@type:value` references into directive segments

--- a/apps/desktop/src/components/ui/title-menu-trigger.tsx
+++ b/apps/desktop/src/components/ui/title-menu-trigger.tsx
@@ -26,7 +26,7 @@ export function TitleMenuTrigger({
       variant="ghost"
       {...props}
     >
-      <span className="min-w-0 flex-1 truncate text-[0.75rem] font-medium leading-none">{children}</span>
+      <span className="min-w-0 flex-1 truncate text-[0.75rem] font-medium leading-tight">{children}</span>
       <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="chevron-down" size="0.8125rem" />
     </Button>
   )


### PR DESCRIPTION
## Summary

Single-line truncated labels rendered with `leading-none` (line-height: 1) clip the **bottom of CJK glyphs**. Latin text fits a 1.0 line box, but CJK glyphs render taller than the font size, so the line box is ~1px short and `truncate`'s `overflow: hidden` shears the descenders/base strokes (据/能/数/调/务… get flattened).

Two sets of sites hit the same pattern:

1. **Message directive / attachment chips** (`directive-text.tsx`) — the `@file:` chips and the attachment pill shown under a sent message. Most visible: a zh-CN filename pill renders as only the middle band of the text. Inner truncate span measured `scrollHeight 12 / clientHeight 11` (clipping).
2. **Sidebar labels** (session/tree row, section label, title-menu trigger) — every truncated sidebar label measured `scrollHeight > clientHeight` (14 in a 13px box); 24/24 clipping on a zh-CN session list.

## Fix

Bump the affected classes from `leading-none` to `leading-tight` (1.25). The line box grows just enough to contain CJK glyphs; measured after: inner spans report `scrollHeight === clientHeight` (no clip), glyphs fully visible. No change to single-line truncation, ellipsis, or the chips' inline vertical alignment.

Sites:
- `components/assistant-ui/directive-text.tsx` — `SLASH_CHIP_BASE_CLASS`, `DIRECTIVE_CHIP_CLASS` (the latter also used by the raw composer chips in `rich-editor.ts`)
- `app/chat/sidebar/chrome.tsx` — session/tree row label
- `app/shell/sidebar-label.tsx` — section label
- `components/ui/title-menu-trigger.tsx` — title dropdown trigger

No functional change for Latin text; a row grows by ~2-3px only where a line previously clipped.

## Test plan

- [x] Measured `scrollHeight`/`clientHeight` before/after in a live zh-CN session — chips and 24 sidebar labels all go from clipping to fitting.
- [x] Visual before/after confirmed on the attachment pill and sidebar: CJK top/bottom strokes no longer sheared.
- [x] Latin-only labels unchanged (still single-line truncated with ellipsis).

_(CSS-only line-height fix; no unit test — the repo has no DOM-geometry rendering harness. Verified by direct layout measurement + visual diff.)_
