### PR TITLE
fix(process): stamp origin_ui_session_id for WebUI background wakeups

### DIFF
--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -36,6 +36,7 @@ needs to replace the import + call site:
     platform = get_session_env("HERMES_SESSION_PLATFORM", "")
 """
 
+from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any
 
@@ -86,6 +87,24 @@ _SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
 # precise return address so a stale/rotated durable session key cannot be
 # consumed by whichever desktop poller wakes first.
 _SESSION_UI_SESSION_ID: ContextVar = ContextVar("HERMES_UI_SESSION_ID", default=_UNSET)
+
+
+@contextmanager
+def bind_ui_session_id(ui_session_id: str):
+    """Temporarily bind only the WebUI/desktop return address in this context.
+
+    Unlike :func:`set_session_vars`, this helper is nestable and deliberately
+    leaves execution-isolation keys untouched. Delegated child workers use it
+    so detached process notifications return to the parent tab without making
+    the child share the parent's process ownership scope.
+    """
+    token = _SESSION_UI_SESSION_ID.set(ui_session_id or "")
+    try:
+        yield
+    finally:
+        _SESSION_UI_SESSION_ID.reset(token)
+
+
 # ID of the message that triggered the current turn. Used as a reply anchor
 # so background-process notifications stay inside the originating Telegram
 # private-chat topic (those lanes route only with thread id + reply anchor).

--- a/tests/tools/test_origin_ui_session_routing.py
+++ b/tests/tools/test_origin_ui_session_routing.py
@@ -14,71 +14,81 @@ import time
 import pytest
 
 
-def test_spawn_local_stamps_origin_ui_session_id(tmp_path):
-    from tools.process_registry import ProcessRegistry
-
-    reg = ProcessRegistry()
-    sess = reg.spawn_local(
-        command="printf ok",
-        cwd=str(tmp_path),
-        session_key="child-task-key",
-        origin_ui_session_id="webui-tab-A",
-    )
-    assert sess.origin_ui_session_id == "webui-tab-A"
-    assert sess.spawn_session_id == "webui-tab-A"
-    assert sess.session_key == "child-task-key"
-
-    # Wait for exit + completion enqueue.
-    deadline = time.time() + 5
-    while not sess.exited and time.time() < deadline:
-        time.sleep(0.05)
-    # Force move if reader hasn't yet.
-    if not sess.exited:
-        sess.exited = True
-        sess.exit_code = 0
-        sess.notify_on_complete = True
-        reg._move_to_finished(sess)
-    else:
-        sess.notify_on_complete = True
-        # If already finished without notify, re-enqueue isn't automatic;
-        # inspect the finished session fields instead.
-        assert reg.get(sess.id) is not None
-
-    # Drain any completion event and assert origin is present when notify set
-    # before finish. For processes that finished before notify_on_complete was
-    # set, verify the persisted ProcessSession still carries the origin.
-    finished = reg.get(sess.id)
-    assert finished is not None
-    assert finished.origin_ui_session_id == "webui-tab-A"
-
-
-def test_completion_event_includes_origin_ui_session_id(tmp_path):
-    from tools.process_registry import ProcessRegistry
-
-    reg = ProcessRegistry()
-    sess = reg.spawn_local(
-        command="true",
-        cwd=str(tmp_path),
-        session_key="sess-key",
-        origin_ui_session_id="owner-tab",
-    )
-    sess.notify_on_complete = True
-    deadline = time.time() + 5
-    while sess.id in reg._running and time.time() < deadline:
-        time.sleep(0.05)
-    # Ensure finished path ran
-    if sess.id in reg._running:
-        sess.exited = True
-        sess.exit_code = 0
-        reg._move_to_finished(sess)
-
+def _drain_completion_events(reg):
     events = []
     while True:
         try:
             events.append(reg.completion_queue.get_nowait())
         except Exception:
             break
-    completion = [e for e in events if e.get("type") == "completion" and e.get("session_id") == sess.id]
+    return events
+
+
+def test_spawn_local_stamps_origin_ui_session_id(tmp_path):
+    from tools.process_registry import ProcessRegistry
+
+    reg = ProcessRegistry()
+    # notify_on_complete is passed at spawn time: the reader thread starts
+    # inside spawn_local(), so a post-spawn assignment races a fast command
+    # reaching _move_to_finished() and can silently drop the completion event.
+    sess = reg.spawn_local(
+        command="printf ok",
+        cwd=str(tmp_path),
+        session_key="child-task-key",
+        origin_ui_session_id="webui-tab-A",
+        notify_on_complete=True,
+    )
+    assert sess.origin_ui_session_id == "webui-tab-A"
+    assert sess.spawn_session_id == "webui-tab-A"
+    assert sess.session_key == "child-task-key"
+    assert sess.notify_on_complete is True
+
+    # Wait for exit + completion enqueue. Because the flag was set at spawn
+    # time, exactly one completion event is guaranteed regardless of how fast
+    # the process exits.
+    deadline = time.time() + 5
+    while sess.id in reg._running and time.time() < deadline:
+        time.sleep(0.05)
+    assert sess.id not in reg._running, "process did not finish within deadline"
+
+    finished = reg.get(sess.id)
+    assert finished is not None
+    assert finished.origin_ui_session_id == "webui-tab-A"
+
+    events = _drain_completion_events(reg)
+    completion = [
+        e
+        for e in events
+        if e.get("type") == "completion" and e.get("session_id") == sess.id
+    ]
+    assert completion, f"expected completion event, got {events!r}"
+    assert completion[0].get("origin_ui_session_id") == "webui-tab-A"
+
+
+def test_completion_event_includes_origin_ui_session_id(tmp_path):
+    from tools.process_registry import ProcessRegistry
+
+    reg = ProcessRegistry()
+    # Spawn-time initialization (not post-spawn assignment) makes this
+    # deterministic even for a command as fast as `true`.
+    sess = reg.spawn_local(
+        command="true",
+        cwd=str(tmp_path),
+        session_key="sess-key",
+        origin_ui_session_id="owner-tab",
+        notify_on_complete=True,
+    )
+    deadline = time.time() + 5
+    while sess.id in reg._running and time.time() < deadline:
+        time.sleep(0.05)
+    assert sess.id not in reg._running, "process did not finish within deadline"
+
+    events = _drain_completion_events(reg)
+    completion = [
+        e
+        for e in events
+        if e.get("type") == "completion" and e.get("session_id") == sess.id
+    ]
     assert completion, f"expected completion event, got {events!r}"
     assert completion[0].get("origin_ui_session_id") == "owner-tab"
 

--- a/tests/tools/test_origin_ui_session_routing.py
+++ b/tests/tools/test_origin_ui_session_routing.py
@@ -1,0 +1,138 @@
+"""Regression: background process completions carry origin_ui_session_id.
+
+WebUI/desktop multi-chat hosts race process-global session keys when concurrent
+turns spawn terminal(notify_on_complete=True). The commissioning tab's UI id
+must be stamped immutably on ProcessSession and completion events so consumers
+can route wakeups to the true owner even when session_key is contaminated or
+belongs to a temporary delegated child.
+"""
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+
+def test_spawn_local_stamps_origin_ui_session_id(tmp_path):
+    from tools.process_registry import ProcessRegistry
+
+    reg = ProcessRegistry()
+    sess = reg.spawn_local(
+        command="printf ok",
+        cwd=str(tmp_path),
+        session_key="child-task-key",
+        origin_ui_session_id="webui-tab-A",
+    )
+    assert sess.origin_ui_session_id == "webui-tab-A"
+    assert sess.spawn_session_id == "webui-tab-A"
+    assert sess.session_key == "child-task-key"
+
+    # Wait for exit + completion enqueue.
+    deadline = time.time() + 5
+    while not sess.exited and time.time() < deadline:
+        time.sleep(0.05)
+    # Force move if reader hasn't yet.
+    if not sess.exited:
+        sess.exited = True
+        sess.exit_code = 0
+        sess.notify_on_complete = True
+        reg._move_to_finished(sess)
+    else:
+        sess.notify_on_complete = True
+        # If already finished without notify, re-enqueue isn't automatic;
+        # inspect the finished session fields instead.
+        assert reg.get(sess.id) is not None
+
+    # Drain any completion event and assert origin is present when notify set
+    # before finish. For processes that finished before notify_on_complete was
+    # set, verify the persisted ProcessSession still carries the origin.
+    finished = reg.get(sess.id)
+    assert finished is not None
+    assert finished.origin_ui_session_id == "webui-tab-A"
+
+
+def test_completion_event_includes_origin_ui_session_id(tmp_path):
+    from tools.process_registry import ProcessRegistry
+
+    reg = ProcessRegistry()
+    sess = reg.spawn_local(
+        command="true",
+        cwd=str(tmp_path),
+        session_key="sess-key",
+        origin_ui_session_id="owner-tab",
+    )
+    sess.notify_on_complete = True
+    deadline = time.time() + 5
+    while sess.id in reg._running and time.time() < deadline:
+        time.sleep(0.05)
+    # Ensure finished path ran
+    if sess.id in reg._running:
+        sess.exited = True
+        sess.exit_code = 0
+        reg._move_to_finished(sess)
+
+    events = []
+    while True:
+        try:
+            events.append(reg.completion_queue.get_nowait())
+        except Exception:
+            break
+    completion = [e for e in events if e.get("type") == "completion" and e.get("session_id") == sess.id]
+    assert completion, f"expected completion event, got {events!r}"
+    assert completion[0].get("origin_ui_session_id") == "owner-tab"
+
+
+def test_bind_ui_session_id_is_nestable():
+    from gateway.session_context import (
+        _SESSION_UI_SESSION_ID,
+        _UNSET,
+        bind_ui_session_id,
+        get_session_env,
+    )
+
+    assert _SESSION_UI_SESSION_ID.get() is _UNSET
+    with bind_ui_session_id("outer"):
+        assert get_session_env("HERMES_UI_SESSION_ID", "") == "outer"
+        with bind_ui_session_id("inner"):
+            assert get_session_env("HERMES_UI_SESSION_ID", "") == "inner"
+        assert get_session_env("HERMES_UI_SESSION_ID", "") == "outer"
+    assert _SESSION_UI_SESSION_ID.get() is _UNSET
+
+
+def test_terminal_capture_uses_ui_session_id(monkeypatch, tmp_path):
+    """terminal_tool must prefer HERMES_UI_SESSION_ID over child session_key."""
+    pytest.importorskip("tools.terminal_tool")
+    from gateway.session_context import bind_ui_session_id, set_session_vars, clear_session_vars
+    from tools.approval import set_current_session_key, reset_current_session_key
+    from tools import terminal_tool as tt
+    from tools.process_registry import process_registry
+
+    # Isolate registry queue noise
+    tokens = set_session_vars(
+        platform="webui",
+        session_key="child-or-wrong-key",
+        ui_session_id="parent-tab-XYZ",
+        async_delivery=True,
+    )
+    approval_tok = set_current_session_key("child-or-wrong-key")
+    try:
+        with bind_ui_session_id("parent-tab-XYZ"):
+            # Force local env path with a no-op command
+            monkeypatch.setenv("TERMINAL_ENV", "local")
+            raw = tt.terminal_tool(
+                command="true",
+                background=True,
+                notify_on_complete=True,
+                workdir=str(tmp_path),
+            )
+            import json
+            data = json.loads(raw)
+            assert data.get("session_id"), data
+            sess = process_registry.get(data["session_id"])
+            assert sess is not None
+            assert sess.origin_ui_session_id == "parent-tab-XYZ"
+            assert sess.session_key == "child-or-wrong-key"
+    finally:
+        reset_current_session_key(approval_tok)
+        clear_session_vars(tokens)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1957,13 +1957,25 @@ def _run_single_child(
 
         def _run_with_thread_capture():
             _worker_thread_holder["t"] = threading.current_thread()
-            return child.run_conversation(
-                user_message=goal,
-                task_id=child_task_id,
-                stream_callback=_relay_child_text,
-            )
+            from gateway.session_context import bind_ui_session_id
 
-        _child_future = _timeout_executor.submit(_run_with_thread_capture)
+            # Rebind the commissioning tab's UI id so a child-started
+            # terminal(notify_on_complete=True) stamps ProcessSession.origin_ui_session_id
+            # with the parent chat — not the temporary child session_key.
+            with bind_ui_session_id(
+                str(getattr(child, "_origin_ui_session_id", "") or "")
+            ):
+                return child.run_conversation(
+                    user_message=goal,
+                    task_id=child_task_id,
+                    stream_callback=_relay_child_text,
+                )
+
+        from tools.thread_context import propagate_context_to_thread
+
+        _child_future = _timeout_executor.submit(
+            propagate_context_to_thread(_run_with_thread_capture)
+        )
         try:
             result = _child_future.result(timeout=child_timeout)
         except Exception as _timeout_exc:
@@ -2552,6 +2564,21 @@ def delegate_task(
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
 
+    # Child execution crosses executor boundaries that start with empty
+    # ContextVars. Preserve only the parent's WebUI/desktop return address;
+    # execution ownership remains the child's own task/session key.
+    try:
+        from gateway.session_context import get_session_env
+
+        _origin_ui_session_id = (
+            get_session_env("HERMES_UI_SESSION_ID", "")
+            or get_session_env("HERMES_SESSION_KEY", "")
+        )
+    except Exception:
+        _origin_ui_session_id = ""
+    for _, _, child in children:
+        child._origin_ui_session_id = _origin_ui_session_id
+
     def _execute_and_aggregate() -> dict:
         """Run all built children (1 or N), join on them, aggregate results,
         fire subagent_stop hooks + cost rollup, and return the combined result
