### PR TITLE
fix(agent): redact the interim-message top-level-content fallback

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4821,7 +4821,15 @@ class AIAgent:
         if visible:
             return visible
         content = assistant_msg.get("content")
-        return self._strip_think_blocks(content or "").strip()
+        # Redact the top-level-content fallback too. The Codex-commentary
+        # branch above is already redacted (via
+        # _extract_codex_interim_visible_parts), but a mid-turn message with no
+        # commentary falls through to raw content here, which
+        # _emit_interim_assistant_message would otherwise surface to the UI
+        # with any secrets intact — the same leak the commentary path guards.
+        return redact_sensitive_text(
+            self._strip_think_blocks(content or "").strip()
+        )
 
     def _interim_text_was_delivered(self, text: str) -> bool:
         normalized = self._normalize_interim_visible_text(text)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2421,6 +2421,30 @@ def test_interim_commentary_redacts_secrets_from_codex_commentary_items(monkeypa
     assert "Using credential" in observed[0]
 
 
+def test_interim_top_level_content_fallback_redacts_secrets(monkeypatch):
+    """A mid-turn assistant message with no Codex commentary falls back to
+    top-level content for interim delivery — that fallback must be redacted
+    too, not just the commentary path (otherwise the interim callback surfaces
+    secrets from raw content to the UI)."""
+    agent = _build_agent(monkeypatch)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+    observed = []
+    agent.interim_assistant_callback = (
+        lambda text, *, already_streamed=False: observed.append(text)
+    )
+    secret = "sk-" + ("B" * 32)
+
+    agent._emit_interim_assistant_message({
+        "role": "assistant",
+        "content": f"Reading credential {secret} from the config.",
+        # No codex_message_items → interim delivery falls back to content.
+    })
+
+    assert len(observed) == 1
+    assert secret not in observed[0]
+    assert "Reading credential" in observed[0]
+
+
 def test_interim_commentary_respects_show_commentary_off(monkeypatch):
     """display.show_commentary=false keeps commentary off the interim path."""
     agent = _build_agent(monkeypatch)


### PR DESCRIPTION
## What does this PR do?

`_emit_interim_assistant_message` surfaces a mid-turn assistant message to the
UI via `interim_assistant_callback`. Its Codex-commentary path is redacted (via
`_extract_codex_interim_visible_parts`), but when a message carries **no**
commentary the delivery falls back to `_interim_assistant_visible_text`, whose
top-level-`content` branch returned `_strip_think_blocks(content)` **verbatim —
no redaction**. So a response that echoes a credential mid-turn leaked it to the
interim UI on the fallback path, while the commentary path (and the sibling
`_emit_interim_assistant_text`) scrubbed it.

This applies `redact_sensitive_text` to the fallback so both branches of the
interim-visible text are scrubbed, closing the leak and matching the
commentary-path guard added in the preceding interim-commentary redaction work.

## Related Issue

No separate issue — follow-up hardening to the interim Codex-commentary
redaction; closes the same leak on the no-commentary (top-level content)
fallback path it didn't cover.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `run_agent.py` — wrap the top-level-`content` fallback in
  `_interim_assistant_visible_text` with `redact_sensitive_text` so
  `_emit_interim_assistant_message` never surfaces raw secrets on the
  no-commentary path.
- `tests/run_agent/test_run_agent_codex_responses.py` — add
  `test_interim_top_level_content_fallback_redacts_secrets`.

## How to Test

1. `pytest tests/run_agent/test_run_agent_codex_responses.py -q -k interim` →
   **13 passed**.
2. Proof the fix works — revert only the `run_agent.py` change and re-run the
   new test: it fails, because the interim callback receives the raw
   `sk-…` secret from top-level content. With the fix the delivered text has the
   secret redacted while the surrounding wording (`"Reading credential …"`) is
   preserved.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suite (`pytest tests/run_agent/test_run_agent_codex_responses.py -q`) and interim tests pass
- [x] I've added tests for my changes
- [x] I've tested locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation — inline rationale added; no external docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure text-redaction path, no OS-specific code)