### PR TITLE
fix(runtime): recover stale model and cache state

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -775,6 +775,14 @@ def classify_api_error(
         if classified is not None:
             return classified
 
+    # Local MoA config drift is deterministic: a persisted session can retain
+    # a preset name that was later renamed/deleted. Retrying the same lookup
+    # cannot recover and makes a clear config error look like an API outage.
+    from agent.errors import MoAPresetNotFoundError
+
+    if isinstance(error, MoAPresetNotFoundError):
+        return _result(FailoverReason.model_not_found, retryable=False)
+
     # ── 3. Error code classification ────────────────────────────────
 
     if error_code:

--- a/agent/errors.py
+++ b/agent/errors.py
@@ -7,3 +7,7 @@ class EmptyStreamError(RuntimeError):
     """Raised when a provider closes a stream without yielding a response."""
 
     pass
+
+
+class MoAPresetNotFoundError(ValueError):
+    """Raised when a persisted MoA preset no longer exists in config."""

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -13,6 +13,20 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
 
 
+def _bounded_prompt_cache_key(value: Any) -> Optional[str]:
+    """Return a provider-safe cache key without changing session identity."""
+    if value is None:
+        return None
+    key = str(value).strip()
+    if not key:
+        return None
+    if len(key) <= 64:
+        return key
+    # Match _content_cache_key's compact, collision-resistant routing-key shape.
+    digest = hashlib.sha256(key.encode("utf-8", errors="replace")).hexdigest()[:24]
+    return f"pck_{digest}"
+
+
 def _content_cache_key(instructions: str, tools: Optional[List[Dict[str, Any]]]) -> Optional[str]:
     """Content-address the prompt cache key from the static request prefix.
 
@@ -304,6 +318,13 @@ class ResponsesApiTransport(ProviderTransport):
         if request_overrides:
             kwargs.update(request_overrides)
 
+        if "prompt_cache_key" in kwargs:
+            bounded_cache_key = _bounded_prompt_cache_key(kwargs["prompt_cache_key"])
+            if bounded_cache_key:
+                kwargs["prompt_cache_key"] = bounded_cache_key
+            else:
+                kwargs.pop("prompt_cache_key", None)
+
         # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
         # supported: service_tier") — hit when ``/fast`` priority-processing
         # mode lingers from a prior model in the same session, or when a
@@ -337,15 +358,7 @@ class ResponsesApiTransport(ProviderTransport):
             # remain high.  Send session_id / x-client-request-id as HTTP
             # headers while keeping ``prompt_cache_key`` in the body for
             # standard OpenAI routing as a belt-and-braces fallback.
-            cache_scope_id = str(session_id or "").strip()
-            # OpenAI/Codex backend enforces 64-char limit on the session_id
-            # and x-client-request-id headers, mapping them internally to
-            # prompt_cache_key. Hash long IDs to stay within the limit;
-            # the hash is a cache-routing hint only, never a correctness bound.
-            if len(cache_scope_id) > 64:
-                cache_scope_id = "pck_" + hashlib.sha256(
-                    cache_scope_id.encode("utf-8", "replace")
-                ).hexdigest()[:24]
+            cache_scope_id = _bounded_prompt_cache_key(session_id)
             if cache_scope_id:
                 existing_extra_headers = kwargs.get("extra_headers")
                 merged_extra_headers: Dict[str, str] = {}
@@ -389,6 +402,14 @@ class ResponsesApiTransport(ProviderTransport):
                 merged_extra_body.update(existing_extra_body)
             merged_extra_body.setdefault("prompt_cache_key", cache_key)
             kwargs["extra_body"] = merged_extra_body
+
+        extra_body = kwargs.get("extra_body")
+        if isinstance(extra_body, dict) and "prompt_cache_key" in extra_body:
+            bounded_cache_key = _bounded_prompt_cache_key(extra_body["prompt_cache_key"])
+            if bounded_cache_key:
+                extra_body["prompt_cache_key"] = bounded_cache_key
+            else:
+                extra_body.pop("prompt_cache_key", None)
 
         return kwargs
 
@@ -478,11 +499,26 @@ class ResponsesApiTransport(ProviderTransport):
         Normalizes input items, strips unsupported fields, validates structure.
         """
         from agent.codex_responses_adapter import _preflight_codex_api_kwargs
-        return _preflight_codex_api_kwargs(
+
+        normalized = _preflight_codex_api_kwargs(
             api_kwargs,
             allow_stream=allow_stream,
             is_github_responses=is_github_responses,
         )
+        if "prompt_cache_key" in normalized:
+            bounded = _bounded_prompt_cache_key(normalized["prompt_cache_key"])
+            if bounded:
+                normalized["prompt_cache_key"] = bounded
+            else:
+                normalized.pop("prompt_cache_key", None)
+        extra_body = normalized.get("extra_body")
+        if isinstance(extra_body, dict) and "prompt_cache_key" in extra_body:
+            bounded = _bounded_prompt_cache_key(extra_body["prompt_cache_key"])
+            if bounded:
+                extra_body["prompt_cache_key"] = bounded
+            else:
+                extra_body.pop("prompt_cache_key", None)
+        return normalized
 
     def map_finish_reason(self, raw_reason: str) -> str:
         """Map Codex response.status to OpenAI finish_reason.

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -338,6 +338,14 @@ class ResponsesApiTransport(ProviderTransport):
             # headers while keeping ``prompt_cache_key`` in the body for
             # standard OpenAI routing as a belt-and-braces fallback.
             cache_scope_id = str(session_id or "").strip()
+            # OpenAI/Codex backend enforces 64-char limit on the session_id
+            # and x-client-request-id headers, mapping them internally to
+            # prompt_cache_key. Hash long IDs to stay within the limit;
+            # the hash is a cache-routing hint only, never a correctness bound.
+            if len(cache_scope_id) > 64:
+                cache_scope_id = "pck_" + hashlib.sha256(
+                    cache_scope_id.encode("utf-8", "replace")
+                ).hexdigest()[:24]
             if cache_scope_id:
                 existing_extra_headers = kwargs.get("extra_headers")
                 merged_extra_headers: Dict[str, str] = {}

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -295,7 +295,13 @@ def resolve_moa_preset(config: Any, name: str | None = None) -> dict[str, Any]:
     preset_name = str(name or cfg.get("default_preset") or DEFAULT_MOA_PRESET_NAME).strip()
     preset = cfg["presets"].get(preset_name)
     if preset is None:
-        raise KeyError(preset_name)
+        from agent.errors import MoAPresetNotFoundError
+
+        available = ", ".join(cfg["presets"]) or "(none)"
+        raise MoAPresetNotFoundError(
+            f"MoA preset '{preset_name}' was not found. Available presets: "
+            f"{available}. Run `hermes moa list`."
+        )
     return deepcopy(preset)
 
 

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -160,6 +160,23 @@ class OSSBackend(Mem0Backend):
         import os
         from mem0 import Memory
 
+        def _provider_block(name: str) -> dict:
+            block = dict(oss_config[name])
+            provider = str(block.get("provider") or "").strip().lower()
+            provider_config = dict(block.get("config", {}))
+            legacy_base = provider_config.pop("api_base", None)
+            if legacy_base:
+                from ._oss_providers import EMBEDDER_PROVIDERS, LLM_PROVIDERS
+
+                provider_def = (
+                    LLM_PROVIDERS if name == "llm" else EMBEDDER_PROVIDERS
+                ).get(provider, {})
+                canonical_key = provider_def.get("base_url_key")
+                if canonical_key:
+                    provider_config.setdefault(canonical_key, legacy_base)
+            block["config"] = provider_config
+            return block
+
         vector_store = dict(oss_config["vector_store"])
         vs_config = dict(vector_store.get("config", {}))
 
@@ -182,8 +199,8 @@ class OSSBackend(Mem0Backend):
 
         config = {
             "vector_store": vector_store,
-            "llm": oss_config["llm"],
-            "embedder": oss_config["embedder"],
+            "llm": _provider_block("llm"),
+            "embedder": _provider_block("embedder"),
             "version": "v1.1",
         }
         self._memory = Memory.from_config(config)

--- a/plugins/memory/mem0/_oss_providers.py
+++ b/plugins/memory/mem0/_oss_providers.py
@@ -11,12 +11,14 @@ LLM_PROVIDERS: dict[str, dict[str, Any]] = {
         "needs_key": True,
         "env_var": "OPENAI_API_KEY",
         "default_model": "gpt-5-mini",
+        "base_url_key": "openai_base_url",
     },
     "ollama": {
         "label": "Ollama (local)",
         "needs_key": False,
         "default_model": "llama3.1:8b",
         "default_url": "http://localhost:11434",
+        "base_url_key": "ollama_base_url",
         "pip_dep": "ollama",
     },
 }
@@ -27,6 +29,7 @@ EMBEDDER_PROVIDERS: dict[str, dict[str, Any]] = {
         "needs_key": True,
         "env_var": "OPENAI_API_KEY",
         "default_model": "text-embedding-3-small",
+        "base_url_key": "openai_base_url",
         "dims": 1536,
     },
     "ollama": {
@@ -34,6 +37,7 @@ EMBEDDER_PROVIDERS: dict[str, dict[str, Any]] = {
         "needs_key": False,
         "default_model": "nomic-embed-text",
         "default_url": "http://localhost:11434",
+        "base_url_key": "ollama_base_url",
         "dims": 768,
         "pip_dep": "ollama",
     },

--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -135,15 +135,17 @@ def build_oss_config(flags: dict[str, str]) -> tuple[dict, dict[str, str]]:
     llm_def = LLM_PROVIDERS[llm_id]
     llm_model = flags.get("oss_llm_model") or llm_def["default_model"]
     llm_config: dict[str, Any] = {"model": llm_model}
-    if "default_url" in llm_def:
-        llm_config["ollama_base_url"] = flags.get("oss_llm_url") or llm_def["default_url"]
+    llm_url = flags.get("oss_llm_url") or llm_def.get("default_url")
+    if llm_url and llm_def.get("base_url_key"):
+        llm_config[llm_def["base_url_key"]] = llm_url
 
     embedder_id = flags.get("oss_embedder", "openai")
     embedder_def = EMBEDDER_PROVIDERS[embedder_id]
     embedder_model = flags.get("oss_embedder_model") or embedder_def["default_model"]
     embedder_config: dict[str, Any] = {"model": embedder_model}
-    if "default_url" in embedder_def:
-        embedder_config["ollama_base_url"] = flags.get("oss_embedder_url") or embedder_def["default_url"]
+    embedder_url = flags.get("oss_embedder_url") or embedder_def.get("default_url")
+    if embedder_url and embedder_def.get("base_url_key"):
+        embedder_config[embedder_def["base_url_key"]] = embedder_url
     dims = KNOWN_DIMS.get(embedder_model)
     if dims:
         embedder_config["embedding_dims"] = dims

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -371,6 +371,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "nicktaylor@TheWorldofNick-Lappy.local": "thegoodguysla",
     "s96919@gmail.com": "s96919",
     "rasitakyol@hotmail.com": "rasitakyol",
     "thatgfsj@gmail.com": "Thatgfsj",

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -341,20 +341,74 @@ class TestCodexBuildKwargs:
         assert kw["prompt_cache_key"].startswith("pck_")
         assert len(kw["prompt_cache_key"]) <= 64
 
-    def test_codex_backend_overlength_cache_scope_is_stable(self, transport):
-        session_id = "paperclip:company:" + "a" * 80
-        kwargs = {
-            "model": "gpt-5.4",
-            "messages": [{"role": "user", "content": "Hi"}],
-            "tools": [],
-            "session_id": session_id,
-            "is_codex_backend": True,
-        }
+    @pytest.mark.parametrize("length", [64, 65])
+    def test_codex_cache_scope_boundary(self, transport, length):
+        session_id = "s" * length
+        scope = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            session_id=session_id,
+            is_codex_backend=True,
+            request_overrides={"extra_headers": {"x-test": "1"}},
+        )["extra_headers"]
 
-        first = transport.build_kwargs(**kwargs)["extra_headers"]["session_id"]
-        second = transport.build_kwargs(**kwargs)["extra_headers"]["session_id"]
+        assert scope["x-test"] == "1"
+        assert len(scope["session_id"]) <= 64
+        assert scope["x-client-request-id"] == scope["session_id"]
+        if length == 64:
+            assert scope["session_id"] == session_id
+        else:
+            assert scope["session_id"].startswith("pck_")
+            assert scope["session_id"] != session_id
 
-        assert first == second
+    def test_codex_backend_overlength_cache_scope_is_stable_and_collision_resistant(self, transport):
+        common = "paperclip:company:" + "a" * 80
+
+        def cache_scope(session_id):
+            return transport.build_kwargs(
+                model="gpt-5.4",
+                messages=[{"role": "user", "content": "Hi"}],
+                tools=[],
+                session_id=session_id,
+                is_codex_backend=True,
+            )["extra_headers"]["session_id"]
+
+        assert cache_scope(common + "1") == cache_scope(common + "1")
+        assert cache_scope(common + "1") != cache_scope(common + "2")
+
+    def test_long_override_keys_are_bounded_at_build_and_preflight(self, transport):
+        long_key = "paperclip:" + "x" * 130
+        kwargs = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            request_overrides={"prompt_cache_key": long_key},
+        )
+        assert len(kwargs["prompt_cache_key"]) <= 64
+
+        middleware_payload = dict(kwargs)
+        middleware_payload["prompt_cache_key"] = long_key
+        preflight = transport.preflight_kwargs(middleware_payload)
+        assert preflight["prompt_cache_key"].startswith("pck_")
+        assert len(preflight["prompt_cache_key"]) <= 64
+
+    def test_xai_long_override_key_is_bounded_at_build_and_preflight(self, transport):
+        long_key = "paperclip:" + "x" * 130
+        kwargs = transport.build_kwargs(
+            model="grok-4.3",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            is_xai_responses=True,
+            request_overrides={"extra_body": {"prompt_cache_key": long_key}},
+        )
+        assert len(kwargs["extra_body"]["prompt_cache_key"]) <= 64
+
+        middleware_payload = dict(kwargs)
+        middleware_payload["extra_body"] = {"prompt_cache_key": long_key}
+        preflight = transport.preflight_kwargs(middleware_payload)
+        assert preflight["extra_body"]["prompt_cache_key"].startswith("pck_")
+        assert len(preflight["extra_body"]["prompt_cache_key"]) <= 64
 
     def test_codex_backend_no_headers_without_session_id(self, transport):
         messages = [{"role": "user", "content": "Hi"}]

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -320,6 +320,42 @@ class TestCodexBuildKwargs:
         assert headers.get("session_id") == "conv-codex-1"
         assert headers.get("x-client-request-id") == "conv-codex-1"
 
+    def test_codex_backend_hashes_overlength_cache_routing_headers(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        long_session_id = "paperclip:company:" + "a" * 80
+
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            session_id=long_session_id,
+            is_codex_backend=True,
+        )
+
+        headers = kw["extra_headers"]
+        cache_scope = headers["session_id"]
+        assert cache_scope == headers["x-client-request-id"]
+        assert cache_scope.startswith("pck_")
+        assert len(cache_scope) <= 64
+        assert cache_scope != long_session_id
+        assert kw["prompt_cache_key"].startswith("pck_")
+        assert len(kw["prompt_cache_key"]) <= 64
+
+    def test_codex_backend_overlength_cache_scope_is_stable(self, transport):
+        session_id = "paperclip:company:" + "a" * 80
+        kwargs = {
+            "model": "gpt-5.4",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "tools": [],
+            "session_id": session_id,
+            "is_codex_backend": True,
+        }
+
+        first = transport.build_kwargs(**kwargs)["extra_headers"]["session_id"]
+        second = transport.build_kwargs(**kwargs)["extra_headers"]["session_id"]
+
+        assert first == second
+
     def test_codex_backend_no_headers_without_session_id(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
 

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -1,3 +1,6 @@
+import pytest
+
+from agent.errors import MoAPresetNotFoundError
 from hermes_cli.moa_config import (
     DEFAULT_MOA_AGGREGATOR,
     DEFAULT_MOA_PRESET_NAME,
@@ -203,6 +206,46 @@ def test_resolve_moa_preset_returns_requested_model_set():
     assert resolve_moa_preset(cfg, "review")["reference_models"] == [
         {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
     ]
+
+
+def test_resolve_missing_moa_preset_has_actionable_error():
+    cfg = {
+        "default_preset": "日常对话-高峰",
+        "presets": {"日常对话-高峰": {}, "日常对话-非高峰": {}},
+    }
+
+    with pytest.raises(MoAPresetNotFoundError) as exc_info:
+        resolve_moa_preset(cfg, "日常对话-高峰期")
+
+    message = str(exc_info.value)
+    assert "日常对话-高峰期" in message
+    assert "日常对话-高峰" in message
+    assert "日常对话-非高峰" in message
+    assert "hermes moa list" in message
+
+
+def test_resolve_missing_moa_preset_does_not_silently_fallback():
+    cfg = {
+        "default_preset": "日常对话-高峰",
+        "presets": {"日常对话-高峰": {}},
+    }
+
+    with pytest.raises(MoAPresetNotFoundError):
+        resolve_moa_preset(cfg, "renamed-preset")
+
+
+def test_missing_moa_preset_is_non_retryable():
+    from agent.error_classifier import FailoverReason, classify_api_error
+
+    result = classify_api_error(
+        MoAPresetNotFoundError("MoA preset 'old' was not found"),
+        provider="moa",
+        model="old",
+    )
+
+    assert result.reason == FailoverReason.model_not_found
+    assert result.retryable is False
+    assert result.should_fallback is False
 
 
 def test_build_moa_turn_prompt_encodes_one_shot_default_preset():

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -1,5 +1,6 @@
 """Tests for Mem0Backend abstraction — PlatformBackend, OSSBackend, SelfHostedBackend."""
 
+import copy
 import pytest
 
 from plugins.memory.mem0._backend import (
@@ -190,6 +191,37 @@ class TestOSSBackend:
         backend, _ = self._make()
         result = backend.delete("m1")
         assert result == {"result": "Memory deleted.", "memory_id": "m1"}
+
+    def test_legacy_api_base_aliases_are_normalized_before_mem0_init(self, monkeypatch):
+        captured = {}
+
+        class Memory:
+            @staticmethod
+            def from_config(config):
+                captured.update(config)
+                return FakeOSSMemory()
+
+        monkeypatch.setattr("mem0.Memory", Memory)
+        raw = {
+            "llm": {
+                "provider": "openai",
+                "config": {"model": "gpt-5-mini", "api_base": "https://llm.example/v1"},
+            },
+            "embedder": {
+                "provider": "ollama",
+                "config": {"model": "nomic-embed-text", "api_base": "http://ollama:11434"},
+            },
+            "vector_store": {"provider": "qdrant", "config": {}},
+        }
+        before = copy.deepcopy(raw)
+
+        OSSBackend(raw)
+
+        assert captured["llm"]["config"]["openai_base_url"] == "https://llm.example/v1"
+        assert captured["embedder"]["config"]["ollama_base_url"] == "http://ollama:11434"
+        assert "api_base" not in captured["llm"]["config"]
+        assert "api_base" not in captured["embedder"]["config"]
+        assert raw == before
 
 
 httpx = pytest.importorskip("httpx")

--- a/tests/plugins/memory/test_mem0_setup.py
+++ b/tests/plugins/memory/test_mem0_setup.py
@@ -96,11 +96,28 @@ class TestBuildOSSConfig:
         assert oss["vector_store"]["provider"] == "qdrant"
         assert env_writes["OPENAI_API_KEY"] == "sk-oai"
 
+    def test_openai_custom_urls_use_mem0_provider_specific_keys(self):
+        flags = parse_flags([
+            "--mode", "oss",
+            "--oss-llm-key", "sk-oai",
+            "--oss-llm-url", "https://llm.example/v1",
+            "--oss-embedder-url", "https://embed.example/v1",
+        ])
+
+        oss, _ = build_oss_config(flags)
+
+        assert oss["llm"]["config"]["openai_base_url"] == "https://llm.example/v1"
+        assert oss["embedder"]["config"]["openai_base_url"] == "https://embed.example/v1"
+        assert "api_base" not in oss["llm"]["config"]
+        assert "api_base" not in oss["embedder"]["config"]
+
     def test_ollama_no_key_needed(self):
         flags = parse_flags(["--mode", "oss", "--oss-llm", "ollama", "--oss-embedder", "ollama"])
         oss, env_writes = build_oss_config(flags)
         assert oss["llm"]["provider"] == "ollama"
         assert "model" in oss["llm"]["config"]
+        assert oss["llm"]["config"]["ollama_base_url"] == "http://localhost:11434"
+        assert oss["embedder"]["config"]["ollama_base_url"] == "http://localhost:11434"
         assert env_writes == {}
 
     def test_embedder_reuses_llm_key(self):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1163,6 +1163,35 @@ def test_copilot_final_preflight_sanitizes_both_middleware_layers(monkeypatch):
     ]
 
 
+def test_codex_final_preflight_bounds_middleware_cache_key(monkeypatch):
+    """Execution middleware cannot reintroduce an over-length provider key."""
+    agent = _build_agent(monkeypatch)
+    setattr(agent, "_disable_streaming", True)
+    captured = {}
+    long_key = "paperclip:" + "x" * 130
+
+    def _execution_middleware(request, next_call, **_context):
+        replacement = dict(request)
+        replacement["prompt_cache_key"] = long_key
+        return next_call(replacement)
+
+    def _capture_api_call(api_kwargs):
+        captured.update(api_kwargs)
+        return _codex_message_response("OK")
+
+    monkeypatch.setattr(
+        "hermes_cli.middleware.run_llm_execution_middleware",
+        _execution_middleware,
+    )
+    monkeypatch.setattr(agent, "_interruptible_api_call", _capture_api_call)
+
+    result = agent.run_conversation("Say OK")
+
+    assert result["completed"] is True
+    assert captured["prompt_cache_key"].startswith("pck_")
+    assert len(captured["prompt_cache_key"]) <= 64
+
+
 def test_run_conversation_codex_empty_output_with_output_text(monkeypatch):
     """Regression: empty response.output + valid output_text should succeed,
     not trigger retry/fallback. The validation stage must defer to


### PR DESCRIPTION
## Summary
Long session identifiers, renamed MoA presets, and legacy Mem0 OSS URL fields now fail safely or self-heal at their owning boundaries.

## Changes
- **Codex transport:** bound over-length cache-scope headers, top-level override keys, and xAI body keys through one deterministic helper; reapply the guard at final preflight after middleware; preserve short IDs and unrelated headers unchanged.
- **MoA config:** keep stale persisted preset names fail-closed, report the missing name, every valid configured preset, and `hermes moa list`, and classify the local lookup as deterministic so it surfaces immediately instead of burning retries.
- **Mem0 OSS:** normalize legacy `api_base` fields to the provider-specific URL key accepted by `mem0ai==2.0.10`, without mutating saved config; centralize URL-key metadata in the provider registry.
- Add full transport/config/backend regression coverage.

The Codex header fix cherry-picks #66272 by @webtecnica with authorship preserved, then folds in the broader final-boundary design from #62349 by @thegoodguysla. @Armib20 first submitted the long-cache-key defense in #24273; @gracejudy supplied the live evidence that isolated the current production failure to cache-scope headers rather than the already-bounded generated body key.

Issue #65847's overflow failure was fixed by #66139. Its Desktop error surface and session-scoped model picker are already present on current main, including #65777; this PR closes the remaining stale-preset and legacy Mem0 configuration failures.

## Validation
| Path | Before | After |
|---|---|---|
| 98-char Codex session ID / late override | unbounded provider-facing cache keys; backend HTTP 400 | deterministic ≤64-char keys at build and final preflight |
| Renamed MoA preset | bare `KeyError`, retried as opaque API failure | immediate actionable valid-preset list; no silent model fallback |
| Mem0 OSS legacy `api_base` | `BaseEmbedderConfig` unexpected-keyword failure | provider-specific accepted URL field |
| Targeted tests | regression reproduced | 277 passed |

Real-import E2E exercised `ResponsesApiTransport.build_kwargs`, `resolve_moa_preset`, and `OSSBackend` against the installed Mem0 2.0.10 boundary.

Fixes #65847.
Fixes #66045.

## Infographic

![Stale state, clear recovery](https://v3b.fal.media/files/b/0aa29d0b/O1KMwVlS2kduuzFc8vLzo_QXeTluYV.png)
