### PR TITLE
fix(gateway): catch dispatch exceptions so the gateway survives handler crashes (#66286)

### DIFF
--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -368,7 +368,29 @@ def main():
             continue
 
         method = req.get("method") if isinstance(req, dict) else None
-        resp = dispatch(req)
+        try:
+            resp = dispatch(req)
+        except Exception as exc:
+            print(
+                f"[gateway-dispatch] {type(exc).__name__}: {exc}",
+                file=sys.stderr, flush=True,
+            )
+            try:
+                os.makedirs(os.path.dirname(_CRASH_LOG), exist_ok=True)
+                with open(_CRASH_LOG, "a", encoding="utf-8") as f:
+                    import traceback
+                    f.write(
+                        f"\n=== dispatch exception · "
+                        f"{time.strftime('%Y-%m-%d %H:%M:%S')} · method={method!r} ===\n"
+                    )
+                    traceback.print_exc(file=f)
+            except Exception:
+                pass
+            resp = {
+                "jsonrpc": "2.0",
+                "error": {"code": -32000, "message": f"internal error: {exc}"},
+                "id": req.get("id") if isinstance(req, dict) else None,
+            }
         if resp is not None:
             if not write_json(resp):
                 _log_exit(f"response write failed for method={method!r} (broken stdout pipe)")


### PR DESCRIPTION
## Problem

The gateway process crashes when a method handler raises an unhandled exception in the RPC dispatch loop (`tui_gateway/entry.py`). For example, processing a long prompt with the opencode-go provider could trigger an error that escapes the handler and propagates up through `dispatch()` — but since the main event loop has no exception guard around `dispatch(req)`, the whole process terminates, leaving the user with a bare `gateway exited` status and no indication of what went wrong.

The crash log file and stderr capture the real error, but the process is already gone by the time anyone reads them.

## Fix

Wrap the `dispatch(req)` call in the main event loop with a `try/except` block:

1. **Log the error** — prints the exception type and message to stderr, and writes the full traceback to the crash-log file so investigation is possible.
2. **Send an error response** — returns a JSON-RPC error (`code: -32000`) to the frontend so the TUI knows the request failed instead of hanging or showing a disconnected state.
3. **Keep running** — the event loop continues after the error, unaffected. Other sessions and future RPCs can proceed normally.

The `_run_prompt_submit` turn handler already had its own `try/except` around agent execution, and SIGPIPE is ignored for orphaned stdout writes — but the outer `dispatch()` layer was still a single point of failure for any method handler that missed an exception path.

## Testing

- `pytest tests/test_tui_gateway_server.py` — 349 passed
- `python3 -c "from tui_gateway.entry import main"` — import/compile OK

Closes #66286
