### PR TITLE
fix(gateway): make expiry finalization atomic and retryable

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8040,10 +8040,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Marking as finalized to prevent infinite retry loop.",
                                 failures, entry.session_id, e,
                             )
-                            await self.async_session_store.set_expiry_finalized(
-                                entry, clear_model_override=False
-                            )
-                            _finalize_failures.pop(entry.session_id, None)
+                            try:
+                                await self.async_session_store.set_expiry_finalized(
+                                    entry, clear_model_override=False
+                                )
+                            except Exception as durable_error:
+                                logger.warning(
+                                    "Session %s cleanup gave up, but its durable "
+                                    "expiry boundary still failed; retaining it "
+                                    "for retry: %s",
+                                    entry.session_id,
+                                    durable_error,
+                                )
+                            else:
+                                _finalize_failures.pop(entry.session_id, None)
                         else:
                             logger.debug(
                                 "Session finalize failed (%d/%d) for %s: %s",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1577,17 +1577,40 @@ class SessionStore:
             logger.debug("Gateway session peer record failed for %s: %s", session_key, exc)
 
     def set_expiry_finalized(
-        self, entry: SessionEntry, *, clear_model_override: bool = True
+        self,
+        entry: SessionEntry,
+        *,
+        clear_model_override: bool = True,
     ) -> None:
-        """Mark a session entry expiry-finalized in memory, sessions.json, AND state.db.
+        """Durably close an expired session, then mark its routing entry finalized.
 
         Single write-path for the expiry watcher (#9006): keeps the durable
-        state.db flag in sync with the JSON routing index so the flag
-        survives sessions.json pruning/loss.
+        state.db boundary in sync with the JSON routing index so it survives
+        sessions.json pruning/loss.
 
-        ``clear_model_override=False`` preserves the give-up path's original
-        behavior (flag only, no override drop).
+        The DB boundary is written first. If it fails, the in-memory flag stays
+        false so the watcher retries instead of recording a false success that
+        stale-route recovery could resurrect (#61220).
         """
+        if self._db:
+            finalizer = getattr(self._db, "finalize_expired_session", None)
+            try:
+                if callable(finalizer):
+                    finalizer(entry.session_id)
+                else:
+                    # Compatibility with older/custom SessionDB facades. The
+                    # recovery query's expiry flag guard still blocks revival.
+                    setter = getattr(self._db, "set_expiry_finalized", None)
+                    if callable(setter):
+                        setter(entry.session_id, True)
+            except Exception as exc:
+                logger.warning(
+                    "Session DB expiry finalization failed for %s: %s",
+                    entry.session_id,
+                    exc,
+                )
+                raise
+
         with self._lock:
             entry.expiry_finalized = True
             if clear_model_override:
@@ -1596,32 +1619,6 @@ class SessionStore:
                 # rehydrate it after the in-memory override was popped.
                 entry.model_override = None
             self._save()
-        if self._db:
-            setter = getattr(self._db, "set_expiry_finalized", None)
-            if callable(setter):
-                try:
-                    setter(entry.session_id, True)
-                except Exception as exc:
-                    logger.debug(
-                        "Session DB expiry_finalized write failed for %s: %s",
-                        entry.session_id, exc,
-                    )
-            try:
-                # Expiry finalization is a real conversation boundary. Without
-                # a durable ``session_reset`` end_reason, later agent cleanup can
-                # close the row as ``agent_close``; stale-route recovery treats
-                # that as resumable and resurrects the expired full history.
-                #
-                # promote_to_session_reset is conditional: it only promotes
-                # live rows or rows ended with ``agent_close``.  Explicit
-                # boundaries (compression, session_reset, new_command, etc.)
-                # are preserved — the first writer wins.
-                self._db.promote_to_session_reset(entry.session_id)
-            except Exception as exc:
-                logger.debug(
-                    "Session DB promote_to_session_reset failed for %s: %s",
-                    entry.session_id, exc,
-                )
     
     def _is_session_expired(self, entry: SessionEntry) -> bool:
         """Check if a session has expired based on its reset policy.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1980,6 +1980,45 @@ class SessionDB:
 
         self._execute_write(_do)
 
+    def finalize_expired_session(self, session_id: str) -> bool:
+        """Atomically persist an expiry boundary and its finalized flag.
+
+        Ordinary ``agent_close`` / ``ws_orphan_reap`` rows remain recoverable
+        because those reasons can mean resource eviction rather than a logical
+        conversation boundary. Expiry is different: once finalized, the old
+        transcript must not be reopened. Update both facts in one SQLite
+        transaction so recovery cannot observe a partially finalized row.
+
+        Existing explicit boundaries (compression, /new, session switch, and
+        similar reasons) are preserved while still recording that expiry
+        cleanup completed. Returns ``False`` only when the row is absent or
+        ``session_id`` is empty.
+        """
+        if not session_id:
+            return False
+        now = time.time()
+
+        def _do(conn):
+            cursor = conn.execute(
+                """
+                UPDATE sessions
+                   SET expiry_finalized = 1,
+                       ended_at = CASE
+                           WHEN ended_at IS NULL
+                             OR end_reason IN ('agent_close', 'ws_orphan_reap')
+                           THEN ? ELSE ended_at END,
+                       end_reason = CASE
+                           WHEN ended_at IS NULL
+                             OR end_reason IN ('agent_close', 'ws_orphan_reap')
+                           THEN 'session_reset' ELSE end_reason END
+                 WHERE id = ?
+                """,
+                (now, session_id),
+            )
+            return cursor.rowcount
+
+        return bool(self._execute_write(_do))
+
     # ── Gateway routing index (replaces sessions.json, #9006 follow-up) ────
 
     def save_gateway_routing_entry(
@@ -2223,6 +2262,7 @@ class SessionDB:
                 SELECT * FROM sessions
                 WHERE session_key = ?
                   AND source = ?
+                  AND COALESCE(expiry_finalized, 0) = 0
                   AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
                   AND (COALESCE(message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1
@@ -2248,6 +2288,7 @@ class SessionDB:
                   AND COALESCE(chat_id, '') = COALESCE(?, '')
                   AND COALESCE(chat_type, '') = COALESCE(?, '')
                   AND COALESCE(thread_id, '') = COALESCE(?, '')
+                  AND COALESCE(expiry_finalized, 0) = 0
                   AND (ended_at IS NULL OR end_reason IN ('agent_close', 'ws_orphan_reap'))
                   AND (COALESCE(message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1

--- a/tests/gateway/test_expiry_finalization_boundary.py
+++ b/tests/gateway/test_expiry_finalization_boundary.py
@@ -1,0 +1,158 @@
+"""Durable session boundary tests for expiry finalization (#61220).
+
+The expiry watcher must make an expired transcript non-recoverable without
+breaking recovery for ordinary agent resource eviction. The database update
+must also be atomic: the expiry flag and logical end reason cannot diverge.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.session import SessionEntry, SessionStore
+from hermes_state import SessionDB
+
+
+_SESSION_KEY = "agent:main:telegram:dm:8494508720"
+_SOURCE = "telegram"
+_USER_ID = "8494508720"
+
+
+@pytest.fixture
+def db(tmp_path: Path):
+    session_db = SessionDB(tmp_path / "state.db")
+    try:
+        yield session_db
+    finally:
+        session_db.close()
+
+
+def _create_recoverable_session(db: SessionDB, session_id: str) -> None:
+    db.create_session(
+        session_id,
+        _SOURCE,
+        user_id=_USER_ID,
+        session_key=_SESSION_KEY,
+        chat_id=_USER_ID,
+        chat_type="dm",
+    )
+    db.append_message(session_id, "user", "hello")
+
+
+def _recover(db: SessionDB):
+    return db.find_latest_gateway_session_for_peer(
+        source=_SOURCE,
+        session_key=_SESSION_KEY,
+        user_id=_USER_ID,
+        chat_id=_USER_ID,
+        chat_type="dm",
+    )
+
+
+@pytest.mark.parametrize("prior_reason", [None, "agent_close", "ws_orphan_reap"])
+def test_finalize_expired_session_atomically_closes_recoverable_rows(
+    db: SessionDB, prior_reason: str | None
+) -> None:
+    _create_recoverable_session(db, "sid-expired")
+    if prior_reason is not None:
+        db.end_session("sid-expired", prior_reason)
+
+    assert db.finalize_expired_session("sid-expired") is True
+
+    row = db.get_session("sid-expired")
+    assert row is not None
+    assert row["expiry_finalized"] == 1
+    assert row["end_reason"] == "session_reset"
+    assert row["ended_at"] is not None
+    assert _recover(db) is None
+
+
+def test_finalize_expired_session_preserves_explicit_boundary(db: SessionDB) -> None:
+    _create_recoverable_session(db, "sid-compressed")
+    db.end_session("sid-compressed", "compression")
+    before = db.get_session("sid-compressed")
+    assert before is not None
+    ended_at = before["ended_at"]
+
+    assert db.finalize_expired_session("sid-compressed") is True
+
+    row = db.get_session("sid-compressed")
+    assert row is not None
+    assert row["expiry_finalized"] == 1
+    assert row["end_reason"] == "compression"
+    assert row["ended_at"] == ended_at
+
+
+def test_recovery_rejects_legacy_finalized_agent_close_row(db: SessionDB) -> None:
+    """Backstop old rows created before end_reason promotion existed."""
+    _create_recoverable_session(db, "sid-legacy")
+    db.end_session("sid-legacy", "agent_close")
+    db.set_expiry_finalized("sid-legacy", True)
+
+    assert _recover(db) is None
+
+
+def test_recovery_keeps_ordinary_agent_close_recoverable(db: SessionDB) -> None:
+    """Resource eviction without expiry must retain #54878 recovery semantics."""
+    _create_recoverable_session(db, "sid-evicted")
+    db.end_session("sid-evicted", "agent_close")
+
+    recovered = _recover(db)
+    assert recovered is not None
+    assert recovered["id"] == "sid-evicted"
+
+
+def _store(tmp_path: Path, db_mock: MagicMock) -> SessionStore:
+    config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+    store._db = db_mock
+    store._loaded = True
+    return store
+
+
+def _entry() -> SessionEntry:
+    now = datetime.now()
+    return SessionEntry(
+        session_key=_SESSION_KEY,
+        session_id="sid-store",
+        created_at=now - timedelta(hours=2),
+        updated_at=now - timedelta(hours=1),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        model_override={"model": "temporary"},
+    )
+
+
+def test_store_does_not_mark_finalized_when_durable_boundary_fails(
+    tmp_path: Path,
+) -> None:
+    """A DB failure must remain retryable instead of becoming a false success."""
+    db_mock = MagicMock()
+    db_mock.finalize_expired_session.side_effect = RuntimeError("database locked")
+    store = _store(tmp_path, db_mock)
+    entry = _entry()
+
+    with pytest.raises(RuntimeError, match="database locked"):
+        store.set_expiry_finalized(entry)
+
+    assert entry.expiry_finalized is False
+    assert entry.model_override == {"model": "temporary"}
+
+
+def test_store_persists_boundary_before_marking_entry_finalized(tmp_path: Path) -> None:
+    db_mock = MagicMock()
+    db_mock.finalize_expired_session.return_value = True
+    store = _store(tmp_path, db_mock)
+    entry = _entry()
+
+    store.set_expiry_finalized(entry)
+
+    db_mock.finalize_expired_session.assert_called_once_with("sid-store")
+    assert entry.expiry_finalized is True
+    assert entry.model_override is None


### PR DESCRIPTION
## Summary

Follow-up to #65783 for the #61220 expired-session resurrection bug class.

- atomically persist `expiry_finalized = 1` and the non-recoverable `session_reset` boundary
- exclude already-finalized legacy rows from both exact-key and peer-tuple recovery
- write the durable DB boundary before marking the routing entry finalized
- keep durable write failures retryable, including after cleanup reaches its retry limit
- preserve ordinary `agent_close` / `ws_orphan_reap` recovery and existing explicit boundaries such as compression or session switch

## Why this is still needed after #65783

The merged fix promotes recoverable end reasons to reset boundaries, but expiry finalization still performs separate best-effort writes: the routing entry is marked first, then `expiry_finalized` and `session_reset` are written independently while DB errors are swallowed. A transient DB failure can therefore record an in-memory/JSON success without a durable non-recoverable boundary, preventing the watcher from retrying. Historical rows with `expiry_finalized = 1` and `end_reason = agent_close` also remain eligible for recovery.

This patch makes the expiry-specific DB transition atomic and treats durable failure as retryable rather than successful.

## Verification

- `python -m py_compile hermes_state.py gateway/session.py gateway/run.py tests/gateway/test_expiry_finalization_boundary.py`
- 486 targeted session/gateway/state tests passed
- `python -m ruff check gateway/run.py gateway/session.py hermes_state.py tests/gateway/test_expiry_finalization_boundary.py`
- `git diff --check origin/main...HEAD`
