### PR TITLE
fix(slack): preserve typed command integrity

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9710,6 +9710,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         reply_to_is_own_message=event.reply_to_is_own_message,
                         auto_skill=event.auto_skill,
                         channel_prompt=event.channel_prompt,
+                        channel_context=event.channel_context,
                         internal=event.internal,
                         timestamp=event.timestamp,
                     )
@@ -9739,6 +9740,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             source=event.source,
                             message_id=event.message_id,
                             channel_prompt=event.channel_prompt,
+                            channel_context=event.channel_context,
                         )
                         adapter._pending_messages[_quick_key] = queued_event
                     return "Agent still starting — /steer queued for the next turn."
@@ -9761,6 +9763,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         source=event.source,
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
+                        channel_context=event.channel_context,
                     )
                     adapter._pending_messages[_quick_key] = queued_event
                 return "No active agent — /steer queued for the next turn."

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -113,6 +113,50 @@ def check_slack_requirements() -> bool:
     return ensure_and_bind("platform.slack", _import, globals(), prompt=False)
 
 
+def _normalize_typed_slack_command(text: str) -> Optional[str]:
+    """Return canonical gateway text for a typed Slack command, if known."""
+    # Slack's composer can prepend nonsemantic indentation; trailing whitespace
+    # belongs to the argument payload and must survive command parsing.
+    normalized = text.lstrip()
+    if normalized.startswith("/"):
+        return normalized
+    if not normalized.startswith("!"):
+        return None
+
+    try:
+        from hermes_cli.commands import is_gateway_known_command
+
+        first_token = normalized[1:].split(maxsplit=1)[0]
+        # Match MessageEvent.get_command() semantics for ``/stop@hermes``.
+        command_name = first_token.split("@", 1)[0].lower()
+        if (
+            command_name
+            and "/" not in command_name
+            and is_gateway_known_command(command_name)
+        ):
+            return "/" + normalized[1:]
+    except Exception:  # pragma: no cover - malformed input / unavailable registry
+        pass
+    return None
+
+
+def _extract_slack_command_thread_id(command: dict) -> Optional[str]:
+    """Extract Slack's thread identity from direct and nested slash payloads."""
+    candidates = [command]
+    for key in ("message", "container"):
+        nested = command.get(key)
+        if isinstance(nested, dict):
+            candidates.append(nested)
+    # A real parent-thread anchor is more specific than a fallback message
+    # timestamp, even if Slack exposes the latter at the top level.
+    for key in ("thread_ts", "message_ts"):
+        for payload in candidates:
+            value = payload.get(key)
+            if value:
+                return str(value)
+    return None
+
+
 def _extract_text_from_slack_blocks(blocks: list) -> str:
     """Extract readable text from Slack Block Kit blocks, including quoted/forwarded content.
 
@@ -3132,33 +3176,13 @@ class SlackAdapter(BasePlatformAdapter):
         if subtype in {"message_changed", "message_deleted"}:
             return
 
-        original_text = event.get("text", "")
-
-        # Slack blocks native slash commands inside threads ("/queue is not
-        # supported in threads. Sorry!").  As a workaround, recognise a
-        # leading ``!`` as an alternate command prefix and rewrite it to
-        # ``/`` so the rest of the pipeline (MessageType.COMMAND tagging,
-        # gateway dispatcher) handles it like a normal slash command.  Only
-        # rewrite when the first token resolves to a known gateway command
-        # so casual messages like "!nice work" pass through unchanged.
-        if original_text.startswith("!"):
-            try:
-                from hermes_cli.commands import is_gateway_known_command
-
-                first_token = original_text[1:].split(maxsplit=1)[0]
-                # Strip "@suffix" the same way get_command() does, so
-                # forms like ``!stop@hermes`` still resolve.
-                cmd_name = first_token.split("@", 1)[0].lower()
-                if (
-                    cmd_name
-                    and "/" not in cmd_name
-                    and is_gateway_known_command(cmd_name)
-                ):
-                    original_text = "/" + original_text[1:]
-            except Exception:  # pragma: no cover - defensive
-                pass
-
-        text = original_text
+        # Keep authored command text separate from later Slack enrichment.
+        # Blocks, unfurls, files, thread history, and Agent-view metadata are
+        # useful prompt context for normal messages, but none may alter a
+        # command token or its arguments.
+        raw_authored_text = event.get("text", "")
+        command_text = _normalize_typed_slack_command(raw_authored_text)
+        text = command_text or raw_authored_text
 
         # Extract quoted/forwarded content from Slack blocks.
         # Slack's modern composer embeds forwarded messages in the ``blocks``
@@ -3339,7 +3363,7 @@ class SlackAdapter(BasePlatformAdapter):
         #   3. The message is in a thread where the bot was previously @mentioned, OR
         #   4. There's an existing session for this thread (survives restarts)
         bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
-        routing_text = original_text or ""
+        routing_text = raw_authored_text or ""
         is_mentioned = bool(
             (bot_uid and f"<@{bot_uid}>" in routing_text)
             or self._slack_message_matches_mention_patterns(routing_text)
@@ -3384,8 +3408,17 @@ class SlackAdapter(BasePlatformAdapter):
                     return
 
         if is_mentioned:
-            # Strip the bot mention from the text
-            text = text.replace(f"<@{bot_uid}>", "").strip()
+            # Strip the bot mention from normal text. For command input, always
+            # normalize the raw authored form so Block Kit enrichment cannot
+            # leak back in after mention stripping.
+            mention = f"<@{bot_uid}>"
+            mention_stripped = raw_authored_text.replace(mention, "").lstrip()
+            mentioned_command = _normalize_typed_slack_command(mention_stripped)
+            if mentioned_command:
+                command_text = mentioned_command
+                text = command_text
+            else:
+                text = text.replace(mention, "").strip()
             # Register this thread so all future messages auto-trigger the bot.
             # Skipped in strict mode: strict_mention=true bots must be
             # re-mentioned every turn, so remembering the thread would
@@ -3400,7 +3433,9 @@ class SlackAdapter(BasePlatformAdapter):
                         self._mentioned_threads.discard(t)
 
         # When entering a thread for the first time (no existing session),
-        # fetch thread context so the agent understands the conversation.
+        # retain prior history as channel context rather than prepending it to
+        # text. The gateway parser requires a command token at character zero.
+        channel_context = None
         if is_thread_reply and not self._has_active_session_for_thread(
             channel_id=channel_id,
             thread_ts=event_thread_ts,
@@ -3414,12 +3449,10 @@ class SlackAdapter(BasePlatformAdapter):
                 team_id=team_id,
             )
             if thread_context:
-                text = thread_context + text
+                channel_context = thread_context
 
-        # Determine message type
-        msg_type = MessageType.TEXT
-        if (original_text or "").startswith("/"):
-            msg_type = MessageType.COMMAND
+        # Determine message type from canonical input, not enriched text.
+        msg_type = MessageType.COMMAND if command_text else MessageType.TEXT
 
         # Handle file attachments
         media_urls = []
@@ -3674,6 +3707,12 @@ class SlackAdapter(BasePlatformAdapter):
             else:
                 msg_type = MessageType.DOCUMENT
 
+        # Every enrichment path above is deliberately allowed for normal
+        # messages. Commands are restored from canonical authored input only.
+        if command_text:
+            text = command_text
+            msg_type = MessageType.COMMAND
+
         # Resolve user display name (cached after first lookup)
         user_name = await self._resolve_user_name(
             user_id, chat_id=channel_id, team_id=team_id
@@ -3686,7 +3725,7 @@ class SlackAdapter(BasePlatformAdapter):
             await self._set_assistant_thread_title(
                 channel_id,
                 thread_ts,
-                original_text or text,
+                raw_authored_text or text,
                 team_id=team_id,
             )
 
@@ -3753,6 +3792,7 @@ class SlackAdapter(BasePlatformAdapter):
             reply_to_message_id=thread_ts if thread_ts != ts else None,
             channel_prompt=_channel_prompt,
             reply_to_text=reply_to_text,
+            channel_context=channel_context,
             auto_skill=_auto_skill,
             metadata={
                 "slack_team_id": team_id,
@@ -3775,7 +3815,11 @@ class SlackAdapter(BasePlatformAdapter):
         # the user switches views and would let stale context bleed into later
         # turns. The agent receives an inert label, never a fetched channel body.
         context_channel_id = agent_context.get("context_channel_id", "")
-        if context_channel_id and context_channel_id != channel_id:
+        if (
+            context_channel_id
+            and context_channel_id != channel_id
+            and msg_event.message_type != MessageType.COMMAND
+        ):
             msg_event.text = (
                 f"[Slack app context: user is viewing channel {context_channel_id}]\n\n"
                 f"{msg_event.text}"
@@ -4507,7 +4551,8 @@ class SlackAdapter(BasePlatformAdapter):
         message).
         """
         slash_name = (command.get("command") or "").lstrip("/").strip()
