### PR TITLE
fix(cli): sanitize terminal escapes in the /history command output

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6836,6 +6836,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 _cli_visible_print("(._.) No conversation history yet.")
             return
 
+        from tools.ansi_strip import sanitize_display_text as _sanitize_display_text
+
         preview_limit = 400
         visible_index = 0
         hidden_tool_messages = 0
@@ -6885,7 +6887,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             visible_index += 1
 
             content = msg.get("content")
-            content_text = "" if content is None else str(content)
+            # Stored history is untrusted for display: strip escape sequences /
+            # control chars so replaying a message via /history can't clear the
+            # screen, retitle the window, or move the cursor — the same guard
+            # the /resume and /status recaps use (tools/ansi_strip).
+            content_text = _sanitize_display_text(
+                "" if content is None else str(content)
+            )
 
             if role == "user":
                 _cli_visible_print(f"\n  [You #{visible_index}]{_ts_suffix(msg)}")

--- a/tests/hermes_cli/test_timestamps_command.py
+++ b/tests/hermes_cli/test_timestamps_command.py
@@ -96,3 +96,22 @@ def test_history_hides_timestamps_when_off():
     # label present, no [HH:MM] suffix
     first_label_line = out.split("[You #1]")[1].split("\n")[0]
     assert "[" not in first_label_line
+
+
+def test_history_sanitizes_terminal_escapes_in_stored_content():
+    """Stored history is untrusted for display: replaying a message via
+    /history must strip terminal escapes / control chars so a crafted turn
+    can't clear the screen or retitle the window (same guard as the /resume
+    and /status recaps)."""
+    # CSI clear-screen + OSC set-window-title + a bare BEL control byte.
+    esc = "\x1b[2J\x1b]0;pwned\x07"
+    hist = [
+        {"role": "user", "content": f"hello {esc} world"},
+        {"role": "assistant", "content": f"reply {esc} here"},
+    ]
+    out = _render_history(hist, show_ts=False)
+    assert "\x1b" not in out  # no ESC byte survives to the terminal
+    assert "\x07" not in out  # no bare BEL
+    # visible text is preserved
+    assert "hello" in out and "world" in out
+    assert "reply" in out and "here" in out


### PR DESCRIPTION
## What does this PR do?

Follow-up to the `/resume` and `/status` recap escape sanitization: the
`/history` command (`HermesCLI.show_history`) replays stored conversation
content to the terminal via `_cli_visible_print` with **no** escape stripping.
Stored history is untrusted for display — pasted content, gateway-origin text,
and model output echoing injected tool results can carry raw CSI/OSC sequences
and control bytes — so a crafted turn shown in `/history` could clear the
screen, retitle the window, move the cursor, or restyle the UI. The recap paths
were hardened for exactly this class; the `/history` panel was the remaining
replay path.

Each message's content now goes through `tools.ansi_strip.sanitize_display_text`
before preview/truncation, matching `_display_resumed_history` and
`build_recap`. Visible text is preserved; only escapes/control chars are removed.

## Related Issue

No separate issue — completes the stored-history escape sanitization for the
`/history` command that the `/resume` + `/status` recap fix didn't cover.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `cli.py` — in `HermesCLI.show_history`, route each message's content through
  `sanitize_display_text` before building the `/history` preview lines.
- `tests/hermes_cli/test_timestamps_command.py` — add
  `test_history_sanitizes_terminal_escapes_in_stored_content`.

## How to Test

1. `pytest tests/hermes_cli/test_timestamps_command.py -q` → **6 passed**.
2. Proof the fix works — revert only the `cli.py` change and re-run the new
   test: it fails because the raw `\x1b`/`\x07` bytes reach the captured output
   (a clear-screen + set-window-title + BEL payload prints verbatim). With the
   fix the delivered lines contain no ESC/BEL bytes while the surrounding words
   are preserved.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the affected suite (`pytest tests/hermes_cli/test_timestamps_command.py -q`) and all tests pass
- [x] I've added tests for my changes
- [x] I've tested locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation — inline rationale added; no external docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (terminal-escape stripping is OS-independent)