### PR TITLE
feat(api): add strict tool-free named conversations

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -164,6 +164,41 @@ def _coerce_request_bool(value: Any, default: bool = False) -> bool:
     return default
 
 
+def _is_complete_agent_result(result: Any) -> bool:
+    """Require an explicit, internally consistent successful turn result."""
+    if not isinstance(result, dict):
+        return False
+    final_response = result.get("final_response")
+    messages = result.get("messages")
+    return (
+        isinstance(final_response, str)
+        and bool(final_response.strip())
+        and isinstance(messages, list)
+        and all(
+            isinstance(message, dict)
+            and message.get("role") != "tool"
+            and not message.get("tool_calls")
+            for message in messages
+        )
+        and result.get("completed") is True
+        and result.get("failed") is False
+        and result.get("partial") is False
+        and result.get("interrupted") is False
+    )
+
+
+def _resolve_agent_toolsets(
+    user_config: Dict[str, Any], tool_choice: Optional[str]
+) -> List[str]:
+    """Resolve API-server toolsets, with a strict request-level deny mode."""
+    if tool_choice == "none":
+        return []
+
+    from hermes_cli.tools_config import _get_platform_tools
+
+    return sorted(_get_platform_tools(user_config, "api_server"))
+
+
 def _normalize_chat_content(
     content: Any, *, _max_depth: int = 10, _depth: int = 0,
 ) -> str:
@@ -422,8 +457,10 @@ class ResponseStore:
             except Exception:
                 db_path = ":memory:"
         self._db_path: Optional[str] = db_path if db_path != ":memory:" else None
+        self._is_durable = False
         try:
             self._conn = sqlite3.connect(db_path, check_same_thread=False)
+            self._is_durable = self._db_path is not None
         except Exception:
             self._conn = sqlite3.connect(":memory:", check_same_thread=False)
             self._db_path = None
@@ -453,6 +490,11 @@ class ResponseStore:
         # rather than after every commit — chmod-on-every-write is wasted
         # syscalls on a hot path.
         self._tighten_file_permissions()
+
+    @property
+    def is_durable(self) -> bool:
+        """Whether this store is file-backed and shareable across API processes."""
+        return self._is_durable
 
     def _tighten_file_permissions(self) -> None:
         """Force owner-only permissions on the DB and SQLite sidecars."""
@@ -499,8 +541,8 @@ class ResponseStore:
             self._conn.commit()
             return None
 
-    def put(self, response_id: str, data: Dict[str, Any]) -> None:
-        """Store a response, evicting the oldest if at capacity."""
+    def _put_uncommitted(self, response_id: str, data: Dict[str, Any]) -> None:
+        """Store one response and apply LRU eviction inside the caller's transaction."""
         self._conn.execute(
             "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
             (response_id, json.dumps(data, default=str), time.time()),
@@ -528,7 +570,39 @@ class ResponseStore:
                     f"DELETE FROM responses WHERE response_id IN ({placeholders})",
                     evict_ids,
                 )
+
+    def put(self, response_id: str, data: Dict[str, Any]) -> None:
+        """Store a response, evicting the oldest if at capacity."""
+        self._put_uncommitted(response_id, data)
         self._conn.commit()
+
+    def put_conversation_if_current(
+        self,
+        name: str,
+        expected_response_id: Optional[str],
+        response_id: str,
+        data: Dict[str, Any],
+    ) -> bool:
+        """Atomically store and advance a conversation if its head is unchanged."""
+        try:
+            self._conn.execute("BEGIN IMMEDIATE")
+            row = self._conn.execute(
+                "SELECT response_id FROM conversations WHERE name = ?", (name,)
+            ).fetchone()
+            current_response_id = row[0] if row else None
+            if current_response_id != expected_response_id:
+                self._conn.rollback()
+                return False
+            self._put_uncommitted(response_id, data)
+            self._conn.execute(
+                "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
+                (name, response_id),
+            )
+            self._conn.commit()
+            return True
+        except Exception:
+            self._conn.rollback()
+            raise
 
     def delete(self, response_id: str) -> bool:
         """Remove a response from the store. Returns True if found and deleted."""
@@ -1707,6 +1781,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        tool_choice: Optional[str] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1736,7 +1811,6 @@ class APIServerAdapter(BasePlatformAdapter):
             _load_gateway_config,
             GatewayRunner,
         )
