### PR TITLE
Add fleet-collab skill: multi-machine collaboration over Tailscale

### DIFF
--- a/optional-skills/devops/fleet-collab/SKILL.md
+++ b/optional-skills/devops/fleet-collab/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: fleet-collab
+description: "Multi-machine collaboration over Tailscale via shared board."
+version: 1.0.0
+author: JannLeo
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [kanban, multi-agent, fleet, tailscale, ssh, collaboration]
+    category: devops
+    related_skills: [kanban-orchestrator, kanban-worker]
+---
+
+# Fleet Collab Skill
+
+Coordinate multiple machines (over Tailscale) on a shared Hermes kanban board. Any node can create tasks; a central hub dispatches ready tasks to remote workers via SSH.
+
+## When to Use
+
+- You have 2+ machines on a Tailscale tailnet, each running Hermes Agent.
+- You want them to collaborate on a shared task board (e.g. compile on the beefy server, test on a small node, summarize on the laptop).
+- You don't want the overhead of a shared filesystem (NFS/SSHFS) — the hub acts as the bridge.
+
+## Prerequisites
+
+1. **Tailscale** connecting all nodes (CGNAT range `100.64.0.0/10`).
+2. **Hermes Agent** installed on each node (`hermes --version` works).
+3. **Passwordless SSH** from the hub to each worker: hub's pubkey in each worker's `~/.ssh/authorized_keys`.
+4. **Reverse SSH** from workers back to the hub: hub's sshd accepts each worker's key (so workers can create tasks on the shared board).
+5. **Proxy bypass**: if any node runs a local HTTP proxy (Clash etc.), add Tailscale IPs to `NO_PROXY` in `~/.hermes/.env` so model calls to `100.x` aren't hijacked:
+   ```
+   NO_PROXY=localhost,127.0.0.1,::1,100.64.0.0/10,<hub-ip>,<worker-ip-1>,<worker-ip-2>
+   no_proxy=localhost,127.0.0.1,::1,100.64.0.0/10,<hub-ip>,<worker-ip-1>,<worker-ip-2>
+   ```
+
+## How to Run
+
+### 1. On the hub — create the shared board and worker profiles
+
+```bash
+# Create a dedicated board
+hermes kanban boards create fleet-collab --name "Fleet Collaboration" --switch
+
+# Create a profile per remote machine (clones hub config)
+hermes profile create worker-<name> --clone
+```
+
+### 2. Deploy the scripts
+
+Copy `scripts/fleet_create.sh` to **every** node (hub + workers).
+Copy `scripts/fleet_dispatch.sh` to the **hub only**.
+
+```bash
+# On the hub, edit fleet_dispatch.sh FLEET_MAP to map assignee -> ssh target:
+#   "worker-<name>|<ssh_user>|<tailscale_ip>|<remote_hermes_path>"
+
+# On each node, edit fleet_create.sh HUB_USER / HUB_IP to point at the hub.
+```
+
+### 3. Create and dispatch tasks
+
+```bash
+# Any node can create a task (writes to the hub's shared board):
+~/fleet_create.sh "Compile firmware and report size" --assignee worker-beefy --body "Run make and report binary size."
+
+# List / inspect tasks from any node:
+~/fleet_create.sh --list
+~/fleet_create.sh --show t_xxxxx
+
+# On the hub, dispatch ready tasks to remote workers:
+~/fleet_dispatch.sh --task t_xxxxx        # single task
+~/fleet_dispatch.sh --loop 30            # poll every 30s, continuously
+```
+
+## Quick Reference
+
+| Script | Runs on | Purpose |
+|---|---|---|
+| `fleet_create.sh` | any node | create / list / show tasks on the shared board (SSH callback to hub) |
+| `fleet_dispatch.sh` | hub only | send ready tasks to remote workers via SSH, write results back to kanban |
+
+## Procedure
+
+1. Hub: `hermes kanban boards create fleet-collab --switch`
+2. Hub: `hermes profile create worker-<n> --clone` for each remote machine.
+3. Establish passwordless SSH hub↔workers (both directions).
+4. Fix `NO_PROXY` on any node running a local proxy.
+5. Deploy `fleet_create.sh` to all nodes; `fleet_dispatch.sh` to the hub.
+6. Edit the `FLEET_MAP` in `fleet_dispatch.sh` and `HUB_*` in `fleet_create.sh`.
+7. Create a task on any node: `~/fleet_create.sh "title" --assignee worker-x --body "..."`
+8. On hub: `~/fleet_dispatch.sh --loop 30` to auto-dispatch.
+
+## Pitfalls
+
+- **Proxy hijacks `100.x`**: a Clash/HTTP proxy on a node will return 502 for Tailscale IPs unless `NO_PROXY` includes `100.64.0.0/10` (the `100.*` glob is *not* recognized by Python httpx). The dispatch script also `unset` proxy env vars before calling the remote hermes as a belt-and-suspenders fix.
+- **SSH arg quoting**: `fleet_create.sh` uses a tempfile + scp to move args to the hub, avoiding shell-quote nesting that breaks `ssh ... "cmd $*"`.
+- **Don't use the SSH terminal backend** (`terminal.backend: ssh`) for these worker profiles: it force-syncs the hub's `~/.hermes/skills` (42 dirs) to the remote on every spawn — slow and overwrites the remote's own config. This skill's `fleet_dispatch.sh` SSHes into the remote's *own* hermes instead, no file sync.
+- **macOS node via Tailscale SSH**: Tailscale SSH may require browser-based device approval; password SSH won't work until approved. Complete the approval first.
+
+## Verification
+
+```bash
+# From any node, create a smoke task:
+~/fleet_create.sh "smoke: report hostname" --assignee worker-x --body "Run hostname, report it."
+
+# On hub, dispatch and confirm:
+~/fleet_dispatch.sh --task t_xxxxx
+~/fleet_create.sh --show t_xxxxx   # status: done, comment contains hostname
+```

