### PR TITLE
fix(desktop): scope messaging sync to active profile

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
@@ -1,0 +1,52 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useBackgroundSync } from './use-background-sync'
+
+const noopAsync = vi.fn().mockResolvedValue(undefined)
+
+function Harness({ refreshMessagingSessions }: { refreshMessagingSessions: () => void }) {
+  useBackgroundSync({
+    activeIsMessaging: false,
+    activeSessionId: null,
+    freshDraftReady: false,
+    gatewayState: 'open',
+    refreshActiveMessagingTranscript: noopAsync,
+    refreshCronJobs: noopAsync,
+    refreshCurrentModel: noopAsync,
+    refreshHermesConfig: noopAsync,
+    refreshMessagingSessions,
+    refreshSessions: noopAsync,
+    requestGateway: noopAsync
+  })
+
+  return null
+}
+
+describe('useBackgroundSync messaging refresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('refreshes after 15 seconds and whenever the window regains focus', () => {
+    const refreshMessagingSessions = vi.fn()
+
+    render(<Harness refreshMessagingSessions={refreshMessagingSessions} />)
+
+    act(() => vi.advanceTimersByTime(14_999))
+    expect(refreshMessagingSessions).not.toHaveBeenCalled()
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(refreshMessagingSessions).toHaveBeenCalledTimes(1)
+
+    act(() => window.dispatchEvent(new Event('focus')))
+    expect(refreshMessagingSessions).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -9,7 +9,7 @@ import type { GatewayRequester } from '../types'
 // the background gateway (Telegram, WeChat, Discord, …) — neither signals the
 // desktop websocket, so poll the bounded lists while the app is visible.
 const CRON_POLL_INTERVAL_MS = 30_000
-const MESSAGING_POLL_INTERVAL_MS = 10_000
+const MESSAGING_POLL_INTERVAL_MS = 15_000
 const ACTIVE_MESSAGING_SESSION_POLL_INTERVAL_MS = 5_000
 
 interface BackgroundSyncParams {
@@ -36,10 +36,12 @@ function visiblePoll(intervalMs: number, tick: () => void): () => void {
   }
 
   const intervalId = window.setInterval(run, intervalMs)
+  window.addEventListener('focus', run)
   document.addEventListener('visibilitychange', run)
 
   return () => {
     window.clearInterval(intervalId)
+    window.removeEventListener('focus', run)
     document.removeEventListener('visibilitychange', run)
   }
 }

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -1,0 +1,92 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { listAllProfileSessions } from '@/hermes'
+import { setActiveProfile } from '@/store/profile'
+import { MESSAGING_SECTION_LIMIT, setMessagingSessions } from '@/store/session'
+
+import { useSessionListActions } from './use-session-list-actions'
+
+vi.mock('@/hermes', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+
+  return {
+    ...actual,
+    getCronJobs: vi.fn().mockResolvedValue([]),
+    listAllProfileSessions: vi.fn().mockResolvedValue({
+      limit: 100,
+      offset: 0,
+      sessions: [],
+      total: 0
+    })
+  }
+})
+
+type SessionListActions = ReturnType<typeof useSessionListActions>
+
+function Harness({ onReady }: { onReady: (actions: SessionListActions) => void }) {
+  const actions = useSessionListActions({ profileScope: 'orchestrator' })
+
+  useEffect(() => {
+    onReady(actions)
+  }, [actions, onReady])
+
+  return null
+}
+
+describe('useSessionListActions messaging scope', () => {
+  beforeEach(() => {
+    setActiveProfile('orchestrator')
+    setMessagingSessions([])
+    vi.mocked(listAllProfileSessions).mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('loads the bounded messaging slice from the active server profile', async () => {
+    let actions: SessionListActions | null = null
+
+    render(<Harness onReady={value => (actions = value)} />)
+    await waitFor(() => expect(actions).not.toBeNull())
+
+    await act(async () => {
+      await actions!.refreshMessagingSessions()
+    })
+
+    expect(listAllProfileSessions).toHaveBeenCalledWith(
+      MESSAGING_SECTION_LIMIT,
+      1,
+      'exclude',
+      'recent',
+      'orchestrator',
+      expect.objectContaining({ excludeSources: expect.any(Array) })
+    )
+  })
+
+  it('coalesces overlapping polling and focus refreshes', async () => {
+    let actions: SessionListActions | null = null
+    let resolveRequest: ((value: Awaited<ReturnType<typeof listAllProfileSessions>>) => void) | null = null
+    const pending = new Promise<Awaited<ReturnType<typeof listAllProfileSessions>>>(resolve => {
+      resolveRequest = resolve
+    })
+
+    vi.mocked(listAllProfileSessions).mockReturnValueOnce(pending)
+    render(<Harness onReady={value => (actions = value)} />)
+    await waitFor(() => expect(actions).not.toBeNull())
+
+    const first = actions!.refreshMessagingSessions()
+    const second = actions!.refreshMessagingSessions()
+
+    expect(first).toBe(second)
+    expect(listAllProfileSessions).toHaveBeenCalledTimes(1)
+
+    resolveRequest!({ limit: 100, offset: 0, sessions: [], total: 0 })
+    await act(async () => {
+      await Promise.all([first, second])
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -10,7 +10,7 @@ import {
 } from '@/lib/session-source'
 import { setCronJobs } from '@/store/cron'
 import { $pinnedSessionIds, $sessionsLimit, bumpSessionsLimit, SIDEBAR_SESSIONS_PAGE_SIZE } from '@/store/layout'
-import { ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
+import { $activeProfile, ALL_PROFILES, normalizeProfileKey } from '@/store/profile'
 import {
   $messagingSessions,
   $selectedStoredSessionId,
@@ -75,6 +75,7 @@ interface UseSessionListActionsArgs {
  *  wires into the sidebar and refresh effects. */
 export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
   const refreshSessionsRequestRef = useRef(0)
+  const messagingRefreshRequestRef = useRef<Promise<void> | null>(null)
 
   // Cron-job sessions as their own list (latest N). Independent of the recents
   // page so the two never compete for slots. Cheap + bounded. Kept (even though
@@ -96,23 +97,43 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   // local recents so each platform renders a self-managed section and never
   // competes with local chats for the recents page budget. One combined fetch
   // seeds every platform; the sidebar splits the rows per source.
-  const refreshMessagingSessions = useCallback(async () => {
-    try {
-      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', 'all', {
-        excludeSources: MESSAGING_EXCLUDED_SOURCES
-      })
-
-      // Drop any non-messaging source the broad exclude didn't catch (custom
-      // sources) — those stay in local recents, not a platform section.
-      const rows = result.sessions.filter(s => isMessagingSource(s.source))
-
-      setMessagingSessions(prev => (sameCronSignature(prev, rows) ? prev : rows))
-      // Hit the cap → at least one platform may have more on disk than loaded,
-      // so platform sections offer their own per-platform "load more".
-      setMessagingTruncated(result.sessions.length >= MESSAGING_SECTION_LIMIT)
-    } catch {
-      // Non-fatal: the messaging sections just stay empty/stale.
+  const refreshMessagingSessions = useCallback((): Promise<void> => {
+    if (messagingRefreshRequestRef.current) {
+      return messagingRefreshRequestRef.current
     }
+
+    const request = (async () => {
+      try {
+        // Messaging belongs to the server profile the desktop backend is running
+        // as. Asking that backend for `all` fans one routine sidebar refresh out
+        // across every configured profile (and every profile persistence pool),
+        // even though the window cannot receive those other gateways' live turns.
+        const profile = normalizeProfileKey($activeProfile.get())
+        const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', profile, {
+          excludeSources: MESSAGING_EXCLUDED_SOURCES
+        })
+
+        // Drop any non-messaging source the broad exclude didn't catch (custom
+        // sources) — those stay in local recents, not a platform section.
+        const rows = result.sessions.filter(s => isMessagingSource(s.source))
+
+        setMessagingSessions(prev => (sameCronSignature(prev, rows) ? prev : rows))
+        // Hit the cap → at least one platform may have more on disk than loaded,
+        // so platform sections offer their own per-platform "load more".
+        setMessagingTruncated(result.sessions.length >= MESSAGING_SECTION_LIMIT)
+      } catch {
+        // Non-fatal: the messaging sections just stay empty/stale.
+      }
+    })()
+
+    messagingRefreshRequestRef.current = request
+    void request.finally(() => {
+      if (messagingRefreshRequestRef.current === request) {
+        messagingRefreshRequestRef.current = null
+      }
+    })
+
+    return request
   }, [])
 
   // Page a single platform's section independently (mirrors the per-profile
@@ -121,8 +142,9 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   const loadMoreMessagingForPlatform = useCallback(async (platform: string) => {
     const inPlatform = (s: SessionInfo) => normalizeSessionSource(s.source) === platform
     const loaded = $messagingSessions.get().filter(inPlatform).length
+    const profile = normalizeProfileKey($activeProfile.get())
 
-    const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', 'all', {
+    const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', profile, {
       source: platform
     })
 


### PR DESCRIPTION
## Problem

The Desktop messaging sidebar polled `/api/profiles/sessions` with `profile=all`. On remote dashboards with many profiles, each routine refresh fanned out across every profile persistence backend and could exhaust a small PostgreSQL connection budget. Focus and interval events could also overlap while a slow refresh was still running.

## Fix

- Request messaging sessions only for the active server profile.
- Keep the existing 100-session messaging cap.
- Poll every 15 seconds and refresh immediately on window focus/visibility return.
- Coalesce overlapping messaging refreshes into one in-flight request.
- Add behavior tests for profile scoping, overlap coalescing, and focus refresh.

## Verification

- `npm test -- --run src/app/session/hooks/use-session-list-actions.test.tsx src/app/contrib/hooks/use-background-sync.test.tsx src/hermes.test.ts`
- `npm run lint -- --quiet`
- `npm run typecheck`