### PR TITLE
fix(update): keep trace upload compatible with transformers

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -94,9 +94,17 @@ class TestAllowlist:
                 assert ld._spec_is_safe(spec), \
                     f"{feature}: spec {spec!r} fails safety check"
 
-    def test_trace_upload_hub_pin_is_compatible_with_transformers(self):
-        # Do not reintroduce the old 1.2.3 pin: transformers requires >=1.5.
-        assert ld.LAZY_DEPS["tool.trace_upload"] == ("huggingface-hub==1.23.0",)
+    @pytest.mark.parametrize(
+        ("installed", "is_missing"),
+        [("1.4.1", True), ("1.5.0", False), ("1.23.0", False), ("2.0.0", True)],
+    )
+    def test_trace_upload_hub_range_matches_transformers(self, monkeypatch, installed, is_missing):
+        def fake_version(package):
+            assert package == "huggingface-hub"
+            return installed
+
+        monkeypatch.setattr("importlib.metadata.version", fake_version)
+        assert bool(ld.feature_missing("tool.trace_upload")) is is_missing
 
     def test_feature_install_command_returns_pip_invocation(self):
         cmd = ld.feature_install_command("memory.honcho")

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -94,6 +94,10 @@ class TestAllowlist:
                 assert ld._spec_is_safe(spec), \
                     f"{feature}: spec {spec!r} fails safety check"
 
+    def test_trace_upload_hub_pin_is_compatible_with_transformers(self):
+        # Do not reintroduce the old 1.2.3 pin: transformers requires >=1.5.
+        assert ld.LAZY_DEPS["tool.trace_upload"] == ("huggingface-hub==1.23.0",)
+
     def test_feature_install_command_returns_pip_invocation(self):
         cmd = ld.feature_install_command("memory.honcho")
         assert cmd is not None

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -240,7 +240,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     ),
     # HF Agent Trace Viewer upload (hermes trace upload / /upload-trace).
     # Keep the lazy trace tool compatible with the shared transformers core.
-    "tool.trace_upload": ("huggingface-hub==1.23.0",),
+    "tool.trace_upload": ("huggingface-hub>=1.5.0,<2",),
 }
 
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -239,7 +239,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "starlette==1.0.1",  # CVE-2026-48710 — keep in sync with pyproject [computer-use]
     ),
     # HF Agent Trace Viewer upload (hermes trace upload / /upload-trace).
-    "tool.trace_upload": ("huggingface-hub==1.2.3",),
+    # Keep the lazy trace tool compatible with the shared transformers core.
+    "tool.trace_upload": ("huggingface-hub==1.23.0",),
 }
 
 


### PR DESCRIPTION
## Summary
Prevent the lazy `tool.trace_upload` dependency from downgrading `huggingface-hub` below the shared `transformers` requirement.

The old exact pin (`1.2.3`) causes `pip check` failures and breaks the Hindsight import chain when active lazy features refresh.

## Verification
- `python -m pytest -q tests/tools/test_lazy_deps.py` — 65 passed
- `python -m py_compile tools/lazy_deps.py`
- `git diff --check`

Adds a regression test for the trace-upload pin.