-        text = command.get("text", "").strip()
+        raw_text = str(command.get("text") or "")
+        text = raw_text
         user_id = command.get("user_id", "")
         channel_id = command.get("channel_id", "")
         team_id = command.get("team_id", "")
@@ -4520,39 +4565,42 @@ class SlackAdapter(BasePlatformAdapter):
             # Legacy /hermes <subcommand> [args] routing + free-form questions.
             # Empty slash_name falls into this branch for backward compat
             # with any caller that didn't populate command["command"].
+            legacy_text = raw_text.strip()
             from hermes_cli.commands import slack_subcommand_map
 
             subcommand_map = slack_subcommand_map()
             subcommand_map["compact"] = "/compress"
             # Guard against whitespace-only text where ``text`` is truthy but
             # ``text.split()`` returns ``[]`` (e.g. user sends ``/hermes   ``).
-            parts = text.split() if text else []
+            parts = legacy_text.split() if legacy_text else []
             first_word = parts[0] if parts else ""
             if first_word in subcommand_map:
-                rest = text[len(first_word) :].strip()
+                rest = legacy_text[len(first_word) :].strip()
                 text = (
                     f"{subcommand_map[first_word]} {rest}".strip()
                     if rest
                     else subcommand_map[first_word]
                 )
-            elif text:
-                pass  # Treat as a regular question
+            elif legacy_text:
+                text = legacy_text  # Treat as a regular question
             else:
                 text = "/help"
         else:
