### PR TITLE
fix(agent): detect aliased model names in _is_claude_model (#66244)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -115,7 +115,19 @@ _NO_XHIGH_CLAUDE_SUBSTRINGS = (
 
 
 def _is_claude_model(model: str | None) -> bool:
-    return "claude" in (model or "").lower()
+    if not model:
+        return False
+    m = model.lower()
+    if "claude" in m:
+        return True
+    # Ambiguous/aliased model names (e.g. "auto", "latest") routed through an
+    # Anthropic-Messages proxy — default to Claude unless the name matches a
+    # known non-Claude Anthropic-compatible model prefix.
+    if m.startswith("minimax") or m.startswith("qwen") or m.startswith("glm"):
+        return False
+    if "kimi" in m or "moonshot" in m:
+        return False
+    return True
 
 
 _FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1615,6 +1615,23 @@ class TestBuildAnthropicKwargs:
             assert _supports_xhigh_effort(m) is False, m
             assert _forbids_sampling_params(m) is False, m
 
+    def test_aliased_model_names_default_to_adaptive(self):
+        """Aliased/ambiguous model names (e.g. "auto") routed through an
+        Anthropic-Messages proxy must default to the modern adaptive contract.
+        Otherwise legacy thinking format is sent and adaptive-only model groups
+        reject it with HTTP 400 (non-retryable in delegate_task)."""
+        from agent.anthropic_adapter import (
+            _is_claude_model,
+            _supports_adaptive_thinking,
+            _supports_xhigh_effort,
+            _forbids_sampling_params,
+        )
+        for m in ("auto", "latest", "best"):
+            assert _is_claude_model(m) is True, m
+            assert _supports_adaptive_thinking(m) is True, m
+            assert _supports_xhigh_effort(m) is True, m
+            assert _forbids_sampling_params(m) is True, m
+
     def test_fast_mode_omitted_for_unsupported_model(self):
         """fast_mode=True on Opus 4.7 must NOT inject speed=fast (API 400s)."""
         kwargs = build_anthropic_kwargs(


### PR DESCRIPTION
## Problem

`_is_claude_model()` uses pure substring matching for `"claude"`, so aliased model names like `"auto"` (routed through a `custom:anthropic` proxy) are always classified as non-Claude. This causes `_supports_adaptive_thinking` to return `False`, so legacy thinking format `{"type": "enabled", "budget_tokens": ...}` is sent instead of the adaptive format. Adaptive-only model groups reject the legacy format with HTTP 400 — which is non-retryable in `delegate_task` subagents.

## Fix

When the model name doesn't contain `"claude"", check against known non-Claude Anthropic-Messages model prefixes (`minimax`, `qwen`, `glm`, `kimi`/`moonshot`). Everything else is assumed Claude-capable, matching the existing "default unknown to modern" contract documented in `_supports_adaptive_thinking`.

## Testing

- All 29 existing tests pass (28 existing + 1 new)
- New test `test_aliased_model_names_default_to_adaptive` verifies that aliases like `"auto"`, `"latest"`, `"best"` are classified as Claude models with adaptive thinking, xhigh effort support, and sampling-param forbidding
- Existing `test_non_claude_anthropic_models_use_manual_path` still passes — known non-Claude models remain on the manual path