### PR TITLE
fix(qqbot): add return_exceptions to asyncio.gather in chunk upload

### DIFF
--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -599,4 +599,7 @@ async def _run_with_concurrency(
         async with sem:
             await thunk()
 
-    await asyncio.gather(*(_wrap(t) for t in tasks))
+    results = await asyncio.gather(*(_wrap(t) for t in tasks), return_exceptions=True)
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result


### PR DESCRIPTION
## Summary

Add `return_exceptions=True` to `asyncio.gather()` in `_run_with_concurrency` (qqbot chunked_upload).

## Problem

`asyncio.gather()` without `return_exceptions=True` propagates the first exception immediately and cancels all other in-flight coroutines. If one chunk of a multipart upload raises (e.g. transient network error), all other in-flight part uploads get cancelled, leaving the multipart upload in an inconsistent state.

## Fix

Add `return_exceptions=True` so each task's exception is captured in the results list. The first exception is re-raised after all tasks settle, preserving the existing `None` return type and caller contract.

## Testing
- Syntax check passed (py_compile)
- Behavior verified