### PR TITLE
fix(desktop): trust Windows system CAs for remote gateways

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5,6 +5,7 @@ import http from 'node:http'
 import https from 'node:https'
 import os from 'node:os'
 import path from 'node:path'
+import tls from 'node:tls'
 import { pathToFileURL } from 'node:url'
 
 import {
@@ -142,6 +143,7 @@ import {
   getVenvSitePackagesEntries,
   resolveVenvHermesCommand
 } from './windows-hermes-path'
+import { installWindowsSystemCaTrust } from './windows-system-ca'
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
@@ -9149,6 +9151,16 @@ app.on('open-url', (event, url) => {
 })
 
 app.whenReady().then(() => {
+  const systemCa = installWindowsSystemCaTrust(tls)
+
+  if (systemCa.applied) {
+    rememberLog(
+      `[tls] trusting ${systemCa.systemCertificateCount} Windows system CA certificate(s) for backend connections`
+    )
+  } else if (systemCa.error) {
+    rememberLog(`[tls] could not load Windows system CA certificates: ${systemCa.error}`)
+  }
+
   if (IS_MAC) {
     Menu.setApplicationMenu(buildApplicationMenu())
   } else {

--- a/apps/desktop/electron/windows-system-ca.test.ts
+++ b/apps/desktop/electron/windows-system-ca.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { installWindowsSystemCaTrust, type NodeTlsCaApi } from './windows-system-ca'
+
+function fakeTlsApi(
+  defaults: string[] = ['bundled-ca', 'extra-ca'],
+  system: string[] = ['windows-root-ca']
+): NodeTlsCaApi & { installed: string[][] } {
+  const installed: string[][] = []
+
+  return {
+    installed,
+    getCACertificates(type = 'default') {
+      return type === 'system' ? [...system] : [...defaults]
+    },
+    setDefaultCACertificates(certificates) {
+      installed.push([...certificates])
+    }
+  }
+}
+
+test('installs Windows system CAs without dropping existing defaults', () => {
+  const tlsApi = fakeTlsApi(['mozilla-root', 'extra-ca'], ['machine-root', 'user-root'])
+
+  const result = installWindowsSystemCaTrust(tlsApi, 'win32')
+
+  assert.deepEqual(tlsApi.installed, [['mozilla-root', 'extra-ca', 'machine-root', 'user-root']])
+  assert.deepEqual(result, {
+    applied: true,
+    systemCertificateCount: 2,
+    totalCertificateCount: 4
+  })
+})
+
+test('does not inspect or replace CAs outside Windows', () => {
+  let reads = 0
+
+  const tlsApi: NodeTlsCaApi = {
+    getCACertificates() {
+      reads += 1
+
+      return []
+    },
+    setDefaultCACertificates() {
+      throw new Error('should not install')
+    }
+  }
+
+  const result = installWindowsSystemCaTrust(tlsApi, 'darwin')
+
+  assert.equal(reads, 0)
+  assert.deepEqual(result, {
+    applied: false,
+    systemCertificateCount: 0,
+    totalCertificateCount: 0
+  })
+})
+
+test('leaves the existing defaults untouched when Windows has no system CAs', () => {
+  const tlsApi = fakeTlsApi(['mozilla-root'], [])
+
+  const result = installWindowsSystemCaTrust(tlsApi, 'win32')
+
+  assert.deepEqual(tlsApi.installed, [])
+  assert.deepEqual(result, {
+    applied: false,
+    systemCertificateCount: 0,
+    totalCertificateCount: 1
+  })
+})
+
+test('fails open when the runtime cannot load the Windows certificate store', () => {
+  const tlsApi: NodeTlsCaApi = {
+    getCACertificates(type = 'default') {
+      if (type === 'system') {
+        throw new Error('certificate store unavailable')
+      }
+
+      return ['mozilla-root']
+    },
+    setDefaultCACertificates() {
+      throw new Error('should not install')
+    }
+  }
+
+  const result = installWindowsSystemCaTrust(tlsApi, 'win32')
+
+  assert.deepEqual(result, {
+    applied: false,
+    systemCertificateCount: 0,
+    totalCertificateCount: 0,
+    error: 'certificate store unavailable'
+  })
+})

--- a/apps/desktop/electron/windows-system-ca.ts
+++ b/apps/desktop/electron/windows-system-ca.ts
@@ -1,0 +1,56 @@
+interface NodeTlsCaApi {
+  getCACertificates(type?: 'default' | 'system'): string[]
+  setDefaultCACertificates(certificates: string[]): void
+}
+
+interface WindowsSystemCaResult {
+  applied: boolean
+  systemCertificateCount: number
+  totalCertificateCount: number
+  error?: string
+}
+
+function installWindowsSystemCaTrust(
+  tlsApi: NodeTlsCaApi,
+  platform = process.platform
+): WindowsSystemCaResult {
+  if (platform !== 'win32') {
+    return {
+      applied: false,
+      systemCertificateCount: 0,
+      totalCertificateCount: 0
+    }
+  }
+
+  try {
+    const defaultCertificates = tlsApi.getCACertificates('default')
+    const systemCertificates = tlsApi.getCACertificates('system')
+
+    if (systemCertificates.length === 0) {
+      return {
+        applied: false,
+        systemCertificateCount: 0,
+        totalCertificateCount: defaultCertificates.length
+      }
+    }
+
+    const certificates = [...defaultCertificates, ...systemCertificates]
+    tlsApi.setDefaultCACertificates(certificates)
+
+    return {
+      applied: true,
+      systemCertificateCount: systemCertificates.length,
+      totalCertificateCount: certificates.length
+    }
+  } catch (error) {
+    return {
+      applied: false,
+      systemCertificateCount: 0,
+      totalCertificateCount: 0,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}
+
+export { installWindowsSystemCaTrust }
+export type { NodeTlsCaApi, WindowsSystemCaResult }


### PR DESCRIPTION
## Summary
- load Windows-trusted CA certificates into Electron's Node TLS defaults before any remote gateway request
- preserve the existing Mozilla and `NODE_EXTRA_CA_CERTS` trust roots
- fail open with a useful `desktop.log` diagnostic if the Windows certificate store cannot be loaded

## Why
Hermes Desktop's Node-side `/api/status` and WebSocket probes do not use the Windows certificate store. A remote gateway signed by a private CA can therefore work in browsers but fail in Desktop with `unable to verify the first certificate`, even when that CA is installed under `LocalMachine\\Root` or `CurrentUser\\Root`.

Electron 40 includes Node 24.11.1, so this uses the native `tls.getCACertificates('system')` and `tls.setDefaultCACertificates()` APIs. Certificate verification remains enabled.

This is the Windows counterpart to #57239, whose keychain fix is explicitly macOS-only.

## Test plan
- [x] `npm run test:desktop:platforms` — 436 passed, 1 skipped
- [x] `npm run typecheck`
- [x] `npx eslint electron/main.ts electron/windows-system-ca.ts electron/windows-system-ca.test.ts`
- [x] `npm run build`