### PR TITLE
fix(dashboard): return loopback identity from /api/auth/me with valid token (#66223)

### DIFF
--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -777,10 +777,35 @@ async def auth_logout(request: Request):
 
 @router.get("/api/auth/me", name="auth_me")
 async def api_auth_me(request: Request):
-    """Return the verified session as JSON. Auth-required (gate enforces)."""
+    """Return the verified session as JSON.
+
+    In gated mode the auth-middleware attaches ``request.state.session``.
+    In loopback mode there is no OAuth session object, but the legacy
+    ``_SESSION_TOKEN`` middleware has already validated the bearer token
+    for non-public ``/api/`` routes, so we return a minimal loopback
+    identity instead of 401-ing (GH #66223).
+    """
     sess = getattr(request.state, "session", None)
     if sess is None:
-        raise HTTPException(status_code=401, detail="Unauthorized")
+        if getattr(request.app.state, "auth_required", False):
+            raise HTTPException(status_code=401, detail="Unauthorized")
+        # Loopback mode: the legacy auth_middleware has already verified
+        # the ephemeral _SESSION_TOKEN.  There is no OAuth Session to
+        # return, but the SPA needs a minimal identity to resolve its
+        # boot state.  Belt-and-braces: re-verify the token here so the
+        # handler stays safe even if the route were ever allowlisted.
+        from hermes_cli.web_server import _has_valid_session_token
+
+        if not _has_valid_session_token(request):
+            raise HTTPException(status_code=401, detail="Unauthorized")
+        return {
+            "user_id": "local",
+            "email": "",
+            "display_name": "Local",
+            "org_id": "",
+            "provider": "loopback",
+            "expires_at": 0,
+        }
     return {
         "user_id": sess.user_id,
         "email": sess.email,

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -263,6 +263,63 @@ def test_api_auth_me_requires_auth(gated_app):
 
 
 # ---------------------------------------------------------------------------
+# Loopback-mode identity probe (GH #66223)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def loopback_app():
+    """Configure web_server.app for loopback mode (auth_required=False).
+
+    Mirrors ``gated_app`` but flips the gate off and clears ``bound_host``
+    so the host-header check doesn't reject the TestClient's requests.
+    """
+    clear_providers()
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = None
+    web_server.app.state.auth_required = False
+    client = TestClient(web_server.app, base_url="http://127.0.0.1")
+    yield client
+    clear_providers()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.auth_required = prev_required
+
+
+def test_api_auth_me_returns_loopback_identity_with_valid_token(loopback_app):
+    """Regression for GH #66223.
+
+    In loopback mode there is no OAuth ``Session``, but the legacy
+    ``auth_middleware`` has already validated the ephemeral
+    ``_SESSION_TOKEN``.  The handler must return a minimal identity so
+    the SPA can resolve its boot state instead of spinning on a 401.
+    """
+    token = web_server._SESSION_TOKEN
+    r = loopback_app.get(
+        "/api/auth/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, (
+        f"Expected 200 with a valid token in loopback mode, "
+        f"got {r.status_code}: {r.text}"
+    )
+    body = r.json()
+    assert body["provider"] == "loopback"
+    assert body["user_id"] == "local"
+    assert "display_name" in body
+    assert "email" in body
+    assert "org_id" in body
+    assert "expires_at" in body
+
+
+def test_api_auth_me_still_rejects_missing_token_in_loopback(loopback_app):
+    """Security boundary (GH #66223): without a valid token the endpoint
+    must still 401 even in loopback mode."""
+    r = loopback_app.get("/api/auth/me")
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
 # Zero-providers fail-closed
 # ---------------------------------------------------------------------------
 

--- a/web/src/components/AuthWidget.test.tsx
+++ b/web/src/components/AuthWidget.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AuthWidget } from "./AuthWidget";
+import { shouldHideAuthWidget } from "./auth-widget-visibility";
+
+// --- Unit tests for the visibility helper ---
+
+describe("AuthWidget loopback identity", () => {
+  it("hides the auth and logout affordance for loopback identity", () => {
+    expect(
+      shouldHideAuthWidget({
+        display_name: "Local",
+        email: "",
+        expires_at: 0,
+        org_id: "",
+        provider: "loopback",
+        user_id: "local",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the widget visible for gated identities", () => {
+    expect(
+      shouldHideAuthWidget({
+        display_name: "",
+        email: "",
+        expires_at: 123,
+        org_id: "org",
+        provider: "portal",
+        user_id: "user-1",
+      }),
+    ).toBe(false);
+  });
+});
+
+// --- Integration tests: AuthWidget + real api.getAuthMe ---
+
+/** Return a fetch mock that resolves with a JSON Response. */
+function jsonFetchMock(body: unknown, status = 200) {
+  return vi.fn<typeof fetch>(
+    async () =>
+      new Response(JSON.stringify(body), {
+        headers: { "Content-Type": "application/json" },
+        status,
+      }),
+  );
+}
+
+/** Wait one microtick for React to flush state updates. */
+function flush() {
+  return act(() => Promise.resolve());
+}
+
+describe("AuthWidget integration (real getAuthMe)", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  afterEach(() => {
+    if (root) {
+      root.unmount();
+    }
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function setupWindow(overrides: Partial<Window> = {}) {
+    vi.stubGlobal("window", {
+      __HERMES_SESSION_TOKEN__: undefined,
+      __HERMES_BASE_PATH__: "",
+      location: { assign: vi.fn(), pathname: "/", search: "" },
+      ...overrides,
+    });
+  }
+
+  function render() {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(<AuthWidget />);
+    });
+  }
+
+  it("hides itself when /api/auth/me returns a loopback identity", async () => {
+    setupWindow({ __HERMES_SESSION_TOKEN__: "loopback-token" });
+    const identity = {
+      display_name: "Local",
+      email: "",
+      expires_at: 0,
+      org_id: "",
+      provider: "loopback",
+      user_id: "local",
+    };
+    const fetchMock = jsonFetchMock(identity);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render();
+
+    // Wait for the async getAuthMe request to resolve and state to flush.
+    await flush();
+
+    // The widget should be hidden: no DOM, no logout button.
+    expect(container.innerHTML).toBe("");
+    expect(container.querySelector('[aria-label="Log out"]')).toBeNull();
+    expect(container.textContent).not.toContain("via");
+
+    // Prove the request went through the real getAuthMe → fetchJSON path.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/auth/me");
+    expect((init!.headers as Headers).get("X-Hermes-Session-Token")).toBe(
+      "loopback-token",
+    );
+  });
+
+  it("renders user info when /api/auth/me returns a non-loopback identity", async () => {
+    setupWindow({ __HERMES_SESSION_TOKEN__: "portal-token" });
+    const identity = {
+      display_name: "Ada",
+      email: "ada@example.com",
+      expires_at: 9999999999,
+      org_id: "org-1",
+      provider: "portal",
+      user_id: "user-ada-123",
+    };
+    const fetchMock = jsonFetchMock(identity);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render();
+    await flush();
+
+    // The widget should be visible with the provider and logout button.
+    expect(container.innerHTML).not.toBe("");
+    expect(container.textContent).toContain("Ada");
+    expect(container.textContent).toContain("via portal");
+    expect(container.querySelector('[aria-label="Log out"]')).not.toBeNull();
+  });
+
+  it("hides on 401 (missing/invalid token in loopback mode)", async () => {
+    setupWindow({ __HERMES_SESSION_TOKEN__: "bad-token" });
+    // fetchJSON throws "401: Unauthorized" for non-OK without envelope.
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        new Response("Unauthorized", {
+          status: 401,
+          statusText: "Unauthorized",
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render();
+    await flush();
+
+    // Widget should hide on 401.
+    expect(container.innerHTML).toBe("");
+    expect(container.querySelector('[aria-label="Log out"]')).toBeNull();
+  });
+});

--- a/web/src/components/AuthWidget.tsx
+++ b/web/src/components/AuthWidget.tsx
@@ -25,6 +25,7 @@
 
 import { useEffect, useState } from "react";
 import { api, type AuthMeResponse } from "@/lib/api";
+import { shouldHideAuthWidget } from "./auth-widget-visibility";
 import { cn } from "@/lib/utils";
 import { LogOut } from "lucide-react";
 
@@ -45,19 +46,16 @@ export function AuthWidget({ className }: AuthWidgetProps) {
   const [hidden, setHidden] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Loopback / --insecure mode: the auth gate is off, so /api/auth/me is a
-  // guaranteed 401. Don't fire the request at all — it only produces console
-  // noise ("Failed to load resource: 401") on every dashboard load.
-  const gated =
-    typeof window !== "undefined" && !!window.__HERMES_AUTH_REQUIRED__;
-
   useEffect(() => {
-    if (!gated) return;
     let cancelled = false;
     api
       .getAuthMe()
       .then((data) => {
         if (cancelled) return;
+        if (shouldHideAuthWidget(data)) {
+          setHidden(true);
+          return;
+        }
         setMe(data);
       })
       .catch((err: unknown) => {
@@ -77,10 +75,7 @@ export function AuthWidget({ className }: AuthWidgetProps) {
     return () => {
       cancelled = true;
     };
-  }, [gated]);
-
-  // Nothing to show in ungated mode — there is no logged-in identity.
-  if (!gated) return null;
+  }, []);
 
   if (hidden) return null;
 

--- a/web/src/components/auth-widget-visibility.ts
+++ b/web/src/components/auth-widget-visibility.ts
@@ -1,0 +1,5 @@
+import type { AuthMeResponse } from '@/lib/api'
+
+export function shouldHideAuthWidget(identity: AuthMeResponse): boolean {
+  return identity.provider === 'loopback'
+}

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -173,3 +173,24 @@ describe("api OAuth helpers", () => {
     }
   });
 });
+
+describe("api.getAuthMe loopback contract", () => {
+  it("accepts a token-authenticated synthetic loopback identity", async () => {
+    vi.stubGlobal("window", { __HERMES_SESSION_TOKEN__: "loopback-token" });
+    const identity = {
+      display_name: "Local",
+      email: "",
+      expires_at: 0,
+      org_id: "",
+      provider: "loopback",
+      user_id: "local",
+    };
+    const fetchMock = jsonFetchMock(identity);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(api.getAuthMe()).resolves.toEqual(identity);
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Headers).get(SESSION_HEADER)).toBe("loopback-token");
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -340,19 +340,14 @@ export const api = {
   /**
    * Identity probe for the dashboard auth gate (Phase 7).
    *
-   * Returns the verified Session as JSON when gated mode is active and a
-   * valid cookie is attached. Loopback mode is unaffected — the endpoint
-   * still exists but is never useful there (no Session, no cookie). The
-   * AuthWidget component swallows 401s from this call: if the gate isn't
-   * engaged, /api/auth/me returns 401 and the widget renders nothing.
+   * Returns the verified Session when gated mode is active. In loopback mode,
+   * a valid injected session token returns a synthetic ``provider=loopback``
+   * identity; AuthWidget recognizes that provider and renders nothing, so it
+   * never exposes a logout action that would redirect to an unavailable login.
    *
-   * ``allowUnauthorized`` is load-bearing: in loopback mode this endpoint
-   * 401s by design, and fetchJSON's default loopback behaviour treats a
-   * 401 as a rotated session token and full-page-reloads to pick up a
-   * fresh one. Because every *other* dashboard request succeeds (and so
-   * clears the one-shot reload guard), that turns this expected 401 into
-   * an infinite reload loop. Opting out keeps the 401 a plain throw the
-   * widget can catch.
+   * ``allowUnauthorized`` remains load-bearing for a missing or stale loopback
+   * token: keep that 401 local to the widget instead of triggering the global
+   * rotated-token reload path.
    */
   getAuthMe: () =>
     fetchJSON<AuthMeResponse>("/api/auth/me", undefined, {
@@ -1324,7 +1319,8 @@ export const api = {
 /** Identity payload returned by ``GET /api/auth/me`` (Phase 7).
  *
  * Returned by the dashboard's gated middleware when a valid session cookie
- * is attached. ``email`` and ``display_name`` are empty strings under the
+ * is attached, or as a synthetic ``provider=loopback`` identity after token
+ * validation in local mode. ``email`` and ``display_name`` are empty strings under the
  * Nous Portal contract V1 (the access token has no email/name claims —
  * see Contract Anchor C4 in the plan). The AuthWidget surfaces a
  * truncated ``user_id`` instead.


### PR DESCRIPTION
## Problem

In loopback mode (`--host 127.0.0.1`, `auth_required=False`), the dashboard SPA shows a blank green screen because `/api/auth/me` returns **401** even with a valid `_SESSION_TOKEN`, while every other `/api/` endpoint (e.g. `/api/sessions`) accepts the same token and returns 200.

## Root Cause

`/api/auth/me` unconditionally checks `request.state.session`. In gated mode (`auth_required=True`) the `gated_auth_middleware` populates that attribute. In **loopback mode**, `gated_auth_middleware` is a **no-op** and never sets `request.state.session` — the legacy `auth_middleware` validates the ephemeral `_SESSION_TOKEN` but does not attach a session object. The handler sees `session=None` and always raises 401.

## Fix

When `request.state.session` is absent **and** the app is in loopback mode (`auth_required=False`), re-verify the `_SESSION_TOKEN` (belt-and-braces) and return a minimal loopback identity:

```json
{"user_id": "local", "email": "", "display_name": "Local", "org_id": "", "provider": "loopback", "expires_at": 0}
```

Gated-mode behavior is unchanged — still requires `request.state.session`.

**Security:** `/api/auth/me` is NOT in `PUBLIC_API_PATHS`, so the legacy `auth_middleware` already gates it with the session token in loopback mode. The handler re-verifies the token as a defense-in-depth measure so the endpoint stays safe even if the route were ever allowlisted.

## Verification

**Fail-without-fix (on `upstream/main` before this change):**
```
test_api_auth_me_returns_loopback_identity_with_valid_token FAILED
  AssertionError: Expected 200 with a valid token in loopback mode, got 401
1 failed, 1 passed
```

**After fix:**
- `tests/hermes_cli/test_dashboard_auth_middleware.py` — **35/35 passed**
  - `test_api_auth_me_returns_loopback_identity_with_valid_token` ✓ (regression — valid token → 200 with loopback identity)
  - `test_api_auth_me_still_rejects_missing_token_in_loopback` ✓ (security boundary — no token → 401)
  - `test_api_auth_me_requires_auth` ✓ (gated mode → 401)
- `ruff check` — clean
- `git diff --check` — clean

Closes #66223.

---
*Auto-published by Moonsong via Path B automated pipeline.*