### PR TITLE
feat: advertise delegation toolset isolation in GET /v1/capabilities (#66268)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1121,6 +1121,27 @@ class APIServerAdapter(BasePlatformAdapter):
         return max(0, value)
 
     @staticmethod
+    def _delegation_mcp_isolation() -> bool:
+        """Whether delegation children are isolated from the parent's MCP toolsets.
+
+        Returns ``True`` when ``delegation.inherit_mcp_toolsets`` is ``False``,
+        meaning narrowed children do NOT inherit the parent's MCP toolsets.
+        Advertised as ``features.delegation_mcp_isolation`` in
+        ``GET /v1/capabilities`` so orchestrators can probe the actual
+        enforcement level at runtime.
+
+        ``delegation`` is imported lazily inside the function because
+        ``tools/delegate_tool.py`` has module-level imports that may not be
+        resolvable at class-definition time (e.g. when the gateway starts
+        without the full agent module tree).
+        """
+        try:
+            from tools.delegate_tool import _get_inherit_mcp_toolsets
+            return not _get_inherit_mcp_toolsets()
+        except Exception:
+            return False
+
+    @staticmethod
     def _resolve_model_name(explicit: str) -> str:
         """Derive the advertised model name for /v1/models.
 
@@ -1997,6 +2018,41 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
+                "safe_delegation_isolation": True,
+                "delegation_mcp_isolation": self._delegation_mcp_isolation(),
+            },
+            "delegation": {
+                "description": (
+                    "When the parent agent spawns a child subagent via \"delegate_task\", "
+                    "the child receives an isolated context with a restricted toolset. "
+                    "Blocked tools and toolsets are always stripped from child sessions "
+                    "to prevent recursive delegation, user interaction, and side effects."
+                ),
+                "blocked_tools": [
+                    "delegate_task",
+                    "clarify",
+                    "memory",
+                    "send_message",
+                    "execute_code",
+                    "cronjob",
+                ],
+                "blocked_toolsets": [
+                    "delegation",
+                    "code_execution",
+                ],
+                "toolset_inheritance": (
+                    "Children inherit the parent's configured toolsets minus the blocked "
+                    "tools and toolsets above. This means the parent's `web`, `terminal`, "
+                    "`file`, `browser`, `vision`, and similar toolsets pass through "
+                    "to the child automatically. MCP toolsets are preserved by default "
+                    "(configurable via delegation.inherit_mcp_toolsets)."
+                ),
+                "orchestrator_role": (
+                    "When a child is spawned with role='orchestrator', the \"delegation\" "
+                    "toolset is re-added (subject to max_spawn_depth), enabling nested "
+                    "subagent spawning. The default role='leaf' strips the delegation "
+                    "toolset, preventing recursive delegation."
+                ),
             },
             "endpoints": {
                 "health": {"method": "GET", "path": "/health"},

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -990,6 +990,21 @@ class TestCapabilitiesEndpoint:
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
+            assert "delegation" in data
+            delegation = data["delegation"]
+            assert "description" in delegation
+            assert "blocked_tools" in delegation
+            assert isinstance(delegation["blocked_tools"], list)
+            assert "delegate_task" in delegation["blocked_tools"]
+            assert "clarify" in delegation["blocked_tools"]
+            assert "execute_code" in delegation["blocked_tools"]
+            assert "cronjob" in delegation["blocked_tools"]
+            assert "blocked_toolsets" in delegation
+            assert isinstance(delegation["blocked_toolsets"], list)
+            assert "delegation" in delegation["blocked_toolsets"]
+            assert "code_execution" in delegation["blocked_toolsets"]
+            assert "toolset_inheritance" in delegation
+            assert "orchestrator_role" in delegation
 
     @pytest.mark.asyncio
     async def test_capabilities_requires_auth_when_key_configured(self, auth_adapter):


### PR DESCRIPTION
## O que foi feito

Adicionado à resposta de `GET /v1/capabilities` informações sobre o isolamento de toolset de delegação:

- **`features.safe_delegation_isolation`** — sempre true (strip de tools bloqueados é incondicional)
- **`features.delegation_mcp_isolation`** — reflete a config `delegation.inherit_mcp_toolsets`
- **`delegation`** — bloco com documentação completa:
  - `blocked_tools`: lista dos 6 tools sempre removidos de filhos
  - `blocked_toolsets`: os 2 toolsets compostos removidos

Isso permite que orquestradores externos descubram programaticamente como a delegação isola agents filhos.

Closes #66268