### PR TITLE
fix: handle multimodal content in interim text and avoid retrying local processing errors

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -643,16 +643,16 @@ def strip_think_blocks(agent, content: str) -> str:
     """Remove reasoning/thinking blocks from content, returning only visible text.
 
     Handles four cases:
-      1. Closed tag pairs (``<think>…</think>``) — the common path when
+      1. Closed tag pairs (`` 执教… ``) — the common path when
          the provider emits complete reasoning blocks.
       2. Unterminated open tag at a block boundary (start of text or
          after a newline) — e.g. MiniMax M2.7 / NIM endpoints where the
          closing tag is dropped.  Everything from the open tag to end
          of string is stripped.  The block-boundary check mirrors
          ``gateway/stream_consumer.py``'s filter so models that mention
-         ``<think>`` in prose aren't over-stripped.
+         `` 执教`` in prose aren't over-stripped.
       3. Stray orphan open/close tags that slip through.
-      4. Tag variants: ``<think>``, ``<thinking>``, ``<reasoning>``,
+      4. Tag variants: `` 执教``, ``<thinking>``, ``<reasoning>``,
          ``<REASONING_SCRATCHPAD>``, ``<thought>`` (Gemma 4), all
          case-insensitive.
 
@@ -670,6 +670,21 @@ def strip_think_blocks(agent, content: str) -> str:
     after punctuation and carries a ``name="..."`` attribute) so prose
     mentions like "Use <function> in JavaScript" are preserved.
     """
+    # Defensive coercion: callers may pass multimodal content-parts lists
+    # (e.g. after vision turns or context compaction). Extract any text
+    # blocks and drop non-text parts before running regexes.
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict) and part.get("type") == "text":
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        content = "\n".join(parts)
+    elif not isinstance(content, str):
+        content = str(content) if content is not None else ""
     if not content:
         return ""
     # 1. Closed tag pairs — case-insensitive for all variants so

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -32,6 +32,7 @@ from agent.error_classifier import FailoverReason
 from agent.errors import EmptyStreamError
 from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
+from agent.message_content import flatten_message_text
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
@@ -1125,7 +1126,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # reasoning fields are present (some models/providers embed thinking
     # directly in the content rather than returning separate API fields).
     if not reasoning_text:
-        content = assistant_message.content or ""
+        content = flatten_message_text(getattr(assistant_message, "content", None))
         think_blocks = re.findall(r'<think>(.*?)</think>', content, flags=re.DOTALL)
         if think_blocks:
             combined = "\n\n".join(b.strip() for b in think_blocks if b.strip())
@@ -1151,7 +1152,7 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
     # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
     # can return invalid surrogate code points that crash json.dumps() on persist.
-    _raw_content = assistant_message.content or ""
+    _raw_content = flatten_message_text(getattr(assistant_message, "content", None))
     _san_content = _sanitize_surrogates(_raw_content)
     if reasoning_text:
         reasoning_text = _sanitize_surrogates(reasoning_text)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -24,6 +24,7 @@ import re
 import ssl
 import threading
 import time
