### PR TITLE
Add vortex-notes skill (productivity): shared markdown memory with local semantic search

### DIFF
--- a/optional-skills/productivity/vortex-notes/SKILL.md
+++ b/optional-skills/productivity/vortex-notes/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: vortex-notes
+description: Read, search, and write the user's Vortex Notes vault — plain-markdown
+  notes with zero-config local semantic search, daily journaling, and durable facts
+  with supersession. Use for "note this down", "remember that…", "what do my notes
+  say about…", and building context before a task. CLI and MCP integration.
+version: 1.0.0
+author: Vortex303
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [Notes, Knowledge-Base, Memory, Markdown, MCP, Search, Local-AI]
+    related_skills: [qmd, obsidian, native-mcp]
+---
+
+# Vortex Notes — the vault your agents can actually use
+
+The user's knowledge base is a folder of plain `.md` files ("the vault") with a
+first-party MCP server and built-in hybrid semantic search (BM25 + multilingual
+embeddings, fully local, no API key).
+
+## When to Use
+
+- The user says "note this down", "add to my notes", "remember that…"
+- You need prior context: "what do my notes say about X", "what did we decide"
+- Daily journaling: observations, decisions, progress logs
+- Any task that benefits from the user's accumulated knowledge
+
+## Prerequisites
+
+```sh
+npm install -g vortex-notes
+vortex-notes init            # creates ~/VortexNotes (or ask the user for their vault)
+```
+
+Vault resolution: `--vault <dir>` flag > `$VORTEX_NOTES_VAULT` > `~/VortexNotes`.
+
+## Quick Reference
+
+| Task | Command / action |
+|---|---|
+| Search (always start here) | `vortex-notes search "<query>" --vault <vault>` |
+| Read a note | read the `.md` file directly |
+| Daily entry | append `- **HH:MM** <entry>` to `daily/YYYY-MM-DD.md` |
+| Durable fact | append dated bullet with `^f-<id>` to `memory/facts.md` |
+| Rebuild index | `vortex-notes index --vault <vault>` |
+
+Search is hybrid keyword + semantic and multilingual — natural-language queries
+work, and a query in English finds notes written in Spanish.
+
+## Writing Conventions
+
+- Notes are markdown with YAML frontmatter (`title`, `tags`, `created`, `updated`).
+  `[[Wikilinks]]` reference other notes by title or filename — follow them.
+- **Daily journal**: `daily/YYYY-MM-DD.md`, one timestamped bullet per entry:
+  `- **HH:MM** shipped the relay deploy`. Create with `title: YYYY-MM-DD` and a
+  `daily` tag if missing.
+- **Facts** ("remember that X"): `memory/facts.md` (or `memory/<topic>.md`):
+  `- **YYYY-MM-DD** <fact> \`^f-<8 random lowercase chars>\``.
+  If a fact REPLACES an older one, strike the old line through and point forward:
+  `- ~~old line~~ → superseded YYYY-MM-DD by \`^f-new\`` — never delete history.
+- **Edits**: surgical (append a section, fix a line); preserve frontmatter and
+  bump `updated`. Never rewrite whole notes unless asked.
+
+The vault's watcher reindexes automatically after any write.
+
+## MCP Integration
+
+Preferred when the harness supports MCP (stdio):
+
+```json
+{ "command": "vortex-notes", "args": ["mcp"], "env": { "VORTEX_NOTES_VAULT": "<vault>" } }
+```
+
+If the user granted this agent its own scoped access via `npx vortex-notes pair`,
+that command wires Hermes automatically and a bare `vortex-notes mcp` (no flags)
+serves the paired vault — nothing else to configure.
+
+If the user granted this agent its own scoped access (an `vnat1_…` agent token),
+a single self-bootstrapping command replaces all setup:
+
+```json
+{ "command": "vortex-notes", "args": ["agent", "mcp", "<vnat1_token>"] }
+```
+
+Tools: `search_notes`, `read_note`, `write_note`, `edit_note` (surgical),
+`append_daily`, `remember` (facts with supersession), `build_context` (top notes
+plus one hop of wikilinks in one call), `recent_activity`, `list_notes`.
+Add `--read-only` for a search/read-only connection. The MCP tools encode all
+the conventions above — prefer `remember` and `append_daily` over manual writes.
+
+## Best Practices
+
+1. Search before writing — the note or fact may already exist (then edit/supersede).
+2. Use `build_context` (MCP) at task start instead of several search+read rounds.
+3. Put durable knowledge in `memory/`, ephemera in `daily/` — don't mix.
+4. Keep facts self-contained: they must make sense without conversation context.
+5. Respect `--read-only` vaults: search and read, never suggest workarounds.
+
+## Data Storage
+
+Vault = plain markdown, portable, Obsidian-compatible. Search index lives in
+`<vault>/.vortex/index.db` (disposable cache — the files are the truth).
+Optional E2EE multi-device sync exists (`vortex-notes sync`); it never changes
+the on-disk format.
+
+## References
+
+- https://github.com/vortex-303/vortex-notes
+- `vortex-notes help`