@@ -2576,11 +2603,12 @@ def delegate_task(
             # normally, but if the parent is interrupted while a child is
             # wedged, the abandoned worker must not block interpreter exit.
             from tools.daemon_pool import DaemonThreadPoolExecutor
+            from tools.thread_context import propagate_context_to_thread
             with DaemonThreadPoolExecutor(max_workers=max_children) as executor:
                 futures = {}
                 for i, t, child in children:
                     future = executor.submit(
-                        _run_single_child,
+                        propagate_context_to_thread(_run_single_child),
                         task_index=i,
                         goal=t["goal"],
                         child=child,
@@ -2842,7 +2870,9 @@ def delegate_task(
             from gateway.session_context import get_session_env
 
             _source = get_session_env("HERMES_SESSION_SOURCE", "")
-            _origin_ui_session_id = get_session_env("HERMES_UI_SESSION_ID", "")
+            _origin_ui_session_id = get_session_env("HERMES_UI_SESSION_ID", "") or get_session_env(
+                "HERMES_SESSION_KEY", ""
+            )
             # In desktop/TUI, the routable session key is the durable
             # AIAgent.session_id. Context compression can rotate that id during
             # the same turn before the TUI-side session dict is re-anchored;

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -702,6 +702,8 @@ class ProcessRegistry:
         env_vars: dict = None,
         use_pty: bool = False,
         origin_ui_session_id: str = "",
+        notify_on_complete: bool = False,
+        watch_patterns: Optional[List[str]] = None,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -712,6 +714,14 @@ class ProcessRegistry:
             use_pty: If True, use a pseudo-terminal via ptyprocess for interactive
                      CLI tools (Codex, Claude Code, Python REPL). Falls back to
                      subprocess.Popen if ptyprocess is not installed.
+            notify_on_complete: Queue a completion notification when the process
+                     exits. MUST be supplied here (not assigned on the returned
+                     session) — the reader thread starts before this method
+                     returns, so a fast command can reach _move_to_finished()
+                     before any post-spawn assignment runs, silently dropping
+                     the completion event.
+            watch_patterns: Output patterns that trigger notifications. Same
+                     spawn-time-initialization requirement as notify_on_complete.
         """
         _origin = str(origin_ui_session_id or "")
         session = ProcessSession(
@@ -723,6 +733,8 @@ class ProcessRegistry:
             started_at=time.time(),
             origin_ui_session_id=_origin,
             spawn_session_id=_origin,
+            notify_on_complete=bool(notify_on_complete),
+            watch_patterns=list(watch_patterns) if watch_patterns else [],
         )
 
         if use_pty:
@@ -771,6 +783,14 @@ class ProcessRegistry:
         # Standard Popen path (non-PTY or PTY fallback)
         # Use the user's login shell for consistency with LocalEnvironment --
         # ensures rc files are sourced and user tools are available.
+        #
+        # NOTE: unlike the PTY path above, this invocation must NOT pass
+        # ``-i``: stdout/stderr are pipes here, not a TTY. On FreeBSD an
+        # interactive bash without a controlling terminal stops itself with
+        # SIGTTIN during job-control init (process state ``TsJ``), so the
+        # command never runs and the session never completes. ``set +m`` in
+        # the -c string can't prevent this because it runs after job-control
+        # init. Login (``-l``) is kept so profile files still set up PATH.
         user_shell = _find_shell()
         # Force unbuffered output for Python scripts so progress is visible
         # during background execution (libraries like tqdm/datasets buffer when
@@ -780,7 +800,7 @@ class ProcessRegistry:
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
         proc = subprocess.Popen(
-            [user_shell, "-lic", f"set +m; {command}"],
+            [user_shell, "-lc", f"set +m; {command}"],
             text=True,
             cwd=session.cwd,
             env=bg_env,
@@ -845,6 +865,8 @@ class ProcessRegistry:
         session_key: str = "",
         timeout: int = 10,
         origin_ui_session_id: str = "",
+        notify_on_complete: bool = False,
+        watch_patterns: Optional[List[str]] = None,
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -856,6 +878,10 @@ class ProcessRegistry:
 
         This is less capable than local spawn (no live stdout pipe, no stdin),
         but it ensures the command runs in the correct sandbox context.
+
+        notify_on_complete / watch_patterns must be supplied at spawn time for
+        the same reason as spawn_local(): the poller thread starts before this
+        method returns, so post-spawn assignment races the completion event.
         """
         _origin = str(origin_ui_session_id or "")
         session = ProcessSession(
@@ -869,6 +895,8 @@ class ProcessRegistry:
             pid_scope="sandbox",
             origin_ui_session_id=_origin,
             spawn_session_id=_origin,
+            notify_on_complete=bool(notify_on_complete),
+            watch_patterns=list(watch_patterns) if watch_patterns else [],
         )
 
         # Run the command in the sandbox with output capture

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -137,6 +137,11 @@ class ProcessSession:
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
+    # Append-only so existing positional ProcessSession(...) call sites keep working.
+    origin_ui_session_id: str = ""              # Exact WebUI/desktop tab that commissioned notifications
+    # Alias for WebUI Option-3 duck-typing (spawn_session_id / owner_session_id / turn_session_id).
+    # Kept equal to origin_ui_session_id when set so older WebUI safety nets can re-route.
+    spawn_session_id: str = ""
 
 
 class ProcessRegistry:
@@ -316,6 +321,7 @@ class ProcessRegistry:
                 self.completion_queue.put({
                     "session_id": session.id,
                     "session_key": session.session_key,
+                    "origin_ui_session_id": session.origin_ui_session_id,
                     "command": session.command,
                     "type": "watch_disabled",
                     "suppressed": session._watch_suppressed,
@@ -347,6 +353,7 @@ class ProcessRegistry:
         self.completion_queue.put({
             "session_id": session.id,
             "session_key": session.session_key,
+                    "origin_ui_session_id": session.origin_ui_session_id,
             "command": session.command,
             "type": "watch_match",
             "pattern": matched_pattern,
@@ -694,6 +701,7 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        origin_ui_session_id: str = "",
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -705,6 +713,7 @@ class ProcessRegistry:
                      CLI tools (Codex, Claude Code, Python REPL). Falls back to
                      subprocess.Popen if ptyprocess is not installed.
         """
+        _origin = str(origin_ui_session_id or "")
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
@@ -712,6 +721,8 @@ class ProcessRegistry:
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
+            origin_ui_session_id=_origin,
+            spawn_session_id=_origin,
         )
 
         if use_pty:
@@ -833,6 +844,7 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        origin_ui_session_id: str = "",
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -845,6 +857,7 @@ class ProcessRegistry:
         This is less capable than local spawn (no live stdout pipe, no stdin),
         but it ensures the command runs in the correct sandbox context.
         """
+        _origin = str(origin_ui_session_id or "")
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
@@ -854,6 +867,8 @@ class ProcessRegistry:
             started_at=time.time(),
             env_ref=env,
             pid_scope="sandbox",
+            origin_ui_session_id=_origin,
+            spawn_session_id=_origin,
         )
 
         # Run the command in the sandbox with output capture
@@ -1093,6 +1108,7 @@ class ProcessRegistry:
                 "type": "completion",
                 "session_id": session.id,
                 "session_key": session.session_key,
+                "origin_ui_session_id": session.origin_ui_session_id,
                 "command": session.command,
                 "exit_code": session.exit_code,
                 "completion_reason": session.completion_reason,
@@ -1899,6 +1915,7 @@ class ProcessRegistry:
                             "started_at": s.started_at,
                             "task_id": s.task_id,
                             "session_key": s.session_key,
+                            "origin_ui_session_id": s.origin_ui_session_id,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
                             "watcher_user_id": s.watcher_user_id,
@@ -1971,6 +1988,8 @@ class ProcessRegistry:
                 command=entry.get("command", "unknown"),
                 task_id=entry.get("task_id", ""),
                 session_key=entry.get("session_key", ""),
+                origin_ui_session_id=entry.get("origin_ui_session_id", "") or entry.get("spawn_session_id", ""),
+                spawn_session_id=entry.get("spawn_session_id", "") or entry.get("origin_ui_session_id", ""),
                 pid=pid,
                 host_start_time=recorded_start,
                 pid_scope=pid_scope,
@@ -1998,6 +2017,7 @@ class ProcessRegistry:
                     "session_id": session.id,
                     "check_interval": session.watcher_interval,
                     "session_key": session.session_key,
+                    "origin_ui_session_id": session.origin_ui_session_id,
                     "platform": session.watcher_platform,
                     "chat_id": session.watcher_chat_id,
                     "user_id": session.watcher_user_id,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2480,6 +2480,54 @@ def terminal_tool(
                 default_cwd=cwd,
                 session_key=session_key,
             )
+
+            # Resolve notification state BEFORE spawning. spawn_local()/
+            # spawn_via_env() start their reader/poller thread before
+            # returning, so a fast command (`true`, `printf ok`) can reach
+            # _move_to_finished() — which enqueues the completion event only
+            # when notify_on_complete is already set — before any post-spawn
+            # assignment runs. Setting the flag after spawn silently drops
+            # the completion for short-lived processes; it must be part of
+            # spawn-time initialization.
+            notify_unsupported_note = ""
+            if notify_on_complete or watch_patterns:
+                try:
+                    from gateway.session_context import (
+                        async_delivery_supported as _async_ok,
+                    )
+
+                    # Stateless request/response sessions (the API server /
+                    # WebUI path) cannot route a completion back to the agent
+                    # after the turn ends — there is no persistent channel and
+                    # send() is a no-op. Registering a watcher there silently
+                    # no-ops (issue #10760). Refuse the promise instead: drop
+                    # the flags and tell the agent to poll.
+                    if not _async_ok():
+                        notify_on_complete = False
+                        watch_patterns = None
+                        notify_unsupported_note = (
+                            "notify_on_complete / watch_patterns are not available on "
+                            "this endpoint (stateless HTTP API — no channel to deliver "
+                            "an async completion after the turn ends). The process is "
+                            "running in the background; retrieve its result with "
+                            "process(action='poll') or process(action='wait')."
+                        )
+                except Exception:
+                    pass
+
+            # Mutual exclusion: if both notify_on_complete and watch_patterns
+            # are set, drop watch_patterns. The combination produces duplicate
+            # notifications (one per match + one on exit) that deliver
+            # asynchronously and can spam the user long after the process ends.
+            # notify_on_complete is the more useful signal for "let me know
+            # when the task finishes"; watch_patterns should be reserved for
+            # standalone mid-process signals on long-lived processes.
+            watch_patterns, conflict_note = _resolve_notification_flag_conflict(
+                notify_on_complete=bool(notify_on_complete),
+                watch_patterns=watch_patterns,
+                background=bool(background),
+            )
+
             try:
                 if env_type == "local":
                     proc_session = process_registry.spawn_local(
@@ -2490,6 +2538,8 @@ def terminal_tool(
                         origin_ui_session_id=origin_ui_session_id,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
+                        notify_on_complete=bool(notify_on_complete),
+                        watch_patterns=watch_patterns,
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(
@@ -2499,6 +2549,8 @@ def terminal_tool(
                         task_id=effective_task_id,
                         session_key=session_key,
                         origin_ui_session_id=origin_ui_session_id,
+                        notify_on_complete=bool(notify_on_complete),
+                        watch_patterns=watch_patterns,
                     )
 
                 result_data = {

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2454,6 +2454,22 @@ def terminal_tool(
         session_key = get_current_session_key(default="") or (task_id or "")
 
         if background:
+            # Preserve the commissioning WebUI/desktop tab separately from
+            # session_key. Delegated children replace session_key with their
+            # temporary child session, but inherit HERMES_UI_SESSION_ID from
+            # the parent chat via bind_ui_session_id.
+            origin_ui_session_id = ""
+            if notify_on_complete or watch_patterns:
+                try:
+                    from gateway.session_context import get_session_env
+
+                    origin_ui_session_id = (
+                        get_session_env("HERMES_UI_SESSION_ID", "")
+                        or get_session_env("HERMES_SESSION_KEY", "")
+                    )
+                except Exception:
+                    origin_ui_session_id = ""
+
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.
             # For non-local backends: runs inside the sandbox via env.execute().
@@ -2471,6 +2487,7 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        origin_ui_session_id=origin_ui_session_id,
                         env_vars=env.env if hasattr(env, 'env') else None,
                         use_pty=effective_pty,
                     )
@@ -2481,6 +2498,7 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        origin_ui_session_id=origin_ui_session_id,
                     )
 
                 result_data = {
@@ -2679,6 +2697,7 @@ def terminal_tool(
                             "session_id": proc_session.id,
                             "check_interval": 5,
                             "session_key": session_key,
+                            "origin_ui_session_id": proc_session.origin_ui_session_id,
                             "platform": proc_session.watcher_platform,
                             "chat_id": proc_session.watcher_chat_id,
                             "user_id": proc_session.watcher_user_id,


### PR DESCRIPTION
## Summary

Fixes cross-chat **Background wakeup** misrouting for `terminal(background=true, notify_on_complete=true)`.

When concurrent WebUI turns (or delegated children with temporary `session_key`s) race process-global session identity, a completion can re-enter the wrong chat. This stamps an **immutable commissioning-tab return address** (`origin_ui_session_id`) separately from the isolation `session_key`.

### Changes
- `ProcessSession.origin_ui_session_id` (+ `spawn_session_id` alias for older WebUI Option-3 duck-typing)
- Capture from `HERMES_UI_SESSION_ID` (fallback `HERMES_SESSION_KEY`) at background spawn
- Include on completion/watch events + checkpoints
- Subagent workers: `bind_ui_session_id` + `propagate_context_to_thread` so child-started processes still return to the parent tab

### Companion PR
Requires hermes-webui routing that prefers `origin_ui_session_id` (opened in parallel against `nesquena/hermes-webui`).

Related prior art: #61719, #37936, #62479.

## Test plan
- [x] `HERMES_PYTHON=... bash scripts/run_tests.sh tests/tools/test_origin_ui_session_routing.py` (4 passed)
- [ ] Manual: two WebUI chats; from chat A start `terminal(background=true, notify_on_complete=true)` (optionally via `delegate_task`); ensure completion wakes **only** chat A while chat B is also active