### PR TITLE
feat(delegation): operator-configured child toolset narrowing + capability advertisement

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1120,6 +1120,11 @@ delegation:
                                               # The parent TUI owns stdin, so blocking would deadlock; non-interactive resolution is required.
                                               # Both choices emit a logger.warning audit line. Flip to true only for cron/batch pipelines.
   # inherit_mcp_toolsets: true                # When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: true). Set false for strict intersection.
+  # child_toolsets: ["file", "web"]           # Server-enforced narrowing for ALL delegated children: intersected with the
+                                              # parent's toolsets, blocked tools always stripped, MCP toolsets kept unless
+                                              # inherit_mcp_toolsets is false. Unset/empty = children inherit the parent's
+                                              # full toolsets (historical behavior). Live state is advertised in
+                                              # GET /v1/capabilities features as safe_delegation_isolation / delegation_mcp_isolation.
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1954,6 +1954,20 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
+        # Delegation isolation is config-dependent, so it is computed live —
+        # the flags must track what delegate_task would actually enforce right
+        # now, never a stale snapshot. Failure to import/read config reads as
+        # "no isolation" so a broken environment can never over-claim safety.
+        try:
+            from tools.delegate_tool import delegation_isolation_state
+
+            isolation = delegation_isolation_state()
+        except Exception:
+            isolation = {
+                "safe_delegation_isolation": False,
+                "delegation_mcp_isolation": False,
+            }
+
         return web.json_response({
             "object": "hermes.api_server.capabilities",
             "platform": "hermes-agent",
@@ -1984,6 +1998,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_approval_response": True,
                 "tool_progress_events": True,
                 "approval_events": True,
+                "safe_delegation_isolation": isolation["safe_delegation_isolation"],
+                "delegation_mcp_isolation": isolation["delegation_mcp_isolation"],
                 "session_resources": True,
                 "session_chat": True,
                 "session_chat_streaming": True,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2283,6 +2283,14 @@ DEFAULT_CONFIG = {
                            # "codex_responses", or "anthropic_messages". Empty = auto-detect
                            # from URL (e.g. /anthropic suffix → anthropic_messages). Set this
                            # explicitly for non-standard endpoints the heuristic can't detect.
+        # Operator-configured server-side toolset narrowing for ALL delegated
+        # children: intersected with the parent's toolsets, blocked tools always
+        # stripped, MCP toolsets kept unless inherit_mcp_toolsets is false. Empty
+        # (default) = children inherit the parent's full toolsets (historical
+        # behavior). Advertised live in GET /v1/capabilities as
+        # safe_delegation_isolation / delegation_mcp_isolation. Operator-only —
+        # the model has no toolsets argument.
+        "child_toolsets": [],
         # When delegate_task narrows child toolsets explicitly, preserve any
         # MCP toolsets the parent already has enabled. On by default so
         # narrowing (e.g. toolsets=["web","browser"]) expresses "I want these

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -986,10 +986,32 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            # Isolation flags default to False: no delegation.child_toolsets
+            # configured means children inherit the parent's full toolsets,
+            # and the advertisement must not over-claim safety.
+            assert data["features"]["safe_delegation_isolation"] is False
+            assert data["features"]["delegation_mcp_isolation"] is False
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
+
+    @pytest.mark.asyncio
+    async def test_capabilities_advertises_live_delegation_isolation(self, adapter):
+        """The flags must track live delegation config: narrowing configured
+        (child_toolsets) flips safe_delegation_isolation, and disabling MCP
+        inheritance additionally flips delegation_mcp_isolation."""
+        from unittest.mock import patch
+
+        app = _create_app(adapter)
+        cfg = {"child_toolsets": ["file"], "inherit_mcp_toolsets": False}
+        with patch("tools.delegate_tool._load_config", return_value=cfg):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/capabilities")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["features"]["safe_delegation_isolation"] is True
+                assert data["features"]["delegation_mcp_isolation"] is True
 
     @pytest.mark.asyncio
     async def test_capabilities_requires_auth_when_key_configured(self, auth_adapter):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -3243,6 +3243,39 @@ class TestDelegationIsolationState(unittest.TestCase):
                 },
             )
 
+    def test_explicit_mcp_selection_does_not_claim_mcp_isolation(self):
+        """An MCP toolset named directly in child_toolsets survives the
+        intersection in _build_child_agent, so the child keeps it even with
+        inherit_mcp_toolsets: false. delegation_mcp_isolation must stay False
+        rather than over-claim — for both the mcp- prefix and registered
+        aliases that resolve to an mcp- toolset. safe_delegation_isolation stays
+        True: narrowing is still in effect."""
+        # (1) canonical mcp- prefix
+        cfg = {"child_toolsets": ["file", "mcp-github"], "inherit_mcp_toolsets": False}
+        with patch("tools.delegate_tool._load_config", return_value=cfg):
+            self.assertEqual(
+                delegation_isolation_state(),
+                {
+                    "safe_delegation_isolation": True,
+                    "delegation_mcp_isolation": False,
+                },
+            )
+        # (2) alias resolving to an mcp- toolset
+        cfg = {"child_toolsets": ["file", "gh"], "inherit_mcp_toolsets": False}
+        with patch(
+            "tools.delegate_tool._load_config", return_value=cfg
+        ), patch(
+            "tools.registry.registry.get_toolset_alias_target",
+            side_effect=lambda n: "mcp-github" if n == "gh" else None,
+        ):
+            self.assertEqual(
+                delegation_isolation_state(),
+                {
+                    "safe_delegation_isolation": True,
+                    "delegation_mcp_isolation": False,
+                },
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -35,6 +35,8 @@ from tools.delegate_tool import (
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
     _inherit_parent_base_url,
+    _get_child_toolsets,
+    delegation_isolation_state,
 )
 
 
@@ -3153,6 +3155,93 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
+
+
+class TestChildToolsetsConfig(unittest.TestCase):
+    """delegation.child_toolsets — operator-configured server-side narrowing."""
+
+    def test_unset_config_means_no_narrowing(self):
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            self.assertIsNone(_get_child_toolsets())
+
+    def test_configured_list_is_cleaned(self):
+        cfg = {"child_toolsets": ["file", " web ", "", 42]}
+        with patch("tools.delegate_tool._load_config", return_value=cfg):
+            self.assertEqual(_get_child_toolsets(), ["file", "web", "42"])
+
+    def test_non_list_and_empty_values_mean_no_narrowing(self):
+        for raw in ("file", {"a": 1}, [], ["  ", ""], None, True):
+            with patch(
+                "tools.delegate_tool._load_config",
+                return_value={"child_toolsets": raw},
+            ):
+                self.assertIsNone(_get_child_toolsets(), raw)
+
+    def test_configured_toolsets_reach_child_narrowing(self):
+        """The config value must flow into _build_child_agent's intersection
+        path: a child of a parent with file+web+terminal, narrowed to ["file"],
+        must not keep web or terminal."""
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["file", "web", "terminal"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            with patch(
+                "tools.delegate_tool._load_config",
+                return_value={"child_toolsets": ["file"]},
+            ):
+                _build_child_agent(
+                    task_index=0,
+                    goal="Narrowed child",
+                    context=None,
+                    toolsets=_get_child_toolsets(),
+                    model=None,
+                    max_iterations=10,
+                    parent_agent=parent,
+                    task_count=1,
+                )
+
+        _, kwargs = MockAgent.call_args
+        child_toolsets = kwargs["enabled_toolsets"]
+        self.assertIn("file", child_toolsets)
+        self.assertNotIn("web", child_toolsets)
+        self.assertNotIn("terminal", child_toolsets)
+
+
+class TestDelegationIsolationState(unittest.TestCase):
+    """Capability advertisement must track live config, never over-claim."""
+
+    def test_no_narrowing_means_no_isolation_claims(self):
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            self.assertEqual(
+                delegation_isolation_state(),
+                {
+                    "safe_delegation_isolation": False,
+                    "delegation_mcp_isolation": False,
+                },
+            )
+
+    def test_narrowing_with_default_mcp_inheritance(self):
+        cfg = {"child_toolsets": ["file"]}
+        with patch("tools.delegate_tool._load_config", return_value=cfg):
+            self.assertEqual(
+                delegation_isolation_state(),
+                {
+                    "safe_delegation_isolation": True,
+                    "delegation_mcp_isolation": False,
+                },
+            )
+
+    def test_narrowing_with_strict_mcp_intersection(self):
+        cfg = {"child_toolsets": ["file"], "inherit_mcp_toolsets": False}
+        with patch("tools.delegate_tool._load_config", return_value=cfg):
+            self.assertEqual(
+                delegation_isolation_state(),
+                {
+                    "safe_delegation_isolation": True,
+                    "delegation_mcp_isolation": True,
+                },
+            )
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -526,6 +526,44 @@ def _get_inherit_mcp_toolsets() -> bool:
     return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=True)
 
 
+def _get_child_toolsets() -> Optional[List[str]]:
+    """Operator-configured toolsets for delegated children (delegation.child_toolsets).
+
+    Returns a cleaned list of toolset names, or None when unset/empty — None
+    preserves the historical behavior (children inherit the parent's toolsets).
+    A configured list re-enters the narrowing path in _build_child_agent:
+    intersection with the parent's expanded toolsets, optional MCP-toolset
+    preservation (inherit_mcp_toolsets), and the unconditional blocked-tool
+    strip. The model still has no toolsets argument — this is operator config,
+    not a model-facing choice.
+    """
+    cfg = _load_config()
+    raw = cfg.get("child_toolsets")
+    if not isinstance(raw, list):
+        return None
+    cleaned = [str(t).strip() for t in raw if str(t).strip()]
+    return cleaned or None
+
+
+def delegation_isolation_state() -> Dict[str, bool]:
+    """Live delegation-isolation facts, advertised via GET /v1/capabilities.
+
+    safe_delegation_isolation — server-side child-toolset narrowing is active
+    (delegation.child_toolsets configured): children run with a restricted,
+    server-enforced toolset instead of inheriting everything the parent holds.
+    delegation_mcp_isolation — additionally, narrowed children do not keep the
+    parent's MCP toolsets (delegation.inherit_mcp_toolsets: false).
+
+    Orchestrators use these to decide whether permitting delegate_task is safe
+    for untrusted-content workloads; keep them truthful to live config.
+    """
+    narrowed = bool(_get_child_toolsets())
+    return {
+        "safe_delegation_isolation": narrowed,
+        "delegation_mcp_isolation": narrowed and not _get_inherit_mcp_toolsets(),
+    }
+
+
 def _is_mcp_toolset_name(name: str) -> bool:
     """Return True for canonical MCP toolsets and their registered aliases."""
     if not name:
@@ -2528,9 +2566,11 @@ def delegate_task(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
-                # Subagents always inherit the parent's toolsets; the model
-                # cannot choose or narrow them (no model-facing toolsets arg).
-                toolsets=None,
+                # The model cannot choose or narrow toolsets (no model-facing
+                # toolsets arg). The OPERATOR can: delegation.child_toolsets
+                # narrows every child server-side; unset, children inherit the
+                # parent's toolsets as before.
+                toolsets=_get_child_toolsets(),
                 model=creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
@@ -2905,9 +2945,9 @@ def delegate_task(
         dispatch = dispatch_async_delegation_batch(
             goals=_goals,
             context=context,
-            # Metadata for the completion block only; subagents inherit the
-            # parent's toolsets (no model-facing toolsets arg).
-            toolsets=None,
+            # Metadata for the completion block only; mirrors the operator's
+            # delegation.child_toolsets narrowing (None = parent inheritance).
+            toolsets=_get_child_toolsets(),
             role=top_role,
             model=creds["model"],
             session_key=_session_key,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -551,16 +551,25 @@ def delegation_isolation_state() -> Dict[str, bool]:
     safe_delegation_isolation — server-side child-toolset narrowing is active
     (delegation.child_toolsets configured): children run with a restricted,
     server-enforced toolset instead of inheriting everything the parent holds.
-    delegation_mcp_isolation — additionally, narrowed children do not keep the
-    parent's MCP toolsets (delegation.inherit_mcp_toolsets: false).
+    delegation_mcp_isolation — additionally, narrowed children hold no MCP
+    toolset: automatic MCP inheritance is off (delegation.inherit_mcp_toolsets:
+    false) AND the operator's own child_toolsets list names no MCP toolset. An
+    explicitly selected MCP toolset (mcp- prefix or a registered alias) survives
+    the intersection in _build_child_agent, so the child would still hold it —
+    the flag stays false there rather than over-claim isolation.
 
     Orchestrators use these to decide whether permitting delegate_task is safe
     for untrusted-content workloads; keep them truthful to live config.
     """
-    narrowed = bool(_get_child_toolsets())
+    child = _get_child_toolsets()
+    narrowed = bool(child)
     return {
         "safe_delegation_isolation": narrowed,
-        "delegation_mcp_isolation": narrowed and not _get_inherit_mcp_toolsets(),
+        "delegation_mcp_isolation": (
+            narrowed
+            and not _get_inherit_mcp_toolsets()
+            and not any(_is_mcp_toolset_name(t) for t in (child or []))
+        ),
     }
 
 


### PR DESCRIPTION
## What does this PR do?

Makes `delegate_task`'s child isolation real and discoverable again. The server-side narrowing machinery (parent-toolset intersection, unconditional blocked-tool strip, `inherit_mcp_toolsets`) still exists in `tools/delegate_tool.py` but became unreachable when the model-facing `toolsets` argument was removed — both `_build_child_agent` call sites pass `toolsets=None`, so children always inherit the parent's full toolsets. And `GET /v1/capabilities` says nothing either way, so an orchestrator cannot distinguish an isolating gateway from a fully-inheriting one and must ban delegation outright for untrusted-content workloads.

Two halves, both non-breaking:

1. **`delegation.child_toolsets`** (new config key, default unset = exactly today's behavior): operator-chosen toolsets applied to ALL delegated children, fed through the existing narrowing path (intersection with the parent's expanded toolsets → optional MCP-toolset preservation per `inherit_mcp_toolsets` → blocked-tool strip). The model still has no toolsets argument — this is operator config, not a model-facing choice.
2. **Honest advertisement**: `GET /v1/capabilities` `features` now include `safe_delegation_isolation` (narrowing active) and `delegation_mcp_isolation` (narrowing active AND `inherit_mcp_toolsets: false`). Computed live per request; any import/config failure reads as `false`, so a broken environment can never over-claim safety.

## Related Issue

Fixes #66268

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/delegate_tool.py` — new `_get_child_toolsets()` + `delegation_isolation_state()`; both `_build_child_agent`/batch-metadata call sites pass the configured narrowing instead of hardcoded `None`.
- `gateway/platforms/api_server.py` — `_handle_capabilities` computes the two feature flags live, fail-closed.
- `cli-config.yaml.example` — documents `delegation.child_toolsets`.
- `tests/tools/test_delegate.py` — config parsing, fail-closed cases, end-to-end narrowing through `_build_child_agent` (child of a `file+web+terminal` parent narrowed to `["file"]` loses `web`/`terminal`), isolation-state truth table.
- `tests/gateway/test_api_server.py` — default flags are `false`; configured narrowing + strict MCP intersection flips both to `true`.

## Testing

`scripts/run_tests.sh tests/tools/test_delegate.py tests/gateway/test_api_server.py` — 366 tests, 0 failed.

Happy to rename the flags or reshape the config key if you'd prefer a different contract — the goal is only that the enforcement that already exists in the codebase becomes reachable and honestly discoverable.