### PR TITLE
fix(api-server): honor configured fast mode

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1648,7 +1648,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
             return {}
 
-        allowed_keys = ("model", "provider", "api_key", "base_url")
+        string_keys = ("model", "provider", "api_key", "base_url")
+        valid_reasoning = {"none", "minimal", "low", "medium", "high", "xhigh"}
         routes: Dict[str, Dict[str, Any]] = {}
         for alias, cfg in raw.items():
             alias_str = str(alias).strip()
@@ -1657,11 +1658,29 @@ class APIServerAdapter(BasePlatformAdapter):
                     "api_server model_routes: dropping invalid route entry %r", alias_str or alias
                 )
                 continue
-            route = {
+            route: Dict[str, Any] = {
                 key: str(cfg[key]).strip()
-                for key in allowed_keys
+                for key in string_keys
                 if cfg.get(key) is not None and str(cfg[key]).strip()
             }
+            effort = str(cfg.get("reasoning_effort") or "").strip().lower()
+            if effort in valid_reasoning:
+                route["reasoning_effort"] = effort
+            if "toolsets" in cfg:
+                raw_toolsets = cfg.get("toolsets")
+                if isinstance(raw_toolsets, str):
+                    raw_toolsets = raw_toolsets.split(",")
+                if isinstance(raw_toolsets, list):
+                    route["toolsets"] = [
+                        str(item).strip() for item in raw_toolsets[:32] if str(item).strip()
+                    ]
+            if "history_messages" in cfg:
+                try:
+                    history_messages = int(cfg["history_messages"])
+                except (TypeError, ValueError):
+                    history_messages = 0
+                if 1 <= history_messages <= 200:
+                    route["history_messages"] = history_messages
             if not route.get("model"):
                 logger.warning(
                     "api_server model_routes: route %r has no 'model'; dropping", alias_str
@@ -1739,7 +1758,7 @@ class APIServerAdapter(BasePlatformAdapter):
         from hermes_cli.tools_config import _get_platform_tools
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
-        reasoning_config = GatewayRunner._load_reasoning_config()
+        reasoning_config = GatewayRunner._load_reasoning_config() or {}
         model = _resolve_gateway_model()
 
         # When the primary provider's auth fails (expired token / 429 quota
@@ -1762,7 +1781,9 @@ class APIServerAdapter(BasePlatformAdapter):
         session_override = self._session_model_override_for(
             gateway_session_key or session_id
         )
+        route_applied = False
         if route and not session_override:
+            route_applied = True
             if route.get("provider"):
                 # Resolve real credentials for the routed provider (mirrors
                 # the channel_overrides path in gateway/run.py) so a route
@@ -1801,6 +1822,14 @@ class APIServerAdapter(BasePlatformAdapter):
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        if route_applied and route is not None:
+            effort = route.get("reasoning_effort")
+            if effort == "none":
+                reasoning_config = {"enabled": False}
+            elif effort:
+                reasoning_config = {"enabled": True, "effort": effort}
+            if "toolsets" in route:
+                enabled_toolsets = list(route["toolsets"])
 
         max_iterations = _current_max_iterations()
 
@@ -2394,13 +2423,19 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = body.get("system_message") or body.get("instructions")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        route = self._resolve_route(body.get("model"))
+        if route and self._session_model_override_for(gateway_session_key or session_id):
+            route = None
         history = self._conversation_history_for_session(session_id)
+        if route and route.get("history_messages"):
+            history = history[-int(route["history_messages"]):]
         result, usage = await self._run_agent(
             user_message=user_message,
             conversation_history=history,
             ephemeral_system_prompt=system_prompt,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
+            route=route,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
@@ -2436,6 +2471,19 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = body.get("system_message") or body.get("instructions")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        route_alias = str(body.get("model") or "").strip()
+        route = self._resolve_route(route_alias)
+        if route and self._session_model_override_for(gateway_session_key or session_id):
+            route = None
+        route_summary = None
+        if route:
+            route_summary = {
+                "alias": route_alias,
+                "model": route.get("model"),
+                "reasoning_effort": route.get("reasoning_effort"),
+                "toolsets": route.get("toolsets"),
+                "history_messages": route.get("history_messages"),
+            }
 
         loop = asyncio.get_running_loop()
         queue: "asyncio.Queue[Optional[tuple[str, Dict[str, Any]]]]" = asyncio.Queue()
@@ -2479,9 +2527,14 @@ class APIServerAdapter(BasePlatformAdapter):
 
         async def _run_and_signal() -> None:
             try:
-                await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": user_message}}))
+                run_started = {"user_message": {"role": "user", "content": user_message}}
+                if route_summary:
+                    run_started["route"] = route_summary
+                await queue.put(_event_payload("run.started", run_started))
                 await queue.put(_event_payload("message.started", {"message": {"id": message_id, "role": "assistant"}}))
                 history = self._conversation_history_for_session(session_id)
+                if route and route.get("history_messages"):
+                    history = history[-int(route["history_messages"]):]
                 result, usage = await self._run_agent(
                     user_message=user_message,
                     conversation_history=history,
@@ -2490,6 +2543,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
                     gateway_session_key=gateway_session_key,
+                    route=route,
                 )
                 final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1808,6 +1808,18 @@ class APIServerAdapter(BasePlatformAdapter):
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).
         fallback_model = GatewayRunner._load_fallback_model()
 
+        # Keep the API-server platform aligned with the native messaging
+        # gateway: global fast/priority mode must reach each AIAgent request.
+        fast_mode_kwargs = {}
+        service_tier = GatewayRunner._load_service_tier()
+        if service_tier:
+            from hermes_cli.models import resolve_fast_mode_overrides
+
+            fast_mode_kwargs = {
+                "service_tier": service_tier,
+                "request_overrides": resolve_fast_mode_overrides(model),
+            }
+
         agent = AIAgent(
             model=model,
             **runtime_kwargs,
@@ -1825,6 +1837,7 @@ class APIServerAdapter(BasePlatformAdapter):
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
+            **fast_mode_kwargs,
             gateway_session_key=gateway_session_key,
         )
         return agent

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -366,6 +366,35 @@ class TestAdapterInit:
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
 
+    def test_create_agent_forwards_fast_mode_to_api_server_runs(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {"provider": "openai-codex", "base_url": "https://example.test/v1", "api_mode": "codex_responses"},
+        )
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "gpt-5.6-sol")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr("gateway.run._current_max_iterations", lambda: 90)
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_reasoning_config", staticmethod(lambda: {}))
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_service_tier", staticmethod(lambda: "priority"))
+        monkeypatch.setattr("hermes_cli.models.resolve_fast_mode_overrides", lambda _model: {"service_tier": "priority"})
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        agent = adapter._create_agent(session_id="api-session")
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["service_tier"] == "priority"
+        assert captured["request_overrides"] == {"service_tier": "priority"}
+
     def test_create_agent_refreshes_max_iterations_from_runtime_config(self, monkeypatch):
         captured = {}
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -366,6 +366,72 @@ class TestAdapterInit:
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
 
+    def test_create_agent_applies_route_reasoning_and_toolsets(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openai-codex",
+                "base_url": "https://example.test/v1",
+                "api_mode": "codex_responses",
+            },
+        )
+        monkeypatch.setattr("gateway.run._resolve_runtime_agent_kwargs_for_provider", lambda _provider: {})
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "gpt-5.6-sol")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr("gateway.run._current_max_iterations", lambda: 90)
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_reasoning_config",
+            staticmethod(lambda _model="": {"enabled": True, "effort": "medium"}),
+        )
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_service_tier", staticmethod(lambda: "priority"))
+        monkeypatch.setattr("hermes_cli.models.resolve_fast_mode_overrides", lambda _model: {"service_tier": "priority"})
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: {"terminal", "web"})
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        route = {
+            "model": "gpt-5.6-luna",
+            "provider": "openai-codex",
+            "reasoning_effort": "low",
+            "toolsets": [],
+            "history_messages": 12,
+        }
+
+        agent = adapter._create_agent(session_id="api-session", route=route)
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["model"] == "gpt-5.6-luna"
+        assert captured["reasoning_config"] == {"enabled": True, "effort": "low"}
+        assert captured["enabled_toolsets"] == []
+        assert captured["request_overrides"] == {"service_tier": "priority"}
+
+    def test_parse_model_routes_preserves_scoped_runtime_controls(self):
+        routes = APIServerAdapter._parse_model_routes({
+            "cortana-fast": {
+                "model": "gpt-5.6-luna",
+                "provider": "openai-codex",
+                "reasoning_effort": "low",
+                "toolsets": [],
+                "history_messages": 12,
+            }
+        })
+
+        assert routes["cortana-fast"] == {
+            "model": "gpt-5.6-luna",
+            "provider": "openai-codex",
+            "reasoning_effort": "low",
+            "toolsets": [],
+            "history_messages": 12,
+        }
+
     def test_create_agent_forwards_fast_mode_to_api_server_runs(self, monkeypatch):
         captured = {}
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -252,6 +252,73 @@ async def test_session_chat_loads_history_and_preserves_session_headers(auth_ada
 
 
 @pytest.mark.asyncio
+async def test_session_chat_applies_model_route_and_history_window(auth_adapter, session_db):
+    session_id = session_db.create_session("routed-chat-session", "api_server")
+    for index in range(8):
+        session_db.append_message(session_id, "user" if index % 2 == 0 else "assistant", f"turn-{index}")
+    route = {
+        "model": "gpt-5.6-luna",
+        "provider": "openai-codex",
+        "reasoning_effort": "low",
+        "toolsets": [],
+        "history_messages": 4,
+    }
+    auth_adapter._model_routes = {"cortana-fast": route}
+
+    mock_run = AsyncMock(return_value=({"final_response": "fast answer", "session_id": session_id}, {"total_tokens": 2}))
+    app = _create_session_app(auth_adapter)
+    with patch.object(auth_adapter, "_run_agent", mock_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "hello", "model": "cortana-fast"},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status == 200, await resp.text()
+
+    _, kwargs = mock_run.call_args
+    assert kwargs["route"] == route
+    assert [item["content"] for item in kwargs["conversation_history"]] == [
+        "turn-4", "turn-5", "turn-6", "turn-7",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_applies_model_route_and_history_window(adapter, session_db):
+    session_id = session_db.create_session("routed-stream-session", "api_server")
+    for index in range(6):
+        session_db.append_message(session_id, "user" if index % 2 == 0 else "assistant", f"turn-{index}")
+    route = {
+        "model": "gpt-5.6-luna",
+        "reasoning_effort": "low",
+        "toolsets": [],
+        "history_messages": 2,
+    }
+    adapter._model_routes = {"cortana-fast": route}
+    captured = {}
+
+    async def fake_run(**kwargs):
+        captured.update(kwargs)
+        kwargs["stream_delta_callback"]("fast")
+        return {"final_response": "fast", "session_id": session_id}, {"total_tokens": 1}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "hello", "model": "cortana-fast"},
+            )
+            assert resp.status == 200, await resp.text()
+            body = await resp.text()
+
+    assert '"alias": "cortana-fast"' in body
+    assert '"model": "gpt-5.6-luna"' in body
+    assert captured["route"] == route
+    assert [item["content"] for item in captured["conversation_history"]] == ["turn-4", "turn-5"]
+
+
+@pytest.mark.asyncio
 async def test_session_chat_accepts_multimodal_message(auth_adapter, session_db):
     session_id = session_db.create_session("image-session", "api_server")
     image_payload = [


### PR DESCRIPTION
## Summary
The API-server platform did not forward `agent.service_tier` / fast-mode request overrides when constructing `AIAgent`, unlike the native messaging gateway. This meant `/v1` and session streaming clients silently stayed on standard processing even when global priority mode was enabled.

This forwards the normalized service tier and provider-specific request overrides only when fast mode is configured.

## Verification
- added regression coverage for API-server `AIAgent` construction
- `TestAdapterInit`: 9 passed
- `py_compile` and `git diff --check` pass