### PR TITLE
fix(desktop): require manual send for restored queue entries

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -7,6 +7,7 @@ import { type ComposerAttachment } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $queuedPromptsBySession,
+  canAutoDrainQueuedPrompt,
   enqueueQueuedPrompt,
   getQueuedPrompts,
   MAX_AUTO_DRAIN_ATTEMPTS,
@@ -274,7 +275,11 @@ export function useComposerQueue({
 
     const entry = pickDrainHead(queuedPrompts)
 
-    if (!entry || (drainFailuresRef.current.get(entry.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS) {
+    if (
+      !entry ||
+      !canAutoDrainQueuedPrompt(entry) ||
+      (drainFailuresRef.current.get(entry.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS
+    ) {
       return
     }
 

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -78,6 +78,22 @@ describe('useBackgroundQueueDrain', () => {
     expect(getQueuedPrompts('stored-session-a')).toHaveLength(1)
   })
 
+  it('does not auto-send an entry restored from a previous Desktop process', async () => {
+    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const submitText = vi.fn(async () => true)
+
+    enqueueQueuedPrompt('stored-session-a', { text: 'month-old ghost prompt', attachments: [] })
+    const entry = getQueuedPrompts('stored-session-a')[0]!
+    $queuedPromptsBySession.set({ 'stored-session-a': [{ ...entry, requiresManualSend: true }] })
+
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+
+    expect(submitText).not.toHaveBeenCalled()
+    expect(getQueuedPrompts('stored-session-a')).toHaveLength(1)
+  })
+
   it('does not drain a background session that is still marked working', async () => {
     const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
     const submitText = vi.fn(async () => true)

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -5,6 +5,7 @@ import { useI18n } from '@/i18n'
 import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $queuedPromptsBySession,
+  canAutoDrainQueuedPrompt,
   getQueuedPrompts,
   MAX_AUTO_DRAIN_ATTEMPTS,
   type QueuedPromptEntry,
@@ -164,7 +165,11 @@ export function useBackgroundQueueDrain({
 
       const entry = entries[0]
 
-      if (!entry || (drainFailuresRef.current.get(entry.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS) {
+      if (
+        !entry ||
+        !canAutoDrainQueuedPrompt(entry) ||
+        (drainFailuresRef.current.get(entry.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS
+      ) {
         continue
       }
 

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import type { ComposerAttachment } from './composer'
 import {
   $queuedPromptsBySession,
+  canAutoDrainQueuedPrompt,
   clearQueuedPrompts,
   dequeueQueuedPrompt,
   enqueueQueuedPrompt,
@@ -166,5 +167,25 @@ describe('shouldAutoDrain', () => {
 
   it('does not drain an empty queue', () => {
     expect(shouldAutoDrain({ isBusy: false, queueLength: 0 })).toBe(false)
+  })
+})
+
+describe('canAutoDrainQueuedPrompt', () => {
+  it('allows entries queued in the current Desktop process', () => {
+    expect(
+      canAutoDrainQueuedPrompt({ id: 'fresh', text: 'send next', attachments: [], queuedAt: Date.now() })
+    ).toBe(true)
+  })
+
+  it('requires an explicit send for entries restored from persistence', () => {
+    expect(
+      canAutoDrainQueuedPrompt({
+        id: 'restored',
+        text: 'old prompt',
+        attachments: [],
+        queuedAt: Date.now() - 86_400_000,
+        requiresManualSend: true
+      })
+    ).toBe(false)
   })
 })

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -7,6 +7,11 @@ export interface QueuedPromptEntry {
   text: string
   attachments: ComposerAttachment[]
   queuedAt: number
+  /** Persisted entries restored by a later Desktop process require an explicit
+   * user send. A queue is an immediate sequencing aid, not a delayed-job
+   * scheduler; silently auto-draining an old entry after restart can submit a
+   * stale prompt into a rebound or recycled session. */
+  requiresManualSend?: boolean
 }
 
 type QueueState = Record<string, QueuedPromptEntry[]>
@@ -22,7 +27,16 @@ const load = (): QueueState => {
     const raw = window.localStorage.getItem(STORAGE_KEY)
     const parsed = raw ? JSON.parse(raw) : null
 
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as QueueState) : {}
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {}
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsed as QueueState).map(([sessionKey, entries]) => [
+        sessionKey,
+        Array.isArray(entries) ? entries.map(entry => ({ ...entry, requiresManualSend: true })) : []
+      ])
+    )
   } catch {
     return {}
   }
@@ -257,6 +271,10 @@ export interface AutoDrainInput {
  * (`drainingQueueRef`) serializes sends so being edge-free can't double-submit.
  */
 export const shouldAutoDrain = ({ isBusy, queueLength }: AutoDrainInput): boolean => !isBusy && queueLength > 0
+
+/** Restored queue entries stay available for review/manual send, but never fire
+ * merely because Desktop restarted, reconnected, or rebound a runtime id. */
+export const canAutoDrainQueuedPrompt = (entry: QueuedPromptEntry): boolean => !entry.requiresManualSend
 
 /** Auto-drain attempts for one entry before we stop retrying and toast. The
  * entry stays queued for a manual send; a remount/reconnect resets the count. */


### PR DESCRIPTION
## Summary

- mark composer queue entries restored from local storage as requiring an explicit manual send
- block both visible-session and background auto-drainers from submitting restored entries
- preserve normal auto-drain behavior for entries queued during the current Desktop process
- keep restored entries available in the queue UI so users can review, send, edit, or delete them

## Problem

Desktop persists queued prompts, including attachments, in `hermes.desktop.composerQueue.v1`. On a later app process, `load()` rehydrated those entries without distinguishing them from prompts queued during the current run. Both auto-drain paths only checked whether the target session was idle and the queue was non-empty.

That allowed an old unsent prompt, including its image attachment, to be submitted automatically after a later restart/reconnect/session rebind. In the reproduced case, the queue entry was almost one month old and had never been explicitly sent by the user.

A composer queue is an immediate sequencing mechanism, not a delayed-job scheduler. Process-restored entries should therefore require renewed user intent.

## Fix

`load()` tags persisted entries with `requiresManualSend: true`. `canAutoDrainQueuedPrompt()` gates both:

- `useComposerQueue` for the mounted/visible session
- `useBackgroundQueueDrain` for offscreen sessions

Manual `sendQueuedNow()` remains unchanged, so restored prompts are not lost and can still be explicitly submitted.

This is complementary to #56444. That PR preserves source-session affinity for active queue drains; this change prevents a persisted entry from automatically draining at all after a new Desktop process starts.

## Tests

- `NODE_OPTIONS=--no-experimental-webstorage npx vitest run --project ui src/store/composer-queue.test.ts src/app/session/hooks/use-background-queue-drain.test.tsx`
  - 22 tests passed
- `NODE_OPTIONS=--no-experimental-webstorage npm run typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage npm run lint`
  - 0 errors, 10 pre-existing warnings
- clean production build and unpacked macOS package
- installed package verified with clean build stamp for this commit