-            # Native slash — /<slash_name> [args].  Route directly through the
-            # gateway command dispatcher by prepending the slash.
-            text = f"/{slash_name} {text}".strip()
+            # Native slash — preserve Slack's raw argument payload after the
+            # single command delimiter, including meaningful trailing spacing.
+            text = f"/{slash_name}" if not raw_text else f"/{slash_name} {raw_text}"
 
         # Slack slash commands can originate from DMs or shared channels.
         # Preserve DM semantics only for DM channel IDs; shared channels must
         # keep group semantics so different users do not collide into one
         # session key.
         is_dm = str(channel_id).startswith("D")
+        thread_id = _extract_slack_command_thread_id(command)
         source = self.build_source(
             chat_id=channel_id,
             chat_type="dm" if is_dm else "group",
             user_id=user_id,
+            thread_id=thread_id,
             scope_id=team_id or None,
         )
 

--- a/tests/gateway/test_queue_command.py
+++ b/tests/gateway/test_queue_command.py
@@ -176,6 +176,25 @@ async def test_queue_preserves_reply_context():
 
 
 @pytest.mark.asyncio
+async def test_queue_preserves_channel_context_backfill():
+    """A queued Slack thread command must retain first-entry history."""
+    runner, adapter = _make_runner(_session_entry())
+    sk = _running(runner)
+    context = "[Thread context]\nAlice: earlier request"
+    event = MessageEvent(
+        text="/queue follow up",
+        source=_make_source(),
+        message_id="q-context",
+        channel_context=context,
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result is not None and "queued" in result.lower()
+    assert adapter._pending_messages[sk].channel_context == context
+
+
+@pytest.mark.asyncio
 async def test_queue_no_text_no_media_returns_usage():
     runner, adapter = _make_runner(_session_entry())
     _running(runner)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -264,6 +264,13 @@ class TestAppMentionHandler:
                 expected
             ), f"Slack slash regex does not match {expected}"
 
