### PR TITLE
fix(mcp): reconnect immediately on transport TaskGroup drop instead o…

### DIFF
--- a/tests/tools/test_mcp_transport_group_reconnect.py
+++ b/tests/tools/test_mcp_transport_group_reconnect.py
@@ -1,0 +1,129 @@
+"""Regression tests for issue #66092.
+
+Streamable-HTTP / SSE MCP transports run their stream pump inside an anyio
+TaskGroup. A transient stream drop (idle timeout, brief backend blip) surfaces
+as a ``BaseExceptionGroup`` escaping the transport context manager. Before the
+fix that group reached ``run()``'s error path, which applied exponential
+backoff and eventually parked the server for 300s and deregistered its tools —
+a multi-minute tool outage for a sub-second glitch.
+
+``_run_http`` now converts such a transport TaskGroup failure into a clean
+``"reconnect"`` (immediate rebuild, no backoff/park), while still propagating
+real shutdown/cancellation and genuine connect/handshake failures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tools.mcp_tool import MCPServerTask
+
+
+def _group(*excs) -> BaseExceptionGroup:
+    return BaseExceptionGroup("transport drop", list(excs))
+
+
+# ── Unit coverage for the decision helper ────────────────────────────────────
+
+class TestReconnectOrReraiseGroup:
+    def test_live_session_transient_drop_reconnects(self):
+        task = MCPServerTask("t")
+        task._ready.set()  # a live session was established this attempt
+        assert task._reconnect_or_reraise_group(
+            _group(ConnectionError("sse stream dropped"))
+        ) == "reconnect"
+
+    def test_shutdown_in_progress_reraises(self):
+        task = MCPServerTask("t")
+        task._ready.set()
+        task._shutdown_event.set()
+        with pytest.raises(BaseExceptionGroup):
+            task._reconnect_or_reraise_group(_group(ConnectionError("x")))
+
+    def test_group_carrying_cancellation_reraises(self):
+        task = MCPServerTask("t")
+        task._ready.set()
+        with pytest.raises(BaseException) as ei:
+            task._reconnect_or_reraise_group(_group(asyncio.CancelledError()))
+        # The cancellation must not be masked as a reconnect.
+        assert ei.value.split(asyncio.CancelledError)[0] is not None
+
+    def test_no_live_session_reraises_for_backoff(self):
+        task = MCPServerTask("t")
+        # _ready NOT set: a connect/handshake failure, not a transient drop —
+        # let run()'s backoff handle it instead of hot-looping.
+        with pytest.raises(BaseExceptionGroup):
+            task._reconnect_or_reraise_group(_group(ConnectionError("handshake")))
+
+
+# ── Integration coverage: real _run_http new-HTTP branch ─────────────────────
+
+class _RaisingTransportCM:
+    """Fake streamable-HTTP transport whose __aexit__ raises a group, mimicking
+    the SDK's anyio TaskGroup tearing down on a stream drop."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    async def __aenter__(self):
+        return (object(), object(), lambda: "session-id")
+
+    async def __aexit__(self, *exc_info):
+        raise self._exc
+
+
+class _FakeSession:
+    async def initialize(self):
+        return object()
+
+
+class _FakeSessionCM:
+    async def __aenter__(self):
+        return _FakeSession()
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+def _make_http_task(monkeypatch, transport_exc):
+    task = MCPServerTask("http-drop")
+
+    monkeypatch.setattr("tools.mcp_tool._MCP_HTTP_AVAILABLE", True, raising=False)
+    monkeypatch.setattr("tools.mcp_tool._MCP_NEW_HTTP", True, raising=False)
+    monkeypatch.setattr(
+        "tools.mcp_tool.streamable_http_client",
+        lambda url, http_client=None: _RaisingTransportCM(transport_exc),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "tools.mcp_tool.ClientSession",
+        lambda *a, **k: _FakeSessionCM(),
+        raising=False,
+    )
+
+    async def _no_discover(self):
+        return None
+
+    async def _reconnect_lifecycle(self):
+        return "reconnect"
+
+    monkeypatch.setattr(MCPServerTask, "_discover_tools", _no_discover)
+    monkeypatch.setattr(MCPServerTask, "_wait_for_lifecycle_event", _reconnect_lifecycle)
+    return task
+
+
+def test_run_http_transport_group_returns_reconnect(monkeypatch):
+    task = _make_http_task(monkeypatch, _group(ConnectionError("stream dropped")))
+    reason = asyncio.run(task._run_http({"url": "http://127.0.0.1:9/mcp"}))
+    assert reason == "reconnect"
+    # We had a live session; readiness stays set for run() to clear on re-entry.
+    assert task._ready.is_set()
+
+
+def test_run_http_transport_group_reraises_on_shutdown(monkeypatch):
+    task = _make_http_task(monkeypatch, _group(ConnectionError("stream dropped")))
+    task._shutdown_event.set()
+    with pytest.raises(BaseExceptionGroup):
+        asyncio.run(task._run_http({"url": "http://127.0.0.1:9/mcp"}))

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2495,6 +2495,44 @@ class MCPServerTask:
             "(e.g. https://host/mcp, not https://host/)."
         )
 
