### PR TITLE
feat(kanban): explicit audited "close as merged" workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1095,9 +1095,9 @@ kanban task.
 - **CLI:** `hermes_cli/kanban.py` wires `hermes kanban` with verbs
   `init`, `create`, `list` (alias `ls`), `show`, `assign`, `link`,
   `unlink`, `comment`, `attach`, `attachments`, `attach-rm`, `complete`,
-  `block`, `unblock`, `archive`, `tail`, plus less-commonly-used `watch`,
-  `stats`, `runs`, `log`, `assignees`, `heartbeat`, `notify-*`,
-  `dispatch`, `daemon`, `gc`.
+  `close-merged`, `block`, `unblock`, `archive`, `tail`, plus
+  less-commonly-used `watch`, `stats`, `runs`, `log`, `assignees`,
+  `heartbeat`, `notify-*`, `dispatch`, `daemon`, `gc`.
 - **Worker/orchestrator toolset:** `tools/kanban_tools.py` exposes
   `kanban_show`, `kanban_complete`, `kanban_block`, `kanban_heartbeat`,
   `kanban_comment`, `kanban_create`, `kanban_link`, `kanban_attach`,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -572,6 +572,37 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="JSON dict of structured facts to store on the latest completed run.",
     )
 
+    p_close_merged = sub.add_parser(
+        "close-merged",
+        help="Close a card as merged (explicit, audited; requires --yes-merged "
+             "+ --reason + --pr + --commit)",
+    )
+    p_close_merged.add_argument("task_id")
+    p_close_merged.add_argument(
+        "--yes-merged",
+        dest="authorized",
+        action="store_true",
+        help="Explicit authorization. REQUIRED — without it the close is "
+             "refused so a merged-close can never happen by accident.",
+    )
+    p_close_merged.add_argument(
+        "--reason",
+        required=True,
+        help="Non-empty human explanation of why the card is closed as merged.",
+    )
+    p_close_merged.add_argument(
+        "--pr",
+        required=True,
+        help="Merge evidence: a GitHub PR URL "
+             "(https://github.com/<owner>/<repo>/pull/<n>) or a PR number.",
+    )
+    p_close_merged.add_argument(
+        "--commit",
+        required=True,
+        help="Merge evidence: the merge commit SHA (7-40 hex chars).",
+    )
+    p_close_merged.add_argument("--json", action="store_true")
+
     p_block = sub.add_parser("block", help="Mark one or more tasks blocked")
     p_block.add_argument("task_id")
     p_block.add_argument("reason", nargs="*", help="Reason (also appended as a comment)")
@@ -974,6 +1005,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "attach-rm": _cmd_attach_rm,
             "complete": _cmd_complete,
             "edit":     _cmd_edit,
+            "close-merged": _cmd_close_merged,
             "block":    _cmd_block,
             "schedule": _cmd_schedule,
             "unblock":  _cmd_unblock,