-        from hermes_cli.tools_config import _get_platform_tools
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         reasoning_config = GatewayRunner._load_reasoning_config()
@@ -1800,7 +1874,7 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         user_config = _load_gateway_config()
-        enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        enabled_toolsets = _resolve_agent_toolsets(user_config, tool_choice)
 
         max_iterations = _current_max_iterations()
 
@@ -1980,6 +2054,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_submission": True,
                 "run_status": True,
                 "run_events_sse": True,
+                "strict_tool_choice_none": True,
+                "durable_conversation_cas": self._response_store.is_durable,
                 "run_stop": True,
                 "run_approval_response": True,
                 "tool_progress_events": True,
@@ -3706,14 +3782,37 @@ class APIServerAdapter(BasePlatformAdapter):
         previous_response_id = body.get("previous_response_id")
         conversation = body.get("conversation")
         store = _coerce_request_bool(body.get("store"), default=True)
+        tool_choice = body.get("tool_choice")
+        if tool_choice == "none" and _coerce_request_bool(
+            body.get("stream"), default=False
+        ):
+            return web.json_response(
+                _openai_error(
+                    "tool_choice 'none' is currently supported only for non-streaming responses",
+                    code="unsupported_tool_choice",
+                ),
+                status=400,
+            )
 
         # conversation and previous_response_id are mutually exclusive
         if conversation and previous_response_id:
             return web.json_response(_openai_error("Cannot use both 'conversation' and 'previous_response_id'"), status=400)
 
-        # Resolve conversation name to latest response_id
+        if conversation and store and not self._response_store.is_durable:
+            return web.json_response(
+                _openai_error(
+                    "Named stored conversations require durable shared response storage",
+                    code="durable_conversation_store_required",
+                ),
+                status=503,
+            )
+
+        # Resolve conversation name to latest response_id. The observed head is
+        # compared again atomically when the completed turn is stored.
+        conversation_head = None
         if conversation:
             previous_response_id = self._response_store.get_conversation(conversation)
+            conversation_head = previous_response_id
             # No error if conversation doesn't exist yet — it's a new conversation
 
         # Normalize input to message list
@@ -3879,13 +3978,22 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
                 route=route,
+                tool_choice=tool_choice,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
             fp = _make_request_fingerprint(
                 body,
-                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools"],
+                keys=[
+                    "input",
+                    "instructions",
+                    "previous_response_id",
+                    "conversation",
+                    "model",
+                    "tools",
+                    "tool_choice",
+                ],
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -3904,6 +4012,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     _openai_error(f"Internal server error: {e}", err_type="server_error"),
                     status=500,
                 )
+
+        if tool_choice == "none" and not _is_complete_agent_result(result):
+            logger.warning("Refusing incomplete strict-none Responses turn")
+            return web.json_response(
+                _openai_error(
+                    "Strict tool-free agent run did not complete successfully",
+                    code="strict_none_run_incomplete",
+                ),
+                status=502,
+            )
 
         final_response = _resolve_media_to_data_urls(result.get("final_response", ""))
         if not final_response:
@@ -3945,18 +4063,35 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         }
 
+        capability_receipt = result.get("_hermes_capabilities")
+        if capability_receipt is not None:
+            response_data["capabilities"] = capability_receipt
+
         # Store the complete response object for future chaining / GET retrieval
         if store:
-            self._response_store.put(response_id, {
+            stored_response = {
                 "response": response_data,
                 "conversation_history": full_history,
                 "instructions": instructions,
                 "session_id": session_id,
-            })
-            # Update conversation mapping so the next request with the same
-            # conversation name automatically chains to this response
+            }
             if conversation:
-                self._response_store.set_conversation(conversation, response_id)
+                advanced = self._response_store.put_conversation_if_current(
+                    conversation,
+                    conversation_head,
+                    response_id,
+                    stored_response,
+                )
+                if not advanced:
+                    return web.json_response(
+                        _openai_error(
+                            "Conversation advanced while this response was running; retry the turn",
+                            code="conversation_conflict",
+                        ),
+                        status=409,
+                    )
+            else:
+                self._response_store.put(response_id, stored_response)
 
         response_headers = {"X-Hermes-Session-Id": session_id}
         if gateway_session_key:
@@ -4528,6 +4663,7 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
         route: Optional[Dict[str, Any]] = None,
