### PR TITLE
fix(codex): close app-server display gaps — approval-drain events, webSearch bubbles, bare hermes-tools names

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -287,9 +287,22 @@ def _record_codex_app_server_compaction(
 # therefore deserve a tool_progress bubble pair). The projector lives in
 # agent/transports/codex_event_projector.py — keep these in sync so the
 # tool name shown in the UI matches the name recorded in messages.
+# webSearch is codex's built-in web search tool — it has no projector
+# entry (codex handles it internally) but still deserves a bubble.
 _CODEX_TOOL_ITEM_TYPES = frozenset(
-    {"commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall"}
+    {"commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall", "webSearch"}
 )
+
+# Internal MCP server that wraps Hermes' native tools for codex. When
+# codex calls back through it, the inner dispatch runs in a SEPARATE
+# hermes-tools-mcp-server subprocess that has no access to the parent
+# agent's tool_progress_callback — so the inner call can never surface
+# its own native progress event. The codex-level mcpToolCall event IS
+# the display event for those calls; we strip the mcp.hermes-tools.*
+# namespacing and emit the bare tool name (web_search, browser_navigate,
+# vision_analyze, ...) since the user thinks of these as Hermes tools,
+# not as MCP calls.
+_INTERNAL_MCP_SERVER = "hermes-tools"
 
 
 def _codex_item_to_tool_name(item: dict) -> str:
@@ -304,9 +317,13 @@ def _codex_item_to_tool_name(item: dict) -> str:
     if item_type == "mcpToolCall":
         server = item.get("server") or "mcp"
         tool = item.get("tool") or "unknown"
+        if server == _INTERNAL_MCP_SERVER:
+            return tool
         return f"mcp.{server}.{tool}"
     if item_type == "dynamicToolCall":
         return item.get("tool") or "dynamic"
+    if item_type == "webSearch":
+        return "web_search"
     return item_type or "unknown"
 
 
@@ -327,6 +344,8 @@ def _codex_item_to_args(item: dict) -> dict:
     if item_type in {"mcpToolCall", "dynamicToolCall"}:
         args = item.get("arguments") or {}
         return args if isinstance(args, dict) else {"arguments": args}
+    if item_type == "webSearch":
+        return {"query": item.get("query") or ""}
     return {}
 
 
@@ -354,6 +373,9 @@ def _codex_item_to_preview(item: dict) -> Any:
             return json.dumps(args, ensure_ascii=False)[:120]
         except (TypeError, ValueError):
             return None
+    if item_type == "webSearch":
+        query = item.get("query") or ""
+        return query[:120] if query else None
     return None
 
 

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -505,6 +505,20 @@ class CodexAppServerSession:
                     pending = self._client.take_notification(timeout=0)
                     if pending is None:
                         break
+                    # Mirror the main notification-handling block below so
+                    # display events surface and stay in step with projector
+                    # state. Without this, item/started / item/completed
+                    # events drained as part of the approval-roundtrip
+                    # preamble are projected into messages but never reach
+                    # the tool-progress display, silently hiding tool
+                    # bubbles around approvals.
+                    if self._on_event is not None:
+                        try:
+                            self._on_event(pending)
+                        except Exception:  # pragma: no cover - display callback
+                            logger.debug(
+                                "on_event callback raised", exc_info=True
+                            )
                     _apply_token_usage_notification(result, pending)
                     _apply_compaction_notification(result, pending)
                     self._track_pending_file_change(pending)

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -79,6 +79,22 @@ class TestCodexItemToToolName:
             {"type": "dynamicToolCall", "tool": "web_search"}
         ) == "web_search"
 
+    def test_hermes_tools_mcp_server_emits_bare_tool_name(self):
+        """The hermes-tools MCP server wraps Hermes' own tools for codex;
+        the inner dispatch subprocess can't fire native progress events,
+        so the codex-level event IS the display event — shown without the
+        mcp.hermes-tools.* namespacing (from #26541 by @simpolism)."""
+        assert _codex_item_to_tool_name(
+            {"type": "mcpToolCall", "server": "hermes-tools", "tool": "web_search"}
+        ) == "web_search"
+        assert _codex_item_to_tool_name(
+            {"type": "mcpToolCall", "server": "hermes-tools", "tool": "browser_navigate"}
+        ) == "browser_navigate"
+
+    def test_web_search_builtin_maps_to_web_search(self):
+        """Codex's built-in webSearch tool gets a bubble too (#26541)."""
+        assert _codex_item_to_tool_name({"type": "webSearch"}) == "web_search"
+
     def test_unknown_type_returns_type_string(self):
         assert _codex_item_to_tool_name(
             {"type": "plan"}
@@ -367,6 +383,27 @@ class TestToolProgressDispatch:
         completed = agent.tool_progress_callback.call_args_list[1]
         assert completed.kwargs["is_error"] is False
         assert "results" in completed.kwargs["result"]
+
+    def test_web_search_builtin_fires_started_and_completed(self):
+        """Codex's built-in webSearch produces a start/complete bubble pair
+        with the query as preview and args (#26541)."""
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_started({
+            "type": "webSearch",
+            "id": "ws-1",
+            "query": "hermes agent docs",
+        }))
+        bridge(_item_completed({
+            "type": "webSearch",
+            "id": "ws-1",
+            "query": "hermes agent docs",
+        }))
+        calls = agent.tool_progress_callback.call_args_list
+        assert [c.args[0] for c in calls] == ["tool.started", "tool.completed"]
+        assert calls[0].args[1] == "web_search"
+        assert calls[0].args[2] == "hermes agent docs"
+        assert calls[0].args[3] == {"query": "hermes agent docs"}
 
     def test_duration_falls_back_to_wall_time_when_codex_missing_ms(self):
         agent = _make_stub_agent()

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -640,6 +640,64 @@ class TestServerRequestRouting:
             for (rid, code, _msg) in client.error_responses
         )
 