+        from hermes_cli.commands import slack_native_slashes
+
+        for command_name, _description, _usage in slack_native_slashes():
+            assert slash_matcher.match(f"/{command_name}"), (
+                f"Slack slash regex does not match registered /{command_name}"
+            )
+
     @pytest.mark.asyncio
     async def test_connect_uses_profile_scoped_app_token(self):
         """Socket Mode must use the active profile's app token in multiplex mode."""
@@ -1316,8 +1323,211 @@ class TestBangPrefixCommands:
         await adapter._handle_slack_message(self._make_event("!model gpt-5.4"))
 
         msg_event = adapter.handle_message.call_args[0][0]
-        assert msg_event.text.startswith("/model gpt-5.4")
+        assert msg_event.text == "/model gpt-5.4"
         assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.get_command() == "model"
+        assert msg_event.get_command_args() == "gpt-5.4"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "authored_text", ["!queue  --flag  value  ", "/queue  --flag  value  "]
+    )
+    async def test_typed_command_preserves_trailing_argument_whitespace(
+        self, adapter, authored_text
+    ):
+        """Canonicalization may remove composer padding, never argument bytes."""
+        await adapter._handle_slack_message(self._make_event(authored_text))
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/queue  --flag  value  "
+        assert msg_event.get_command_args() == "--flag  value  "
+
+    @pytest.mark.asyncio
+    async def test_bang_command_ignores_rich_text_echo(self, adapter):
+        """Slack's unnormalised rich-text echo cannot append a second command."""
+        event = self._make_event("!reasoning xhigh")
+        event["blocks"] = [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [{"type": "text", "text": "!reasoning xhigh"}],
+                    }
+                ],
+            }
+        ]
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/reasoning xhigh"
+        assert msg_event.get_command_args() == "xhigh"
+
+    @pytest.mark.asyncio
+    async def test_mentioned_bang_command_is_normalized(self, adapter):
+        """Mention stripping must not leave ``!command`` as ordinary text."""
+        event = self._make_event(
+            "<@U_BOT> !reasoning xhigh  ",
+            channel_type="channel",
+            channel="C123",
+        )
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/reasoning xhigh  "
+        assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.get_command() == "reasoning"
+        assert msg_event.get_command_args() == "xhigh  "
+
+    @pytest.mark.asyncio
+    async def test_mentioned_bang_command_ignores_rich_text_context(self, adapter):
+        """The combined mention + composer-block path retains exact arguments."""
+        event = self._make_event(
+            "<@U_BOT> !reasoning xhigh",
+            channel_type="channel",
+            channel="C123",
+        )
+        event["blocks"] = [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [
+                            {"type": "user", "user_id": "U_BOT"},
+                            {"type": "text", "text": " !reasoning xhigh"},
+                        ],
+                    },
+                    {
+                        "type": "rich_text_quote",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [{"type": "text", "text": "quoted context"}],
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/reasoning xhigh"
+        assert msg_event.get_command_args() == "xhigh"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "enrichment",
+        [
+            {"attachments": [{"title": "Spec", "from_url": "https://example.com/spec", "text": "preview"}]},
+            {"blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "UI metadata"}}]},
+        ],
+        ids=["unfurl", "block-kit"],
+    )
+    async def test_bang_command_ignores_enrichment(self, adapter, enrichment):
+        """Rich Slack metadata is agent context, never command arguments."""
+        event = self._make_event("!reasoning xhigh")
+        event.update(enrichment)
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/reasoning xhigh"
+        assert msg_event.get_command_args() == "xhigh"
+
+    @pytest.mark.asyncio
+    async def test_bang_command_ignores_attachment_failure_notice(self, adapter):
+        """A failed Slack download cannot prefix a command with an error notice."""
+        adapter._download_slack_file = AsyncMock(side_effect=RuntimeError("403"))
+        adapter._describe_slack_download_failure = MagicMock(return_value="download denied")
+        event = self._make_event("!reasoning xhigh")
+        event["files"] = [{
+            "id": "F123", "mimetype": "image/jpeg", "name": "photo.jpg",
+            "url_private_download": "https://files.slack.com/photo.jpg", "size": 16,
+        }]
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/reasoning xhigh"
+        assert msg_event.get_command_args() == "xhigh"
+
+    @pytest.mark.asyncio
+    async def test_bang_command_ignores_text_file_injection(self, adapter):
+        """Text-file content must not be prepended ahead of a command token."""
+        adapter._download_slack_file_bytes = AsyncMock(return_value=b"mode: accidental")
+        event = self._make_event("!reasoning xhigh")
+        event["files"] = [{
+            "id": "F123", "mimetype": "text/plain", "name": "settings.txt",
+            "url_private_download": "https://files.slack.com/settings.txt", "size": 16,
+        }]
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/reasoning xhigh"
+        assert msg_event.get_command_args() == "xhigh"
+        assert msg_event.media_urls
+
+    @pytest.mark.asyncio
+    async def test_bang_command_keeps_thread_context_out_of_command_text(self, adapter):
+        """Thread backfill remains available without becoming command input."""
+        thread_context = "[Older thread context]\n"
+        adapter._fetch_thread_context = AsyncMock(return_value=thread_context)
+        event = self._make_event("!reasoning xhigh", thread_ts="1111111111.000001")
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/reasoning xhigh"
+        assert msg_event.get_command_args() == "xhigh"
+        assert msg_event.channel_context == thread_context
+
+    @pytest.mark.asyncio
+    async def test_non_command_thread_backfill_uses_channel_context(self, adapter):
+        """Normal thread messages keep authored text and retain prior history."""
+        thread_context = "[Older thread context]\n"
+        adapter._fetch_thread_context = AsyncMock(return_value=thread_context)
+        event = self._make_event("follow up", thread_ts="1111111111.000001")
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "follow up"
+        assert msg_event.message_type == MessageType.TEXT
+        assert msg_event.channel_context == thread_context
+
+    @pytest.mark.asyncio
+    async def test_bang_command_ignores_app_view_context(self, adapter):
+        """Slack Agent-view metadata is prompt context, never command input."""
+        event = self._make_event("!reasoning xhigh")
+        event["app_context"] = {"channel_id": "C_VIEWED"}
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/reasoning xhigh"
+        assert msg_event.get_command() == "reasoning"
+        assert msg_event.get_command_args() == "xhigh"
+
+    @pytest.mark.asyncio
+    async def test_non_command_retains_app_view_context(self, adapter):
+        """Skipping app context is command-specific, not a loss of prompt context."""
+        event = self._make_event("What is happening?")
+        event["app_context"] = {"channel_id": "C_VIEWED"}
+
+        await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.TEXT
+        assert msg_event.text.startswith(
+            "[Slack app context: user is viewing channel C_VIEWED]\n\n"
+        )
+        assert msg_event.text.endswith("What is happening?")
 
     @pytest.mark.asyncio
     async def test_bang_works_inside_thread(self, adapter):
@@ -3903,6 +4113,59 @@ class TestSlashCommands:
         await adapter._handle_slash_command(command)
         msg = adapter.handle_message.call_args[0][0]
         assert msg.text == "/model anthropic/claude-sonnet-4"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("thread_payload", "expected_thread_id"),
+        [
+            ({"thread_ts": "1111111111.000001"}, "1111111111.000001"),
+            ({"message": {"thread_ts": "2222222222.000001"}}, "2222222222.000001"),
+            ({"container": {"thread_ts": "3333333333.000001"}}, "3333333333.000001"),
+            ({"message_ts": "4444444444.000001"}, "4444444444.000001"),
+            ({"container": {"message_ts": "5555555555.000001"}}, "5555555555.000001"),
+            (
+                {
+                    "message_ts": "fallback-message-ts",
+                    "message": {"thread_ts": "parent-thread-ts"},
+                },
+                "parent-thread-ts",
+            ),
+        ],
+    )
+    async def test_native_slash_preserves_thread_identity(
+        self, adapter, thread_payload, expected_thread_id
+    ):
+        """Native Slack slash payload variants keep replies in their thread."""
+        command = {
+            "command": "/reasoning",
+            "text": "xhigh",
+            "user_id": "U1",
+            "channel_id": "C1",
+            **thread_payload,
+        }
+
+        await adapter._handle_slash_command(command)
+
+        msg = adapter.handle_message.call_args[0][0]
+        assert msg.source.thread_id == expected_thread_id
+        assert msg.text == "/reasoning xhigh"
+
+    @pytest.mark.asyncio
+    async def test_native_slash_preserves_raw_argument_payload(self, adapter):
+        """Only the command delimiter is nonsemantic; raw Slack input stays intact."""
+        raw_args = "  --flag  value  "
+        command = {
+            "command": "/queue",
+            "text": raw_args,
+            "user_id": "U1",
+            "channel_id": "C1",
+        }
+
+        await adapter._handle_slash_command(command)
+
+        msg = adapter.handle_message.call_args[0][0]
+        assert msg.text == f"/queue {raw_args}"
+        assert msg.get_command_args() == "--flag  value  "
 
     @pytest.mark.asyncio
     async def test_legacy_hermes_prefix_still_works(self, adapter):

