### PR TITLE
feat(moa): support per-slot extra_body passthrough

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -219,6 +219,13 @@ def _slot_runtime(slot: dict[str, Any]) -> dict[str, Any]:
                 out["extra_body"] = dict(extra_body)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("MoA slot runtime resolution failed for %s: %s", _slot_label(slot), exc)
+    # Per-slot extra_body from the preset (e.g. service_tier for OpenAI
+    # priority/fast mode) layers over the provider's declared
+    # request_overrides defaults — see _merge_slot_extra_body for the full
+    # precedence contract (provider defaults < slot config < caller).
+    merged_extra_body = _merge_slot_extra_body(out.get("extra_body"), slot.get("extra_body"))
+    if merged_extra_body:
+        out["extra_body"] = merged_extra_body
     return out
 
 
@@ -226,7 +233,26 @@ def _merge_slot_extra_body(
     slot_extra_body: Any,
     caller_extra_body: Any,
 ) -> Any:
-    """Merge slot defaults with a caller override for ``call_llm``."""
+    """Merge two ``extra_body`` layers for ``call_llm``; the caller wins.
+
+    MoA resolves ``extra_body`` in three layers, lowest to highest
+    precedence:
+
+    1. Provider defaults — a custom provider's
+       ``request_overrides.extra_body`` (e.g. Qwen/DashScope's
+       ``enable_thinking: false``).
+    2. Slot config — the preset slot's own ``extra_body`` (e.g. OpenAI's
+       ``service_tier: priority``), layered over the provider defaults by
+       ``_slot_runtime``.
+    3. Caller — an explicit ``extra_body`` passed to the MoA call site
+       (e.g. ``MoAChatCompletions.create(extra_body=...)``), merged over
+       the slot's resolved value at the call site.
+
+    Each call to this helper merges one adjacent pair: pass the
+    lower-precedence mapping as ``slot_extra_body`` and the
+    higher-precedence mapping as ``caller_extra_body``; shared keys
+    resolve to the caller.
+    """
     if isinstance(slot_extra_body, dict) and slot_extra_body:
         if isinstance(caller_extra_body, dict):
             return {**slot_extra_body, **caller_extra_body}

--- a/hermes_cli/moa_config.py
+++ b/hermes_cli/moa_config.py
@@ -105,6 +105,9 @@ def _clean_slot(slot: Any) -> dict[str, Any] | None:
     effort = _clean_reasoning_effort(slot.get("reasoning_effort"))
     if effort:
         clean["reasoning_effort"] = effort
+    extra_body = slot.get("extra_body")
+    if isinstance(extra_body, dict) and extra_body:
+        clean["extra_body"] = dict(extra_body)
     return clean
 
 

--- a/tests/agent/test_moa_slot_api_mode.py
+++ b/tests/agent/test_moa_slot_api_mode.py
@@ -92,6 +92,43 @@ class TestSlotRuntimeApiMode:
             "reasoning": {"effort": "none"},
         }
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_slot_config_extra_body_layers_over_provider_defaults(self, mock_resolve):
+        """Precedence pin: provider defaults < slot config.
+
+        A preset slot's own ``extra_body`` merges over the custom provider's
+        ``request_overrides.extra_body`` (slot config wins on shared keys);
+        the caller layer on top of this is covered by
+        ``test_moa_aggregator_merges_slot_extra_body_with_caller_override``.
+        """
+        mock_resolve.return_value = {
+            "provider": "custom",
+            "model": "qwen3.7-max",
+            "base_url": "https://dashscope.example/v1",
+            "api_key": "test-key",
+            "api_mode": "chat_completions",
+            "request_overrides": {
+                "extra_body": {
+                    "enable_thinking": False,
+                    "shared": "provider",
+                }
+            },
+        }
+        from agent.moa_loop import _slot_runtime
+
+        result = _slot_runtime(
+            {
+                "provider": "dashscope",
+                "model": "qwen3.7-max",
+                "extra_body": {"service_tier": "priority", "shared": "slot"},
+            }
+        )
+        assert result["extra_body"] == {
+            "enable_thinking": False,
+            "service_tier": "priority",
+            "shared": "slot",
+        }
+
 
 def test_run_reference_passes_slot_extra_body(monkeypatch):
     """Reference advisors should receive custom provider extra_body."""

--- a/tests/hermes_cli/test_moa_config.py
+++ b/tests/hermes_cli/test_moa_config.py
@@ -125,6 +125,56 @@ def test_normalize_moa_config_preserves_slot_reasoning_effort():
     assert preset["aggregator"]["reasoning_effort"] == "xhigh"
 
 