+        tool_choice: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -4569,7 +4705,14 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_complete_callback=tool_complete_callback,
                         gateway_session_key=gateway_session_key,
                         route=route,
+                        tool_choice=tool_choice,
                     )
+                    if tool_choice == "none":
+                        resolved_tools = getattr(agent, "tools", None) or []
+                        if resolved_tools:
+                            raise RuntimeError(
+                                "tool_choice 'none' resolved a non-empty tool surface"
+                            )
                     if agent_ref is not None:
                         agent_ref[0] = agent
                     effective_task_id = session_id or str(uuid.uuid4())
@@ -4578,6 +4721,11 @@ class APIServerAdapter(BasePlatformAdapter):
                         conversation_history=conversation_history,
                         task_id=effective_task_id,
                     )
+                    if tool_choice == "none" and _is_complete_agent_result(result):
+                        result["_hermes_capabilities"] = {
+                            "tool_choice": "none",
+                            "resolved_tools": [],
+                        }
                     usage = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -24,6 +24,7 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+import gateway.platforms.api_server as api_server
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
@@ -94,6 +95,24 @@ class TestResponseStore:
         store = ResponseStore(max_size=10)
         assert store.get("resp_missing") is None
 
+    def test_memory_store_is_not_durable(self):
+        store = ResponseStore(max_size=10, db_path=":memory:")
+        assert store.is_durable is False
+
+    def test_failed_file_open_falls_back_without_durable_attestation(self, tmp_path):
+        durable_path = str(tmp_path / "unavailable" / "responses.db")
+        real_connect = api_server.sqlite3.connect
+
+        def connect(path, *args, **kwargs):
+            if path == durable_path:
+                raise OSError("durable path unavailable")
+            return real_connect(path, *args, **kwargs)
+
+        with patch.object(api_server.sqlite3, "connect", side_effect=connect):
+            store = ResponseStore(max_size=10, db_path=durable_path)
+
+        assert store.is_durable is False
+
     def test_lru_eviction(self):
         store = ResponseStore(max_size=3)
         store.put("resp_1", {"output": "one"})
@@ -157,6 +176,25 @@ class TestResponseStore:
         assert store.get_conversation("chat-a") is None
         # resp_2 mapping should still be intact
         assert store.get_conversation("chat-b") == "resp_2"
+
+    def test_conversation_compare_and_set_is_shared_across_connections(self, tmp_path):
+        db_path = tmp_path / "responses.db"
+        first = ResponseStore(max_size=10, db_path=str(db_path))
+        second = ResponseStore(max_size=10, db_path=str(db_path))
+        try:
+            assert first.get_conversation("shared") is None
+            assert second.get_conversation("shared") is None
+            assert first.put_conversation_if_current(
+                "shared", None, "resp_winner", {"response": {"id": "resp_winner"}}
+            )
+            assert not second.put_conversation_if_current(
+                "shared", None, "resp_loser", {"response": {"id": "resp_loser"}}
+            )
+            assert second.get_conversation("shared") == "resp_winner"
+            assert second.get("resp_loser") is None
+        finally:
+            first.close()
+            second.close()
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are platform-specific")
     def test_file_store_created_owner_only_under_permissive_umask(self, tmp_path):
@@ -690,6 +728,16 @@ def auth_adapter():
 
 
 class TestAgentExecution:
+    def test_strict_none_bypasses_configured_toolset_resolution(self):
+        with patch(
+            "hermes_cli.tools_config._get_platform_tools",
+            return_value={"default", "web"},
+        ) as get_platform_tools:
+            resolved = api_server._resolve_agent_toolsets({}, "none")
+
+        assert resolved == []
+        get_platform_tools.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_run_agent_uses_session_id_as_task_id(self, adapter):
         mock_agent = MagicMock()
@@ -717,6 +765,137 @@ class TestAgentExecution:
             conversation_history=[],
             task_id="session-123",
         )
