### PR TITLE
fix(tts): support configurable ElevenLabs URLs

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -116,6 +116,11 @@ def _import_elevenlabs():
     from elevenlabs.client import ElevenLabs
     return ElevenLabs
 
+def _import_elevenlabs_environment():
+    """Lazy import ElevenLabs environment class."""
+    from elevenlabs.environment import ElevenLabsEnvironment
+    return ElevenLabsEnvironment
+
 def _import_openai_client():
     """Lazy import OpenAI client. Returns the class or raises ImportError."""
     from openai import OpenAI as OpenAIClient
@@ -993,6 +998,8 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     el_config = tts_config.get("elevenlabs") or {}
     voice_id = el_config.get("voice_id", DEFAULT_ELEVENLABS_VOICE_ID)
     model_id = el_config.get("model_id", DEFAULT_ELEVENLABS_MODEL_ID)
+    base_url = el_config.get("base_url")
+    wss_url = el_config.get("wss_url")
 
     # Determine output format based on file extension
     if output_path.endswith(".ogg"):
@@ -1001,7 +1008,11 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
         output_format = "mp3_44100_128"
 
     ElevenLabs = _import_elevenlabs()
-    client = ElevenLabs(api_key=api_key)
+    if base_url and wss_url:
+        ElevenLabsEnvironment = _import_elevenlabs_environment()
+        client = ElevenLabs(api_key=api_key, environment=ElevenLabsEnvironment(base=base_url, wss=wss_url))
+    else:
+        client = ElevenLabs(api_key=api_key)
     audio_generator = client.text_to_speech.convert(
         text=text,
         voice_id=voice_id,
@@ -2780,6 +2791,8 @@ def stream_tts_to_speaker(
         voice_id = el_config.get("voice_id", voice_id)
         model_id = el_config.get("streaming_model_id",
                                  el_config.get("model_id", model_id))
+        base_url = el_config.get("base_url")
+        wss_url = el_config.get("wss_url")
         # Per-sentence cap for the streaming path. Look up the cap against
         # the *streaming* model_id (defaults to eleven_flash_v2_5 = 40k chars),
         # not the sync model_id. A user override
@@ -2795,7 +2808,11 @@ def stream_tts_to_speaker(
         else:
             try:
                 ElevenLabs = _import_elevenlabs()
-                client = ElevenLabs(api_key=api_key)
+                if base_url and wss_url:
+                    ElevenLabsEnvironment = _import_elevenlabs_environment()
+                    client = ElevenLabs(api_key=api_key, environment=ElevenLabsEnvironment(base=base_url, wss=wss_url))
+                else:
+                    client = ElevenLabs(api_key=api_key)
             except ImportError:
                 logger.warning("elevenlabs package not installed; streaming TTS disabled")
 


### PR DESCRIPTION
Certain elevenlabs environments require non-default URLs. This is already supported on STT, but for some reason was omitted on TTS.

This minimal change reads an optional `base_url` and `wss_url` from the tts.elevenlabs config block, mirroring how the OpenAI TTS provider reads tts.openai.base_url. When unset, the ElevenLabs client is constructed exactly as before (no behavior change). When set, it is passed through environment=ElevenLabsEnvironment(...), since the ElevenLabs SDK does not accept a base_url kwarg directly.

Applied to both construction sites: the sync _generate_elevenlabs handler and the streaming stream_tts_to_speaker path.

## What does this PR do?

Fixes an omission where elevenlabs base_url is only supported on STT but not TTS. 

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- tts_tool.py - add lazy import for ElevenLabsEnvironment from current dependency
- tts_tool.py - check if base_url and wss_url are configured, and set them in the client

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

