### PR TITLE
feat(telegram): add compact topic titles and semantic icons

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -80,8 +80,8 @@ _TITLE_PROMPT_TEMPLATE = (
     "- Never answer the message. Name it.\n"
     "- Always produce something, even for a bare greeting.\n"
     "__LANGUAGE_RULE__\n"
-    'Good: {"title": "Fix login button on mobile"}\n'
-    'Good: {"title": "Postgres connection pool exhaustion"}\n'
+    'Good: {"title": "Fix mobile login"}\n'
+    'Good: {"title": "Postgres pool exhaustion"}\n'
     'Good: {"title": "Friendly greeting"}\n'
     'Too vague: {"title": "Code changes"}\n'
     'Too long: {"title": "Investigate and fix the issue where the login button '
@@ -253,7 +253,8 @@ def _build_title_prompt(
     # Placeholder substitution, not str.format: the prompt embeds literal JSON
     # braces as few-shot examples, which format() would try to interpolate.
     return (
-        _TITLE_PROMPT_TEMPLATE.replace("__LANGUAGE_RULE__", language_rule)
+        _TITLE_PROMPT_TEMPLATE
+        .replace("__LANGUAGE_RULE__", language_rule)
         .replace("__LENGTH_RULE__", length_rule)
         .replace("__ALIAS_RULE__", alias_rule)
     )
@@ -536,6 +537,129 @@ def generate_title(
                 failure_callback("title generation", e)
             except Exception:
                 logger.debug("Title generation failure_callback raised", exc_info=True)
+        return None
+
+
+def choose_topic_icon(
+    title: str,
+    user_message: str,
+    allowed_emojis: list[str],
+    timeout: float = 30.0,
+    *,
+    recent_emojis: Optional[list[str]] = None,
+) -> Optional[str]:
+    """Choose a varied semantic Telegram topic emoji from a live allowlist.
+
+    The auxiliary model ranks several valid candidates so the caller can avoid
+    recently used icons without sacrificing semantic fit. The returned value is
+    a normal emoji key; the Telegram adapter resolves it to the allowed
+    sticker's ``custom_emoji_id``.
+    """
+    allowed = list(
+        dict.fromkeys(str(emoji).strip() for emoji in allowed_emojis if str(emoji).strip())
+    )
+    if not allowed:
+        return None
+
+    def _emoji_key(value: str) -> str:
+        return value.replace("\ufe0e", "").replace("\ufe0f", "")
+
+    allowed_by_key = {_emoji_key(emoji): emoji for emoji in allowed}
+    recent = list(
+        dict.fromkeys(
+            allowed_by_key[key]
+            for emoji in (recent_emojis or [])
+            if (key := _emoji_key(str(emoji).strip())) in allowed_by_key
+        )
+    )
+    recent_keys = {_emoji_key(emoji) for emoji in recent}
+    fresh_allowed = [emoji for emoji in allowed if _emoji_key(emoji) not in recent_keys]
+    # When there are enough fresh choices, omit recent icons from the model's
+    # candidate pool entirely. Prompt wording and temperature are advisory;
+    # allowlist exclusion is what guarantees real rotation across the live set.
+    exclude_recent = bool(recent) and len(fresh_allowed) >= min(4, len(allowed))
+    selection_pool = fresh_allowed if exclude_recent else allowed
+    candidate_count = min(4, len(selection_pool))
+    prompt = (
+        f"Choose {candidate_count} distinct ranked emoji candidates for a conversation topic, "
+        "from best fit to least preferred. Select only from this allowed list: "
+        + json.dumps(selection_pool, ensure_ascii=False)
+        + ". Prefer specific, playful visual metaphors over generic computer, robot, or rocket "
+        "icons when a more distinctive allowed icon fits. Keep every candidate clearly related "
+        "to the topic; novelty must not override meaning. Return only the ranked emoji characters "
+        "separated by spaces, with no words or explanation."
+    )
+    if recent:
+        if exclude_recent:
+            prompt += (
+                " Icons used recently in this chat were removed from the allowed list: "
+                + json.dumps(recent, ensure_ascii=False)
+                + ". Do not return them."
+            )
+        else:
+            prompt += (
+                " These icons were used recently in this chat: "
+                + json.dumps(recent, ensure_ascii=False)
+                + ". Avoid repeating them unless one is unmistakably the best semantic fit."
+            )
+    messages = [
+        {"role": "system", "content": prompt},
+        {
+            "role": "user",
+            "content": (
+                f"Title: {str(title or '')[:120]}\n"
+                f"Opening request: {str(user_message or '')[:500]}"
+            ),
+        },
+    ]
+
+    try:
+        response = call_llm(
+            task="title_generation",
+            messages=messages,
+            max_tokens=64,
+            temperature=0.7,
+            timeout=timeout,
+        )
+        content = response.choices[0].message.content or ""
+        from agent.agent_runtime_helpers import strip_think_blocks
+
+        choice = strip_think_blocks(None, content).strip().strip("\"'")
+        normalized_choice = _emoji_key(choice)
+
+        # Extract allowed emojis in the model's ranked response order. Matching
+        # the variation-selector-free form accepts e.g. ``⚡`` for allowed
+        # ``⚡️`` while overlap filtering keeps a compound emoji from also
+        # matching one of its component glyphs.
+        hits: list[tuple[int, int, int, str]] = []
+        for allowed_index, emoji in enumerate(selection_pool):
+            key = _emoji_key(emoji)
+            start = normalized_choice.find(key)
+            while start >= 0:
+                hits.append((start, start + len(key), allowed_index, emoji))
+                start = normalized_choice.find(key, start + max(1, len(key)))
+        hits.sort(key=lambda hit: (hit[0], -(hit[1] - hit[0]), hit[2]))
+
+        candidates: list[str] = []
+        occupied: list[tuple[int, int]] = []
+        for start, end, _, emoji in hits:
+            if any(
+                start < used_end and end > used_start
+                for used_start, used_end in occupied
+            ):
+                continue
+            occupied.append((start, end))
+            if emoji not in candidates:
+                candidates.append(emoji)
+        if not candidates:
+            return None
+
+        return next(
+            (emoji for emoji in candidates if _emoji_key(emoji) not in recent_keys),
+            candidates[0],
+        )
+    except Exception:
+        logger.debug("Telegram topic icon selection failed", exc_info=True)
         return None
 
 

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -21,6 +21,7 @@ import json
 import logging
 import re
 import threading
+from contextvars import copy_context
 from typing import Any, Callable, Optional
 
 from agent.auxiliary_client import call_llm
@@ -67,10 +68,14 @@ _TITLE_PROMPT_TEMPLATE = (
     "You name chat sessions. Given the user's opening message, write a title "
     "that lets them find this conversation again in a list.\n\n"
     "Rules:\n"
-    "- 3 to 7 words, sentence case (capitalize only the first word and proper nouns).\n"
+    "__LENGTH_RULE__\n"
     "- Name what the user wants DONE, not that they asked a question.\n"
+    "- Prefer an explicitly named project, person, product, or other proper name.\n"
+    "- Avoid generic leading labels such as Fixing, Update, or Analysis when a specific subject is available.\n"
     "- Keep technical terms, filenames, numbers, and error codes exact.\n"
+    "__ALIAS_RULE__"
     "- Drop filler words: the, this, my, a, an.\n"
+    "- Do not include emoji.\n"
     "- No trailing punctuation, no quotes, no tool names, no 'Title:' prefix.\n"
     "- Never answer the message. Name it.\n"
     "- Always produce something, even for a bare greeting.\n"
@@ -157,6 +162,101 @@ def _title_language() -> str:
         ).strip()
     except Exception:
         return ""
+
+
+def _title_preferences() -> tuple[int, int, int, dict[str, str]]:
+    """Return compact-title limits and user-defined canonical aliases."""
+    default_min_words = 2
+    default_max_words = 3
+    default_max_characters = 40
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        title_config = ((load_config_readonly() or {}).get("auxiliary") or {}).get(
+            "title_generation", {}
+        )
+        max_words = max(
+            1, min(int(title_config.get("max_words", default_max_words)), 12)
+        )
+        min_words = max(
+            1,
+            min(
+                int(title_config.get("min_words", default_min_words)),
+                max_words,
+            ),
+        )
+        max_characters = max(
+            12,
+            min(
+                int(title_config.get("max_characters", default_max_characters)),
+                120,
+            ),
+        )
+        raw_aliases = title_config.get("name_aliases", {})
+        aliases = (
+            {
+                str(alias).strip(): str(canonical).strip()
+                for alias, canonical in raw_aliases.items()
+                if str(alias).strip() and str(canonical).strip()
+            }
+            if isinstance(raw_aliases, dict)
+            else {}
+        )
+        return min_words, max_words, max_characters, aliases
+    except Exception:
+        return default_min_words, default_max_words, default_max_characters, {}
+
+
+def _canonical_name_for_message(
+    user_message: str, name_aliases: dict[str, str]
+) -> Optional[str]:
+    """Return the canonical name for the longest whole-term alias match."""
+    for alias, canonical in sorted(
+        name_aliases.items(), key=lambda item: len(item[0]), reverse=True
+    ):
+        if re.search(rf"(?<!\w){re.escape(alias)}(?!\w)", user_message, re.IGNORECASE):
+            return canonical
+    return None
+
+
+def _build_title_prompt(
+    *,
+    language: str,
+    min_words: int,
+    max_words: int,
+    max_characters: int,
+    name_aliases: dict[str, str],
+) -> str:
+    """Build the structured-output title prompt from user preferences."""
+    language_rule = (
+        _LANGUAGE_RULE_PINNED.format(language=language)
+        if language
+        else _LANGUAGE_RULE_MATCH_USER
+    )
+    if min_words == max_words:
+        word_preference = f"exactly {max_words} " + (
+            "word" if max_words == 1 else "words"
+        )
+    else:
+        word_preference = f"{min_words}-{max_words} words"
+    length_rule = (
+        f"- Prefer {word_preference} and at most {max_characters} characters; "
+        "use sentence case (capitalize only the first word and proper nouns)."
+    )
+    alias_rule = ""
+    if name_aliases:
+        aliases_json = json.dumps(name_aliases, ensure_ascii=False, sort_keys=True)
+        alias_rule = (
+            "- Use these case-insensitive canonical name replacements when the "
+            f"opening message contains an alias: {aliases_json}.\n"
+        )
+    # Placeholder substitution, not str.format: the prompt embeds literal JSON
+    # braces as few-shot examples, which format() would try to interpolate.
+    return (
+        _TITLE_PROMPT_TEMPLATE.replace("__LANGUAGE_RULE__", language_rule)
+        .replace("__LENGTH_RULE__", length_rule)
+        .replace("__ALIAS_RULE__", alias_rule)
+    )
 
 
 def _auto_title_enabled() -> bool:
@@ -315,7 +415,7 @@ def _extract_title_text(content: str) -> str:
     return raw.strip("\"'").strip()
 
 
-def _clean_title(text: str) -> Optional[str]:
+def _clean_title(text: str, max_characters: int = 80) -> Optional[str]:
     """Normalize a model-produced title, or None when nothing usable remains."""
     title = " ".join((text or "").split())
     title = title.strip("\"'").strip()
@@ -325,9 +425,19 @@ def _clean_title(text: str) -> Optional[str]:
     title = title.rstrip(".!,;:")
     if not title:
         return None
-    if len(title) > 80:
-        title = title[:77].rstrip() + "..."
+    if len(title) > max_characters:
+        title = title[: max_characters - 3].rstrip() + "..."
     return title
+
+
+def _enforce_max_words(title: Optional[str], max_words: int) -> Optional[str]:
+    """Deterministically enforce the configured title word maximum."""
+    if not title:
+        return None
+    words = title.split()
+    if len(words) <= max_words:
+        return title
+    return " ".join(words[:max_words]).rstrip(".!,;:")
 
 
 def generate_title(
@@ -372,19 +482,23 @@ def generate_title(
             # Fail open: a broken validator must not disable titling.
             logger.debug("Title runtime validator raised; proceeding", exc_info=True)
 
-    user_snippet = _summarize_user_message(user_message)[:MAX_TITLE_INPUT_CHARS]
+    # Collapse slash-skill scaffolding before prompt construction, deterministic
+    # alias matching, and truncation. Hidden expanded skill prose must not win
+    # over the user's visible instruction.
+    summarized_user_message = _summarize_user_message(user_message)
+    user_snippet = summarized_user_message[:MAX_TITLE_INPUT_CHARS]
     if not user_snippet.strip():
         return None
 
     language = _title_language()
-    language_rule = (
-        _LANGUAGE_RULE_PINNED.format(language=language)
-        if language
-        else _LANGUAGE_RULE_MATCH_USER
+    min_words, max_words, max_characters, name_aliases = _title_preferences()
+    prompt = _build_title_prompt(
+        language=language,
+        min_words=min_words,
+        max_words=max_words,
+        max_characters=max_characters,
+        name_aliases=name_aliases,
     )
-    # Placeholder substitution, not str.format: the prompt embeds literal JSON
-    # braces as few-shot examples, which format() would try to interpolate.
-    prompt = _TITLE_PROMPT_TEMPLATE.replace("__LANGUAGE_RULE__", language_rule)
 
     messages = [
         {"role": "system", "content": prompt},
@@ -404,7 +518,14 @@ def generate_title(
             extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
         )
         content = response.choices[0].message.content or ""
-        return _clean_title(_extract_title_text(content))
+        title = _clean_title(_extract_title_text(content), max_characters)
+        canonical_name = _canonical_name_for_message(
+            summarized_user_message, name_aliases
+        )
+        # Canonical names are explicit user config and intentionally outrank the
+        # generic character preference. The word maximum remains a deterministic
+        # display policy for both model output and configured aliases.
+        return _enforce_max_words(canonical_name or title, max_words)
     except Exception as e:
         # Log at WARNING so this shows up in agent.log without debug mode.
         # Full detail at debug level for operators who need the stack.
@@ -724,9 +845,13 @@ def maybe_auto_title(
 
     apply_instant_title(session_db, session_id, user_message, title_callback)
 
+    # Context vars carry the active Hermes profile and runtime provenance. A
+    # plain daemon thread starts with an empty context and can read the wrong
+    # profile's config or credentials.
+    context = copy_context()
     thread = threading.Thread(
-        target=auto_title_session,
-        args=(session_db, session_id, user_message),
+        target=context.run,
+        args=(auto_title_session, session_db, session_id, user_message),
         kwargs={
             "failure_callback": failure_callback,
             "main_runtime": main_runtime,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -90,6 +90,8 @@ _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 # on timeout the latch stays clear and the next tick retries).
 _STALL_NOTIFY_SEND_TIMEOUT_SECONDS = 15.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
+_TELEGRAM_TOPIC_ICON_HISTORY_LIMIT = 12
+_TELEGRAM_TOPIC_ICON_CHAT_CACHE_LIMIT = 256
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 _GATEWAY_HYGIENE_PLATFORM = "gateway_hygiene"
 
@@ -4480,7 +4482,10 @@ class TurnRunner:
                 agent._on_session_title = lambda title, title_source: (
                     title_source == "llm"
                     and self._runner._schedule_telegram_topic_title_rename(
-                        source, session_id, title,
+                        source,
+                        session_id,
+                        title,
+                        user_message=getattr(ctx, "message", "") or "",
                     )
                 )
             elif self._runner._is_discord_auto_thread_lane(source) or (
@@ -20560,10 +20565,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             loop = getattr(self, "_gateway_loop", None)
         if loop is None or loop.is_closed():
             return
-        try:
-            copied_source = dataclasses.replace(source)
-        except Exception:
-            copied_source = source
+        copied_source = self._copy_source_for_background_rename(source)
         future = safe_schedule_threadsafe(
             self._rename_discord_auto_thread_for_session_title(
                 copied_source, session_id, title, relay_info=relay_info
@@ -20583,11 +20585,255 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         future.add_done_callback(_log_rename_failure)
 
+    @staticmethod
+    def _copy_source_for_background_rename(source: SessionSource) -> SessionSource:
+        """Snapshot a source without losing its live transport provenance."""
+        try:
+            copied_source = dataclasses.replace(source)
+        except Exception:
+            return source
+        transport_ref = getattr(source, "_transport_adapter_ref", None)
+        if callable(transport_ref):
+            setattr(copied_source, "_transport_adapter_ref", transport_ref)
+        return copied_source
+
+    async def _select_telegram_topic_icon_id(
+        self,
+        adapter,
+        source: SessionSource,
+        title: str,
+        user_message: str,
+    ) -> Optional[str]:
+        """Serialize icon selection per chat so recent-history rotation is race-free."""
+        history_key = str(source.chat_id)
+        lock_store = getattr(self, "_telegram_topic_icon_locks", None)
+        if not isinstance(lock_store, OrderedDict):
+            lock_store = OrderedDict()
+            self._telegram_topic_icon_locks = lock_store
+
+        def _prune_idle_locks() -> None:
+            if len(lock_store) <= _TELEGRAM_TOPIC_ICON_CHAT_CACHE_LIMIT:
+                return
+            history_store = getattr(self, "_telegram_topic_icon_history", None)
+            for stale_key, stale_entry in list(lock_store.items()):
+                if len(lock_store) <= _TELEGRAM_TOPIC_ICON_CHAT_CACHE_LIMIT:
+                    break
+                stale_users = (
+                    int(stale_entry.get("users", 0))
+                    if isinstance(stale_entry, dict)
+                    else 0
+                )
+                if stale_users == 0:
+                    lock_store.pop(stale_key, None)
+                    if isinstance(history_store, dict):
+                        history_store.pop(stale_key, None)
+
+        entry = lock_store.get(history_key)
+        if not isinstance(entry, dict) or not isinstance(entry.get("lock"), asyncio.Lock):
+            entry = {"lock": asyncio.Lock(), "users": 0}
+            lock_store[history_key] = entry
+        else:
+            lock_store.move_to_end(history_key)
+        entry["users"] = int(entry.get("users", 0)) + 1
+        _prune_idle_locks()
+
+        try:
+            async with entry["lock"]:
+                return await self._select_telegram_topic_icon_id_unlocked(
+                    adapter,
+                    source,
+                    title,
+                    user_message,
+                )
+        finally:
+            entry["users"] = max(0, int(entry.get("users", 1)) - 1)
+            if lock_store.get(history_key) is entry:
+                lock_store.move_to_end(history_key)
+            _prune_idle_locks()
+
+    def _telegram_topic_extra(self, source: SessionSource, adapter=None) -> dict:
+        """Return topic settings from the transport-owning profile config."""
+        resolved_adapter = adapter if adapter is not None else self._adapter_for_source(source)
+        adapter_config = (
+            getattr(resolved_adapter, "config", None)
+            if resolved_adapter is not None
+            else None
+        )
+        if isinstance(adapter_config, PlatformConfig):
+            adapter_extra = getattr(adapter_config, "extra", None)
+            if isinstance(adapter_extra, dict):
+                return adapter_extra
+
+        platform_cfg = (
+            self.config.platforms.get(source.platform)
+            if getattr(self, "config", None) and getattr(self.config, "platforms", None)
+            else None
+        )
+        fallback_extra = getattr(platform_cfg, "extra", None) or {}
+        return fallback_extra if isinstance(fallback_extra, dict) else {}
+
+    async def _select_telegram_topic_icon_id_unlocked(
+        self,
+        adapter,
+        source: SessionSource,
+        title: str,
+        user_message: str,
+    ) -> Optional[str]:
+        """Resolve an allowed full-size topic icon when the operator opts in."""
+        extra = self._telegram_topic_extra(source, adapter)
+        if not is_truthy_value(extra.get("auto_topic_icons"), default=False):
+            return None
+
+        preserve_manual = is_truthy_value(
+            extra.get("preserve_manual_topic_icons"),
+            default=True,
+        )
+        if preserve_manual:
+            state_fn = getattr(adapter, "dm_topic_custom_icon_state", None)
+            if not callable(state_fn):
+                return None
+            try:
+                state = state_fn(str(source.chat_id), str(source.thread_id))
+            except Exception:
+                logger.debug("Failed to inspect Telegram topic icon state", exc_info=True)
+                return None
+            # True = the gateway observed a user-selected custom icon.
+            # False = it observed the default icon. None is also eligible here:
+            # Telegram DM topics often arrive without a forum_topic_created
+            # service message, and treating that as manual was the reason new
+            # topics kept the default letter bubble.
+            if state is True:
+                return None
+
+        options_fn = getattr(adapter, "get_forum_topic_icon_options", None)
+        if not callable(options_fn):
+            return None
+        try:
+            options_result = options_fn()
+            raw_options = (
+                await options_result
+                if inspect.isawaitable(options_result)
+                else options_result
+            )
+        except Exception:
+            logger.debug("Failed to fetch Telegram topic icon options", exc_info=True)
+            return None
+
+        option_items = raw_options if isinstance(raw_options, (list, tuple)) else []
+        options = [
+            option
+            for option in option_items
+            if isinstance(option, dict)
+            and str(option.get("emoji") or "").strip()
+            and str(option.get("custom_emoji_id") or "").strip()
+        ]
+        if not options:
+            return None
+        icon_ids = {
+            str(option["emoji"]).strip(): str(option["custom_emoji_id"]).strip()
+            for option in options
+        }
+
+        def _emoji_key(value: str) -> str:
+            return value.replace("\ufe0e", "").replace("\ufe0f", "")
+
+        normalized_icons: dict[str, tuple[str, str]] = {}
+        for emoji, custom_id in icon_ids.items():
+            normalized_icons.setdefault(_emoji_key(emoji), (emoji, custom_id))
+
+        history_store = getattr(self, "_telegram_topic_icon_history", None)
+        if not isinstance(history_store, OrderedDict):
+            history_store = OrderedDict(
+                history_store.items() if isinstance(history_store, dict) else ()
+            )
+            self._telegram_topic_icon_history = history_store
+        history_key = str(source.chat_id)
+        if history_key in history_store:
+            history_store.move_to_end(history_key)
+        recent_icons = [
+            emoji
+            for emoji in history_store.get(history_key, [])
+            if _emoji_key(emoji) in normalized_icons
+        ][-_TELEGRAM_TOPIC_ICON_HISTORY_LIMIT:]
+
+        selected_emoji = None
+        selected_id = None
+        overrides = extra.get("topic_icon_overrides")
+        normalized_title = re.sub(r"\s+", " ", str(title or "")).strip().casefold()
+        # Session-title deduplication appends `` #N``. Project overrides are
+        # keyed by the semantic/base title, so keep them effective for later
+        # sessions in the same lineage.
+        normalized_base_title = re.sub(r"\s+#\d+$", "", normalized_title).strip()
+        base_override_emoji = None
+        if isinstance(overrides, dict):
+            for override_title, override_emoji in overrides.items():
+                normalized_override = re.sub(
+                    r"\s+", " ", str(override_title or "")
+                ).strip().casefold()
+                if normalized_override == normalized_title:
+                    selected_emoji = str(override_emoji or "").strip()
+                    break
+                if (
+                    base_override_emoji is None
+                    and normalized_override == normalized_base_title
+                ):
+                    base_override_emoji = str(override_emoji or "").strip()
+        if selected_emoji is None:
+            selected_emoji = base_override_emoji
+
+        if selected_emoji:
+            selected_id = icon_ids.get(selected_emoji)
+            if selected_id is None:
+                normalized_match = normalized_icons.get(_emoji_key(selected_emoji))
+                if normalized_match is not None:
+                    selected_emoji, selected_id = normalized_match
+
+        if selected_id is None:
+            from agent.title_generator import choose_topic_icon
+
+            selected_emoji = await asyncio.to_thread(
+                choose_topic_icon,
+                title,
+                user_message,
+                list(icon_ids),
+                recent_emojis=recent_icons,
+            )
+            selected_id = icon_ids.get(selected_emoji or "")
+        if selected_id and preserve_manual:
+            # The auxiliary choice can take a few seconds. Recheck after it
+            # returns so an icon the user selected meanwhile still wins.
+            latest_state_fn = getattr(adapter, "dm_topic_custom_icon_state", None)
+            if not callable(latest_state_fn):
+                return None
+            try:
+                if latest_state_fn(str(source.chat_id), str(source.thread_id)) is True:
+                    return None
+            except Exception:
+                logger.debug("Failed to recheck Telegram topic icon state", exc_info=True)
+                return None
+        if selected_id and selected_emoji:
+            history_store[history_key] = (
+                [emoji for emoji in recent_icons if emoji != selected_emoji]
+                + [selected_emoji]
+            )[-_TELEGRAM_TOPIC_ICON_HISTORY_LIMIT:]
+            history_store.move_to_end(history_key)
+            while len(history_store) > _TELEGRAM_TOPIC_ICON_CHAT_CACHE_LIMIT:
+                history_store.popitem(last=False)
+            logger.info(
+                "Selected Telegram topic icon %s for chat %s thread_id=%s title=%r",
+                selected_emoji,
+                source.chat_id,
+                source.thread_id,
+                title,
+            )
+        return selected_id
+
     async def _rename_telegram_topic_for_session_title(
         self,
         source: SessionSource,
         session_id: str,
         title: str,
+        user_message: str = "",
     ) -> None:
         """Best-effort rename of a Telegram DM topic when Hermes auto-titles a session."""
         if not await asyncio.to_thread(self._is_telegram_topic_lane, source) or not source.chat_id or not source.thread_id:
@@ -20603,25 +20849,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Skip rename when the topic is operator-declared via
         # extra.dm_topics. Those topics have fixed names chosen by the
         # operator (plus optional skill binding); auto-renaming would
-        # silently mutate operator config.
+        # silently mutate operator config. Do not use _get_dm_topic_info for
+        # the primary check: it also returns names learned from ordinary
+        # incoming Telegram messages, and those transient cache entries are
+        # exactly the fresh topics that should be auto-renamed.
         #
         # Check the class, not the instance — getattr() on MagicMock
-        # auto-creates attributes, so `hasattr(adapter, "_get_dm_topic_info")`
-        # would return True for every test double.
+        # auto-creates attributes, so `hasattr(adapter, ...)` would return
+        # True for every test double.
         adapter = self._adapter_for_source(source)
         if adapter is not None:
-            get_info = getattr(type(adapter), "_get_dm_topic_info", None)
-            if callable(get_info):
+            is_declared = getattr(
+                type(adapter), "_is_dm_topic_operator_declared", None
+            )
+            if callable(is_declared):
                 try:
-                    operator_topic = get_info(adapter, str(source.chat_id), str(source.thread_id))
+                    if is_declared(
+                        adapter,
+                        str(source.chat_id),
+                        str(source.thread_id),
+                    ):
+                        return
                 except Exception:
-                    operator_topic = None
-                # Only treat dict-shaped returns as operator-declared; a
-                # bare MagicMock or other sentinel shouldn't count.
-                if isinstance(operator_topic, dict):
+                    logger.debug(
+                        "Failed to check whether Telegram topic is operator-declared",
+                        exc_info=True,
+                    )
+                    # Preserve the operator-owned-name safety boundary when
+                    # the dedicated check itself fails.
                     return
+            else:
+                # Compatibility fallback for third-party/older adapters that
+                # predate the dedicated declaration check.
+                get_info = getattr(type(adapter), "_get_dm_topic_info", None)
+                if callable(get_info):
+                    try:
+                        operator_topic = get_info(
+                            adapter,
+                            str(source.chat_id),
+                            str(source.thread_id),
+                        )
+                    except Exception:
+                        operator_topic = None
+                    if isinstance(operator_topic, dict):
+                        return
 
         session_db = getattr(self, "_session_db", None)
+        binding = None
         if session_db is not None:
             try:
                 binding = await session_db.get_telegram_topic_binding(
@@ -20637,13 +20911,65 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if adapter is None:
             return
         topic_name = self._sanitize_telegram_topic_title(title)
-        try:
-            rename_topic = getattr(adapter, "rename_dm_topic", None)
-            if rename_topic is not None:
-                await rename_topic(
+        icon_custom_emoji_id = await self._select_telegram_topic_icon_id(
+            adapter,
+            source,
+            topic_name,
+            user_message,
+        )
+        if session_db is not None:
+            try:
+                latest_binding = await session_db.get_telegram_topic_binding(
                     chat_id=str(source.chat_id),
                     thread_id=str(source.thread_id),
-                    name=topic_name,
+                )
+                if latest_binding:
+                    if str(latest_binding.get("session_id") or "") != str(session_id):
+                        return
+                elif binding:
+                    # A binding that disappeared while the auxiliary model was
+                    # running is no longer safe to rename.
+                    return
+            except Exception:
+                logger.debug(
+                    "Failed to recheck Telegram topic binding after icon selection",
+                    exc_info=True,
+                )
+                return
+        if icon_custom_emoji_id:
+            extra = self._telegram_topic_extra(source, adapter)
+            preserve_manual = is_truthy_value(
+                extra.get("preserve_manual_topic_icons"),
+                default=True,
+            )
+            if preserve_manual:
+                final_state_fn = getattr(adapter, "dm_topic_custom_icon_state", None)
+                if not callable(final_state_fn):
+                    icon_custom_emoji_id = None
+                else:
+                    try:
+                        if final_state_fn(
+                            str(source.chat_id), str(source.thread_id)
+                        ) is True:
+                            icon_custom_emoji_id = None
+                    except Exception:
+                        logger.debug(
+                            "Failed final Telegram topic icon state check",
+                            exc_info=True,
+                        )
+                        icon_custom_emoji_id = None
+        rename_topic = getattr(adapter, "rename_dm_topic", None)
+        try:
+            if rename_topic is not None:
+                rename_kwargs = {
+                    "chat_id": str(source.chat_id),
+                    "thread_id": str(source.thread_id),
+                    "name": topic_name,
+                }
+                if icon_custom_emoji_id:
+                    rename_kwargs["icon_custom_emoji_id"] = icon_custom_emoji_id
+                await rename_topic(
+                    **rename_kwargs,
                 )
                 return
 
@@ -20654,16 +20980,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if edit_forum_topic is None:
                 return
             try:
+                edit_kwargs = {
+                    "chat_id": int(source.chat_id),
+                    "message_thread_id": int(source.thread_id),
+                    "name": topic_name,
+                }
+                if icon_custom_emoji_id:
+                    edit_kwargs["icon_custom_emoji_id"] = icon_custom_emoji_id
                 await edit_forum_topic(
-                    chat_id=int(source.chat_id),
-                    message_thread_id=int(source.thread_id),
-                    name=topic_name,
+                    **edit_kwargs,
                 )
             except (TypeError, ValueError):
+                edit_kwargs = {
+                    "chat_id": source.chat_id,
+                    "message_thread_id": source.thread_id,
+                    "name": topic_name,
+                }
+                if icon_custom_emoji_id:
+                    edit_kwargs["icon_custom_emoji_id"] = icon_custom_emoji_id
                 await edit_forum_topic(
-                    chat_id=source.chat_id,
-                    message_thread_id=source.thread_id,
-                    name=topic_name,
+                    **edit_kwargs,
                 )
         except Exception:
             logger.debug("Failed to rename Telegram topic for auto-generated title", exc_info=True)
@@ -20674,14 +21010,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Controlled via ``gateway.platforms.telegram.extra.disable_topic_auto_rename``.
         Default is False (auto-rename enabled, preserves prior behaviour).
         """
-        platform_cfg = (
-            self.config.platforms.get(source.platform)
-            if getattr(self, "config", None) and getattr(self.config, "platforms", None)
-            else None
-        )
-        if platform_cfg is None:
-            return False
-        extra = getattr(platform_cfg, "extra", None) or {}
+        extra = self._telegram_topic_extra(source)
         value = extra.get("disable_topic_auto_rename")
         if value is None:
             return False
@@ -20696,6 +21025,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         source: SessionSource,
         session_id: str,
         title: str,
+        user_message: str = "",
     ) -> None:
         """Schedule a topic rename from the auto-title background thread."""
         if not title or not self._is_telegram_topic_lane(source):
@@ -20708,12 +21038,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             loop = getattr(self, "_gateway_loop", None)
         if loop is None or loop.is_closed():
             return
-        try:
-            copied_source = dataclasses.replace(source)
-        except Exception:
-            copied_source = source
+        copied_source = self._copy_source_for_background_rename(source)
         future = safe_schedule_threadsafe(
-            self._rename_telegram_topic_for_session_title(copied_source, session_id, title),
+            self._rename_telegram_topic_for_session_title(
+                copied_source,
+                session_id,
+                title,
+                user_message=user_message,
+            ),
             loop,
             logger=logger,
             log_message="Telegram topic title rename failed to schedule",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -970,6 +970,13 @@ DEFAULT_CONFIG = {
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
             "language": "",
+            # Compact title preferences. The range guides the model; max_words
+            # and the character budget are enforced after generation.
+            "min_words": 2,
+            "max_words": 3,
+            "max_characters": 40,
+            # Case-insensitive aliases mapped to canonical display names.
+            "name_aliases": {},
         },
         "memory_query_rewrite": {
             "provider": "auto",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -833,6 +833,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self._general_request_drain_lock = asyncio.Lock()
         # DM Topics: map of topic_name -> message_thread_id (populated at startup)
         self._dm_topics: Dict[str, int] = {}
+        # Creation-time custom icon state for user-created DM topics. Missing
+        # key = unknown (usually gateway restarted); None = Telegram default
+        # bubble; string = a user-selected full-size custom topic icon.
+        self._dm_topic_creation_icons: Dict[str, Optional[str]] = {}
         # Track forum chats where we've already registered bot commands
         self._forum_command_registered: set[int] = set()
         # Lock per la registrazione sicura dei comandi nei forum supergroup
@@ -3286,6 +3290,9 @@ class TelegramAdapter(BasePlatformAdapter):
 
             topic = await self._bot.create_forum_topic(**kwargs)
             thread_id = topic.message_thread_id
+            self._remember_dm_topic_creation_icon(
+                str(chat_id), str(thread_id), icon_custom_emoji_id
+            )
             logger.info(
                 "[%s] Created DM topic '%s' in chat %s -> thread_id=%s",
                 self.name, name, chat_id, thread_id,
@@ -3390,23 +3397,77 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id: int,
         thread_id: int,
         name: str,
+        icon_custom_emoji_id: Optional[str] = None,
     ) -> None:
-        """Rename a forum topic in a private (DM) chat."""
+        """Rename a private-chat topic and optionally assign a full-size icon."""
         if not self._bot:
             return
         try:
             chat_id_arg = int(chat_id)
         except (TypeError, ValueError):
             chat_id_arg = chat_id
+        kwargs: Dict[str, Any] = {
+            "chat_id": chat_id_arg,
+            "message_thread_id": int(thread_id),
+            "name": name,
+        }
+        if icon_custom_emoji_id:
+            kwargs["icon_custom_emoji_id"] = icon_custom_emoji_id
         await self._bot.edit_forum_topic(
-            chat_id=chat_id_arg,
-            message_thread_id=int(thread_id),
-            name=name,
+            **kwargs,
         )
         logger.info(
             "[%s] Renamed DM topic in chat %s thread_id=%s -> '%s'",
             self.name, chat_id, thread_id, name,
         )
+
+    async def get_forum_topic_icon_options(self) -> List[Dict[str, str]]:
+        """Return Telegram's live allowed topic emojis and custom IDs."""
+        if not self._bot:
+            return []
+        try:
+            stickers = await self._bot.get_forum_topic_icon_stickers()
+        except Exception:
+            logger.debug("[%s] Failed to fetch forum topic icon stickers", self.name, exc_info=True)
+            return []
+
+        options: List[Dict[str, str]] = []
+        seen: Set[tuple[str, str]] = set()
+        for sticker in stickers or []:
+            emoji = str(getattr(sticker, "emoji", "") or "").strip()
+            custom_id = str(getattr(sticker, "custom_emoji_id", "") or "").strip()
+            key = (emoji, custom_id)
+            if not emoji or not custom_id or key in seen:
+                continue
+            seen.add(key)
+            options.append({"emoji": emoji, "custom_emoji_id": custom_id})
+        return options
+
+    @staticmethod
+    def _dm_topic_icon_key(chat_id: str, thread_id: str) -> str:
+        return f"{chat_id}:{thread_id}"
+
+    def _remember_dm_topic_creation_icon(
+        self,
+        chat_id: str,
+        thread_id: str,
+        custom_emoji_id: Optional[str],
+    ) -> None:
+        custom_id = str(custom_emoji_id or "").strip() or None
+        self._dm_topic_creation_icons[
+            self._dm_topic_icon_key(str(chat_id), str(thread_id))
+        ] = custom_id
+
+    def dm_topic_custom_icon_state(
+        self,
+        chat_id: str,
+        thread_id: str,
+    ) -> Optional[bool]:
+        """Return True for manual custom icon, False for default, None if unknown."""
+        key = self._dm_topic_icon_key(str(chat_id), str(thread_id))
+        if key not in self._dm_topic_creation_icons:
+            return None
+        return bool(self._dm_topic_creation_icons[key])
 
     def _persist_dm_topic_thread_id(
         self,
@@ -3679,6 +3740,38 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._post_connect_task is asyncio.current_task():
                 self._post_connect_task = None
 
+    def _register_handlers(self) -> None:
+        """Register Telegram update handlers on the built application."""
+        if self._app is None:
+            return
+
+        topic_status_filter = (
+            filters.StatusUpdate.FORUM_TOPIC_CREATED
+            | filters.StatusUpdate.FORUM_TOPIC_EDITED
+        ) & filters.ChatType.PRIVATE
+        self._app.add_handler(TelegramMessageHandler(
+            topic_status_filter,
+            self._handle_dm_topic_status_update,
+        ))
+        self._app.add_handler(TelegramMessageHandler(
+            filters.TEXT & ~filters.COMMAND,
+            self._handle_text_message
+        ))
+        self._app.add_handler(TelegramMessageHandler(
+            filters.COMMAND,
+            self._handle_command
+        ))
+        self._app.add_handler(TelegramMessageHandler(
+            filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
+            self._handle_location_message
+        ))
+        self._app.add_handler(TelegramMessageHandler(
+            filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
+            self._handle_media_message
+        ))
+        # Handle inline keyboard button callbacks (update prompts)
+        self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to Telegram via polling or webhook.
 
@@ -3891,25 +3984,7 @@ class TelegramAdapter(BasePlatformAdapter):
             self._app = builder.build()
             self._bot = self._app.bot
             
-            # Register handlers
-            self._app.add_handler(TelegramMessageHandler(
-                filters.TEXT & ~filters.COMMAND,
-                self._handle_text_message
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.COMMAND,
-                self._handle_command
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
-                self._handle_location_message
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
-                self._handle_media_message
-            ))
-            # Handle inline keyboard button callbacks (update prompts)
-            self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            self._register_handlers()
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable
@@ -8903,6 +8978,67 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    def _record_dm_topic_status_update(
+        self,
+        message: Message,
+        thread_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Record DM topic creation/edit state without dispatching a prompt."""
+        chat = getattr(message, "chat", None)
+        chat_type = (
+            str(getattr(chat, "type", "")).split(".")[-1].lower()
+            if chat is not None
+            else ""
+        )
+        if chat_type != "private":
+            return None
+
+        effective_thread_id = thread_id or self._effective_message_thread_id(message)
+        if not effective_thread_id:
+            return None
+        chat_id = str(getattr(chat, "id", ""))
+        if not chat_id:
+            return None
+
+        created_name = None
+        created = getattr(message, "forum_topic_created", None)
+        if created:
+            created_name = str(getattr(created, "name", "") or "").strip() or None
+            self._remember_dm_topic_creation_icon(
+                chat_id,
+                effective_thread_id,
+                getattr(created, "icon_custom_emoji_id", None),
+            )
+            if created_name:
+                self._cache_dm_topic_from_message(
+                    chat_id,
+                    effective_thread_id,
+                    created_name,
+                )
+
+        # Telegram uses None when only another field changed, and an empty
+        # string when the custom icon was explicitly removed.
+        edited = getattr(message, "forum_topic_edited", None)
+        if edited:
+            edited_icon = getattr(edited, "icon_custom_emoji_id", None)
+            if edited_icon is not None:
+                self._remember_dm_topic_creation_icon(
+                    chat_id,
+                    effective_thread_id,
+                    edited_icon,
+                )
+        return created_name
+
+    async def _handle_dm_topic_status_update(
+        self,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,
+    ) -> None:
+        """Observe forum topic service updates without dispatching them."""
+        message = self._effective_update_message(update)
+        if message is not None:
+            self._record_dm_topic_status_update(message)
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -9633,11 +9769,56 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.debug("[%s] Failed to reload dm_topics from config: %s", self.name, e)
 
-    def _get_dm_topic_info(self, chat_id: str, thread_id: Optional[str]) -> Optional[Dict[str, Any]]:
-        """Look up DM topic config by chat_id and thread_id.
+    def _is_dm_topic_operator_declared(
+        self,
+        chat_id: str,
+        thread_id: Optional[str],
+    ) -> bool:
+        """Return whether ``thread_id`` belongs to an ``extra.dm_topics`` entry.
 
-        Returns the topic config dict (name, skill, etc.) if this thread_id
-        matches a known DM topic, or None.
+        ``_dm_topics`` also contains names learned from ordinary incoming
+        Telegram messages.  Those transient cache entries are useful for
+        routing, but they must not be treated as operator-owned configuration:
+        doing so suppresses the one-shot semantic title/icon rename.
+        """
+        if not thread_id:
+            return False
+        try:
+            thread_id_int = int(thread_id)
+        except (TypeError, ValueError):
+            return False
+
+        def _configured_match() -> bool:
+            for chat_entry in self._dm_topics_config:
+                if str(chat_entry.get("chat_id")) != str(chat_id):
+                    continue
+                for topic in chat_entry.get("topics", []):
+                    configured_thread_id = topic.get("thread_id")
+                    if configured_thread_id is not None:
+                        try:
+                            if int(configured_thread_id) == thread_id_int:
+                                return True
+                        except (TypeError, ValueError):
+                            continue
+                    topic_name = str(topic.get("name") or "")
+                    if topic_name and self._dm_topics.get(
+                        f"{chat_id}:{topic_name}"
+                    ) == thread_id_int:
+                        return True
+            return False
+
+        if _configured_match():
+            return True
+        self._reload_dm_topics_from_config()
+        return _configured_match()
+
+    def _get_dm_topic_info(self, chat_id: str, thread_id: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Look up a known DM topic by chat_id and thread_id.
+
+        Returns the full operator config dict for an ``extra.dm_topics``
+        entry, or a name-only dict for a topic learned from an incoming
+        Telegram message. Call ``_is_dm_topic_operator_declared`` when the
+        distinction matters.
         """
         if not thread_id:
             return None
@@ -9796,13 +9977,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 chat_topic = topic_info.get("name")
                 topic_skill = topic_info.get("skill")
 
-            # Also check forum_topic_created service message for topic discovery
-            if hasattr(message, "forum_topic_created") and message.forum_topic_created:
-                created_name = message.forum_topic_created.name
-                if created_name:
-                    self._cache_dm_topic_from_message(str(chat.id), thread_id_str, created_name)
-                    if not chat_topic:
-                        chat_topic = created_name
+            # Status updates normally arrive through the dedicated observer,
+            # but keep this idempotent fallback for direct event builders.
+            created_name = self._record_dm_topic_status_update(
+                message,
+                thread_id=thread_id_str,
+            )
+            if created_name and not chat_topic:
+                chat_topic = created_name
 
         elif chat_type == "group" and thread_id_str:
             # Group/supergroup forum topic skill binding via config.extra['group_topics'].

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -1,5 +1,7 @@
 """Tests for agent.title_generator — auto-generated session titles."""
 
+from contextvars import ContextVar
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -55,12 +57,12 @@ class TestGenerateTitle:
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = (
             "<think>The user wants a title. I'll summarize the topic "
-            "concisely.</think>Debugging Python Import Errors"
+            "concisely.</think>Debugging Python imports"
         )
 
         with patch("agent.title_generator.call_llm", return_value=mock_response):
             title = generate_title("help me fix this import")
-            assert title == "Debugging Python Import Errors"
+            assert title == "Debugging Python imports"
             assert "<think>" not in title
             assert "summarize" not in title
 
@@ -87,7 +89,8 @@ class TestGenerateTitle:
 
         with patch("agent.title_generator.call_llm", return_value=mock_response):
             title = generate_title("question")
-            assert len(title) == 80
+            assert title is not None
+            assert len(title) == 40
             assert title.endswith("...")
 
 
@@ -101,7 +104,7 @@ class TestGenerateTitle:
 
         exc = RuntimeError("openrouter 402: credits exhausted")
         with patch("agent.title_generator.call_llm", side_effect=exc):
-            result = generate_title("question", "answer", failure_callback=_cb)
+            result = generate_title("question", failure_callback=_cb)
 
         assert result is None
         assert len(captured) == 1
@@ -116,6 +119,236 @@ class TestGenerateTitle:
 
 
 
+
+
+    def test_default_prompt_is_compact_and_matches_user_language(self):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = '{"title": "Some title"}'
+
+        with patch("agent.title_generator.call_llm", return_value=response) as llm:
+            generate_title("質問です")
+
+        prompt = llm.call_args.kwargs["messages"][0]["content"]
+        assert "same language as the user's message" in prompt
+        assert "2-3 words" in prompt
+        assert "named project" in prompt
+        assert "Fixing" in prompt
+        assert "Do not include emoji" in prompt
+
+    def test_compact_preferences_and_name_aliases_are_configurable(self):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = '{"title": "Planning flow"}'
+        config = {
+            "auxiliary": {
+                "title_generation": {
+                    "min_words": 1,
+                    "max_words": 2,
+                    "max_characters": 24,
+                    "name_aliases": {
+                        "project atlas": "ProjectAtlas",
+                        "atlas app": "ProjectAtlas",
+                    },
+                }
+            }
+        }
+
+        with (
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+            patch("agent.title_generator.call_llm", return_value=response) as llm,
+        ):
+            assert generate_title("Update the ATLAS APP") == "ProjectAtlas"
+
+        prompt = llm.call_args.kwargs["messages"][0]["content"]
+        assert "1-2 words" in prompt
+        assert "24 characters" in prompt
+        assert '\"project atlas\": \"ProjectAtlas\"' in prompt
+        assert '\"atlas app\": \"ProjectAtlas\"' in prompt
+
+    def test_invalid_word_range_clamps_minimum_to_maximum(self):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = '{"title": "Discord title"}'
+        config = {
+            "auxiliary": {
+                "title_generation": {"min_words": 7, "max_words": 2}
+            }
+        }
+
+        with (
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+            patch("agent.title_generator.call_llm", return_value=response) as llm,
+        ):
+            assert generate_title("Tune Discord titles") == "Discord title"
+
+        prompt = llm.call_args.kwargs["messages"][0]["content"]
+        assert "Prefer exactly 2 words" in prompt
+
+    def test_configured_word_maximum_is_enforced_after_generation(self):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = (
+            '{"title": "Discord semantic thread title rollout"}'
+        )
+        config = {
+            "auxiliary": {
+                "title_generation": {"min_words": 2, "max_words": 3}
+            }
+        }
+
+        with (
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+            patch("agent.title_generator.call_llm", return_value=response),
+        ):
+            title = generate_title("Tune Discord semantic thread titles")
+
+        assert title == "Discord semantic thread"
+
+    def test_configured_word_maximum_is_enforced_after_alias_handling(self):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = '{"title": "Atlas rollout"}'
+        config = {
+            "auxiliary": {
+                "title_generation": {
+                    "min_words": 2,
+                    "max_words": 3,
+                    "name_aliases": {
+                        "atlas app": "Project Atlas migration rollout"
+                    },
+                }
+            }
+        }
+
+        with (
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+            patch("agent.title_generator.call_llm", return_value=response),
+        ):
+            title = generate_title("Open the atlas app")
+
+        assert title == "Project Atlas migration"
+
+    def test_name_aliases_match_whole_terms_not_substrings(self):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = '{"title": "Atlassian migration"}'
+        config = {
+            "auxiliary": {
+                "title_generation": {"name_aliases": {"atlas": "ProjectAtlas"}}
+            }
+        }
+
+        with (
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+            patch("agent.title_generator.call_llm", return_value=response),
+        ):
+            title = generate_title("Plan the Atlassian migration")
+
+        assert title == "Atlassian migration"
+
+    def test_longest_matching_alias_wins(self):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = '{"title": "Atlas"}'
+        config = {
+            "auxiliary": {
+                "title_generation": {
+                    "name_aliases": {"atlas": "Atlas", "atlas app": "ProjectAtlas"}
+                }
+            }
+        }
+
+        with (
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+            patch("agent.title_generator.call_llm", return_value=response),
+        ):
+            title = generate_title("Open the atlas app")
+
+        assert title == "ProjectAtlas"
+
+    def test_canonical_alias_outranks_character_preference(self):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = '{"title": "Atlas"}'
+        config = {
+            "auxiliary": {
+                "title_generation": {
+                    "max_characters": 12,
+                    "name_aliases": {"atlas app": "ProjectAtlasLongName"},
+                }
+            }
+        }
+
+        with (
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+            patch("agent.title_generator.call_llm", return_value=response),
+        ):
+            title = generate_title("Open the atlas app")
+
+        assert title == "ProjectAtlasLongName"
+
+    def test_name_alias_after_prompt_snippet_is_still_enforced(self):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = '{"title": "Planning flow"}'
+        config = {
+            "auxiliary": {
+                "title_generation": {"name_aliases": {"atlas app": "ProjectAtlas"}}
+            }
+        }
+
+        with (
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+            patch("agent.title_generator.call_llm", return_value=response),
+        ):
+            title = generate_title("x" * 1100 + " atlas app")
+
+        assert title == "ProjectAtlas"
+
+    def test_name_aliases_ignore_hidden_skill_scaffolding(self):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = '{"title": "Title leak"}'
+        config = {
+            "auxiliary": {
+                "title_generation": {"name_aliases": {"worktree": "Worktree"}}
+            }
+        }
+
+        with (
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+            patch("agent.title_generator.call_llm", return_value=response),
+            patch(
+                "agent.title_generator._summarize_user_message",
+                return_value="/work — fix the title leak",
+            ),
+        ):
+            title = generate_title(
+                "/work scaffolding with hidden instructions about a fresh worktree"
+            )
+
+        assert title == "Title leak"
+
+    def test_configured_character_limit_is_enforced(self):
+        response = MagicMock()
+        response.choices = [MagicMock()]
+        response.choices[0].message.content = '{"title": "' + "A" * 40 + '"}'
+        config = {
+            "auxiliary": {
+                "title_generation": {"max_words": 2, "max_characters": 24}
+            }
+        }
+
+        with (
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+            patch("agent.title_generator.call_llm", return_value=response),
+        ):
+            title = generate_title("question")
+
+        assert title is not None
+        assert len(title) == 24
+        assert title.endswith("...")
 
 
 class TestAutoTitleSession:
@@ -369,9 +602,42 @@ class TestMaybeAutoTitle:
             maybe_auto_title(db, "sess-1", "hi", [])
         assert db.get_session_title("sess-1") is None
 
+    def test_background_thread_preserves_contextvars(self, tmp_path):
+        marker = ContextVar("title-test-marker", default="primary")
+        seen = []
+        db = SessionDB(tmp_path / "state.db")
+        db.create_session(session_id="sess-1", source="cli")
+        token = marker.set("secondary")
 
+        try:
+            with patch("agent.title_generator.auto_title_session") as mock_auto:
+                import threading
 
+                called = threading.Event()
 
+                def _capture(*_args, **_kwargs):
+                    seen.append(marker.get())
+                    called.set()
+
+                mock_auto.side_effect = _capture
+                maybe_auto_title(db, "sess-1", "hello", [])
+                assert called.wait(timeout=10), "auto_title thread never ran"
+        finally:
+            marker.reset(token)
+
+        assert seen == ["secondary"]
+
+    def test_skips_when_title_generation_disabled(self):
+        db = MagicMock()
+        config = {"auxiliary": {"title_generation": {"enabled": False}}}
+
+        with (
+            patch("hermes_cli.config.load_config_readonly", return_value=config),
+            patch("agent.title_generator.auto_title_session") as mock_auto,
+        ):
+            maybe_auto_title(db, "sess-1", "hello", [])
+
+        mock_auto.assert_not_called()
 
 
 class TestAutoTitleDuplicateHandling:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from agent.title_generator import (
     generate_title,
+    choose_topic_icon,
     auto_title_session,
     maybe_auto_title,
     _title_language,
@@ -349,6 +350,117 @@ class TestGenerateTitle:
         assert title is not None
         assert len(title) == 24
         assert title.endswith("...")
+
+
+class TestChooseTopicIcon:
+    def test_returns_exact_allowed_emoji(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "🚀"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response) as llm:
+            result = choose_topic_icon(
+                "ProjectAtlas",
+                "Let's improve the ProjectAtlas planning workflow",
+                ["📊", "🚀", "🛠️"],
+            )
+
+        assert result == "🚀"
+        prompt = llm.call_args.kwargs["messages"][0]["content"]
+        assert "ranked" in prompt
+        assert "specific, playful visual metaphors" in prompt
+        assert "📊" in prompt and "🚀" in prompt and "🛠️" in prompt
+        assert llm.call_args.kwargs["temperature"] == 0.7
+
+    def test_extracts_single_allowed_emoji_from_wrapped_response(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Emoji: 💳"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert choose_topic_icon("Finance", "credit card benefits", ["🚀", "💳"]) == "💳"
+
+    def test_matches_allowed_variation_selector_form(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "⚡"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert choose_topic_icon("ProjectBolt", "fast analysis", ["⚡️", "💡"]) == "⚡️"
+
+    def test_prefers_ranked_candidate_that_was_not_used_recently(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "🚀 📊 🧪"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response) as llm:
+            assert choose_topic_icon(
+                "Launch",
+                "compare metrics",
+                ["🚀", "📊", "🧪"],
+                recent_emojis=["🚀"],
+            ) == "📊"
+
+        prompt = llm.call_args.kwargs["messages"][0]["content"]
+        assert "used recently" in prompt
+        assert "🚀" in prompt
+
+    def test_excludes_recent_icons_from_large_candidate_pool(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "💻"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert choose_topic_icon(
+                "Developer Tools",
+                "debug the agent",
+                ["💻", "🎨", "🧪", "🔭", "🛠️"],
+                recent_emojis=["💻"],
+            ) is None
+
+    def test_compound_emoji_wins_over_overlapping_component(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "👮‍♂️ ⚡"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert choose_topic_icon(
+                "Safety",
+                "police safety workflow",
+                ["👮", "👮‍♂️", "♂️", "⚡️"],
+            ) == "👮‍♂️"
+            assert choose_topic_icon(
+                "Safety",
+                "police safety workflow",
+                ["👮", "👮‍♂️", "♂️", "⚡️"],
+                recent_emojis=["👮‍♂️"],
+            ) == "⚡️"
+
+    def test_falls_back_to_top_ranked_candidate_when_all_were_recent(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "💻 🤖"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert choose_topic_icon(
+                "Developer Tools",
+                "debug the agent",
+                ["💻", "🤖"],
+                recent_emojis=["💻", "🤖"],
+            ) == "💻"
+
+    def test_rejects_response_without_an_allowed_candidate(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "🛸"
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert choose_topic_icon("Launch", "ship it", ["🚀", "📊"]) is None
+
+    def test_skips_without_allowed_icons(self):
+        with patch("agent.title_generator.call_llm") as llm:
+            assert choose_topic_icon("Launch", "ship it", []) is None
+        llm.assert_not_called()
 
 
 class TestAutoTitleSession:
@@ -716,7 +828,7 @@ class TestRuntimeValidator:
 
         with patch("agent.title_generator.call_llm", return_value=mock_response) as mock_llm:
             title = generate_title(
-                "question", "answer",
+                "question",
                 runtime_validator=_bad_validator,
             )
             assert title == "Resilient Title"

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -327,11 +327,58 @@ def test_cache_dm_topic_from_message_no_overwrite():
     assert adapter._dm_topics["111:General"] == 100  # unchanged
 
 
+@pytest.mark.asyncio
+async def test_forum_topic_icon_options_use_live_sticker_ids():
+    adapter = _make_adapter()
+    adapter._bot = AsyncMock()
+    adapter._bot.get_forum_topic_icon_stickers.return_value = [
+        SimpleNamespace(emoji="🚀", custom_emoji_id="rocket-id"),
+        SimpleNamespace(emoji="📊", custom_emoji_id="chart-id"),
+        SimpleNamespace(emoji=None, custom_emoji_id="missing-label"),
+    ]
+
+    assert await adapter.get_forum_topic_icon_options() == [
+        {"emoji": "🚀", "custom_emoji_id": "rocket-id"},
+        {"emoji": "📊", "custom_emoji_id": "chart-id"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rename_dm_topic_can_apply_full_size_custom_icon():
+    adapter = _make_adapter()
+    adapter._bot = AsyncMock()
+
+    await adapter.rename_dm_topic(
+        chat_id="111",
+        thread_id="42",
+        name="ProjectAtlas",
+        icon_custom_emoji_id="rocket-id",
+    )
+
+    adapter._bot.edit_forum_topic.assert_awaited_once_with(
+        chat_id=111,
+        message_thread_id=42,
+        name="ProjectAtlas",
+        icon_custom_emoji_id="rocket-id",
+    )
+
+
+def test_topic_creation_icon_state_distinguishes_default_manual_and_unknown():
+    adapter = _make_adapter()
+
+    assert adapter.dm_topic_custom_icon_state("111", "42") is None
+    adapter._remember_dm_topic_creation_icon("111", "42", None)
+    assert adapter.dm_topic_custom_icon_state("111", "42") is False
+    adapter._remember_dm_topic_creation_icon("111", "43", "manual-id")
+    assert adapter.dm_topic_custom_icon_state("111", "43") is True
+
+
 # ── _build_message_event: auto_skill binding ──
 
 
 def _make_mock_message(chat_id=111, chat_type="private", text="hello", thread_id=None,
                        user_id=42, user_name="Test User", forum_topic_created=None,
+                       forum_topic_edited=None,
                        is_topic_message=None, is_forum=None):
     """Create a mock Telegram Message for _build_message_event tests."""
     chat = SimpleNamespace(
@@ -363,6 +410,7 @@ def _make_mock_message(chat_id=111, chat_type="private", text="hello", thread_id
         reply_to_message=None,
         date=None,
         forum_topic_created=forum_topic_created,
+        forum_topic_edited=forum_topic_edited,
     )
     return msg
 
@@ -408,6 +456,43 @@ def test_build_message_event_no_auto_skill_without_binding():
 
     assert event.auto_skill is None
     assert event.source.chat_topic == "General"
+
+
+def test_build_message_event_remembers_manual_topic_icon():
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    created = SimpleNamespace(name="ProjectAtlas", icon_custom_emoji_id="rocket-id")
+    msg = _make_mock_message(
+        chat_id=111,
+        thread_id=201,
+        text="",
+        forum_topic_created=created,
+        is_topic_message=True,
+    )
+
+    adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert adapter.dm_topic_custom_icon_state("111", "201") is True
+
+
+def test_build_message_event_tracks_manual_icon_edit_before_auto_title():
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    adapter._remember_dm_topic_creation_icon("111", "201", None)
+    edited = SimpleNamespace(name=None, icon_custom_emoji_id="manual-id")
+    msg = _make_mock_message(
+        chat_id=111,
+        thread_id=201,
+        text="",
+        forum_topic_edited=edited,
+        is_topic_message=True,
+    )
+
+    adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert adapter.dm_topic_custom_icon_state("111", "201") is True
 
 
 # ── _build_message_event: group_topics skill binding ──
@@ -477,4 +562,24 @@ def test_group_topic_skill_binding_second_topic():
 
 # ── _build_message_event: from_user=None fallback in DMs ──
 
+def test_operator_declared_topic_check_ignores_message_only_cache():
+    """A Telegram-supplied topic name is not an operator dm_topics entry."""
+    adapter = _make_adapter()
+    adapter._cache_dm_topic_from_message("111", "100", "Can you still or")
+    adapter._reload_dm_topics_from_config = lambda: None
+
+    # General topic lookup still exposes the cached display name for routing.
+    assert adapter._get_dm_topic_info("111", "100") == {"name": "Can you still or"}
+    # The rename guard must not mistake that transient cache entry for config.
+    assert adapter._is_dm_topic_operator_declared("111", "100") is False
+
+
+def test_operator_declared_topic_check_accepts_configured_cache_entry():
+    """A topic explicitly present in extra.dm_topics remains protected."""
+    adapter = _make_adapter([
+        {"chat_id": 111, "topics": [{"name": "Research", "skill": "arxiv"}]}
+    ])
+    adapter._dm_topics["111:Research"] = 100
+
+    assert adapter._is_dm_topic_operator_declared("111", "100") is True
 

--- a/tests/gateway/test_session_title_rename_lane.py
+++ b/tests/gateway/test_session_title_rename_lane.py
@@ -27,7 +27,7 @@ def _attach(lane):
         _is_discord_auto_thread_lane=lambda src: lane == "discord",
         _is_relay_discord_channel_lane=lambda src: False,
         _schedule_telegram_topic_title_rename=(
-            lambda src, sid, title: renames.append(title)
+            lambda src, sid, title, **kwargs: renames.append(title)
         ),
         _schedule_discord_semantic_thread_rename=(
             lambda src, sid, title: renames.append(title)
@@ -53,3 +53,31 @@ def test_the_rename_waits_for_the_model_title(lane):
 
     callback("Fix flaky auth test", "llm")
     assert renames == ["Fix flaky auth test"]
+
+
+def test_telegram_callback_forwards_opening_message_to_icon_selector():
+    calls = []
+    source = types.SimpleNamespace(platform=Platform.TELEGRAM, chat_id="chat-1")
+    runner = types.SimpleNamespace(
+        _is_telegram_topic_lane=lambda src: True,
+        _is_discord_auto_thread_lane=lambda src: False,
+        _is_relay_discord_channel_lane=lambda src: False,
+        _schedule_telegram_topic_title_rename=(
+            lambda src, sid, title, **kwargs: calls.append((title, kwargs))
+        ),
+        _schedule_discord_semantic_thread_rename=lambda *args, **kwargs: None,
+    )
+    holder = types.SimpleNamespace(
+        _runner=runner,
+        _attach_session_title_callback=TurnRunner._attach_session_title_callback,
+    )
+    agent = types.SimpleNamespace(session_id="sess-1")
+    holder._attach_session_title_callback(
+        holder,
+        agent,
+        types.SimpleNamespace(source=source, message="Build a lunar calendar"),
+    )
+
+    agent._on_session_title("Lunar calendar", "llm")
+
+    assert calls == [("Lunar calendar", {"user_message": "Build a lunar calendar"})]

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -4,9 +4,13 @@ Topic mode makes the root Telegram DM a system lobby while user-created
 Telegram topics act as independent Hermes session lanes.
 """
 
+import asyncio
+import threading
+from collections import OrderedDict
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -67,6 +71,8 @@ def _make_runner(session_db=None):
     adapter._bot = None
     adapter._create_dm_topic = AsyncMock(return_value=None)
     adapter.rename_dm_topic = AsyncMock()
+    adapter.get_forum_topic_icon_options = AsyncMock(return_value=[])
+    adapter.dm_topic_custom_icon_state = MagicMock(return_value=None)
     runner.adapters = {Platform.TELEGRAM: adapter}
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(
@@ -567,7 +573,7 @@ async def test_handoff_to_telegram_dm_topic_uses_dm_lane_not_generic_thread(tmp_
         chat_id="208214988",
         name="Tester DM",
     )
-    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
     adapter.create_handoff_thread = AsyncMock(return_value="17585")
     adapter.send.return_value = SimpleNamespace(success=True)
     captured = {}
@@ -762,3 +768,719 @@ def test_get_telegram_topic_binding_by_session_returns_binding(tmp_path):
 # Test for session-split thread_id recovery (issue #27166)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.asyncio
+async def test_first_auto_title_assigns_icon_when_creation_state_is_unknown(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    runner.config.platforms[Platform.TELEGRAM].extra["auto_topic_icons"] = True
+    runner.config.platforms[Platform.TELEGRAM].extra["preserve_manual_topic_icons"] = True
+    # Private DM topics do not reliably emit forum_topic_created updates. The
+    # one-shot first-title path must remain eligible when state is unknown, or
+    # every such topic keeps Telegram's default letter bubble.
+    adapter.dm_topic_custom_icon_state.return_value = None
+    adapter.get_forum_topic_icon_options.return_value = [
+        {"emoji": "📊", "custom_emoji_id": "chart-id"},
+        {"emoji": "🚀", "custom_emoji_id": "rocket-id"},
+    ]
+
+    with patch("agent.title_generator.choose_topic_icon", return_value="🚀") as choose:
+        await runner._rename_telegram_topic_for_session_title(
+            _make_source(thread_id="42"),
+            "sess-topic",
+            "ProjectAtlas",
+            user_message="Improve the ProjectAtlas planning flow",
+        )
+
+    choose.assert_called_once_with(
+        "ProjectAtlas",
+        "Improve the ProjectAtlas planning flow",
+        ["📊", "🚀"],
+        recent_emojis=[],
+    )
+    adapter.rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="ProjectAtlas",
+        icon_custom_emoji_id="rocket-id",
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_icon_uses_secondary_transport_profile_config():
+    runner = _make_runner()
+    default_adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    default_adapter.config = runner.config.platforms[Platform.TELEGRAM]
+    runner.config.platforms[Platform.TELEGRAM].extra["auto_topic_icons"] = False
+
+    secondary_config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={
+            "auto_topic_icons": True,
+            "preserve_manual_topic_icons": False,
+            "disable_topic_auto_rename": True,
+        },
+    )
+    secondary_adapter = MagicMock()
+    secondary_adapter.config = secondary_config
+    secondary_adapter.get_forum_topic_icon_options = AsyncMock(
+        return_value=[{"emoji": "🚀", "custom_emoji_id": "rocket-id"}]
+    )
+    runner._profile_adapters = {
+        "work": {Platform.TELEGRAM: secondary_adapter},
+    }
+    source = _make_source(thread_id="42")
+    source.profile = "work"
+
+    with patch("agent.title_generator.choose_topic_icon", return_value="🚀"):
+        selected = await runner._select_telegram_topic_icon_id(
+            secondary_adapter,
+            source,
+            "ProjectAtlas",
+            "Work on ProjectAtlas",
+        )
+
+    assert selected == "rocket-id"
+    assert runner._telegram_topic_auto_rename_disabled(source) is True
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_icon_selection_remembers_recent_choices_per_chat():
+    runner = _make_runner()
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    extra = runner.config.platforms[Platform.TELEGRAM].extra
+    extra["auto_topic_icons"] = True
+    adapter.dm_topic_custom_icon_state.return_value = False
+    adapter.get_forum_topic_icon_options.return_value = [
+        {"emoji": "💻", "custom_emoji_id": "computer-id"},
+        {"emoji": "🎨", "custom_emoji_id": "art-id"},
+        {"emoji": "🧪", "custom_emoji_id": "lab-id"},
+    ]
+    source = _make_source(thread_id="42")
+
+    with patch(
+        "agent.title_generator.choose_topic_icon",
+        side_effect=["💻", "🎨"],
+    ) as choose:
+        first = await runner._select_telegram_topic_icon_id(
+            adapter,
+            source,
+            "Developer Tools",
+            "debug the agent",
+        )
+        second = await runner._select_telegram_topic_icon_id(
+            adapter,
+            source,
+            "Creative Assets",
+            "design a campaign",
+        )
+
+    assert first == "computer-id"
+    assert second == "art-id"
+    assert choose.call_args_list == [
+        call(
+            "Developer Tools",
+            "debug the agent",
+            ["💻", "🎨", "🧪"],
+            recent_emojis=[],
+        ),
+        call(
+            "Creative Assets",
+            "design a campaign",
+            ["💻", "🎨", "🧪"],
+            recent_emojis=["💻"],
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_icon_selection_serializes_same_chat_history():
+    runner = _make_runner()
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    runner.config.platforms[Platform.TELEGRAM].extra["auto_topic_icons"] = True
+    adapter.dm_topic_custom_icon_state.return_value = False
+    adapter.get_forum_topic_icon_options.return_value = [
+        {"emoji": "💻", "custom_emoji_id": "computer-id"},
+        {"emoji": "🎨", "custom_emoji_id": "art-id"},
+    ]
+    source = _make_source(thread_id="42")
+    first_started = threading.Event()
+    release_first = threading.Event()
+    observed_recent: list[list[str]] = []
+
+    def choose(*args, recent_emojis, **kwargs):
+        observed_recent.append(list(recent_emojis))
+        if len(observed_recent) == 1:
+            first_started.set()
+            assert release_first.wait(timeout=2)
+            return "💻"
+        return "🎨"
+
+    with patch("agent.title_generator.choose_topic_icon", side_effect=choose):
+        first_task = asyncio.create_task(
+            runner._select_telegram_topic_icon_id(
+                adapter,
+                source,
+                "Developer Tools",
+                "debug the agent",
+            )
+        )
+        assert await asyncio.to_thread(first_started.wait, 2)
+        second_task = asyncio.create_task(
+            runner._select_telegram_topic_icon_id(
+                adapter,
+                source,
+                "Creative Assets",
+                "design a campaign",
+            )
+        )
+        await asyncio.sleep(0.05)
+        release_first.set()
+        assert await asyncio.gather(first_task, second_task) == [
+            "computer-id",
+            "art-id",
+        ]
+
+    assert observed_recent == [[], ["💻"]]
+    entry = runner._telegram_topic_icon_locks["208214988"]
+    assert entry["users"] == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_icon_history_is_isolated_per_chat():
+    runner = _make_runner()
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    runner.config.platforms[Platform.TELEGRAM].extra["auto_topic_icons"] = True
+    adapter.dm_topic_custom_icon_state.return_value = False
+    adapter.get_forum_topic_icon_options.return_value = [
+        {"emoji": "💻", "custom_emoji_id": "computer-id"},
+        {"emoji": "🎨", "custom_emoji_id": "art-id"},
+    ]
+    first_source = _make_source(thread_id="42")
+    second_source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="999",
+        chat_id="999",
+        user_name="other",
+        chat_type="dm",
+        thread_id="43",
+    )
+
+    with patch(
+        "agent.title_generator.choose_topic_icon",
+        side_effect=["💻", "🎨"],
+    ) as choose:
+        await runner._select_telegram_topic_icon_id(
+            adapter,
+            first_source,
+            "Developer Tools",
+            "debug the agent",
+        )
+        await runner._select_telegram_topic_icon_id(
+            adapter,
+            second_source,
+            "Creative Assets",
+            "design a campaign",
+        )
+
+    assert choose.call_args_list[0].kwargs["recent_emojis"] == []
+    assert choose.call_args_list[1].kwargs["recent_emojis"] == []
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_icon_per_chat_state_is_lru_bounded():
+    runner = _make_runner()
+    runner._telegram_topic_icon_locks = OrderedDict(
+        (str(index), {"lock": asyncio.Lock(), "users": 0})
+        for index in range(256)
+    )
+    runner._telegram_topic_icon_history = OrderedDict(
+        (str(index), ["💻"]) for index in range(256)
+    )
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+
+    result = await runner._select_telegram_topic_icon_id(
+        adapter,
+        _make_source(thread_id="42"),
+        "Developer Tools",
+        "debug the agent",
+    )
+
+    assert result is None
+    assert len(runner._telegram_topic_icon_locks) == 256
+    assert "208214988" in runner._telegram_topic_icon_locks
+    assert "0" not in runner._telegram_topic_icon_locks
+    assert "0" not in runner._telegram_topic_icon_history
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_icon_lock_cache_recovers_after_concurrent_pressure():
+    runner = _make_runner()
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    all_started = asyncio.Event()
+    release = asyncio.Event()
+    started = 0
+
+    async def blocked_selection(adapter, source, title, user_message):
+        nonlocal started
+        started += 1
+        if started == 300:
+            all_started.set()
+        await release.wait()
+        return None
+
+    runner._select_telegram_topic_icon_id_unlocked = blocked_selection
+    tasks = [
+        asyncio.create_task(
+            runner._select_telegram_topic_icon_id(
+                adapter,
+                SessionSource(
+                    platform=Platform.TELEGRAM,
+                    user_id=str(index),
+                    chat_id=str(index),
+                    user_name="tester",
+                    chat_type="dm",
+                    thread_id="42",
+                ),
+                f"Topic {index}",
+                f"Opening request {index}",
+            )
+        )
+        for index in range(300)
+    ]
+
+    await asyncio.wait_for(all_started.wait(), timeout=2)
+    assert len(runner._telegram_topic_icon_locks) == 300
+    assert all(
+        entry["users"] == 1
+        for entry in runner._telegram_topic_icon_locks.values()
+    )
+    release.set()
+    await asyncio.gather(*tasks)
+
+    assert len(runner._telegram_topic_icon_locks) == 256
+    assert all(
+        entry["users"] == 0
+        for entry in runner._telegram_topic_icon_locks.values()
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_icon_history_keeps_only_twelve_recent_unique_choices():
+    runner = _make_runner()
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    runner.config.platforms[Platform.TELEGRAM].extra["auto_topic_icons"] = True
+    adapter.dm_topic_custom_icon_state.return_value = False
+    emojis = [
+        "📰", "💡", "⚡️", "🎙", "🔝", "🗣", "🆒",
+        "❗️", "📝", "📆", "📁", "🔎", "📣", "🔥",
+    ]
+    adapter.get_forum_topic_icon_options.return_value = [
+        {"emoji": emoji, "custom_emoji_id": f"icon-{index}"}
+        for index, emoji in enumerate(emojis)
+    ]
+    source = _make_source(thread_id="42")
+
+    with patch(
+        "agent.title_generator.choose_topic_icon",
+        side_effect=emojis,
+    ) as choose:
+        for index in range(len(emojis)):
+            selected_id = await runner._select_telegram_topic_icon_id(
+                adapter,
+                source,
+                f"Topic {index}",
+                f"Opening request {index}",
+            )
+            assert selected_id == f"icon-{index}"
+
+    assert runner._telegram_topic_icon_history["208214988"] == emojis[-12:]
+    assert choose.call_args_list[-1].kwargs["recent_emojis"] == emojis[1:13]
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_icons_preserve_manual_custom_icon(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    runner.config.platforms[Platform.TELEGRAM].extra["auto_topic_icons"] = True
+    adapter.dm_topic_custom_icon_state.return_value = True
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "ProjectAtlas",
+        user_message="Improve the onboarding flow",
+    )
+
+    adapter.get_forum_topic_icon_options.assert_not_called()
+    adapter.rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="ProjectAtlas",
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_icons_recheck_manual_icon_after_llm_choice(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    runner.config.platforms[Platform.TELEGRAM].extra["auto_topic_icons"] = True
+    adapter.dm_topic_custom_icon_state.side_effect = [False, True]
+    adapter.get_forum_topic_icon_options.return_value = [
+        {"emoji": "🔭", "custom_emoji_id": "scope-id"},
+    ]
+
+    with patch("agent.title_generator.choose_topic_icon", return_value="🔭"):
+        await runner._rename_telegram_topic_for_session_title(
+            _make_source(thread_id="42"),
+            "sess-topic",
+            "ProjectAtlas",
+            user_message="Improve the ProjectAtlas planning flow",
+        )
+
+    adapter.rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="ProjectAtlas",
+    )
+    assert getattr(runner, "_telegram_topic_icon_history", {}) == {}
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_icon_override_uses_live_matching_sticker_without_llm(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    extra = runner.config.platforms[Platform.TELEGRAM].extra
+    extra["auto_topic_icons"] = True
+    extra["topic_icon_overrides"] = {"projectatlas": "🚀"}
+    adapter.dm_topic_custom_icon_state.return_value = False
+    adapter.get_forum_topic_icon_options.return_value = [
+        {"emoji": "🚀", "custom_emoji_id": "rocket-id"},
+    ]
+
+    with patch("agent.title_generator.choose_topic_icon") as choose:
+        await runner._rename_telegram_topic_for_session_title(
+            _make_source(thread_id="42"),
+            "sess-topic",
+            "ProjectAtlas",
+            user_message="Improve onboarding",
+        )
+
+    choose.assert_not_called()
+    adapter.rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="ProjectAtlas",
+        icon_custom_emoji_id="rocket-id",
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_icon_override_matches_deduped_lineage_title():
+    runner = _make_runner()
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    extra = runner.config.platforms[Platform.TELEGRAM].extra
+    extra["auto_topic_icons"] = True
+    extra["topic_icon_overrides"] = {"projectatlas": "🔭"}
+    adapter.dm_topic_custom_icon_state.return_value = False
+    adapter.get_forum_topic_icon_options.return_value = [
+        {"emoji": "🔭", "custom_emoji_id": "telescope-id"},
+        {"emoji": "🚀", "custom_emoji_id": "rocket-id"},
+    ]
+
+    with patch("agent.title_generator.choose_topic_icon") as choose:
+        selected = await runner._select_telegram_topic_icon_id(
+            adapter,
+            _make_source(thread_id="42"),
+            "ProjectAtlas #2",
+            "Improve onboarding",
+        )
+
+    choose.assert_not_called()
+    assert selected == "telescope-id"
+
+
+@pytest.mark.asyncio
+async def test_exact_deduped_override_beats_earlier_base_override():
+    runner = _make_runner()
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    extra = runner.config.platforms[Platform.TELEGRAM].extra
+    extra["auto_topic_icons"] = True
+    # Base is intentionally inserted first; the exact title must still win.
+    extra["topic_icon_overrides"] = {
+        "projectatlas": "🔭",
+        "projectatlas #2": "🚀",
+    }
+    adapter.dm_topic_custom_icon_state.return_value = False
+    adapter.get_forum_topic_icon_options.return_value = [
+        {"emoji": "🔭", "custom_emoji_id": "telescope-id"},
+        {"emoji": "🚀", "custom_emoji_id": "rocket-id"},
+    ]
+
+    with patch("agent.title_generator.choose_topic_icon") as choose:
+        selected = await runner._select_telegram_topic_icon_id(
+            adapter,
+            _make_source(thread_id="42"),
+            "ProjectAtlas #2",
+            "Improve onboarding",
+        )
+
+    choose.assert_not_called()
+    assert selected == "rocket-id"
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_icon_override_matches_variation_selector_form(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    extra = runner.config.platforms[Platform.TELEGRAM].extra
+    extra["auto_topic_icons"] = True
+    extra["topic_icon_overrides"] = {"projectbolt": "⚡"}
+    adapter.dm_topic_custom_icon_state.return_value = False
+    adapter.get_forum_topic_icon_options.return_value = [
+        {"emoji": "⚡️", "custom_emoji_id": "bolt-id"},
+    ]
+
+    with patch("agent.title_generator.choose_topic_icon") as choose:
+        await runner._rename_telegram_topic_for_session_title(
+            _make_source(thread_id="42"),
+            "sess-topic",
+            "ProjectBolt",
+            user_message="Improve performance",
+        )
+
+    choose.assert_not_called()
+    adapter.rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="ProjectBolt",
+        icon_custom_emoji_id="bolt-id",
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_generated_title_rechecks_binding_after_icon_selection():
+    session_db = MagicMock()
+    session_db.get_telegram_topic_binding.side_effect = [
+        {"session_id": "sess-topic"},
+        {"session_id": "sess-other"},
+    ]
+    runner = _make_runner(session_db=session_db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    runner.config.platforms[Platform.TELEGRAM].extra["auto_topic_icons"] = True
+    adapter.dm_topic_custom_icon_state.return_value = False
+    adapter.get_forum_topic_icon_options.return_value = [
+        {"emoji": "🔭", "custom_emoji_id": "scope-id"},
+    ]
+
+    with patch("agent.title_generator.choose_topic_icon", return_value="🔭"):
+        await runner._rename_telegram_topic_for_session_title(
+            _make_source(thread_id="42"),
+            "sess-topic",
+            "ProjectAtlas",
+            user_message="Improve planning",
+        )
+
+    assert session_db.get_telegram_topic_binding.call_count == 2
+    adapter.rename_dm_topic.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_manual_icon_change_during_binding_recheck_prevents_icon_overwrite():
+    second_binding_started = threading.Event()
+    release_second_binding = threading.Event()
+    binding_calls = 0
+
+    def get_binding(**kwargs):
+        nonlocal binding_calls
+        binding_calls += 1
+        if binding_calls == 2:
+            second_binding_started.set()
+            assert release_second_binding.wait(timeout=2)
+        return {"session_id": "sess-topic"}
+
+    session_db = MagicMock()
+    session_db.get_telegram_topic_binding.side_effect = get_binding
+    runner = _make_runner(session_db=session_db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    adapter = cast(Any, runner.adapters[Platform.TELEGRAM])
+    extra = runner.config.platforms[Platform.TELEGRAM].extra
+    extra["auto_topic_icons"] = True
+    extra["preserve_manual_topic_icons"] = True
+    adapter.dm_topic_custom_icon_state.return_value = False
+    adapter.get_forum_topic_icon_options.return_value = [
+        {"emoji": "🔭", "custom_emoji_id": "scope-id"},
+    ]
+
+    with patch("agent.title_generator.choose_topic_icon", return_value="🔭"):
+        rename_task = asyncio.create_task(
+            runner._rename_telegram_topic_for_session_title(
+                _make_source(thread_id="42"),
+                "sess-topic",
+                "ProjectAtlas",
+                user_message="Improve planning",
+            )
+        )
+        assert await asyncio.to_thread(second_binding_started.wait, 2)
+        adapter.dm_topic_custom_icon_state.return_value = True
+        release_second_binding.set()
+        await rename_task
+
+    assert session_db.get_telegram_topic_binding.call_count == 2
+    assert adapter.dm_topic_custom_icon_state.call_count == 3
+    adapter.rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="ProjectAtlas",
+    )
+
+@pytest.mark.asyncio
+async def test_message_cached_topic_is_still_auto_renamed(tmp_path):
+    """Telegram's incoming topic-name cache must not disable semantic rename."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session(session_id="sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=build_session_key(_make_source(thread_id="17585")),
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+
+    # Exercise the real adapter state that caused the production regression:
+    # Telegram supplied a topic name before the first title callback ran.
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = TelegramAdapter(
+        PlatformConfig(enabled=True, token="***", extra={})
+    )
+    bot = SimpleNamespace(edit_forum_topic=AsyncMock())
+    adapter._bot = cast(Any, bot)
+    adapter._cache_dm_topic_from_message(
+        "208214988", "17585", "Can you still or"
+    )
+    adapter._reload_dm_topics_from_config = lambda: None
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="17585"),
+        "sess-topic",
+        "Grab",
+    )
+
+    bot.edit_forum_topic.assert_awaited_once_with(
+        chat_id=208214988,
+        message_thread_id=17585,
+        name="Grab",
+    )
+
+def test_background_rename_copy_preserves_transport_adapter_provenance():
+    runner = _make_runner()
+    default_adapter = runner.adapters[Platform.TELEGRAM]
+    secondary_adapter = MagicMock()
+    runner._profile_adapters = {
+        "work": {Platform.TELEGRAM: secondary_adapter},
+    }
+    source = _make_source(thread_id="42")
+    source.profile = "work"
+    setattr(source, "_transport_adapter_ref", lambda: default_adapter)
+
+    copied = runner._copy_source_for_background_rename(source)
+
+    assert copied is not source
+    assert copied.profile == "work"
+    assert runner._adapter_for_source(copied) is default_adapter
+
+@pytest.mark.asyncio
+async def test_operator_declared_topic_is_not_auto_renamed(tmp_path):
+    """Operator-configured topic names remain untouched by auto-title."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session(session_id="sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=build_session_key(_make_source(thread_id="17585")),
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+
+    class _FakeAdapter:
+        def _is_dm_topic_operator_declared(self, chat_id, thread_id):
+            return True
+
+        async def rename_dm_topic(self, **kwargs):
+            return None
+
+    fake = _FakeAdapter()
+    fake.rename_dm_topic = AsyncMock()
+    runner.adapters[Platform.TELEGRAM] = cast(Any, fake)
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="17585"),
+        "sess-topic",
+        "Auto-generated title",
+    )
+
+    fake.rename_dm_topic.assert_not_called()

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -41,6 +41,10 @@ def test_title_generation_present_in_default_config():
     assert tg["model"] == ""
     assert tg["timeout"] > 0
     assert tg["extra_body"] == {}
+    assert tg["min_words"] == 2
+    assert tg["max_words"] == 3
+    assert tg["max_characters"] == 40
+    assert tg["name_aliases"] == {}
 
 
 

--- a/tests/test_telegram_topic_status_ptb.py
+++ b/tests/test_telegram_topic_status_ptb.py
@@ -1,0 +1,120 @@
+"""PTB handler-routing coverage for Telegram DM topic status updates."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+
+def test_registered_status_observer_matches_dm_topic_updates_without_dispatching():
+    """Exercise real PTB filters in a clean interpreter, outside gateway mocks."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script = textwrap.dedent(
+        r"""
+        import asyncio
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        import telegram
+
+        from gateway.config import PlatformConfig
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+        class HandlerCollector:
+            def __init__(self):
+                self.handlers = []
+                self.bot = None
+
+            def add_handler(self, handler, *args, **kwargs):
+                self.handlers.append(handler)
+
+
+        def message_update(*, update_id, chat_type="private", created=None,
+                           edited=None, text=None):
+            chat = {"id": 111, "type": chat_type}
+            if chat_type == "private":
+                chat["first_name"] = "Test"
+            else:
+                chat["title"] = "Test Group"
+            message = {
+                "message_id": update_id,
+                "date": 1,
+                "chat": chat,
+                "message_thread_id": 201,
+                "is_topic_message": True,
+            }
+            if created is not None:
+                message["forum_topic_created"] = created
+            if edited is not None:
+                message["forum_topic_edited"] = edited
+            if text is not None:
+                message["text"] = text
+            return telegram.Update.de_json(
+                {"update_id": update_id, "message": message},
+                bot=None,
+            )
+
+
+        async def main():
+            adapter = TelegramAdapter(
+                PlatformConfig(enabled=True, token="123456:test-token")
+            )
+            collector = HandlerCollector()
+            adapter._app = collector
+            adapter.handle_message = AsyncMock()
+            adapter._register_handlers()
+
+            status_handlers = [
+                handler
+                for handler in collector.handlers
+                if handler.callback == adapter._handle_dm_topic_status_update
+            ]
+            assert len(status_handlers) == 1
+            handler = status_handlers[0]
+
+            created_update = message_update(
+                update_id=1,
+                created={"name": "ProjectAtlas", "icon_color": 7322096},
+            )
+            edited_update = message_update(
+                update_id=2,
+                edited={"icon_custom_emoji_id": "manual-id"},
+            )
+            text_update = message_update(update_id=3, text="hello")
+            group_update = message_update(
+                update_id=4,
+                chat_type="supergroup",
+                created={"name": "Group Topic", "icon_color": 7322096},
+            )
+
+            assert handler.check_update(created_update)
+            assert handler.check_update(edited_update)
+            assert not handler.check_update(text_update)
+            assert not handler.check_update(group_update)
+
+            await handler.callback(created_update, SimpleNamespace())
+            assert adapter.dm_topic_custom_icon_state("111", "201") is False
+            assert adapter._dm_topics["111:ProjectAtlas"] == 201
+
+            await handler.callback(edited_update, SimpleNamespace())
+            assert adapter.dm_topic_custom_icon_state("111", "201") is True
+            adapter.handle_message.assert_not_awaited()
+
+
+        asyncio.run(main())
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -786,9 +786,24 @@ Every topic gets its own conversation history, model state, tool execution, and 
 
 ### Auto-renamed topics
 
-When Hermes generates a session title for a topic (via the auto-title pipeline, after the first exchange), the Telegram topic itself is renamed to match — e.g. "New Topic" becomes "Database migration plan". The rename is best-effort: failures are logged but don't break the session.
+When Hermes titles a session from its opening message, the Telegram topic itself is renamed to match — e.g. "New Topic" becomes "Database". An instant derived title appears first and the title model upgrades it in the background. Titles prefer 2–3 words, favor an explicitly named project or proper name, and avoid filler such as "Fixing", "Update", or "Analysis".
 
-To disable this and keep your manually-chosen topic names untouched, set:
+The title policy is configurable for every Hermes surface:
+
+```yaml
+auxiliary:
+  title_generation:
+    min_words: 2
+    max_words: 3
+    max_characters: 24
+    name_aliases:
+      project atlas: ProjectAtlas
+      atlas app: ProjectAtlas
+```
+
+`min_words` and `max_words` guide the model toward a compact range. Hermes also enforces `max_words` after generation, so an overlong model response cannot escape the configured display policy. `name_aliases` is case-insensitive and keeps personal project vocabulary in user config rather than Hermes source code. When an alias appears in the opening message, Hermes deterministically uses its configured canonical name even if the title model returns something else; explicit canonical names take precedence over the generic character preference.
+
+To disable topic renaming and keep your manually-chosen topic names untouched, set:
 
 ```yaml
 gateway:

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -786,7 +786,7 @@ Every topic gets its own conversation history, model state, tool execution, and 
 
 ### Auto-renamed topics
 
-When Hermes titles a session from its opening message, the Telegram topic itself is renamed to match — e.g. "New Topic" becomes "Database". An instant derived title appears first and the title model upgrades it in the background. Titles prefer 2–3 words, favor an explicitly named project or proper name, and avoid filler such as "Fixing", "Update", or "Analysis".
+When Hermes titles a session from its opening message, the Telegram topic itself is renamed to match — e.g. "New Topic" becomes "Database". Internally, an instant derived title is stored first; the title model upgrades it in the background, and Telegram waits for that upgrade to avoid two remote renames. Titles prefer 2–3 words, favor an explicitly named project or proper name, and avoid filler such as "Fixing", "Update", or "Analysis".
 
 The title policy is configurable for every Hermes surface:
 
@@ -803,7 +803,28 @@ auxiliary:
 
 `min_words` and `max_words` guide the model toward a compact range. Hermes also enforces `max_words` after generation, so an overlong model response cannot escape the configured display policy. `name_aliases` is case-insensitive and keeps personal project vocabulary in user config rather than Hermes source code. When an alias appears in the opening message, Hermes deterministically uses its configured canonical name even if the title model returns something else; explicit canonical names take precedence over the generic character preference.
 
-To disable topic renaming and keep your manually-chosen topic names untouched, set:
+Telegram can also choose a semantically matching **full-size topic icon** instead of leaving the default colored bubble. This is opt-in because it makes one additional lightweight title-generation call when a new topic is named:
+
+```yaml
+gateway:
+  platforms:
+    telegram:
+      extra:
+        auto_topic_icons: true
+        preserve_manual_topic_icons: true
+        topic_icon_overrides:
+          ProjectAtlas: "🔭"
+```
+
+Hermes fetches the currently allowed icons with `getForumTopicIconStickers`, asks the title model for a ranked set of up to four semantically valid candidates from that live set, and applies the matching `custom_emoji_id`. The selector prefers specific, playful visual metaphors over generic computer, robot, or rocket icons when a clearer alternative fits. It keeps the 12 most recent selections per chat out of the next model candidate pool whenever at least four fresh options remain, then falls back to ranked non-recent selection for smaller live sets. This bounded diversity history is process-local and resets when the gateway restarts.
+
+`topic_icon_overrides` is optional and uses ordinary emoji characters as portable selectors rather than hard-coded Telegram IDs. An exact override always wins, which is useful when a recurring project should keep a recognizable signature icon.
+
+With `preserve_manual_topic_icons: true` (the default), Hermes preserves a custom icon it positively observed during topic creation or editing. Private DM topics do not always deliver a creation update, so unknown icon state remains eligible during each session's one-shot first-title path, including after `/new` in an existing topic; this never triggers a background scan or mass edit. Because Telegram provides no topic-icon read-back endpoint, preservation can only be guaranteed for state the running gateway observed. Hermes rechecks that state after icon selection so a manual change made while the auxiliary call is running still wins.
+
+The rename and icon assignment are best-effort: failures are logged but don't break the session.
+
+To disable renaming entirely and keep your manually-chosen topic names untouched, set:
 
 ```yaml
 gateway:


### PR DESCRIPTION
## Summary

- replace the fixed 3–7 word title prompt with a configurable compact title range and optional canonical-name aliases
- deterministically enforce the configured word maximum after normalization and alias handling, including case-insensitive whole-term matching and explicit canonical-name precedence
- mirror each generated session title into its Telegram DM forum-topic name
- distinguish Telegram message-learned topic names from operator-declared `extra.dm_topics` entries so fresh topics still receive their one-shot semantic rename
- choose semantically matching full-size Telegram topic icons from Telegram's live allowed set when enabled
- rank up to four topic-specific, playful icon candidates and rotate away from the 12 most recent per-chat selections
- preserve positively observed manual topic icons, including edits received while icon selection is in flight
- observe private topic-created/topic-edited service updates without dispatching them as prompts
- update Telegram setup guidance and regression coverage

## Review structure

The behavior-preserving rebase is split into two focused commits:

1. `feat(title): add compact titles and canonical aliases`
2. `feat(telegram): add semantic topic icons and robust auto-renames`

The second commit contains the Telegram transport, topic-state, race-safety, profile-routing, and icon-selection behavior. Keeping those dependent invariants together avoids a partially working intermediate Telegram implementation.

## Configuration

```yaml
auxiliary:
  title_generation:
    enabled: true
    min_words: 2
    max_words: 3
    max_characters: 24
    name_aliases:
      project atlas: ProjectAtlas
      atlas app: ProjectAtlas

gateway:
  platforms:
    telegram:
      extra:
        auto_topic_icons: true
        preserve_manual_topic_icons: true
        topic_icon_overrides:
          ProjectAtlas: "🔭"
```

## Safety

- topic naming remains best-effort and does not block sessions
- icons use the live `getForumTopicIconStickers` set rather than hard-coded custom emoji IDs
- recent icons are removed from the next model allowlist whenever at least four fresh live choices remain
- per-chat selection is serialized so concurrent titles cannot observe stale diversity history
- diversity state is process-local and bounded to 12 selections across 256 recent chats
- exact title overrides win; variation-selector-equivalent emoji resolve to the matching live sticker
- manual custom icons observed on topic creation or edit are preserved by default
- private topic service updates are recorded by a non-dispatching status observer
- unknown icon state is eligible only during each session's one-shot first-title path; existing topics are never scanned or mass-renamed
- the topic/session binding is rechecked after auxiliary icon selection before any Telegram edit
- `disable_topic_auto_rename: true` still prevents Telegram topic edits
- operator-declared `extra.dm_topics` names remain protected while transient message-learned topic-name cache entries remain eligible for first-title rename/icon assignment
- explicit configured aliases take precedence over generic character preferences
- background title generation preserves routed profile context and Telegram transport provenance

## Review follow-up

- `min_words` now defines the lower end of the model prompt range; invalid ranges clamp the minimum to `max_words`
- `max_words` is enforced deterministically after output normalization and alias handling, so the maximum is a policy rather than prompt-only guidance
- aliases are enforced deterministically after the model returns, not only included in the prompt
- alias matching is case-insensitive, respects whole-term boundaries, and cannot span the user/assistant message boundary
- canonical aliases remain exact even when longer than the generic character preference
- unknown topic-icon state is explicitly documented and regression-tested
- real PTB filter coverage verifies private topic-created/topic-edited updates reach the observer without prompt dispatch
- observed manual icon state is rechecked after auxiliary icon selection before any edit
- icon candidates are validated against the current Telegram live set, including variation-selector and compound-emoji handling
- same-chat icon selection is race-free, history is per-chat/LRU-bounded, and topic rebinding during the auxiliary call prevents the rename
- fresh-topic renaming uses a dedicated configured-topic predicate instead of the general routing cache; the exact real-adapter cache → binding → rename sequence is regression-tested

## Verification

- 49 title/config tests passed for the revised title-policy commit in isolation
- 135 focused tests passed on the exact final candidate across title generation, turn context, auxiliary config, title callbacks, Telegram DM topics/topic mode, and real PTB status handling
- focused Ruff checks passed on all affected Python files
- Python compilation, `git diff --check`, conflict-marker, unmerged-index, and current-upstream merge-tree checks passed
- the final tree differs from the previous published candidate only in the five title-policy code/config/test/doc files requested by this review
- exact leased publication dry-run passed against the previous public head
- independent exact-delta review returned **NO BLOCKERS**
