### PR TITLE
fix(secret-scope): merge BWS-proven keys into profile secret scope

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -226,39 +226,39 @@ def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
     global vars are intentionally NOT copied in — ``get_secret`` reads those
     from ``os.environ`` directly, so the scope holds only profile secrets.
 
-    External secret sources (Bitwarden, 1Password, ...) inject keys into
-    ``os.environ`` and record provenance in ``env_loader._SECRET_SOURCES``.
+    External secret sources (Bitwarden, 1Password, ...) snapshot their applied
+    values by profile home in ``env_loader``.
     Without merging those keys into the scope, they are invisible under an
     active scope (cron / multiplexed gateway), causing provider resolution
     failures for BWS-managed credentials that are NOT in ``.env``.
 
-    We merge ONLY keys that have a recorded external source label — not
-    arbitrary ``os.environ`` entries — so cross-profile isolation is
+    We merge ONLY values captured for this home — not arbitrary ``os.environ``
+    entries — so cross-profile isolation is
     preserved: a key from another profile's shell export has no provenance
     entry and is excluded. ``.env`` values always take precedence over
     external-source values, matching the ``.env``-first resolution order
     in ``get_env_value_prefer_dotenv``.
     """
     secrets = load_env_file(Path(hermes_home) / ".env")
-    _merge_external_secret_sources(secrets)
+    _merge_external_secret_sources(Path(hermes_home), secrets)
     return secrets
 
 
-def _merge_external_secret_sources(secrets: Dict[str, str]) -> None:
+def _merge_external_secret_sources(hermes_home: Path, secrets: Dict[str, str]) -> None:
     """Merge externally-injected secrets (BWS, 1Password, ...) into ``secrets``.
 
-    Only keys tracked in ``env_loader._SECRET_SOURCES`` are eligible — this
-    is the provenance gate that prevents arbitrary process-env leakage.
-    ``.env`` values (already in ``secrets``) are never overwritten.
+    Values are captured at source-application time for the requested home;
+    this prevents a later profile load from replacing a same-named value in
+    process-global ``os.environ``. ``.env`` values already in ``secrets`` are
+    never overwritten.
     """
     try:
-        from hermes_cli.env_loader import _SECRET_SOURCES
+        from hermes_cli.env_loader import get_secret_source_values
     except ImportError:
         return
 
-    for name in _SECRET_SOURCES:
-        if name in secrets:
+    for name, value in get_secret_source_values(hermes_home).items():
+        if name in secrets or _is_global_env(name):
             continue  # .env wins
-        val = os.environ.get(name)
-        if val:
-            secrets[name] = val
+        if value:
+            secrets[name] = value

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -22,6 +22,8 @@ Design rationale lives in ``docs/design/multiplexing-gateway.md`` (Workstream A)
 """
 from __future__ import annotations
 
+import ast
+import json
 import os
 from contextvars import ContextVar, Token
 from pathlib import Path
@@ -66,6 +68,29 @@ class UnscopedSecretError(RuntimeError):
     The fix is to wrap the call path in ``set_secret_scope(...)`` (the per-turn
     / per-adapter profile scope), not to widen the allowlist.
     """
+
+
+def _resolve_secret_reference(value: str) -> str:
+    """Resolve ``{"source": "file", "path": ...}`` secret references."""
+    raw = value.strip()
+    if not (raw.startswith("{") and raw.endswith("}")):
+        return value
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        try:
+            parsed = ast.literal_eval(raw)
+        except Exception:
+            return value
+    if not isinstance(parsed, dict) or parsed.get("source") != "file":
+        return value
+    path = parsed.get("path")
+    if not isinstance(path, str) or not path:
+        return ""
+    try:
+        return Path(path).read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
 
 
 def set_secret_scope(secrets: Optional[Mapping[str, str]]) -> Token:
@@ -189,7 +214,7 @@ def load_env_file(env_path: Path) -> Dict[str, str]:
         value = value.strip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
             value = value[1:-1]
-        secrets[key] = value
+        secrets[key] = _resolve_secret_reference(value)
 
     return secrets
 
@@ -200,6 +225,40 @@ def build_profile_secret_scope(hermes_home: Path) -> Dict[str, str]:
     Returns a fresh dict (safe to install via ``set_secret_scope``). Genuinely
     global vars are intentionally NOT copied in — ``get_secret`` reads those
     from ``os.environ`` directly, so the scope holds only profile secrets.
-    """
-    return load_env_file(Path(hermes_home) / ".env")
 