--- a/optional-skills/devops/fleet-collab/SKILL.md
+++ b/optional-skills/devops/fleet-collab/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: fleet-collab
-description: Multi-machine collaboration over Tailscale using shared kanban board and SSH remote dispatch.
+description: "Multi-machine collaboration over Tailscale via shared board."
 version: 1.0.0
 author: JannLeo
 license: MIT
-platforms: [linux, macos]
+platforms: [linux]
 metadata:
   hermes:
     tags: [kanban, multi-agent, fleet, tailscale, ssh, collaboration]

--- a/optional-skills/devops/fleet-collab/SKILL.md
+++ b/optional-skills/devops/fleet-collab/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fleet-collab
-description: "Multi-machine collaboration over Tailscale via shared board."
+description: Multi-machine collaboration over Tailscale using shared kanban board and SSH remote dispatch.
 version: 1.0.0
 author: JannLeo
 license: MIT
@@ -97,6 +97,38 @@ Copy `scripts/fleet_dispatch.sh` to the **hub only**.
 - **SSH arg quoting**: `fleet_create.sh` uses a tempfile + scp to move args to the hub, avoiding shell-quote nesting that breaks `ssh ... "cmd $*"`.
 - **Don't use the SSH terminal backend** (`terminal.backend: ssh`) for these worker profiles: it force-syncs the hub's `~/.hermes/skills` (42 dirs) to the remote on every spawn — slow and overwrites the remote's own config. This skill's `fleet_dispatch.sh` SSHes into the remote's *own* hermes instead, no file sync.
 - **macOS node via Tailscale SSH**: Tailscale SSH may require browser-based device approval; password SSH won't work until approved. Complete the approval first.
+- **Worker "spoke and stopped" protocol violation**: some models (e.g. MiniMax) finish a task without calling `kanban_complete`/`kanban_block`, triggering `protocol violation` and auto-block after `failure_limit` (default 2) consecutive crashes. Mitigations: raise `kanban.failure_limit` in config, or use a stronger worker model. The orchestrator (below) can recover by re-decomposing.
+
+## Recursive Decomposition (Orchestrator SOUL)
+
+The built-in `auto_decompose` is a **one-shot** aux-LLM call that splits a triage task into ≤6 children. For large goals (multiple feature areas, multi-file work), a single child can still be too big — the worker burns its turn budget, gets blocked, and the loop stalls.
+
+**Teach the orchestrator profile to recursively decompose.** Add this to the orchestrator profile's `SOUL.md` (or `personalities.<name>` in config.yaml):
+
+```
+When you wake up after children complete, inspect each child's result with kanban_show:
+- done + real progress → accept, move on.
+- blocked OR summary indicates too-large/turn-exhausted → re-decompose.
+
+To re-decompose a too-large blocked task:
+1. kanban_archive the blocked child.
+2. Create 2-4 smaller child tasks via kanban_create --parent <root_id>, each with a
+   single-file-or-single-feature body spec.
+3. Always set --parent so the root stays gated until all children complete.
+
+Sizing heuristic for manual fan-out:
+- Small (1 turn, ~5 min): "implement X in file Y" → single task
+- Medium (2-3 turns, ~15 min): "add endpoint + tests + verify" → single task
+- Large (multi-file, >30 min): DO NOT send as one task — split into medium tasks
+  with --parent linking in dependency order.
+
+Anti-patterns:
+- One huge task with 5+ feature areas → worker will fail.
+- Blocking the root when children fail → re-decompose instead.
+- Forgetting --parent → children run ungated, root never wakes.
+```
+
+This turns the orchestrator from a passive "wait for children" role into an active loop driver that keeps the board moving even when the one-shot decomposer under-splits.
 
 ## Verification
 

