### PR TITLE
test(file-safety): drop stale _get_live_tracking_cwd monkeypatch breaking CI slice 4/8

### DIFF
--- a/tests/agent/test_file_safety_session_state.py
+++ b/tests/agent/test_file_safety_session_state.py
@@ -16,13 +16,20 @@ import pytest
 
 @pytest.fixture()
 def fake_homes(tmp_path, monkeypatch):
-    import agent.file_safety as fs
+    """Point HERMES_HOME at a temp profile dir.
 
+    Uses the real env-var resolution chain (get_hermes_home /
+    get_default_hermes_root) instead of monkeypatching private helpers —
+    a stale monkeypatch on a since-deleted helper broke CI in July 2026
+    (monkeypatch.setattr raises AttributeError on missing attributes).
+    HERMES_HOME=<root>/profiles/<name> makes get_default_hermes_root()
+    derive <root> via the `profiles` parent-dir rule, so both the
+    profile-scoped and root-scoped deny lists resolve into tmp_path.
+    """
     root = tmp_path / ".hermes"
     profile = root / "profiles" / "work"
     profile.mkdir(parents=True)
-    monkeypatch.setattr(fs, "_hermes_home_path", lambda: profile)
-    monkeypatch.setattr(fs, "_hermes_root_path", lambda: root)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
     return root, profile
 
 
@@ -58,14 +65,13 @@ def test_project_local_state_db_remains_writable(fake_homes, tmp_path):
     assert is_write_denied(str(target)) is False
 
 
-def test_write_file_tool_preserves_existing_session_snapshot(fake_homes, monkeypatch):
+def test_write_file_tool_preserves_existing_session_snapshot(fake_homes):
     import tools.file_tools as ft
 
     _root, profile = fake_homes
     target = profile / "sessions" / "session_abc.json"
     target.parent.mkdir(parents=True)
     target.write_text("original transcript", encoding="utf-8")
-    monkeypatch.setattr(ft, "_get_live_tracking_cwd", lambda task_id="default": None)
 
     result = json.loads(ft.write_file_tool(str(target), "tampered"))
 


### PR DESCRIPTION
## Summary

Repairs CI test slice 4/8, red on main for every open PR: `test_write_file_tool_preserves_existing_session_snapshot` monkeypatches `tools.file_tools._get_live_tracking_cwd`, which was deleted in the cwd-tracking refactor (c80b244b5, "delete legacy env-side cwd tracking step 4"). `monkeypatch.setattr` on a missing attribute raises `AttributeError` before the test body runs.

Also de-flakes the whole file against recurrence: the fixture previously monkeypatched the private `_hermes_home_path`/`_hermes_root_path` helpers — the same stale-symbol failure class waiting to happen on the next rename. It now sets `HERMES_HOME=<root>/profiles/work` and lets the real resolution chain (`get_hermes_home` / `get_default_hermes_root`'s profiles-parent rule) derive both paths. Zero private symbols referenced; the test now exercises the production resolution path.

## Changes

- `tests/agent/test_file_safety_session_state.py`: drop the stale `_get_live_tracking_cwd` monkeypatch; fixture switched from private-helper monkeypatching to `monkeypatch.setenv("HERMES_HOME", ...)`

## Validation

| | Result |
|---|---|
| `test_file_safety_session_state.py` | 5/5 passed (was 4/5 with AttributeError) |
| All 4 file-safety suites | 65/65 passed |
| Repro on clean origin/main checkout | confirmed failing before fix |
| ruff | clean |

Discovered while watching CI on #66282.

## Infographic

![CI test repair infographic](https://v3b.fal.media/files/b/0aa29c7a/OcHlyaw7R2An_cGsQ1IEv_tGK1DsYh.png)
