### PR TITLE
fix(desktop): stop telling installer users they installed Hermes from the command line

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -150,6 +150,7 @@ import {
 } from './ssh-connection'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
+import { classifyWindowsManualUpdate } from './update-install-kind'
 import { readLiveUpdateMarker, writeUpdateMarker } from './update-marker'
 import { runRebuildWithRetry } from './update-rebuild'
 import {
@@ -2633,16 +2634,30 @@ async function applyUpdates(opts = {}) {
     }
 
     if (!updater) {
-      // No staged updater binary — this is a CLI-installed user (they ran
+      // No staged updater binary — usually a CLI-installed user (they ran
       // `hermes desktop`, never the Tauri installer that self-copies
-      // hermes-setup.exe into HERMES_HOME). They DO have a working `hermes`
-      // on PATH / in the venv, so the correct path is the one-liner in their
-      // native medium. We show the EXACT command, branch-pinned to the
-      // checkout they're on — bare `hermes update` defaults to main and would
-      // silently switch a bb/gui (or any non-main) install off-branch. Mirror
-      // the GUI button's contract: append --branch <current> for non-main
-      // checkouts, keep it bare for main so the card stays clean.
+      // hermes-setup.exe into HERMES_HOME). But installer-deployed desktops
+      // land here too (#66095): the NSIS/MSI shell's first-launch bootstrap
+      // never stages hermes-setup.exe, and the Tauri installer's self-copy is
+      // best-effort. classifyWindowsManualUpdate tells the two apart so the
+      // dialog doesn't falsely claim "you installed from the command line".
+      // Either way the user DOES have a working `hermes` on PATH / in the
+      // venv (install.ps1's hermes-command stage), so the correct path is the
+      // one-liner in their native medium. We show the EXACT command,
+      // branch-pinned to the checkout they're on — bare `hermes update`
+      // defaults to main and would silently switch a bb/gui (or any non-main)
+      // install off-branch. Mirror the GUI button's contract: append
+      // --branch <current> for non-main checkouts, keep it bare for main so
+      // the card stays clean.
       const updateRoot = resolveUpdateRoot()
+
+      const installKind = classifyWindowsManualUpdate({
+        execPath: process.execPath,
+        updateRoot,
+        isPackaged: IS_PACKAGED,
+        hasInstallerLog: fileExists(path.join(HERMES_HOME, 'logs', 'bootstrap-installer.log'))
+      })
+
       let command = 'hermes update'
 
       try {
@@ -2660,10 +2675,10 @@ async function applyUpdates(opts = {}) {
         // Best-effort: fall back to bare `hermes update` if branch detection fails.
       }
 
-      rememberLog(`[updates] no staged updater; surfacing manual \`${command}\` for CLI install at ${updateRoot}`)
-      emitUpdateProgress({ stage: 'manual', message: command, percent: null })
+      rememberLog(`[updates] no staged updater; surfacing manual \`${command}\` for ${installKind} install at ${updateRoot}`)
+      emitUpdateProgress({ stage: 'manual', message: command, percent: null, installKind })
 
-      return { ok: true, manual: true, command, hermesRoot: updateRoot }
+      return { ok: true, manual: true, command, hermesRoot: updateRoot, installKind }
     }
 
     emitUpdateProgress({

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2675,7 +2675,9 @@ async function applyUpdates(opts = {}) {
         // Best-effort: fall back to bare `hermes update` if branch detection fails.
       }
 
-      rememberLog(`[updates] no staged updater; surfacing manual \`${command}\` for ${installKind} install at ${updateRoot}`)
+      rememberLog(
+        `[updates] no staged updater; surfacing manual \`${command}\` for ${installKind} install at ${updateRoot}`
+      )
       emitUpdateProgress({ stage: 'manual', message: command, percent: null, installKind })
 
       return { ok: true, manual: true, command, hermesRoot: updateRoot, installKind }

--- a/apps/desktop/electron/update-install-kind.test.ts
+++ b/apps/desktop/electron/update-install-kind.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { classifyWindowsManualUpdate } from './update-install-kind'
+
+const REPO_ROOT = 'C:\\Users\\u\\AppData\\Local\\hermes\\hermes-agent'
+const REPO_EXE = `${REPO_ROOT}\\apps\\desktop\\release\\win-unpacked\\Hermes.exe`
+const NSIS_EXE = 'C:\\Users\\u\\AppData\\Local\\Programs\\Hermes\\Hermes.exe'
+
+test('packaged exe outside the managed checkout is an installer deployment (#66095)', () => {
+  assert.equal(
+    classifyWindowsManualUpdate({
+      execPath: NSIS_EXE,
+      updateRoot: REPO_ROOT,
+      isPackaged: true,
+      hasInstallerLog: false
+    }),
+    'installer'
+  )
+})
+
+test('packaged exe inside the managed checkout is a CLI install', () => {
+  assert.equal(
+    classifyWindowsManualUpdate({
+      execPath: REPO_EXE,
+      updateRoot: REPO_ROOT,
+      isPackaged: true,
+      hasInstallerLog: false
+    }),
+    'cli'
+  )
+})
+
+test('Hermes-Setup breadcrumb wins even when the exe lives inside the checkout', () => {
+  // The Tauri installer points shortcuts at the repo-tree packed exe, so when
+  // its best-effort self-copy failed the exe location alone looks like a CLI
+  // install. The installer log it always writes is the tiebreaker.
+  assert.equal(
+    classifyWindowsManualUpdate({
+      execPath: REPO_EXE,
+      updateRoot: REPO_ROOT,
+      isPackaged: true,
+      hasInstallerLog: true
+    }),
+    'installer'
+  )
+})
+
+test('path containment is case-insensitive and separator-agnostic on Windows', () => {
+  assert.equal(
+    classifyWindowsManualUpdate({
+      execPath: 'c:/users/U/appdata/local/HERMES/hermes-agent/apps/desktop/release/win-unpacked/Hermes.exe',
+      updateRoot: REPO_ROOT,
+      isPackaged: true,
+      hasInstallerLog: false
+    }),
+    'cli'
+  )
+})
+
+test('a sibling directory sharing the checkout prefix is NOT inside it', () => {
+  // "...\hermes-agent-nightly" starts with the "...\hermes-agent" string but is
+  // a different directory; a naive startsWith would misclassify it as CLI.
+  assert.equal(
+    classifyWindowsManualUpdate({
+      execPath: `${REPO_ROOT}-nightly\\Hermes.exe`,
+      updateRoot: REPO_ROOT,
+      isPackaged: true,
+      hasInstallerLog: false
+    }),
+    'installer'
+  )
+})
+
+test('unpackaged (dev) runs stay on the CLI message', () => {
+  // `npm run dev` launches node_modules electron.exe, which is outside any
+  // checkout; without the isPackaged gate every dev run would misclassify.
+  assert.equal(
+    classifyWindowsManualUpdate({
+      execPath: 'C:\\src\\hermes-agent\\node_modules\\electron\\dist\\electron.exe',
+      updateRoot: 'C:\\src\\hermes-agent',
+      isPackaged: false,
+      hasInstallerLog: false
+    }),
+    'cli'
+  )
+})
+
+test('missing exec path or update root degrades to the CLI message', () => {
+  assert.equal(
+    classifyWindowsManualUpdate({ execPath: '', updateRoot: REPO_ROOT, isPackaged: true, hasInstallerLog: false }),
+    'cli'
+  )
+  assert.equal(
+    classifyWindowsManualUpdate({ execPath: NSIS_EXE, updateRoot: '', isPackaged: true, hasInstallerLog: false }),
+    'cli'
+  )
+})

--- a/apps/desktop/electron/update-install-kind.ts
+++ b/apps/desktop/electron/update-install-kind.ts
@@ -1,0 +1,61 @@
+// Classify WHY the Windows staged updater (HERMES_HOME/hermes-setup.exe) is
+// missing when the user hits "Update", so the manual-fallback dialog doesn't
+// tell installer users "You installed Hermes from the command line" (#66095).
+//
+// Two installer-deployed layouts can reach the manual fallback:
+//   - The electron-builder NSIS/MSI desktop installer puts Hermes.exe OUTSIDE
+//     the managed checkout (e.g. %LOCALAPPDATA%\Programs\Hermes) and its
+//     first-launch bootstrap never stages hermes-setup.exe — that binary is
+//     only staged by the Tauri Hermes-Setup installer.
+//   - The Tauri Hermes-Setup installer normally stages hermes-setup.exe, but
+//     the copy is best-effort (paths::copy_self_to_hermes_home); when it
+//     failed, the only remaining breadcrumb is the log it writes to
+//     HERMES_HOME/logs/bootstrap-installer.log.
+// A genuine CLI install (`hermes desktop`) launches the packed exe from
+// <checkout>/apps/desktop/release/*-unpacked/, i.e. INSIDE the update root.
+//
+// Only the Windows manual fallback consults this (POSIX takes the in-app
+// update path), so path containment deliberately uses win32 semantics:
+// case-insensitive, both separators. Pure so it unit-tests without Electron.
+
+import path from 'node:path'
+
+export type DesktopInstallKind = 'installer' | 'cli'
+
+function isInsideWindowsPath(parent: string, child: string): boolean {
+  const rel = path.win32.relative(parent.toLowerCase(), child.toLowerCase())
+
+  return rel !== '' && !rel.startsWith('..') && !path.win32.isAbsolute(rel)
+}
+
+/**
+ * Decide which manual-update message the Windows fallback should show.
+ *
+ * @param execPath        process.execPath of the running desktop app
+ * @param updateRoot      resolveUpdateRoot() — the managed hermes-agent checkout
+ * @param isPackaged      IS_PACKAGED; dev runs launch node_modules' electron.exe
+ *                        (outside any checkout) and must not misclassify
+ * @param hasInstallerLog whether HERMES_HOME/logs/bootstrap-installer.log exists
+ *                        (only the Tauri Hermes-Setup installer writes it)
+ */
+export function classifyWindowsManualUpdate({
+  execPath,
+  updateRoot,
+  isPackaged,
+  hasInstallerLog
+}: {
+  execPath: string
+  updateRoot: string
+  isPackaged: boolean
+  hasInstallerLog: boolean
+}): DesktopInstallKind {
+  if (hasInstallerLog) {
+    return 'installer'
+  }
+
+  if (isPackaged && execPath && updateRoot && !isInsideWindowsPath(updateRoot, execPath)) {
+    return 'installer'
+  }
+
+  return 'cli'
+}

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -14,7 +14,7 @@ import {
 import { ErrorIcon, ErrorState } from '@/components/ui/error-state'
 import { Loader } from '@/components/ui/loader'
 import { Progress } from '@/components/ui/progress'
-import type { DesktopUpdateCommit, DesktopUpdateStage, DesktopUpdateStatus } from '@/global'
+import type { DesktopInstallKind, DesktopUpdateCommit, DesktopUpdateStage, DesktopUpdateStatus } from '@/global'
 import { useI18n } from '@/i18n'
 import { buildCommitChangelog, type CommitGroup } from '@/lib/commit-changelog'
 import { AlertCircle, Check, Copy, Terminal } from '@/lib/icons'
@@ -111,7 +111,12 @@ export function UpdatesOverlay() {
         {phase === 'applying' && <ApplyingView apply={apply} isBackend={isBackend} />}
 
         {phase === 'manual' && (
-          <ManualView command={apply.command ?? null} message={apply.message} onDone={() => handleClose(false)} />
+          <ManualView
+            command={apply.command ?? null}
+            installKind={apply.installKind}
+            message={apply.message}
+            onDone={() => handleClose(false)}
+          />
         )}
 
         {phase === 'guiSkew' && <GuiSkewView message={apply.message} onDone={() => handleClose(false)} />}
@@ -225,7 +230,7 @@ function IdleView({
   const remaining = Math.max(0, behind - shownItems)
 
   // Name what's being updated. In remote mode the overlay acts on the connected
-  // backend, not the local client — say so. When there are no commit rows to
+  // backend, not the local client ??say so. When there are no commit rows to
   // show (e.g. pip/non-git backend), degrade to honest "no release notes" copy
   // instead of generic filler.
   const { title, body } = resolveUpdateCopy({ target, shownItems, copy: u })
@@ -269,10 +274,24 @@ function IdleView({
   )
 }
 
-function ManualView({ command, message, onDone }: { command: string | null; message?: string; onDone: () => void }) {
+function ManualView({
+  command,
+  installKind,
+  message,
+  onDone
+}: {
+  command: string | null
+  installKind?: DesktopInstallKind | null
+  message?: string
+  onDone: () => void
+}) {
   const { t } = useI18n()
   const u = t.updates
   const [copied, setCopied] = useState(false)
+  // Installer-deployed desktops missing their staged updater helper must not
+  // be told "you installed from the command line" (#66095) ??the terminal
+  // command is the same recovery path, only the explanation differs.
+  const body = installKind === 'installer' ? u.manualBodyMissingUpdater : u.manualBody
 
   const handleCopy = () => {
     if (!command) {
@@ -310,7 +329,7 @@ function ManualView({ command, message, onDone }: { command: string | null; mess
         <Terminal className="size-8 text-primary" />
 
         <DialogTitle className="text-center text-xl">{u.manualTitle}</DialogTitle>
-        <DialogDescription className="text-center text-sm">{u.manualBody}</DialogDescription>
+        <DialogDescription className="text-center text-sm">{body}</DialogDescription>
       </div>
 
       <button
@@ -347,7 +366,7 @@ function ManualView({ command, message, onDone }: { command: string | null; mess
 
 // Linux GUI/backend skew (#45205): backend updated, but the running desktop app
 // package (AppImage/.deb/.rpm) was NOT changed. Closeable terminal state that
-// tells the user to update/reinstall the desktop app — never claims the GUI was
+// tells the user to update/reinstall the desktop app ??never claims the GUI was
 // updated.
 function GuiSkewView({ message, onDone }: { message?: string; onDone: () => void }) {
   const { t } = useI18n()

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -344,6 +344,10 @@ export interface DesktopUpdateApplyResult {
   manual?: boolean
   command?: string
   hermesRoot?: string
+  /** With `manual`: how this desktop was deployed. 'installer' means an
+   *  installer-deployed app whose staged updater is missing (#66095) — the
+   *  dialog must not claim the user installed from the command line. */
+  installKind?: DesktopInstallKind
   /** True when the backend was updated but the GUI couldn't be relaunched in
    *  place (AppImage / dev run): the new version loads on next launch. */
   backendUpdated?: boolean
@@ -384,12 +388,16 @@ export type DesktopUpdateStage =
   | 'guiSkew'
   | 'error'
 
+export type DesktopInstallKind = 'installer' | 'cli'
+
 export interface DesktopUpdateProgress {
   stage: DesktopUpdateStage
   message: string
   percent: number | null
   error: string | null
   at: number
+  /** With stage 'manual': see DesktopUpdateApplyResult.installKind. */
+  installKind?: DesktopInstallKind
 }
 
 export interface HermesConnection {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1999,6 +1999,8 @@ export const en: Translations = {
     moreChanges: count => `+ ${count} more change${count === 1 ? '' : 's'} included.`,
     manualTitle: 'Update from your terminal',
     manualBody: 'You installed Hermes from the command line, so updates run there too. Paste this into your terminal:',
+    manualBodyMissingUpdater:
+      'This Hermes install is missing its updater helper, so the app can’t update itself right now. Paste this into your terminal to update:',
     manualPickedUp: 'Hermes will pick up the new version next time you launch it.',
     guiSkewTitle: 'Update the desktop app',
     guiSkewBody:

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1934,6 +1934,8 @@ export const ja = defineLocale({
     manualTitle: 'ターミナルから更新',
     manualBody:
       'Hermes をコマンドラインからインストールしたため、更新もそこで実行されます。これをターミナルに貼り付けてください:',
+    manualBodyMissingUpdater:
+      'この Hermes インストールには更新ヘルパーが見つからないため、アプリは今のところ自動で更新できません。更新するには、これをターミナルに貼り付けてください:',
     manualPickedUp: 'Hermes は次回起動時に新しいバージョンを読み込みます。',
     guiSkewTitle: 'デスクトップアプリを更新してください',
     guiSkewBody:

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1649,6 +1649,10 @@ export interface Translations {
     moreChanges: (count: number) => string
     manualTitle: string
     manualBody: string
+    /** Manual-update body for installer-deployed desktops whose staged
+     *  updater helper is missing (#66095): same terminal command, but must
+     *  not claim the user installed from the command line. */
+    manualBodyMissingUpdater: string
     manualPickedUp: string
     /** GUI/backend skew (#45205): backend updated but the running desktop app
      *  package (AppImage/.deb/.rpm) was not changed and must be reinstalled. */

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1876,6 +1876,7 @@ export const zhHant = defineLocale({
     moreChanges: count => `另有 ${count} 項變更。`,
     manualTitle: '從終端機更新',
     manualBody: '您是從命令列安裝的 Hermes，因此更新也需要在那裡執行。請將此指令貼到終端機：',
+    manualBodyMissingUpdater: '此 Hermes 安裝缺少更新助手，應用程式暫時無法自行更新。請將此指令貼到終端機來完成更新：',
     manualPickedUp: '下次啟動 Hermes 時會使用新版本。',
     guiSkewTitle: '請更新桌面應用程式',
     guiSkewBody:

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2187,6 +2187,7 @@ export const zh: Translations = {
     moreChanges: count => `另有 ${count} 项更改。`,
     manualTitle: '从终端更新',
     manualBody: '你是从命令行安装的 Hermes，因此更新也需要在那里运行。请将此命令粘贴到终端：',
+    manualBodyMissingUpdater: '此 Hermes 安装缺少更新助手，应用暂时无法自行更新。请将此命令粘贴到终端来完成更新：',
     manualPickedUp: '下次启动 Hermes 时会使用新版本。',
     guiSkewTitle: '请更新桌面应用',
     guiSkewBody:

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { DesktopUpdateStatus } from '@/global'
+import type { DesktopUpdateProgress, DesktopUpdateStatus } from '@/global'
 
 const storage = new Map<string, string>()
 
@@ -547,5 +547,33 @@ describe('startUpdatePoller', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     expect(checkMock).toHaveBeenCalled()
+  })
+
+  it('carries installKind from a manual progress event into $updateApply (#66095)', () => {
+    // Main emits installKind on the progress channel before apply() resolves
+    // (preload → onProgress → ingestProgress). The apply()-result tests above
+    // do not cover this path; the overlay reads installKind from $updateApply
+    // either way, so both transports need to carry it.
+    resetUpdateApplyState()
+    startUpdatePoller()
+
+    const onProgress = onProgressMock.mock.calls[0]?.[0] as
+      | ((payload: DesktopUpdateProgress) => void)
+      | undefined
+    expect(onProgress).toEqual(expect.any(Function))
+
+    onProgress!({
+      stage: 'manual',
+      message: 'hermes update',
+      percent: null,
+      error: null,
+      at: 1,
+      installKind: 'installer'
+    })
+
+    expect($updateApply.get().stage).toBe('manual')
+    expect($updateApply.get().command).toBe('hermes update')
+    expect($updateApply.get().installKind).toBe('installer')
+    expect($updateApply.get().applying).toBe(false)
   })
 })

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -311,14 +311,35 @@ describe('applyUpdates terminal state', () => {
   })
 
   it('keeps the manual command state for CLI installs with no staged updater', async () => {
-    applyMock.mockResolvedValue({ ok: true, manual: true, command: 'hermes update' })
+    applyMock.mockResolvedValue({ ok: true, manual: true, command: 'hermes update', installKind: 'cli' })
 
     await applyUpdates()
 
     expect($updateApply.get().stage).toBe('manual')
     expect($updateApply.get().command).toBe('hermes update')
+    expect($updateApply.get().installKind).toBe('cli')
     expect($updateOverlayOpen.get()).toBe(true)
     expect(notifySpy).not.toHaveBeenCalled()
+  })
+
+  it('carries the installer kind so the manual dialog does not claim a CLI install (#66095)', async () => {
+    // Installer-deployed desktop (NSIS/MSI shell, or a Tauri install whose
+    // best-effort updater self-copy failed): same manual command, but the
+    // overlay must show the missing-updater explanation, not the CLI one.
+    applyMock.mockResolvedValue({ ok: true, manual: true, command: 'hermes update', installKind: 'installer' })
+
+    await applyUpdates()
+
+    expect($updateApply.get().stage).toBe('manual')
+    expect($updateApply.get().installKind).toBe('installer')
+  })
+
+  it('defaults installKind to null when an older main process omits it', async () => {
+    applyMock.mockResolvedValue({ ok: true, manual: true, command: 'hermes update' })
+
+    await applyUpdates()
+
+    expect($updateApply.get().installKind).toBeNull()
   })
 
   it('lands on the guiSkew terminal state for a GUI/backend skew (AppImage/.deb/.rpm), without claiming a GUI update', async () => {
@@ -380,6 +401,7 @@ describe('applyBackendUpdate recovery', () => {
       percent: null,
       error: null,
       command: null,
+      installKind: null,
       log: []
     })
     vi.useFakeTimers()

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -6,6 +6,7 @@
 import { atom } from 'nanostores'
 
 import type {
+  DesktopInstallKind,
   DesktopUpdateApplyOptions,
   DesktopUpdateApplyResult,
   DesktopUpdateProgress,
@@ -27,8 +28,12 @@ export interface UpdateApplyState {
   percent: number | null
   error: string | null
   /** When the stage is 'manual': the exact command the user should run
-   *  (CLI install with no staged updater). */
+   *  (no staged updater). */
   command: string | null
+  /** When the stage is 'manual': whether this desktop is a CLI install or an
+   *  installer deployment missing its updater helper (#66095). Drives which
+   *  explanation the manual dialog shows. */
+  installKind: DesktopInstallKind | null
   log: readonly { stage: DesktopUpdateStage; message: string; at: number }[]
 }
 
@@ -39,6 +44,7 @@ const IDLE: UpdateApplyState = {
   percent: null,
   error: null,
   command: null,
+  installKind: null,
   log: []
 }
 
@@ -385,7 +391,8 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
         applying: false,
         stage: 'manual',
         message: result.command ?? 'hermes update',
-        command: result.command ?? 'hermes update'
+        command: result.command ?? 'hermes update',
+        installKind: result.installKind ?? null
       })
 
       return result
@@ -634,6 +641,7 @@ function ingestProgress(payload: DesktopUpdateProgress): void {
     error: payload.error,
     // 'manual' carries the command to run in its message field.
     command: payload.stage === 'manual' ? payload.message : current.command,
+    installKind: payload.stage === 'manual' ? (payload.installKind ?? null) : current.installKind,
     log
   })
 }


### PR DESCRIPTION
## What does this PR do?

Windows users who installed Hermes with an official installer get a false dialog when they click Update: "You installed Hermes from the command line, so updates run there too." (#66095, reported with filesystem evidence.)

Root cause: the manual fallback in `applyUpdates()` (`apps/desktop/electron/main.ts`) treats a missing staged updater (`HERMES_HOME/hermes-setup.exe`) as proof of a CLI install. Two installer flows land in that branch:

- The electron-builder NSIS/MSI desktop installer puts `Hermes.exe` outside the managed checkout, and its first-launch bootstrap (`bootstrap-runner.ts` driving `install.ps1`) never stages `hermes-setup.exe`. Only the Tauri Hermes-Setup installer stages that binary (`paths::copy_self_to_hermes_home`). This matches the reporter's evidence exactly: repo cloned under `%LOCALAPPDATA%\hermes\hermes-agent`, no `hermes-setup.exe`, no `.install_method` in `HERMES_HOME`.
- The Tauri installer's self-copy is best-effort (`bootstrap.rs` logs a warning and continues on failure), so that flow can also end up without the staged updater.

This PR tells the two cases apart and shows an honest explanation. The recovery command (branch-pinned `hermes update`) stays the same because it works for installer users too: `install.ps1`'s `Set-PathVariable` persists the venv `Scripts` dir to the user PATH.

Detection lives in a new pure module, `apps/desktop/electron/update-install-kind.ts`:

- a packaged desktop whose `process.execPath` is outside `resolveUpdateRoot()` is installer-deployed (a CLI `hermes desktop` launch always runs the packed exe from `<checkout>/apps/desktop/release/*-unpacked/`, per `_desktop_packaged_executable` in `hermes_cli/main.py`);
- `HERMES_HOME/logs/bootstrap-installer.log` is a Hermes-Setup breadcrumb, created by `init_logging()` at installer startup, so it exists even when the self-copy failed;
- everything else keeps today's CLI message, including unpackaged dev runs.

Scope notes: this PR does not make the installers stage `hermes-setup.exe` (a packaging pipeline change; the NSIS shell would have to ship the separate Tauri updater binary), and it does not touch the backend's `.install_method` detection (#61827). The adjacent updater PRs solve different failure modes: #37748 validates a staged updater that exists, #61093 finds one staged in a different Hermes home. Here the updater never existed.

## Related Issue

Fixes #66095

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/update-install-kind.ts` (new): pure `classifyWindowsManualUpdate()` with win32 path-containment semantics (case-insensitive, both separators, no sibling-prefix false positives).
- `apps/desktop/electron/update-install-kind.test.ts` (new): 7 unit tests covering the NSIS layout from the issue, the failed-self-copy Tauri case, case/separator variance, sibling-prefix dirs, dev runs, and missing inputs.
- `apps/desktop/electron/main.ts`: the manual fallback computes `installKind` and carries it on the apply result and the `hermes:updates:progress` payload; the log line now records which kind was detected.
- `apps/desktop/src/global.d.ts`, `apps/desktop/src/store/updates.ts`: thread `installKind` through `UpdateApplyState` on both the result and progress paths.
- `apps/desktop/src/app/updates-overlay.tsx`: `ManualView` shows the missing-updater body when `installKind === 'installer'`.
- `apps/desktop/src/i18n/{types,en,zh,zh-hant,ja}.ts`: new `updates.manualBodyMissingUpdater` string.
- `apps/desktop/src/store/updates.test.ts`: 3 store cases (cli kind, installer kind, and null default when an older main process omits the field).

## How to Test

1. On Windows, install Hermes with the official desktop installer (or delete `%LOCALAPPDATA%\hermes\hermes-setup.exe` from a Hermes-Setup install to simulate the failed self-copy).
2. Open Hermes and click the update button when an update is available.
3. Before: the dialog claims you installed from the command line. After: the dialog says the install is missing its updater helper and offers the same `hermes update` command.

Verification I actually ran (Windows 11, this branch):

```
$ npx vitest run --project electron update-install-kind
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ npx vitest run --project ui src/store/updates.test.ts
 Test Files  1 passed (1)
      Tests  27 passed (27)

$ npm run typecheck
> tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit
(clean)

$ npx eslint electron/update-install-kind.ts electron/update-install-kind.test.ts electron/main.ts \
    src/store/updates.ts src/store/updates.test.ts src/app/updates-overlay.tsx src/global.d.ts \
    src/i18n/en.ts src/i18n/zh.ts src/i18n/zh-hant.ts src/i18n/ja.ts src/i18n/types.ts
(clean)

$ npx prettier --check electron/main.ts electron/update-install-kind.ts electron/update-install-kind.test.ts \
    src/app/updates-overlay.tsx src/global.d.ts src/i18n/en.ts src/i18n/ja.ts src/i18n/types.ts \
    src/i18n/zh-hant.ts src/i18n/zh.ts src/store/updates.test.ts src/store/updates.ts
Checking formatting...
All matched files use Prettier code style!
```

(An earlier revision of this branch had one log line in `main.ts` over the Prettier print width; the last commit wraps it, and the check above is from the final tree.)

A full `vitest run` in `apps/desktop` shows 6 failing test files (`scripts/before-pack.test.mjs`, `scripts/stage-native-deps.test.mjs`, `electron/update-relaunch.test.ts`, `electron/windows-hermes-path.test.ts`, `src/app/messaging/index.test.tsx`, `src/app/skills/index.test.tsx`). I stashed my changes and re-ran on a clean origin/main checkout: the same 6 files fail there, so they are pre-existing on this machine and unrelated to this change.

Honest boundary: I verified the detection and dialog logic at the unit level plus typecheck and lint. I did not build the NSIS installer artifact or drive a packaged desktop end to end; the classifier tests encode the exact filesystem layouts the two install flows produce.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (checked #37748, #61093, #40558, #42382; none address installer misdetection)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run: this PR touches only apps/desktop TypeScript, no Python; I ran the desktop vitest projects, tsc, and eslint instead, output above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (unit tests, typecheck, lint; no packaged end-to-end run, see boundary note above)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior documented in code comments; no docs page describes the manual dialog)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the changed branch is Windows-only (POSIX takes the in-app update path before it), and the classifier deliberately uses win32 path semantics
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

See the command output in "How to Test" above.

Written by Stan Shih (stantheman0128) with Claude Code assisting on implementation and tests.
