### PR TITLE
fix(desktop): skip host electronDist for cross-target builds

### DIFF
--- a/apps/desktop/scripts/run-electron-builder-lib.mjs
+++ b/apps/desktop/scripts/run-electron-builder-lib.mjs
@@ -1,0 +1,43 @@
+const PLATFORM_FLAGS = new Map([
+  ['--linux', 'linux'],
+  ['--mac', 'darwin'],
+  ['--win', 'win32'],
+])
+
+export function requestedTargetPlatforms(argv = []) {
+  const targets = new Set()
+  for (const arg of argv) {
+    const platform = PLATFORM_FLAGS.get(arg)
+    if (platform) {
+      targets.add(platform)
+    }
+  }
+  return targets
+}
+
+export function shouldUseLocalElectronDist({ argv = [], hostPlatform = process.platform } = {}) {
+  const targets = requestedTargetPlatforms(argv)
+  if (targets.size === 0) {
+    return true
+  }
+  for (const target of targets) {
+    if (target !== hostPlatform) {
+      return false
+    }
+  }
+  return true
+}
+
+export function computeElectronBuilderArgs({
+  argv = [],
+  dist = null,
+  hasBinary = false,
+  hostPlatform = process.platform,
+} = {}) {
+  const args = []
+  if (dist && hasBinary && shouldUseLocalElectronDist({ argv, hostPlatform })) {
+    args.push(`-c.electronDist=${dist}`)
+  }
+  args.push(...argv)
+  return args
+}

--- a/apps/desktop/scripts/run-electron-builder-lib.test.mjs
+++ b/apps/desktop/scripts/run-electron-builder-lib.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+
+import { computeElectronBuilderArgs } from '../scripts/run-electron-builder-lib.mjs'
+
+test('computeElectronBuilderArgs keeps local electronDist for host-target builds', () => {
+  const args = computeElectronBuilderArgs({
+    argv: ['--linux', 'AppImage'],
+    dist: '/tmp/electron-dist',
+    hasBinary: true,
+    hostPlatform: 'linux'
+  })
+
+  assert.deepEqual(args, ['-c.electronDist=/tmp/electron-dist', '--linux', 'AppImage'])
+})
+
+test('computeElectronBuilderArgs drops local electronDist for linux-to-windows cross-builds', () => {
+  const args = computeElectronBuilderArgs({
+    argv: ['--win', 'nsis', '--dir'],
+    dist: '/tmp/electron-dist',
+    hasBinary: true,
+    hostPlatform: 'linux'
+  })
+
+  assert.deepEqual(args, ['--win', 'nsis', '--dir'])
+})
+
+test('computeElectronBuilderArgs keeps explicit args even when no local electron binary exists', () => {
+  const args = computeElectronBuilderArgs({
+    argv: ['--win', 'nsis'],
+    dist: '/tmp/electron-dist',
+    hasBinary: false,
+    hostPlatform: 'linux'
+  })
+
+  assert.deepEqual(args, ['--win', 'nsis'])
+})

--- a/apps/desktop/scripts/run-electron-builder.mjs
+++ b/apps/desktop/scripts/run-electron-builder.mjs
@@ -8,6 +8,9 @@ import fs from "node:fs"
 import path from "node:path"
 import { spawnSync } from "node:child_process"
 import { createRequire } from "node:module"
+import { pathToFileURL } from "node:url"
+
+import { computeElectronBuilderArgs, shouldUseLocalElectronDist } from './run-electron-builder-lib.mjs'
 
 const require = createRequire(import.meta.url)
 
@@ -37,22 +40,37 @@ function electronBuilderCli() {
 }
 
 const dist = electronDistDir()
-const args = []
-if (dist && fs.existsSync(distBinary(dist))) {
-  args.push(`-c.electronDist=${dist}`)
-} else {
+const argv = process.argv.slice(2)
+const hasBinary = dist ? fs.existsSync(distBinary(dist)) : false
+const args = computeElectronBuilderArgs({
+  argv,
+  dist,
+  hasBinary,
+  hostPlatform: process.platform,
+})
+if (dist && !hasBinary) {
   console.warn(
     "[run-electron-builder] no local electron dist; electron-builder will fetch " +
       "via @electron/get (electronVersion + ELECTRON_MIRROR)."
   )
+} else if (dist && !shouldUseLocalElectronDist({ argv, hostPlatform: process.platform })) {
+  console.warn(
+    "[run-electron-builder] cross-target build requested; skipping host electronDist " +
+      "so electron-builder can fetch the target platform via @electron/get."
+  )
 }
-args.push(...process.argv.slice(2))
 
-const result = spawnSync(process.execPath, [electronBuilderCli(), ...args], {
-  stdio: "inherit",
-})
-if (result.error) {
-  console.error(`[run-electron-builder] spawn failed: ${result.error.message}`)
-  process.exit(1)
+function main() {
+  const result = spawnSync(process.execPath, [electronBuilderCli(), ...args], {
+    stdio: "inherit",
+  })
+  if (result.error) {
+    console.error(`[run-electron-builder] spawn failed: ${result.error.message}`)
+    process.exit(1)
+  }
+  process.exit(result.status == null ? 1 : result.status)
 }
-process.exit(result.status == null ? 1 : result.status)
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
+}


### PR DESCRIPTION
Closes #66344

## Summary

Fix Desktop cross-target packaging so `run-electron-builder.mjs` does not reuse the host platform's local `electronDist` when the requested build target is a different OS.

Current `main` dynamically resolves local `electronDist`, which fixed the workspace-path / missing-dist class of failures (#47266 / #47917 / #48084). But it still assumes the host platform's local dist is valid for every build.

That assumption breaks Linux/WSL -> Windows builds: the script passes a Linux `electronDist` into a Windows target build, and electron-builder later fails when it expects `electron.exe` in `win-unpacked`.

## What changed

- Added `apps/desktop/scripts/run-electron-builder-lib.mjs`
  - parses requested target platform flags from argv
  - decides whether host-local `electronDist` is safe to reuse
- Updated `apps/desktop/scripts/run-electron-builder.mjs`
  - keeps local `electronDist` for host-target builds
  - skips host `electronDist` for cross-target builds so electron-builder / `@electron/get` can fetch the target platform payload
- Added focused regression tests:
  - `apps/desktop/scripts/run-electron-builder-lib.test.mjs`

## Behavior before

Linux / WSL host:

```bash
cd apps/desktop
node scripts/run-electron-builder.mjs --win nsis --dir --publish never
```

Would incorrectly pass a Linux `electronDist` into the Windows build and fail around:

```text
rename '.../release/win-unpacked/electron.exe' -> '.../release/win-unpacked/Hermes.exe'
```

## Behavior after

- host-target build: still reuses local `electronDist`
- cross-target build: skips host `electronDist`, allowing target-specific Electron download

## Validation

Ran focused regression coverage:

```bash
cd apps/desktop
npx vitest run scripts/run-electron-builder-lib.test.mjs scripts/stage-native-deps.test.mjs
```

Result:
- `run-electron-builder-lib.test.mjs`: 3 passed
- `stage-native-deps.test.mjs`: 15 passed
- total: 18 passed

I also verified the practical Linux/WSL -> Windows packaging path after this change:
- valid `win-unpacked/Hermes.exe`
- valid `Hermes-0.17.0-win-x64.exe`

## Related issues

This PR is primarily for the cross-target boundary bug described in the new issue this PR addresses.

Additional related `electronDist` / Windows desktop context:
- #47266
- #47917
- #48084
- #43715

These are related background/context, but this PR is not claiming to solve all of them.
