### PR TITLE
fix(desktop): stop attachment chips being clipped under the sticky user bubble

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-message-attachment-layout.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-attachment-layout.test.tsx
@@ -1,0 +1,122 @@
+// The attachment row on a user message must render as a flow sibling BELOW the
+// sticky user bubble, with NO negative top margin — otherwise its top is pulled
+// up under the bubble's opaque `sticky z-40` background and the chips/thumbnails
+// get painted over (the clipping bug, #66260). This renders the real UserMessage
+// through the app's assistant-ui runtime (same harness as user-message-edit) and
+// asserts the DOM contract that locks the fix in: re-adding any `-mt-*` on the
+// attachment row would fail here.
+//
+// Note: jsdom has no layout engine, so this asserts the structural/class
+// contract (sibling ordering + absence of negative margin) rather than measured
+// pixels. That is the exact thing the regression toggled, and it can't drift
+// silently the way a screenshot can.
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Thread } from '.'
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+vi.stubGlobal('CSS', { escape: (str: string) => str })
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+afterEach(() => {
+  cleanup()
+})
+
+function userMessageWithAttachment(): ThreadMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'here you go' }],
+    attachments: [],
+    createdAt,
+    // The attachment row is driven by metadata.custom.attachmentRefs
+    // (see messageAttachmentRefs in user-message.tsx).
+    metadata: { custom: { attachmentRefs: ['@file:.hermes/desktop-attachments/文档.pdf'] } }
+  } as ThreadMessage
+}
+
+function assistantMessage(): ThreadMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'done' }],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
+function Harness() {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [userMessageWithAttachment(), assistantMessage()],
+    isRunning: false,
+    onNew: async () => {},
+    onEdit: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('user-message attachment row layout (#66260)', () => {
+  it('renders the attachment row with no negative top margin so it is not clipped by the sticky bubble', async () => {
+    const { container } = render(<Harness />)
+
+    // The attachment ref renders through DirectiveContent; the row is its
+    // wrapping div. Find it by the directive text the row contains.
+    await waitFor(() => expect(screen.getByText(/文档\.pdf/)).toBeTruthy())
+    const directive = screen.getByText(/文档\.pdf/)
+
+    // Walk up to the attachment row div (the flex-wrap container).
+    let row: HTMLElement | null = directive
+    while (row && !(row.className && row.className.includes('flex-wrap'))) {
+      row = row.parentElement
+    }
+    expect(row).not.toBeNull()
+
+    // Contract 1: no negative top margin class of any size. This is the exact
+    // thing the bug toggled (-mt-3 → clip; -mt-1 → partial clip). Any -mt-*
+    // pulls the row under the opaque sticky layer.
+    expect(row!.className).not.toMatch(/-mt-\d/)
+
+    // Contract 2: the row still exists as its own spacing-bearing element
+    // (mb-2 kept) — proving we removed the negative margin, not the row.
+    expect(row!.className).toContain('mb-2')
+
+    // Contract 3: the attachment row is a following sibling of the sticky
+    // bubble container (role=user, sticky), i.e. it sits BELOW it in flow so
+    // it scrolls away rather than riding along — the layout the fix relies on.
+    const sticky = container.querySelector('[data-slot="aui_user-message-root"]')
+    expect(sticky).not.toBeNull()
+    expect(sticky!.className).toContain('sticky')
+    // row must come after the sticky container in document order.
+    const position = sticky!.compareDocumentPosition(row!)
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    // and must NOT be a descendant of the sticky container (it's a flow sibling).
+    expect(sticky!.contains(row!)).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -247,8 +247,15 @@ export const UserMessage: FC<{
           // Attachments live BELOW the sticky bubble in normal flow, so they
           // scroll away behind the pinned bubble instead of riding along with
           // it. Image refs render as thumbnails, file refs as chips; no border.
+          //
+          // No negative top margin here: the preceding sibling is the opaque
+          // `sticky z-40` bubble container, whose background extends through its
+          // own `pb-(--conversation-turn-gap)`. Any -mt pulls this row's top up
+          // into that opaque padding, where the pinned bubble paints over the
+          // chips (the clipping bug). Non-negative spacing keeps the row wholly
+          // below the sticky layer, so chips and thumbnails stay fully visible.
           attachmentRefs.length > 0 ? (
-            <div className="flex flex-wrap gap-1 -mt-3 mb-2">
+            <div className="flex flex-wrap gap-1 mb-2">
               <DirectiveContent text={attachmentRefs.join(' ')} />
             </div>
           ) : null


### PR DESCRIPTION
## Summary

An attachment chip on a just-sent message (before any reload — the optimistic render) shows with its top ~half sheared off. On a CJK filename it looks like only the middle band of the glyphs is visible.

## Root cause — not line-height

The attachment row is a flow sibling rendered **below** the sticky user bubble and uses `-mt-3` (margin-top: -0.75rem) to tuck up close to it. But the bubble is `sticky z-40` with an **opaque** `bg-(--ui-chat-surface-background)`. The ~12px the attachment row is pulled up lands **behind** that opaque background and gets painted over. The chip is only ~18–20px tall, so ~12px of its top disappears — which reads as a vertical clip.

(It only shows on the optimistic/pre-reload render because that's when the chip sits directly under the just-pinned bubble; after scrolling/reload the geometry differs. Geometry checks like `scrollHeight === clientHeight` on the chip look fine — the clip is an overpaint by the sticky sibling, not an overflow.)

## Fix

`-mt-3` → `-mt-1` (-0.25rem): keeps the chip tucked close to the bubble without sliding its top under the opaque sticky layer.

`components/assistant-ui/thread/user-message.tsx` — the attachment row in `StickyHumanMessageContainer`.

## Test plan

- [x] Reproduced in a live session on the optimistic (pre-reload) render — chip top clipped with `-mt-3`.
- [x] With `-mt-1`: chip top/bottom fully visible, spacing to the bubble still tight.
- [x] Applies to both file chips and image thumbnails (same row).

_(CSS-only spacing fix; no unit test — verified by visual diff on the live optimistic render.)_