+
+    @pytest.mark.asyncio
+    async def test_run_agent_rejects_surviving_tools_in_strict_none_mode(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.tools = [
+            {
+                "type": "function",
+                "function": {"name": "terminal", "parameters": {}},
+            }
+        ]
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            with pytest.raises(
+                RuntimeError,
+                match="tool_choice 'none' resolved a non-empty tool surface",
+            ):
+                await adapter._run_agent(
+                    user_message="hello",
+                    conversation_history=[],
+                    tool_choice="none",
+                )
+
+        mock_agent.run_conversation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_agent_rejects_opaque_tools_in_strict_none_mode(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.tools = [{"type": "future_custom_tool", "opaque": True}]
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            with pytest.raises(
+                RuntimeError,
+                match="tool_choice 'none' resolved a non-empty tool surface",
+            ):
+                await adapter._run_agent(
+                    user_message="hello",
+                    conversation_history=[],
+                    tool_choice="none",
+                )
+
+        mock_agent.run_conversation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_agent_receipts_empty_tools_in_strict_none_mode(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.tools = []
+        mock_agent.run_conversation.return_value = {
+            "final_response": "ok",
+            "messages": [],
+            "completed": True,
+            "failed": False,
+            "partial": False,
+            "interrupted": False,
+        }
+        mock_agent.session_prompt_tokens = 1
+        mock_agent.session_completion_tokens = 2
+        mock_agent.session_total_tokens = 3
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            result, _usage = await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                tool_choice="none",
+            )
+
+        assert result["_hermes_capabilities"] == {
+            "tool_choice": "none",
+            "resolved_tools": [],
+        }
+
+    @pytest.mark.asyncio
+    async def test_run_agent_does_not_receipt_incomplete_strict_none_turn(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.tools = []
+        mock_agent.run_conversation.return_value = {
+            "final_response": "provider failed",
+            "completed": False,
+            "failed": True,
+            "partial": True,
+            "interrupted": False,
+        }
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            result, _usage = await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                tool_choice="none",
+            )
+
+        assert "_hermes_capabilities" not in result
+
+    @pytest.mark.parametrize(
+        "invalid_result",
+        [
+            {
+                "messages": [],
+                "completed": True,
+                "failed": False,
+                "partial": False,
+                "interrupted": False,
+            },
+            {
+                "final_response": "   ",
+                "messages": [],
+                "completed": True,
+                "failed": False,
+                "partial": False,
+                "interrupted": False,
+            },
+            {
+                "final_response": "answer",
+                "messages": "not-a-list",
+                "completed": True,
+                "failed": False,
+                "partial": False,
+                "interrupted": False,
+            },
+            {
+                "final_response": "answer",
+                "messages": [{"role": "assistant", "tool_calls": [{}]}],
+                "completed": True,
+                "failed": False,
+                "partial": False,
+                "interrupted": False,
+            },
+        ],
+    )
+    def test_strict_none_completion_rejects_malformed_result_shapes(
+        self, invalid_result
+    ):
+        assert api_server._is_complete_agent_result(invalid_result) is False
 
 
 # ---------------------------------------------------------------------------
@@ -968,7 +1147,10 @@ class TestModelsEndpoint:
 
 class TestCapabilitiesEndpoint:
     @pytest.mark.asyncio
-    async def test_capabilities_advertises_plugin_safe_contract(self, adapter):
+    async def test_capabilities_advertises_plugin_safe_contract(self, adapter, tmp_path):
+        adapter._response_store = ResponseStore(
+            db_path=str(tmp_path / "durable-responses.db")
+        )
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/v1/capabilities")
@@ -986,10 +1168,22 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["strict_tool_choice_none"] is True
+            assert data["features"]["durable_conversation_cas"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
+
+    @pytest.mark.asyncio
+    async def test_capabilities_discloses_memory_store_is_not_durable(self, adapter):
+        adapter._response_store = ResponseStore(db_path=":memory:")
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["features"]["durable_conversation_cas"] is False
 
     @pytest.mark.asyncio
     async def test_capabilities_requires_auth_when_key_configured(self, auth_adapter):
@@ -1893,6 +2087,166 @@ class TestResponsesEndpoint:
             assert data["output"][0]["content"][0]["text"] == "Paris is the capital of France."
 
     @pytest.mark.asyncio
+    async def test_tool_choice_none_is_strict_and_receipted(self, adapter):
+        mock_result = {
+            "final_response": "Advisory only.",
+            "messages": [],
+            "api_calls": 1,
+            "completed": True,
+            "failed": False,
+            "partial": False,
+            "interrupted": False,
+            "_hermes_capabilities": {
+                "tool_choice": "none",
+                "resolved_tools": [],
+            },
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Explain the supplied focus.",
+                        "tool_choice": "none",
+                        "store": True,
+                    },
+                )
+
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["tool_choice"] == "none"
+            data = await resp.json()
+            assert data["capabilities"] == {
+                "tool_choice": "none",
+                "resolved_tools": [],
+            }
+            stored = adapter._response_store.get(data["id"])
+            assert stored["response"]["capabilities"] == data["capabilities"]
+
+    @pytest.mark.asyncio
+    async def test_tool_choice_none_refuses_failed_partial_turn(self, adapter):
+        conversation = f"failed-strict-{uuid.uuid4().hex}"
+        failed_result = {
+            "final_response": "provider failure text",
+            "messages": [],
+            "api_calls": 1,
+            "completed": False,
+            "failed": True,
+            "partial": True,
+            "interrupted": False,
+            "_hermes_capabilities": {
+                "tool_choice": "none",
+                "resolved_tools": [],
+            },
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    failed_result,
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "Explain the supplied focus.",
+                        "tool_choice": "none",
+                        "conversation": conversation,
+                        "store": True,
+                    },
+                )
+                payload = await resp.json()
+
+        assert resp.status == 502
+        assert payload["error"]["code"] == "strict_none_run_incomplete"
+        assert adapter._response_store.get_conversation(conversation) is None
+
+    @pytest.mark.asyncio
+    async def test_tool_choice_none_refuses_missing_final_response(self, adapter):
+        conversation = f"malformed-strict-{uuid.uuid4().hex}"
+        malformed_result = {
+            "messages": [],
+            "completed": True,
+            "failed": False,
+            "partial": False,
+            "interrupted": False,
+            "_hermes_capabilities": {
+                "tool_choice": "none",
+                "resolved_tools": [],
+            },
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    malformed_result,
+                    {"input_tokens": 1, "output_tokens": 0, "total_tokens": 1},
+                )
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "Explain the supplied focus.",
+                        "tool_choice": "none",
+                        "conversation": conversation,
+                        "store": True,
+                    },
+                )
+                payload = await resp.json()
+
+        assert resp.status == 502
+        assert payload["error"]["code"] == "strict_none_run_incomplete"
+        assert adapter._response_store.get_conversation(conversation) is None
+
+    @pytest.mark.asyncio
+    async def test_idempotency_fingerprint_includes_tool_choice(self, adapter):
+        key = f"tool-choice-{uuid.uuid4().hex}"
+        usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        strict_result = {
+            "final_response": "strict",
+            "messages": [],
+            "completed": True,
+            "failed": False,
+            "partial": False,
+            "interrupted": False,
+            "_hermes_capabilities": {
+                "tool_choice": "none",
+                "resolved_tools": [],
+            },
+        }
+        default_result = {"final_response": "default", "messages": []}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.side_effect = [
+                    (strict_result, usage),
+                    (default_result, usage),
+                ]
+                first = await cli.post(
+                    "/v1/responses",
+                    headers={"Idempotency-Key": key},
+                    json={"input": "same", "tool_choice": "none"},
+                )
+                second = await cli.post(
+                    "/v1/responses",
+                    headers={"Idempotency-Key": key},
+                    json={"input": "same"},
+                )
+
+                assert first.status == 200
+                assert second.status == 200
+                assert mock_run.call_count == 2
+                assert "capabilities" not in await second.json()
+
+    @pytest.mark.asyncio
     async def test_successful_response_with_array_input(self, adapter):
         """Array input with role/content objects."""
         mock_result = {"final_response": "Done", "messages": [], "api_calls": 1}
