### PR TITLE
fix(desktop): make speech synthesis timeout configurable

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -2,7 +2,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getHermesConfig } from '@/hermes'
+import { getHermesConfig, setSpeechSynthesisAdaptiveTimeout, setSpeechSynthesisTimeoutSeconds } from '@/hermes'
 import { persistString } from '@/lib/storage'
 import {
   $currentCwd,
@@ -21,7 +21,9 @@ import { useHermesConfig } from './use-hermes-config'
 
 vi.mock('@/hermes', () => ({
   getHermesConfig: vi.fn(),
-  getHermesConfigDefaults: vi.fn().mockResolvedValue({})
+  getHermesConfigDefaults: vi.fn().mockResolvedValue({}),
+  setSpeechSynthesisAdaptiveTimeout: vi.fn(),
+  setSpeechSynthesisTimeoutSeconds: vi.fn()
 }))
 
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
@@ -47,7 +49,21 @@ describe('useHermesConfig refreshHermesConfig', () => {
     setCurrentModelSource('')
     setCurrentReasoningEffort('')
     setDefaultReasoningEffort('')
+    vi.mocked(setSpeechSynthesisAdaptiveTimeout).mockClear()
+    vi.mocked(setSpeechSynthesisTimeoutSeconds).mockClear()
     persistString(WORKSPACE_CWD_KEY, null)
+  })
+
+  it('applies speech timeout policy from voice config', async () => {
+    mockConfig({ voice: { synthesis_timeout_adaptive: true, synthesis_timeout_seconds: 240 } })
+    const { result } = renderHook(() => useHermesConfig({ activeSessionIdRef: { current: null } }))
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect(setSpeechSynthesisTimeoutSeconds).toHaveBeenCalledWith(240)
+    expect(setSpeechSynthesisAdaptiveTimeout).toHaveBeenCalledWith(true)
   })
 
   // Regression: the composer keeps a manual model pick sticky, which skips the

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -1,6 +1,11 @@
 import { type MutableRefObject, useCallback, useRef, useState } from 'react'
 
-import { getHermesConfig, getHermesConfigDefaults, setSpeechSynthesisTimeoutSeconds } from '@/hermes'
+import {
+  getHermesConfig,
+  getHermesConfigDefaults,
+  setSpeechSynthesisAdaptiveTimeout,
+  setSpeechSynthesisTimeoutSeconds
+} from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
 import { normalize } from '@/lib/text'
 import {
@@ -104,6 +109,7 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
 
         setVoiceMaxRecordingSeconds(recordingLimit(config.voice?.max_recording_seconds))
         setSpeechSynthesisTimeoutSeconds(config.voice?.synthesis_timeout_seconds)
+        setSpeechSynthesisAdaptiveTimeout(config.voice?.synthesis_timeout_adaptive)
         setSttEnabled(config.stt?.enabled !== false)
         applyAutoSpeakFromConfig(config)
       } catch {

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -1,6 +1,6 @@
 import { type MutableRefObject, useCallback, useRef, useState } from 'react'
 
-import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
+import { getHermesConfig, getHermesConfigDefaults, setSpeechSynthesisTimeoutSeconds } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
 import { normalize } from '@/lib/text'
 import {
@@ -103,6 +103,7 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
         setCurrentServiceTier(prev => (activeSessionIdRef.current ? prev : tier))
 
         setVoiceMaxRecordingSeconds(recordingLimit(config.voice?.max_recording_seconds))
+        setSpeechSynthesisTimeoutSeconds(config.voice?.synthesis_timeout_seconds)
         setSttEnabled(config.stt?.enabled !== false)
         applyAutoSpeakFromConfig(config)
       } catch {

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -446,6 +446,7 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   voice: {
     recordKey: 'Voice Shortcut',
     maxRecordingSeconds: 'Max Recording Length',
+    synthesisTimeoutAdaptive: 'Adaptive Speech Timeout',
     synthesisTimeoutSeconds: 'Speech Synthesis Timeout',
     autoTts: 'Read Responses Aloud'
   },
@@ -605,7 +606,8 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   },
   voice: {
     autoTts: 'Automatically speak assistant responses.',
-    synthesisTimeoutSeconds: 'Seconds Desktop waits for speech generation before reporting a timeout.'
+    synthesisTimeoutAdaptive: 'Choose a shorter timeout from text length without exceeding the configured maximum.',
+    synthesisTimeoutSeconds: 'Fixed timeout, or maximum timeout when adaptive timing is enabled.'
   },
   tts: {
     xai: {
@@ -748,6 +750,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.elevenlabs.diarize',
       'voice.record_key',
       'voice.max_recording_seconds',
+      'voice.synthesis_timeout_adaptive',
       'voice.synthesis_timeout_seconds'
     ]
   },

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -446,6 +446,7 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   voice: {
     recordKey: 'Voice Shortcut',
     maxRecordingSeconds: 'Max Recording Length',
+    synthesisTimeoutSeconds: 'Speech Synthesis Timeout',
     autoTts: 'Read Responses Aloud'
   },
   stt: {
@@ -603,7 +604,8 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     enabled: 'Summarize older context when conversations get large.'
   },
   voice: {
-    autoTts: 'Automatically speak assistant responses.'
+    autoTts: 'Automatically speak assistant responses.',
+    synthesisTimeoutSeconds: 'Optional fixed timeout in seconds. Leave blank to use adaptive speech timing.'
   },
   tts: {
     xai: {
@@ -745,7 +747,8 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.elevenlabs.tag_audio_events',
       'stt.elevenlabs.diarize',
       'voice.record_key',
-      'voice.max_recording_seconds'
+      'voice.max_recording_seconds',
+      'voice.synthesis_timeout_seconds'
     ]
   },
   {

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -605,7 +605,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   },
   voice: {
     autoTts: 'Automatically speak assistant responses.',
-    synthesisTimeoutSeconds: 'Optional fixed timeout in seconds. Leave blank to use adaptive speech timing.'
+    synthesisTimeoutSeconds: 'Seconds Desktop waits for speech generation before reporting a timeout.'
   },
   tts: {
     xai: {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  AUDIO_SPEAK_ADAPTIVE_MIN_REQUEST_TIMEOUT_MS,
   AUDIO_TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS,
   AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS,
   audioTranscribeRequestTimeoutMs,
@@ -18,6 +19,7 @@ import {
   listSidebarSessions,
   resetSidebarBatchCapability,
   setApiRequestProfile,
+  setSpeechSynthesisAdaptiveTimeout,
   setSpeechSynthesisTimeoutSeconds,
   speakText,
   transcribeAudio
@@ -45,6 +47,7 @@ describe('Hermes REST helpers', () => {
 
   afterEach(() => {
     setApiRequestProfile(null)
+    setSpeechSynthesisAdaptiveTimeout(false)
     setSpeechSynthesisTimeoutSeconds(undefined)
     vi.restoreAllMocks()
     Reflect.deleteProperty(window, 'hermesDesktop')
@@ -341,6 +344,25 @@ describe('Hermes REST helpers', () => {
     await speakText('Read this aloud')
 
     expect(api).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 300_000 }))
+  })
+
+  it('scales the configured speech timeout only when adaptive mode is enabled', async () => {
+    setSpeechSynthesisAdaptiveTimeout(true)
+
+    await speakText('short')
+    expect(api).toHaveBeenLastCalledWith(
+      expect.objectContaining({ timeoutMs: AUDIO_SPEAK_ADAPTIVE_MIN_REQUEST_TIMEOUT_MS })
+    )
+
+    await speakText('x'.repeat(100_000))
+    expect(api).toHaveBeenLastCalledWith(expect.objectContaining({ timeoutMs: DEFAULT_SPEECH_SYNTHESIS_TIMEOUT_MS }))
+
+    setSpeechSynthesisTimeoutSeconds(600)
+    await speakText('x'.repeat(8_000))
+    expect(api).toHaveBeenLastCalledWith(expect.objectContaining({ timeoutMs: 280_000 }))
+
+    await speakText('x'.repeat(100_000))
+    expect(api).toHaveBeenLastCalledWith(expect.objectContaining({ timeoutMs: 600_000 }))
   })
 
   it('routes speech synthesis through the active profile', async () => {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -19,6 +19,8 @@ import {
   listSessions,
   listSidebarSessions,
   resetSidebarBatchCapability,
+  setApiRequestProfile,
+  setSpeechSynthesisTimeoutSeconds,
   speakText,
   transcribeAudio
 } from './hermes'
@@ -44,6 +46,7 @@ describe('Hermes REST helpers', () => {
   })
 
   afterEach(() => {
+    setSpeechSynthesisTimeoutSeconds(undefined)
     vi.restoreAllMocks()
     Reflect.deleteProperty(window, 'hermesDesktop')
   })
@@ -318,6 +321,50 @@ describe('Hermes REST helpers', () => {
     const call = api.mock.calls[0]?.[0] as { path: string; timeoutMs?: number }
     expect(call.path).toBe('/api/status')
     expect(call.timeoutMs).toBeUndefined()
+  })
+
+  it('allows local speech synthesis to outlive the generic REST timeout', async () => {
+    api.mockResolvedValue({ audio_url: 'data:audio/wav;base64,dGVzdA==' })
+
+    await speakText('Read this aloud')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/audio/speak',
+      method: 'POST',
+      body: { text: 'Read this aloud' },
+      timeoutMs: 180_000
+    })
+  })
+
+  it('uses the configured speech synthesis timeout', async () => {
+    setSpeechSynthesisTimeoutSeconds(300)
+
+    await speakText('Read this aloud')
+
+    expect(api).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 300_000 }))
+  })
+
+  it('routes speech synthesis through the active profile', async () => {
+    setApiRequestProfile('voice-profile')
+
+    await speakText('Read this aloud')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/audio/speak',
+        profile: 'voice-profile'
+      })
+    )
+  })
+
+  it('bounds the configured speech synthesis timeout', async () => {
+    setSpeechSynthesisTimeoutSeconds(1)
+    await speakText('Minimum')
+    expect(api).toHaveBeenLastCalledWith(expect.objectContaining({ timeoutMs: 15_000 }))
+
+    setSpeechSynthesisTimeoutSeconds(10_000)
+    await speakText('Maximum')
+    expect(api).toHaveBeenLastCalledWith(expect.objectContaining({ timeoutMs: 1_800_000 }))
   })
 
   it('tags cross-profile message reads for Electron routing and backend lookup', async () => {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -46,6 +46,7 @@ describe('Hermes REST helpers', () => {
   })
 
   afterEach(() => {
+    setApiRequestProfile(null)
     setSpeechSynthesisTimeoutSeconds(undefined)
     vi.restoreAllMocks()
     Reflect.deleteProperty(window, 'hermesDesktop')

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,12 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
-  AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS,
-  AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS,
   AUDIO_TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS,
   AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS,
-  audioSpeakRequestTimeoutMs,
   audioTranscribeRequestTimeoutMs,
+  DEFAULT_SPEECH_SYNTHESIS_TIMEOUT_MS,
   getCronJobs,
   getGlobalModelInfo,
   getGlobalModelOptions,
@@ -379,12 +377,6 @@ describe('Hermes REST helpers', () => {
     })
   })
 
-  it('bounds blocking TTS synthesis timeouts by text length', () => {
-    expect(audioSpeakRequestTimeoutMs('short message')).toBe(AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS)
-    expect(audioSpeakRequestTimeoutMs('x'.repeat(8_000))).toBe(280_000)
-    expect(audioSpeakRequestTimeoutMs('x'.repeat(100_000))).toBe(AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS)
-  })
-
   it('uses an extended timeout for blocking TTS synthesis', async () => {
     api.mockResolvedValueOnce({
       data_url: 'data:audio/mpeg;base64,AA==',
@@ -404,7 +396,7 @@ describe('Hermes REST helpers', () => {
       body: { text: 'Read this aloud' },
       method: 'POST',
       path: '/api/audio/speak',
-      timeoutMs: AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS
+      timeoutMs: DEFAULT_SPEECH_SYNTHESIS_TIMEOUT_MS
     })
   })
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -85,6 +85,18 @@ export const DEFAULT_SPEECH_SYNTHESIS_TIMEOUT_MS = 180_000
 const MIN_SPEECH_SYNTHESIS_TIMEOUT_SECONDS = 15
 const MAX_SPEECH_SYNTHESIS_TIMEOUT_SECONDS = 1_800
 let speechSynthesisRequestTimeoutMs = DEFAULT_SPEECH_SYNTHESIS_TIMEOUT_MS
+let speechSynthesisAdaptiveTimeout = false
+export const AUDIO_SPEAK_ADAPTIVE_MIN_REQUEST_TIMEOUT_MS = 15_000
+const AUDIO_SPEAK_TIMEOUT_MS_PER_CHAR = 35
+
+export function audioSpeakRequestTimeoutMs(text: string, maximumMs = speechSynthesisRequestTimeoutMs): number {
+  const estimated = Math.max(
+    AUDIO_SPEAK_ADAPTIVE_MIN_REQUEST_TIMEOUT_MS,
+    Math.ceil(String(text || '').length * AUDIO_SPEAK_TIMEOUT_MS_PER_CHAR)
+  )
+
+  return Math.min(maximumMs, estimated)
+}
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
 // stream / message.complete events, NOT by the RPC return. A long turn (MoA
 // presets running references + aggregator in series, deep reasoning, large tool
@@ -231,6 +243,10 @@ export function setSpeechSynthesisTimeoutSeconds(value: unknown): void {
 
   const bounded = Math.min(MAX_SPEECH_SYNTHESIS_TIMEOUT_SECONDS, Math.max(MIN_SPEECH_SYNTHESIS_TIMEOUT_SECONDS, value))
   speechSynthesisRequestTimeoutMs = Math.round(bounded * 1_000)
+}
+
+export function setSpeechSynthesisAdaptiveTimeout(value: unknown): void {
+  speechSynthesisAdaptiveTimeout = value === true
 }
 
 // Profile that profile-scoped REST settings (config/env/skills/tools/model/…)
@@ -1535,7 +1551,9 @@ export function speakText(text: string): Promise<AudioSpeakResponse> {
     // TTS blocks until provider synthesis, file read, and base64 encoding
     // finish. Remote providers and large messages regularly exceed the
     // default 15s Electron backend timeout.
-    timeoutMs: speechSynthesisRequestTimeoutMs
+    timeoutMs: speechSynthesisAdaptiveTimeout
+      ? audioSpeakRequestTimeoutMs(text, speechSynthesisRequestTimeoutMs)
+      : speechSynthesisRequestTimeoutMs
   })
 }
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -81,9 +81,10 @@ import type {
 export const STARTUP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
+export const DEFAULT_SPEECH_SYNTHESIS_TIMEOUT_MS = 180_000
 const MIN_SPEECH_SYNTHESIS_TIMEOUT_SECONDS = 15
 const MAX_SPEECH_SYNTHESIS_TIMEOUT_SECONDS = 1_800
-let speechSynthesisRequestTimeoutMs: null | number = null
+let speechSynthesisRequestTimeoutMs = DEFAULT_SPEECH_SYNTHESIS_TIMEOUT_MS
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
 // stream / message.complete events, NOT by the RPC return. A long turn (MoA
 // presets running references + aggregator in series, deep reasoning, large tool
@@ -93,19 +94,6 @@ let speechSynthesisRequestTimeoutMs: null | number = null
 // agent-turn ceiling (agent.gateway_timeout = 1800s) so the ack timeout only
 // ever fires when the turn itself would have been abandoned server-side.
 export const PROMPT_SUBMIT_REQUEST_TIMEOUT_MS = 1_800_000
-export const AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS = 180_000
-export const AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS = 600_000
-const AUDIO_SPEAK_TIMEOUT_MS_PER_CHAR = 35
-
-export function audioSpeakRequestTimeoutMs(text: string): number {
-  const estimated = Math.max(
-    AUDIO_SPEAK_MIN_REQUEST_TIMEOUT_MS,
-    Math.ceil(String(text || '').length * AUDIO_SPEAK_TIMEOUT_MS_PER_CHAR)
-  )
-
-  return Math.min(AUDIO_SPEAK_MAX_REQUEST_TIMEOUT_MS, estimated)
-}
-
 export const AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS = 180_000
 export const AUDIO_TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS = 600_000
 // The transcribe payload is the base64 audio data URL itself, so its string
@@ -236,7 +224,7 @@ export class HermesGateway extends JsonRpcGatewayClient {
 
 export function setSpeechSynthesisTimeoutSeconds(value: unknown): void {
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    speechSynthesisRequestTimeoutMs = null
+    speechSynthesisRequestTimeoutMs = DEFAULT_SPEECH_SYNTHESIS_TIMEOUT_MS
 
     return
   }
@@ -1547,7 +1535,7 @@ export function speakText(text: string): Promise<AudioSpeakResponse> {
     // TTS blocks until provider synthesis, file read, and base64 encoding
     // finish. Remote providers and large messages regularly exceed the
     // default 15s Electron backend timeout.
-    timeoutMs: speechSynthesisRequestTimeoutMs ?? audioSpeakRequestTimeoutMs(text)
+    timeoutMs: speechSynthesisRequestTimeoutMs
   })
 }
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -81,6 +81,9 @@ import type {
 export const STARTUP_REQUEST_TIMEOUT_MS = 60_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
+const MIN_SPEECH_SYNTHESIS_TIMEOUT_SECONDS = 15
+const MAX_SPEECH_SYNTHESIS_TIMEOUT_SECONDS = 1_800
+let speechSynthesisRequestTimeoutMs: null | number = null
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
 // stream / message.complete events, NOT by the RPC return. A long turn (MoA
 // presets running references + aggregator in series, deep reasoning, large tool
@@ -229,6 +232,17 @@ export class HermesGateway extends JsonRpcGatewayClient {
       requestTimeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS
     })
   }
+}
+
+export function setSpeechSynthesisTimeoutSeconds(value: unknown): void {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    speechSynthesisRequestTimeoutMs = null
+
+    return
+  }
+
+  const bounded = Math.min(MAX_SPEECH_SYNTHESIS_TIMEOUT_SECONDS, Math.max(MIN_SPEECH_SYNTHESIS_TIMEOUT_SECONDS, value))
+  speechSynthesisRequestTimeoutMs = Math.round(bounded * 1_000)
 }
 
 // Profile that profile-scoped REST settings (config/env/skills/tools/model/…)
