### PR TITLE
feat(kanban): add terminal task recovery action

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -602,6 +602,17 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_unblock.add_argument("task_ids", nargs="+")
 
+    p_recover = sub.add_parser(
+        "recover",
+        help="Resume a blocked, terminal task while preserving its workspace",
+    )
+    p_recover.add_argument("task_id")
+    p_recover.add_argument(
+        "reason",
+        nargs="+",
+        help="Required continuation reason, recorded in the recovery event",
+    )
+
     p_promote = sub.add_parser(
         "promote",
         help="Manually move one or more todo/blocked tasks to ready (recovery path)",
@@ -962,6 +973,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "show":     _cmd_show,
             "assign":   _cmd_assign,
             "reclaim":  _cmd_reclaim,
+            "recover":  _cmd_recover,
             "reassign": _cmd_reassign,
             "diagnostics": _cmd_diagnostics,
             "diag":     _cmd_diagnostics,
@@ -1660,6 +1672,20 @@ def _cmd_reclaim(args: argparse.Namespace) -> int:
         )
         return 1
     print(f"Reclaimed {args.task_id}")
+    return 0
+
+
+def _cmd_recover(args: argparse.Namespace) -> int:
+    reason = " ".join(args.reason).strip()
+    with kb.connect_closing() as conn:
+        ok = kb.recover_task(conn, args.task_id, reason=reason)
+    if not ok:
+        print(
+            f"cannot recover {args.task_id} (task must be blocked with no active claim)",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Recovered {args.task_id}; existing workspace preserved")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3924,6 +3924,81 @@ def reclaim_task(
     return True
 
 
+def recover_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: str,
+) -> bool:
+    """Resume a terminally blocked task as one explicit continuation.
+
+    Recovery is for a task whose worker ended (for example, iteration-budget
+    exhaustion) but whose task workspace and handoff must be preserved.  It
+    never touches the workspace, never kills a worker, and refuses a task with
+    an active claim.  Parent gating is re-evaluated before the task becomes
+    dispatchable, so an unfinished dependency returns it to ``todo`` instead
+    of bypassing the scheduler's invariant.
+    """
+    clean_reason = (reason or "").strip()
+    if not clean_reason:
+        raise ValueError("recovery reason is required")
+
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT current_run_id FROM tasks "
+            "WHERE id = ? AND status = 'blocked' AND claim_lock IS NULL",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            return False
+
+        # A terminal block normally closes its run.  Close a leaked pointer
+        # defensively, preserving the one-current-run invariant.
+        if row["current_run_id"]:
+            now = int(time.time())
+            conn.execute(
+                """
+                UPDATE task_runs
+                   SET status = 'reclaimed', outcome = 'reclaimed',
+                       summary = COALESCE(summary, 'invariant recovery on recover'),
+                       ended_at = ?, claim_lock = NULL, claim_expires = NULL,
+                       worker_pid = NULL
+                 WHERE id = ? AND ended_at IS NULL
+                """,
+                (now, int(row["current_run_id"])),
+            )
+
+        undone_parent = conn.execute(
+            "SELECT 1 FROM task_links l JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        new_status = "todo" if undone_parent else "ready"
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET status = ?, current_run_id = NULL, claim_expires = NULL,
+                   worker_pid = NULL, consecutive_failures = 0,
+                   last_failure_error = NULL
+             WHERE id = ? AND status = 'blocked' AND claim_lock IS NULL
+            """,
+            (new_status, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        _append_event(
+            conn,
+            task_id,
+            "recovered",
+            {
+                "reason": clean_reason,
+                "preserve_workspace": True,
+                "status": new_status,
+            },
+        )
+    return True
+
+
 def reassign_task(
     conn: sqlite3.Connection,
     task_id: str,

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -925,9 +925,9 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     # Find the most recent event that put this task into ready.
     # ``created`` covers tasks born ready; ``promoted`` covers parent-
     # done auto-promotion; ``reclaimed`` covers TTL/crash recovery;
-    # ``unblocked`` covers human-driven resumes.
+    # ``unblocked`` and ``recovered`` cover deliberate human resumes.
     READY_TRANSITION_KINDS = {
-        "created", "promoted", "reclaimed", "unblocked",
+        "created", "promoted", "reclaimed", "unblocked", "recovered",
     }
     last_ready_ts = 0
     for ev in events:

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3085,6 +3085,22 @@
     // a status flip (may update title AND body AND emit an audit
     // comment — or fail with a human-readable reason that the UI
     // surfaces inline without treating it as an HTTP error).
+    const doRecover = function (reason) {
+      return SDK.fetchJSON(
+        withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/recover`, boardSlug),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reason: reason }),
+        }
+      ).then(function () {
+        load();
+        props.onRefresh();
+      }).catch(function (e) {
+        setPatchErr(parseApiErrorMessage(e));
+      });
+    };
+
     const doSpecify = function () {
       return SDK.fetchJSON(
         withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/specify`, boardSlug),
@@ -3209,6 +3225,7 @@
           assignees: props.assignees || [],
           boardSlug: boardSlug,
           onPatch: doPatch,
+          onRecover: doRecover,
           onSpecify: doSpecify,
           onDecompose: doDecompose,
           onAddParent: addLink,
@@ -3406,6 +3423,7 @@
       h(StatusActions, {
         task: t,
         onPatch: props.onPatch,
+        onRecover: props.onRecover,
         onSpecify: props.onSpecify,
         onDecompose: props.onDecompose,
       }),
@@ -3943,6 +3961,20 @@
       }, label);
     };
 
+    const recoverButton = (task.status === "blocked" && props.onRecover)
+      ? h(Button, {
+          onClick: function () {
+            const reason = window.prompt(
+              "Recovery reason (the existing workspace will be preserved):",
+              "resume preserved work",
+            );
+            if (reason && reason.trim()) props.onRecover(reason.trim());
+          },
+          size: "sm",
+          title: "Resume this terminal task as a controlled continuation",
+        }, "Recover")
+      : null;
+
     // "Specify" appears only when the task is in the Triage column — the
     // one column where an auxiliary LLM pass is meaningful. Elsewhere
     // the backend would return ok:false with "not in triage" anyway,
@@ -4028,6 +4060,7 @@
 
     return h("div", null,
       h("div", { className: "hermes-kanban-actions" },
+        recoverButton,
         specifyButton,
         decomposeButton,
         b("→ triage",  { status: "triage" },   task.status !== "triage"),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1641,6 +1641,36 @@ def specify_task_endpoint(
     }
 
 
+class RecoverBody(BaseModel):
+    reason: str
+
+
+@router.post("/tasks/{task_id}/recover")
+def recover_task_endpoint(
+    task_id: str,
+    payload: RecoverBody,
+    board: Optional[str] = Query(None),
+):
+    """Resume a terminally blocked task without replacing its workspace."""
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        try:
+            ok = kanban_db.recover_task(conn, task_id, reason=payload.reason)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        if not ok:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"cannot recover {task_id}: it must be blocked with no active claim"
+                ),
+            )
+        return {"ok": True, "task_id": task_id, "workspace_preserved": True}
+    finally:
+        conn.close()
+
+
 class ReassignBody(BaseModel):
     profile: Optional[str] = None  # "" or None = unassign
     reclaim_first: bool = False

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -200,6 +200,51 @@ def test_reassign_resets_failure_counter_for_new_profile(kanban_home, all_assign
         conn.close()
 
 
+def test_recover_resumes_blocked_exhausted_task_and_preserves_workspace(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="preserved WIP", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'blocked', consecutive_failures = 2, "
+                "last_failure_error = 'iteration budget exhausted' WHERE id = ?",
+                (tid,),
+            )
+
+        assert kb.recover_task(conn, tid, reason="resume preserved worktree") is True
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.assignee == "worker"
+        assert task.claim_lock is None
+        assert task.consecutive_failures == 0
+        assert task.last_failure_error is None
+        assert any(
+            event.kind == "recovered"
+            and event.payload == {
+                "reason": "resume preserved worktree",
+                "preserve_workspace": True,
+                "status": "ready",
+            }
+            for event in kb.list_events(conn, tid)
+        )
+    finally:
+        conn.close()
+
+
+def test_recover_refuses_non_blocked_or_claimed_task(kanban_home):
+    conn = kb.connect()
+    try:
+        ready = kb.create_task(conn, title="already ready", assignee="worker")
+        assert kb.recover_task(conn, ready, reason="no-op") is False
+
+        blocked = kb.create_task(conn, title="claimed", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'blocked', claim_lock = 'live' WHERE id = ?", (blocked,))
+        assert kb.recover_task(conn, blocked, reason="must not steal") is False
+    finally:
+        conn.close()
+
+
 def test_per_task_max_retries_overrides_dispatcher_limit(kanban_home, all_assignees_spawnable):
     """Per-task ``max_retries`` overrides both the caller-supplied
     ``failure_limit`` (gateway config) and the hardcoded default.

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -547,6 +547,18 @@ def test_stranded_in_ready_uses_latest_ready_transition():
     assert [d for d in diags if d.kind == "stranded_in_ready"] == []
 
 
+def test_stranded_in_ready_uses_recovery_transition():
+    """A just-recovered task gets a fresh stranded-work timer."""
+    now = 100_000
+    task = _task(status="ready", assignee="demo")
+    events = [
+        _event("created", ts=now - 6 * 3600),
+        _event("recovered", ts=now - 20 * 60),
+    ]
+    diags = kd.compute_task_diagnostics(task, events, [], now=now)
+    assert [d for d in diags if d.kind == "stranded_in_ready"] == []
+
+
 def test_stranded_in_ready_severity_escalates_with_age():
     """warning → error → critical at 2x and 6x threshold."""
     now = 100_000

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -60,6 +60,33 @@ def client(kanban_home):
     return TestClient(app)
 
 
+def test_recover_endpoint_resumes_terminal_blocked_task(client):
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="preserved WIP", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'blocked', consecutive_failures = 2, "
+                "last_failure_error = 'iteration budget exhausted' WHERE id = ?",
+                (task_id,),
+            )
+
+    response = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/recover",
+        json={"reason": "resume preserved worktree"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "ok": True,
+        "task_id": task_id,
+        "workspace_preserved": True,
+    }
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+        assert any(event.kind == "recovered" for event in kb.list_events(conn, task_id))
+
+
 # ---------------------------------------------------------------------------
 # GET /board on an empty DB
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Adds an explicit, evidence-gated recovery path for terminally blocked Kanban tasks that retain a workspace/handoff after a worker exhausts its budget.