--- a/optional-skills/productivity/vortex-notes/SKILL.md
+++ b/optional-skills/productivity/vortex-notes/SKILL.md
@@ -1,111 +1,100 @@
 ---
 name: vortex-notes
-description: Read, search, and write the user's Vortex Notes vault — plain-markdown
-  notes with zero-config local semantic search, daily journaling, and durable facts
-  with supersession. Use for "note this down", "remember that…", "what do my notes
-  say about…", and building context before a task. CLI and MCP integration.
-version: 1.0.0
-author: Vortex303
+description: Read, search, and update the user's encrypted notes vault.
+version: 1.1.0
+author: Nico Ruggieri (@vortex-303)
 license: MIT
-platforms: [macos, linux]
+platforms: [macos, linux, windows]
 metadata:
   hermes:
-    tags: [Notes, Knowledge-Base, Memory, Markdown, MCP, Search, Local-AI]
+    tags: [Notes, Knowledge-Base, Memory, Markdown, MCP]
     related_skills: [qmd, obsidian, native-mcp]
 ---
 
-# Vortex Notes — the vault your agents can actually use
+# Vortex Notes Skill
 
-The user's knowledge base is a folder of plain `.md` files ("the vault") with a
-first-party MCP server and built-in hybrid semantic search (BM25 + multilingual
-embeddings, fully local, no API key).
+The user's knowledge base is a folder of plain markdown files ("the vault") that
+Vortex Notes exposes through a first-party MCP server with built-in on-device
+semantic search. Use this skill to read, search, and write that vault. It does
+NOT manage arbitrary files or the user's editor, and it never touches sync keys —
+it speaks only to the paired Vortex Notes vault.
 
 ## When to Use
 
-- The user says "note this down", "add to my notes", "remember that…"
-- You need prior context: "what do my notes say about X", "what did we decide"
-- Daily journaling: observations, decisions, progress logs
-- Any task that benefits from the user's accumulated knowledge
+- The user says "note this down", "add to my notes", "remember that…".
+- You need prior context: "what do my notes say about X", "what did we decide".
+- Daily journaling: observations, decisions, progress logs.
+- Building context before a task from the user's accumulated knowledge.
 
 ## Prerequisites
 
+This skill drives the **`vortex-notes` MCP server** (preferred), with a CLI fallback.
+
+Install and connect once, via the `terminal` tool:
+
 ```sh
 npm install -g vortex-notes
-vortex-notes init            # creates ~/VortexNotes (or ask the user for their vault)
+npx vortex-notes pair          # prints a 6-letter code; the user approves it in the app
 ```
 
-Vault resolution: `--vault <dir>` flag > `$VORTEX_NOTES_VAULT` > `~/VortexNotes`.
+Pairing gives this agent its own scoped, revocable key — it never sees the user's
+recovery phrase, and every edit it makes is signed as the agent. Once the host
+has the `vortex-notes` MCP server wired, no per-call CLI is needed. CLI-fallback
+vault resolution: `$VORTEX_NOTES_VAULT` > the paired vault.
+
+## How to Run
+
+Prefer the MCP tools exposed by the `vortex-notes` server:
+
+- `search_notes` — hybrid keyword + semantic, multilingual. **Always start here.**
+- `read_note` — fetch a note by path.
+- `write_note` / `edit_note` — create or surgically update a note.
+- `append_daily` — add a timestamped line to today's journal.
+- `remember` — record a durable fact; supersedes the prior version rather than
+  overwriting it.
+- `build_context` — assemble the relevant notes for the current task.
+
+If the MCP server is unavailable, fall back to native Hermes tools against the
+vault directory: `search_files` to locate notes, `read_file` to read a `.md`,
+and `patch` to edit one.
 
 ## Quick Reference
 
