### PR TITLE
feat: route Telegram coding workers through Threadwire

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4423,7 +4423,13 @@ def run_conversation(
                 
                 if agent.verbose_logging:
                     for tc in assistant_message.tool_calls:
-                        logging.debug(f"Tool call: {tc.function.name} with args: {tc.function.arguments[:200]}...")
+                        arguments = tc.function.arguments
+                        argument_length = len(arguments) if arguments is not None else 0
+                        logging.debug(
+                            "Tool call: %s (argument length: %d)",
+                            tc.function.name,
+                            argument_length,
+                        )
                 
                 # Validate tool call names - detect model hallucinations
                 # Repair mismatched tool names before validating
@@ -4658,7 +4664,13 @@ def run_conversation(
                 agent._post_tool_empty_retried = False
 
                 messages.append(assistant_msg)
-                agent._emit_interim_assistant_message(assistant_msg)
+                # Interim callbacks are observers, not execution surfaces.
+                # Give them a safe copy while retaining raw arguments in the
+                # live message until dispatch has completed below.
+                from agent.tool_privacy import redact_message_for_persistence
+                agent._emit_interim_assistant_message(
+                    redact_message_for_persistence(assistant_msg)
+                )
                 try:
                     # Persist the assistant tool-call turn before any tool
                     # side effects run. If a destructive tool restarts or
@@ -4685,7 +4697,17 @@ def run_conversation(
                     except Exception:
                         pass
 
-                agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+                try:
+                    agent._execute_tool_calls(
+                        assistant_message, messages, effective_task_id, api_call_count
+                    )
+                finally:
+                    # Private dispatch arguments are needed through immediate
+                    # execution and guardrail/post-hook bookkeeping, but must
+                    # not survive even when dispatch raises. Keep IDs and call
+                    # structure intact for assistant/tool protocol pairing.
+                    from agent.tool_privacy import redact_executed_tool_calls_in_place
+                    redact_executed_tool_calls_in_place(assistant_msg)
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision

--- a/agent/display.py
+++ b/agent/display.py
@@ -389,6 +389,16 @@ def redact_tool_args_for_display(tool_name: str, args: dict | None) -> dict | No
     """
     if not isinstance(args, dict):
         return args
+    if tool_name == "telegram_coding_worker":
+        # This tool runs inside a messaging gateway. Its target is deliberately
+        # absent from model arguments, and every remaining value may contain a
+        # prompt, local path, provider option, or provider session identifier.
+        # Keep progress/log callbacks useful without echoing any of those values
+        # into Telegram or ordinary Hermes logs.
+        safe_args = {key: "<redacted>" for key in args}
+        if "provider" in args:
+            safe_args["provider"] = "coding worker"
+        return safe_args
     if tool_name == "browser_type" and isinstance(args.get("text"), str):
         safe_args = dict(args)
         safe_args["text"] = redact_sensitive_text(args["text"], force=True)
@@ -420,6 +430,8 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
     if not args:
         return None
     args = redact_tool_args_for_display(tool_name, args) or args
+    if tool_name == "telegram_coding_worker":
+        return "coding worker"
     primary_args = {
         "terminal": "command", "web_search": "query", "web_extract": "urls",
         "read_file": "path", "write_file": "path", "patch": "path",
@@ -1436,5 +1448,4 @@ def get_cute_tool_message(
 # =========================================================================
 # Honcho session line (one-liner with clickable OSC 8 hyperlink)
 # =========================================================================
-
 

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -344,6 +344,9 @@ def _trajectory_normalize_msg(msg: Dict[str, Any]) -> Dict[str, Any]:
     """
     if not isinstance(msg, dict):
         return msg
+    from agent.tool_privacy import redact_message_for_persistence
+
+    msg = redact_message_for_persistence(msg)
     content = msg.get("content")
     if _is_multimodal_tool_result(content):
         return {**msg, "content": _multimodal_text_summary(content)}

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -255,9 +255,11 @@ def _apply_tool_request_middleware_for_agent(
     try:
         from hermes_cli.middleware import apply_tool_request_middleware
 
+        from agent.tool_privacy import redact_tool_args_for_observers
+        observer_args = redact_tool_args_for_observers(function_name, function_args)
         result = apply_tool_request_middleware(
             function_name,
-            function_args,
+            observer_args,
             task_id=effective_task_id or "",
             session_id=getattr(agent, "session_id", "") or "",
             tool_call_id=tool_call_id or "",
@@ -265,6 +267,8 @@ def _apply_tool_request_middleware_for_agent(
             api_request_id=getattr(agent, "_current_api_request_id", "") or "",
         )
         payload = result.payload if isinstance(result.payload, dict) else function_args
+        if function_name == "telegram_coding_worker":
+            payload = function_args
         return payload, list(result.trace)
     except Exception as exc:
         logger.debug("tool_request middleware error: %s", exc)
@@ -280,20 +284,28 @@ def _run_agent_tool_execution_middleware(
     tool_call_id: str,
     execute,
 ) -> tuple[Any, dict]:
+    from agent.tool_privacy import redact_tool_args_for_observers
+
+    private_tool = function_name == "telegram_coding_worker"
+    observer_args = redact_tool_args_for_observers(function_name, function_args)
     observed_args = function_args
 
     def _execute(next_args: dict) -> Any:
         nonlocal observed_args
-        observed_args = next_args if isinstance(next_args, dict) else function_args
+        observed_args = (
+            function_args
+            if private_tool
+            else next_args if isinstance(next_args, dict) else function_args
+        )
         return execute(observed_args)
 
     from hermes_cli.middleware import run_tool_execution_middleware
 
     result = run_tool_execution_middleware(
         function_name,
-        function_args,
+        observer_args,
         _execute,
-        original_args=function_args,
+        original_args=observer_args,
         task_id=effective_task_id or "",
         session_id=getattr(agent, "session_id", "") or "",
         tool_call_id=tool_call_id or "",
@@ -415,10 +427,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             )
         else:
             try:
+                from agent.tool_privacy import redact_tool_args_for_observers
                 from hermes_cli.plugins import resolve_pre_tool_block
                 block_message = resolve_pre_tool_block(
                     function_name,
-                    function_args,
+                    redact_tool_args_for_observers(function_name, function_args),
                     task_id=effective_task_id or "",
                     session_id=getattr(agent, "session_id", "") or "",
                     tool_call_id=getattr(tool_call, "id", "") or "",
@@ -1034,10 +1047,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             _block_error_type = "tool_scope_block"
         else:
             try:
+                from agent.tool_privacy import redact_tool_args_for_observers
                 from hermes_cli.plugins import resolve_pre_tool_block
                 _block_msg = resolve_pre_tool_block(
                     function_name,
-                    function_args,
+                    redact_tool_args_for_observers(function_name, function_args),
                     task_id=effective_task_id or "",
                     session_id=getattr(agent, "session_id", "") or "",
                     tool_call_id=getattr(tool_call, "id", "") or "",

--- a/agent/tool_privacy.py
+++ b/agent/tool_privacy.py
@@ -1,0 +1,75 @@
+"""Tool-specific privacy boundaries for arguments that must stay transient."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from typing import Any
+
+
+PRIVATE_ARGUMENT_TOOL = "telegram_coding_worker"
+REDACTED_ARGUMENT_VALUE = "[redacted]"
+
+
+def redact_tool_args_for_observers(tool_name: str, args: Any) -> Any:
+    """Return an observer-safe copy of *args* without changing live arguments."""
+    if tool_name != PRIVATE_ARGUMENT_TOOL:
+        return args
+    if not isinstance(args, dict):
+        return {}
+    return {str(key): REDACTED_ARGUMENT_VALUE for key in args}
+
+
+def redact_tool_calls_for_persistence(tool_calls: Any) -> Any:
+    """Copy tool calls and redact private-tool argument values for storage."""
+    try:
+        cleaned = deepcopy(tool_calls)
+    except Exception:
+        cleaned = tool_calls
+    if not isinstance(cleaned, list):
+        return cleaned
+    for call in cleaned:
+        if not isinstance(call, dict):
+            continue
+        function = call.get("function")
+        if isinstance(function, dict):
+            name = function.get("name")
+            arguments_owner = function
+        else:
+            name = call.get("name")
+            arguments_owner = call
+        if name != PRIVATE_ARGUMENT_TOOL or "arguments" not in arguments_owner:
+            continue
+        arguments = arguments_owner.get("arguments")
+        if isinstance(arguments, str):
+            try:
+                arguments = json.loads(arguments)
+            except (TypeError, ValueError):
+                arguments = {}
+            redacted = redact_tool_args_for_observers(name, arguments)
+            arguments_owner["arguments"] = json.dumps(redacted, ensure_ascii=False)
+        else:
+            arguments_owner["arguments"] = redact_tool_args_for_observers(name, arguments)
+    return cleaned
+
+
+def redact_message_for_persistence(message: Any) -> Any:
+    """Return a storage-safe message copy while leaving live context untouched."""
+    if not isinstance(message, dict) or not isinstance(message.get("tool_calls"), list):
+        return message
+    return {
+        **message,
+        "tool_calls": redact_tool_calls_for_persistence(message["tool_calls"]),
+    }
+
+
+def redact_executed_tool_calls_in_place(message: Any) -> None:
+    """Redact private arguments on a live assistant message after dispatch.
+
+    The caller must invoke this only after execution and its guardrail/hook
+    bookkeeping have finished.  Replacing just ``tool_calls`` preserves the
+    assistant message object, call IDs, and provider-required message order.
+    """
+    if not isinstance(message, dict) or not isinstance(message.get("tool_calls"), list):
+        return
+    message["tool_calls"] = redact_tool_calls_for_persistence(message["tool_calls"])

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -316,6 +316,20 @@ def get_session_env(name: str, default: str = "") -> str:
     return os.getenv(name, default)
 
 
+def get_bound_session_env(name: str, default: str = "") -> str:
+    """Read a session value only when its ContextVar is bound here.
+
+    Unlike :func:`get_session_env`, this helper never falls back to the
+    process environment. Unknown names and ContextVars that are ``_UNSET`` in
+    the current context return *default*.
+    """
+    var = _VAR_MAP.get(name)
+    if var is None:
+        return default
+    value = var.get()
+    return default if value is _UNSET else value
+
+
 def async_delivery_supported() -> bool:
     """Whether the current session can deliver a background completion later.
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3447,6 +3447,9 @@ class SessionDB:
             json.dumps(codex_message_items)
             if codex_message_items else None
         )
+        if tool_calls:
+            from agent.tool_privacy import redact_tool_calls_for_persistence
+            tool_calls = redact_tool_calls_for_persistence(tool_calls)
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
@@ -3553,6 +3556,9 @@ class SessionDB:
             codex_message_items_json = (
                 json.dumps(codex_message_items) if codex_message_items else None
             )
+            if tool_calls:
+                from agent.tool_privacy import redact_tool_calls_for_persistence
+                tool_calls = redact_tool_calls_for_persistence(tool_calls)
             tool_calls_json = json.dumps(tool_calls) if tool_calls else None
             # Accept either `platform_message_id` (new explicit name) or
             # `message_id` (yuanbao's existing convention on message dicts).

--- a/model_tools.py
+++ b/model_tools.py
@@ -996,10 +996,12 @@ def _emit_post_tool_call_hook(
             return
         if status is None:
             status, error_type, error_message = _tool_result_observer_fields(result)
+        from agent.tool_privacy import redact_tool_args_for_observers
+        observer_args = redact_tool_args_for_observers(function_name, function_args)
         invoke_hook(
             "post_tool_call",
             tool_name=function_name,
-            args=function_args,
+            args=observer_args,
             result=result,
             task_id=task_id or "",
             session_id=session_id or "",
@@ -1138,20 +1140,27 @@ def handle_function_call(
             )
 
     _tool_original_args = dict(function_args)
+    from agent.tool_privacy import redact_tool_args_for_observers
+    _private_execution_args = dict(function_args)
+    _observer_args = redact_tool_args_for_observers(function_name, function_args)
     if not skip_tool_request_middleware:
         try:
             from hermes_cli.middleware import apply_tool_request_middleware
 
             _tool_request_mw = apply_tool_request_middleware(
                 function_name,
-                function_args,
+                _observer_args,
                 task_id=task_id or "",
                 session_id=session_id or "",
                 tool_call_id=tool_call_id or "",
                 turn_id=turn_id or "",
                 api_request_id=api_request_id or "",
             )
-            function_args = _tool_request_mw.payload
+            function_args = (
+                _private_execution_args
+                if function_name == "telegram_coding_worker"
+                else _tool_request_mw.payload
+            )
             _tool_original_args = _tool_request_mw.original_payload
             _tool_middleware_trace = _tool_request_mw.trace
         except Exception as _mw_err:
@@ -1178,7 +1187,7 @@ def handle_function_call(
                 from hermes_cli.plugins import resolve_pre_tool_block
                 block_message = resolve_pre_tool_block(
                     function_name,
-                    function_args,
+                    redact_tool_args_for_observers(function_name, function_args),
                     task_id=task_id or "",
                     session_id=session_id or "",
                     tool_call_id=tool_call_id or "",
@@ -1272,11 +1281,22 @@ def handle_function_call(
                     )
             from hermes_cli.middleware import run_tool_execution_middleware
 
+            execution_observer_args = redact_tool_args_for_observers(
+                function_name, function_args
+            )
+
+            def _observer_dispatch(next_args: Dict[str, Any]) -> Any:
+                if function_name == "telegram_coding_worker":
+                    return _dispatch(function_args)
+                return _dispatch(next_args)
+
             result = run_tool_execution_middleware(
                 function_name,
-                function_args,
-                _dispatch,
-                original_args=_tool_original_args,
+                execution_observer_args,
+                _observer_dispatch,
+                original_args=redact_tool_args_for_observers(
+                    function_name, _tool_original_args
+                ),
                 task_id=task_id or "",
                 session_id=session_id or "",
                 tool_call_id=tool_call_id or "",
@@ -1319,7 +1339,7 @@ def handle_function_call(
                 hook_results = invoke_hook(
                     "transform_tool_result",
                     tool_name=function_name,
-                    args=function_args,
+                    args=redact_tool_args_for_observers(function_name, function_args),
                     result=result,
                     task_id=task_id or "",
                     session_id=session_id or "",

--- a/run_agent.py
+++ b/run_agent.py
@@ -1860,6 +1860,9 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
+                if tool_calls_data is not None:
+                    from agent.tool_privacy import redact_tool_calls_for_persistence
+                    tool_calls_data = redact_tool_calls_for_persistence(tool_calls_data)
                 self._session_db.append_message(
                     session_id=self.session_id,
                     role=role,
@@ -2562,6 +2565,8 @@ class AIAgent:
                 # internal retry state, never durable transcript content.
                 if _is_ephemeral_scaffolding(msg):
                     continue
+                from agent.tool_privacy import redact_message_for_persistence
+                msg = redact_message_for_persistence(msg)
                 if msg.get("role") == "assistant" and msg.get("content"):
                     msg = dict(msg)
                     msg["content"] = self._clean_session_content(msg["content"])

--- a/skills/autonomous-ai-agents/claude-code/SKILL.md
+++ b/skills/autonomous-ai-agents/claude-code/SKILL.md
@@ -15,6 +15,11 @@ metadata:
 
 Delegate coding tasks to [Claude Code](https://code.claude.com/docs/en/cli-reference) (Anthropic's autonomous coding agent CLI) via the Hermes terminal. Claude Code v2.x can read files, write code, run shell commands, spawn subagents, and manage git workflows autonomously.
 
+When the current conversation originates from Telegram, use the structured
+`telegram_coding_worker` tool with `provider="claude"` instead of launching
+Claude Code through `terminal`. The tool derives its delivery target from the
+authenticated current-session context; never supply or infer a target.
+
 ## Prerequisites
 
 - **Install:** `npm install -g @anthropic-ai/claude-code`

--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -15,6 +15,11 @@ metadata:
 
 Delegate coding tasks to [Codex](https://github.com/openai/codex) via the Hermes terminal. Codex is OpenAI's autonomous coding agent CLI.
 
+When the current conversation originates from Telegram, use the structured
+`telegram_coding_worker` tool with `provider="codex"` instead of launching
+Codex through `terminal`. The tool derives its delivery target from the
+authenticated current-session context; never supply or infer a target.
+
 ## When to use
 
 - Building features

--- a/skills/autonomous-ai-agents/opencode/SKILL.md
+++ b/skills/autonomous-ai-agents/opencode/SKILL.md
@@ -15,6 +15,11 @@ metadata:
 
 Use [OpenCode](https://opencode.ai) as an autonomous coding worker orchestrated by Hermes terminal/process tools. OpenCode is a provider-agnostic, open-source AI coding agent with a TUI and CLI.
 
+When the current conversation originates from Telegram, use the structured
+`telegram_coding_worker` tool with `provider="opencode"` instead of launching
+OpenCode through `terminal`. The tool derives its delivery target from the
+authenticated current-session context; never supply or infer a target.
+
 ## When to Use
 
 - User explicitly asks to use OpenCode

--- a/tests/agent/test_empty_tool_name_loop_dampening.py
+++ b/tests/agent/test_empty_tool_name_loop_dampening.py
@@ -22,6 +22,7 @@ of the message string.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
 import sys
@@ -181,3 +182,28 @@ def test_unknown_nonempty_name_keeps_catalog(agent_env):
     assert "frobnicate_xyz" in joined
     assert "Available tools:" in joined
     assert "tool name was empty" not in joined
+
+
+def test_verbose_tool_call_log_omits_telegram_worker_arguments(
+    agent_env, caplog, monkeypatch
+):
+    """Verbose diagnostics expose metadata, never raw coding-worker prompts."""
+    agent, handler = agent_env
+    sentinel = "TELEGRAM_WORKER_PROMPT_MUST_NOT_REACH_LOGS_7f24"
+    arguments = json.dumps({"provider": "codex", "prompt": sentinel})
+    handler.response_queue.append(_tc_resp("telegram_coding_worker", arguments))
+    handler.response_queue.append(_text_resp("done"))
+    agent.valid_tool_names.add("telegram_coding_worker")
+    agent.verbose_logging = True
+
+    monkeypatch.setattr("run_agent.handle_function_call", lambda *_a, **_kw: "ok")
+    with caplog.at_level(logging.DEBUG):
+        agent.run_conversation(
+            "delegate this task", conversation_history=[], task_id="t"
+        )
+
+    verbose_log = caplog.text
+    assert "Tool call: telegram_coding_worker" in verbose_log
+    assert f"argument length: {len(arguments)}" in verbose_log
+    assert sentinel not in verbose_log
+    assert arguments not in verbose_log

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -7,6 +7,7 @@ from gateway.config import Platform
 from gateway.run import GatewayRunner
 from gateway.session import SessionContext, SessionSource
 from gateway.session_context import (
+    get_bound_session_env,
     get_session_env,
     set_session_vars,
     clear_session_vars,
@@ -145,6 +146,18 @@ def test_get_session_env_default_when_nothing_set(monkeypatch):
 
     assert get_session_env("HERMES_SESSION_PLATFORM") == ""
     assert get_session_env("HERMES_SESSION_PLATFORM", "fallback") == "fallback"
+
+
+def test_get_bound_session_env_never_falls_back_to_process_environment(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+
+    assert get_bound_session_env("HERMES_SESSION_PLATFORM") == ""
+    assert get_bound_session_env("HERMES_SESSION_PLATFORM", "fallback") == "fallback"
+    assert get_bound_session_env("HERMES_SESSION_UNKNOWN", "fallback") == "fallback"
+
+    tokens = set_session_vars(platform="telegram")
+    assert get_bound_session_env("HERMES_SESSION_PLATFORM") == "telegram"
+    clear_session_vars(tokens)
 
 
 def test_set_session_env_handles_missing_optional_fields():
@@ -393,4 +406,3 @@ async def test_gateway_executor_refuses_resurrection_after_shutdown():
             await runner._run_in_executor_with_context(lambda: "second")
     finally:
         runner._shutdown_executor()
-

--- a/tests/gateway/test_telegram_coding_worker_routing.py
+++ b/tests/gateway/test_telegram_coding_worker_routing.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionContext, SessionSource
+from tools import threadwire_telegram_worker_tool as worker
+
+
+def test_gateway_bound_source_reaches_tool_dispatch(monkeypatch, tmp_path):
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100123",
+        chat_type="group",
+        user_id="44",
+        thread_id="7",
+    )
+    context = SessionContext(
+        source=source,
+        connected_platforms=[Platform.TELEGRAM],
+        home_channels={},
+        session_key="safe-test-key",
+    )
+    captured = []
+
+    class FakeProcess:
+        pid = 123
+        stdin = None
+
+        def poll(self):
+            return 0
+
+        def wait(self, timeout=None):
+            return 0
+
+    def fake_popen(argv, **kwargs):
+        captured.append((argv, kwargs))
+        return FakeProcess()
+
+    monkeypatch.setattr(worker, "check_threadwire_requirements", lambda: True)
+    monkeypatch.setattr(worker.subprocess, "Popen", fake_popen)
+    tokens = runner._set_session_env(context)
+    try:
+        result = worker._handle_threadwire({
+            "provider": "codex", "prompt": "work", "cwd": str(tmp_path)
+        })
+    finally:
+        runner._clear_session_env(tokens)
+
+    assert json.loads(result) == {"status": "completed", "exit_code": 0}
+    argv = captured[0][0]
+    assert argv[argv.index("--target") + 1] == "telegram:-100123:7"
+
+
+def test_bound_context_wins_over_conflicting_process_environment(monkeypatch, tmp_path):
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    context = SessionContext(
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="333",
+            chat_type="dm",
+            user_id="333",
+        ),
+        connected_platforms=[Platform.TELEGRAM],
+        home_channels={},
+    )
+    captured = []
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "999")
+    monkeypatch.setattr(worker, "check_threadwire_requirements", lambda: True)
+    monkeypatch.setattr(
+        worker.subprocess,
+        "Popen",
+        lambda argv, **kwargs: captured.append(argv) or SimpleNamespace(
+            pid=123, stdin=None, poll=lambda: 0, wait=lambda timeout=None: 0
+        ),
+    )
+
+    tokens = runner._set_session_env(context)
+    try:
+        result = worker.launch_telegram_coding_worker({
+            "provider": "claude", "prompt": "work", "cwd": str(tmp_path)
+        })
+    finally:
+        runner._clear_session_env(tokens)
+
+    assert json.loads(result)["status"] == "completed"
+    assert captured[0][captured[0].index("--target") + 1] == "telegram:333"

--- a/tests/run_agent/test_telegram_worker_privacy.py
+++ b/tests/run_agent/test_telegram_worker_privacy.py
@@ -1,0 +1,190 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.tool_dispatch_helpers import make_tool_result_message
+from run_agent import AIAgent, _trajectory_normalize_msg
+
+
+SENTINEL = "telegram-worker-prompt-sentinel"
+
+
+def _agent(session_db):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_db=session_db,
+        )
+
+
+def _conversation_agent():
+    tool_def = {
+        "type": "function",
+        "function": {
+            "name": "telegram_coding_worker",
+            "description": "dispatch coding work",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[tool_def]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _response(content, finish_reason, tool_calls=None):
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+        model="test/model",
+        usage=None,
+    )
+
+
+def _assistant_call():
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{
+            "id": "call-1",
+            "type": "function",
+            "function": {
+                "name": "telegram_coding_worker",
+                "arguments": json.dumps({"provider": "codex", "prompt": SENTINEL}),
+            },
+        }],
+    }
+
+
+def test_session_db_redacts_worker_args_without_mutating_live_message():
+    session_db = MagicMock()
+    agent = _agent(session_db)
+    message = _assistant_call()
+
+    agent._flush_messages_to_session_db([message])
+
+    stored = session_db.append_message.call_args.kwargs["tool_calls"]
+    assert SENTINEL not in json.dumps(stored)
+    assert SENTINEL in message["tool_calls"][0]["function"]["arguments"]
+
+
+def test_trajectory_conversion_redacts_worker_args_without_mutation():
+    agent = _agent(MagicMock())
+    message = _assistant_call()
+    messages = [
+        {"role": "user", "content": "start worker"},
+        message,
+        {"role": "tool", "content": "completed", "tool_call_id": "call-1"},
+    ]
+
+    normalized = _trajectory_normalize_msg(message)
+    trajectory = agent._convert_to_trajectory_format(messages, "start worker", True)
+
+    assert SENTINEL not in json.dumps(normalized)
+    assert SENTINEL not in json.dumps(trajectory)
+    assert SENTINEL in message["tool_calls"][0]["function"]["arguments"]
+
+
+def test_live_conversation_redacts_worker_args_after_dispatch_before_all_observers():
+    agent = _conversation_agent()
+    raw_arguments = json.dumps({"provider": "codex", "prompt": SENTINEL})
+    tool_call = SimpleNamespace(
+        id="call-1",
+        type="function",
+        function=SimpleNamespace(
+            name="telegram_coding_worker",
+            arguments=raw_arguments,
+        ),
+    )
+    dispatched = []
+    next_request_messages = []
+    external_memory_messages = []
+    background_snapshots = []
+    interim_messages = []
+
+    def _execute(assistant_message, messages, effective_task_id, api_call_count=0):
+        dispatched.append(assistant_message.tool_calls[0].function.arguments)
+        messages.append(
+            make_tool_result_message(
+                "telegram_coding_worker", "completed", "call-1"
+            )
+        )
+
+    request_count = 0
+
+    def _respond(*args, **kwargs):
+        nonlocal request_count
+        request_count += 1
+        if request_count == 1:
+            return _response("", "tool_calls", [tool_call])
+        next_request_messages.append(kwargs["messages"])
+        return _response("done", "stop")
+
+    agent.client.chat.completions.create.side_effect = _respond
+    agent.valid_tool_names.add("memory")
+    agent._memory_store = MagicMock()
+    agent._memory_nudge_interval = 1
+    agent._turns_since_memory = 0
+
+    with (
+        patch.object(agent, "_execute_tool_calls", side_effect=_execute),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(
+            agent,
+            "_emit_interim_assistant_message",
+            side_effect=lambda message: interim_messages.append(message),
+        ),
+        patch.object(
+            agent,
+            "_sync_external_memory_for_turn",
+            side_effect=lambda **kwargs: external_memory_messages.append(kwargs["messages"]),
+        ),
+        patch.object(
+            agent,
+            "_spawn_background_review",
+            side_effect=lambda **kwargs: background_snapshots.append(
+                kwargs["messages_snapshot"]
+            ),
+        ),
+    ):
+        result = agent.run_conversation("start worker")
+
+    assert SENTINEL in dispatched[0]
+    assert len(interim_messages) == 1
+    assert len(next_request_messages) == 1
+    assert len(external_memory_messages) == 1
+    assert len(background_snapshots) == 1
+    assert SENTINEL not in json.dumps(next_request_messages)
+    assert SENTINEL not in json.dumps(interim_messages)
+    assert SENTINEL not in json.dumps(result["messages"])
+    assert SENTINEL not in json.dumps(external_memory_messages)
+    assert SENTINEL not in json.dumps(background_snapshots)
+    live_call = next(
+        message for message in result["messages"] if message.get("tool_calls")
+    )["tool_calls"][0]
+    assert live_call["id"] == "call-1"
+    assert live_call["function"]["name"] == "telegram_coding_worker"

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -19,6 +19,44 @@ from model_tools import (
 # =========================================================================
 
 class TestHandleFunctionCall:
+    def test_private_worker_args_are_redacted_for_observers_but_raw_for_dispatch(self, monkeypatch):
+        sentinel = "telegram-worker-prompt-sentinel"
+        observed = []
+        executed = []
+
+        def request_middleware(kind, **kwargs):
+            observed.append((kind, kwargs))
+            return []
+
+        def execution_middleware(**kwargs):
+            observed.append(("tool_execution", kwargs))
+            return kwargs["next_call"](kwargs["args"])
+
+        manager = type("Manager", (), {"_middleware": {
+            "tool_request": [request_middleware],
+            "tool_execution": [execution_middleware],
+        }})()
+        monkeypatch.setattr("hermes_cli.plugins.invoke_middleware", request_middleware)
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda name, **kwargs: observed.append((name, kwargs)) or [],
+        )
+        monkeypatch.setattr("hermes_cli.plugins.has_hook", lambda _name: True)
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda _name, args, **_kwargs: executed.append(args) or '{"ok":true}',
+        )
+
+        result = handle_function_call(
+            "telegram_coding_worker",
+            {"provider": "codex", "prompt": sentinel},
+        )
+
+        assert result == '{"ok":true}'
+        assert executed == [{"provider": "codex", "prompt": sentinel}]
+        assert sentinel not in json.dumps(observed, default=str)
+
     def test_agent_loop_tool_returns_error(self):
         for tool_name in _AGENT_LOOP_TOOLS:
             result = json.loads(handle_function_call(tool_name, {}))

--- a/tests/tools/test_telegram_coding_worker_tool.py
+++ b/tests/tools/test_telegram_coding_worker_tool.py
@@ -1,0 +1,674 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import cast
+
+import pytest
+
+from gateway.session_context import reset_session_vars, set_session_vars
+from tools import threadwire_telegram_worker_tool as worker
+
+
+class FakeProcess:
+    def __init__(self, returncode: int | None = 0):
+        self.pid = 4242
+        self._returncode = returncode
+        self.stdin = io.StringIO()
+        self.signals = []
+        self.killed = False
+        self.wait_timeouts = []
+
+    def poll(self):
+        return self._returncode
+
+    def send_signal(self, sig):
+        self.signals.append(sig)
+
+    def kill(self):
+        self.killed = True
+        self._returncode = -9
+
+    def wait(self, timeout=None):
+        self.wait_timeouts.append(timeout)
+        return self._returncode
+
+
+@pytest.fixture(autouse=True)
+def clean_session_context():
+    reset_session_vars()
+    yield
+    reset_session_vars()
+
+
+@pytest.fixture
+def available_threadwire(monkeypatch):
+    monkeypatch.setattr(worker, "check_threadwire_requirements", lambda: True)
+
+
+def _bind(*, platform="telegram", chat_id="123", thread_id=""):
+    set_session_vars(platform=platform, chat_id=chat_id, thread_id=thread_id)
+
+
+def _capture_spawn(monkeypatch, *, returncode=0):
+    calls = []
+
+    def fake_popen(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return FakeProcess(returncode)
+
+    monkeypatch.setattr(worker.subprocess, "Popen", fake_popen)
+    return calls
+
+
+def test_dm_target_uses_authenticated_context_only(monkeypatch, tmp_path, available_threadwire):
+    _bind(chat_id="123456")
+    calls = _capture_spawn(monkeypatch)
+
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": "codex", "prompt": "do work", "cwd": str(tmp_path)
+    }))
+
+    assert result == {"status": "completed", "exit_code": 0}
+    argv, kwargs = calls[0]
+    assert argv[:2] == [worker.THREADWIRE_EXECUTABLE, "run"]
+    assert argv[argv.index("--target") + 1] == "telegram:123456"
+    assert kwargs["shell"] is False
+    assert kwargs["cwd"] == str(tmp_path)
+    assert kwargs["stdout"] is subprocess.DEVNULL
+    assert kwargs["stderr"] is subprocess.DEVNULL
+    assert kwargs["start_new_session"] is True
+    assert "--prompt" not in argv
+    assert "do work" not in argv
+    assert kwargs["stdin"].closed
+
+
+def test_forum_topic_target_and_passthrough(monkeypatch, tmp_path, available_threadwire):
+    _bind(chat_id="-100987", thread_id="42")
+    calls = _capture_spawn(monkeypatch)
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": "claude",
+        "prompt": "do work",
+        "cwd": str(tmp_path),
+        "process_number": 7,
+        "max_output_length": 2048,
+        "resume_session": "session-1",
+        "provider_arguments": ["--model", "sonnet"],
+    }))
+
+    assert result["status"] == "completed"
+    argv = calls[0][0]
+    assert argv[argv.index("--target") + 1] == "telegram:-100987:42"
+    assert ["--process-number", "7"] == argv[argv.index("--process-number"):argv.index("--process-number") + 2]
+    assert ["--max-output-length", "2048"] == argv[argv.index("--max-output-length"):argv.index("--max-output-length") + 2]
+    assert ["--resume-session", "session-1"] == argv[argv.index("--resume-session"):argv.index("--resume-session") + 2]
+    assert "--activity-log" not in argv
+    assert argv[-3:] == ["--", "--model", "sonnet"]
+
+
+def test_prompt_file_is_forwarded_without_hermes_reading_it(
+    monkeypatch, tmp_path, available_threadwire
+):
+    _bind()
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("file prompt sentinel", encoding="utf-8")
+    calls = _capture_spawn(monkeypatch)
+
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": "opencode",
+        "prompt_file": str(prompt_file),
+        "cwd": str(tmp_path),
+    }))
+
+    assert result == {"status": "completed", "exit_code": 0}
+    argv = calls[0][0]
+    assert argv[argv.index("--prompt-file") + 1] == str(prompt_file)
+    assert "file prompt sentinel" not in argv
+
+
+@pytest.mark.parametrize(
+    ("platform", "chat_id", "thread_id"),
+    [
+        ("discord", "123", ""),
+        ("", "123", ""),
+        ("telegram", "", ""),
+        ("telegram", "0", ""),
+        ("telegram", "+12", ""),
+        ("telegram", " 12", ""),
+        ("telegram", "12", "0"),
+        ("telegram", "12", "-1"),
+        ("telegram", "12", "topic"),
+        ("telegram", "12", str(2**53)),
+    ],
+)
+def test_invalid_context_fails_before_spawn(
+    monkeypatch, tmp_path, available_threadwire, platform, chat_id, thread_id
+):
+    _bind(platform=platform, chat_id=chat_id, thread_id=thread_id)
+    calls = _capture_spawn(monkeypatch)
+
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": "codex", "prompt": "do work", "cwd": str(tmp_path)
+    }))
+
+    assert result["status"] == "blocked"
+    assert calls == []
+
+
+def test_process_environment_cannot_spoof_telegram_context(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "123456")
+    monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "42")
+    requirement_checks = []
+    monkeypatch.setattr(
+        worker,
+        "check_threadwire_requirements",
+        lambda: requirement_checks.append(True) or True,
+    )
+    calls = _capture_spawn(monkeypatch)
+
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": "codex", "prompt": "do work", "cwd": str(tmp_path)
+    }))
+
+    assert result["status"] == "blocked"
+    assert requirement_checks == []
+    assert calls == []
+
+
+def test_malformed_authenticated_request_fails_before_service_probe(monkeypatch, tmp_path):
+    _bind()
+    requirement_checks = []
+    monkeypatch.setattr(
+        worker,
+        "check_threadwire_requirements",
+        lambda: requirement_checks.append(True) or True,
+    )
+    calls = _capture_spawn(monkeypatch)
+
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": "codex",
+        "prompt": "work",
+        "target": "telegram:999",
+        "cwd": str(tmp_path),
+    }))
+
+    assert result["status"] == "blocked"
+    assert requirement_checks == []
+    assert calls == []
+
+
+def test_authenticated_request_preserves_service_unavailable_error(monkeypatch, tmp_path):
+    _bind()
+    monkeypatch.setattr(worker, "check_threadwire_requirements", lambda: False)
+    calls = _capture_spawn(monkeypatch)
+
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": "codex", "prompt": "work", "cwd": str(tmp_path)
+    }))
+
+    assert result == {
+        "status": "error",
+        "error": "Telegram coding-worker service is unavailable",
+    }
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"target": "telegram:999"},
+        {"chat_id": "999"},
+        {"thread_id": "9"},
+        {"provider_arguments": ["--target", "telegram:999"]},
+        {"provider_arguments": ["--target=telegram:999"]},
+        {"command": "/opt/data/bin/codex"},
+        {"executable": "/opt/data/bin/claude"},
+        {"env": {"HERMES_SESSION_CHAT_ID": "999"}},
+        {"shell": True},
+    ],
+)
+def test_caller_overrides_fail_before_spawn(
+    monkeypatch, tmp_path, available_threadwire, override
+):
+    _bind()
+    calls = _capture_spawn(monkeypatch)
+    args = {"provider": "codex", "prompt": "do work", "cwd": str(tmp_path), **override}
+
+    result = json.loads(worker.launch_telegram_coding_worker(args))
+
+    assert result["status"] == "blocked"
+    assert calls == []
+
+
+@pytest.mark.parametrize("provider", ["", "gpt", "Codex", None, 1])
+def test_invalid_provider_fails_before_spawn(
+    monkeypatch, tmp_path, available_threadwire, provider
+):
+    _bind()
+    calls = _capture_spawn(monkeypatch)
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": provider, "prompt": "do work", "cwd": str(tmp_path)
+    }))
+    assert result["status"] == "blocked"
+    assert calls == []
+
+
+def test_exact_threadwire_argv_never_uses_provider_helpers(
+    monkeypatch, tmp_path, available_threadwire
+):
+    _bind()
+    calls = _capture_spawn(monkeypatch)
+
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": "opencode", "stdin": "private prompt", "cwd": str(tmp_path)
+    }))
+
+    argv, kwargs = calls[0]
+    assert result == {"status": "completed", "exit_code": 0}
+    assert argv[0] == "/opt/data/bin/threadwire"
+    assert not any(
+        item in argv
+        for item in (
+            "/opt/data/bin/codex",
+            "/opt/data/bin/claude",
+            "/opt/data/bin/opencode-local-fleet",
+        )
+    )
+    assert kwargs["shell"] is False
+
+
+def test_large_stdin_uses_private_file_not_child_pipe(
+    monkeypatch, tmp_path, available_threadwire
+):
+    _bind()
+    private_prompt = "private-large-prompt-" * 100_000
+    captured = {}
+
+    def fake_popen(argv, **kwargs):
+        captured["argv"] = argv
+        captured["stdin"] = kwargs["stdin"]
+        assert kwargs["stdin"] is not subprocess.PIPE
+        assert kwargs["stdin"].read() == private_prompt
+        return FakeProcess()
+
+    monkeypatch.setattr(worker.subprocess, "Popen", fake_popen)
+
+    result = worker.launch_telegram_coding_worker({
+        "provider": "codex",
+        "stdin": private_prompt,
+        "cwd": str(tmp_path),
+    })
+
+    assert json.loads(result) == {"status": "completed", "exit_code": 0}
+    assert private_prompt not in captured["argv"]
+    assert private_prompt not in result
+    assert captured["stdin"].closed
+
+
+def test_direct_prompt_uses_private_stdin_file_and_never_argv(
+    monkeypatch, tmp_path, available_threadwire
+):
+    _bind()
+    private_prompt = "direct-prompt-process-list-sentinel"
+    captured = {}
+
+    def fake_popen(argv, **kwargs):
+        captured["argv"] = argv
+        captured["stdin"] = kwargs["stdin"]
+        assert kwargs["stdin"].read() == private_prompt
+        return FakeProcess()
+
+    monkeypatch.setattr(worker.subprocess, "Popen", fake_popen)
+
+    result = worker.launch_telegram_coding_worker({
+        "provider": "codex",
+        "prompt": private_prompt,
+        "cwd": str(tmp_path),
+    })
+
+    assert json.loads(result) == {"status": "completed", "exit_code": 0}
+    assert "--prompt" not in captured["argv"]
+    assert private_prompt not in captured["argv"]
+    assert captured["stdin"].closed
+
+
+def test_stdin_staging_honors_cancellation_before_spawn(
+    monkeypatch, tmp_path, available_threadwire
+):
+    _bind()
+    calls = _capture_spawn(monkeypatch)
+    monkeypatch.setattr(worker, "is_interrupted", lambda: True)
+
+    result = worker.launch_telegram_coding_worker({
+        "provider": "codex",
+        "stdin": "private prompt",
+        "cwd": str(tmp_path),
+    })
+
+    assert json.loads(result) == {
+        "status": "cancelled",
+        "error": "Coding-worker launch was cancelled",
+    }
+    assert calls == []
+
+
+def test_stdin_staging_honors_deadline_before_spawn(
+    monkeypatch, tmp_path, available_threadwire
+):
+    _bind()
+    calls = _capture_spawn(monkeypatch)
+    clock = iter([0.0, 2.0])
+    monkeypatch.setattr(worker.time, "monotonic", lambda: next(clock))
+
+    result = worker.launch_telegram_coding_worker({
+        "provider": "codex",
+        "stdin": "private prompt",
+        "cwd": str(tmp_path),
+        "timeout": 1,
+    })
+
+    assert json.loads(result) == {
+        "status": "timed_out",
+        "error": "Coding-worker launch timed out",
+    }
+    assert calls == []
+
+
+@pytest.mark.parametrize("raised", [KeyboardInterrupt(), SystemExit(7)])
+def test_stdin_staging_closes_file_and_propagates_base_exception(monkeypatch, raised):
+    staged = io.StringIO()
+    monkeypatch.setattr(worker.tempfile, "TemporaryFile", lambda **_kwargs: staged)
+    monkeypatch.setattr(worker, "is_interrupted", lambda: (_ for _ in ()).throw(raised))
+
+    with pytest.raises(type(raised)):
+        worker._stage_stdin("private prompt", float("inf"))
+
+    assert staged.closed
+
+
+def test_registry_discovery_does_not_probe_threadwire(monkeypatch):
+    entry = worker.registry.get_entry("telegram_coding_worker")
+    assert entry is not None
+    assert entry.check_fn is None
+
+    monkeypatch.setattr(
+        worker,
+        "check_threadwire_requirements",
+        lambda: pytest.fail("discovery must not probe Threadwire"),
+    )
+    definitions = worker.registry.get_definitions({"telegram_coding_worker"})
+
+    assert any(
+        definition["function"]["name"] == "telegram_coding_worker"
+        for definition in definitions
+    )
+    definition = next(
+        item for item in definitions
+        if item["function"]["name"] == "telegram_coding_worker"
+    )
+    assert "activity_log" not in definition["function"]["parameters"]["properties"]
+
+
+def test_activity_log_is_rejected_before_spawn(monkeypatch, tmp_path):
+    _bind()
+    calls = _capture_spawn(monkeypatch)
+
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": "codex",
+        "prompt": "private prompt",
+        "cwd": str(tmp_path),
+        "activity_log": str(tmp_path / "activity.jsonl"),
+    }))
+
+    assert result["status"] == "blocked"
+    assert calls == []
+
+
+def test_telegram_credentials_are_absent_from_child_and_logs(
+    monkeypatch, tmp_path, available_threadwire, caplog
+):
+    _bind(chat_id="765", thread_id="8")
+    calls = _capture_spawn(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "source-token-sentinel")
+    monkeypatch.setenv("THREADWIRE_TELEGRAM_BOT_TOKEN", "private-token-sentinel")
+    monkeypatch.setenv("THREADWIRE_VALIDATE_ONLY", "1")
+
+    result = worker.launch_telegram_coding_worker({
+        "provider": "codex",
+        "prompt": "prompt-sentinel",
+        "cwd": str(tmp_path),
+        "resume_session": "session-sentinel",
+    })
+
+    child_env = calls[0][1]["env"]
+    assert "TELEGRAM_BOT_TOKEN" not in child_env
+    assert "THREADWIRE_TELEGRAM_BOT_TOKEN" not in child_env
+    assert "THREADWIRE_VALIDATE_ONLY" not in child_env
+    combined = result + "\n" + caplog.text
+    for secret in (
+        "source-token-sentinel",
+        "private-token-sentinel",
+        "prompt-sentinel",
+        "session-sentinel",
+        "telegram:765:8",
+    ):
+        assert secret not in combined
+
+
+def test_gateway_session_metadata_is_absent_from_child_environment(
+    monkeypatch, tmp_path, available_threadwire
+):
+    _bind(chat_id="765", thread_id="8")
+    monkeypatch.setenv("HERMES_SESSION_KEY", "session-key-sentinel")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "user-sentinel")
+    monkeypatch.setenv("HERMES_SESSION_MESSAGE_ID", "message-sentinel")
+    monkeypatch.setenv("HERMES_SESSION_FUTURE_METADATA", "future-sentinel")
+    calls = _capture_spawn(monkeypatch)
+
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": "codex", "prompt": "work", "cwd": str(tmp_path)
+    }))
+
+    assert result == {"status": "completed", "exit_code": 0}
+    child_env = calls[0][1]["env"]
+    assert not any(name.startswith("HERMES_SESSION_") for name in child_env)
+
+
+def test_child_env_builder_never_reads_excluded_telegram_values(monkeypatch):
+    from tools.environments import local
+
+    class GuardedEnvironment(dict):
+        def __getitem__(self, key):
+            if key in {"TELEGRAM_BOT_TOKEN", "THREADWIRE_TELEGRAM_BOT_TOKEN"}:
+                raise AssertionError("Telegram credential value was read")
+            return super().__getitem__(key)
+
+    guarded = GuardedEnvironment({
+        "PATH": os.defpath,
+        "TELEGRAM_BOT_TOKEN": "must-not-be-read",
+        "THREADWIRE_TELEGRAM_BOT_TOKEN": "must-not-be-read",
+    })
+    monkeypatch.setattr(local.os, "environ", guarded)
+
+    env = local.hermes_subprocess_env(
+        inherit_credentials=True,
+        exclude_keys=frozenset({"THREADWIRE_TELEGRAM_BOT_TOKEN"}),
+    )
+
+    assert "TELEGRAM_BOT_TOKEN" not in env
+    assert "THREADWIRE_TELEGRAM_BOT_TOKEN" not in env
+
+
+def test_contextvars_isolate_concurrent_targets(monkeypatch, tmp_path, available_threadwire):
+    barrier = threading.Barrier(2)
+    targets = []
+    lock = threading.Lock()
+
+    def fake_popen(argv, **_kwargs):
+        barrier.wait(timeout=2)
+        with lock:
+            targets.append(argv[argv.index("--target") + 1])
+        return FakeProcess()
+
+    monkeypatch.setattr(worker.subprocess, "Popen", fake_popen)
+
+    def launch(chat_id, thread_id):
+        set_session_vars(platform="telegram", chat_id=chat_id, thread_id=thread_id)
+        return worker.launch_telegram_coding_worker({
+            "provider": "codex", "prompt": "work", "cwd": str(tmp_path)
+        })
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda pair: launch(*pair), [("111", ""), ("222", "9")]))
+
+    assert sorted(targets) == ["telegram:111", "telegram:222:9"]
+    assert all(json.loads(result)["status"] == "completed" for result in results)
+
+
+def test_user_cancellation_is_forwarded_and_returns_only_safe_status(
+    monkeypatch, tmp_path, available_threadwire
+):
+    _bind()
+
+    class RunningProcess(FakeProcess):
+        def __init__(self):
+            super().__init__(None)
+
+        def send_signal(self, sig):
+            super().send_signal(sig)
+            self._returncode = -int(sig)
+
+    proc = RunningProcess()
+    killed_groups = []
+    interrupted = iter([False, True])
+    monkeypatch.setattr(worker.subprocess, "Popen", lambda *_a, **_k: proc)
+    monkeypatch.setattr(worker, "is_interrupted", lambda: next(interrupted))
+    monkeypatch.setattr(
+        worker.os,
+        "killpg",
+        lambda pid, sig: (killed_groups.append((pid, sig)), setattr(proc, "_returncode", -int(sig))),
+    )
+
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": "codex", "prompt": "secret prompt", "cwd": str(tmp_path)
+    }))
+
+    assert result == {"status": "cancelled", "error": "Coding-worker launch was cancelled"}
+    assert killed_groups == [(proc.pid, worker.signal.SIGINT)]
+    assert proc.signals == []
+
+
+def test_timeout_terminates_threadwire_and_returns_only_safe_status(
+    monkeypatch, tmp_path, available_threadwire
+):
+    _bind()
+
+    class RunningProcess(FakeProcess):
+        def __init__(self):
+            super().__init__(None)
+
+        def send_signal(self, sig):
+            super().send_signal(sig)
+            self._returncode = -int(sig)
+
+    proc = RunningProcess()
+    killed_groups = []
+    clock = iter([0.0, 0.0, 2.0, 2.0])
+    monkeypatch.setattr(worker.subprocess, "Popen", lambda *_a, **_k: proc)
+    monkeypatch.setattr(worker, "is_interrupted", lambda: False)
+    monkeypatch.setattr(worker.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(
+        worker.os,
+        "killpg",
+        lambda pid, sig: (killed_groups.append((pid, sig)), setattr(proc, "_returncode", -int(sig))),
+    )
+
+    result = json.loads(worker.launch_telegram_coding_worker({
+        "provider": "claude", "prompt": "secret prompt", "cwd": str(tmp_path), "timeout": 1
+    }))
+
+    assert result == {"status": "timed_out", "error": "Coding-worker launch timed out"}
+    assert killed_groups == [(proc.pid, worker.signal.SIGTERM)]
+    assert proc.signals == []
+
+
+def test_forced_kill_reaps_direct_child(monkeypatch):
+    proc = FakeProcess(None)
+    clock = iter([0.0, 4.0])
+    killed_groups = []
+    monkeypatch.setattr(worker.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(
+        worker.os,
+        "killpg",
+        lambda pid, sig: (
+            killed_groups.append((pid, sig)),
+            setattr(proc, "_returncode", -9) if sig == worker.signal.SIGKILL else None,
+        ),
+    )
+
+    worker._stop_process(cast(subprocess.Popen, proc), worker.signal.SIGTERM)
+
+    assert proc.signals == []
+    assert killed_groups == [
+        (proc.pid, worker.signal.SIGTERM),
+        (proc.pid, worker.signal.SIGKILL),
+    ]
+    assert proc.wait_timeouts == [worker._TERMINATE_GRACE_SECONDS]
+
+
+@pytest.mark.parametrize("raised", [KeyboardInterrupt(), SystemExit(7)])
+def test_base_exception_after_spawn_cleans_group_reaps_and_propagates(
+    monkeypatch, tmp_path, available_threadwire, raised
+):
+    _bind()
+    proc = FakeProcess(None)
+    raised_once = False
+
+    def interrupt_poll():
+        nonlocal raised_once
+        if not raised_once:
+            raised_once = True
+            raise raised
+        return proc._returncode
+
+    monkeypatch.setattr(proc, "poll", interrupt_poll)
+    monkeypatch.setattr(worker.subprocess, "Popen", lambda *_a, **_k: proc)
+    killed_groups = []
+    monkeypatch.setattr(
+        worker.os,
+        "killpg",
+        lambda pid, sig: (killed_groups.append((pid, sig)), setattr(proc, "_returncode", -int(sig))),
+    )
+
+    with pytest.raises(type(raised)):
+        worker.launch_telegram_coding_worker({
+            "provider": "codex", "prompt": "work", "cwd": str(tmp_path)
+        })
+
+    assert killed_groups == [(proc.pid, worker.signal.SIGTERM)]
+    assert proc.signals == []
+    assert proc.wait_timeouts == [worker._TERMINATE_GRACE_SECONDS]
+
+
+def test_display_redaction_hides_all_sensitive_worker_arguments(tmp_path):
+    from agent.display import build_tool_preview, redact_tool_args_for_display
+
+    args = {
+        "provider": "codex",
+        "prompt": "prompt-sentinel",
+        "cwd": str(tmp_path),
+        "provider_arguments": ["--model", "secret-model"],
+        "resume_session": "session-sentinel",
+    }
+    safe = redact_tool_args_for_display("telegram_coding_worker", args)
+    rendered = json.dumps(safe)
+    assert "prompt-sentinel" not in rendered
+    assert str(tmp_path) not in rendered
+    assert "secret-model" not in rendered
+    assert "session-sentinel" not in rendered
+    assert build_tool_preview("telegram_coding_worker", args) == "coding worker"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -431,7 +431,11 @@ _ALWAYS_STRIP_KEYS: frozenset[str] = frozenset({
 })
 
 
-def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str]:
+def hermes_subprocess_env(
+    *,
+    inherit_credentials: bool = False,
+    exclude_keys: frozenset[str] | set[str] | tuple[str, ...] = (),
+) -> dict[str, str]:
     """Build a sanitized environment dict for a spawned subprocess.
 
     Centralized helper for the **non-terminal** spawn surface (browser,
@@ -463,7 +467,16 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     ``inherit_credentials=False`` and copy just those keys back from
     ``os.environ`` into the returned dict.
     """
-    env = os.environ.copy()
+    # Skip Tier-1 and caller-owned secret names *before* reading their values.
+    # This is stronger than copying os.environ and popping afterward: a caller
+    # such as the Telegram Threadwire boundary can guarantee that Hermes never
+    # even materializes the transport credential in its child-env dictionary.
+    pre_excluded = _ALWAYS_STRIP_KEYS | frozenset(exclude_keys)
+    env = {
+        key: os.environ[key]
+        for key in os.environ
+        if key not in pre_excluded and not _is_hermes_internal_secret(key)
+    }
 
     # Tier 1 — always strip.
     for key in _ALWAYS_STRIP_KEYS:

--- a/tools/threadwire_telegram_worker_tool.py
+++ b/tools/threadwire_telegram_worker_tool.py
@@ -1,0 +1,408 @@
+"""Authenticated Telegram -> Threadwire coding-worker launch boundary.
+
+This tool is intentionally separate from ``terminal``.  It accepts structured
+worker inputs, derives the delivery target only from the current gateway
+ContextVars, and invokes the fixed Threadwire launcher with an argv list.
+Threadwire alone loads Telegram credentials and delivers worker output.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import signal
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from agent.runtime_cwd import resolve_agent_cwd
+from gateway.session_context import get_bound_session_env
+from tools.environments.local import hermes_subprocess_env
+from tools.interrupt import is_interrupted
+from tools.registry import registry
+
+
+THREADWIRE_EXECUTABLE = "/opt/data/bin/threadwire"
+SUPPORTED_PROVIDERS = frozenset({"codex", "claude", "opencode"})
+_CHAT_ID_RE = re.compile(r"-?[1-9][0-9]*\Z")
+_THREAD_ID_RE = re.compile(r"[1-9][0-9]*\Z")
+_SESSION_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,511}\Z")
+_FORBIDDEN_PROVIDER_OPTIONS = ("--target",)
+_ALLOWED_ARGUMENTS = frozenset({
+    "provider",
+    "prompt",
+    "prompt_file",
+    "stdin",
+    "cwd",
+    "timeout",
+    "process_number",
+    "max_output_length",
+    "resume_session",
+    "provider_arguments",
+})
+_POLL_SECONDS = 0.1
+_TERMINATE_GRACE_SECONDS = 3.0
+_DEFAULT_TIMEOUT_SECONDS = 3600
+_MAX_TIMEOUT_SECONDS = 86400
+_STDIN_STAGE_CHARS = 64 * 1024
+
+
+def check_threadwire_requirements() -> bool:
+    """Return whether the fixed launcher is installed and executable."""
+    return os.path.isfile(THREADWIRE_EXECUTABLE) and os.access(
+        THREADWIRE_EXECUTABLE, os.X_OK
+    )
+
+
+def _error(reason: str, *, status: str = "blocked") -> str:
+    # Deliberately generic: never put IDs, targets, argv, prompts, paths,
+    # provider output, or exception text into a Telegram-bound tool result.
+    return json.dumps({"status": status, "error": reason}, ensure_ascii=False)
+
+
+def _success(returncode: int) -> str:
+    return json.dumps(
+        {
+            "status": "completed" if returncode == 0 else "failed",
+            "exit_code": returncode,
+        },
+        ensure_ascii=False,
+    )
+
+
+def _positive_integer(value: Any, name: str) -> int:
+    # bool is an int subclass; accepting it would silently turn True into 1.
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"Invalid {name}")
+    if value > 2**53 - 1:
+        raise ValueError(f"Invalid {name}")
+    return value
+
+
+def _validated_target() -> str:
+    platform = get_bound_session_env("HERMES_SESSION_PLATFORM", "")
+    if platform != "telegram":
+        raise ValueError("This worker launch requires an authenticated Telegram session")
+
+    chat_id = get_bound_session_env("HERMES_SESSION_CHAT_ID", "")
+    if not isinstance(chat_id, str) or not _CHAT_ID_RE.fullmatch(chat_id):
+        raise ValueError("Authenticated Telegram chat context is invalid")
+
+    thread_id = get_bound_session_env("HERMES_SESSION_THREAD_ID", "")
+    if thread_id is None:
+        thread_id = ""
+    if not isinstance(thread_id, str):
+        raise ValueError("Authenticated Telegram topic context is invalid")
+    if thread_id and not _THREAD_ID_RE.fullmatch(thread_id):
+        raise ValueError("Authenticated Telegram topic context is invalid")
+    if thread_id and int(thread_id) > 2**53 - 1:
+        # Threadwire converts Telegram topic IDs to JavaScript Number and
+        # rejects values outside the exact-integer range. Mirror that check so
+        # malformed authenticated context is rejected before process creation.
+        raise ValueError("Authenticated Telegram topic context is invalid")
+
+    return f"telegram:{chat_id}" + (f":{thread_id}" if thread_id else "")
+
+
+def _validated_path(value: Any, *, name: str, directory: bool) -> str:
+    if not isinstance(value, str) or not value or "\x00" in value:
+        raise ValueError(f"Invalid {name}")
+    path = Path(value)
+    if not path.is_absolute():
+        raise ValueError(f"Invalid {name}")
+    if directory and not path.is_dir():
+        raise ValueError(f"Invalid {name}")
+    if not directory and not path.is_file():
+        raise ValueError(f"Invalid {name}")
+    return str(path)
+
+
+def _validated_provider_arguments(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("Invalid provider arguments")
+    result: list[str] = []
+    for argument in value:
+        if not isinstance(argument, str) or "\x00" in argument:
+            raise ValueError("Invalid provider arguments")
+        if any(
+            argument == option or argument.startswith(f"{option}=")
+            for option in _FORBIDDEN_PROVIDER_OPTIONS
+        ):
+            raise ValueError("Caller-supplied delivery targets are forbidden")
+        result.append(argument)
+    return result
+
+
+def _build_invocation(args: dict[str, Any]) -> tuple[list[str], str, str | None, int]:
+    if not isinstance(args, dict):
+        raise ValueError("Invalid worker request")
+    unknown = set(args) - _ALLOWED_ARGUMENTS
+    if unknown:
+        if unknown & {"target", "chat_id", "thread_id"}:
+            raise ValueError("Caller-supplied delivery targets are forbidden")
+        raise ValueError("Unsupported worker option")
+
+    # Resolve the authenticated target before doing filesystem work and before
+    # process creation.  No tool argument can participate in this value.
+    target = _validated_target()
+
+    provider = args.get("provider")
+    if provider not in SUPPORTED_PROVIDERS:
+        raise ValueError("Invalid coding-worker provider")
+
+    prompt_fields = [
+        name for name in ("prompt", "prompt_file", "stdin") if args.get(name) is not None
+    ]
+    if len(prompt_fields) != 1:
+        raise ValueError("Exactly one prompt source is required")
+
+    stdin_text: str | None = None
+    prompt_argv: list[str]
+    prompt_field = prompt_fields[0]
+    prompt_value = args[prompt_field]
+    if prompt_field == "prompt":
+        if not isinstance(prompt_value, str) or not prompt_value.strip():
+            raise ValueError("Prompt cannot be empty")
+        stdin_text = prompt_value
+        prompt_argv = []
+    elif prompt_field == "prompt_file":
+        prompt_path = _validated_path(prompt_value, name="prompt file", directory=False)
+        prompt_argv = ["--prompt-file", prompt_path]
+    else:
+        if not isinstance(prompt_value, str) or not prompt_value.strip():
+            raise ValueError("Prompt cannot be empty")
+        stdin_text = prompt_value
+        prompt_argv = []
+
+    cwd_value = args.get("cwd")
+    if cwd_value is None:
+        cwd = str(resolve_agent_cwd())
+        if not Path(cwd).is_dir():
+            raise ValueError("Invalid working directory")
+    else:
+        cwd = _validated_path(cwd_value, name="working directory", directory=True)
+
+    timeout_value = args.get("timeout", _DEFAULT_TIMEOUT_SECONDS)
+    timeout = _positive_integer(timeout_value, "timeout")
+    if timeout > _MAX_TIMEOUT_SECONDS:
+        raise ValueError("Invalid timeout")
+
+    argv = [
+        THREADWIRE_EXECUTABLE,
+        "run",
+        "--provider",
+        provider,
+        "--target",
+        target,
+        "--cwd",
+        cwd,
+    ]
+
+    for key, option in (
+        ("process_number", "--process-number"),
+        ("max_output_length", "--max-output-length"),
+    ):
+        if args.get(key) is not None:
+            argv.extend([option, str(_positive_integer(args[key], key.replace("_", " ")))])
+
+    resume_session = args.get("resume_session")
+    if resume_session is not None:
+        if not isinstance(resume_session, str) or not _SESSION_ID_RE.fullmatch(resume_session):
+            raise ValueError("Invalid provider session")
+        argv.extend(["--resume-session", resume_session])
+
+    argv.extend(prompt_argv)
+    provider_arguments = _validated_provider_arguments(args.get("provider_arguments"))
+    if provider_arguments:
+        argv.extend(["--", *provider_arguments])
+    return argv, cwd, stdin_text, timeout
+
+
+def _child_environment() -> dict[str, str]:
+    # Threadwire is a model-driving CLI, so preserve provider auth according to
+    # the existing audited convention.  The shared helper always strips the
+    # gateway Telegram token; remove Threadwire's private names defensively too.
+    env = hermes_subprocess_env(
+        inherit_credentials=True,
+        exclude_keys=frozenset({
+            "TELEGRAM_BOT_TOKEN",
+            "THREADWIRE_TELEGRAM_BOT_TOKEN",
+            "THREADWIRE_VALIDATE_ONLY",
+        }),
+    )
+    # Threadwire routing is carried exclusively by the validated --target.
+    # The shared helper bridges task-local gateway context for child processes,
+    # but none of that metadata belongs across this provider boundary.
+    for name in tuple(env):
+        if name.startswith("HERMES_SESSION_"):
+            del env[name]
+    return env
+
+
+def _reap_process(proc: subprocess.Popen) -> None:
+    """Reap the direct child without allowing an unbounded wait."""
+    try:
+        proc.wait(timeout=_TERMINATE_GRACE_SECONDS)
+    except (subprocess.TimeoutExpired, OSError, ProcessLookupError):
+        pass
+
+
+def _stop_process(proc: subprocess.Popen, initial_signal: signal.Signals) -> None:
+    if proc.poll() is None:
+        try:
+            # start_new_session=True makes the child's PID its process-group
+            # ID. Signal the whole worker tree so provider descendants receive
+            # the same graceful cancellation/deadline notification.
+            if hasattr(os, "killpg"):
+                os.killpg(proc.pid, initial_signal)
+            else:
+                proc.send_signal(initial_signal)
+        except (AttributeError, OSError, ProcessLookupError):
+            try:
+                proc.send_signal(initial_signal)
+            except (OSError, ProcessLookupError):
+                pass
+        deadline = time.monotonic() + _TERMINATE_GRACE_SECONDS
+        while proc.poll() is None and time.monotonic() < deadline:
+            time.sleep(_POLL_SECONDS)
+        if proc.poll() is None:
+            try:
+                # The child starts a new session. Kill the group only after
+                # Threadwire has had a bounded opportunity to handle the first
+                # signal and forward it to its provider.
+                os.killpg(proc.pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+            except (AttributeError, OSError, ProcessLookupError):
+                try:
+                    proc.kill()
+                except (OSError, ProcessLookupError):
+                    pass
+    _reap_process(proc)
+
+
+def _stage_stdin(stdin_text: str, deadline: float):
+    """Stage private stdin without a child pipe or an unbounded copy."""
+    staged = tempfile.TemporaryFile(mode="w+", encoding="utf-8")
+    try:
+        for offset in range(0, len(stdin_text), _STDIN_STAGE_CHARS):
+            if is_interrupted():
+                raise InterruptedError
+            if time.monotonic() >= deadline:
+                raise TimeoutError
+            staged.write(stdin_text[offset : offset + _STDIN_STAGE_CHARS])
+        staged.seek(0)
+        return staged
+    except BaseException:
+        staged.close()
+        raise
+
+
+def launch_telegram_coding_worker(args: dict[str, Any]) -> str:
+    """Validate and synchronously supervise one Threadwire worker."""
+    proc: subprocess.Popen | None = None
+    staged_stdin = None
+    try:
+        # Authenticate from task-local gateway context before probing or
+        # starting Threadwire. Process environment values are not identity.
+        _validated_target()
+        argv, cwd, stdin_text, timeout = _build_invocation(args)
+        if not check_threadwire_requirements():
+            return _error("Telegram coding-worker service is unavailable", status="error")
+        deadline = time.monotonic() + timeout
+        if stdin_text is not None:
+            staged_stdin = _stage_stdin(stdin_text, deadline)
+        proc = subprocess.Popen(
+            argv,
+            shell=False,
+            cwd=cwd,
+            env=_child_environment(),
+            stdin=staged_stdin if staged_stdin is not None else subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            start_new_session=True,
+        )
+        while True:
+            returncode = proc.poll()
+            if returncode is not None:
+                return _success(returncode)
+            if is_interrupted():
+                _stop_process(proc, signal.SIGINT)
+                return _error("Coding-worker launch was cancelled", status="cancelled")
+            if time.monotonic() >= deadline:
+                _stop_process(proc, signal.SIGTERM)
+                return _error("Coding-worker launch timed out", status="timed_out")
+            time.sleep(_POLL_SECONDS)
+    except InterruptedError:
+        return _error("Coding-worker launch was cancelled", status="cancelled")
+    except TimeoutError:
+        return _error("Coding-worker launch timed out", status="timed_out")
+    except (OSError, ValueError):
+        return _error("Telegram coding-worker launch was rejected")
+    except Exception:
+        return _error("Telegram coding-worker launch failed", status="error")
+    finally:
+        if proc is not None:
+            _stop_process(proc, signal.SIGTERM)
+        if staged_stdin is not None:
+            staged_stdin.close()
+
+
+THREADWIRE_SCHEMA = {
+    "name": "telegram_coding_worker",
+    "description": (
+        "Launch a coding worker for the current authenticated Telegram chat/topic. "
+        "The delivery target is derived internally and cannot be supplied. Use this "
+        "instead of terminal-based Codex, Claude, or OpenCode launch commands when "
+        "the current conversation originates from Telegram."
+    ),
+    "parameters": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "provider": {"type": "string", "enum": sorted(SUPPORTED_PROVIDERS)},
+            "prompt": {"type": "string", "description": "Direct worker prompt."},
+            "prompt_file": {"type": "string", "description": "Absolute prompt file path."},
+            "stdin": {"type": "string", "description": "Worker prompt supplied on stdin."},
+            "cwd": {"type": "string", "description": "Existing absolute worker directory."},
+            "timeout": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": _MAX_TIMEOUT_SECONDS,
+                "default": _DEFAULT_TIMEOUT_SECONDS,
+            },
+            "process_number": {"type": "integer", "minimum": 1},
+            "max_output_length": {"type": "integer", "minimum": 1},
+            "resume_session": {"type": "string"},
+            "provider_arguments": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Arguments passed to the selected provider after --.",
+            },
+        },
+        "required": ["provider"],
+        "oneOf": [
+            {"required": ["prompt"]},
+            {"required": ["prompt_file"]},
+            {"required": ["stdin"]},
+        ],
+    },
+}
+
+
+def _handle_threadwire(args: dict[str, Any], **_kwargs: Any) -> str:
+    return launch_telegram_coding_worker(args)
+
+
+registry.register(
+    name="telegram_coding_worker",
+    toolset="terminal",
+    schema=THREADWIRE_SCHEMA,
+    handler=_handle_threadwire,
+    emoji="🧵",
+    max_result_size_chars=2_000,
+)


### PR DESCRIPTION
## Summary
- Add a Telegram-context-bound Threadwire coding-worker tool for Codex, Claude, and OpenCode.
- Keep child worker environments and activity/output privacy-safe.
- Redact worker prompts before logs, middleware/hooks, snapshots, session persistence, and subsequent model turns.

## Validation
- Focused Hermes pytest suite: 122 passed.
- Ruff: passed.
- Threadwire launcher help and npm test: 80 passed.
- Full Hermes suite was attempted after syncing ACP; it exceeded the 10-minute runner limit while reporting unrelated baseline failures outside this change.
