### PR TITLE
fix: cap cache-scope headers at 64 chars to avoid Codex 400 error (#66045)

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -338,6 +338,14 @@ class ResponsesApiTransport(ProviderTransport):
             # headers while keeping ``prompt_cache_key`` in the body for
             # standard OpenAI routing as a belt-and-braces fallback.
             cache_scope_id = str(session_id or "").strip()
+            # OpenAI/Codex backend enforces 64-char limit on the session_id
+            # and x-client-request-id headers, mapping them internally to
+            # prompt_cache_key. Hash long IDs to stay within the limit;
+            # the hash is a cache-routing hint only, never a correctness bound.
+            if len(cache_scope_id) > 64:
+                cache_scope_id = "pck_" + hashlib.sha256(
+                    cache_scope_id.encode("utf-8", "replace")
+                ).hexdigest()[:24]
             if cache_scope_id:
                 existing_extra_headers = kwargs.get("extra_headers")
                 merged_extra_headers: Dict[str, str] = {}


### PR DESCRIPTION
## Root cause

@gracejudy identificou que o `prompt_cache_key` no body já era curto (28 chars). O erro 400 vinha dos **HTTP headers** `session_id` e `x-client-request-id`, que recebiam o session_id bruto (97 chars). O backend Codex mapeia esses headers para `prompt_cache_key` internamente.

## Fix

Guarda de 64 chars em `cache_scope_id` no `build_kwargs()`. Quando >64 chars, faz hash SHA256 truncado (`pck_` + 24 hex). Seguro porque é cache-routing hint, não correctness bound.

Closes #66045
Co-authored-by: gracejudy