+def test_normalize_moa_config_preserves_slot_extra_body():
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "p": {
+                    "reference_models": [
+                        {
+                            "provider": "openai-codex",
+                            "model": "gpt-5.6-sol",
+                            "extra_body": {"service_tier": "priority"},
+                        },
+                    ],
+                    "aggregator": {
+                        "provider": "openai-codex",
+                        "model": "gpt-5.6-sol",
+                        "extra_body": {"reasoning": {"effort": "high"}},
+                    },
+                }
+            }
+        }
+    )
+
+    preset = cfg["presets"]["p"]
+    assert preset["reference_models"][0]["extra_body"] == {"service_tier": "priority"}
+    assert preset["aggregator"]["extra_body"] == {"reasoning": {"effort": "high"}}
+
+
+def test_normalize_moa_config_drops_invalid_extra_body():
+    cfg = normalize_moa_config(
+        {
+            "presets": {
+                "p": {
+                    "reference_models": [
+                        {"provider": "openai-codex", "model": "gpt-5.6-sol", "extra_body": "not-a-dict"},
+                        {"provider": "openai-codex", "model": "gpt-5.6-sol", "extra_body": {}},
+                        {"provider": "openai-codex", "model": "gpt-5.6-sol", "extra_body": None},
+                    ],
+                    "aggregator": {"provider": "openai-codex", "model": "gpt-5.6-sol"},
+                }
+            }
+        }
+    )
+
+    preset = cfg["presets"]["p"]
+    assert "extra_body" not in preset["reference_models"][0]
+    assert "extra_body" not in preset["reference_models"][1]
+    assert "extra_body" not in preset["reference_models"][2]
+    assert "extra_body" not in preset["aggregator"]
+
+
 def test_normalize_moa_config_coerces_numeric_strings():
     """Valid numeric strings (e.g. from YAML round-trip) must coerce correctly."""
     cfg = normalize_moa_config({"max_tokens": "8192", "reference_temperature": "0.9"})

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -459,6 +459,30 @@ def test_run_reference_prepends_advisory_system_prompt(monkeypatch):
     assert msgs[-1]["role"] == "user"
 
 
+def test_run_reference_forwards_slot_extra_body(monkeypatch):
+    from agent.moa_loop import _run_reference
+
+    captured = {}
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return _response("advice")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    extra_body = {"service_tier": "priority", "provider_flag": True}
+    _run_reference(
+        {
+            "provider": "openrouter",
+            "model": "vendor/advisor",
+            "extra_body": extra_body,
+        },
+        [{"role": "user", "content": "review this"}],
+    )
+
+    assert captured["extra_body"] == extra_body
+
+
 def test_moa_facade_references_get_trimmed_messages(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -563,6 +587,52 @@ moa:
     # Aggregator gets the unmodified user message (no MoA guidance appended).
     agg_call = calls[0]
     assert agg_call["messages"][-1]["content"] == "question"
+
+
+def test_moa_aggregator_merges_request_and_slot_extra_body(monkeypatch, tmp_path):
+    """Caller extra_body merges over slot config (caller wins, per
+    _merge_slot_extra_body's documented precedence:
+    provider defaults < slot config < caller)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      enabled: false
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+        extra_body:
+          slot_only: slot
+          shared: slot
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    captured = {}
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return _response("acted")
+
+    monkeypatch.setattr("agent.moa_loop.call_llm", fake_call_llm)
+
+    from agent.moa_loop import MoAChatCompletions
+
+    facade = MoAChatCompletions("review")
+    facade.create(
+        messages=[{"role": "user", "content": "question"}],
+        extra_body={"request_only": "request", "shared": "request"},
+    )
+
+    assert captured["extra_body"] == {
+        "request_only": "request",
+        "slot_only": "slot",
+        "shared": "request",
+    }
 
 
 def test_references_run_in_parallel(monkeypatch):


### PR DESCRIPTION
## Rationale

MoA slots (reference models and aggregator) currently only support `provider`, `model`, and `reasoning_effort`. There's no way to pass provider-specific request parameters like OpenAI's `service_tier` (for priority/fast mode) or any other `extra_body` fields on a per-slot basis.

This is limiting when you want e.g. the aggregator to run at standard tier but a reference model to run at priority tier, or vice versa.

## What changed

- `hermes_cli/moa_config.py`: `_clean_slot` now preserves an optional `extra_body` dict from the slot config
- `agent/moa_loop.py`: `_slot_runtime` layers the slot's `extra_body` over the provider's `request_overrides.extra_body` via the existing `_merge_slot_extra_body()` helper (#70160) — no parallel merge path; the value then flows to `call_llm` on all three MoA call paths (advisor fan-out, one-shot `/moa` synthesis, acting aggregator)

## Merge precedence

`extra_body` resolves in three layers, lowest to highest:

1. **Provider defaults** — a custom provider's `request_overrides.extra_body`
2. **Slot config** — the preset slot's own `extra_body`
3. **Caller** — an explicit `extra_body` passed to the MoA call site

The ordering is documented in `_merge_slot_extra_body()`'s docstring and pinned by tests: `test_slot_config_extra_body_layers_over_provider_defaults` (slot config > provider defaults) and `test_moa_aggregator_merges_request_and_slot_extra_body` (caller > slot config).

## Example usage

```yaml
moa:
  reference_models:
    - provider: openai-codex
      model: gpt-5.6-sol-high
      extra_body:
        service_tier: priority  # OpenAI fast mode
  aggregator:
    provider: kimi
    model: k3
```

## Test plan

- [x] `pytest tests/hermes_cli/test_moa_config.py` — 37 pass (incl. extra_body passthrough + invalid-shape dropped)
- [x] `pytest tests/run_agent/test_moa_loop_mode.py` — 38 pass (incl. caller-over-slot aggregator merge)
- [x] `pytest tests/agent/test_moa_slot_api_mode.py` — 9 pass (incl. slot-config-over-provider-defaults precedence pin)
- [x] 6 sibling MoA suites — 31 pass