--- a/optional-skills/devops/fleet-collab/scripts/fleet_create.sh
+++ b/optional-skills/devops/fleet-collab/scripts/fleet_create.sh
@@ -14,14 +14,14 @@
 set -euo pipefail
 
 # ===== 按你的环境修改以下三行 =====
-HUB_USER="test"
-HUB_IP="100.83.245.24"
-HUB_HERMES="/home/test/.local/bin/hermes"
+HUB_USER="<hub_ssh_user>"
+HUB_IP="<hub_tailscale_ip>"
+HUB_HERMES="<path_to_hermes_on_hub>"
 # ================================
 
 # 判断当前是否在 hub 上（改成你的 hub 主机名）
 IS_HUB=0
-hostname | grep -qi "latitude-5550" && IS_HUB=1
+hostname | grep -qi "<hub_hostname>" && IS_HUB=1
 
 # 核心函数：在本机执行 hermes kanban <subcmd> <args...>
 # 参数通过临时文件 + scp 传输，避免 shell 引号问题

--- a/optional-skills/devops/fleet-collab/scripts/fleet_create.sh
+++ b/optional-skills/devops/fleet-collab/scripts/fleet_create.sh
@@ -32,18 +32,20 @@ run_on_hub() {
   printf '%s\n' "$@" > "$tmpargs"
 
   if [[ $IS_HUB -eq 1 ]]; then
-    # 本机：mapfile 读参数后执行
-    mapfile -t ARGS < "$tmpargs"
+    # 本机：用 while-read 循环读参数（兼容 macOS bash 3.2）
+    local ARGS=()
+    while IFS= read -r line; do ARGS+=("$line"); done < "$tmpargs"
     rm -f "$tmpargs"
     "$HUB_HERMES" kanban "$subcmd" "${ARGS[@]}"
   else
-    # 远程：scp 参数文件到本机，本机读取后执行
+    # 远程：scp 参数文件到 hub，hub 读取后执行
     local remote_tmp="/tmp/fleet_args_remote_$$"
     scp -o BatchMode=yes -o ConnectTimeout=15 "$tmpargs" \
         "$HUB_USER@$HUB_IP:$remote_tmp" >/dev/null 2>&1
     rm -f "$tmpargs"
+    # 远程用 while-read 兼容 macOS bash 3.2
     ssh -o BatchMode=yes -o ConnectTimeout=15 "$HUB_USER@$HUB_IP" \
-      "mapfile -t A < $remote_tmp; rm -f $remote_tmp; $HUB_HERMES kanban $subcmd \"\${A[@]}\""
+      "A=(); while IFS= read -r L; do A+=(\"\$L\"); done < $remote_tmp; rm -f $remote_tmp; $HUB_HERMES kanban $subcmd \"\${A[@]}\""
   fi
 }
 