## Related Issue

No upstream issue; extracted from a live recovery incident.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Why `recover` is different from `unblock`

| Action | Use when | What it means | Workspace / run handling |
| --- | --- | --- | --- |
| `unblock` | A human or dependency hold has been resolved. | Resume normal scheduling after an intentional block. | Generic status transition; it does not assert that a worker terminally failed or that its WIP must be resumed. |
| `recover` | A worker has **ended terminally**—for example, it exhausted its iteration budget—but left a preserved worktree, branch, handoff, or partial implementation. | Start one explicit, audited continuation rather than treating the card as fresh work. | Requires `blocked` + no active claim; preserves the existing workspace untouched, records a `recovered` event/reason, clears the exhausted retry gate, and re-checks dependency gating. |

`recover` deliberately refuses ready, running, done, archived, and claimed tasks. It is not a shortcut for reclaiming a live worker or bypassing review/PR safeguards.

## Changes Made

- Adds `hermes kanban recover <task-id> <reason>` for blocked, unclaimed tasks.
- Preserves the workspace and records a durable `recovered` event.
- Adds `POST /tasks/{task_id}/recover` and a Recover button in the Kanban task drawer.
- Re-gates parent dependencies and resets the stranded-task age from the recovery event.

## How to Test

1. Create or identify a blocked task with no active claim.
2. Run `hermes kanban recover <task-id> "resume preserved worktree"`.
3. Confirm it becomes ready (or todo when a parent remains incomplete), preserves its workspace, and emits `recovered`.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits.
- [x] My PR contains only changes related to this feature.
- [x] I added tests for my changes.
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Documentation update is N/A; command/API are self-documented.
- [x] No config keys or tool schemas changed.

## Screenshots / Logs

Local verification: `334 passed, 1 skipped` across Kanban core, diagnostics, and dashboard-plugin test modules; CLI smoke test, FastAPI endpoint test, and dashboard JavaScript syntax check passed.