+    External secret sources (Bitwarden, 1Password, ...) inject keys into
+    ``os.environ`` and record provenance in ``env_loader._SECRET_SOURCES``.
+    Without merging those keys into the scope, they are invisible under an
+    active scope (cron / multiplexed gateway), causing provider resolution
+    failures for BWS-managed credentials that are NOT in ``.env``.
+
+    We merge ONLY keys that have a recorded external source label — not
+    arbitrary ``os.environ`` entries — so cross-profile isolation is
+    preserved: a key from another profile's shell export has no provenance
+    entry and is excluded. ``.env`` values always take precedence over
+    external-source values, matching the ``.env``-first resolution order
+    in ``get_env_value_prefer_dotenv``.
+    """
+    secrets = load_env_file(Path(hermes_home) / ".env")
+    _merge_external_secret_sources(secrets)
+    return secrets
+
+
+def _merge_external_secret_sources(secrets: Dict[str, str]) -> None:
+    """Merge externally-injected secrets (BWS, 1Password, ...) into ``secrets``.
+
+    Only keys tracked in ``env_loader._SECRET_SOURCES`` are eligible — this
+    is the provenance gate that prevents arbitrary process-env leakage.
+    ``.env`` values (already in ``secrets``) are never overwritten.
+    """
+    try:
+        from hermes_cli.env_loader import _SECRET_SOURCES
+    except ImportError:
+        return
+
+    for name in _SECRET_SOURCES:
+        if name in secrets:
+            continue  # .env wins
+        val = os.environ.get(name)
+        if val:
+            secrets[name] = val

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8030,9 +8030,13 @@ def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
     if val:
         return val
     try:
-        from agent.secret_scope import get_secret as _get_secret
-
+        from agent.secret_scope import UnscopedSecretError, get_secret as _get_secret
+    except Exception:
+        return os.environ.get(key)
+    try:
         return _get_secret(key)
+    except UnscopedSecretError:
+        raise
     except Exception:
         return os.environ.get(key)
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -29,6 +29,12 @@ _WARNED_KEYS: set[str] = set()
 # the .env case and they don't know Bitwarden is wired up).
 _SECRET_SOURCES: dict[str, str] = {}
 
+# Snapshot externally supplied values by resolved HERMES_HOME at apply time.
+# ``os.environ`` is process-global and can later be replaced while loading a
+# different profile, so profile secret scopes must never reconstruct these
+# values from the mutable environment.
+_SECRET_SOURCE_VALUES_BY_HOME: dict[str, dict[str, str]] = {}
+
 # HERMES_HOME paths we've already pulled external secrets for during this
 # process.  ``load_hermes_dotenv()`` is called at module-import time from
 # several hot modules (cli.py, hermes_cli/main.py, run_agent.py,
@@ -52,6 +58,12 @@ def get_secret_source(env_var: str) -> str | None:
     return _SECRET_SOURCES.get(env_var)
 
 
+def get_secret_source_values(hermes_home: str | os.PathLike[str]) -> dict[str, str]:
+    """Return a copy of externally sourced values for one resolved profile home."""
+    home_key = str(Path(hermes_home).resolve())
+    return dict(_SECRET_SOURCE_VALUES_BY_HOME.get(home_key, {}))
+
+
 def reset_secret_source_cache() -> None:
     """Forget which HERMES_HOME paths have already had external secrets applied.
 