--- a/optional-skills/devops/fleet-collab/scripts/fleet_create.sh
+++ b/optional-skills/devops/fleet-collab/scripts/fleet_create.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# fleet_create.sh — 在任意机器上创建协同任务到 hub 的 fleet-collab 看板
+#
+# 原理：把 hermes kanban 的参数写到临时文件，scp 到 hub，hub 读取后执行。
+# 这样完全避免 SSH 引号嵌套和参数拆分问题。
+#
+# 用法：
+#   fleet_create.sh "任务标题" [--assignee worker-<name>] [--body "描述"]
+#   fleet_create.sh --list              # 列出看板任务
+#   fleet_create.sh --show t_xxxxx      # 查看任务详情
+#
+# 部署到每台机器。请按需修改下面的 HUB_* 和 IS_HUB 判断。
+
+set -euo pipefail
+
+# ===== 按你的环境修改以下三行 =====
+HUB_USER="test"
+HUB_IP="100.83.245.24"
+HUB_HERMES="/home/test/.local/bin/hermes"
+# ================================
+
+# 判断当前是否在 hub 上（改成你的 hub 主机名）
+IS_HUB=0
+hostname | grep -qi "latitude-5550" && IS_HUB=1
+
+# 核心函数：在本机执行 hermes kanban <subcmd> <args...>
+# 参数通过临时文件 + scp 传输，避免 shell 引号问题
+run_on_hub() {
+  local subcmd="$1"; shift
+  local tmpargs="/tmp/fleet_args_$$"
+  # 每行一个参数写入临时文件
+  printf '%s\n' "$@" > "$tmpargs"
+
+  if [[ $IS_HUB -eq 1 ]]; then
+    # 本机：mapfile 读参数后执行
+    mapfile -t ARGS < "$tmpargs"
+    rm -f "$tmpargs"
+    "$HUB_HERMES" kanban "$subcmd" "${ARGS[@]}"
+  else
+    # 远程：scp 参数文件到本机，本机读取后执行
+    local remote_tmp="/tmp/fleet_args_remote_$$"
+    scp -o BatchMode=yes -o ConnectTimeout=15 "$tmpargs" \
+        "$HUB_USER@$HUB_IP:$remote_tmp" >/dev/null 2>&1
+    rm -f "$tmpargs"
+    ssh -o BatchMode=yes -o ConnectTimeout=15 "$HUB_USER@$HUB_IP" \
+      "mapfile -t A < $remote_tmp; rm -f $remote_tmp; $HUB_HERMES kanban $subcmd \"\${A[@]}\""
+  fi
+}
+
+case "${1:-}" in
+  --list|ls)
+    if [[ $IS_HUB -eq 1 ]]; then
+      "$HUB_HERMES" kanban list
+    else
+      ssh -o BatchMode=yes -o ConnectTimeout=15 "$HUB_USER@$HUB_IP" "$HUB_HERMES kanban list"
+    fi
+    ;;
+  --show)
+    shift
+    if [[ $IS_HUB -eq 1 ]]; then
+      "$HUB_HERMES" kanban show "$@"
+    else
+      ssh -o BatchMode=yes -o ConnectTimeout=15 "$HUB_USER@$HUB_IP" "$HUB_HERMES kanban show $*"
+    fi
+    ;;
+  "")
+    echo "用法: $0 \"任务标题\" [--assignee <profile>] [--body \"描述\"]"
+    echo "      $0 --list | --show t_xxx"
+    exit 1
+    ;;
+  *)
+    run_on_hub create "$@"
+    ;;
+esac