+    def _reconnect_or_reraise_group(self, eg: BaseExceptionGroup) -> str:
+        """Map an SDK transport TaskGroup failure to a clean ``"reconnect"``.
+
+        Streamable-HTTP / SSE transports run their stream pump inside an anyio
+        TaskGroup. A transient stream drop (idle timeout, brief backend blip,
+        server-side TCP close) surfaces as a ``BaseExceptionGroup`` escaping the
+        transport context manager. Left unwrapped it reaches ``run()``'s error
+        path, which applies exponential backoff and eventually *parks* the
+        server for 300s and deregisters its tools — a multi-minute tool outage
+        for what is usually a sub-second glitch while the POST path stays
+        healthy (issue #66092).
+
+        Returning ``"reconnect"`` instead lets ``run()`` rebuild the session
+        immediately with no backoff, no park, and no tool deregistration.
+
+        Re-raise (rather than mask) when the failure is not a transient drop:
+        - shutdown is in progress (``shutdown()`` sets ``_shutdown_event``
+          before it ever cancels the task);
+        - the group carries a real ``CancelledError`` (task cancellation must
+          propagate to asyncio, mirroring the ``run()`` guard for #9930);
+        - we never reached a live session this attempt (``_ready`` unset) — a
+          connect/handshake failure SHOULD fall through to ``run()``'s backoff
+          rather than hot-loop reconnects against a broken endpoint.
+        """
+        if self._shutdown_event.is_set():
+            raise eg
+        cancelled, _rest = eg.split(asyncio.CancelledError)
+        if cancelled is not None:
+            raise eg
+        if not self._ready.is_set():
+            raise eg
+        logger.debug(
+            "MCP server '%s': transport TaskGroup exited after a live session "
+            "(%r) — reconnecting immediately instead of backing off",
+            self.name, eg,
+        )
+        return "reconnect"
+
     async def _run_http(self, config: dict):
         """Run the server using HTTP/StreamableHTTP transport."""
         if not _MCP_HTTP_AVAILABLE:
@@ -2601,31 +2639,36 @@ class MCPServerTask:
                     return _httpx_mod.AsyncClient(**kwargs)
 
                 _sse_kwargs["httpx_client_factory"] = _mcp_http_client_factory