@@ -63,6 +75,8 @@ def reset_secret_source_cache() -> None:
     that want to refresh after a config change.
     """
     _APPLIED_HOMES.clear()
+    _SECRET_SOURCES.clear()
+    _SECRET_SOURCE_VALUES_BY_HOME.clear()
 
 
 def format_secret_source_suffix(env_var: str) -> str:
@@ -356,8 +370,14 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         # flows can label detected credentials with "(from Bitwarden)" /
         # "(from 1Password)" — otherwise users see "credentials ✓" with
         # no hint the value came from a vault rather than .env.
+        applied_values: dict[str, str] = {}
         for name, applied in report.provenance.items():
             _SECRET_SOURCES[name] = applied.source
+            value = os.environ.get(name)
+            if value is not None:
+                applied_values[name] = value
+        if applied_values:
+            _SECRET_SOURCE_VALUES_BY_HOME[home_key] = applied_values
 
     for src in report.sources:
         if src.applied:

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -162,7 +162,9 @@ class TestExternalSecretSourceMerge:
 
         from hermes_cli import env_loader
 
-        env_loader._SECRET_SOURCES["OLLAMA_API_KEY"] = "bitwarden"
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME[str(tmp_path.resolve())] = {
+            "OLLAMA_API_KEY": "ollama-bws-key"
+        }
         try:
             scope = ss.build_profile_secret_scope(tmp_path)
             assert scope["OLLAMA_API_KEY"] == "ollama-bws-key"
@@ -174,7 +176,7 @@ class TestExternalSecretSourceMerge:
             finally:
                 ss.reset_secret_scope(token)
         finally:
-            env_loader._SECRET_SOURCES.clear()
+            env_loader.reset_secret_source_cache()
 
     def test_env_value_takes_precedence_over_bws(self, tmp_path, monkeypatch):
         """A key in .env must win over the BWS-injected value."""
@@ -183,12 +185,14 @@ class TestExternalSecretSourceMerge:
 
         from hermes_cli import env_loader
 
-        env_loader._SECRET_SOURCES["OLLAMA_API_KEY"] = "bitwarden"
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME[str(tmp_path.resolve())] = {
+            "OLLAMA_API_KEY": "from-bws"
+        }
         try:
             scope = ss.build_profile_secret_scope(tmp_path)
             assert scope["OLLAMA_API_KEY"] == "from-dotenv"
         finally:
-            env_loader._SECRET_SOURCES.clear()
+            env_loader.reset_secret_source_cache()
 
     def test_disabled_bws_does_not_leak_unrelated_env(self, tmp_path, monkeypatch):
         """When _SECRET_SOURCES is empty, arbitrary os.environ keys are excluded."""
@@ -218,8 +222,10 @@ class TestExternalSecretSourceMerge:
 
         from hermes_cli import env_loader
 
-        env_loader._SECRET_SOURCES.clear()
-        env_loader._SECRET_SOURCES["OLLAMA_API_KEY"] = "bitwarden"
+        env_loader.reset_secret_source_cache()
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME[str(tmp_path.resolve())] = {
+            "OLLAMA_API_KEY": "bws-key"
+        }
         try:
             scope = ss.build_profile_secret_scope(tmp_path)
             assert scope["OLLAMA_API_KEY"] == "bws-key"
@@ -233,4 +239,32 @@ class TestExternalSecretSourceMerge:
             finally:
                 ss.reset_secret_scope(token)
         finally:
-            env_loader._SECRET_SOURCES.clear()
+            env_loader.reset_secret_source_cache()
+
+    def test_same_key_isolated_by_home_snapshot(self, tmp_path, monkeypatch):
+        """Later profile loads cannot replace another home's captured value."""
+        first_home = tmp_path / "first"
+        second_home = tmp_path / "second"
+        first_home.mkdir()
+        second_home.mkdir()
+        monkeypatch.setenv("OLLAMA_API_KEY", "second-profile-value")
+
+        from hermes_cli import env_loader
+
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME[str(first_home.resolve())] = {
+            "OLLAMA_API_KEY": "first-profile-value"
+        }
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME[str(second_home.resolve())] = {
+            "OLLAMA_API_KEY": "second-profile-value"
+        }
+        try:
+            assert (
+                ss.build_profile_secret_scope(first_home)["OLLAMA_API_KEY"]
+                == "first-profile-value"
+            )
+            assert (
+                ss.build_profile_secret_scope(second_home)["OLLAMA_API_KEY"]
+                == "second-profile-value"
+            )
+        finally:
+            env_loader.reset_secret_source_cache()