--- a/optional-skills/devops/fleet-collab/scripts/fleet_dispatch.sh
+++ b/optional-skills/devops/fleet-collab/scripts/fleet_dispatch.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# fleet_dispatch.sh — 跨机协同调度器
+#
+# 工作原理：
+#   1. 扫描当前 kanban 看板里 status=ready 的任务
+#   2. 按 assignee 映射到对应远程机器（通过 Tailscale SSH）
+#   3. 把任务 body 通过 SSH 发给远程机器的 hermes 执行（hermes chat -q）
+#   4. 远程 hermes 的输出回传，本机代为 kanban comment + complete
+#
+# 远程机器不需要访问本机 kanban.db —— 本机脚本当桥梁。
+# 远程 hermes 只负责执行任务指令，不读写 kanban 状态。
+#
+# 用法：
+#   ./fleet_dispatch.sh            # 扫描并派发所有 ready 任务（一次）
+#   ./fleet_dispatch.sh --loop 30  # 每 30 秒扫一次，持续运行
+#   ./fleet_dispatch.sh --task t_xxx  # 只派发指定任务
+#
+# assignee 到远程机器的映射在下面的 FLEET_MAP 里配置。
+
+set -euo pipefail
+
+# ========== 配置：assignee -> SSH 目标 ==========
+# 格式："assignee_name|ssh_user|tailscale_ip|remote_hermes_cmd"
+# remote_hermes_cmd 是远程机器上调用 hermes 的命令（确保 PATH 含 ~/.local/bin）
+# ===== 按你的环境修改下面的映射 =====
+FLEET_MAP=(
+  "worker-<name1>|<ssh_user>|<tailscale_ip>|<remote_hermes_path>"
+  "worker-<name2>|<ssh_user>|<tailscale_ip>|<remote_hermes_path>"
+  # 示例：
+  # "worker-beefy|alice|100.112.35.71|/home/alice/.local/bin/hermes"
+  # "worker-mini|bob|100.112.232.110|/home/bob/.local/bin/hermes"
+)
+# ================================================
+
+# 本机 hermes 命令
+LOCAL_HERMES="/home/test/.local/bin/hermes"
+
+# ========== 工具函数 ==========
+
+log() { echo "[$(date +%H:%M:%S)] $*" >&2; }
+
+# 按 assignee 名查 FLEET_MAP，输出 "user|ip|hermes_cmd"
+lookup_fleet() {
+  local assignee="$1"
+  for entry in "${FLEET_MAP[@]}"; do
+    local name="${entry%%|*}"
+    if [[ "$name" == "$assignee" ]]; then
+      # 去掉首字段，剩下 "user|ip|hermes_cmd"
+      echo "${entry#*|}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# 获取任务的 body（描述）。用 hermes kanban show 提取 Body 部分
+get_task_body() {
+  local task_id="$1"
+  "$LOCAL_HERMES" kanban show "$task_id" 2>/dev/null \
+    | awk '/^Body:/{f=1; sub(/^Body:[[:space:]]*/,""); print; next} f&&/^---|^Events|^Comments|^Runs|^Latest/{f=0} f{print}'
+}
+
+# 获取任务的 assignee
+get_task_assignee() {
+  local task_id="$1"
+  "$LOCAL_HERMES" kanban show "$task_id" 2>/dev/null \
+    | awk '/^  assignee:/{gsub(/^[[:space:]]*assignee:[[:space:]]*/,""); print; exit}'
+}
+
+# 列出所有 ready 任务 ID
+list_ready_tasks() {
+  "$LOCAL_HERMES" kanban list --status ready 2>/dev/null \
+    | grep -oE 't_[a-f0-9]+' || true
+}
+
+# 派发单个任务到远程机器
+dispatch_task() {
+  local task_id="$1"
+  local assignee body fleet user ip rhermes
+
+  assignee=$(get_task_assignee "$task_id")
+  [[ -z "$assignee" || "$assignee" == "default" ]] && {
+    log "任务 $task_id assignee=$assignee，跳过（default 由本机 gateway 处理）"
+    return 0
+  }
+
+  fleet=$(lookup_fleet "$assignee") || {
+    log "任务 $task_id assignee=$assignee 无对应远程机器，跳过"
+    return 0
+  }
+  IFS='|' read -r user ip rhermes <<<"$fleet"
+
+  body=$(get_task_body "$task_id")
+  [[ -z "$body" ]] && body="执行任务 $task_id"
+
+  log "派发 $task_id -> $assignee ($user@$ip)"
+
+  # 把 body 写到临时文件，scp 到远程，远程 hermes 从文件读
+  # 这样完全避免 shell 引号嵌套和 SSH SetEnv 限制
+  local tmpbody="/tmp/fleet_task_${task_id}.txt"
+  printf '%s' "$body" > "$tmpbody"
+  local remote_body="/tmp/fleet_task_${task_id}.txt"
+
+  scp -o BatchMode=yes -o ConnectTimeout=15 "$tmpbody" "$user@$ip:$remote_body" 2>&1 | tail -1 || true
+
+  local result
+  if result=$(ssh -o BatchMode=yes -o ConnectTimeout=15 "$user@$ip" \
+        "export PATH=\"\$HOME/.local/bin:\$PATH\";
+         # 显式清掉代理，确保 hermes 对 Tailscale 内网直连（各机器都有 Clash 代理会劫持 100.x）
+         unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy;
+         export NO_PROXY='localhost,127.0.0.1,::1,100.64.0.0/10,100.112.35.71,100.65.252.24,100.112.232.110,100.83.245.24';
+         export no_proxy=\"\$NO_PROXY\";
+         BODY=\$(cat $remote_body);
+         timeout 600 \"\$HOME/.local/bin/hermes\" chat --yolo -q \"\$BODY\" 2>&1;
+         rm -f $remote_body" 2>&1); then
+    log "$task_id 远程执行完成"
+  else
+    log "$task_id 远程执行失败: $result"
+    result="远程执行失败: $result"
+  fi
+  rm -f "$tmpbody"
+
+  # 把结果写回 kanban（评论 + 完成）
+  "$LOCAL_HERMES" kanban comment "$task_id" "$result" >/dev/null 2>&1
+  "$LOCAL_HERMES" kanban complete "$task_id" >/dev/null 2>&1
+  log "$task_id 已完成并写回 kanban"
+}
+
+# ========== 主逻辑 ==========
+
+main() {
+  local loop=0 interval=30 single_task=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --loop) loop=1; interval="${2:-30}"; shift 2;;
+      --task) single_task="$2"; shift 2;;
+      *) echo "用法: $0 [--loop N] [--task t_xxx]"; exit 1;;
+    esac
+  done
+
+  while true; do
+    if [[ -n "$single_task" ]]; then
+      dispatch_task "$single_task"
+      break
+    fi
+
+    local tasks
+    tasks=$(list_ready_tasks)
+    if [[ -z "$tasks" ]]; then
+      log "无 ready 任务"
+    else
+      while IFS= read -r tid; do
+        [[ -n "$tid" ]] && dispatch_task "$tid"
+      done <<<"$tasks"
+    fi
+
+    [[ $loop -eq 0 ]] && break
+    log "等待 ${interval}s 后下一轮..."
+    sleep "$interval"
+  done
+}
+
+main "$@"

