### PR TITLE
fix(gateway): extract_media glues two MEDIA tags on one line into one path

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1496,10 +1496,14 @@ _MEDIA_EXT_ALTERNATION = "|".join(
 # consumer so both behave identically.
 # Path anchors: ``~/`` (Unix home-relative), ``/`` (Unix absolute),
 # ``X:\\`` or ``X:/`` (Windows drive-letter absolute — #34632).
+# The unquoted-path branch accepts spaces inside a filename, so its
+# space-separated continuation repeat must refuse to start a segment at
+# another ``MEDIA:`` tag opener (negative lookahead) — otherwise two tags
+# on one line are glued into a single bogus path.
 MEDIA_TAG_CLEANUP_RE = re.compile(
     r'''[`"']?MEDIA:\s*'''
     r'''(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|'''
-    r'''(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+\S+)*?\.(?:''' + _MEDIA_EXT_ALTERNATION + r'''))'''
+    r'''(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+(?![`"']?MEDIA:)\S+)*?\.(?:''' + _MEDIA_EXT_ALTERNATION + r'''))'''
     r'''(?=[\s`"',;:)\]}]|$)[`"']?''',
     re.IGNORECASE,
 )

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -385,6 +385,38 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_two_tags_on_one_line_are_not_glued(self):
+        """Two MEDIA tags separated by prose on one line must yield two
+        separate paths. The spaced-continuation repeat in
+        MEDIA_TAG_CLEANUP_RE used to glue everything between the first
+        path and the second tag's extension into one bogus path."""
+        content = "Files: MEDIA:/tmp/a.docx and MEDIA:/tmp/b.pdf"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/a.docx", False), ("/tmp/b.pdf", False)]
+        assert "MEDIA:" not in cleaned
+        assert "Files:" in cleaned
+
+    def test_two_tags_separated_by_a_single_space(self):
+        content = "MEDIA:/tmp/a.docx MEDIA:/tmp/b.pdf"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/a.docx", False), ("/tmp/b.pdf", False)]
+
+    def test_second_tag_quoted_on_same_line_is_not_glued(self):
+        content = 'MEDIA:/tmp/a.docx and "MEDIA:/tmp/b.pdf"'
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/a.docx", False), ("/tmp/b.pdf", False)]
+
+    def test_adjacency_guard_keeps_unquoted_filenames_with_spaces(self):
+        """The lookahead only refuses continuation segments that start
+        another MEDIA tag — unquoted filenames with spaces still work,
+        including when another tag follows on the same line."""
+        content = "MEDIA:/docs/my report final.docx and MEDIA:/tmp/b.pdf"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == [
+            ("/docs/my report final.docx", False),
+            ("/tmp/b.pdf", False),
+        ]
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the


### PR DESCRIPTION
# DRAFT — not submitted

Suggested branch: `fix/media-tag-adjacent-glue`
Suggested commit: `fix(gateway): stop MEDIA_TAG_CLEANUP_RE gluing two MEDIA tags on one line`
Target: `NousResearch/hermes-agent`, base `main` (bug present at `v2026.7.7.2`)

---

## What does this PR do?

Fixes a path-extraction bug in `MEDIA_TAG_CLEANUP_RE` (`gateway/platforms/base.py`):
when an agent reply contains **two `MEDIA:` tags on the same line**, the first
match swallows the second tag and everything between them, producing a single
bogus path. Both attachments are lost — the glued path does not exist on disk,
and the second tag never becomes its own match.

The unquoted-path branch of the regex supports filenames with spaces via a lazy
space-separated continuation repeat:

```
(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+\S+)*?\.(?:<ext-alternation>)
```

On `MEDIA:/tmp/a.docx and MEDIA:/tmp/b.pdf` the engine first fails to terminate
at `.docx` (backtracking prefers expanding the lazy continuation over shrinking
`\S+`), walks across ` and MEDIA:/tmp/b`, and terminates at `.pdf` — one match,
path group `/tmp/a.docx and MEDIA:/tmp/b.pdf`.

**Fix (one line):** the continuation repeat refuses to start a segment at
another `MEDIA:` tag opener, using a negative lookahead that mirrors the
pattern's own opener (`[`"']?MEDIA:`):

```
(?:[^\S\n]+(?![`"']?MEDIA:)\S+)*?
```

With the lookahead, backtracking falls through to shrinking `\S+`, so the first
match terminates at its own extension and the second tag is matched separately.

## Related Issue

Fixes # <!-- TODO: search/open an issue first, per CONTRIBUTING "Search First" -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py` — negative lookahead in the spaced-continuation
  repeat of `MEDIA_TAG_CLEANUP_RE` (+ a short comment explaining why).
- `tests/gateway/test_platform_base.py` — four new tests in `TestExtractMedia`:
  - `test_two_tags_on_one_line_are_not_glued`
  - `test_two_tags_separated_by_a_single_space`
  - `test_second_tag_quoted_on_same_line_is_not_glued`
  - `test_adjacency_guard_keeps_unquoted_filenames_with_spaces`

## How to Test

Reproduction on stock `v2026.7.7.2` (before the fix):

```python
from gateway.platforms.base import BasePlatformAdapter

media, cleaned = BasePlatformAdapter.extract_media(
    "Files: MEDIA:/tmp/a.docx and MEDIA:/tmp/b.pdf"
)
print(media)
# stock:  [('/tmp/a.docx and MEDIA:/tmp/b.pdf', False)]   <- ONE glued path
# fixed:  [('/tmp/a.docx', False), ('/tmp/b.pdf', False)]
```

The quoted variant is glued too (stock):

```python
BasePlatformAdapter.extract_media('MEDIA:/tmp/a.docx and "MEDIA:/tmp/b.pdf"')
# stock:  [('/tmp/a.docx and "MEDIA:/tmp/b.pdf', False)]
# fixed:  [('/tmp/a.docx', False), ('/tmp/b.pdf', False)]
```

1. Run the snippet above on `main` — observe the glued single path.
2. Apply the patch, run again — two clean paths.
3. `pytest tests/gateway/test_platform_base.py -q` — the four new tests pass;
   every pre-existing `TestExtractMedia` case still passes (verified: 29 tests
   of the class, 0 failures).

Real-world trigger: any reply that lists two produced files on one line, e.g.
"Done: MEDIA:/out/report.docx and MEDIA:/out/summary.pdf" — we hit this in
production on a Telegram gateway.

## Limitations / notes

- A filename segment that itself begins with a literal `MEDIA:` inside an
  unquoted spaced path (e.g. `/docs/report MEDIA:final.docx`) now terminates
  the previous match — the tag opener wins. Such paths were already fragile;
  quoting the path (`MEDIA: "/docs/report MEDIA:final.docx"`) still works.
- Tags inside inline code / fenced code blocks stay protected by the existing
  masking (`_mask_protected_spans`, #35695) — behavior unchanged (covered by
  existing tests).
- `MEDIA_EXTENSIONLESS_TAG_RE` is not touched: its path branch is `[^\s\n`"']+`
  (no spaced continuation), so it cannot glue across a second tag.

Follow-up (intentionally **not** in this PR, one logical change per PR): we
also run a small extension in production that tolerates markdown bold/italic
wrappers around tags (`**MEDIA:/path/file.docx**` — some models decorate the
tag). Happy to submit it as a separate PR if there is interest.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits (`fix(gateway): …`)
- [ ] Searched existing PRs/issues for duplicates (**TODO before submitting**:
      `gh search prs --repo NousResearch/hermes-agent --state all "MEDIA tag glue two tags one line"`)
- [x] PR contains only changes related to this fix
- [ ] `pytest tests/ -q` full run (**TODO on a dev machine** — on the
      production box we ran the affected class standalone: 29/29 pass)
- [x] Tests added for the change
- [x] Tested on: Ubuntu 22.04 (production gateway host)

### Documentation & Housekeeping

- [x] Docstrings/comments updated (comment above the regex) — no user-facing
      docs affected
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered: pure-regex change, Windows-path
      branch (`X:\` anchors, #34632) untouched and covered by existing tests
- [x] Tool descriptions/schemas — N/A