@@ -2320,6 +2674,25 @@ class TestResponsesEndpoint:
 
 
 class TestResponsesStreaming:
+    @pytest.mark.asyncio
+    async def test_streaming_strict_none_fails_closed_before_agent_run(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Do not expose tools.",
+                        "stream": True,
+                        "tool_choice": "none",
+                    },
+                )
+                assert resp.status == 400
+                data = await resp.json()
+                assert data["error"]["code"] == "unsupported_tool_choice"
+                mock_run.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_stream_true_returns_responses_sse(self, adapter):
         app = _create_app(adapter)
@@ -3518,6 +3891,23 @@ class TestCORS:
 
 class TestConversationParameter:
     @pytest.mark.asyncio
+    async def test_named_stored_conversation_refuses_memory_fallback(self, adapter):
+        adapter._response_store = ResponseStore(db_path=":memory:")
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post("/v1/responses", json={
+                    "input": "hi",
+                    "conversation": "my-chat",
+                    "store": True,
+                })
+                payload = await resp.json()
+
+        assert resp.status == 503
+        assert payload["error"]["code"] == "durable_conversation_store_required"
+        mock_run.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_conversation_creates_new(self, adapter):
         """First request with a conversation name works (new conversation)."""
         app = _create_app(adapter)
@@ -3574,6 +3964,47 @@ class TestConversationParameter:
                           second_call_kwargs[1].get("conversation_history", []) if len(second_call_kwargs) > 1 else [])
                 # History should be non-empty (contains messages from first response)
                 assert len(history) > 0
