### PR TITLE
fix(state): heal alternation at every remaining live-replay restore site (salvage #65672)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -534,9 +534,15 @@ class SessionManager:
 
         model = row.get("model") or None
 
-        # Load conversation history.
+        # Load conversation history. repair_alternation: this restore feeds
+        # LIVE REPLAY — the loaded list becomes the resumed agent's working
+        # conversation. A durable ``user;user`` violation left in state.db would
+        # otherwise re-fire the pre-request defensive repair on every request
+        # for the rest of the session (see hermes_state.get_messages_as_conversation).
         try:
-            history = db.get_messages_as_conversation(session_id)
+            history = db.get_messages_as_conversation(
+                session_id, repair_alternation=True
+            )
         except Exception:
             logger.warning("Failed to load messages for ACP session %s", session_id, exc_info=True)
             history = []

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -770,8 +770,14 @@ class CLICommandsMixin:
         self._pending_title = None
         _sync_process_session_id(target_id)
 
-        # Load conversation history (strip transcript-only metadata entries)
-        restored = self._session_db.get_messages_as_conversation(target_id)
+        # Load conversation history (strip transcript-only metadata entries).
+        # repair_alternation: this /resume feeds LIVE REPLAY — ``restored``
+        # becomes ``self.conversation_history`` for subsequent turns. Heal a
+        # durable ``user;user`` violation once here instead of re-firing the
+        # pre-request repair on every request for the rest of the session.
+        restored = self._session_db.get_messages_as_conversation(
+            target_id, repair_alternation=True
+        )
         restored = [m for m in (restored or []) if m.get("role") != "session_meta"]
         self.conversation_history = restored
 

--- a/tests/hermes_state/test_restore_alternation_repair.py
+++ b/tests/hermes_state/test_restore_alternation_repair.py
@@ -70,3 +70,45 @@ def test_repair_noop_on_clean_transcript(db):
     repaired = db.get_messages_as_conversation("s2", repair_alternation=True)
     assert [m["role"] for m in repaired] == [m["role"] for m in verbatim]
     assert [m["content"] for m in repaired] == [m["content"] for m in verbatim]
+
+
+# ---------------------------------------------------------------------------
+# The live-replay restore SITES must pass repair_alternation=True. The initial
+# fix covered gateway load_transcript + CLI startup resume; these are the other
+# live-replay restore paths (ACP session resume, CLI /resume, TUI resume) that
+# hand the loaded transcript to a live agent for subsequent turns.
+# ---------------------------------------------------------------------------
+
+
+def _seed_wedged_acp_session(db, session_id="acp1"):
+    db.create_session(session_id, "acp")
+    db.append_message(session_id=session_id, role="user", content="first ask")
+    db.append_message(session_id=session_id, role="assistant", content="first reply")
+    db.append_message(session_id=session_id, role="user", content="unanswered turn")
+    db.append_message(session_id=session_id, role="user", content="next turn")
+    db.append_message(session_id=session_id, role="assistant", content="next reply")
+
+
+def test_acp_restore_heals_alternation_for_live_replay(db):
+    """acp_adapter.SessionManager._restore feeds LIVE REPLAY: the loaded history
+    becomes the resumed agent's working conversation. It must be alternation-
+    clean so the pre-request repair doesn't re-fire every turn."""
+    from acp_adapter.session import SessionManager
+
+    _seed_wedged_acp_session(db, "acp1")
+
+    class _StubAgent:
+        model = "stub"
+
+    mgr = SessionManager(agent_factory=lambda: _StubAgent(), db=db)
+    state = mgr._restore("acp1")
+
+    assert state is not None
+    roles = [m["role"] for m in state.history]
+    # No consecutive user turns — the durable user;user wedge was healed.
+    assert roles == ["user", "assistant", "user", "assistant"], roles
+    for a, b in zip(roles, roles[1:]):
+        assert not (a == "user" and b == "user"), "unhealed user;user in ACP live replay"
+    # No user input lost — both user texts survive, merged in order.
+    merged = state.history[2]["content"]
+    assert "unanswered turn" in merged and "next turn" in merged

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1392,7 +1392,7 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
         def reopen_session(self, target):
             captured["reopened"] = target
 
-        def get_messages_as_conversation(self, target, include_ancestors=False):
+        def get_messages_as_conversation(self, target, include_ancestors=False, repair_alternation=False):
             captured.setdefault("history_calls", []).append((target, include_ancestors))
             return (
                 [
@@ -1528,7 +1528,7 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
         def reopen_session(self, target):
             pass
 
-        def get_messages_as_conversation(self, target, include_ancestors=False):
+        def get_messages_as_conversation(self, target, include_ancestors=False, repair_alternation=False):
             return [{"role": "user", "content": "hello"}]
 
     def fake_make_agent(sid, key, session_id=None, session_db=None, **kwargs):
@@ -1588,7 +1588,7 @@ def test_session_resume_profile_uses_profile_db_cwd(monkeypatch, tmp_path):
         def reopen_session(self, _target):
             captured["reopened"] = _target
 
-        def get_messages_as_conversation(self, _target, include_ancestors=False):
+        def get_messages_as_conversation(self, _target, include_ancestors=False, repair_alternation=False):
             return [{"role": "user", "content": "hello"}]
 
         def update_session_cwd(self, *_args):
@@ -5262,7 +5262,7 @@ def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
                 "pinned": True,
             }
 
-        def get_messages_as_conversation(self, key, include_ancestors=True):
+        def get_messages_as_conversation(self, key, include_ancestors=True, repair_alternation=False):
             assert key == "session-key"
             assert include_ancestors is True
             return list(history_from_db)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -562,7 +562,11 @@ class TestToolNamePreservation(unittest.TestCase):
             captured["acp_command"] = kwargs.get("acp_command")
             captured["acp_args"] = kwargs.get("acp_args")
 
-        mock_which.assert_called_with("copilot")
+        # any_call, not called_with: the patch is global to shutil.which, so an
+        # unrelated which("uv") from a code path reached later in the same
+        # process (order-dependent under CI test-slicing) can be the *last*
+        # call. The intent here is only that the copilot binary was probed.
+        mock_which.assert_any_call("copilot")
         self.assertNotEqual(
             captured["provider"],
             "copilot-acp",

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -346,7 +346,7 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
         def reopen_session(self, _sid):
             return None
 
-        def get_messages_as_conversation(self, _sid, include_ancestors=False):
+        def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [
                 {"role": "user", "content": "hello"},
                 {"role": "assistant", "content": "yo", "reasoning": "thoughts"},
@@ -406,7 +406,7 @@ def test_session_resume_defaults_to_deferred_build(server, monkeypatch):
         def reopen_session(self, _sid):
             return None
 
-        def get_messages_as_conversation(self, _sid, include_ancestors=False):
+        def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [
                 {"role": "user", "content": "hello"},
                 {"role": "assistant", "content": "yo"},
@@ -547,7 +547,7 @@ def test_session_resume_handles_multimodal_list_content(server, monkeypatch):
         def reopen_session(self, _sid):
             return None
 
-        def get_messages_as_conversation(self, _sid, include_ancestors=False):
+        def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [multimodal_user, text_only_assistant]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
@@ -597,7 +597,7 @@ def test_session_resume_lazy_registers_watch_session_without_agent(server, monke
         def reopen_session(self, _sid):
             return None
 
-        def get_messages_as_conversation(self, _sid, include_ancestors=False):
+        def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [
                 {"role": "user", "content": "delegated goal"},
             ]
@@ -670,7 +670,7 @@ def test_session_resume_lazy_reports_running_for_inflight_child(server, monkeypa
         def reopen_session(self, _sid):
             return None
 
-        def get_messages_as_conversation(self, _sid, include_ancestors=False):
+        def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [{"role": "user", "content": "delegated goal"}]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
@@ -721,7 +721,7 @@ def test_session_resume_lazy_tolerates_missing_row_for_active_child(server, monk
         def reopen_session(self, _sid):
             return None
 
-        def get_messages_as_conversation(self, _sid, include_ancestors=False):
+        def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             # No rows for an unwritten session.
             return []
 
@@ -818,7 +818,7 @@ def test_session_resume_reuses_existing_live_session(server, monkeypatch):
         def reopen_session(self, _sid):
             return None
 
-        def get_messages_as_conversation(self, _sid, include_ancestors=False):
+        def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             return [
                 {"role": "user", "content": "hello"},
                 {"role": "assistant", "content": "yo"},
@@ -1035,7 +1035,7 @@ def test_session_resume_live_payload_uses_current_history_with_ancestors(server,
         def reopen_session(self, _sid):
             return None
 
-        def get_messages_as_conversation(self, _sid, include_ancestors=False):
+        def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
             if include_ancestors:
                 return ancestor_history + current_history
             return list(current_history)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6000,7 +6000,11 @@ def _(rid, params: dict) -> dict:
             db.reopen_session(target)
             # The child's OWN conversation only — include_ancestors would prepend
             # the parent's transcript onto the subagent's branch.
-            history = db.get_messages_as_conversation(target)
+            # repair_alternation: this resume feeds LIVE REPLAY (the loaded
+            # history becomes the resumed session record's working conversation),
+            # so heal a durable ``user;user`` violation once here instead of
+            # re-firing the pre-request repair on every subsequent turn.
+            history = db.get_messages_as_conversation(target, repair_alternation=True)
         except Exception as e:
             if lease is not None:
                 lease.release()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6069,7 +6069,11 @@ def _(rid, params: dict) -> dict:
         _enable_gateway_prompts()
         try:
             db.reopen_session(target)
-            raw_history = db.get_messages_as_conversation(target)
+            # repair_alternation on the model-fed copy only: this resume feeds
+            # LIVE REPLAY (raw_history → sanitize_replay_history → the resumed
+            # session's working conversation). display_history stays verbatim —
+            # inspection/export must show what is actually stored.
+            raw_history = db.get_messages_as_conversation(target, repair_alternation=True)
             display_history = db.get_messages_as_conversation(target, include_ancestors=True)
         except Exception as e:
             if lease is not None:
@@ -6143,7 +6147,9 @@ def _(rid, params: dict) -> dict:
     )
     try:
         db.reopen_session(target)
-        raw_history = db.get_messages_as_conversation(target)
+        # repair_alternation on the model-fed copy only (see the interactive
+        # resume above): this loads LIVE REPLAY history; display stays verbatim.
+        raw_history = db.get_messages_as_conversation(target, repair_alternation=True)
         display_history = db.get_messages_as_conversation(
             target, include_ancestors=True
         )
@@ -12715,8 +12721,12 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 5008, f"undo: {e}")
         # Reload the active-only transcript into the in-memory session
         # history so subsequent turns see the truncated view.
+        # repair_alternation: this reload feeds LIVE REPLAY — session["history"]
+        # is the working conversation for subsequent turns, and a rewind that
+        # lands on a durable user;user pair would otherwise re-fire the
+        # pre-request repair on every request from here on.
         try:
-            active = db.get_messages_as_conversation(session_key)
+            active = db.get_messages_as_conversation(session_key, repair_alternation=True)
         except Exception:
             active = []
         with session["history_lock"]:


### PR DESCRIPTION
## Summary
Every live-replay restore path now heals durable alternation violations once at load time — salvaging #65672 (@Frowtek, 3 commits cherry-picked with authorship preserved) and widening it to two additional sites found in the sibling audit.

Context (#64934): a turn that persists a `user` row with no `assistant` row leaves a durable `user;user` pair in state.db. Restoring such a session verbatim makes the loaded list the resumed agent's working conversation, so the defensive pre-request `repair_message_sequence` re-fires on every request for the rest of the session's life (observed: 297 times over two weeks on one session) — it only mutates the per-request copy, never the restored base. #65492 healed the gateway `load_transcript` and CLI startup-resume sites; this completes the set.

## Changes
- @Frowtek (#65672): `repair_alternation=True` at ACP session restore (`acp_adapter/session.py`), CLI `/resume` (`hermes_cli/cli_commands_mixin.py`), TUI lazy resume (`tui_gateway/server.py`); regression tests incl. an ACP restore heal test; de-flaked a delegate test (`assert_any_call`).
- Follow-up (sibling audit): the interactive TUI resume and profile-scoped resume also feed live replay via `raw_history → sanitize_replay_history` — healed on the model-fed copy only, `display_history` stays verbatim so inspection/export shows true stored rows. The `/undo` history reload (feeds `session["history"]`) healed too. Display-only consumers (`session.history` RPC, formatted transcript output) intentionally left verbatim.

## Validation
| | Result |
|---|---|
| tests/hermes_state/test_restore_alternation_repair.py (incl. new ACP test) | pass |
| tests/tui_gateway/ + tests/acp_adapter/ + delegate tests | 549/549 pass |

Issue #64934 stays open: this heals existing wedged DBs at every restore boundary; the merged tripwire (#65499) will name the dispatch route that lets two turns overlap, and the serialization fix lands after that.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa29d09/PFv45Ab08G5T5rYVImqG6_wpF2sWBC.png)
