### PR TITLE
feat(gateway): per-topic toolsets override via channel_overrides extra

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2609,6 +2609,51 @@ def _get_channel_override(
     return None
 
 
+def _get_topic_toolsets_override(
+    user_config: Dict[str, Any],
+    platform_key: str,
+    thread_id: Optional[str],
+) -> Optional[List[str]]:
+    """Return the per-topic toolset list for this thread, or None.
+
+    Reads ``platforms.<platform>.extra.topic_toolsets`` — a mapping of a
+    forum-topic / thread id to the list of toolsets enabled for messages
+    arriving in that topic::
+
+        platforms:
+          telegram:
+            extra:
+              topic_toolsets:
+                "137": [telegram, skills]
+                "141": [telegram, web_search, files]
+
+    The per-topic list replaces the platform-level toolsets wholesale, so
+    the existing MCP-allowlist semantics apply to it unchanged. A missing
+    or empty entry means "no override" for that topic — an empty list does
+    NOT disable all toolsets. Complements ``channel_overrides`` (per-topic
+    model / provider / system_prompt) with per-topic tool scoping.
+    """
+    if not thread_id:
+        return None
+    thread_key = str(thread_id)
+    platform_cfg = (user_config.get("platforms") or {}).get(platform_key)
+    if not isinstance(platform_cfg, dict):
+        return None
+    extra = platform_cfg.get("extra")
+    if not isinstance(extra, dict):
+        return None
+    topic_toolsets = extra.get("topic_toolsets")
+    if not isinstance(topic_toolsets, dict):
+        return None
+    toolsets = topic_toolsets.get(thread_key)
+    if toolsets is None and thread_key.isdigit():
+        # YAML users often write bare integer topic ids; accept both.
+        toolsets = topic_toolsets.get(int(thread_key))
+    if not isinstance(toolsets, (list, tuple, set)) or not toolsets:
+        return None
+    return sorted({str(t) for t in toolsets})
+
+
 def _resolve_hermes_bin() -> Optional[list[str]]:
     """Resolve the Hermes update command as argv parts.
 
@@ -13907,6 +13952,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             from hermes_cli.tools_config import _get_platform_tools
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            topic_toolsets = _get_topic_toolsets_override(
+                user_config, platform_key, getattr(source, "thread_id", None)
+            )
+            if topic_toolsets is not None:
+                enabled_toolsets = topic_toolsets
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
@@ -17787,6 +17837,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         from hermes_cli.tools_config import _get_platform_tools
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        topic_toolsets = _get_topic_toolsets_override(
+            user_config, platform_key, getattr(source, "thread_id", None)
+        )
+        if topic_toolsets is not None:
+            enabled_toolsets = topic_toolsets
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 

--- a/tests/gateway/test_topic_toolsets.py
+++ b/tests/gateway/test_topic_toolsets.py
@@ -1,0 +1,71 @@
+"""Tests for per-topic toolset overrides (platforms.<name>.extra.topic_toolsets)."""
+
+from gateway.run import _get_topic_toolsets_override
+
+
+def _config(topic_toolsets=None, extra=None, platform="telegram"):
+    if extra is None:
+        extra = {}
+        if topic_toolsets is not None:
+            extra["topic_toolsets"] = topic_toolsets
+    return {"platforms": {platform: {"enabled": True, "extra": extra}}}
+
+
+class TestGetTopicToolsetsOverride:
+    def test_none_when_no_thread_id(self):
+        cfg = _config({"137": ["telegram", "skills"]})
+        assert _get_topic_toolsets_override(cfg, "telegram", None) is None
+        assert _get_topic_toolsets_override(cfg, "telegram", "") is None
+
+    def test_none_when_platform_missing(self):
+        cfg = _config({"137": ["telegram"]})
+        assert _get_topic_toolsets_override(cfg, "discord", "137") is None
+
+    def test_none_when_no_platforms_section(self):
+        assert _get_topic_toolsets_override({}, "telegram", "137") is None
+
+    def test_none_when_extra_missing_or_wrong_type(self):
+        cfg = {"platforms": {"telegram": {"enabled": True}}}
+        assert _get_topic_toolsets_override(cfg, "telegram", "137") is None
+        cfg = {"platforms": {"telegram": {"enabled": True, "extra": "nope"}}}
+        assert _get_topic_toolsets_override(cfg, "telegram", "137") is None
+
+    def test_none_when_topic_not_listed(self):
+        cfg = _config({"137": ["telegram"]})
+        assert _get_topic_toolsets_override(cfg, "telegram", "999") is None
+
+    def test_returns_sorted_deduplicated_list(self):
+        cfg = _config({"137": ["web_search", "telegram", "web_search"]})
+        assert _get_topic_toolsets_override(cfg, "telegram", "137") == [
+            "telegram",
+            "web_search",
+        ]
+
+    def test_matches_integer_keys_from_yaml(self):
+        """YAML users often write bare integer topic ids."""
+        cfg = _config({137: ["files"]})
+        assert _get_topic_toolsets_override(cfg, "telegram", "137") == ["files"]
+
+    def test_string_key_takes_precedence_over_int_key(self):
+        cfg = _config({"137": ["files"], 137: ["web_search"]})
+        assert _get_topic_toolsets_override(cfg, "telegram", "137") == ["files"]
+
+    def test_empty_list_means_no_override(self):
+        """An empty per-topic list is "not configured", not "disable all"."""
+        cfg = _config({"137": []})
+        assert _get_topic_toolsets_override(cfg, "telegram", "137") is None
+
+    def test_non_list_value_is_ignored(self):
+        cfg = _config({"137": "telegram"})
+        assert _get_topic_toolsets_override(cfg, "telegram", "137") is None
+
+    def test_non_dict_topic_toolsets_is_ignored(self):
+        cfg = _config(extra={"topic_toolsets": ["telegram"]})
+        assert _get_topic_toolsets_override(cfg, "telegram", "137") is None
+
+    def test_values_coerced_to_str(self):
+        cfg = _config({"137": ["telegram", 42]})
+        assert _get_topic_toolsets_override(cfg, "telegram", "137") == [
+            "42",
+            "telegram",
+        ]


### PR DESCRIPTION
# DRAFT — not submitted

Suggested branch: `feat/per-topic-toolsets`
Suggested commit: `feat(gateway): per-topic toolset overrides via platforms.<name>.extra.topic_toolsets`
Target: `NousResearch/hermes-agent`, base `main` (developed against `v2026.7.7.2`)

---

## What does this PR do?

Adds **per-topic (per-thread) toolset scoping** to the gateway.

The gateway already routes forum topics / threads individually: per-topic
`model`, `provider` and `system_prompt` via `channel_overrides` (looked up by
`chat_id` → `thread_id` → `parent_id`), plus `group_topics` /
`allowed_topics`. What it cannot do yet is give different topics different
**tools**. `enabled_toolsets` is resolved per platform only
(`_get_platform_tools(user_config, platform_key)`).

Use case (our production setup): one Telegram supergroup where each forum
topic is a differently-scoped workspace — a "logs" topic where the agent must
not run any tools, a "research" topic with web tools, an "ops" topic with the
terminal, a "files" pipeline topic. Per-topic system prompts already work;
per-topic tools are the missing half.

New config key, under the existing platform-specific `extra` escape hatch:

```yaml
platforms:
  telegram:
    extra:
      topic_toolsets:
        "137": [telegram, skills]
        "141": [telegram, web_search, files]
```

When a message arrives with a `thread_id` listed in `topic_toolsets`, the
per-topic list **replaces** the platform-level `enabled_toolsets` wholesale.
All downstream semantics (MCP allowlist behavior, `agent.disabled_toolsets`)
apply to the substituted list unchanged.

Semantics:

- keys may be strings or bare YAML integers (`"137"` and `137` both match);
- a missing or **empty** entry means "no override" — an empty list does NOT
  disable all toolsets (misconfiguration guard);
- values are deduplicated, coerced to `str` and sorted (mirrors the
  `sorted(_get_platform_tools(...))` call sites);
- malformed shapes (non-dict `topic_toolsets`, non-list entry) are ignored
  rather than crashing message handling.

### Design note for reviewers

We used `platforms.<name>.extra` because it is the documented
"platform-specific settings" escape hatch and requires zero schema churn. A
reasonable alternative is a `toolsets` field on `ChannelOverride` (next to
`model` / `provider` / `system_prompt`), resolved through
`_get_channel_override`, which would also inherit the
`chat_id → thread_id → parent_id` lookup order and work for whole channels,
not just threads. If you prefer that shape, we are happy to rework the PR —
the helper is isolated, so the move is mechanical.

## Related Issue

<!-- TODO: search for an existing feature request before submitting;
     link or open one. -->

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/run.py` — new module-level helper `_get_topic_toolsets_override`
  (placed next to `_get_channel_override`, same style: pure function over the
  config dict, returns `None` when not configured).
- `gateway/run.py` — the two `enabled_toolsets` resolution sites apply the
  override: the main agent path (`_run_agent_inner`) and the background-task
  path (`_run_background_task`), so `/background` jobs get the same tool
  scoping as foreground replies.
- `tests/gateway/test_topic_toolsets.py` — new file, 12 tests
  (mirrors the structure of `tests/gateway/test_channel_overrides.py`).

## How to Test

1. `pytest tests/gateway/test_topic_toolsets.py -q` — 12 tests pass.
2. Manual: in a Telegram supergroup with topics, add to `~/.hermes/config.yaml`:

   ```yaml
   platforms:
     telegram:
       extra:
         topic_toolsets:
           "<your topic thread_id>": [telegram]
   ```

3. Restart the gateway, write in that topic: the agent has only the
   `telegram` toolset (e.g. asks it to run a shell command — no terminal
   tool available). Write in any other topic: full platform toolsets as
   before.
4. `hermes background ...` from that topic: the background task inherits the
   same restricted toolsets.

We have been running the equivalent logic in production on a Telegram
gateway (v0.18.2, 13 topic profiles) since 2026-07 — this PR is that patch
reworked into a reviewable helper + tests.

## Limitations

- Lookup is by exact `thread_id` only; no `chat_id`/`parent_id` fallback
  chain (unlike `_channel_override_lookup_keys`). Fine for forum topics;
  switching to the `ChannelOverride` shape (see design note) would add that
  for free.
- Substitution is wholesale — no additive/subtractive syntax
  (`+web_search`/`-terminal`). Kept minimal on purpose.
- Platform-agnostic by construction (anything that sets
  `SessionSource.thread_id`: Telegram forum topics, Discord threads, …), but
  tested in production on Telegram only.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits (`feat(gateway): …`)
- [ ] Searched existing PRs/issues for duplicates (**TODO before submitting**:
      `gh search prs --repo NousResearch/hermes-agent --state all "per-topic toolsets"`)
- [x] PR contains only changes related to this feature
- [ ] `pytest tests/ -q` full run (**TODO on a dev machine** — on the
      production box we ran the new test class standalone: 12/12 pass)
- [x] Tests added
- [x] Tested on: Ubuntu 22.04 (production gateway host)

### Documentation & Housekeeping

- [x] Docstring on the helper documents the config shape and semantics
- [ ] `cli-config.yaml.example` — **open question**: `channel_overrides`
      itself is not in the example config either; happy to add a commented
      `topic_toolsets` block if maintainers want it documented there
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (config-driven logic, no file I/O)
- [x] Tool descriptions/schemas — N/A (which toolsets load is config routing,
      not tool behavior)