--- a/tests/gateway/test_steer_command.py
+++ b/tests/gateway/test_steer_command.py
@@ -33,11 +33,12 @@ def _make_source() -> SessionSource:
     )
 
 
-def _make_event(text: str) -> MessageEvent:
+def _make_event(text: str, channel_context: str | None = None) -> MessageEvent:
     return MessageEvent(
         text=text,
         source=_make_source(),
         message_id="m1",
+        channel_context=channel_context,
     )
 
 
@@ -140,13 +141,17 @@ async def test_steer_with_pending_sentinel_falls_back_to_queue():
     sk = build_session_key(_make_source())
     runner._running_agents[sk] = _AGENT_PENDING_SENTINEL
 
-    result = await runner._handle_message(_make_event("/steer wait up"))
+    context = "[Thread context]\nAlice: earlier request"
+    result = await runner._handle_message(
+        _make_event("/steer wait up", channel_context=context)
+    )
 
     assert result is not None
     assert "queued" in result.lower() or "starting" in result.lower()
-    # The fallback put the text into the adapter's pending queue.
+    # The fallback put the full turn payload into the adapter's pending queue.
     assert sk in adapter._pending_messages
     assert adapter._pending_messages[sk].text == "wait up"
+    assert adapter._pending_messages[sk].channel_context == context
 
 
 @pytest.mark.asyncio