+    def test_on_event_fires_during_approval_drain(self):
+        """When a server-initiated approval request arrives, the session
+        drains up to 8 pending notifications first so per-turn state
+        (e.g. _pending_file_changes for fileChange approvals) is current.
+        Those drained notifications must also reach the on_event display
+        hook — otherwise tool bubbles around approvals silently disappear.
+
+        Regression for the issue where item/started events that landed
+        in the queue alongside (or just before) an approval request got
+        projected into messages but never displayed.
+        """
+        client = FakeClient()
+        # An item/started notification is queued first, then a server
+        # request — the session sees both during a single drain loop.
+        client.queue_notification(
+            "item/started",
+            item={
+                "type": "commandExecution",
+                "id": "exec-1",
+                "command": "echo drained",
+                "cwd": "/tmp",
+            },
+        )
+        client.queue_server_request(
+            "item/commandExecution/requestApproval", request_id="req-d",
+            command="echo drained",
+            cwd="/tmp",
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+
+        events: list[dict] = []
+
+        def cb(command, description, *, allow_permanent=True):
+            return "once"
+
+        s = make_session(
+            client,
+            approval_callback=cb,
+            on_event=events.append,
+        )
+        s.run_turn("hi", turn_timeout=1.0)
+
+        # The on_event hook must have seen the item/started even though
+        # it was drained as part of the approval roundtrip — not just
+        # events that arrive on the main notification path.
+        item_started_events = [
+            e for e in events
+            if e.get("method") == "item/started"
+        ]
+        assert item_started_events, (
+            "item/started drained alongside the approval was not "
+            "forwarded to on_event — display will miss tool bubbles "
+            "around approvals"
+        )
+
     def test_mcp_elicitation_for_hermes_tools_auto_accepts(self):
         """When codex elicits on behalf of hermes-tools (our own callback),
         accept automatically — the user already opted in by enabling the


### PR DESCRIPTION
## Summary

Closes the three display gaps left after the app-server bridge merge (#66142) — all three independently identified by contributors in the same PR family, with the drain-loop bug confirmed by three separate submissions (#26541, #64698, #65412).

## Changes

- `agent/transports/codex_app_server_session.py`: the approval-drain loop in `run_turn` now forwards drained notifications to `on_event` — previously up to 8 events consumed just before an approval prompt (including the `item/started` for the command awaiting approval) were projected into messages but never displayed. Cherry-grafted from #26541 with @simpolism's authorship on the commit.
- `agent/codex_runtime.py`: `webSearch` added to `_CODEX_TOOL_ITEM_TYPES` — codex's built-in web search now produces a `tool.started`/`tool.completed` bubble pair (query as preview + args); previously it showed nothing.
- `agent/codex_runtime.py`: `mcp.hermes-tools.*` names stripped to bare tool names (`web_search`, not `mcp.hermes-tools.web_search`) — the hermes-tools MCP server is Hermes' own tool callback running in a subprocess that can't fire native progress events, so the codex-level event is the display event and should carry the name users know.
- Tests: drain-loop regression test (verified RED without the fix, GREEN with), webSearch dispatch pair, bare-name rule, both mapper variants.

## Validation

| | Result |
|---|---|
| Bridge + session + integration suites | 140/140 passed |
| Drain-loop regression test with fix stashed | FAILED (RED) — pins the fix |
| ruff | clean |
| E2E (real bridge, synthetic notifications) | webSearch pair fires with query preview; hermes-tools → bare name; user MCP still namespaced |

## Credit

All three behaviors were designed and first implemented by @simpolism in #26541 (May 15 — the earliest submission of the entire app-server display-bridge family, predating #33294). The drain-loop bug was independently found by @filaebot (#64698) and @HaiderSultanArc (#65412). @simpolism's drain-loop commit is preserved with their authorship.

## Infographic

![Bridge gap closure infographic](https://v3b.fal.media/files/b/0aa29c19/8X1MFBMAEWKwFlLDSGiiT_xpOQSrlj.png)