-| Task | Command / action |
-|---|---|
-| Search (always start here) | `vortex-notes search "<query>" --vault <vault>` |
-| Read a note | read the `.md` file directly |
-| Daily entry | append `- **HH:MM** <entry>` to `daily/YYYY-MM-DD.md` |
-| Durable fact | append dated bullet with `^f-<id>` to `memory/facts.md` |
-| Rebuild index | `vortex-notes index --vault <vault>` |
+| Task | MCP tool | Native fallback |
+|---|---|---|
+| Find notes (start here) | `search_notes` | `search_files` |
+| Read a note | `read_note` | `read_file` |
+| Add / update a note | `write_note` / `edit_note` | `patch` |
+| Daily entry | `append_daily` | `patch` on `daily/YYYY-MM-DD.md` |
+| Durable fact | `remember` | `patch` on `memory/facts.md` |
 
-Search is hybrid keyword + semantic and multilingual — natural-language queries
-work, and a query in English finds notes written in Spanish.
+## Procedure
 
-## Writing Conventions
+1. **Search before writing.** Call `search_notes` (or `search_files`) to see
+   whether the topic already exists; prefer updating over duplicating.
+2. **Read the candidate** with `read_note` / `read_file` before editing.
+3. **Write the smallest change** with `edit_note` / `patch`, keeping notes plain
+   markdown so they stay Obsidian-compatible.
+4. **Journal transient observations** with `append_daily`; reserve `remember`
+   for durable facts that should supersede an earlier belief.
+5. **Write in the user's voice only when asked** — the agent's edits are already
+   signed as the agent.
 
-- Notes are markdown with YAML frontmatter (`title`, `tags`, `created`, `updated`).
-  `[[Wikilinks]]` reference other notes by title or filename — follow them.
-- **Daily journal**: `daily/YYYY-MM-DD.md`, one timestamped bullet per entry:
-  `- **HH:MM** shipped the relay deploy`. Create with `title: YYYY-MM-DD` and a
-  `daily` tag if missing.
-- **Facts** ("remember that X"): `memory/facts.md` (or `memory/<topic>.md`):
-  `- **YYYY-MM-DD** <fact> \`^f-<8 random lowercase chars>\``.
-  If a fact REPLACES an older one, strike the old line through and point forward:
-  `- ~~old line~~ → superseded YYYY-MM-DD by \`^f-new\`` — never delete history.
-- **Edits**: surgical (append a section, fix a line); preserve frontmatter and
-  bump `updated`. Never rewrite whole notes unless asked.
+## Pitfalls
 
-The vault's watcher reindexes automatically after any write.
+- Don't create a new note when `search_notes` shows a close match — update it.
+- `remember` supersedes; don't hand-delete the old fact — the struck-through
+  trail is intentional and auditable.
+- The vault may be end-to-end encrypted; never read raw sync blobs or the relay —
+  always go through the MCP server or the paired vault files.
+- A password-locked note returns a placeholder from `read_note`; do not treat
+  that placeholder as the note's content.
+- Pairing is per-agent and revocable; if calls start failing with an auth error,
+  the user likely revoked this agent — ask them to re-pair.
 
-## MCP Integration
+## Verification
 
-Preferred when the harness supports MCP (stdio):
-
-```json
-{ "command": "vortex-notes", "args": ["mcp"], "env": { "VORTEX_NOTES_VAULT": "<vault>" } }
-```
-
-If the user granted this agent its own scoped access via `npx vortex-notes pair`,
-that command wires Hermes automatically and a bare `vortex-notes mcp` (no flags)
-serves the paired vault — nothing else to configure.
-
-If the user granted this agent its own scoped access (an `vnat1_…` agent token),
-a single self-bootstrapping command replaces all setup:
-
-```json
-{ "command": "vortex-notes", "args": ["agent", "mcp", "<vnat1_token>"] }
-```
-
-Tools: `search_notes`, `read_note`, `write_note`, `edit_note` (surgical),
-`append_daily`, `remember` (facts with supersession), `build_context` (top notes
-plus one hop of wikilinks in one call), `recent_activity`, `list_notes`.
-Add `--read-only` for a search/read-only connection. The MCP tools encode all
-the conventions above — prefer `remember` and `append_daily` over manual writes.
-
-## Best Practices
-
-1. Search before writing — the note or fact may already exist (then edit/supersede).
-2. Use `build_context` (MCP) at task start instead of several search+read rounds.
-3. Put durable knowledge in `memory/`, ephemera in `daily/` — don't mix.
-4. Keep facts self-contained: they must make sense without conversation context.
-5. Respect `--read-only` vaults: search and read, never suggest workarounds.
-
-## Data Storage
-
-Vault = plain markdown, portable, Obsidian-compatible. Search index lives in
-`<vault>/.vortex/index.db` (disposable cache — the files are the truth).
-Optional E2EE multi-device sync exists (`vortex-notes sync`); it never changes
-the on-disk format.
-
-## References
-
-- https://github.com/vortex-303/vortex-notes
-- `vortex-notes help`
+- `search_notes "<recent topic>"` returns the note you just wrote.
+- After `append_daily`, `read_note daily/<today>` shows the new timestamped line.
+- After `remember`, the fact appears once, with any prior version struck through
+  and linked — not duplicated.