@@ -161,13 +166,17 @@ async def test_steer_agent_without_steer_method_falls_back():
     running_agent = MagicMock(spec=[])
     runner._running_agents[sk] = running_agent
 
-    result = await runner._handle_message(_make_event("/steer fallback"))
+    context = "[Thread context]\nAlice: earlier request"
+    result = await runner._handle_message(
+        _make_event("/steer fallback", channel_context=context)
+    )
 
     assert result is not None
     # Must mention queueing since steer wasn't available
     assert "queued" in result.lower()
     assert sk in adapter._pending_messages
     assert adapter._pending_messages[sk].text == "fallback"
+    assert adapter._pending_messages[sk].channel_context == context
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes the complete Slack typed-command integrity path, rather than a single command-specific symptom.

Slack thread replies use `!command` because Slack blocks native `/command` text there. The adapter now keeps a canonical command string separate from Slack enrichment. Rich-text blocks, Block Kit payloads, link unfurls, attachment failures, text-file injection, thread-history backfill, and Agent-view context cannot become command arguments or move `/` away from character zero.

First-entry thread history is preserved in `MessageEvent.channel_context` for both commands and normal messages. `/queue` and `/steer` fallbacks preserve that context when they create deferred follow-up events, so a Slack command retains thread history through dispatch and queueing.

