### PR TITLE
feat(matrix): enable progressive edit-based streaming

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17331,8 +17331,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
                     _buffer_only = False
                     if source.platform == Platform.MATRIX:
-                        _effective_cursor = ""
-                        _buffer_only = True
+                        _effective_cursor = ""  # ▉ tofu on most Matrix clients
                     # Fresh-final applies to Telegram only — other
                     # platforms either edit in place cheaply (Discord,
                     # Slack) or don't have the timestamp-on-edit

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18753,8 +18753,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # streaming text on Matrix, but suppress the cursor.
                         _buffer_only = False
                         if source.platform == Platform.MATRIX:
-                            _effective_cursor = ""
-                            _buffer_only = True
+                            _effective_cursor = ""  # ▉ tofu on most Matrix clients
                         # Fresh-final applies to Telegram only — other
                         # platforms either edit in place cheaply or don't
                         # have the edit-timestamp-stays-stale problem.

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -5309,3 +5309,73 @@ class TestMatrixDispatchSyncIsolation:
 
         assert ran["ok"] is True  # the sibling handler still ran
         assert "event handler failed" in caplog.text  # failure surfaced, not swallowed
+
+
+# ---------------------------------------------------------------------------
+# Progressive streaming (Matrix should use edit-based streaming, not buffer-only)
+# ---------------------------------------------------------------------------
+
+class TestMatrixProgressiveStreaming:
+    """Matrix streaming should use progressive edits, not buffer-only."""
+
+    @pytest.mark.asyncio
+    async def test_progressive_streaming_not_buffer_only(self):
+        """Regression: buffer_only=True was hardcoded for Matrix in gateway/run.py.
+
+        With buffer_only=False, the consumer sends the initial message then
+        progressively calls edit_message() as new tokens arrive.
+        """
+        from types import SimpleNamespace
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = MagicMock()
+        send_result = SimpleNamespace(success=True, message_id="m1")
+        edit_result = SimpleNamespace(success=True, message_id="m1")
+        adapter.send = AsyncMock(return_value=send_result)
+        adapter.edit_message = AsyncMock(return_value=edit_result)
+        adapter.SUPPORTS_MESSAGE_EDITING = True
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        cfg = StreamConsumerConfig(
+            edit_interval=0.01,
+            buffer_threshold=5,
+            cursor="",           # Matrix: no cursor (tofu)
+            buffer_only=False,   # Matrix: progressive edits enabled
+        )
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="!test:matrix.local",
+            config=cfg,
+        )
+
+        # Feed the first batch of tokens — enough to cross buffer_threshold
+        # so the consumer sends the initial message.
+        consumer.on_delta("Ciao")
+        consumer.on_delta(" mondo")
+
+        # Start the consumer in background so we can feed more tokens
+        # while it runs its edit loop.
+        run_task = asyncio.create_task(consumer.run())
+
+        # Wait for the initial send to fire
+        await asyncio.sleep(0.15)
+
+        # Feed more tokens — this should trigger progressive edits
+        consumer.on_delta("! Come")
+        consumer.on_delta(" stai?")
+
+        # Wait for edits to fire
+        await asyncio.sleep(0.15)
+
+        # Finish the stream
+        consumer.finish()
+
+        # Wait for the consumer to complete
+        await asyncio.wait_for(run_task, timeout=2.0)
+
+        # Must have sent initial message then edited
+        assert adapter.send.called, "initial send() should have fired"
+        assert adapter.edit_message.called, (
+            "edit_message() must be called for progressive streaming; "
+            "buffer_only=True would suppress this"
+        )


### PR DESCRIPTION
## Summary

Enable progressive (edit-based) streaming on Matrix by removing the hardcoded `buffer_only=True` override in `gateway/run.py`. Matrix already has a working `edit_message()` via `m.replace` — the override was unnecessarily disabling progressive edits.

## Changes

- **gateway/run.py** (2 occurrences): Remove `_buffer_only = True` for Matrix in both primary and multiplex streaming paths. Keep `_effective_cursor = ""` to avoid tofu (▉) rendering issues on Matrix clients.
- **tests/gateway/test_matrix.py**: Add regression test verifying Matrix uses progressive edits (not buffer-only).

## Why

Matrix streaming was forced into buffer-only mode, sending the entire response at once after generation completed. This caused long silences during tool calls. All other platforms with `edit_message()` support (Discord, Slack, Slack, Mattermost) already use progressive edits.

## Testing

- ✅ All existing tests pass
- ✅ New regression test passes
- ✅ Manual test: progressive edits appear on Element Android/Desktop
- ✅ No 429 rate limit errors (Synapse rc_message configured: 5/sec, burst 20)
- ✅ No tofu cursor artifacts
- ✅ edit_interval: 1.2s (well within Synapse rate limits)

## Notes

- The `▉` cursor character renders as tofu (white box) on most Matrix clients, so it remains suppressed (`_effective_cursor = ""`).
- For very long responses (>4000 chars), the stream consumer's overflow splitting handles the transition from edit to new message. This path has a known edge case with the final delivery that will be addressed in a follow-up.