### PR TITLE
fix(tirith): respect fail_open: false in circuit breaker guard (#66285)

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -750,7 +750,13 @@ def check_command_security(command: str) -> dict:
     # → fail-open → agent retry loop, hanging the user for 20+ minutes
     # (issue #41400).
     if _circuit_open:
-        return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+        fail_open = cfg["tirith_fail_open"]
+        if fail_open:
+            return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker; fail-open)"}
+        logger.warning(
+            "tirith circuit breaker open — blocking command (fail_closed=true)"
+        )
+        return {"action": "block", "findings": [], "summary": "tirith disabled (circuit breaker; fail-closed)"}
 
     # Unsupported platform (Windows etc.) — tirith has no binary here and
     # never will. Skip the resolver entirely so we don't even try to spawn.


### PR DESCRIPTION
## Problem

When the Tirith circuit breaker opens (after 3 consecutive spawn failures), the guard unconditionally returns `allow`, ignoring the operator's configured `tirith_fail_open: false`. An operator who explicitly configured fail-closed gets fail-open behaviour silently.

## Fix

1. Reads `tirith_fail_open` from config before the circuit breaker check
2. When circuit is **OPEN** and `fail_open` is **false** → returns `block` (DENY)
3. When circuit is **OPEN** and `fail_open` is **true** → returns `allow` (preserved current behaviour)
4. Adds `logger.warning` so the operator sees the circuit breaker took action

## Before

```python
if _circuit_open:
    return {"action": "allow", ...}  # ignores fail_open: false
```

## After

```python
if _circuit_open:
    fail_open = cfg["tirith_fail_open"]
    if fail_open:
        return {"action": "allow", ...}  # fail-open: pass through
    logger.warning("tirith circuit breaker open — blocking command (fail_closed=true)")
    return {"action": "block", ...}  # fail-closed: block command
```

Fixes #66285