### PR TITLE
chore(dev): sync lockfile and add Claude Code dev-server launch config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "hermes-web",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "web", "run", "dev"],
+      "port": 5173
+    },
+    {
+      "name": "hermes-website",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "website", "run", "start"],
+      "port": 3000
+    },
+    {
+      "name": "hermes-dashboard",
+      "runtimeExecutable": ".venv/bin/hermes",
+      "runtimeArgs": ["dashboard", "--host", "127.0.0.1", "--no-open"],
+      "port": 9119
+    },
+    {
+      "name": "hermes-ui-tui",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "ui-tui", "run", "dev"]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1875,7 +1875,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1892,7 +1891,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1909,7 +1907,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1926,7 +1923,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1943,7 +1939,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1960,7 +1955,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1977,7 +1971,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1994,7 +1987,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2011,7 +2003,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2028,7 +2019,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2045,7 +2035,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2062,7 +2051,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2079,7 +2067,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2096,7 +2083,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2113,7 +2099,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2130,7 +2115,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2147,7 +2131,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2164,7 +2147,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2181,7 +2163,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2198,7 +2179,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2215,7 +2195,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2232,7 +2211,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2249,7 +2227,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2266,7 +2243,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2283,7 +2259,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2300,7 +2275,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
## What does this PR do?

Fixes a stale lockfile that was breaking the `ui-tui` workspace's dev server, and adds a `.claude/launch.json` so Claude Code's preview tooling can start this repo's dev servers (web, website, dashboard, ui-tui) directly from the project root.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `package-lock.json`: re-synced via `npm install` at the repo root. The lockfile was out of date relative to the workspace `package.json` files (web, ui-tui, root), so `ui-tui`'s dev server crashed with `ERR_MODULE_NOT_FOUND: Cannot find package 'undici'` — it couldn't resolve a hoisted root dependency that had never actually been installed.
- `.claude/launch.json` (new): defines the four dev servers in this repo (`hermes-web` on 5173, `hermes-website` on 3000, `hermes-dashboard` on 9119, `hermes-ui-tui`) so they can be started via Claude Code's built-in dev-server preview tooling.

## How to Test

1. `rm -rf node_modules web/node_modules ui-tui/node_modules && npm install` at the repo root — should complete without missing-package errors.
2. `npm run dev --prefix ui-tui` — should start cleanly instead of throwing `Cannot find package 'undici'`.
3. Open a Claude Code session with this repo as cwd and confirm the four servers listed in `.claude/launch.json` start successfully.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, no Python changes
- [ ] I've added tests for my changes — N/A, lockfile/config only
- [x] I've tested on my platform: Ubuntu 26.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A, no architecture/workflow change
- [x] I've considered cross-platform impact — N/A, Node/npm lockfile and IDE config only
- [x] I've updated tool descriptions/schemas — N/A