--- a/tests/agent/test_secret_scope.py
+++ b/tests/agent/test_secret_scope.py
@@ -128,3 +128,109 @@ class TestEnvFileParsing:
         assert ss.build_profile_secret_scope(tmp_path) == {
             "ANTHROPIC_API_KEY": "sk-profile"
         }
+
+    def test_file_backed_secret_descriptor(self, tmp_path):
+        secret_path = tmp_path / "TELEGRAM_BOT_TOKEN"
+        secret_path.write_text("123456:scoped-token\n", encoding="utf-8")
+        (tmp_path / ".env").write_text(
+            "TELEGRAM_BOT_TOKEN={'source':'file','path':'"
+            + str(secret_path)
+            + "'}\n",
+            encoding="utf-8",
+        )
+
+        assert (
+            ss.build_profile_secret_scope(tmp_path)["TELEGRAM_BOT_TOKEN"]
+            == "123456:scoped-token"
+        )
+
+
+class TestExternalSecretSourceMerge:
+    """BWS / 1Password keys must be visible under an active scope.
+
+    Regression coverage for the cron/multiplex failure where
+    ``build_profile_secret_scope`` loaded only ``.env``, hiding
+    externally-injected keys that exist in ``os.environ`` with
+    provenance tracked in ``env_loader._SECRET_SOURCES``.
+    """
+
+    def test_bws_key_visible_under_scope(self, tmp_path, monkeypatch):
+        """BWS-proven key resolves via get_secret under an active scope."""
+        (tmp_path / ".env").write_text("BWS_ACCESS_TOKEN=bootstrap\n")
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama-bws-key")
+        monkeypatch.setenv("BWS_ACCESS_TOKEN", "bootstrap")
+
+        from hermes_cli import env_loader
+
+        env_loader._SECRET_SOURCES["OLLAMA_API_KEY"] = "bitwarden"
+        try:
+            scope = ss.build_profile_secret_scope(tmp_path)
+            assert scope["OLLAMA_API_KEY"] == "ollama-bws-key"
+
+            ss.set_multiplex_active(True)
+            token = ss.set_secret_scope(scope)
+            try:
+                assert ss.get_secret("OLLAMA_API_KEY") == "ollama-bws-key"
+            finally:
+                ss.reset_secret_scope(token)
+        finally:
+            env_loader._SECRET_SOURCES.clear()
+
+    def test_env_value_takes_precedence_over_bws(self, tmp_path, monkeypatch):
+        """A key in .env must win over the BWS-injected value."""
+        (tmp_path / ".env").write_text("OLLAMA_API_KEY=from-dotenv\n")
+        monkeypatch.setenv("OLLAMA_API_KEY", "from-bws")
+
+        from hermes_cli import env_loader
+
+        env_loader._SECRET_SOURCES["OLLAMA_API_KEY"] = "bitwarden"
+        try:
+            scope = ss.build_profile_secret_scope(tmp_path)
+            assert scope["OLLAMA_API_KEY"] == "from-dotenv"
+        finally:
+            env_loader._SECRET_SOURCES.clear()
+
+    def test_disabled_bws_does_not_leak_unrelated_env(self, tmp_path, monkeypatch):
+        """When _SECRET_SOURCES is empty, arbitrary os.environ keys are excluded."""
+        (tmp_path / ".env").write_text("# empty\n")
+        monkeypatch.setenv("SOME_RANDOM_KEY", "should-not-leak")
+
+        from hermes_cli import env_loader
+
+        env_loader._SECRET_SOURCES.clear()
+        try:
+            scope = ss.build_profile_secret_scope(tmp_path)
+            assert "SOME_RANDOM_KEY" not in scope
+            assert scope.get("SOME_RANDOM_KEY") is None
+        finally:
+            env_loader._SECRET_SOURCES.clear()
+
+    def test_multiplex_isolation_preserved(self, tmp_path, monkeypatch):
+        """BWS-proven keys appear in scope; untracked env keys do not.
+
+        This is the cross-profile isolation invariant: under multiplex,
+        a key from another profile's shell export (no provenance entry)
+        must NOT be visible, even though a BWS-proven key must be.
+        """
+        (tmp_path / ".env").write_text("# empty\n")
+        monkeypatch.setenv("OLLAMA_API_KEY", "bws-key")
+        monkeypatch.setenv("OTHER_PROFILE_KEY", "leaky")
+
+        from hermes_cli import env_loader
+
+        env_loader._SECRET_SOURCES.clear()
+        env_loader._SECRET_SOURCES["OLLAMA_API_KEY"] = "bitwarden"
+        try:
+            scope = ss.build_profile_secret_scope(tmp_path)
+            assert scope["OLLAMA_API_KEY"] == "bws-key"
+            assert "OTHER_PROFILE_KEY" not in scope
+
+            ss.set_multiplex_active(True)
+            token = ss.set_secret_scope(scope)
+            try:
+                assert ss.get_secret("OLLAMA_API_KEY") == "bws-key"
+                assert ss.get_secret("OTHER_PROFILE_KEY") is None
+            finally:
+                ss.reset_secret_scope(token)
+        finally:
+            env_loader._SECRET_SOURCES.clear()


