### PR TITLE
fix(memory): substring replace preserves content in all paths (single + batch)

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -431,7 +431,7 @@ class MemoryStore:
 
             # Check that replacement doesn't blow the budget
             test_entries = entries.copy()
-            test_entries[idx] = new_content
+            test_entries[idx] = entries[idx].replace(old_text, new_content, 1)
             new_total = len(ENTRY_DELIMITER.join(test_entries))
 
             if new_total > limit:
@@ -448,7 +448,7 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
-            entries[idx] = new_content
+            entries[idx] = entries[idx].replace(old_text, new_content, 1)
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
@@ -559,7 +559,7 @@ class MemoryStore:
                             target,
                             f"{pos}: '{old_text}' matched multiple distinct entries -- be more specific.",
                         )
-                    working[matches[0]] = content
+                    working[matches[0]] = working[matches[0]].replace(old_text, content, 1)
 
                 elif act == "remove":
                     if not old_text:


### PR DESCRIPTION
## Summary

Fixes #59184 — memory replace with partial old_text on composite entries truncates everything outside the match.

Unlike #59206 and #61357 which only fix the single-operation path, this PR fixes all three affected code paths.

### Fix

Changed = new_content to .replace(old_text, new_content, 1) in three locations:

| Path | Line | Before | After |
|------|------|--------|-------|
| Budget check | 434 | test_entries[idx] = new_content | test_entries[idx] = entries[idx].replace(old_text, new_content, 1) |
| Single replace | 451 | entries[idx] = new_content | entries[idx] = entries[idx].replace(old_text, new_content, 1) |
| Batch replace | 562 | working[matches[0]] = content | working[matches[0]] = working[matches[0]].replace(old_text, content, 1) |

### Why this PR

#59206 (canonical) and #61357 only fix the single-operation path. teknium1 and Petsku01 both identified that apply_batch() has the same bug at line 562.

This PR fixes all three paths in one commit.

Closes #59184