@@ -1526,13 +1540,14 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
 
 export function speakText(text: string): Promise<AudioSpeakResponse> {
   return window.hermesDesktop.api<AudioSpeakResponse>({
+    ...profileScoped(),
     path: '/api/audio/speak',
     method: 'POST',
     body: { text },
     // TTS blocks until provider synthesis, file read, and base64 encoding
     // finish. Remote providers and large messages regularly exceed the
     // default 15s Electron backend timeout.
-    timeoutMs: audioSpeakRequestTimeoutMs(text)
+    timeoutMs: speechSynthesisRequestTimeoutMs ?? audioSpeakRequestTimeoutMs(text)
   })
 }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -324,6 +324,7 @@ export interface HermesConfig {
   }
   voice?: {
     max_recording_seconds?: number
+    synthesis_timeout_adaptive?: boolean
     synthesis_timeout_seconds?: null | number
     auto_tts?: boolean
   }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -324,6 +324,7 @@ export interface HermesConfig {
   }
   voice?: {
     max_recording_seconds?: number
+    synthesis_timeout_seconds?: null | number
     auto_tts?: boolean
   }
 }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2347,6 +2347,7 @@ DEFAULT_CONFIG = {
     "voice": {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
+        "synthesis_timeout_seconds": None,  # Optional fixed Desktop read-aloud timeout (15-1800s)
         "auto_tts": False,
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "silence_threshold": 200,     # RMS below this = silence (0-32767)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2347,7 +2347,8 @@ DEFAULT_CONFIG = {
     "voice": {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
-        "synthesis_timeout_seconds": 180,  # Desktop read-aloud request timeout (15-1800s)
+        "synthesis_timeout_adaptive": False,  # Shorten by text length without exceeding the configured maximum
+        "synthesis_timeout_seconds": 180,  # Fixed timeout or adaptive maximum (15-1800s)
         "auto_tts": False,
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "silence_threshold": 200,     # RMS below this = silence (0-32767)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2347,7 +2347,7 @@ DEFAULT_CONFIG = {
     "voice": {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
-        "synthesis_timeout_seconds": None,  # Optional fixed Desktop read-aloud timeout (15-1800s)
+        "synthesis_timeout_seconds": 180,  # Desktop read-aloud request timeout (15-1800s)
         "auto_tts": False,
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "silence_threshold": 200,     # RMS below this = silence (0-32767)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -851,7 +851,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     },
     "voice.synthesis_timeout_seconds": {
         "type": "number",
-        "description": "Seconds Desktop waits for speech synthesis (15-1800)",
+        "description": "Fixed speech timeout, or adaptive maximum, in seconds (15-1800)",
     },
     "stt.provider": {
         "type": "select",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -851,7 +851,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     },
     "voice.synthesis_timeout_seconds": {
         "type": "number",
-        "description": "Optional fixed Desktop speech timeout in seconds (15-1800; blank uses adaptive timing)",
+        "description": "Seconds Desktop waits for speech synthesis (15-1800)",
     },
     "stt.provider": {
         "type": "select",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -849,6 +849,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Text-to-speech provider",
         "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper"],
     },
+    "voice.synthesis_timeout_seconds": {
+        "type": "number",
+        "description": "Optional fixed Desktop speech timeout in seconds (15-1800; blank uses adaptive timing)",
+    },
     "stt.provider": {
         "type": "select",
         "description": "Speech-to-text provider",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5297,6 +5297,15 @@ class TestBuildSchemaFromConfig:
             assert "options" in entry
             assert "local" in entry["options"]
 
+    def test_voice_synthesis_timeout_is_configurable(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        from hermes_cli.web_server import CONFIG_SCHEMA
+
+        assert DEFAULT_CONFIG["voice"]["synthesis_timeout_seconds"] == 180
+        entry = CONFIG_SCHEMA["voice.synthesis_timeout_seconds"]
+        assert entry["type"] == "number"
+        assert entry["category"] == "voice"
+
     def test_memory_provider_field_present_as_select(self):
         """memory.provider must stay in the config schema.
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5302,9 +5302,13 @@ class TestBuildSchemaFromConfig:
         from hermes_cli.web_server import CONFIG_SCHEMA
 
         assert DEFAULT_CONFIG["voice"]["synthesis_timeout_seconds"] == 180
+        assert DEFAULT_CONFIG["voice"]["synthesis_timeout_adaptive"] is False
         entry = CONFIG_SCHEMA["voice.synthesis_timeout_seconds"]
         assert entry["type"] == "number"
         assert entry["category"] == "voice"
+        adaptive = CONFIG_SCHEMA["voice.synthesis_timeout_adaptive"]
+        assert adaptive["type"] == "boolean"
+        assert adaptive["category"] == "voice"
 
     def test_memory_provider_field_present_as_select(self):
         """memory.provider must stay in the config schema.


### PR DESCRIPTION
## Summary

- add `voice.synthesis_timeout_seconds` with a 180-second default
- apply the configured timeout only to Desktop `/api/audio/speak` requests
- expose the setting in Settings > Voice and bound runtime values to 15-1800 seconds

## Root cause

Desktop speech synthesis inherited the generic 15-second REST timeout. Local TTS backends can legitimately exceed that while loading a model or generating audio, causing Read aloud to fail even though the backend remained healthy and completed the request.

## Validation

- `npm run test:ui -- src/hermes.test.ts src/app/settings/voice-field-visible.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npx prettier --check apps/desktop/src/hermes.ts apps/desktop/src/hermes.test.ts apps/desktop/src/types/hermes.ts apps/desktop/src/app/session/hooks/use-hermes-config.ts apps/desktop/src/app/settings/constants.ts`
- `python -m pytest -q tests/hermes_cli/test_web_server.py::TestBuildSchemaFromConfig`
- live local-TTS request through the Desktop gateway route returned HTTP 200 with an MP3 payload
