### PR TITLE
fix: extend gpt-5.6 fallback chain, serve apple-touch-icon in headless mode, and add password-only auth tests

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -52,12 +52,12 @@ DEFAULT_CODEX_MODELS: List[str] = [
 ]
 
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
-    ("gpt-5.6-sol", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-sol-pro", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-terra", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-terra-pro", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-luna", ("gpt-5.5", "gpt-5.4")),
-    ("gpt-5.6-luna-pro", ("gpt-5.5", "gpt-5.4")),
+    ("gpt-5.6-sol", ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
+    ("gpt-5.6-sol-pro", ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
+    ("gpt-5.6-terra", ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
+    ("gpt-5.6-terra-pro", ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
+    ("gpt-5.6-luna", ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
+    ("gpt-5.6-luna-pro", ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
     ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
     ("gpt-5.4-mini", ("gpt-5.3-codex",)),
     ("gpt-5.4", ("gpt-5.3-codex",)),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15971,6 +15971,10 @@ def mount_spa(application: FastAPI):
 
         @application.get("/{full_path:path}")
         async def no_frontend(full_path: str):
+            if full_path == "apple-touch-icon.png":
+                icon_path = WEB_DIST / "apple-touch-icon.png"
+                if icon_path.is_file():
+                    return FileResponse(icon_path, media_type="image/png")
             return JSONResponse({"error": _msg}, status_code=404)
         return
 

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -351,6 +351,25 @@ class TestPasswordLoginRoute:
         )
         assert resp.status_code == 200
 
+    def test_html_navigation_with_only_password_provider_renders_login_form(self, gated_app):
+        # Regression: auto-SSO is only valid for OAuth providers.  A single
+        # password-only provider must not redirect to /auth/login?provider=...
+        # because password providers intentionally have no OAuth start_login
+        # implementation; the browser needs the /login form instead.
+        resp = gated_app.get("/", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login?next=%2F"
+
+    def test_direct_oauth_login_url_for_password_provider_redirects_to_form(self, gated_app):
+        # Defence-in-depth for stale clients/cached redirects: even if the
+        # password provider is requested through the OAuth entrypoint, do not
+        # call start_login() (which raises by design).
+        resp = gated_app.get(
+            "/auth/login?provider=testpw&next=%2F", follow_redirects=False
+        )
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/login?next=%2F"
+
 
 # ---------------------------------------------------------------------------
 # Transparent refresh — expired access token, live refresh token


### PR DESCRIPTION
## Summary

Three fixes bundled in this branch:

### 1. Extended gpt-5.6 fallback chain (`hermes_cli/codex_models.py`)

The forward-compat fallback templates for `gpt-5.6-*` models previously only cascaded to `gpt-5.5` → `gpt-5.4`. Added `gpt-5.4-mini` and `gpt-5.3-codex` to the chain so that when a 5.6 variant is unavailable, the agent can fall back through the full lower tier instead of dead-ending at `gpt-5.4`.

### 2. Serve `apple-touch-icon.png` in headless mode (`hermes_cli/web_server.py``

When the dashboard runs in headless mode (no built frontend), iOS Safari requests `/apple-touch-icon.png` and was getting a 404 JSON response. Added a special case in the headless SPA catch-all to serve the icon file if it exists in `web_dist/`.

### 3. Password-only auth regression tests (`tests/hermes_cli/test_dashboard_auth_password_login.py`)

Two new tests guarding against a regression where a single password-only auth provider could redirect to the OAuth `start_login` path (which has no implementation for password providers by design):
- `test_html_navigation_with_only_password_provider_renders_login_form` — root `/` must redirect to `/login?next=%2F`, not to an OAuth provider URL
- `test_direct_oauth_login_url_for_password_provider_redirects_to_form` — defence-in-depth: even a stale/cached `/auth/login?provider=...` URL must redirect to the login form, not call `start_login()`

## Test plan

- [x] `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_password_login.py` passes
- [ ] Full CI suite green