## Related Issue

Consolidates and completes the valid scopes of open PRs #30592 and #66069, which address overlapping portions of the same Slack command path. Neither can be directly updated from this fork.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/slack/adapter.py`
  - Canonicalize known typed `!command`, direct `/command`, and mention-prefixed `!command` once from authored Slack text.
  - Preserve unknown `!text` as ordinary text.
  - Restore canonical command text after normal Slack enrichment paths.
  - Keep first-entry thread history in `channel_context`, not command text.
  - Preserve app-view context for normal messages without corrupting commands.
  - Preserve native slash-command thread identity from direct, `message`, and `container` payload variants.
- `gateway/run.py`
  - Preserve `channel_context` when `/queue` or deferred `/steer` fallbacks create a follow-up event.
- `tests/gateway/test_slack.py`
  - Add regressions for typed command enrichment, mentions, thread backfill, app context, native slash identity, and registered slash coverage.
- `tests/gateway/test_queue_command.py` and `tests/gateway/test_steer_command.py`
  - Assert deferred events retain `channel_context`.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_slack.py tests/gateway/test_queue_command.py tests/gateway/test_steer_command.py tests/gateway/test_reasoning_command.py -q`.
2. Run `ruff check gateway/run.py plugins/platforms/slack/adapter.py tests/gateway/test_queue_command.py tests/gateway/test_steer_command.py tests/gateway/test_slack.py`.
3. Run `python scripts/check-windows-footguns.py --diff origin/main`.
4. In a Slack thread without an active Hermes session, send `!queue follow up after the current task`; confirm it dispatches with exact arguments and has prior thread context.
5. Repeat with `@Hermes !reasoning xhigh`, a composer rich-text block, an unfurl, and a text-file attachment; confirm only the canonical command reaches the dispatcher.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs and compared #30592 and #66069.
- [x] My commit contains only this Slack command-integrity fix.
- [x] I've run the focused repository test runner: 294 passed, 0 failed.
- [ ] Full `scripts/run_tests.sh` was not clean in this checkout: at 14% it hit two failures outside this PR's paths (`tests/agent/test_file_safety_session_state.py`, `tests/agent/test_skill_utils.py`); this PR does not modify their code or tests.
- [x] I've added regression tests for all repaired paths.
- [x] I've tested on Ubuntu Linux, Python 3.11.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing syntax changed.
- [x] `cli-config.yaml.example`: N/A; no config changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow changed.
- [x] Cross-platform check passed: no Windows footguns in 4 changed files.
- [x] Tool descriptions/schemas: N/A; no tool behavior changed.

## Screenshots / Logs

```text
scripts/run_tests.sh tests/gateway/test_slack.py tests/gateway/test_queue_command.py tests/gateway/test_steer_command.py tests/gateway/test_reasoning_command.py -q
294 passed, 0 failed

ruff check gateway/run.py plugins/platforms/slack/adapter.py tests/gateway/test_queue_command.py tests/gateway/test_steer_command.py tests/gateway/test_slack.py
All checks passed!

python scripts/check-windows-footguns.py --diff origin/main
No Windows footguns found (4 files scanned).

git diff --check origin/main...HEAD
passed
```