-            async with sse_client(**_sse_kwargs) as (read_stream, write_stream):
-                async with ClientSession(
-                    read_stream, write_stream, **sampling_kwargs
-                ) as session:
-                    # Bound the handshake — same orphaned-task hang as the
-                    # stdio path (#59349): an endpoint that accepts the
-                    # connection but never answers ``initialize`` parks this
-                    # coroutine forever on the background loop.
-                    self.initialize_result = await asyncio.wait_for(
-                        session.initialize(), timeout=float(connect_timeout)
-                    )
-                    self.session = session
-                    await self._discover_tools()
-                    self._ready.set()
-                    # Session is live again: clear any breaker state from a
-                    # prior outage so the first call after recovery isn't
-                    # gated on a stale consecutive-failure count (#16788).
-                    _reset_server_error(self.name)
-                    self._reconnect_retries = 0
-                    reason = await self._wait_for_lifecycle_event()
-                    if reason == "reconnect":
-                        logger.info(
-                            "MCP server '%s': reconnect requested — "
-                            "tearing down SSE session", self.name,
+            try:
+                async with sse_client(**_sse_kwargs) as (read_stream, write_stream):
+                    async with ClientSession(
+                        read_stream, write_stream, **sampling_kwargs
+                    ) as session:
+                        # Bound the handshake — same orphaned-task hang as the
+                        # stdio path (#59349): an endpoint that accepts the
+                        # connection but never answers ``initialize`` parks this
+                        # coroutine forever on the background loop.
+                        self.initialize_result = await asyncio.wait_for(
+                            session.initialize(), timeout=float(connect_timeout)
                         )
+                        self.session = session
+                        await self._discover_tools()
+                        self._ready.set()
+                        # Session is live again: clear any breaker state from a
+                        # prior outage so the first call after recovery isn't
+                        # gated on a stale consecutive-failure count (#16788).
+                        _reset_server_error(self.name)
+                        self._reconnect_retries = 0
+                        reason = await self._wait_for_lifecycle_event()
+                        if reason == "reconnect":
+                            logger.info(
+                                "MCP server '%s': reconnect requested — "
+                                "tearing down SSE session", self.name,
+                            )
+            except BaseExceptionGroup as _eg:
+                # SSE transport TaskGroup dropped (idle timeout / stream blip):
+                # reconnect immediately instead of backoff/park (#66092).
+                reason = self._reconnect_or_reraise_group(_eg)
             return reason
 
         if _MCP_NEW_HTTP:
@@ -2660,29 +2703,34 @@ class MCPServerTask:
 
             # Caller owns the client lifecycle — the SDK skips cleanup when
             # http_client is provided, so we wrap in async-with.
-            async with httpx.AsyncClient(**client_kwargs) as http_client:
-                async with streamable_http_client(url, http_client=http_client) as (
-                    read_stream, write_stream, _get_session_id,
-                ):
-                    async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
-                        # Bound the handshake (#59349) — see stdio path.
-                        self.initialize_result = await asyncio.wait_for(
-                            session.initialize(), timeout=float(connect_timeout)
-                        )
-                        self.session = session
-                        await self._discover_tools()
-                        self._ready.set()
-                        # Session is live again: clear any breaker state from
-                        # a prior outage so the first call after recovery
-                        # isn't gated on a stale failure count (#16788).
-                        _reset_server_error(self.name)
-                        self._reconnect_retries = 0
-                        reason = await self._wait_for_lifecycle_event()
-                        if reason == "reconnect":
-                            logger.info(
-                                "MCP server '%s': reconnect requested — "
-                                "tearing down HTTP session", self.name,
+            try:
+                async with httpx.AsyncClient(**client_kwargs) as http_client:
+                    async with streamable_http_client(url, http_client=http_client) as (
+                        read_stream, write_stream, _get_session_id,
+                    ):
+                        async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                            # Bound the handshake (#59349) — see stdio path.
+                            self.initialize_result = await asyncio.wait_for(
+                                session.initialize(), timeout=float(connect_timeout)
                             )
+                            self.session = session
+                            await self._discover_tools()
+                            self._ready.set()
+                            # Session is live again: clear any breaker state from
+                            # a prior outage so the first call after recovery
+                            # isn't gated on a stale failure count (#16788).
+                            _reset_server_error(self.name)
+                            self._reconnect_retries = 0
+                            reason = await self._wait_for_lifecycle_event()
+                            if reason == "reconnect":
+                                logger.info(
+                                    "MCP server '%s': reconnect requested — "
+                                    "tearing down HTTP session", self.name,
+                                )
+            except BaseExceptionGroup as _eg:
+                # Streamable-HTTP transport TaskGroup dropped: reconnect
+                # immediately instead of backoff/park (#66092).
+                reason = self._reconnect_or_reraise_group(_eg)
             return reason
         else:
             # Deprecated API (mcp < 1.24.0): manages httpx client internally.
@@ -2693,28 +2741,33 @@ class MCPServerTask:
             }
             if _oauth_auth is not None:
                 _http_kwargs["auth"] = _oauth_auth
-            async with streamablehttp_client(url, **_http_kwargs) as (
-                read_stream, write_stream, _get_session_id,
-            ):
-                async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
-                    # Bound the handshake (#59349) — see stdio path.
-                    self.initialize_result = await asyncio.wait_for(
-                        session.initialize(), timeout=float(connect_timeout)
-                    )
-                    self.session = session
-                    await self._discover_tools()
-                    self._ready.set()
-                    # Session is live again: clear any breaker state from a
-                    # prior outage so the first call after recovery isn't
-                    # gated on a stale consecutive-failure count (#16788).
-                    _reset_server_error(self.name)
-                    self._reconnect_retries = 0
-                    reason = await self._wait_for_lifecycle_event()
-                    if reason == "reconnect":
-                        logger.info(
-                            "MCP server '%s': reconnect requested — "
-                            "tearing down legacy HTTP session", self.name,
+            try:
+                async with streamablehttp_client(url, **_http_kwargs) as (
+                    read_stream, write_stream, _get_session_id,
+                ):
+                    async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                        # Bound the handshake (#59349) — see stdio path.
+                        self.initialize_result = await asyncio.wait_for(
+                            session.initialize(), timeout=float(connect_timeout)
                         )
+                        self.session = session
+                        await self._discover_tools()
+                        self._ready.set()
+                        # Session is live again: clear any breaker state from a
+                        # prior outage so the first call after recovery isn't
+                        # gated on a stale consecutive-failure count (#16788).
+                        _reset_server_error(self.name)
+                        self._reconnect_retries = 0
+                        reason = await self._wait_for_lifecycle_event()
+                        if reason == "reconnect":
+                            logger.info(
+                                "MCP server '%s': reconnect requested — "
+                                "tearing down legacy HTTP session", self.name,
+                            )
+            except BaseExceptionGroup as _eg:
+                # Legacy Streamable-HTTP transport TaskGroup dropped: reconnect
+                # immediately instead of backoff/park (#66092).
+                reason = self._reconnect_or_reraise_group(_eg)
             return reason
 
     async def _discover_tools(self):


### PR DESCRIPTION
## What does this PR do?

Streamable-HTTP / SSE MCP transports run their stream pump inside an anyio `TaskGroup`. A transient stream drop (idle timeout, brief backend blip, server-side TCP close) surfaces as a `BaseExceptionGroup` escaping the transport context manager in `_run_http`, reaches `run()`'s error path, and triggers exponential backoff → a 300s park + tool deregistration. A sub-second glitch becomes a multi-minute tool outage even though the POST path is healthy.

`_run_http` now routes a transport `BaseExceptionGroup` through a new `_reconnect_or_reraise_group()` helper that returns `"reconnect"` (immediate rebuild, no backoff/park/deregister), while re-raising real shutdown/cancellation and genuine connect/handshake failures.

## Related Issue

Fixes #66092

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: add `MCPServerTask._reconnect_or_reraise_group()`; map transport TaskGroup failures to a clean `"reconnect"`, re-raising when (a) `_shutdown_event` is set, (b) the group carries a `CancelledError`, or (c) no live session was established this attempt (`_ready` unset → let `run()`'s backoff handle a connect/handshake failure).
- `tools/mcp_tool.py`: wrap all three `_run_http` transport branches (SSE, new + deprecated Streamable-HTTP) with `except BaseExceptionGroup` routed through the helper.
- `tests/tools/test_mcp_transport_group_reconnect.py`: new unit + integration coverage.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_mcp_transport_group_reconnect.py -q` — 6 passed.
2. `scripts/run_tests.sh tests/tools/test_mcp_cancelled_error_propagation.py tests/tools/test_mcp_reconnect_signal.py tests/tools/test_mcp_reconnect_retry_reset.py tests/tools/test_mcp_stability.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_sse_transport.py tests/tools/test_mcp_parked_self_probe.py tests/tools/test_mcp_transport_group_reconnect.py` — 255 passed, 0 failed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite (`scripts/run_tests.sh`, the repo's sanctioned wrapper) and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure asyncio/exception-group logic, no platform-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A