### PR TITLE
fix: guard against multimodal content list in reasoning extraction and surrogate sanitization (#66267)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1091,6 +1091,11 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # directly in the content rather than returning separate API fields).
     if not reasoning_text:
         content = assistant_message.content or ""
+        if isinstance(content, list):
+            content = " ".join(
+                part.get("text", "") for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            )
         think_blocks = re.findall(r'<think>(.*?)</think>', content, flags=re.DOTALL)
         if think_blocks:
             combined = "\n\n".join(b.strip() for b in think_blocks if b.strip())
@@ -1117,6 +1122,11 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
     # can return invalid surrogate code points that crash json.dumps() on persist.
     _raw_content = assistant_message.content or ""
+    if isinstance(_raw_content, list):
+        _raw_content = " ".join(
+            part.get("text", "") for part in _raw_content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
     _san_content = _sanitize_surrogates(_raw_content)
     if reasoning_text:
         reasoning_text = _sanitize_surrogates(reasoning_text)


### PR DESCRIPTION
**Bug:** After an image/vision turn, `assistant_message.content` can be a list of multimodal parts. Two locations in `chat_completion_helpers.py` assumed it was always a string:

1. **Line 1093-1094** — Reasoning extraction: `re.findall(..., content)` crashes when content is a list
2. **Line 1119** — Surrogate sanitization: `_sanitize_surrogates(_raw_content)` crashes when content is a list

**Fix:** Added `isinstance(content, list)` guard in both locations, extracting text parts and joining them with spaces.

Closes #66267