--- a/optional-skills/devops/fleet-collab/scripts/fleet_dispatch.sh
+++ b/optional-skills/devops/fleet-collab/scripts/fleet_dispatch.sh
@@ -111,19 +111,21 @@ dispatch_task() {
          export NO_PROXY='localhost,127.0.0.1,::1,100.64.0.0/10,<hub_tailscale_ip>,<worker_ips...>';
          export no_proxy=\"\$NO_PROXY\";
          BODY=\$(cat $remote_body);
-         timeout 600 \"\$HOME/.local/bin/hermes\" chat --yolo -q \"\$BODY\" 2>&1;
+         timeout 600 \"$rhermes\" chat --yolo -q \"\$BODY\" 2>&1;
          rm -f $remote_body" 2>&1); then
     log "$task_id 远程执行完成"
+    # 把结果写回 kanban（评论 + 完成）
+    "$LOCAL_HERMES" kanban comment "$task_id" "$result" >/dev/null 2>&1
+    "$LOCAL_HERMES" kanban complete "$task_id" >/dev/null 2>&1
+    log "$task_id 已完成并写回 kanban"
   else
     log "$task_id 远程执行失败: $result"
-    result="远程执行失败: $result"
+    # 失败时只评论错误，不标 done —— 保持 retryable 或 block 供操作者处理
+    "$LOCAL_HERMES" kanban comment "$task_id" "远程执行失败: $result" >/dev/null 2>&1
+    "$LOCAL_HERMES" kanban block "$task_id" "远程执行失败，待排查" >/dev/null 2>&1
+    log "$task_id 已标记为 blocked（远程执行失败）"
   fi
   rm -f "$tmpbody"
-
-  # 把结果写回 kanban（评论 + 完成）
-  "$LOCAL_HERMES" kanban comment "$task_id" "$result" >/dev/null 2>&1
-  "$LOCAL_HERMES" kanban complete "$task_id" >/dev/null 2>&1
-  log "$task_id 已完成并写回 kanban"
 }
 
 # ========== 主逻辑 ==========

--- a/optional-skills/devops/fleet-collab/scripts/fleet_dispatch.sh
+++ b/optional-skills/devops/fleet-collab/scripts/fleet_dispatch.sh
@@ -27,13 +27,13 @@ FLEET_MAP=(
   "worker-<name1>|<ssh_user>|<tailscale_ip>|<remote_hermes_path>"
   "worker-<name2>|<ssh_user>|<tailscale_ip>|<remote_hermes_path>"
   # 示例：
-  # "worker-beefy|alice|100.112.35.71|/home/alice/.local/bin/hermes"
-  # "worker-mini|bob|100.112.232.110|/home/bob/.local/bin/hermes"
+  # "worker-beefy|alice|100.64.0.10|/home/alice/.local/bin/hermes"
+  # "worker-mini|bob|100.64.0.11|/home/bob/.local/bin/hermes"
 )
 # ================================================
 
 # 本机 hermes 命令
-LOCAL_HERMES="/home/test/.local/bin/hermes"
+LOCAL_HERMES="<path_to_hermes_on_hub>"
 
 # ========== 工具函数 ==========
 
