### PR TITLE
fix(codex): hash over-length prompt_cache_key to fit 64-char limit

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -265,6 +265,12 @@ class ResponsesApiTransport(ProviderTransport):
         # the cache-scope routing headers below. Falls back to session_id when
         # there is no static content to hash.
         cache_key = _content_cache_key(instructions, response_tools) or session_id
+        # The backend rejects prompt_cache_key > 64 chars with HTTP 400.
+        # When _content_cache_key falls back to session_id the key can be
+        # arbitrarily long (e.g. "paperclip:company:<uuid>:agent:<uuid>" at
+        # 97 chars).  Hash over-length keys so they always fit.
+        if cache_key and len(cache_key) > 64:
+            cache_key = f"pck_{hashlib.sha256(cache_key.encode('utf-8', 'replace')).hexdigest()[:24]}"
         # xAI Responses takes prompt_cache_key in extra_body (set further
         # down); GitHub Models opts out of cache-key routing entirely.
         if not is_github_responses and not is_xai_responses and cache_key:


### PR DESCRIPTION
## Problem

The Codex/OpenAI backend rejects `prompt_cache_key` > 64 chars with HTTP 400. When `_content_cache_key` has no static content to hash, it falls back to the raw `session_id` — which can be arbitrarily long (e.g. `paperclip:company:<uuid>:agent:<uuid>` at 97 chars). The 400 is silently masked by the fallback chain, making the primary provider appear unused.

## Fix

After computing `cache_key`, hash it to `pck_<sha256[:24]>` when it exceeds 64 chars. `hashlib` is already imported in the module. The xAI `extra_body` path also benefits since it reads the same `cache_key` variable.

1 file, 6 lines added.

Closes #66045
