### PR TITLE
fix(photon): route iMessage voice notes through STT pipeline

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -671,6 +671,9 @@ class PhotonAdapter(BasePlatformAdapter):
             is_voice = payload.get("type") == "voice"
             name = payload.get("name") or ("voice" if is_voice else "(unnamed)")
             mime = payload.get("mimeType") or ""
+            # Only .caf files are promoted to VOICE (iMessage voice notes use CAF).
+            if not is_voice and name.lower().endswith(".caf"):
+                is_voice = True
             mtype = MessageType.VOICE if is_voice else _attachment_message_type(mime)
             cached = _cache_inbound_attachment(
                 payload, name, mime, force_audio=is_voice

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -490,6 +490,11 @@ class PhotonAdapter(BasePlatformAdapter):
             except Exception:
                 pass
             self._inbound_task = None
+        # Cancel any pending U+FFFC placeholder tasks.
+        for chat_key, (_, fffc_task) in list(self._pending_fffc.items()):
+            if fffc_task and not fffc_task.done():
+                fffc_task.cancel()
+        self._pending_fffc.clear()
         await self._stop_sidecar()
         if self._http_client is not None:
             try:
@@ -683,8 +688,10 @@ class PhotonAdapter(BasePlatformAdapter):
             is_voice = payload.get("type") == "voice"
             name = payload.get("name") or ("voice" if is_voice else "(unnamed)")
             mime = payload.get("mimeType") or ""
-            # Only .caf files are promoted to VOICE (iMessage voice notes use CAF).
-            if not is_voice and name.lower().endswith(".caf"):
+            # Promote CAF attachments to VOICE (iMessage voice notes use CAF).
+            # Check both filename and MIME: the sidecar may send "(unnamed)"
+            # when no name is supplied, so the MIME type is the reliable signal.
+            if not is_voice and (name.lower().endswith(".caf") or mime == "audio/x-caf"):
                 is_voice = True
             mtype = MessageType.VOICE if is_voice else _attachment_message_type(mime)
             cached = _cache_inbound_attachment(
@@ -756,6 +763,28 @@ class PhotonAdapter(BasePlatformAdapter):
                 )
             )
             return
+        # U+FFFC placeholder — wait for the real attachment instead of
+        # dispatching. Detected before _record_last_inbound so the placeholder
+        # is not recorded as the reaction target — the real attachment will be.
+        if ctype == "text" and (content.get("text") or "").strip() == "\ufffc":
+            chat_key = space_id
+            prev = self._pending_fffc.pop(chat_key, None)
+            if prev and prev[1] and not prev[1].done():
+                prev[1].cancel()
+            task = asyncio.create_task(
+                self._fffc_timeout_handler(chat_key, event.get("messageId") or "")
+            )
+            self._pending_fffc[chat_key] = (time.monotonic(), task)
+            logger.debug("[photon] U+FFFC placeholder received — waiting for attachment")
+            return
+
+        # Cancel any pending U+FFFC timeout — the real message arrived.
+        if ctype in {"attachment", "voice"}:
+            prev = self._pending_fffc.pop(space_id, None)
+            if prev and prev[1] and not prev[1].done():
+                prev[1].cancel()
+                logger.debug("[photon] attachment arrived — cancelling U+FFFC timeout")
+
         # Anything past here is a real (reactable) message — remember it as
         # the chat's latest inbound so `add_reaction` can target it when the
         # caller doesn't pass an explicit message id. Recorded before the
@@ -763,25 +792,8 @@ class PhotonAdapter(BasePlatformAdapter):
         self._record_last_inbound(space_id, event.get("messageId"))
         if ctype == "text":
             text = content.get("text") or ""
-            # U+FFFC placeholder — wait for the real attachment instead of dispatching.
-            if text.strip() == "\ufffc":
-                chat_key = space_id
-                prev = self._pending_fffc.pop(chat_key, None)
-                if prev and prev[1] and not prev[1].done():
-                    prev[1].cancel()
-                task = asyncio.create_task(
-                    self._fffc_timeout_handler(chat_key, event.get("messageId") or "")
-                )
-                self._pending_fffc[chat_key] = (time.monotonic(), task)
-                logger.debug("[photon] U+FFFC placeholder received — waiting for attachment")
-                return
             mtype = MessageType.TEXT
         elif ctype in {"attachment", "voice"}:
-            # Cancel any pending U+FFFC timeout — the real attachment arrived.
-            prev = self._pending_fffc.pop(space_id, None)
-            if prev and prev[1] and not prev[1].done():
-                prev[1].cancel()
-                logger.debug("[photon] attachment arrived — cancelling U+FFFC timeout")
             text, mtype, media_urls, media_types = _normalize_binary_payload(content)
         elif ctype == "group":
             text_parts: List[str] = []

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1593,7 +1593,7 @@ _AUDIO_EXT_BY_MIME = {
     "audio/mpeg": ".mp3",
     "audio/ogg": ".ogg",
     "audio/wav": ".wav",
-    "audio/x-caf": ".mp3",
+    "audio/x-caf": ".caf",
     "audio/mp4": ".m4a",
     "audio/aac": ".m4a",
 }

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -83,6 +83,8 @@ _MAX_MESSAGE_LENGTH = 8000
 _DEDUP_MAX_SIZE = 4000
 _DEDUP_WINDOW_SECONDS = 48 * 3600
 
+_FFFC_WAIT_SECONDS = 15.0  # Timeout for waiting on an attachment after a U+FFFC placeholder.
+
 _SIDECAR_DIR = Path(__file__).parent / "sidecar"
 
 # Cap on a self-heal `npm ci`/`npm install` of the sidecar deps. A cold
@@ -333,6 +335,8 @@ class PhotonAdapter(BasePlatformAdapter):
         self._last_inbound_by_chat: Dict[str, str] = {}
         # Last time we sent a typing indicator per chat, for cooldown gating.
         self._typing_last_sent: Dict[str, float] = {}
+
+        self._pending_fffc: Dict[str, tuple[float, Any]] = {}  # chat_key → (timestamp, asyncio.Task)
 
         # Group-chat mention gating (parity with BlueBubbles). When enabled,
         # group messages are ignored unless they match a wake word; DMs are
@@ -611,6 +615,14 @@ class PhotonAdapter(BasePlatformAdapter):
                 del seen[old]
         return False
 
+    async def _fffc_timeout_handler(self, chat_key: str, message_id: str) -> None:
+        await asyncio.sleep(_FFFC_WAIT_SECONDS)
+        if self._pending_fffc.pop(chat_key, None):
+            logger.warning(
+                "[photon] wait for attachment was too long, can't retrieve attachment data "
+                "(message %s, chat %s)", message_id, chat_key,
+            )
+
     async def _dispatch_inbound(self, event: Dict[str, Any]) -> None:
         """Normalize a sidecar inbound event and dispatch it to the gateway.
 
@@ -751,8 +763,25 @@ class PhotonAdapter(BasePlatformAdapter):
         self._record_last_inbound(space_id, event.get("messageId"))
         if ctype == "text":
             text = content.get("text") or ""
+            # U+FFFC placeholder — wait for the real attachment instead of dispatching.
+            if text.strip() == "\ufffc":
+                chat_key = space_id
+                prev = self._pending_fffc.pop(chat_key, None)
+                if prev and prev[1] and not prev[1].done():
+                    prev[1].cancel()
+                task = asyncio.create_task(
+                    self._fffc_timeout_handler(chat_key, event.get("messageId") or "")
+                )
+                self._pending_fffc[chat_key] = (time.monotonic(), task)
+                logger.debug("[photon] U+FFFC placeholder received — waiting for attachment")
+                return
             mtype = MessageType.TEXT
         elif ctype in {"attachment", "voice"}:
+            # Cancel any pending U+FFFC timeout — the real attachment arrived.
+            prev = self._pending_fffc.pop(space_id, None)
+            if prev and prev[1] and not prev[1].done():
+                prev[1].cancel()
+                logger.debug("[photon] attachment arrived — cancelling U+FFFC timeout")
             text, mtype, media_urls, media_types = _normalize_binary_payload(content)
         elif ctype == "group":
             text_parts: List[str] = []

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -6,6 +6,7 @@ sidecar-event parsing without spawning the Node sidecar or binding ports.
 """
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 from pathlib import Path
@@ -362,3 +363,220 @@ def test_check_requirements_without_node(monkeypatch: pytest.MonkeyPatch) -> Non
 
     monkeypatch.setattr(adapter_mod.shutil, "which", lambda _name: None)
     assert adapter_mod.check_requirements() is False
