### PR TITLE
Fix/provider picker credential visibility

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1395,22 +1395,27 @@ _picker_prewarm_done = _threading.Event()
 
 
 def _credential_pool_is_usable(provider: str, *, raw_pool_present: bool = False) -> bool:
-    """Return whether *provider* has a credential that can be selected now.
+    """Return whether *provider* has credentials configured.
 
     ``auth.json`` historically allowed opaque token-style pool values that do
     not deserialize into ``PooledCredential`` entries. Preserve visibility for
-    those legacy values, but when a real pool exists its availability state is
-    authoritative: an all-exhausted/dead pool is not authenticated.
+    those legacy values.
+
+    A pool with entries — even all temporarily rate-limited — is considered
+    usable so the provider remains visible in the model picker.  Hiding a
+    provider when all keys are in cooldown is incorrect: rate limits are
+    per-model for many providers (e.g. Google Gemini), and switching to a
+    different model under the same provider should work immediately.
     """
     try:
         from agent.credential_pool import load_pool
 
         pool = load_pool(provider)
         if pool.has_credentials():
-            return pool.has_available()
+            return True
     except Exception:
         pass
-    return raw_pool_present
+    return bool(raw_pool_present)
 
 
 def _extra_headers_from_config(entry: Any) -> dict[str, str]:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1395,27 +1395,22 @@ _picker_prewarm_done = _threading.Event()
 
 
 def _credential_pool_is_usable(provider: str, *, raw_pool_present: bool = False) -> bool:
-    """Return whether *provider* has credentials configured.
+    """Return whether *provider* has a credential that can be selected now.
 
     ``auth.json`` historically allowed opaque token-style pool values that do
     not deserialize into ``PooledCredential`` entries. Preserve visibility for
-    those legacy values.
-
-    A pool with entries — even all temporarily rate-limited — is considered
-    usable so the provider remains visible in the model picker.  Hiding a
-    provider when all keys are in cooldown is incorrect: rate limits are
-    per-model for many providers (e.g. Google Gemini), and switching to a
-    different model under the same provider should work immediately.
+    those legacy values, but when a real pool exists its availability state is
+    authoritative: an all-exhausted/dead pool is not authenticated.
     """
     try:
         from agent.credential_pool import load_pool
 
         pool = load_pool(provider)
         if pool.has_credentials():
-            return True
+            return pool.has_available()
     except Exception:
         pass
-    return bool(raw_pool_present)
+    return raw_pool_present
 
 
 def _extra_headers_from_config(entry: Any) -> dict[str, str]:
@@ -1485,6 +1480,7 @@ def list_authenticated_providers(
     refresh: bool = False,
     probe_custom_providers: bool = True,
     probe_current_custom_provider: bool = False,
+    for_picker: bool = False,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -1832,6 +1828,20 @@ def list_authenticated_providers(
             try:
                 if _credential_pool_is_usable(hermes_slug):
                     has_creds = True
+                elif for_picker:
+                    # For the interactive /model picker, also show providers
+                    # whose credential pool has entries but all are temporarily
+                    # rate-limited.  Rate limits are per-model for many
+                    # providers (e.g. Google Gemini) — switching to a different
+                    # model under the same provider may work even when all keys
+                    # are in cooldown.
+                    try:
+                        from agent.credential_pool import load_pool
+                        _pool = load_pool(hermes_slug)
+                        if _pool.has_credentials():
+                            has_creds = True
+                    except Exception:
+                        pass
             except Exception as exc:
                 logger.debug("Credential pool check failed for %s: %s", hermes_slug, exc)
         # Fallback: check external credential files directly.
@@ -2477,6 +2487,7 @@ def list_picker_providers(
         custom_providers=custom_providers,
         max_models=max_models,
         current_model=current_model,
+        for_picker=True,
     )
     if include_moa:
         providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)

--- a/tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
+++ b/tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
@@ -95,3 +95,22 @@ def test_opaque_legacy_pool_value_stays_visible(monkeypatch):
     )
 
     assert _credential_pool_is_usable("opencode-go", raw_pool_present=True)
+
+
+def test_picker_shows_exhausted_pool_provider(monkeypatch):
+    """The interactive picker must include providers whose credential pool
+    entries are all exhausted, so the user can still switch to a different
+    model under the same provider."""
+    from hermes_cli.model_switch import list_picker_providers
+
+    _patch_opencode_pool(monkeypatch, available=False)
+    providers = list_picker_providers(
+        current_provider="alibaba",
+        user_providers={},
+        custom_providers=[],
+    )
+    slugs = [p["slug"] for p in providers]
+    assert "opencode-go" in slugs, (
+        "Picker must show exhausted-pool providers so the user can select "
+        "a different model under the same provider"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a gap in the interactive `/model` picker: when a provider's credential pool has entries but all are temporarily rate-limited (exhausted), `list_authenticated_providers()` excludes the provider because `_credential_pool_is_usable()` returns `False`. This hides the provider from the Interactive Picker even though the user may want to select a **different model** under the same provider — rate limits are per-model for many providers (e.g. Google Gemini), so an exhausted key for model-A may still work for model-B.

**Before:** Gemini provider with 6 exhausted keys → hidden from `/model` picker → user cannot select a different Gemini model.

**After:** Gemini provider stays visible in the picker with "all keys in cooldown" models listed → user can tap a different model → `try_activate_fallback()` resets the pool and retries.

The runtime authentication/resolution path (`get_authenticated_provider_slugs`) is **unchanged** — exhausted pools still do not count as authenticated for automatic provider resolution, preserving the fix for #45759.

## Related Issue

No open issue specifically covers this gap. Related prior work:
- #45759 — established the rule that exhausted pools are not authenticated (preserved for resolution path)
- PR #5753 — made credential-pool providers visible in `/model` picker when pool entries exist (this extends it to the exhausted-pool case)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

### `hermes_cli/model_switch.py` (+22/-10)

- **`_credential_pool_is_usable()`** — reverted to its original `pool.has_available()` semantics. The earlier `return True` change (from the credential-exhaustion branch) was reverted because it broke the #45759 invariant for the resolution path.

- **`list_authenticated_providers()`** — added an optional `for_picker: bool = False` parameter. When `True`, the credential-pool check falls back to `pool.has_credentials()` when `_credential_pool_is_usable()` returns `False`, so providers with exhausted pools remain in the result set for display purposes.

- **`list_picker_providers()`** — passes `for_picker=True` to `list_authenticated_providers()`, enabling the relaxed check for the interactive picker only.

### `tests/hermes_cli/test_authenticated_providers_exhausted_pool.py` (+19)

- **`test_picker_shows_exhausted_pool_provider`** — verifies that `list_picker_providers()` includes a provider whose credential pool has entries but none are `available`, while the existing `test_exhausted_pool_provider_is_not_authenticated` still passes (provider excluded from `get_authenticated_provider_slugs`).

## How to Test

1. Run the existing exhausted-pool tests to confirm backward compatibility:
   ```
   pytest tests/hermes_cli/test_authenticated_providers_exhausted_pool.py -v
   ```
   Expected: all 4 tests pass (3 existing + 1 new).

2. Manual smoke test with a real exhausted pool:
   - Temp-exhaust a credential: `python3 -c "from agent.credential_pool import load_pool; p=load_pool('gemini'); p.mark_exhausted_and_rotate(status_code=429); p.persist()"`
   - Run `hermes model` (pick the interactive variant if on TUI, or trigger `/model` in a gateway session).
   - **Expected:** Gemini provider still appears in the picker even though its pool entries are exhausted.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — behavioral change visible through test results and `/model` picker output.
