### PR TITLE
fix(agent): fail fast on in-stream 4xx errors via message-text status recovery

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2670,6 +2670,12 @@ def run_conversation(
                     classified.retryable, classified.should_compress,
                     classified.should_rotate_credential, classified.should_fallback,
                 )
+                # In-stream errors carry no status attribute; the classifier
+                # may have recovered one from message text. Backfill so the
+                # error hook, 413 check, and non-retryable rendering below
+                # report the real status instead of "HTTP None".
+                if status_code is None:
+                    status_code = classified.status_code
                 agent._invoke_api_request_error_hook(
                     task_id=effective_task_id,
                     turn_id=turn_id,
@@ -3105,7 +3111,10 @@ def run_conversation(
                 # Check for 413 payload-too-large BEFORE generic 4xx handler.
                 # A 413 is a payload-size error — the correct response is to
                 # compress history and retry, not abort immediately.
-                status_code = getattr(api_error, "status_code", None)
+                # Preserve a status recovered by the classifier (in-stream
+                # errors have no status attribute) — don't clobber with None.
+                if getattr(api_error, "status_code", None) is not None:
+                    status_code = api_error.status_code
 
                 # ── Respect disabled auto-compaction on overflow ──────
                 # Ported from anomalyco/opencode#30749.  When the user has

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -550,6 +551,14 @@ def classify_api_error(
     # fallback gating) fires correctly instead of misclassifying as generic.
     if status_code is None and error_type == "RateLimitError":
         status_code = 429
+    # Last resort: recover the status from the message text. Routers/proxies
+    # can surface an upstream failure as an error frame inside an HTTP-200
+    # SSE stream, in which case the raised exception has no status attribute
+    # and only the message (e.g. "Client error: HTTP 400") carries the code.
+    # Without this, a deterministic 4xx classifies as unknown/retryable and
+    # burns every retry before failing with the same error.
+    if status_code is None:
+        status_code = _extract_status_code_from_message(str(error).lower())
     body = _extract_error_body(error)
     error_code = _extract_error_code(body)
 
@@ -1466,6 +1475,36 @@ def _classify_by_message(
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────
+
+# Conservative message-text patterns for a last-resort HTTP status recovery.
+# Each requires an explicit status/HTTP prefix so bare numbers in ordinary
+# prose (token counts, model names, dates) can never match.
+_MESSAGE_STATUS_PATTERNS = (
+    re.compile(r"\bhttp[ /_-]?(?:status[ :]*)?(\d{3})\b"),
+    re.compile(r"\bstatus(?:[ _-]?code)?[ :=]+(\d{3})\b"),
+    re.compile(r"\berror[ _-]?code[ :=]+(\d{3})\b"),
+)
+
+
+def _extract_status_code_from_message(error_msg: str) -> Optional[int]:
+    """Last-resort HTTP status extraction from lowercased message text.
+
+    A router/proxy can deliver an upstream failure as an error frame inside an
+    HTTP-200 SSE stream (e.g. continuum-router emits
+    ``{"error": {"message": "Client error: HTTP 400"}}`` mid-stream). The
+    exception raised for that frame carries no ``.status``/``.status_code``
+    attribute, so without this fallback a deterministic 400 classified as
+    ``unknown`` (retryable) and burned every retry. Only 4xx/5xx are accepted:
+    2xx/3xx mentions ("expected HTTP 200") are not failure statuses.
+    """
+    for pattern in _MESSAGE_STATUS_PATTERNS:
+        match = pattern.search(error_msg)
+        if match:
+            code = int(match.group(1))
+            if 400 <= code < 600:
+                return code
+    return None
+
 
 def _extract_status_code(error: Exception) -> Optional[int]:
     """Walk the error and its cause chain to find an HTTP status code."""

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -6,6 +6,7 @@ from agent.error_classifier import (
     FailoverReason,
     classify_api_error,
     _extract_status_code,
+    _extract_status_code_from_message,
     _extract_error_body,
     _extract_error_code,
     _classify_402,
@@ -120,6 +121,58 @@ class TestExtractStatusCode:
         class ErrWeirdStatus(Exception):
             status = 42
         assert _extract_status_code(ErrWeirdStatus()) is None
+
+
+# ── Test: Status code recovery from message text ───────────────────────
+
+class TestExtractStatusCodeFromMessage:
+    """Last-resort status recovery for in-stream error frames.
+
+    Routers/proxies (e.g. continuum-router) can deliver an upstream failure
+    as an error frame inside an HTTP-200 SSE stream; the raised exception
+    then has no status attribute and only the message carries the code.
+    """
+
+    def test_client_error_http_pattern(self):
+        assert _extract_status_code_from_message("client error: http 400") == 400
+
+    def test_http_status_pattern(self):
+        assert _extract_status_code_from_message("upstream http status 502") == 502
+
+    def test_status_code_pattern(self):
+        assert _extract_status_code_from_message("failed with status code: 503") == 503
+
+    def test_error_code_pattern(self):
+        assert _extract_status_code_from_message("error code: 429 - rate limited") == 429
+
+    def test_rejects_success_status(self):
+        """2xx/3xx mentions are not failure statuses."""
+        assert _extract_status_code_from_message("expected http 200 but got eof") is None
+
+    def test_rejects_bare_numbers(self):
+        """Numbers without a status/HTTP prefix must not match."""
+        assert _extract_status_code_from_message("generated 400 tokens in 429 ms") is None
+
+    def test_returns_none_for_plain_message(self):
+        assert _extract_status_code_from_message("connection reset by peer") is None
+
+    def test_classify_in_stream_400_fails_fast(self):
+        """The end-to-end case from the report: a proxied 400 delivered as an
+        in-stream error frame must classify as a non-retryable format_error
+        instead of unknown/retryable (which burned all retries)."""
+        e = Exception("Client error: HTTP 400")
+        result = classify_api_error(e, provider="aigo-router", model="local-model")
+        assert result.status_code == 400
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    def test_classify_plain_message_still_unknown(self):
+        """No status signal in the message keeps the retryable unknown path."""
+        e = Exception("something odd happened")
+        result = classify_api_error(e, provider="p", model="m")
+        assert result.status_code is None
+        assert result.reason == FailoverReason.unknown
+        assert result.retryable is True
 
 
 # ── Test: Error body extraction ────────────────────────────────────────

--- a/tests/run_agent/test_instream_status_recovery_loop.py
+++ b/tests/run_agent/test_instream_status_recovery_loop.py
@@ -1,0 +1,106 @@
+"""Loop-level regression for in-stream status recovery (#66358 review).
+
+An OpenAI-compatible router can deliver an upstream 4xx as an error frame
+inside an HTTP-200 SSE stream; the raised exception then has no
+``status_code`` attribute. The classifier recovers the status from message
+text — these tests pin that the *loop* actually uses the recovered value:
+the turn aborts without burning retries, and user-facing status lines say
+``HTTP 400``, never ``HTTP None``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_instream_400_error() -> Exception:
+    # No .status_code / .status attribute — only message text.
+    return Exception("Error in stream response: Client error: HTTP 400")
+
+
+def _make_agent() -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="http://127.0.0.1:39080/v1",
+            provider="openrouter",
+            api_mode="chat_completions",
+            model="unsloth/gemma-4-12b-it-UD",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    a.client = MagicMock()
+    a._cached_system_prompt = "You are helpful."
+    a._use_prompt_caching = False
+    a.tool_delay = 0
+    a.compression_enabled = False
+    a.save_trajectories = False
+    return a
+
+
+def test_instream_400_fails_fast_with_recovered_status_in_output():
+    agent = _make_agent()
+    agent.client.chat.completions.create.side_effect = _make_instream_400_error()
+
+    status_lines = []
+
+    def _record(msg, *a, **k):
+        status_lines.append(str(msg))
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(agent, "_vprint", side_effect=_record),
+        patch.object(agent, "_buffer_status", side_effect=_record),
+        patch.object(agent, "_emit_status", side_effect=_record),
+        patch.object(agent, "_buffer_vprint", side_effect=_record),
+    ):
+        result = agent.run_conversation("hello")
+
+    # Guard against a vacuous pass: the mocked error must be what aborted.
+    assert agent.client.chat.completions.create.called
+    assert result.get("failed") is True
+
+    # Fail fast: a deterministic in-stream 4xx must not burn retries.
+    assert agent.client.chat.completions.create.call_count == 1
+
+    # The recovered status reaches user-facing output — never "HTTP None".
+    joined = "\n".join(status_lines)
+    assert "HTTP None" not in joined
+    assert any("400" in line for line in status_lines)
+
+
+def test_attribute_status_still_wins_over_message_text():
+    """An exception carrying a real status attribute is untouched by the
+    backfill — the attribute stays authoritative for the 413 check."""
+    agent = _make_agent()
+    err = Exception("HTTP 400 mentioned in text but attribute says 403")
+    err.status_code = 403
+    agent.client.chat.completions.create.side_effect = err
+
+    status_lines = []
+
+    def _record(msg, *a, **k):
+        status_lines.append(str(msg))
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(agent, "_vprint", side_effect=_record),
+        patch.object(agent, "_buffer_status", side_effect=_record),
+        patch.object(agent, "_emit_status", side_effect=_record),
+        patch.object(agent, "_buffer_vprint", side_effect=_record),
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result.get("failed") is True
+    joined = "\n".join(status_lines)
+    assert "HTTP None" not in joined
+    assert "HTTP 403" in joined


### PR DESCRIPTION
## Symptom

When an OpenAI-compatible router/proxy delivers an upstream failure as an error frame inside an HTTP-200 SSE stream (continuum-router's unix-socket path does this: `{"error": {"message": "Client error: HTTP 400"}}`), the raised exception has no `.status`/`.status_code` attribute. `classify_api_error` then falls through to `unknown` (retryable), and the loop burns all retries on a deterministic 400:

```
API call failed after 3 retries: Client error: HTTP 400
```

## Change

`agent/error_classifier.py`: when the attribute walk finds no status, recover it from conservative message-text patterns (`HTTP 400`, `status code: 503`, `error code: 429`). Patterns require an explicit HTTP/status prefix so bare numbers (token counts, model names) can never match, and only 4xx/5xx are accepted so "expected HTTP 200" mentions are ignored. An in-stream 400 now classifies as `format_error` (non-retryable) and takes the existing fail-fast client-error path, which already prints provider/model/endpoint guidance.

## Scope note

An earlier revision of this PR also added provider/model/endpoint to the retries-exhausted `final_response`. That hunk was dropped: #66352 makes the same terminal-message change together with the matching gateway noise-filter shape update, so the presentation change lives there and this PR is classification-only. The two compose: with this fix a deterministic in-stream 4xx fails fast through the non-retryable path, and #66352 improves the message for calls that genuinely exhaust retries.

## Testing

- `scripts/run_tests.sh tests/agent/test_error_classifier.py`: 203 passed (9 new tests: pattern extraction, success-status and bare-number rejection, and an end-to-end classify of the reported in-stream 400 → `format_error`/non-retryable).
- `scripts/run_tests.sh tests/agent/`: 5748 passed; the small set of failures reproduces identically on clean main (local-credential/LSP environment issues, unrelated).
- `scripts/run_tests.sh tests/run_agent/ tests/gateway/test_telegram_noise_filter.py tests/hermes_cli/test_tui_resume_flow.py tests/cron/test_scheduler.py`: 2518 passed, 0 failed.
- Blocking `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
