### PR TITLE
fix(moa): surface stale presets without retries

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -775,6 +775,14 @@ def classify_api_error(
         if classified is not None:
             return classified
 
+    # Local MoA config drift is deterministic: a persisted session can retain
+    # a preset name that was later renamed/deleted. Retrying the same lookup
+    # cannot recover and makes a clear config error look like an API outage.
+    from agent.errors import MoAPresetNotFoundError
+
+    if isinstance(error, MoAPresetNotFoundError):
+        return _result(FailoverReason.model_not_found, retryable=False)
+
     # ── 3. Error code classification ────────────────────────────────
 
     if error_code:

--- a/agent/errors.py
+++ b/agent/errors.py
@@ -7,3 +7,7 @@ class EmptyStreamError(RuntimeError):
     """Raised when a provider closes a stream without yielding a response."""
 
     pass
+
+
+class MoAPresetNotFoundError(ValueError):
+    """Raised when a persisted MoA preset no longer exists in config."""

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -295,7 +295,13 @@ def resolve_moa_preset(config: Any, name: str | None = None) -> dict[str, Any]:
     preset_name = str(name or cfg.get("default_preset") or DEFAULT_MOA_PRESET_NAME).strip()
     preset = cfg["presets"].get(preset_name)
     if preset is None:
-        raise KeyError(preset_name)
+        from agent.errors import MoAPresetNotFoundError
+
+        available = ", ".join(cfg["presets"]) or "(none)"
+        raise MoAPresetNotFoundError(
+            f"MoA preset '{preset_name}' was not found. Available presets: "
+            f"{available}. Run `hermes moa list`."
+        )
     return deepcopy(preset)
 
 

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -1,3 +1,6 @@
+import pytest
+
+from agent.errors import MoAPresetNotFoundError
 from hermes_cli.moa_config import (
     DEFAULT_MOA_AGGREGATOR,
     DEFAULT_MOA_PRESET_NAME,
@@ -203,6 +206,46 @@ def test_resolve_moa_preset_returns_requested_model_set():
     assert resolve_moa_preset(cfg, "review")["reference_models"] == [
         {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
     ]
+
+
+def test_resolve_missing_moa_preset_has_actionable_error():
+    cfg = {
+        "default_preset": "日常对话-高峰",
+        "presets": {"日常对话-高峰": {}, "日常对话-非高峰": {}},
+    }
+
+    with pytest.raises(MoAPresetNotFoundError) as exc_info:
+        resolve_moa_preset(cfg, "日常对话-高峰期")
+
+    message = str(exc_info.value)
+    assert "日常对话-高峰期" in message
+    assert "日常对话-高峰" in message
+    assert "日常对话-非高峰" in message
+    assert "hermes moa list" in message
+
+
+def test_resolve_missing_moa_preset_does_not_silently_fallback():
+    cfg = {
+        "default_preset": "日常对话-高峰",
+        "presets": {"日常对话-高峰": {}},
+    }
+
+    with pytest.raises(MoAPresetNotFoundError):
+        resolve_moa_preset(cfg, "renamed-preset")
+
+
+def test_missing_moa_preset_is_non_retryable():
+    from agent.error_classifier import FailoverReason, classify_api_error
+
+    result = classify_api_error(
+        MoAPresetNotFoundError("MoA preset 'old' was not found"),
+        provider="moa",
+        model="old",
+    )
+
+    assert result.reason == FailoverReason.model_not_found
+    assert result.retryable is False
+    assert result.should_fallback is False
 
 
 def test_build_moa_turn_prompt_encodes_one_shot_default_preset():


### PR DESCRIPTION
## Summary
Sessions that reference a renamed or deleted MoA preset now fail once with an actionable recovery message instead of retrying a bare `KeyError` three times.

## Changes
- Add a dedicated `MoAPresetNotFoundError` for persisted MoA config drift.
- Preserve fail-closed behavior: an explicit missing preset never silently runs another preset with different providers, cost, privacy, or reasoning behavior.
- Show the missing name, every valid configured preset, and `hermes moa list`.
- Classify the local lookup as deterministic and non-retryable so Desktop receives the failure after one attempt.
- Cover actionable text, strict no-fallback semantics, and classifier behavior.

The overflow half of #65847 was fixed by #66139. Desktop already renders failed `message.complete` turns inline and as error UI on current main; this fixes the remaining stale-preset runtime failure.

## Validation
- `tests/hermes_cli/test_moa_config.py`
- `tests/run_agent/test_moa_loop_mode.py`
- 69 targeted tests passed
- Ruff and `git diff --check` passed
- Real `AIAgent(provider="moa", model="renamed")` probe failed after exactly one API attempt with valid choices and recovery command

Fixes #65847.

## Infographic

![Stale preset, clear answer](https://v3b.fal.media/files/b/0aa29e74/qrzoLCPl_1M8FK6AzaeP0_PIYYlMTd.png)