+
+    @pytest.mark.asyncio
+    async def test_concurrent_same_conversation_has_one_atomic_winner(self, adapter):
+        """Concurrent turns from one head must not silently fork the conversation."""
+        app = _create_app(adapter)
+        both_started = asyncio.Event()
+        release = asyncio.Event()
+        histories = []
+
+        async def run_agent(**kwargs):
+            histories.append(list(kwargs["conversation_history"]))
+            if len(histories) == 2:
+                both_started.set()
+            await release.wait()
+            return (
+                {"final_response": "Concurrent response", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", side_effect=run_agent):
+                first = asyncio.create_task(cli.post(
+                    "/v1/responses",
+                    json={"input": "first", "conversation": "one-head"},
+                ))
+                second = asyncio.create_task(cli.post(
+                    "/v1/responses",
+                    json={"input": "second", "conversation": "one-head"},
+                ))
+                await asyncio.wait_for(both_started.wait(), timeout=1)
+                release.set()
+                responses = await asyncio.gather(first, second)
+                statuses = sorted(response.status for response in responses)
+                payloads = [await response.json() for response in responses]
+
+        assert statuses == [200, 409]
+        winner = next(payload for payload in payloads if payload.get("status") == "completed")
+        loser = next(payload for payload in payloads if "error" in payload)
+        assert loser["error"]["code"] == "conversation_conflict"
+        assert adapter._response_store.get_conversation("one-head") == winner["id"]
+        assert histories == [[], []]
 
     @pytest.mark.asyncio
     async def test_conversation_and_previous_response_id_conflict(self, adapter):


### PR DESCRIPTION
## Summary

Adds a strict tool-free mode to the OpenAI-compatible Responses API and makes named stored conversations durable, conflict-safe, and truthful about completion.

Key behavior:
- `tool_choice: "none"` resolves an empty tool surface before agent construction and verifies no tools survived.
- successful strict-none turns carry an exact capability receipt.
- failed, partial, interrupted, blank, malformed, or tool-bearing results return a typed error before response construction or storage.
- named conversations use SQLite compare-and-set so concurrent turns produce one winner and one typed conflict.
- memory-store fallback is disclosed and refused for named stored conversations.
- `/v1/capabilities` advertises strict-none support and durable conversation CAS.

## Why

A server-side client needs to send private, bounded context to a named Hermes agent while proving that the specific turn had no action capability and that conversation history cannot silently fork across workers.

Prompt instructions such as “advisory only” are not a capability boundary. This patch makes the boundary mechanical and receipts it per turn.

## Test plan

- `tests/gateway/test_api_server.py`: 221 passed on current `origin/main`; one unrelated upstream baseline failure remains in `TestHealthDetailedEndpoint::test_health_detailed_returns_ok`.
- The same health test fails identically on a pristine detached `origin/main` worktree (`degraded` vs expected `ok`).
- strict-none hostile result-shape probes reject incomplete, empty, malformed, and tool-bearing outputs.
- separate SQLite connections prove conversation compare-and-set and loser non-storage.
- disposable real HTTP boundary from the downstream Hub client passed against this current-upstream branch.
- `git diff --check`: clean.

## Scope

This changes only `gateway/platforms/api_server.py` and its API-server tests. It does not configure or restart any resident gateway, add tools, alter provider credentials, or activate a downstream production route.

## Review focus

Please scrutinize `_is_complete_agent_result`, `_resolve_agent_toolsets`, `ResponseStore.put_conversation_if_current`, `/v1/capabilities`, the named-conversation fail-closed path, and strict-none receipt minting in `_run_agent`.