+
+
+# ---------------------------------------------------------------------------
+# CAF attachment promotion + U+FFFC placeholder tests
+# ---------------------------------------------------------------------------
+
+_CAF_BYTES = b"caff" + b"\x00" * 60  # Minimal CAF header magic
+
+
+def _caf_attachment_event(
+    content: Dict[str, Any], msg_id: str = "spc-msg-caf"
+) -> Dict[str, Any]:
+    return {
+        "messageId": msg_id,
+        "space": {"id": "+155****4567", "type": "dm", "phone": "+155****4567"},
+        "sender": {"id": "+155****4567"},
+        "content": {"type": "attachment", **content},
+        "timestamp": "2026-05-14T19:06:32.000Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_caf_attachment_named_promoted_to_voice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A named .caf attachment is promoted to VOICE for STT routing."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    raw = _CAF_BYTES
+    event = _caf_attachment_event(
+        {
+            "name": "voice_note.caf",
+            "mimeType": "audio/x-caf",
+            "size": len(raw),
+            "data": base64.b64encode(raw).decode("ascii"),
+            "encoding": "base64",
+        }
+    )
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    ev = captured[0]
+    assert ev.message_type == MessageType.VOICE
+    assert ev.media_types == ["audio/x-caf"]
+    assert len(ev.media_urls) == 1
+    cached = Path(ev.media_urls[0])
+    try:
+        assert cached.is_file()
+        assert cached.read_bytes() == raw
+        assert ev.text == "(voice)"
+    finally:
+        cached.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_caf_attachment_unnamed_promoted_via_mime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unnamed attachment with mimeType audio/x-caf is promoted to VOICE.
+
+    The sidecar sends "(unnamed)" when no filename is supplied, so the MIME
+    type must be the fallback signal for CAF promotion.
+    """
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    raw = _CAF_BYTES
+    event = _caf_attachment_event(
+        {
+            "name": "(unnamed)",
+            "mimeType": "audio/x-caf",
+            "size": len(raw),
+            "data": base64.b64encode(raw).decode("ascii"),
+            "encoding": "base64",
+        }
+    )
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    ev = captured[0]
+    assert ev.message_type == MessageType.VOICE
+    assert ev.media_types == ["audio/x-caf"]
+    cached = Path(ev.media_urls[0])
+    try:
+        assert cached.is_file()
+        assert cached.suffix == ".caf"
+    finally:
+        cached.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_fffc_placeholder_no_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A U+FFFC placeholder text does not trigger a message dispatch."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _dm_event("\ufffc", msg_id="spc-msg-fffc")
+    chat_key = event["space"]["id"]
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 0
+    assert chat_key in adapter._pending_fffc
+
+
+@pytest.mark.asyncio
+async def test_fffc_placeholder_not_recorded_as_last_inbound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The U+FFFC placeholder must not be recorded as the reaction target.
+
+    _record_last_inbound runs after the U+FFFC early-return, so the placeholder
+    message id is never stored. A subsequent real message will be recorded.
+    """
+    adapter = _make_adapter(monkeypatch)
+    _capture(adapter, monkeypatch)
+
+    fffc_event = _dm_event("\ufffc", msg_id="spc-msg-fffc")
+    chat_key = fffc_event["space"]["id"]
+    await adapter._dispatch_inbound(fffc_event)
+    assert chat_key not in adapter._last_inbound_by_chat
+
+    real_event = _dm_event("hello", msg_id="spc-msg-real")
+    await adapter._dispatch_inbound(real_event)
+    assert adapter._last_inbound_by_chat.get(chat_key) == "spc-msg-real"
+
+
+@pytest.mark.asyncio
+async def test_fffc_then_attachment_cancels_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When an attachment arrives after a U+FFFC placeholder, the pending
+    timeout task is cancelled and the attachment is dispatched normally."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    fffc_event = _dm_event("\ufffc", msg_id="spc-msg-fffc")
+    chat_key = fffc_event["space"]["id"]
+    await adapter._dispatch_inbound(fffc_event)
+    assert len(captured) == 0
+    assert chat_key in adapter._pending_fffc
+
+    raw = _CAF_BYTES
+    att_event = _caf_attachment_event(
+        {
+            "name": "voice.caf",
+            "mimeType": "audio/x-caf",
+            "size": len(raw),
+            "data": base64.b64encode(raw).decode("ascii"),
+            "encoding": "base64",
+        },
+        msg_id="spc-msg-att",
+    )
+    att_event["space"]["id"] = chat_key
+    await adapter._dispatch_inbound(att_event)
+
+    assert len(captured) == 1
+    assert captured[0].message_type == MessageType.VOICE
+    assert chat_key not in adapter._pending_fffc
+    assert adapter._last_inbound_by_chat.get(chat_key) == "spc-msg-att"
+
+    cached = Path(captured[0].media_urls[0])
+    try:
+        assert cached.is_file()
+    finally:
+        cached.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_fffc_timeout_fires_when_no_attachment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no attachment arrives within the timeout, the pending entry is
+    cleaned up and a warning is logged."""
+    import plugins.platforms.photon.adapter as adapter_mod
+
+    monkeypatch.setattr(adapter_mod, "_FFFC_WAIT_SECONDS", 0.1)
+
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    fffc_event = _dm_event("\ufffc", msg_id="spc-msg-fffc")
+    chat_key = fffc_event["space"]["id"]
+    await adapter._dispatch_inbound(fffc_event)
+    assert chat_key in adapter._pending_fffc
+
+    await asyncio.sleep(0.3)
+
+    assert chat_key not in adapter._pending_fffc
+    assert len(captured) == 0
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_pending_fffc_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """disconnect() cancels any pending U+FFFC placeholder tasks."""
+    adapter = _make_adapter(monkeypatch)
+    _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_dm_event("\ufffc", msg_id="spc-msg-fffc"))
+    assert len(adapter._pending_fffc) == 1
+
+    async def _noop_stop_sidecar():
+        pass
+
+    monkeypatch.setattr(adapter, "_stop_sidecar", _noop_stop_sidecar)
+    monkeypatch.setattr(adapter, "_inbound_running", False)
+    monkeypatch.setattr(adapter, "_inbound_task", None)
+    monkeypatch.setattr(adapter, "_sidecar_health_task", None)
+    monkeypatch.setattr(adapter, "_http_client", None)
+
+    await adapter.disconnect()
+
+    assert len(adapter._pending_fffc) == 0

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -11,6 +11,7 @@ import struct
 import subprocess
 import types
 import wave
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1578,3 +1579,144 @@ class TestShellSafety:
         monkeypatch.delenv(LOCAL_STT_COMMAND_ENV, raising=False)
         use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
         assert use_shell is False
+
+
+# ============================================================================
+# CAF (iMessage voice note) conversion tests
+# ============================================================================
+
+class TestCafConversion:
+    """Tests for _convert_caf_to_wav and CAF dispatch in transcribe_audio."""
+
+    def test_convert_caf_with_ffmpeg(self, tmp_path, monkeypatch):
+        """_convert_caf_to_wav uses ffmpeg when available."""
+        caf_path = tmp_path / "voice.caf"
+        caf_path.write_bytes(b"caff\x00" * 20)
+        wav_path = str(tmp_path / "voice.wav")
+
+        def fake_run(cmd, **kwargs):
+            Path(wav_path).write_bytes(b"RIFF\x00\x00\x00\x00")
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(
+            "tools.transcription_tools._find_ffmpeg_binary",
+            lambda: "/usr/bin/ffmpeg",
+        )
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        from tools.transcription_tools import _convert_caf_to_wav
+        result = _convert_caf_to_wav(str(caf_path))
+        assert result == wav_path
+        assert Path(result).exists()
+
+    def test_convert_caf_fallback_to_afconvert(self, tmp_path, monkeypatch):
+        """When ffmpeg is not found, falls back to afconvert (macOS)."""
+        caf_path = tmp_path / "voice.caf"
+        caf_path.write_bytes(b"caff\x00" * 20)
+        wav_path = str(tmp_path / "voice.wav")
+
+        call_count = {"n": 0}
+
+        def fake_run(cmd, **kwargs):
+            call_count["n"] += 1
+            if cmd[0] == "/usr/bin/ffmpeg":
+                raise subprocess.CalledProcessError(1, cmd)
+            Path(wav_path).write_bytes(b"RIFF\x00\x00\x00\x00")
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(
+            "tools.transcription_tools._find_ffmpeg_binary",
+            lambda: "/usr/bin/ffmpeg",
+        )
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "tools.transcription_tools.shutil.which",
+            lambda name: "/usr/bin/afconvert" if name == "afconvert" else None,
+        )
+
+        from tools.transcription_tools import _convert_caf_to_wav
+        result = _convert_caf_to_wav(str(caf_path))
+        assert result == wav_path
+        assert call_count["n"] == 2
+
+    def test_convert_caf_all_converters_fail(self, tmp_path, monkeypatch):
+        """When both ffmpeg and afconvert are unavailable, returns None."""
+        caf_path = tmp_path / "voice.caf"
+        caf_path.write_bytes(b"caff\x00" * 20)
+
+        monkeypatch.setattr(
+            "tools.transcription_tools._find_ffmpeg_binary", lambda: None
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools.shutil.which", lambda name: None
+        )
+
+        from tools.transcription_tools import _convert_caf_to_wav
+        result = _convert_caf_to_wav(str(caf_path))
+        assert result is None
+
+    def test_transcribe_caf_converted_before_groq(self, tmp_path, monkeypatch):
+        """transcribe_audio converts .caf to .wav before dispatching to Groq."""
+        caf_path = tmp_path / "voice.caf"
+        caf_path.write_bytes(b"caff\x00" * 20)
+        wav_path = str(tmp_path / "voice.wav")
+
+        def fake_convert(file_path):
+            Path(wav_path).write_bytes(b"RIFF\x00\x00\x00\x00")
+            return wav_path
+
+        with patch("tools.transcription_tools._load_stt_config",
+                   return_value={"provider": "groq"}), \
+             patch("tools.transcription_tools._get_provider",
+                   return_value="groq"), \
+             patch("tools.transcription_tools._convert_caf_to_wav",
+                   side_effect=fake_convert) as mock_convert, \
+             patch("tools.transcription_tools._transcribe_groq",
+                   return_value={"success": True, "transcript": "hello",
+                                 "provider": "groq"}) as mock_groq:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(str(caf_path))
+
+        assert result["success"] is True
+        mock_convert.assert_called_once_with(str(caf_path))
+        mock_groq.assert_called_once()
+        call_args = mock_groq.call_args
+        sent_path = call_args[0][0] if call_args[0] else call_args[1].get("file_path")
+        assert sent_path == wav_path
+
+    def test_transcribe_caf_conversion_failure_returns_error(
+        self, tmp_path, monkeypatch
+    ):
+        """When CAF conversion fails, transcribe_audio returns an error."""
+        caf_path = tmp_path / "voice.caf"
+        caf_path.write_bytes(b"caff\x00" * 20)
+
+        with patch("tools.transcription_tools._load_stt_config",
+                   return_value={"provider": "groq"}), \
+             patch("tools.transcription_tools._get_provider",
+                   return_value="groq"), \
+             patch("tools.transcription_tools._convert_caf_to_wav",
+                   return_value=None):
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(str(caf_path))
+
+        assert result["success"] is False
+        assert "could not be converted" in result["error"]
+
+    def test_transcribe_caf_not_converted_for_local(self, tmp_path, monkeypatch):
+        """CAF conversion is skipped for local provider (native handling)."""
+        caf_path = tmp_path / "voice.caf"
+        caf_path.write_bytes(b"caff\x00" * 20)
+
+        with patch("tools.transcription_tools._load_stt_config",
+                   return_value={"provider": "local"}), \
+             patch("tools.transcription_tools._get_provider",
+                   return_value="local"), \
+             patch("tools.transcription_tools._convert_caf_to_wav") as mock_convert, \
+             patch("tools.transcription_tools._transcribe_local",
+                   return_value={"success": True, "transcript": "hi"}):
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(str(caf_path))
+
+        assert result["success"] is True
+        mock_convert.assert_not_called()

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -101,7 +101,7 @@ XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
 ELEVENLABS_STT_BASE_URL = os.getenv("ELEVENLABS_STT_BASE_URL", "https://api.elevenlabs.io/v1")
 # DeepInfra STT base URL now resolved via hermes_cli.models.deepinfra_base_url (shared).
 
-SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
+SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac", ".caf"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 
@@ -1218,6 +1218,32 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
         return None, f"Failed to convert audio for local STT: {details}"
 
 
+def _convert_caf_to_wav(file_path: str) -> Optional[str]:
+    """Convert CAF to WAV using ffmpeg or afconvert (macOS)."""
+    audio_path = Path(file_path)
+    wav_path = os.path.join(audio_path.parent, f"{audio_path.stem}.wav")
+    ffmpeg = _find_ffmpeg_binary()
+    if ffmpeg:
+        try:
+            subprocess.run([ffmpeg, "-y", "-i", file_path, wav_path],
+                check=True, capture_output=True, text=True,
+                timeout=300, stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags())
+            return wav_path
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            logger.warning("ffmpeg CAF to WAV failed for %s: %s", file_path, e)
+    afconvert = shutil.which("afconvert")
+    if afconvert:
+        try:
+            subprocess.run([afconvert, file_path, wav_path, "-d", "LEI16", "-f", "WAVE"],
+                check=True, capture_output=True, text=True,
+                timeout=300, stdin=subprocess.DEVNULL)
+            return wav_path
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            logger.warning("afconvert CAF to WAV failed for %s: %s", file_path, e)
+    return None
+
+
 def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]:
     """Run the configured local STT command template and read back a .txt transcript."""
     command_template = _get_local_command_template()
@@ -1743,6 +1769,15 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         }
 
     provider = _get_provider(stt_config)
+
+    # Convert CAF (iMessage voice notes) to WAV for cloud STT providers.
+    if Path(file_path).suffix.lower() == ".caf" and provider not in ("local", "local_command"):
+        converted = _convert_caf_to_wav(file_path)
+        if converted:
+            file_path = converted
+        else:
+            return {"success": False, "transcript": "",
+                    "error": "CAF audio could not be converted to WAV."}
 
     if provider == "local":
         local_cfg = stt_config.get("local") or {}


### PR DESCRIPTION
## Bug

iMessage voice notes received through the Photon adapter are **never auto-transcribed** by the STT pipeline. Instead, a U+FFFC placeholder character arrives as a text message, which:

1. Triggers a spurious agent turn ("⚡ Interrupting current task..."), disrupting any active conversation
2. Produces no transcription — the agent receives an empty text message instead of the voice content

The actual audio file (`.caf`) may arrive separately as an attachment, but it is classified as `MessageType.DOCUMENT` or `MessageType.AUDIO`, bypassing the STT routing logic entirely (the gateway only transcribes `MessageType.VOICE`).

## Root cause

The `@spectrum-ts/imessage` SDK (cloud gRPC mode, used by the Photon sidecar) has three issues:

### 1. Voice notes classified as `attachment`, not `voice`
The SDK classifies all inbound attachments as `type: "attachment"` — it never calls `asVoice()` on the inbound path. The `isAudioMessage` protobuf flag (tag 320) is ignored by the inbound mapper.

### 2. U+FFFC placeholder fires before CloudKit syncs the attachment
Apple's gRPC cloud push emits a U+FFFC text placeholder where the attachment should be, but `attachments` is still empty. The local SDK path has a retry (`refetchUntilAttachmentsSettle`), but the remote/cloud path has none.

### 3. CAF format not supported by cloud STT providers
The `.caf` file cannot be parsed by cloud Whisper APIs. Additionally, `audio/x-caf` was mapped to `.mp3` extension, producing corrupt files.

## Expected behavior

When a user sends an iMessage voice note via Photon:

1. The U+FFFC placeholder should **not** trigger a spurious agent turn or interrupt the active task
2. The real audio attachment should be detected and classified as `MessageType.VOICE`
3. The audio should be converted from CAF to WAV (using ffmpeg or afconvert)
4. The WAV file should be sent to the configured STT provider (e.g., Groq Whisper)
5. The transcription should be delivered to the agent as the message text
6. If no attachment arrives within a reasonable timeout, a warning should be logged

## Environment

- Hermes Agent with Photon adapter (spectrum-ts cloud gRPC mode)
- STT provider: Groq Whisper (`whisper-large-v3`)
- Platform: macOS

## Related

- #38299 (Feishu): same class of bug — voice messages routed as AUDIO instead of VOICE
- #57882 (LINE): same class of bug — audio routed through image cache instead of STT
- #54514 (Photon): fixes a media placeholder race condition but does not address STT

Fixes : 
1. Map `audio/x-caf` to `.caf` extension (was `.mp3`)
2. Promote `.caf` attachments to `MessageType.VOICE`
3. Handle U+FFFC placeholder with a non-blocking deferred wait (15s timeout)
4. Add `.caf` to `SUPPORTED_FORMATS` + CAF→WAV conversion via ffmpeg/afconvert