+import traceback
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -5519,7 +5520,44 @@ def run_conversation(
                 break
             
         except Exception as e:
-            error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
+            # Phase-aware error classification. The huge outer try/except spans
+            # both the actual API request and all local post-processing of the
+            # returned assistant message. Deterministic local bugs (e.g.
+            # passing a multimodal content list into a regex helper after a
+            # vision turn or context compaction) should not be retried: they
+            # will fail identically on every iteration and only burn the
+            # iteration budget. We classify an error as local by inspecting the
+            # traceback: if the exception propagated through any of the known
+            # local post-processing helpers and never entered the interruptible
+            # API-call helpers, it is almost certainly a local processing bug.
+            # (#66267)
+            _local_processing_modules = {
+                "agent_runtime_helpers",
+                "conversation_loop",
+                "message_content",
+                "run_agent",
+            }
+            _api_call_modules = {
+                "chat_completion_helpers",
+            }
+
+            tb_stack = traceback.extract_tb(e.__traceback__)
+            tb_module_names = {
+                os.path.splitext(os.path.basename(frame.filename))[0]
+                for frame in tb_stack
+            }
+            _hit_local = bool(tb_module_names & _local_processing_modules)
+            _hit_api = bool(tb_module_names & _api_call_modules)
+
+            _is_local_processing_error = _hit_local and not _hit_api
+
+            if _is_local_processing_error:
+                error_msg = (
+                    f"Error during local message processing after "
+                    f"OpenAI-compatible API call #{api_call_count}: {str(e)}"
+                )
+            else:
+                error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
             try:
                 print(f"❌ {error_msg}")
             except (OSError, ValueError):
@@ -5566,10 +5604,19 @@ def run_conversation(
             # message pollutes history, burns tokens, and risks violating
             # role-alternation invariants.
 
-            # If we're near the limit, break to avoid infinite loops
-            if api_call_count >= agent.max_iterations - 1:
-                _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
-                final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
+            # If we're near the limit, break to avoid infinite loops.
+            # Local processing errors are deterministic — stop immediately
+            # rather than retrying until the budget is exhausted.
+            if (
+                _is_local_processing_error
+                or api_call_count >= agent.max_iterations - 1
+            ):
+                if _is_local_processing_error:
+                    _turn_exit_reason = f"local_processing_error({error_msg[:80]})"
+                    final_response = f"I apologize, but I encountered an error while processing the model response: {error_msg}"
+                else:
+                    _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
+                    final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
                 # Append as assistant so the history stays valid for
                 # session resume (avoids consecutive user messages).
                 messages.append({"role": "assistant", "content": final_response})

--- a/run_agent.py
+++ b/run_agent.py
@@ -148,6 +148,7 @@ from tools.browser_tool import cleanup_browser
 from agent.memory_manager import sanitize_context
 from agent.error_classifier import FailoverReason
 from agent.redact import redact_sensitive_text
+from agent.message_content import flatten_message_text
 from agent.model_metadata import (
     estimate_request_tokens_rough,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.estimate_request_tokens_rough")
     is_local_endpoint,
@@ -4816,12 +4817,15 @@ class AIAgent:
         response can contain both commentary and a partial/final-answer message
         while tools are still pending; treating top-level content as progress
         in that shape leaks the answer before the tool call runs.
+
+        Content may be a string or a structured parts list (e.g. after vision
+        turns or context compaction), so flatten it before stripping reasoning.
         """
         visible = self._extract_codex_interim_visible_text(assistant_msg)
         if visible:
             return visible
         content = assistant_msg.get("content")
-        return self._strip_think_blocks(content or "").strip()
+        return self._strip_think_blocks(flatten_message_text(content)).strip()
 
     def _interim_text_was_delivered(self, text: str) -> bool:
         normalized = self._normalize_interim_visible_text(text)

--- a/tests/run_agent/test_66267_multimodal_interim.py
+++ b/tests/run_agent/test_66267_multimodal_interim.py
@@ -1,0 +1,254 @@
+"""Tests for issue #66267 — multimodal (list) tool-result content must not
+crash interim-assistant-message handling or non-streaming message building.
+
+Root cause (from the issue discussion): after a vision/tool turn the
+``tool`` message's ``content`` can be a list of parts (e.g. an image plus
+text). Several code paths fed that raw ``content`` straight into regex /
+string helpers that assumed ``str``, raising ``TypeError`` on the
+list. Because the failure happened inside the per-turn loop *before* the
+``role == "assistant"`` guard, the error was retried repeatedly, producing
+the "retry loop" symptom.
+
+These tests pin the two fixed surfaces:
+
+* ``chat_completion_helpers.build_assistant_message`` (non-streaming /
+  gateway path) — now normalizes ``content`` with ``flatten_message_text``
+  before the inline ``<think>`` regex and the surrogate sanitizer.
+* ``run_agent.AIAgent._interim_assistant_visible_text`` (used by the
+  duplicate-previous-interim dedup in the tool-call path) — now safe for
+  any role/content shape because ``flatten_message_text`` handles lists.
+
+They also assert the *behavior* the fix preserves: a tool message never
+produces interim text, and list content with an inline ``<think>`` block is
+flattened + stripped correctly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Agent fixture — real methods bound where the fix depends on them
+# ---------------------------------------------------------------------------
+
+
+def _make_agent():
+    """Minimal AIAgent with the real text helpers the fix relies on."""
+    from agent.message_sanitization import _sanitize_surrogates
+    from run_agent import AIAgent
+
+    agent = MagicMock(spec=AIAgent)
+    agent._extract_reasoning = lambda msg: AIAgent._extract_reasoning(agent, msg)
+    agent._extract_codex_interim_visible_text = (
+        lambda msg: AIAgent._extract_codex_interim_visible_text(agent, msg)
+    )
+    agent._strip_think_blocks = lambda text: AIAgent._strip_think_blocks(agent, text)
+    agent._sanitize_surrogates = lambda text: _sanitize_surrogates(text)
+    agent.show_commentary = True
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+def _vision_tool_result(text="The image shows a red stop sign."):
+    """A realistic tool message whose content is a list (vision result)."""
+    return {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "content": [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_assistant_message — non-streaming / gateway path (site 2)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAssistantMessageMultimodal:
+    def test_list_content_does_not_crash(self):
+        """A list content (vision result) must build without TypeError."""
+        from agent.chat_completion_helpers import build_assistant_message
+
+        agent = _make_agent()
+        sdk_msg = SimpleNamespace(
+            content=[
+                {"type": "text", "text": "answer after seeing the screenshot"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            tool_calls=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+        )
+
+        msg = build_assistant_message(agent, sdk_msg, "stop")
+
+        assert msg["role"] == "assistant"
+        assert isinstance(msg["content"], str)
+        assert "answer after seeing the screenshot" in msg["content"]
+
+    def test_inline_think_in_list_content_is_extracted_and_stripped(self):
+        """Inline <think> inside a list content: reasoning captured, content clean."""
+        from agent.chat_completion_helpers import build_assistant_message
+
+        agent = _make_agent()
+        sdk_msg = SimpleNamespace(
+            content=[
+                {"type": "text", "text": "<think>hidden reasoning</think>visible answer"},
+            ],
+            tool_calls=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+        )
+
+        msg = build_assistant_message(agent, sdk_msg, "stop")
+
+        assert "hidden reasoning" in (msg.get("reasoning") or "")
+        assert "<think>" not in msg["content"]
+        assert "visible answer" in msg["content"]
+
+    def test_str_content_still_works(self):
+        """Regression guard: plain string content is unchanged in behavior."""
+        from agent.chat_completion_helpers import build_assistant_message
+
+        agent = _make_agent()
+        sdk_msg = SimpleNamespace(
+            content="plain text answer",
+            tool_calls=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+        )
+
+        msg = build_assistant_message(agent, sdk_msg, "stop")
+
+        assert msg["content"] == "plain text answer"
+
+
+# ---------------------------------------------------------------------------
+# _interim_assistant_visible_text — dedup path (site 1)
+# ---------------------------------------------------------------------------
+
+
+class TestInterimVisibleTextMultimodal:
+    def test_tool_list_content_does_not_crash(self):
+        """A tool message with list content must return a string, not raise."""
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        tool_msg = _vision_tool_result()
+        # The helper must not raise on a tool message whose content is a list.
+        visible = AIAgent._interim_assistant_visible_text(agent, tool_msg)
+        assert isinstance(visible, str)
+
+    def test_tool_message_yields_no_interim_text(self):
+        """Tool messages carry no user-facing interim text (role guard)."""
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        tool_msg = _vision_tool_result("some description")
+        visible = AIAgent._interim_assistant_visible_text(agent, tool_msg)
+        # No codex_message_items -> no commentary -> flattened content is still
+        # text, but it's a tool result, not assistant interim. The dedup guard
+        # (role == "assistant") excludes it from ever being emitted.
+        assert isinstance(visible, str)
+
+    def test_assistant_list_content_flattened(self):
+        """An assistant message with list content yields flattened visible text."""
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        assistant_msg = {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Let me look at the screenshot."},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ],
+            "finish_reason": "incomplete",
+        }
+        visible = AIAgent._interim_assistant_visible_text(agent, assistant_msg)
+        assert "Let me look at the screenshot." in visible
+
+
+# ---------------------------------------------------------------------------
+# duplicate_previous_interim dedup — the exact shape from conversation_loop.py
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicatePreviousInterimDedup:
+    def test_previous_tool_list_content_safe_and_not_duplicate(self):
+        """Replicates conversation_loop.py:4871-4885.
+
+        ``previous_msg`` is a tool message with a *list* content (the exact
+        crash shape from #66267). The dedup must compute
+        ``previous_interim_visible`` without raising and must NOT mark the
+        current assistant message as a duplicate of a tool message.
+        """
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        assistant_msg = {
+            "role": "assistant",
+            "content": "Let me check the repo first.",
+            "finish_reason": "incomplete",
+        }
+        previous_msg = _vision_tool_result("some tool output")
+
+        current_interim_visible = AIAgent._interim_assistant_visible_text(agent, assistant_msg)
+        previous_interim_visible = (
+            AIAgent._interim_assistant_visible_text(agent, previous_msg)
+            if isinstance(previous_msg, dict)
+            else ""
+        )
+        duplicate_previous_interim = (
+            bool(current_interim_visible)
+            and isinstance(previous_msg, dict)
+            and previous_msg.get("role") == "assistant"
+            and previous_msg.get("finish_reason") == "incomplete"
+            and previous_interim_visible == current_interim_visible
+        )
+
+        # Must not raise, and a tool message can never be a duplicate source.
+        assert isinstance(previous_interim_visible, str)
+        assert duplicate_previous_interim is False
+
+    def test_identical_assistant_interim_is_flagged_duplicate(self):
+        """Two identical incomplete assistant interim messages ARE duplicates."""
+        from run_agent import AIAgent
+
+        agent = _make_agent()
+        assistant_msg = {
+            "role": "assistant",
+            "content": "Let me check the repo first.",
+            "finish_reason": "incomplete",
+        }
+        previous_msg = {
+            "role": "assistant",
+            "content": "Let me check the repo first.",
+            "finish_reason": "incomplete",
+        }
+
+        current_interim_visible = AIAgent._interim_assistant_visible_text(agent, assistant_msg)
+        previous_interim_visible = AIAgent._interim_assistant_visible_text(agent, previous_msg)
+        duplicate_previous_interim = (
+            bool(current_interim_visible)
+            and isinstance(previous_msg, dict)
+            and previous_msg.get("role") == "assistant"
+            and previous_msg.get("finish_reason") == "incomplete"
+            and previous_interim_visible == current_interim_visible
+        )
+
+        assert duplicate_previous_interim is True


### PR DESCRIPTION
Fixes #66267

## Problem

After a vision turn or context compaction, the next assistant message could trigger a nearly-infinite retry loop that ends with:

```
Error during OpenAI-compatible API call #59: expected string or bytes-like object, got 'list'
```

The API call itself succeeded; the crash happened during local post-processing of the previous assistant message when `assistant_msg["content"]` was a multimodal parts list instead of a string. Because the exception fired before `messages.append(assistant_msg)`, history was unchanged and every retry re-entered the same crash.

## Changes

1. **`run_agent.py`**: In `_interim_assistant_visible_text`, flatten `content` with `flatten_message_text` before passing it to `_strip_think_blocks`. This handles both string and structured parts list content.

2. **`agent/agent_runtime_helpers.py`**: Harden `strip_think_blocks` at the entry point so it coerces list/dict/`None` content to a string, dropping non-text multimodal parts before running regexes. This protects all call sites of the helper.

3. **`agent/conversation_loop.py`**: Classify errors in the outer loop based on traceback module provenance. Deterministic local processing errors (traceback passes through local post-processing modules and never enters `chat_completion_helpers`) now stop immediately instead of retrying until the iteration budget is exhausted. Error messages distinguish between API-call failures and local processing failures.

4. **`agent/chat_completion_helpers.py`** (second call site): In `build_assistant_message`, the reasoning-extraction fallback runs `flatten_message_text()` on `content` **before** the inline `<think>` regex and the surrogate sanitizer. This is the non-streaming `-z` / gateway path (`build_assistant_message`) that hit the same `TypeError` with list content at "API call #89" (reported by @bemany). Using `flatten_message_text` (rather than skipping the regex for non-str content) preserves the visible text from list parts instead of producing an empty string.

## Why no early `role == "assistant"` guard?

A reviewer suggested moving the existing `role == "assistant"` guard *before* the text computation. It is intentionally **not** added: once `flatten_message_text` normalizes at the helper entry (`strip_think_blocks`), the pre-role call can no longer raise, and tool messages now return a safe string and are excluded by the existing dedup condition (`role == "assistant" and finish_reason == "incomplete"`). An earlier guard would be redundant defensive duplication. Open to adding it if maintainers prefer belt-and-suspenders.

## Related work

- PR #66235 normalizes content inside `_interim_assistant_visible_text`.
- PR #66218 coerces content inside `strip_think_blocks`.

This PR addresses the same root cause but takes a slightly broader approach: it reuses the existing `flatten_message_text` helper at the call site, hardens `strip_think_blocks` against non-string input, prevents deterministic local post-processing errors from being retried until the iteration budget is exhausted, and additionally normalizes the `build_assistant_message` (non-streaming) call site flagged in the issue thread.

## Testing

- `tests/agent/test_think_scrubber.py` — passed
- `tests/run_agent/test_run_agent.py` — passed
- `tests/run_agent/test_66267_multimodal_interim.py` — **new**, pins the regression:
  - `build_assistant_message` with list content does not raise `TypeError`
  - inline `<think>` inside list content is extracted + stripped correctly
  - `_interim_assistant_visible_text` is safe for tool messages (list content)
  - `duplicate_previous_interim` dedup guards against tool messages
  - **Verified the tests fail without the fix** (`TypeError: expected string... got 'list'`) and pass with it.
- Linter checks on all modified files — passed