--- a/optional-skills/productivity/vortex-notes/SKILL.md
+++ b/optional-skills/productivity/vortex-notes/SKILL.md
@@ -2,7 +2,7 @@
 name: vortex-notes
 description: Read, search, and update the user's encrypted notes vault.
 version: 1.1.0
-author: Nico Ruggieri (@vortex-303)
+author: Vortex303 (@vortex-303)
 license: MIT
 platforms: [macos, linux, windows]
 metadata:

--- a/tests/skills/test_vortex_notes_skill.py
+++ b/tests/skills/test_vortex_notes_skill.py
@@ -1,0 +1,98 @@
+"""
+Structural tests for the vortex-notes optional skill.
+
+The skill talks to a paired, possibly end-to-end-encrypted vault over an MCP
+server, so we can't exercise it in CI. These tests verify the SKILL.md conforms
+to the hardline authoring standards:
+  - frontmatter shape + ≤60-char description
+  - the human contributor is credited
+  - modern section order
+  - prose points at native Hermes tools / MCP, not raw shell utilities
+stdlib + pytest + pyyaml only; no network.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "productivity" / "vortex-notes"
+
+MARKETING = ("powerful", "comprehensive", "seamless", "advanced")
+REQUIRED_SECTIONS = (
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+)
+
+
+@pytest.fixture(scope="module")
+def source() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text()
+
+
+@pytest.fixture(scope="module")
+def frontmatter(source) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", source, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+@pytest.fixture(scope="module")
+def body(source) -> str:
+    return source.split("\n---\n", 1)[1]
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline ≤60): {desc!r}"
+    assert desc.endswith("."), "description must be one sentence ending with a period"
+    assert "vortex" not in desc.lower(), "description must not repeat the skill name"
+    for word in MARKETING:
+        assert word not in desc.lower(), f"marketing word {word!r} in description"
+
+
+def test_required_frontmatter_fields(frontmatter) -> None:
+    for field in ("name", "version", "author", "license", "platforms"):
+        assert frontmatter.get(field), f"missing frontmatter field: {field}"
+
+
+def test_author_credits_human(frontmatter) -> None:
+    author = str(frontmatter["author"])
+    assert "@vortex-303" in author, "author must credit the human contributor + handle"
+    assert "Hermes Agent" not in author, "credit the human, not the tool"
+
+
+def test_modern_section_order(body) -> None:
+    positions = []
+    for section in REQUIRED_SECTIONS:
+        idx = body.find(section)
+        assert idx != -1, f"missing required section: {section}"
+        positions.append(idx)
+    assert positions == sorted(positions), "sections are out of the required order"
+
+
+def test_no_raw_shell_utilities_headlined(body) -> None:
+    for tool in ("`grep`", "`cat`", "`sed`", "`awk`", "`find`"):
+        assert tool not in body, f"{tool} should map to a native Hermes tool, not be headlined"
+
+
+def test_points_at_native_tools_or_mcp(body) -> None:
+    assert "MCP" in body and "vortex-notes" in body, "must name the expected MCP server"
+    assert any(t in body for t in ("`read_file`", "`search_files`", "`patch`", "`terminal`")), (
+        "must point at native Hermes tools by name"
+    )


### PR DESCRIPTION
Adds a skill for [vortex-notes](https://github.com/vortex-303/vortex-notes) (MIT) — a plain-markdown knowledge base that the user and their agents share.

What it gives Hermes:
- Hybrid local semantic search over the user's notes (BM25 + multilingual embeddings via sqlite-vec — no API key, ~100 languages)
- Daily-note journaling and durable facts with supersession (superseded facts are struck through, never deleted — the agent's beliefs stay auditable)
- MCP integration (stdio) with task-shaped tools: search_notes, read_note, surgical edit_note, append_daily, remember, build_context
- Optional scoped access: `npx vortex-notes pair` shows a 6-letter code, the user approves from their phone, and Hermes gets its own key — scoped to granted spaces, read-only optional, revocable, every edit signed as the agent. E2EE sync included (self-hostable relay).

Skill follows the repo conventions (frontmatter modeled on `research/qmd`, placed in `productivity/` next to siyuan). Happy to adjust anything.