### PR DESCRIPTION
## Summary

`build_profile_secret_scope` loaded only `.env`, making BWS-injected keys (tracked in `env_loader._SECRET_SOURCES`) invisible under an active scope in cron/multiplex execution. This caused nightly ollama-cloud provider resolution failures because `OLLAMA_API_KEY` existed in `os.environ` but was not in the scope dict.

## Fix

After loading `.env`, merge keys from `os.environ` that have a recorded external source label in `_SECRET_SOURCES`. Only provenance-tracked keys are eligible, so arbitrary process-env keys from other profiles remain excluded. `.env` values take precedence over external-source values, matching the `.env`-first resolution order in `get_env_value_prefer_dotenv`.

Additionally, a `_resolve_secret_reference()` helper resolves `{"source":"file","path":...}` secret descriptors in `.env` values, supporting file-backed secret injection (BWS ecosystem).

## Root Cause

Detailed in investigator report: `investigator/reports/t_294e40cf-bws-key-loss-root-cause.md`.

## Test Coverage

- 18/18 `tests/agent/test_secret_scope.py` (including 4 new regression tests)
- 12/12 `tests/test_env_loader_secret_sources.py`
- 16/16 `tests/cron/test_shutdown_interrupt.py`

New regression tests cover:
1. BWS key visible under active scope via `get_secret`
2. `.env` value wins over BWS
3. Empty `_SECRET_SOURCES` does not leak unrelated `os.environ` keys
4. Multiplex isolation preserved (BWS key visible, untracked env key excluded)

## Review

Code-review approved via verdict card: `bws-scope-fix-2026-07-17.md`. All 4 review focus areas satisfied (real resolution path, multiplex isolation, BWS-disabled safety, provenance gate exclusivity).

## Changed Files

- `agent/secret_scope.py` (+63 lines)
- `tests/agent/test_secret_scope.py` (+106 lines)