### PR TITLE
fix(cli): stop creating .install_method in Git checkout (#66189)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,11 @@ docs/superpowers/*
 # treat it as a local edit and autostash it on every run (#38529).
 .hermes-bootstrap-complete
 
+# Installer install-method marker written into the managed checkout root.
+# It is runtime state, never a code change; ignore it so `hermes update`
+# does not autostash it on every run (#66189).
+/.install_method
+
 # Persistent dev sandbox dir (scripts/dev-sandbox.sh --persistent)
 .hermes-sandbox/
 

--- a/tests/test_install_sh_install_method_stamp.py
+++ b/tests/test_install_sh_install_method_stamp.py
@@ -18,14 +18,18 @@ shared data dir.
 from __future__ import annotations
 
 import re
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 
 def test_install_sh_stamps_code_tree_not_home() -> None:
-    text = INSTALL_SH.read_text()
+    text = INSTALL_SH.read_text(encoding="utf-8")
 
     # Stamps the code tree.
     assert text.count('echo "git" > "$INSTALL_DIR/.install_method"') >= 1, (
@@ -37,4 +41,32 @@ def test_install_sh_stamps_code_tree_not_home() -> None:
         "install.sh must not stamp $HERMES_HOME/.install_method — that data "
         "dir may be shared with a Docker gateway whose 'docker' stamp would "
         "clobber it and block host-side `hermes update`"
+    )
+
+
+def test_install_method_marker_is_ignored_by_git(tmp_path: Path) -> None:
+    """The installer-created marker should not dirty the checkout."""
+    if shutil.which("git") is None:
+        pytest.skip("git executable is required for gitignore contract test")
+
+    (tmp_path / ".gitignore").write_text(
+        (REPO_ROOT / ".gitignore").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (tmp_path / ".install_method").write_text("git\n", encoding="utf-8")
+
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=tmp_path,
+        check=True,
+    )
+    ignored = subprocess.run(
+        ["git", "check-ignore", "--quiet", ".install_method"],
+        cwd=tmp_path,
+        check=False,
+    )
+
+    assert ignored.returncode == 0, (
+        ".install_method must be ignored by Git so hermes update does not "
+        "treat the installer-created marker as checkout dirt (#66189)"
     )


### PR DESCRIPTION
Fixes #66189