@@ -108,7 +108,7 @@ dispatch_task() {
         "export PATH=\"\$HOME/.local/bin:\$PATH\";
          # 显式清掉代理，确保 hermes 对 Tailscale 内网直连（各机器都有 Clash 代理会劫持 100.x）
          unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy;
-         export NO_PROXY='localhost,127.0.0.1,::1,100.64.0.0/10,100.112.35.71,100.65.252.24,100.112.232.110,100.83.245.24';
+         export NO_PROXY='localhost,127.0.0.1,::1,100.64.0.0/10,<hub_tailscale_ip>,<worker_ips...>';
          export no_proxy=\"\$NO_PROXY\";
          BODY=\$(cat $remote_body);
          timeout 600 \"\$HOME/.local/bin/hermes\" chat --yolo -q \"\$BODY\" 2>&1;

--- a/tests/skills/test_fleet_collab_skill.py
+++ b/tests/skills/test_fleet_collab_skill.py
@@ -1,0 +1,165 @@
+"""Hermetic contract tests for the fleet-collab skill scripts.
+
+Validates the script-level contracts documented in SKILL.md:
+- fleet_dispatch.sh: FLEET_MAP parsing, rhermes usage, failure -> block (not complete)
+- fleet_create.sh: arg transport via tempfile, while-read (no mapfile), IS_HUB routing
+- SKILL.md frontmatter: description <= 60 chars, platforms gate
+
+No network calls, no live SSH — all external commands are mocked.
+Run via: scripts/run_tests.sh tests/skills/test_fleet_collab_skill.py -q
+"""
+
+import os
+import re
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "devops" / "fleet-collab"
+DISPATCH = SKILL_DIR / "scripts" / "fleet_dispatch.sh"
+CREATE = SKILL_DIR / "scripts" / "fleet_create.sh"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class TestSkillFrontmatter(unittest.TestCase):
+    """SKILL.md frontmatter meets the skill authoring standard."""
+
+    def setUp(self):
+        self.content = _read(SKILL_MD)
+
+    def _frontmatter(self):
+        m = re.search(r"^---\s*\n(.*?)\n---\s*\n", self.content, re.DOTALL)
+        self.assertIsNotNone(m, "SKILL.md must have YAML frontmatter delimiters")
+        return m.group(1)
+
+    def test_description_le_60_chars(self):
+        fm = self._frontmatter()
+        m = re.search(r'^description:\s*"?(.*?)"?\s*$', fm, re.MULTILINE)
+        self.assertIsNotNone(m, "frontmatter must have a description field")
+        desc = m.group(1).strip()
+        self.assertLessEqual(
+            len(desc), 60,
+            f"description is {len(desc)} chars, must be <= 60: {desc!r}",
+        )
+
+    def test_platforms_linux_only(self):
+        """fleet_dispatch.sh uses GNU timeout; macOS not supported without coreutils."""
+        fm = self._frontmatter()
+        m = re.search(r"^platforms:\s*\[(.*?)\]", fm, re.MULTILINE)
+        self.assertIsNotNone(m, "frontmatter must declare platforms")
+        platforms = [p.strip() for p in m.group(1).split(",")]
+        self.assertIn("linux", platforms)
+        self.assertNotIn("macos", platforms, "macOS lacks GNU timeout by default")
+
+
+class TestDispatchScriptContract(unittest.TestCase):
+    """fleet_dispatch.sh must honor the FLEET_MAP rhermes field and not
+    mark failed dispatches as done."""
+
+    def setUp(self):
+        self.src = _read(DISPATCH)
+
+    def test_uses_rhermes_variable(self):
+        """The SSH command must invoke $rhermes, not a hardcoded path."""
+        # The remote execution line should reference $rhermes (the parsed 4th FLEET_MAP field)
+        self.assertIn("$rhermes", self.src,
+                      "dispatch must use the $rhermes variable from FLEET_MAP, not a hardcoded path")
+        # Must NOT hardcode $HOME/.local/bin/hermes in the ssh exec line
+        ssh_lines = [l for l in self.src.splitlines() if "ssh " in l and "chat" in l]
+        for line in ssh_lines:
+            self.assertNotIn('"$HOME/.local/bin/hermes"', line,
+                             "ssh exec line must use $rhermes, not hardcoded $HOME/.local/bin/hermes")
+
+    def test_failure_blocks_not_completes(self):
+        """On remote failure, the script must block the task, not complete it."""
+        # The else branch (failure) must call kanban block, not kanban complete
+        lines = self.src.splitlines()
+        in_else = False
+        else_has_block = False
+        else_has_complete = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped == "else":
+                in_else = True
+                continue
+            if in_else:
+                if stripped == "fi":
+                    in_else = False
+                    # Check this else block
+                    if else_has_block and not else_has_complete:
+                        break  # found a correct else
+                    else_has_block = False
+                    else_has_complete = False
+                if "kanban block" in stripped:
+                    else_has_block = True
+                if "kanban complete" in stripped:
+                    else_has_complete = True
+        self.assertTrue(
+            else_has_block,
+            "failure branch must call 'kanban block' to keep the card retryable"
+        )
+
+    def test_success_branch_completes(self):
+        """On success, the script must comment + complete."""
+        self.assertIn("kanban comment", self.src)
+        self.assertIn("kanban complete", self.src)
+
+    def test_no_mapfile_usage(self):
+        """mapfile is bash 4+ only; macOS default bash is 3.2."""
+        self.assertNotIn("mapfile", self.src, "use while-read instead of mapfile for portability")
+
+
+class TestCreateScriptContract(unittest.TestCase):
+    """fleet_create.sh must transport args without mapfile (bash 3.2 compatible)."""
+
+    def setUp(self):
+        self.src = _read(CREATE)
+
+    def test_no_mapfile_usage(self):
+        """mapfile is bash 4+ only; macOS default bash is 3.2."""
+        self.assertNotIn("mapfile", self.src,
+                         "fleet_create.sh must use while-read, not mapfile (bash 3.2 compat)")
+
+    def test_uses_while_read_for_args(self):
+        """Args must be read via while-read loop, not mapfile."""
+        self.assertIn("while IFS= read", self.src,
+                      "must use 'while IFS= read' loop for portable arg reading")
+
+    def test_tempfile_transport(self):
+        """Args must be transported via tempfile + scp (avoids shell quote nesting)."""
+        self.assertIn("tmpargs", self.src)
+        self.assertIn("scp", self.src)
+
+    def test_is_hub_routing(self):
+        """Script must branch on IS_HUB to decide local vs remote execution."""
+        self.assertIn("IS_HUB", self.src)
+        self.assertIn("$HUB_HERMES", self.src)
+
+
+class TestScriptSyntax(unittest.TestCase):
+    """Scripts must pass bash -n syntax check."""
+
+    def test_dispatch_syntax(self):
+        result = subprocess.run(
+            ["bash", "-n", str(DISPATCH)],
+            capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 0,
+                         f"fleet_dispatch.sh syntax error:\n{result.stderr}")
+
+    def test_create_syntax(self):
+        result = subprocess.run(
+            ["bash", "-n", str(CREATE)],
+            capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 0,
+                         f"fleet_create.sh syntax error:\n{result.stderr}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Adds a new optional skill, `fleet-collab`, for coordinating multiple Tailscale-connected machines on a shared Hermes kanban board via SSH remote dispatch — no shared filesystem (NFS/SSHFS) required.

This targets users who run Hermes on a small fleet of machines (e.g. a beefy server for compilation, a mini node for testing, a laptop as the hub) and want them to collaborate on a single task board. The hub holds the shared `kanban.db`; any node can create/list/show tasks via an SSH callback to the hub, and the hub dispatches ready tasks by SSH-ing into each worker's *own* hermes (avoiding the SSH terminal backend's heavy skills-dir sync).

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/devops/fleet-collab/SKILL.md` — skill metadata (description ≤ 60 chars per the skill authoring standard) + full playbook (When to Use, Prerequisites, How to Run, Quick Reference, Procedure, Pitfalls, Verification)
- `optional-skills/devops/fleet-collab/scripts/fleet_create.sh` — create/list/show tasks from any node (SSH callback to the hub's `hermes kanban`); args moved via tempfile + scp to avoid shell-quote nesting
- `optional-skills/devops/fleet-collab/scripts/fleet_dispatch.sh` — hub-only dispatcher that sends ready tasks to remote workers, with placeholder `FLEET_MAP` for users to edit

Placed under `optional-skills/` (not bundled `skills/`) since multi-machine Tailscale fleets are useful but not universally needed — consistent with `CONTRIBUTING.md`'s "Should the Skill be bundled?" guidance.

## How to Test

Tested end-to-end on a 4-node fleet (Linux hub + 2 Linux workers + 1 macOS worker pending Tailscale device approval) over Tailscale:

1. On the hub: `hermes kanban boards create fleet-collab --switch` and `hermes profile create worker-<n> --clone` per remote machine.
2. Set up passwordless SSH hub↔workers (both directions) and fixed `NO_PROXY` on nodes running a local HTTP proxy (Clash was hijacking `100.x` Tailscale IPs → 502).
3. Deployed `fleet_create.sh` to all nodes and `fleet_dispatch.sh` to the hub (edited `HUB_*` / `FLEET_MAP` placeholders).
4. From a **worker** node: `~/fleet_create.sh "report hostname" --assignee worker-x --body "run hostname"` → task appears on the hub's shared board.
5. On the hub: `~/fleet_dispatch.sh --task t_xxxxx` → task dispatched over SSH, remote hermes ran the command, result written back to the kanban, status `done`.
6. `~/fleet_create.sh --list` from any node shows all tasks (single shared board).

Smoke tasks completed on both Linux workers (e.g. `hostname=szserver`, `nproc=48`; `hostname=niuniu`, `nproc=4`).

## Checklist

- [x] SKILL.md `description` ≤ 60 characters, one sentence
- [x] Tools referenced in SKILL.md prose are native Hermes tools (`terminal`, `hermes kanban`) — no shell-utility name leakage
- [x] `platforms:` gated to `[linux, macos]` (Tailscale SSH on macOS needs device approval; the Pitfalls section documents this)
- [x] Scripts use placeholder config (`<ssh_user>`, `<tailscale_ip>`, ...) with example comments — no hardcoded credentials
- [x] Placed in `optional-skills/devops/` per the bundled-vs-optional guidance