@@ -2035,6 +2067,57 @@ def _cmd_edit(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_close_merged(args: argparse.Namespace) -> int:
+    """Explicitly close a card as merged (dedicated, audited terminal action).
+
+    Requires the explicit ``--yes-merged`` authorization flag, a non-empty
+    ``--reason``, and merge evidence (``--pr`` + ``--commit``). Validation and
+    the state transition live in ``kanban_db.close_task_as_merged``; this
+    handler just adapts CLI args and reports the outcome. It never spawns a
+    worker, so there is no recursive-agent risk.
+    """
+    as_json = getattr(args, "json", False)
+
+    def _fail(msg: str, code: int = 2) -> int:
+        if as_json:
+            print(json.dumps({"ok": False, "task_id": args.task_id, "error": msg}))
+        else:
+            print(f"kanban: {msg}", file=sys.stderr)
+        return code
+
+    try:
+        with kb.connect_closing() as conn:
+            ok = kb.close_task_as_merged(
+                conn,
+                args.task_id,
+                reason=args.reason,
+                pr=args.pr,
+                commit=args.commit,
+                authorized=bool(getattr(args, "authorized", False)),
+                authorized_by=_profile_author(),
+            )
+    except (kb.MergeAuthorizationError, kb.MergeEvidenceError) as exc:
+        return _fail(str(exc))
+    if not ok:
+        return _fail(
+            f"cannot close {args.task_id} as merged "
+            f"(unknown id or already terminal: done/archived)",
+            code=1,
+        )
+    if as_json:
+        print(json.dumps({
+            "ok": True,
+            "task_id": args.task_id,
+            "status": "done",
+            "outcome": kb.MERGED_OUTCOME,
+            "pr": args.pr,
+            "commit": args.commit,
+        }))
+    else:
+        print(f"Closed {args.task_id} as merged (PR {args.pr} @ {args.commit})")
+    return 0
+
+
 def _cmd_block(args: argparse.Namespace) -> int:
     reason = " ".join(args.reason).strip() if args.reason else None
     kind = getattr(args, "kind", None)
@@ -2854,6 +2937,7 @@ Common subcommands:
   `comment <id> <msg>`  Append a comment
   `attach <id> <path>`  Attach a local file; `attachments <id>` to list
   `complete <id>…`      Mark task(s) done
+  `close-merged <id>`   Close a card as merged (audited; needs --yes-merged --reason --pr --commit)
   `block <id> [reason]` Mark blocked; `schedule <id> [reason]` parks time-delay work; `unblock <id>` to revive
   `assign <id> <profile>`  Reassign
   `boards list`         Show all boards

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -132,6 +132,24 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # spirit (default 2) but counts a different signal: manual unblock recurrences,
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
+
+# Run/audit outcome recorded when a card is retired through the explicit
+# "close as merged" workflow (:func:`close_task_as_merged`). Deliberately
+# distinct from the ordinary ``completed`` outcome so the audit trail makes
+# clear the card was closed because its work landed in a MERGED pull request,
+# not because a worker ran it to completion. See ``VALID_BLOCK_KINDS`` for the
+# sibling "typed reason" pattern.
+MERGED_OUTCOME = "merged"
+
+# Statuses a card may be closed-as-merged FROM. Excludes the already-terminal
+# states (``done`` / ``archived``) so a double-close — or closing an archived
+# card — fails safely (returns False, no mutation) instead of silently
+# rewriting terminal history. Kept as a sorted tuple so the SQL ``IN (...)``
+# placeholder order is deterministic.
+CLOSE_MERGED_FROM_STATUSES = (
+    "blocked", "ready", "review", "running", "scheduled", "todo", "triage",
+)
+
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
@@ -4087,6 +4105,26 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+class MergeAuthorizationError(ValueError):
+    """Raised by ``close_task_as_merged`` when the caller did not explicitly
+    authorize the close.
+
+    The merged-close is a deliberately guarded terminal transition — it must
+    never happen by accident — so the caller has to pass ``authorized=True``.
+    Kept as a ``ValueError`` subclass so existing tool-error handlers treat it
+    as a recoverable user error rather than a crash.
+    """
+
+
+class MergeEvidenceError(ValueError):
+    """Raised by ``close_task_as_merged`` when the supplied merge evidence
+    (reason, pull-request reference, or commit SHA) is missing or malformed.
+
+    The task is never mutated on a rejected attempt — evidence is validated
+    before any write — so an accidental or unmerged-looking close fails safe.
+    """
+
+
 class ArtifactPreservationError(RuntimeError):
     """Raised when a declared scratch deliverable cannot be preserved."""
 
@@ -4297,6 +4335,289 @@ def complete_task(
         assignee=_done_task.assignee if _done_task else None,
         run_id=run_id,
         summary=(summary if summary is not None else result),
+    )
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Close as merged (explicit, audited terminal transition)
+# ---------------------------------------------------------------------------
+
+# A GitHub PR URL, capturing owner/repo/number so we can normalize away any
+# trailing ``/files``, ``#discussion_r…`` fragment, or ``?query`` string.
+_GITHUB_PR_URL_RE = re.compile(
+    r"^https://github\.com/(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/pull/(?P<num>\d+)"
+    r"(?:[/#?].*)?$",
+    re.IGNORECASE,
+)
+# A bare PR reference: ``123`` or ``#123``.
+_PR_NUMBER_RE = re.compile(r"^#?(\d+)$")
+# A git commit SHA: 7–40 hex chars (abbreviated through full length).
+_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
+# Refs that look like a SHA argument but are NOT an immutable commit id. These
+# would let an "unmerged" close slip through (a branch tip moves), so reject.
+_NON_SHA_REFS = {"head", "main", "master", "develop", "trunk"}
+
+
+def _normalize_pr_reference(pr: object) -> str:
+    """Validate a merge pull-request reference and return a canonical string.
+
+    Accepts a full GitHub PR URL (``https://github.com/o/r/pull/123`` — with or
+    without a trailing ``/files``/fragment/query), a ``#123`` or ``123`` PR
+    number, or a positive ``int``. Returns the canonical PR URL (for URL input)
+    or ``#<n>`` (for bare numbers).
+
+    Rejects branch names, ``/compare/`` and ``/commit/`` URLs, non-GitHub URLs,
+    zero/negative numbers, booleans, and empty input by raising
+    :class:`MergeEvidenceError`. This is what makes "accidental / unmerged
+    evidence" fail safe: only something that unambiguously names a pull request
+    is accepted.
+    """
+    if pr is None:
+        raise MergeEvidenceError(
+            "merge evidence requires a pull request URL or number"
+        )
+    # ``bool`` is an ``int`` subclass — reject it before the int branch so
+    # ``pr=True`` can't masquerade as PR #1.
+    if isinstance(pr, bool):
+        raise MergeEvidenceError(
+            "pull request reference must be a URL or number, not a boolean"
+        )
+    if isinstance(pr, int):
+        if pr <= 0:
+            raise MergeEvidenceError(
+                f"pull request number must be a positive integer, got {pr!r}"
+            )
+        return f"#{pr}"
+    text = str(pr).strip()
+    if not text:
+        raise MergeEvidenceError("pull request reference must not be empty")
+    m = _GITHUB_PR_URL_RE.match(text)
+    if m:
+        return (
+            f"https://github.com/{m.group('owner')}/{m.group('repo')}"
+            f"/pull/{int(m.group('num'))}"
+        )
+    m = _PR_NUMBER_RE.match(text)
+    if m:
+        num = int(m.group(1))
+        if num <= 0:
+            raise MergeEvidenceError(
+                f"pull request number must be a positive integer, got {text!r}"
+            )
+        return f"#{num}"
+    raise MergeEvidenceError(
+        f"{pr!r} is not a valid pull request reference — expected a GitHub PR "
+        f"URL (https://github.com/<owner>/<repo>/pull/<n>) or a PR number"
+    )
+
+
+def _normalize_commit_sha(commit: object) -> str:
+    """Validate a merge commit SHA and return it lower-cased.
+
+    Accepts a 7–40 char hex string (abbreviated through full commit id).
+    Rejects empty input, refs/branch names (``HEAD``, ``main``, anything with a
+    ``/``), and non-hex text by raising :class:`MergeEvidenceError`. Requiring
+    an immutable commit id — not a moving ref — is part of rejecting
+    "unmerged" evidence.
+    """
+    if commit is None:
+        raise MergeEvidenceError("merge evidence requires a commit SHA")
+    if isinstance(commit, bool):
+        raise MergeEvidenceError("commit SHA must be a hex string, not a boolean")
+    text = str(commit).strip().lower()
+    if not text:
+        raise MergeEvidenceError("commit SHA must not be empty")
+    if "/" in text or text in _NON_SHA_REFS:
+        raise MergeEvidenceError(
+            f"{commit!r} is not a commit SHA (looks like a branch/ref); pass the "
+            f"immutable merge commit hash"
+        )
+    if not _COMMIT_SHA_RE.match(text):
+        raise MergeEvidenceError(
+            f"commit SHA must be 7-40 hexadecimal characters, got {commit!r}"
+        )
+    return text
+
+
+def close_task_as_merged(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: str,
+    pr: object,
+    commit: object,
+    authorized: bool = False,
+    authorized_by: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Explicitly retire a card as *closed-as-merged*.
+
+    This is the dedicated, audited terminal transition for the case where a
+    card's work already landed in a merged pull request and the card should be
+    closed with a durable merge record — NOT by editing the card body, and NOT
+    by faking an ordinary ``complete_task``. It never spawns a worker or agent
+    (the card lands in ``done``, which the dispatcher never picks up), so it
+    cannot trigger recursive agent spawning.
+
+    Safety contract — every check runs BEFORE any write, and the card is left
+    untouched unless all pass:
+
+    * ``authorized`` MUST be ``True``. The caller has to opt in explicitly, so
+      a merged-close can never happen by accident. Otherwise
+      :class:`MergeAuthorizationError`.
+    * ``reason`` MUST be a non-empty human explanation. Otherwise
+      :class:`MergeEvidenceError`.
+    * ``pr`` MUST resolve to a valid GitHub PR URL or PR number, and ``commit``
+      MUST be a 7-40 char hex SHA (see :func:`_normalize_pr_reference` /
+      :func:`_normalize_commit_sha`). Malformed / unmerged-looking evidence
+      raises :class:`MergeEvidenceError`.
+    * The card MUST be in a non-terminal state (one of
+      :data:`CLOSE_MERGED_FROM_STATUSES`). A card that is already ``done`` or
+      ``archived`` (or unknown) returns ``False`` with no mutation, so a
+      double-close can't rewrite terminal history.
+
+    On success the card transitions to ``done`` with a ``merged`` run outcome,
+    a durable dedicated ``closed_merged`` audit event carrying the full merge
+    metadata (pull request, commit, reason, authorizer, prior status), and a
+    ``completed`` lifecycle event so gateway notifiers (Discord, …) deliver the
+    close automatically through the existing terminal-event path. The card's
+    ``body`` and all prior audit events are never modified.
+
+    Returns ``True`` on a successful close, ``False`` when the card is unknown
+    or already terminal. Raises on a rejected (unauthorized / invalid-evidence)
+    attempt.
+    """
+    # --- Gate: authorization + evidence, validated before any write. ---
+    if not authorized:
+        raise MergeAuthorizationError(
+            "close_task_as_merged requires explicit authorization "
+            "(authorized=True); refusing to close a card as merged by accident"
+        )
+    reason_text = reason.strip() if isinstance(reason, str) else ""
+    if not reason_text:
+        raise MergeEvidenceError(
+            "close_task_as_merged requires a non-empty reason explaining the merge"
+        )
+    pr_ref = _normalize_pr_reference(pr)
+    sha = _normalize_commit_sha(commit)
+    author = (authorized_by or "").strip() or None
+
+    now = int(time.time())
+    merge_result = f"Closed as merged: PR {pr_ref} @ {sha} — {reason_text}"
+    # Metadata block persisted on the closing run AND the audit event, so the
+    # merge provenance survives independently of the card body.
+    merge_meta: dict = {
+        "outcome": MERGED_OUTCOME,
+        "pull_request": pr_ref,
+        "commit": sha,
+        "reason": reason_text,
+        "authorized": True,
+        "authorized_by": author,
+    }
+
+    placeholders = ",".join("?" for _ in CLOSE_MERGED_FROM_STATUSES)
+    run_id: Optional[int] = None
+    with write_txn(conn):
+        # Snapshot the prior status so the audit event immutably records where
+        # the card came from (blocked, review, running, …).
+        prior = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if prior is None:
+            return False
+        prior_status = prior["status"]
+        if expected_run_id is None:
+            cur = conn.execute(
+                f"""
+                UPDATE tasks
+                   SET status       = 'done',
+                       result       = ?,
+                       completed_at = ?,
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL,
+                       block_kind   = NULL,
+                       block_recurrences = 0
+                 WHERE id = ?
+                   AND status IN ({placeholders})
+                """,
+                (merge_result, now, task_id, *CLOSE_MERGED_FROM_STATUSES),
+            )
+        else:
+            cur = conn.execute(
+                f"""
+                UPDATE tasks
+                   SET status       = 'done',
+                       result       = ?,
+                       completed_at = ?,
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL,
+                       block_kind   = NULL,
+                       block_recurrences = 0
+                 WHERE id = ?
+                   AND status IN ({placeholders})
+                   AND current_run_id = ?
+                """,
+                (
+                    merge_result, now, task_id,
+                    *CLOSE_MERGED_FROM_STATUSES, int(expected_run_id),
+                ),
+            )
+        if cur.rowcount != 1:
+            # Already terminal (done/archived), unknown status, or the
+            # expected-run CAS lost. No mutation happened.
+            return False
+        # Close any in-flight run with the merged outcome; synthesize a
+        # zero-duration run when the card was never claimed (the common
+        # operator path: closing a blocked/review card).
+        run_id = _end_run(
+            conn, task_id,
+            outcome=MERGED_OUTCOME, status="done",
+            summary=merge_result, metadata=merge_meta,
+        )
+        if run_id is None:
+            run_id = _synthesize_ended_run(
+                conn, task_id,
+                outcome=MERGED_OUTCOME,
+                summary=merge_result, metadata=merge_meta,
+            )
+        # Durable, dedicated audit record — the authoritative merge event.
+        _append_event(
+            conn, task_id, "closed_merged",
+            {**merge_meta, "prior_status": prior_status},
+            run_id=run_id,
+        )
+        # Lifecycle terminal event so existing gateway notifiers deliver the
+        # close automatically (Discord, etc.) through the shared "completed"
+        # path — the notifier keys on ``completed``; the payload flags the
+        # merged provenance and carries the human-facing summary.
+        _append_event(
+            conn, task_id, "completed",
+            {
+                "result_len": len(merge_result),
+                "summary": merge_result,
+                "closed_as_merged": True,
+                "outcome": MERGED_OUTCOME,
+                "pull_request": pr_ref,
+                "commit": sha,
+            },
+            run_id=run_id,
+        )
+    # Mirror complete_task's post-commit housekeeping (each opens its own txn).
+    _clear_failure_counter(conn, task_id)
+    recompute_ready(conn)
+    _cleanup_workspace(conn, task_id)
+    _closed_task = get_task(conn, task_id)
+    _fire_kanban_lifecycle_hook(
+        "kanban_task_completed",
+        task_id,
+        board=get_current_board(),
+        assignee=_closed_task.assignee if _closed_task else None,
+        run_id=run_id,
+        summary=merge_result,
+        outcome=MERGED_OUTCOME,
     )
     return True
 

--- a/tests/hermes_cli/test_kanban_close_merged.py
+++ b/tests/hermes_cli/test_kanban_close_merged.py
@@ -1,0 +1,430 @@
+"""Tests for the explicit, audited "close as merged" Kanban workflow.
+
+Covers ``kanban_db.close_task_as_merged`` (DB layer) and the
+``hermes kanban close-merged`` CLI verb. The scenarios mirror the
+requirements: a no-merge card later explicitly authorized and closed
+merged, missing/invalid evidence failing safely, ordinary completion
+staying unchanged, and archived/terminal consistency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+# The kinds the gateway kanban-notifier subscribes to (mirrors
+# ``gateway.kanban_watchers.TERMINAL_KINDS`` — a function-local constant we
+# can't import). Used to prove the merged-close is auto-delivered to Discord
+# et al. through the shared ``completed`` event path.
+NOTIFIER_TERMINAL_KINDS = (
+    "completed", "blocked", "gave_up", "crashed", "timed_out",
+    "status", "archived", "unblocked",
+)
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _events(conn, task_id):
+    return kb.list_events(conn, task_id)
+
+
+def _event_kinds(conn, task_id):
+    return [e.kind for e in _events(conn, task_id)]
+
+
+def _first_event(conn, task_id, kind):
+    for e in _events(conn, task_id):
+        if e.kind == kind:
+            return e
+    return None
+
+
+def _make_blocked_card(conn, *, title="ship feature", body="the original body"):
+    """A card that was worked but never merged — then blocked for review."""
+    tid = kb.create_task(conn, title=title, body=body, initial_status="running")
+    assert kb.block_task(conn, tid, reason="needs review", kind="needs_input")
+    task = kb.get_task(conn, tid)
+    assert task.status == "blocked"
+    return tid
+
+
+# ---------------------------------------------------------------------------
+# Happy path — no-merge card explicitly authorized and closed merged
+# ---------------------------------------------------------------------------
+
+def test_close_merged_blocked_card_success(kanban_home):
+    with kb.connect() as conn:
+        tid = _make_blocked_card(conn)
+        kinds_before = _event_kinds(conn, tid)
+
+        ok = kb.close_task_as_merged(
+            conn, tid,
+            reason="PR landed on main after review",
+            pr="https://github.com/NousResearch/hermes-agent/pull/123",
+            commit="abc1234",
+            authorized=True,
+            authorized_by="bishop",
+        )
+        assert ok is True
+
+        task = kb.get_task(conn, tid)
+        # Terminal done state with a clear merged result.
+        assert task.status == "done"
+        assert task.completed_at is not None
+        assert "Closed as merged" in task.result
+        assert "#123" not in task.result  # full URL is normalized, not a bare #
+        assert "pull/123" in task.result
+        # Immutable body preserved.
+        assert task.body == "the original body"
+        # Block bookkeeping cleared on the terminal transition.
+        assert task.block_kind is None
+        assert task.block_recurrences == 0
+
+        # Durable, dedicated audit event with full metadata.
+        ev = _first_event(conn, tid, "closed_merged")
+        assert ev is not None
+        assert ev.payload["outcome"] == "merged"
+        assert ev.payload["pull_request"] == (
+            "https://github.com/NousResearch/hermes-agent/pull/123"
+        )
+        assert ev.payload["commit"] == "abc1234"
+        assert ev.payload["reason"] == "PR landed on main after review"
+        assert ev.payload["authorized"] is True
+        assert ev.payload["authorized_by"] == "bishop"
+        assert ev.payload["prior_status"] == "blocked"
+
+        # Prior audit history is preserved (not rewritten).
+        for k in kinds_before:
+            assert k in _event_kinds(conn, tid)
+
+        # A run carries the merged outcome for attempt history / stats.
+        runs = kb.list_runs(conn, tid)
+        assert any(r.outcome == "merged" for r in runs)
+
+
+def test_close_merged_emits_completed_event_for_discord_delivery(kanban_home):
+    """The merged-close must auto-deliver through the notifier's shared
+    ``completed`` path, and the non-terminal ``closed_merged`` audit row must
+    not wedge the cursor."""
+    with kb.connect() as conn:
+        tid = _make_blocked_card(conn)
+        kb.add_notify_sub(
+            conn, task_id=tid, platform="discord", chat_id="chan-1",
+        )
+        assert kb.close_task_as_merged(
+            conn, tid,
+            reason="merged",
+            pr="42",
+            commit="deadbeef",
+            authorized=True,
+        )
+
+        # The completed event exists and is flagged as a merged close.
+        completed = _first_event(conn, tid, "completed")
+        assert completed is not None
+        assert completed.payload["closed_as_merged"] is True
+        assert completed.payload["outcome"] == "merged"
+        assert completed.payload["summary"].startswith("Closed as merged")
+
+        # What the gateway notifier would actually claim & deliver.
+        _old, _new, delivered = kb.claim_unseen_events_for_sub(
+            conn, task_id=tid, platform="discord", chat_id="chan-1",
+            kinds=NOTIFIER_TERMINAL_KINDS,
+        )
+        delivered_kinds = [e.kind for e in delivered]
+        # The completed event IS delivered (Discord auto-delivery confirmed);
+        # the closed_merged audit row is skipped, not wedged behind the cursor.
+        assert "completed" in delivered_kinds
+        assert "closed_merged" not in delivered_kinds
+
+
+@pytest.mark.parametrize(
+    "pr_in,expected",
+    [
+        (123, "#123"),
+        ("123", "#123"),
+        ("#123", "#123"),
+        (
+            "https://github.com/o/r/pull/7/files",
+            "https://github.com/o/r/pull/7",
+        ),
+        (
+            "https://github.com/o/r/pull/7#discussion_r99",
+            "https://github.com/o/r/pull/7",
+        ),
+    ],
+)
+def test_pr_reference_normalization(pr_in, expected):
+    assert kb._normalize_pr_reference(pr_in) == expected
+
+
+def test_commit_sha_is_lowercased(kanban_home):
+    with kb.connect() as conn:
+        tid = _make_blocked_card(conn)
+        assert kb.close_task_as_merged(
+            conn, tid, reason="x", pr="1", commit="ABCDEF1234", authorized=True,
+        )
+        ev = _first_event(conn, tid, "closed_merged")
+        assert ev.payload["commit"] == "abcdef1234"
+
+
+# ---------------------------------------------------------------------------
+# Missing / invalid evidence fails safely (no mutation)
+# ---------------------------------------------------------------------------
+
+def test_close_merged_requires_explicit_authorization(kanban_home):
+    with kb.connect() as conn:
+        tid = _make_blocked_card(conn)
+        with pytest.raises(kb.MergeAuthorizationError):
+            kb.close_task_as_merged(
+                conn, tid, reason="x", pr="1", commit="abc1234",
+                authorized=False,
+            )
+        # Untouched.
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert "closed_merged" not in _event_kinds(conn, tid)
+
+
+@pytest.mark.parametrize("reason", ["", "   ", "\n\t "])
+def test_close_merged_requires_non_empty_reason(kanban_home, reason):
+    with kb.connect() as conn:
+        tid = _make_blocked_card(conn)
+        with pytest.raises(kb.MergeEvidenceError):
+            kb.close_task_as_merged(
+                conn, tid, reason=reason, pr="1", commit="abc1234",
+                authorized=True,
+            )
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert "closed_merged" not in _event_kinds(conn, tid)
+
+
+@pytest.mark.parametrize(
+    "bad_pr",
+    [
+        None,
+        "",
+        "   ",
+        0,
+        -3,
+        True,
+        "not-a-pr",
+        "https://github.com/o/r/compare/main...feat",
+        "https://github.com/o/r/commit/abc1234",
+        "https://gitlab.com/o/r/pull/1",
+        "feature/my-branch",
+    ],
+)
+def test_close_merged_rejects_invalid_pr(kanban_home, bad_pr):
+    with kb.connect() as conn:
+        tid = _make_blocked_card(conn)
+        with pytest.raises(kb.MergeEvidenceError):
+            kb.close_task_as_merged(
+                conn, tid, reason="x", pr=bad_pr, commit="abc1234",
+                authorized=True,
+            )
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert "closed_merged" not in _event_kinds(conn, tid)
+
+
+@pytest.mark.parametrize(
+    "bad_sha",
+    [
+        None,
+        "",
+        "   ",
+        True,
+        "HEAD",
+        "main",
+        "master",
+        "feature/x",
+        "abc",          # too short (< 7)
+        "z" * 8,        # non-hex
+        "g1234567",     # non-hex leading char
+        "a" * 41,       # too long (> 40)
+    ],
+)
+def test_close_merged_rejects_invalid_commit(kanban_home, bad_sha):
+    with kb.connect() as conn:
+        tid = _make_blocked_card(conn)
+        with pytest.raises(kb.MergeEvidenceError):
+            kb.close_task_as_merged(
+                conn, tid, reason="x", pr="1", commit=bad_sha,
+                authorized=True,
+            )
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert "closed_merged" not in _event_kinds(conn, tid)
+
+
+# ---------------------------------------------------------------------------
+# Ordinary completion is unchanged
+# ---------------------------------------------------------------------------
+
+def test_ordinary_completion_unchanged(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="normal", initial_status="running")
+        assert kb.complete_task(conn, tid, result="did the thing")
+        task = kb.get_task(conn, tid)
+        assert task.status == "done"
+        assert task.result == "did the thing"
+        # No merged provenance leaked into the ordinary path.
+        assert "closed_merged" not in _event_kinds(conn, tid)
+        assert "completed" in _event_kinds(conn, tid)
+        runs = kb.list_runs(conn, tid)
+        assert any(r.outcome == "completed" for r in runs)
+        assert not any(r.outcome == "merged" for r in runs)
+
+
+# ---------------------------------------------------------------------------
+# Archived / terminal consistency
+# ---------------------------------------------------------------------------
+
+def test_close_merged_rejects_already_done(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="done card", initial_status="running")
+        assert kb.complete_task(conn, tid, result="ordinary result")
+        # Cannot merged-close a card that already reached done.
+        ok = kb.close_task_as_merged(
+            conn, tid, reason="x", pr="1", commit="abc1234", authorized=True,
+        )
+        assert ok is False
+        task = kb.get_task(conn, tid)
+        assert task.status == "done"
+        assert task.result == "ordinary result"  # untouched
+        assert "closed_merged" not in _event_kinds(conn, tid)
+
+
+def test_close_merged_rejects_archived(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="arch card", initial_status="running")
+        assert kb.complete_task(conn, tid, result="r")
+        assert kb.archive_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "archived"
+        ok = kb.close_task_as_merged(
+            conn, tid, reason="x", pr="1", commit="abc1234", authorized=True,
+        )
+        assert ok is False
+        assert kb.get_task(conn, tid).status == "archived"
+
+
+def test_close_merged_double_close_is_safe(kanban_home):
+    with kb.connect() as conn:
+        tid = _make_blocked_card(conn)
+        assert kb.close_task_as_merged(
+            conn, tid, reason="first", pr="1", commit="abc1234", authorized=True,
+        )
+        # Second attempt is a no-op — card is already terminal.
+        assert kb.close_task_as_merged(
+            conn, tid, reason="second", pr="2", commit="def5678", authorized=True,
+        ) is False
+        merged_events = [e for e in _events(conn, tid) if e.kind == "closed_merged"]
+        assert len(merged_events) == 1
+        assert merged_events[0].payload["reason"] == "first"
+
+
+def test_close_merged_unknown_task_returns_false(kanban_home):
+    with kb.connect() as conn:
+        assert kb.close_task_as_merged(
+            conn, "t_doesnotexist", reason="x", pr="1", commit="abc1234",
+            authorized=True,
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# CLI verb: hermes kanban close-merged
+# ---------------------------------------------------------------------------
+
+def _parse(tokens):
+    """Parse a ``kanban …`` token list through the real argparse tree."""
+    root = argparse.ArgumentParser(prog="hermes")
+    subs = root.add_subparsers(dest="command")
+    kanban_parser = kc.build_parser(subs)
+    kanban_parser.set_defaults(_kanban_parser=kanban_parser)
+    return root.parse_args(["kanban", *tokens])
+
+
+def test_cli_close_merged_success(kanban_home, capsys):
+    with kb.connect() as conn:
+        tid = _make_blocked_card(conn)
+    args = _parse([
+        "close-merged", tid,
+        "--yes-merged",
+        "--reason", "landed in prod",
+        "--pr", "123",
+        "--commit", "abc1234",
+    ])
+    assert kc.kanban_command(args) == 0
+    out = capsys.readouterr().out
+    assert "as merged" in out
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "done"
+
+
+def test_cli_close_merged_json(kanban_home, capsys):
+    with kb.connect() as conn:
+        tid = _make_blocked_card(conn)
+    args = _parse([
+        "close-merged", tid,
+        "--yes-merged", "--reason", "x", "--pr", "9", "--commit", "abcdef0",
+        "--json",
+    ])
+    assert kc.kanban_command(args) == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["ok"] is True
+    assert payload["outcome"] == "merged"
+    assert payload["status"] == "done"
+
+
+def test_cli_close_merged_without_authorization_flag_fails(kanban_home, capsys):
+    """Omitting --yes-merged is refused (the DB raises; the handler reports)."""
+    with kb.connect() as conn:
+        tid = _make_blocked_card(conn)
+    args = _parse([
+        "close-merged", tid,
+        "--reason", "x", "--pr", "1", "--commit", "abc1234",
+    ])
+    rc = kc.kanban_command(args)
+    assert rc != 0
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_cli_close_merged_invalid_evidence_fails(kanban_home):
+    with kb.connect() as conn:
+        tid = _make_blocked_card(conn)
+    args = _parse([
+        "close-merged", tid,
+        "--yes-merged", "--reason", "x", "--pr", "not-a-pr", "--commit", "abc1234",
+    ])
+    assert kc.kanban_command(args) != 0
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        ["close-merged", "t_x", "--yes-merged", "--pr", "1", "--commit", "abc1234"],
+        ["close-merged", "t_x", "--yes-merged", "--reason", "r", "--commit", "abc1234"],
+        ["close-merged", "t_x", "--yes-merged", "--reason", "r", "--pr", "1"],
+    ],
+)
+def test_cli_close_merged_requires_evidence_flags(kanban_home, missing):
+    # argparse enforces required=True on --reason/--pr/--commit.
+    with pytest.raises(SystemExit):
+        _parse(missing)


### PR DESCRIPTION
Adds a dedicated, audited **close as merged** workflow for Kanban cards: a `close_task_as_merged` DB action and a `hermes kanban close-merged` CLI verb.

It retires a card whose work already landed in a merged PR without mutating the immutable card body or faking an ordinary completion.

**Safety contract** (all validated before any write; the card is untouched on rejection):
- explicit `--yes-merged` authorization flag (no accidental closes),
- a non-empty `--reason`,
- merge evidence: a valid GitHub PR URL/number (`--pr`) plus a 7-40 hex commit SHA (`--commit`).

Malformed/unmerged-looking evidence is rejected; already-`done`/`archived` cards fail safe. On success the card moves to terminal `done` with a `merged` run outcome, a durable dedicated `closed_merged` audit event, and a `completed` lifecycle event so the gateway notifier auto-delivers the close (Discord, etc.) through the existing terminal-event path. Prior audit history is preserved and no worker/agent is spawned.

New tests in `tests/hermes_cli/test_kanban_close_merged.py` cover the happy path, missing/invalid evidence, unchanged ordinary completion, archived/terminal consistency, notifier auto-delivery, and the CLI verb.
